### PR TITLE
Fix create image PATH

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 
 Google Inc.
 Baozeng Ding
+Lorenzo Stoakes

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Google Inc.
  Andrey Konovalov
  David Drysdale
  Baozeng Ding
+Lorenzo Stoakes

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -24,7 +24,8 @@ ssh-keygen -f ssh/id_rsa -t rsa -N ''
 cat ssh/id_rsa.pub | sudo tee wheezy/root/.ssh/authorized_keys
 
 # Install some misc packages.
-sudo chroot wheezy /bin/bash -c "apt-get update; ( yes | apt-get install curl tar time strace)"
+sudo chroot wheezy /bin/bash -c "export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin; " \
+"apt-get update; apt-get install --yes curl tar time strace"
 
 # Build a disk image
 dd if=/dev/zero of=wheezy.img bs=1M seek=1023 count=1
@@ -33,4 +34,3 @@ sudo mkdir -p /mnt/wheezy
 sudo mount -o loop wheezy.img /mnt/wheezy
 sudo cp -a wheezy/. /mnt/wheezy/.
 sudo umount /mnt/wheezy
-


### PR DESCRIPTION
I'm using arch linux and the chroot fails for me because I don't have all of the required directories in my path. This is an issue that others might face who happen to have a distribution that doesn't satisfy debian's requirements.

This patch sets a `PATH` referencing all of the required directories inside the `chroot` to avoid the host `PATH` playing any role in what the `chroot` is doing.

Additionally, as part of the change I've switched out `( yes | apt-get install ...)` into `apt-get install --yes` which, unless I've missed something ought to achieve the same thing.