### PR TITLE
support getsockopt for sctp and also support kcm and netrom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ upgrade:
 SYSCALL_FILES=sys/sys.txt sys/socket.txt sys/tty.txt sys/perf.txt \
 	sys/key.txt sys/bpf.txt sys/fuse.txt sys/dri.txt sys/kdbus.txt sys/sctp.txt \
 	sys/kvm.txt sys/sndseq.txt sys/sndtimer.txt sys/sndcontrol.txt sys/input.txt \
-	sys/netlink.txt sys/tun.txt sys/random.txt
+	sys/netlink.txt sys/tun.txt sys/random.txt sys/kcm.txt sys/netrom.txt
 generate: bin/syz-sysgen $(SYSCALL_FILES)
 	bin/syz-sysgen -linux=$(LINUX) -linuxbld=$(LINUXBLD) $(SYSCALL_FILES)
 bin/syz-sysgen: sysgen/*.go

--- a/sys/decl.go
+++ b/sys/decl.go
@@ -114,6 +114,8 @@ const (
 	FdInputEvent
 	FdTun
 	FdRandom
+	FdKcm
+	FdNetRom
 
 	IPCMsq
 	IPCSem
@@ -143,7 +145,8 @@ func ResourceSubkinds(kind ResourceKind) []ResourceSubkind {
 			FdDRI, FdFuse, FdKdbus, FdBpfMap, FdBpfProg, FdPerf, FdUserFault,
 			FdAlg, FdAlgConn, FdNfcRaw, FdNfcLlcp, FdBtHci, FdBtSco, FdBtL2cap,
 			FdBtRfcomm, FdBtHidp, FdBtCmtp, FdBtBnep, FdUnix, FdSctp, FdNetlink, FdKvm, FdKvmVm,
-			FdKvmCpu, FdSndSeq, FdSndTimer, FdSndControl, FdInputEvent, FdTun, FdRandom}
+			FdKvmCpu, FdSndSeq, FdSndTimer, FdSndControl, FdInputEvent, FdTun, FdRandom, FdKcm,
+			FdNetRom}
 	case ResIPC:
 		return []ResourceSubkind{IPCMsq, IPCSem, IPCShm}
 	case ResIOCtx, ResKey, ResInotifyDesc, ResPid, ResUid, ResGid, ResTimerid, ResIocbPtr, ResDrmCtx:

--- a/sys/kcm.txt
+++ b/sys/kcm.txt
@@ -1,0 +1,29 @@
+# Copyright 2016 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+include <linux/kcm.h>
+
+socket$kcm(domain const[AF_KCM], type flags[kcm_socket_type], proto const[KCMPROTO_CONNECTED]) fd[kcm]
+setsockopt$KCM_RECV_DISABLE(fd fd[kcm], level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[in, int32], len len[val])
+getsockopt$KCM_RECV_DISABLE(fd fd[kcm], level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[out, int32], len len[val])
+sendmsg$kcm(fd fd[kcm], msg ptr[in, send_msghdr], f flags[send_flags])
+recvmsg$kcm(fd fd[kcm], msg ptr[in, recv_msghdr], f flags[recv_flags])
+
+ioctl$SIOCKCMATTACH(fd fd[kcm], cmd const[SIOCKCMATTACH], arg ptr[in, kcm_attach])
+ioctl$SIOCKCMUNATTACH(fd fd[kcm], cmd const[SIOCKCMUNATTACH], arg ptr[in, kcm_unattach])
+ioctl$SIOCKCMCLONE(fd fd[kcm], cmd const[SIOCKCMCLONE], arg ptr[inout, kcm_clone])
+
+kcm_socket_type = SOCK_DGRAM, SOCK_SEQPACKET
+
+kcm_attach {
+	fd	fd[sock]
+	bpf_fd	int32
+}
+
+kcm_unattach {
+	fd	fd[sock]
+}
+
+kcm_clone {
+	fd	fd[sock]
+}

--- a/sys/netrom.txt
+++ b/sys/netrom.txt
@@ -1,0 +1,62 @@
+# Copyright 2016 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+include <linux/netrom.h>
+
+socket$netrom(domain const[AF_NETROM], type const[SOCK_SEQPACKET], proto const[0]) fd[netrom]
+bind$netrom(fd fd[netrom], addr ptr[in, sockaddr_netrom], addrlen len[addr])
+connect$netrom(fd fd[netrom], addr ptr[in, sockaddr_netrom], addrlen len[addr])
+accept$netrom(fd fd[netrom], peer ptr[out, sockaddr_netrom, opt], peerlen ptr[inout, len[peer, int32]]) fd[netrom]
+listen$netrom(fd fd[netrom], backlog int32)
+sendmsg$netrom(fd fd[netrom], msg ptr[in, msghdr_netrom], f flags[send_flags])
+recvmsg$netrom(fd fd[netrom], msg ptr[in, msghdr_netrom], f flags[recv_flags])
+getsockname$netrom(fd fd[netrom], addr ptr[out, sockaddr_netrom], addrlen ptr[inout, len[addr, int32]])
+getpeername$netrom(fd fd[netrom], peer ptr[out, sockaddr_netrom], peerlen ptr[inout, len[peer, int32]])
+
+setsockopt$NETROM_T1(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T1], arg ptr[in, int32], arglen len[arg])
+setsockopt$NETROM_T2(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T2], arg ptr[in, int32], arglen len[arg])
+setsockopt$NETROM_N2(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_N2], arg ptr[in, int32], arglen len[arg])
+setsockopt$NETROM_T4(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T4], arg ptr[in, int32], arglen len[arg])
+setsockopt$NETROM_IDLE(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_IDLE], arg ptr[in, int32], arglen len[arg])
+
+getsockopt$NETROM_T1(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T1], arg ptr[out, int32], arglen ptr[inout, len[arg, int32]])
+getsockopt$NETROM_T2(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T2], arg ptr[in, int32], arglen ptr[inout, len[arg, int32]])
+getsockopt$NETROM_N2(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_N2], arg ptr[in, int32], arglen ptr[inout, len[arg, int32]])
+getsockopt$NETROM_T4(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_T4], arg ptr[in, int32], arglen ptr[inout, len[arg, int32]])
+getsockopt$NETROM_IDLE(fd fd[netrom], level const[SOL_NETROM], opt const[NETROM_IDLE], arg ptr[in, int32], arglen ptr[inout, len[arg, int32]])
+
+ioctl$NETROM_TIOCOUTQ(fd fd[netrom], cmd const[TIOCOUTQ], arg ptr[out, int32])
+ioctl$NETROM_TIOCINQ(fd fd[netrom], cmd const[TIOCINQ], arg ptr[out, int32])
+ioctl$NETROM_SIOCGSTAMP(fd fd[netrom], cmd const[SIOCGSTAMP], arg ptr[out, int32])
+ioctl$NETROM_SIOCGSTAMPNS(fd fd[netrom], cmd const[SIOCGSTAMPNS], arg ptr[out, int32])
+ioctl$NETROM_SIOCADDRT(fd fd[netrom], cmd const[SIOCADDRT], arg ptr[out, int32])
+
+ax25_address {
+	call	array[int8, 7]
+}
+
+sockaddr_ax25 {
+	family	const[AF_NETROM, int16]
+	call	ax25_address
+	ndigis	int32
+}
+
+full_sockaddr_ax25 {
+	ax25	sockaddr_ax25
+	dig	array[ax25_address, AX25_MAX_DIGIS]
+}
+
+sockaddr_netrom [
+	ax25	sockaddr_ax25
+	full	full_sockaddr_ax25
+] [varlen]
+
+msghdr_netrom {
+	addr	ptr[in, sockaddr_netrom]
+	addrlen	len[addr, int32]
+	vec	ptr[in, array[iovec_in]]
+	vlen	len[vec, intptr]
+	ctrl	ptr[in, array[cmsghdr], opt]
+	ctrllen	len[ctrl, intptr]
+	f	flags[send_flags, int32]
+}

--- a/sys/sctp.txt
+++ b/sys/sctp.txt
@@ -51,6 +51,45 @@ setsockopt$SCTP_PEER_ADDR_THLDS(fd fd[sctp], level const[SOL_SCTP], opt const[SC
 setsockopt$SCTP_RECVRCVINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_RECVRCVINFO], val ptr[in, int32], len len[val])
 setsockopt$SCTP_RECVNXTINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_RECVNXTINFO], val ptr[in, int32], len len[val])
 
+getsockopt$SCTP_STATUS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_STATUS], val ptr[inout, sctp_status], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_DISABLE_FRAGMENTS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_DISABLE_FRAGMENTS], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_EVENTS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_EVENTS], val ptr[out, sctp_event_subscribe], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_AUTOCLOSE(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_AUTOCLOSE], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_SOCKOPT_PEELOFF(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_SOCKOPT_PEELOFF], val ptr[inout, sctp_peeloff_arg_t], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_PEER_ADDR_PARAMS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_PARAMS], val ptr[inout, sctp_paddrparams], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_DELAYED_SACK(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_DELAYED_SACK], val ptr[inout, sctp_sack_info], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_INITMSG(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_INITMSG], val ptr[out, sctp_initmsg], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_PEER_ADDRS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDRS], val ptr[inout, sctp_getaddrs], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_LOCAL_ADDRS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_LOCAL_ADDRS], val ptr[inout, sctp_getaddrs], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_SOCKOPT_CONNECTX3(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX3], val ptr[inout, sctp_getaddrs_old], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_DEFAULT_SEND_PARAM(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_DEFAULT_SEND_PARAM], val ptr[inout, sctp_sndrcvinfo], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_DEFAULT_SNDINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_DEFAULT_SNDINFO], val ptr[inout, sctp_sndinfo], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_PRIMARY_ADDR(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_PRIMARY_ADDR], val ptr[inout, sctp_prim], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_NODELAY(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_NODELAY], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_RTOINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_RTOINFO], val ptr[inout, sctp_rtoinfo], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_ASSOCINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_ASSOCINFO], val ptr[inout, sctp_sndinfo], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_I_WANT_MAPPED_V4_ADDR(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_I_WANT_MAPPED_V4_ADDR], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_MAXSEG(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_MAXSEG], val ptr[inout, sctp_assoc_value], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_PEER_ADDR_INFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDR_INFO], val ptr[inout, sctp_paddrinfo], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_ADAPTATION_LAYER(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_ADAPTATION_LAYER], val ptr[out, sctp_setadaptation], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_CONTEXT(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_CONTEXT], val ptr[inout, sctp_assoc_value], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_FRAGMENT_INTERLEAVE(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_FRAGMENT_INTERLEAVE], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_PARTIAL_DELIVERY_POINT(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_PARTIAL_DELIVERY_POINT], val ptr[inout, sctp_assoc_value], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_MAX_BURST(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_MAX_BURST], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_HMAC_IDENT(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_HMAC_IDENT], val ptr[inout, sctp_authkeyid], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_AUTH_ACTIVE_KEY(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_AUTH_ACTIVE_KEY], val ptr[inout, sctp_authkeyid], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_PEER_AUTH_CHUNKS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_PEER_AUTH_CHUNKS], val ptr[inout, sctp_authchunks], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_LOCAL_AUTH_CHUNKS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_LOCAL_AUTH_CHUNKS], val ptr[inout, sctp_authchunks], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_ASSOC_NUMBER(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_NUMBER], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_ASSOC_ID_LIST(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_ID_LIST], val ptr[out, sctp_assoc_ids], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_AUTO_ASCONF(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_AUTO_ASCONF], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_PEER_ADDR_THLDS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_THLDS], val ptr[inout, sctp_paddrthlds], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_GET_ASSOC_STATS(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_STATS], val ptr[inout, sctp_assoc_stats], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_RECVRCVINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_RECVRCVINFO], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+getsockopt$SCTP_RECVNXTINFO(fd fd[sctp], level const[SOL_SCTP], opt const[SCTP_RECVNXTINFO], val ptr[out, int32], len ptr[inout, len[val, int32]] )
+
+ioctl$SCTP_SIOCINQ(fd fd[sctp], cmd const[SIOCINQ], arg ptr[out, int32])
+
 sctp_socket_type = SOCK_STREAM, SOCK_SEQPACKET
 sctp_sndrcv_flags = SCTP_UNORDERED, SCTP_ADDR_OVER, SCTP_ABORT, SCTP_EOF
 sctp_spp_flags = SPP_HB_ENABLE, SPP_HB_DISABLE, SPP_HB_DEMAND, SPP_HB_TIME_IS_ZERO, SPP_PMTUD_ENABLE, SPP_PMTUD_DISABLE, SPP_SACKDELAY_ENABLE, SPP_SACKDELAY_DISABLE
@@ -219,4 +258,62 @@ sctp_paddrthlds {
 	addr	sockaddr_storage_sctp
 	maxrxt	int16
 	pfthld	int16
+}
+
+sctp_paddrinfo {
+	assoc   int32
+	addr    sockaddr_storage_sctp
+	state   int32
+	cwnd    int32
+	srtt    int32
+	rto     int32
+	mtu     int32
+} [packed, align_4]
+
+sctp_status {
+	assoc   int32
+	state   int32
+	rwnd    int32
+	unpack  int16
+	pend    int16
+	in      int16
+	out     int16
+	frag    int32
+	prim    sctp_paddrinfo
+}
+
+sctp_getaddrs_old {
+	assoc	int32
+	num	int32
+	addrs	ptr[in, sockaddr_sctp]
+}
+
+sctp_getaddrs {
+	assoc	int32
+	num	int32
+	addrs	int8
+}
+
+sctp_peeloff_arg_t {
+	assoc	int32
+	sd	int32
+}
+
+sctp_assoc_stats {
+	assoc	int32
+	rto	sockaddr_storage_sctp
+	status	array[int64, 15]
+}
+
+sctp_assoc_ids {
+	num	int32
+	assoc	array[int32]
+}
+
+sctp_authchunks {
+	chunk	int8
+}
+
+sctp_setadaptation {
+	adpt	int32
 }

--- a/sysgen/sysgen.go
+++ b/sysgen/sysgen.go
@@ -470,6 +470,10 @@ func fmtFdKind(s string) string {
 		return "FdTun"
 	case "random":
 		return "FdRandom"
+	case "kcm":
+		return "FdKcm"
+	case "netrom":
+		return "FdNetRom"
 	default:
 		failf("bad fd type %v", s)
 		return ""


### PR DESCRIPTION
Hi Dmitry, this pull request support more network protocols.
The first commit add getsockopt functions for sctp network protocol. Currently setsockopt is implemented for sctp, but getsockopt is not implemented. The commit make fuzzy sctp protocol more complete.
The second commit supports KCM(Kernel Connection Multiplexor)(supported from Linux 4.6) and netrom. Thank you.