### PR TITLE
vm/qemu: strip ssh warnings

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -321,5 +321,6 @@ func (inst *instance) sshArgs(portArg string) []string {
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "IdentitiesOnly=yes",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "LogLevel=error",
 	}
 }


### PR DESCRIPTION
This patch sets the ssh loglevel to error to avoid noisy warnings, specifically known host errors like:

`Warning: Permanently added '[localhost]:1569' (ECDSA) to the list of known hosts.`

Previously this appeared at the top of every crash report.