### PR TITLE
add missing comma in example.cfg

### DIFF
--- a/syz-manager/example.cfg
+++ b/syz-manager/example.cfg
@@ -10,7 +10,7 @@
 	"count": 16,
 	"procs": 4,
 	"cpu": 2,
-	"mem": 2048
+	"mem": 2048,
 	"disable_syscalls": [
 		"keyctl",
 		"add_key",


### PR DESCRIPTION
Missing comma makes it so that syz-manager does not properly parse the example
config.