### PR TITLE
extract.sh: allow generating constants for Android devices.

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -6,25 +6,42 @@
 # sudo apt-get install gcc-aarch64-linux-gnu gcc-powerpc64le-linux-gnu
 
 if [ "$LINUX" == "" ]; then
-	echo "usage: make extract LINUX=/linux/checkout]"
-	exit 1
+	if [ "$ANDROID" == "" ]; then
+		echo "usage: make extract LINUX=/linux/checkout]"
+		echo "OR: make extract ANDROID=/linux/checkout]"
+		exit 1
+	else
+		LINUX=$ANDROID
+		BUILD_FOR_ANDROID=yes
+	fi
+else
+	BUILD_FOR_ANDROID=no
 fi
 
-FILES="sys/sys.txt sys/socket.txt sys/tty.txt sys/perf.txt sys/kvm.txt \
+COMMON_FILES="sys/socket.txt sys/tty.txt sys/perf.txt sys/kvm.txt \
 	sys/key.txt sys/bpf.txt sys/fuse.txt sys/dri.txt sys/kdbus.txt sys/sctp.txt \
 	sys/sndseq.txt sys/sndtimer.txt sys/sndcontrol.txt sys/input.txt \
-	sys/netlink.txt sys/tun.txt sys/random.txt sys/kcm.txt sys/netrom.txt"
+	sys/netlink.txt sys/tun.txt sys/random.txt sys/netrom.txt"
+
+UPSTREAM_FILES="sys/sys.txt sys/kcm.txt"
+ANDROID_FILES=sys/tlk_device.txt
+
+if [ "$BUILD_FOR_ANDROID" == "no" ]; then
+	FILES="$COMMON_FILES $UPSTREAM_FILES"
+else
+	FILES="$ANDROID_FILES"
+fi
 
 generate_arch() {
 	echo generating arch $1...
 	echo "cd $LINUX; make defconfig"
-	OUT=`(cd $LINUX; make ARCH=$2 CROSS_COMPILE=/usr/bin/$3-linux-gnu- defconfig 2>&1)`
+	OUT=`(cd $LINUX; make ARCH=$2 CROSS_COMPILE=$3-linux-gnu- defconfig 2>&1)`
 	if [ $? -ne 0 ]; then
 		echo "$OUT"
 		exit 1
 	fi
 	echo "cd $LINUX; make"
-	OUT=`(cd $LINUX; make ARCH=$2 CROSS_COMPILE=/usr/bin/$3-linux-gnu- init/main.o 2>&1)`
+	OUT=`(cd $LINUX; make ARCH=$2 CROSS_COMPILE=$3-linux-gnu- init/main.o 2>&1)`
 	if [ $? -ne 0 ]; then
 		echo "$OUT"
 		exit 1
@@ -41,4 +58,6 @@ generate_arch() {
 
 generate_arch amd64 x86_64 x86_64
 generate_arch arm64 arm64 aarch64
-generate_arch ppc64le powerpc powerpc64le
+if [ "$BUILD_FOR_ANDROID" == "no" ]; then
+	generate_arch ppc64le powerpc powerpc64le
+fi


### PR DESCRIPTION
To generate Android-specific constants run extract.sh with
ANDROID=/path/to/kernel/checkout instead of LINUX=...
Also remove /usr/bin from `make defconfig` invocations to let the user
supply custom CC.