### PR TITLE
Use readelf to obtain the upper 32 bits of addresses returned by kcov.

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -20,8 +20,8 @@ func Copy(cov Cover) Cover {
 	return append(Cover{}, cov...)
 }
 
-func RestorePC(pc uint32) uint64 {
-	return uint64(0xffffffff)<<32 + uint64(pc)
+func RestorePC(pc uint32, base uint32) uint64 {
+	return uint64(base)<<32 + uint64(pc)
 }
 
 /* Canonicalize sorts and removes duplicates. */

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -110,7 +110,7 @@ func main() {
 						buf := new(bytes.Buffer)
 						binary.Write(buf, binary.LittleEndian, uint64(0xC0BFFFFFFFFFFF64))
 						for _, pc := range c {
-							binary.Write(buf, binary.LittleEndian, cover.RestorePC(pc))
+							binary.Write(buf, binary.LittleEndian, cover.RestorePC(pc, 0xffffffff))
 						}
 						err := ioutil.WriteFile(fmt.Sprintf("%v.%v", *flagCoverFile, i), buf.Bytes(), 0660)
 						if err != nil {


### PR DESCRIPTION
When executors send coverage data to the manager, they clamp the addresses
of covered blocks to 32 bits. Manager uses RestorePC() to restore the original
addresses.
Previously, RestorePC() assumed that the upper 4 bytes of a kernel code
address were 0xffffffff, which is not so on Android.
Instead we now parse `readelf -SW vmlinux` output to obtain the upper bytes of
PROGBITS sections VMAs in the case those VMAs are non-zero. We assume that
the upper 4 bytes are the same for every section.