### PR TITLE
Allow range sized arrays

### DIFF
--- a/prog/rand.go
+++ b/prog/rand.go
@@ -26,6 +26,10 @@ func (r *randGen) rand(n int) uintptr {
 	return uintptr(r.Intn(n))
 }
 
+func (r *randGen) randRange(begin int, end int) uintptr {
+	return uintptr(begin + r.Intn(end-begin+1))
+}
+
 func (r *randGen) bin() bool {
 	return r.Intn(2) == 0
 }
@@ -770,9 +774,12 @@ func (r *randGen) generateArg(s *state, typ sys.Type, dir ArgDir, sizes map[stri
 		filename := r.filename(s)
 		return dataArg([]byte(filename)), nil, nil
 	case sys.ArrayType:
-		count := a.Len
-		if count == 0 {
+		count := uintptr(0)
+		switch a.Kind {
+		case sys.ArrayRandLen:
 			count = r.rand(6)
+		case sys.ArrayRangeLen:
+			count = r.randRange(int(a.RangeBegin), int(a.RangeEnd))
 		}
 		sz := constArg(count)
 		var inner []*Arg

--- a/sys/README.md
+++ b/sys/README.md
@@ -45,7 +45,7 @@ rest of the type-options are type-specific:
 	"ptr": a pointer to an object, type-options:
 		type of the object; direction (in/out/inout)
 	"array": a variable/fixed-length array, type-options:
-		type of elements, optional size for fixed-length arrays
+		type of elements, optional size (fixed "5", or ranged "5:10", boundaries inclusive)
 	"intN"/"intptr": an integer without a particular meaning, type-options:
 		range of values (e.g. "5:10", or "-100:200", optional)
 ```

--- a/sys/align.go
+++ b/sys/align.go
@@ -64,7 +64,7 @@ func addAlignment(t *StructType) Type {
 		}
 		off += f.Size()
 		fields = append(fields, f)
-		if at, ok := f.(ArrayType); ok && at.Len == 0 {
+		if at, ok := f.(ArrayType); ok && (at.Kind == ArrayRandLen || (at.Kind == ArrayRangeLen && at.RangeBegin != at.RangeEnd)) {
 			varLen = true
 		}
 		if varLen && i != len(t.Fields)-1 {

--- a/sys/decl.go
+++ b/sys/decl.go
@@ -236,21 +236,27 @@ func (t FilenameType) Align() uintptr {
 	return 1
 }
 
+type ArrayKind int
+
+const (
+	ArrayRandLen ArrayKind = iota
+	ArrayRangeLen
+)
+
 type ArrayType struct {
 	TypeCommon
-	Type Type
-	Len  uintptr // 0 if variable-length, unused for now
+	Type       Type
+	Kind       ArrayKind
+	RangeBegin uintptr
+	RangeEnd   uintptr
 }
 
 func (t ArrayType) Size() uintptr {
-	if t.Len == 0 {
-		return 0 // for trailing embed arrays
-	}
-	return t.Len * t.Type.Size()
+	panic("should not be called")
 }
 
 func (t ArrayType) Align() uintptr {
-	return t.Type.Align()
+	panic("should not be called")
 }
 
 type PtrType struct {


### PR DESCRIPTION
The syntax is:
```
struct {
  field array[int8, 10:16]
}
```