### PR TITLE
manager: add ignorehangs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ following keys in its top-level object:
  - `dropprivs` : Whether the executor program should try to use namespaces to drop privileges
    before executing (requires a kernel built with `CONFIG_NAMESPACES`, `CONFIG_UTS_NS`,
    `CONFIG_USER_NS`, `CONFIG_PID_NS` and `CONFIG_NET_NS`).
+ - `ignorehangs` : Whether the manager should ignore cases where the fuzzer appears to have hanged
+   (a hanged fuzzer might indicate a kernel deadlock so by default this case is not ignored.)
  - `enable_syscalls`: List of syscalls to test (optional).
  - `disable_syscalls`: List of system calls that should be treated as disabled (optional).
  - `suppressions`: List of regexps for known bugs.

--- a/config/config.go
+++ b/config/config.go
@@ -37,9 +37,10 @@ type Config struct {
 	Count     int    // number of VMs
 	Procs     int    // number of parallel processes inside of every VM
 
-	Cover     bool // use kcov coverage (default: true)
-	DropPrivs bool // drop privileges during fuzzing (default: true)
-	Leak      bool // do memory leak checking
+	Cover       bool // use kcov coverage (default: true)
+	DropPrivs   bool // drop privileges during fuzzing (default: true)
+	Leak        bool // do memory leak checking
+	IgnoreHangs bool // ignore hanged fuzzers
 
 	ConsoleDev string // console device for adb vm
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -332,10 +332,15 @@ func (mgr *Manager) runInstance(vmCfg *vm.Config, first bool) bool {
 				return true
 			}
 		case <-ticker.C:
-			if mgr.cfg.Type != "local" {
-				saveCrasher("no output", output)
-				return true
+			if mgr.cfg.Type == "local" {
+				continue
 			}
+
+			if !mgr.cfg.IgnoreHangs {
+				saveCrasher("no output", output)
+			}
+
+			return true
 		}
 	}
 }


### PR DESCRIPTION
By default, syz-manager will report timed out fuzzers as 'no output' and save
the crash log. This is valid as a hung fuzzer might indicate a kernel deadlock,
however it's also useful to have the option to ignore these when searching only
for definite oopses.