### PR TITLE
support range int

### DIFF
--- a/prog/prio.go
+++ b/prog/prio.go
@@ -1,4 +1,4 @@
-// Copyright 2015 syzkaller project authors. All rights reserved.
+// Copyright 2015/2016 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 package prog
@@ -90,6 +90,7 @@ func calcStaticPriorities() [][]float32 {
 			case sys.IntType:
 				switch a.Kind {
 				case sys.IntPlain:
+				case sys.IntRange:
 				case sys.IntSignalno:
 					noteUsage(1.0, "signalno")
 				case sys.IntInaddr:

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -1,4 +1,4 @@
-// Copyright 2015 syzkaller project authors. All rights reserved.
+// Copyright 2015/2016 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 package prog
@@ -69,6 +69,10 @@ func (r *randGen) randInt() uintptr {
 		1, func() { v = uintptr(-int(v)) },
 	)
 	return v
+}
+
+func (r *randGen) randRangeInt(begin int64, end int64) uintptr {
+	return uintptr(begin + r.Int63n(end - begin + 1))
 }
 
 // biasedRand returns a random int in range [0..n),
@@ -744,6 +748,8 @@ func (r *randGen) generateArg(s *state, typ sys.Type, dir ArgDir, sizes map[stri
 			v = uintptr(r.inaddr(s))
 		case sys.IntInport:
 			v = uintptr(r.inport(s))
+		case sys.IntRange:
+			v = r.randRangeInt(a.RangeBegin, a.RangeEnd)
 		}
 		return constArg(v), nil, nil
 	case sys.FilenameType:

--- a/sys/decl.go
+++ b/sys/decl.go
@@ -1,4 +1,4 @@
-// Copyright 2015 syzkaller project authors. All rights reserved.
+// Copyright 2015/2016 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 package sys
@@ -385,12 +385,15 @@ const (
 	IntSignalno
 	IntInaddr
 	IntInport
+	IntRange
 )
 
 type IntType struct {
 	TypeCommon
 	TypeSize uintptr
 	Kind     IntKind
+	RangeBegin int64
+	RangeEnd int64
 }
 
 func (t IntType) Size() uintptr {

--- a/sysgen/parser.go
+++ b/sysgen/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2015 syzkaller project authors. All rights reserved.
+// Copyright 2015/2016 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 package main
@@ -81,7 +81,8 @@ func (p *Parser) Ident() string {
 			(p.s[p.i] >= 'a' && p.s[p.i] <= 'z' ||
 				p.s[p.i] >= 'A' && p.s[p.i] <= 'Z' ||
 				p.s[p.i] >= '0' && p.s[p.i] <= '9' ||
-				p.s[p.i] == '_' || p.s[p.i] == '$') { // $ is for n-way syscalls (like ptrace$peek)
+				p.s[p.i] == '_' || p.s[p.i] == '$' || // $ is for n-way syscalls (like ptrace$peek)
+				p.s[p.i] == '-' || p.s[p.i] == '~') { // ~ is for ranged int (like int32[-3~10])
 			p.i++
 		}
 		if start == p.i {


### PR DESCRIPTION
This commit support range int. For instance,   a filed x with int8 [3, 6], means that x could be 3, 4, 5. This is useful for some system calls ,which only accepts a range integer.