### PR TITLE
Refactor & improve len type handling

### DIFF
--- a/prog/mutation_test.go
+++ b/prog/mutation_test.go
@@ -50,10 +50,10 @@ func TestMutateTable(t *testing.T) {
 	tests := [][2]string{
 		// Insert calls.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"sched_yield()\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 		},
@@ -119,7 +119,7 @@ func TestMutateTable(t *testing.T) {
 			"r0 = open(&(0x7f0000001000)=\"2e2f66696c653000\", 0x22c0, 0x1)\n" +
 				"readv(r0, &(0x7f0000000000)=[{&(0x7f0000001000)=nil, 0x1}, {&(0x7f0000002000)=nil, 0x2}], 0x2)\n",
 
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"r0 = open(&(0x7f0000001000)=\"2e2f66696c653000\", 0x22c0, 0x1)\n" +
 				"readv(r0, &(0x7f0000000000)=[{&(0x7f0000001000)=nil, 0x1}, {&(0x7f0000002000)=nil, 0x2}, {&(0x7f0000000000)=nil, 0x3}], 0x3)\n",
 		},
@@ -158,7 +158,7 @@ func TestMinimize(t *testing.T) {
 	}{
 		// Predicate always returns false, so must get the same program.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"sched_yield()\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 			2,
@@ -171,14 +171,14 @@ func TestMinimize(t *testing.T) {
 				}
 				return false
 			},
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"sched_yield()\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 			2,
 		},
 		// Remove a call.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"sched_yield()\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 			2,
@@ -186,13 +186,13 @@ func TestMinimize(t *testing.T) {
 				// Aim at removal of sched_yield.
 				return len(p.Calls) == 2 && p.Calls[0].Meta.Name == "mmap" && p.Calls[1].Meta.Name == "pipe2"
 			},
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n",
 			1,
 		},
 		// Remove two dependent calls.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"pipe2(&(0x7f0000000000)={0x0, 0x0}, 0x0)\n" +
 				"sched_yield()\n",
 			2,
@@ -211,7 +211,7 @@ func TestMinimize(t *testing.T) {
 		},
 		// Remove a call and replace results.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"pipe2(&(0x7f0000000000)={<r0=>0x0, 0x0}, 0x0)\n" +
 				"write(r0, &(0x7f0000000000)=\"1155\", 0x2)\n" +
 				"sched_yield()\n",
@@ -219,14 +219,14 @@ func TestMinimize(t *testing.T) {
 			func(p *Prog, callIndex int) bool {
 				return p.String() == "mmap-write-sched_yield"
 			},
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"write(0xffffffffffffffff, &(0x7f0000000000)=\"1155\", 0x2)\n" +
 				"sched_yield()\n",
 			2,
 		},
 		// Remove a call and replace results.
 		{
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"r0=open(&(0x7f0000000000)=\"1155\", 0x0, 0x0)\n" +
 				"write(r0, &(0x7f0000000000)=\"1155\", 0x2)\n" +
 				"sched_yield()\n",
@@ -234,7 +234,7 @@ func TestMinimize(t *testing.T) {
 			func(p *Prog, callIndex int) bool {
 				return p.String() == "mmap-write-sched_yield"
 			},
-			"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"write(0xffffffffffffffff, &(0x7f0000000000)=\"1155\", 0x2)\n" +
 				"sched_yield()\n",
 			-1,
@@ -242,15 +242,15 @@ func TestMinimize(t *testing.T) {
 		// Glue several mmaps together.
 		{
 			"sched_yield()\n" +
-				"mmap(&(0x7f0000000000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
-				"mmap(&(0x7f0000001000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+				"mmap(&(0x7f0000000000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+				"mmap(&(0x7f0000001000/0x1000)=nil, (0x1000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"getpid()\n" +
-				"mmap(&(0x7f0000005000)=nil, (0x2000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n",
+				"mmap(&(0x7f0000005000/0x5000)=nil, (0x2000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n",
 			3,
 			func(p *Prog, callIndex int) bool {
 				return p.String() == "mmap-sched_yield-getpid"
 			},
-			"mmap(&(0x7f0000000000)=nil, (0x7000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
+			"mmap(&(0x7f0000000000/0x7000)=nil, (0x7000), 0x3, 0x32, 0xffffffffffffffff, 0x0)\n" +
 				"sched_yield()\n" +
 				"getpid()\n",
 			2,

--- a/prog/size_test.go
+++ b/prog/size_test.go
@@ -1,0 +1,123 @@
+// Copyright 2016 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package prog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAssignSizeRandom(t *testing.T) {
+	rs, iters := initTest(t)
+	for i := 0; i < iters; i++ {
+		p := Generate(rs, 10, nil)
+		data0 := p.Serialize()
+		for _, call := range p.Calls {
+			assignSizesCall(call)
+			assignTypeAndDir(call)
+		}
+		if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
+			t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
+		}
+		for try := 0; try <= 10; try++ {
+			p.Mutate(rs, 10, nil)
+			data0 := p.Serialize()
+			for _, call := range p.Calls {
+				assignSizesCall(call)
+				assignTypeAndDir(call)
+			}
+			if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
+				t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
+			}
+		}
+	}
+}
+
+func TestAssignSize(t *testing.T) {
+	tests := []struct {
+		unsizedProg string
+		sizedProg   string
+	}{
+		{
+			"syz_test$length0(&(0x7f0000000000)={0xff, 0x0})",
+			"syz_test$length0(&(0x7f0000000000)={0xff, 0x2})",
+		},
+		{
+			"syz_test$length1(&(0x7f0000001000)={0xff, 0x0})",
+			"syz_test$length1(&(0x7f0000001000)={0xff, 0x4})",
+		},
+		{
+			"syz_test$length2(&(0x7f0000001000)={0xff, 0x0})",
+			"syz_test$length2(&(0x7f0000001000)={0xff, 0x8})",
+		},
+		{
+			"syz_test$length3(&(0x7f0000005000)={0xff, 0x0, 0x0})",
+			"syz_test$length3(&(0x7f0000005000)={0xff, 0x4, 0x2})",
+		},
+		{
+			"syz_test$length4(&(0x7f0000003000)={0x0, 0x0})",
+			"syz_test$length4(&(0x7f0000003000)={0x2, 0x2})",
+		},
+		{
+			"syz_test$length5(&(0x7f0000002000)={0xff, 0x0})",
+			"syz_test$length5(&(0x7f0000002000)={0xff, 0x4})",
+		},
+		{
+			"syz_test$length6(&(0x7f0000002000)={[0xff, 0xff, 0xff, 0xff], 0x0})",
+			"syz_test$length6(&(0x7f0000002000)={[0xff, 0xff, 0xff, 0xff], 0x4})",
+		},
+		{
+			"syz_test$length7(&(0x7f0000003000)={[0xff, 0xff, 0xff, 0xff], 0x0})",
+			"syz_test$length7(&(0x7f0000003000)={[0xff, 0xff, 0xff, 0xff], 0x8})",
+		},
+		{
+			"syz_test$length8(&(0x7f000001f000)={0x00, {0xff, 0x0, 0x00, [0xff, 0xff, 0xff]}, [{0xff, 0x0, 0x00, [0xff, 0xff, 0xff]}], 0x00, 0x0, [0xff, 0xff]})",
+			"syz_test$length8(&(0x7f000001f000)={0x32, {0xff, 0x1, 0x10, [0xff, 0xff, 0xff]}, [{0xff, 0x1, 0x10, [0xff, 0xff, 0xff]}], 0x10, 0x1, [0xff, 0xff]})",
+		},
+		{
+			"syz_test$length9(&(0x7f000001f000)={&(0x7f0000000000/0x5000)=nil, (0x0000)})",
+			"syz_test$length9(&(0x7f000001f000)={&(0x7f0000000000/0x5000)=nil, (0x5000)})",
+		},
+		{
+			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, (0x0000))",
+			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, (0x5000))",
+		},
+		{
+			"syz_test$length11(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, 0x00)",
+			"syz_test$length11(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, 0x30)",
+		},
+		{
+			"syz_test$length12(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, 0x00)",
+			"syz_test$length12(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, 0x30)",
+		},
+		{
+			"syz_test$length13(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, &(0x7f0000001000)=0x00)",
+			"syz_test$length13(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, &(0x7f0000001000)=0x30)",
+		},
+		{
+			"syz_test$length14(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, &(0x7f0000001000)=0x00)",
+			"syz_test$length14(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, &(0x7f0000001000)=0x30)",
+		},
+		{
+			"syz_test$length15(0xff, 0x0)",
+			"syz_test$length15(0xff, 0x2)",
+		},
+	}
+
+	for i, test := range tests {
+		p, err := Deserialize([]byte(test.unsizedProg))
+		if err != nil {
+			t.Fatalf("failed to deserialize prog %v: %v", i, err)
+		}
+		for _, call := range p.Calls {
+			assignSizesCall(call)
+			assignTypeAndDir(call)
+		}
+		p1 := strings.TrimSpace(string(p.Serialize()))
+		if p1 != test.sizedProg {
+			t.Fatalf("failed to assign sizes in prog %v\ngot  %v\nwant %v", i, p1, test.sizedProg)
+		}
+	}
+}

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -120,11 +120,17 @@ func (c *Call) validate(ctx *validCtx) error {
 				if arg.Res != nil {
 					return fmt.Errorf("syscall %v: vma arg '%v' has data", c.Meta.Name, typ.Name())
 				}
+				if arg.AddrPagesNum == 0 {
+					return fmt.Errorf("syscall %v: vma arg '%v' has size 0", c.Meta.Name, typ.Name())
+				}
 			case sys.PtrType:
 				if arg.Res != nil {
 					if err := checkArg(arg.Res, typ1.Type); err != nil {
 						return err
 					}
+				}
+				if arg.AddrPagesNum != 0 {
+					return fmt.Errorf("syscall %v: pointer arg '%v' has nonzero size", c.Meta.Name, typ.Name())
 				}
 			default:
 				return fmt.Errorf("syscall %v: pointer arg '%v' has bad meta type %+v", c.Meta.Name, typ.Name(), typ)

--- a/sys/decl.go
+++ b/sys/decl.go
@@ -25,6 +25,7 @@ type Type interface {
 	Default() uintptr
 	Size() uintptr
 	Align() uintptr
+	InnerType() Type // returns inner type for PtrType
 }
 
 func IsPad(t Type) bool {
@@ -83,6 +84,10 @@ func (t ResourceType) Align() uintptr {
 	return t.Desc.Type.Align()
 }
 
+func (t ResourceType) InnerType() Type {
+	return t
+}
+
 type FileoffType struct {
 	TypeCommon
 	TypeSize uintptr
@@ -95,6 +100,10 @@ func (t FileoffType) Size() uintptr {
 
 func (t FileoffType) Align() uintptr {
 	return t.Size()
+}
+
+func (t FileoffType) InnerType() Type {
+	return t
 }
 
 type BufferKind int
@@ -136,6 +145,10 @@ func (t BufferType) Align() uintptr {
 	return 1
 }
 
+func (t BufferType) InnerType() Type {
+	return t
+}
+
 type VmaType struct {
 	TypeCommon
 }
@@ -146,6 +159,10 @@ func (t VmaType) Size() uintptr {
 
 func (t VmaType) Align() uintptr {
 	return t.Size()
+}
+
+func (t VmaType) InnerType() Type {
+	return t
 }
 
 type LenType struct {
@@ -163,6 +180,10 @@ func (t LenType) Align() uintptr {
 	return t.Size()
 }
 
+func (t LenType) InnerType() Type {
+	return t
+}
+
 type FlagsType struct {
 	TypeCommon
 	TypeSize uintptr
@@ -175,6 +196,10 @@ func (t FlagsType) Size() uintptr {
 
 func (t FlagsType) Align() uintptr {
 	return t.Size()
+}
+
+func (t FlagsType) InnerType() Type {
+	return t
 }
 
 type ConstType struct {
@@ -192,6 +217,10 @@ func (t ConstType) Align() uintptr {
 	return t.Size()
 }
 
+func (t ConstType) InnerType() Type {
+	return t
+}
+
 type StrConstType struct {
 	TypeCommon
 	TypeSize uintptr
@@ -204,6 +233,10 @@ func (t StrConstType) Size() uintptr {
 
 func (t StrConstType) Align() uintptr {
 	return t.Size()
+}
+
+func (t StrConstType) InnerType() Type {
+	return t
 }
 
 type IntKind int
@@ -232,6 +265,10 @@ func (t IntType) Align() uintptr {
 	return t.Size()
 }
 
+func (t IntType) InnerType() Type {
+	return t
+}
+
 type FilenameType struct {
 	TypeCommon
 }
@@ -242,6 +279,10 @@ func (t FilenameType) Size() uintptr {
 
 func (t FilenameType) Align() uintptr {
 	return 1
+}
+
+func (t FilenameType) InnerType() Type {
+	return t
 }
 
 type ArrayKind int
@@ -270,6 +311,10 @@ func (t ArrayType) Align() uintptr {
 	return t.Type.Align()
 }
 
+func (t ArrayType) InnerType() Type {
+	return t
+}
+
 type PtrType struct {
 	TypeCommon
 	Type Type
@@ -282,6 +327,10 @@ func (t PtrType) Size() uintptr {
 
 func (t PtrType) Align() uintptr {
 	return t.Size()
+}
+
+func (t PtrType) InnerType() Type {
+	return t.Type.InnerType()
 }
 
 type StructType struct {
@@ -316,6 +365,10 @@ func (t *StructType) Align() uintptr {
 	return align
 }
 
+func (t *StructType) InnerType() Type {
+	return t
+}
+
 type UnionType struct {
 	TypeCommon
 	Options []Type
@@ -343,6 +396,10 @@ func (t *UnionType) Align() uintptr {
 		}
 	}
 	return align
+}
+
+func (t *UnionType) InnerType() Type {
+	return t
 }
 
 type Dir int

--- a/sys/fuse.txt
+++ b/sys/fuse.txt
@@ -91,13 +91,13 @@ fuse_notify_poll_wakeup_out {
 }
 
 fuse_notify_inval_inode_out {
-	len	len[parent, int32]
+	len1	len[parent, int32]
 	err	int32
 	unique	const[0, int64]
 
 	ino	int64
 	off	int64
-	len	int16
+	len2	int16
 }
 
 fuse_notify_inval_entry_out {
@@ -105,7 +105,7 @@ fuse_notify_inval_entry_out {
 	err	int32
 	unique	const[0, int64]
 
-	parent	int64
+	par	int64
 	namelen	int32
 }
 
@@ -114,7 +114,7 @@ fuse_notify_delete_out {
 	err	int32
 	unique	const[0, int64]
 
-	parent	int64
+	par	int64
 	child	int64
 	namelen	int32
 }
@@ -132,9 +132,9 @@ fuse_notify_store_out {
 fuse_notify_retrieve_out {
 	len	len[parent, int32]
 	err	int32
-	unique	const[0, int64]
+	unique1	const[0, int64]
 
-	unique	int64
+	unique2	int64
 	nodeid	int64
 	off	int64
 	size	int32

--- a/sys/kdbus.txt
+++ b/sys/kdbus.txt
@@ -51,10 +51,10 @@ kdbus_cmd_ep_update {
 kdbus_cmd_hello {
 	size	len[parent, int64]
 	flags	flags[kdbus_hello_flags, int64]
-	rflags	const[0, int64]
+	rflags1	const[0, int64]
 
 	sflags	flags[kdbus_attach_flags, int64]
-	rflags	flags[kdbus_attach_flags, int64]
+	rflags2	flags[kdbus_attach_flags, int64]
 	bflags	int64
 	id	int64
 	poolsz	int64
@@ -248,32 +248,32 @@ kdbus_pids_parameter {
 	size	len[parent, int64]
 	type	const[KDBUS_ITEM_PIDS, int64]
 	pid	pid
-	pad	const[0, int32]
+	pad1	const[0, int32]
 	tid	pid
-	pad	const[0, int32]
+	pad2	const[0, int32]
 	ppid	pid
-	pad	const[0, int32]
+	pad3	const[0, int32]
 }
 
 kdbus_creds_parameter {
 	size	len[parent, int64]
 	type	const[KDBUS_ITEM_CREDS, int64]
 	uid	uid
-	pad	const[0, int32]
+	pad1	const[0, int32]
 	euid	uid
-	pad	const[0, int32]
+	pad2	const[0, int32]
 	suid	uid
-	pad	const[0, int32]
+	pad3	const[0, int32]
 	fsuid	uid
-	pad	const[0, int32]
+	pad4	const[0, int32]
 	gid	uid
-	pad	const[0, int32]
+	pad5	const[0, int32]
 	egid	uid
-	pad	const[0, int32]
+	pad6	const[0, int32]
 	sgid	uid
-	pad	const[0, int32]
+	pad7	const[0, int32]
 	fsgid	uid
-	pad	const[0, int32]
+	pad8	const[0, int32]
 }
 
 kdbus_seclabel_parameter {
@@ -284,17 +284,17 @@ kdbus_seclabel_parameter {
 }
 
 kdbus_payload_vec {
-	size	len[parent, int64]
+	size1	len[parent, int64]
 	type	const[KDBUS_ITEM_PAYLOAD_VEC, int64]
-	size	len[data, int64]
+	size2	len[data, int64]
 	data	buffer[in]
 }
 
 kdbus_payload_memfd {
-	size	len[parent, int64]
+	size1	len[parent, int64]
 	type	const[KDBUS_ITEM_PAYLOAD_MEMFD, int64]
 	start	int64
-	size	int64
+	size2	int64
 	fd	fd
 }
 

--- a/sys/kvm.txt
+++ b/sys/kvm.txt
@@ -315,7 +315,7 @@ kvm_vcpu_events {
 	exinjec	int8
 	exnr	int8
 	exhec	int8
-	pad	const[0, int8]
+	pad1	const[0, int8]
 	exec	int32
 
 	ininjec	int8
@@ -326,7 +326,7 @@ kvm_vcpu_events {
 	nmiinj	int8
 	nmipend	int8
 	nmimask	int8
-	pad	const[0, int8]
+	pad2	const[0, int8]
 
 	sipi	int32
 	flags	int32

--- a/sys/sndcontrol.txt
+++ b/sys/sndcontrol.txt
@@ -63,9 +63,9 @@ snd_ctl_elem_info {
 	name	array[int8, 64]
 	nameptr	string
 	namelen	len[nameptr, int32]
-	pad	array[const[0, int8], 44]
+	pad1	array[const[0, int8], 44]
 	d	array[int16, 4]
-	pad	array[const[0, int8], 56]
+	pad2	array[const[0, int8], 56]
 }
 
 snd_ctl_elem_value {

--- a/sys/sndseq.txt
+++ b/sys/sndseq.txt
@@ -65,8 +65,8 @@ snd_seq_running_info {
 	client	int8
 	bigend	int8
 	cpumode	int8
-	pad	const[0, int8]
-	pad	array[const[0, int8], 12]
+	pad1	const[0, int8]
+	pad2	array[const[0, int8], 12]
 }
 
 snd_seq_client_info {
@@ -105,8 +105,8 @@ snd_seq_port_subscribe {
 	voices	int32
 	flags	flags[snd_seq_sub_flags, int32]
 	queue	int8
-	pad	array[const[0, int8], 3]
-	pad	array[const[0, int8], 64]
+	pad1	array[const[0, int8], 3]
+	pad2	array[const[0, int8], 64]
 }
 
 snd_seq_queue_info {

--- a/sys/sndtimer.txt
+++ b/sys/sndtimer.txt
@@ -32,12 +32,12 @@ snd_timer_ginfo {
 # TODO: the following two fields should be a fixed-size embeded string.
 	id	array[int8, 64]
 	name	array[int8, 80]
-	pad	const[0, intptr]
+	pad1	const[0, intptr]
 	res	intptr
 	resmin	intptr
 	resmax	intptr
 	clients	int32
-	pad	array[const[0, int8], 32]
+	pad2	array[const[0, int8], 32]
 }
 
 snd_timer_gparams {
@@ -64,7 +64,7 @@ snd_timer_params {
 	flags	flags[snd_timer_flags, int32]
 	ticks	int32
 	qsize	int32
-	pad	const[0, int32]
+	pad1	const[0, int32]
 	filter	flags[snd_timer_filter, int32]
-	pad	array[const[0, int8], 60]
+	pad2	array[const[0, int8], 60]
 }

--- a/sys/sys.txt
+++ b/sys/sys.txt
@@ -224,7 +224,7 @@ prctl$setname(option const[PR_SET_NAME], name string)
 prctl$getname(option const[PR_GET_NAME], name buffer[out])
 prctl$setptracer(option const[PR_SET_PTRACER], pid pid)
 prctl$seccomp(option const[PR_SET_SECCOMP], mode flags[prctl_seccomp_mode], prog ptr[in, sock_fprog])
-prctl$setmm(option const[PR_SET_MM], option flags[prctl_mm_option], val vma)
+prctl$setmm(option1 const[PR_SET_MM], option2 flags[prctl_mm_option], val vma)
 
 arch_prctl(code flags[arch_prctl_code], addr buffer[in])
 seccomp(op flags[seccomp_op], flags flags[seccomp_flags], prog ptr[in, sock_fprog])
@@ -315,7 +315,7 @@ inotify_init1(flags flags[inotify_flags]) fd_inotify
 inotify_add_watch(fd fd_inotify, file filename, mask flags[inotify_mask]) inotifydesc
 inotify_rm_watch(fd fd_inotify, wd inotifydesc)
 fanotify_init(flags flags[fanotify_flags], events flags[fanotify_events]) fd_fanotify
-fanotify_mark(fd fd_fanotify, flags flags[fanotify_mark], mask flags[fanotify_mask], fd fd_dir, path filename)
+fanotify_mark(fd fd_fanotify, flags flags[fanotify_mark], mask flags[fanotify_mask], fddir fd_dir, path filename)
 
 link(old filename, new filename)
 linkat(oldfd fd_dir, old filename, newfd fd_dir, new filename, flags flags[linkat_flags])
@@ -548,8 +548,8 @@ stat {
 	mnsec	int32
 	ctime	int32
 	cnsec	int32
-	pad	int32
-	pad	int32
+	pad1	int32
+	pad2	int32
 }
 
 pollfd {
@@ -704,7 +704,6 @@ shmid_ds {
 	mode	int16
 	seq	int16
 	segsz	intptr
-	atime	intptr
 	atime	intptr
 	dtime	intptr
 	ctime	intptr
@@ -1038,12 +1037,12 @@ fiemap_extent {
 	logical	int64
 	phys	int64
 	len	int64
-	pad	const[0, int64]
-	pad	const[0, int64]
+	pad1	const[0, int64]
+	pad2	const[0, int64]
 	flags	flags[fiemap_extent_flags, int32]
-	pad	const[0, int32]
-	pad	const[0, int32]
-	pad	const[0, int32]
+	pad3	const[0, int32]
+	pad4	const[0, int32]
+	pad5	const[0, int32]
 }
 
 uffdio_api {

--- a/sys/test.txt
+++ b/sys/test.txt
@@ -76,3 +76,93 @@ syz_array_blob {
 	f1	array[int8, 16]
 	f2	int16
 }
+
+# Length.
+
+syz_test$length0(a0 ptr[in, syz_length_int_struct])
+syz_test$length1(a0 ptr[in, syz_length_const_struct])
+syz_test$length2(a0 ptr[in, syz_length_flags_struct])
+syz_test$length3(a0 ptr[in, syz_length_len_struct])
+syz_test$length4(a0 ptr[in, syz_length_len2_struct])
+syz_test$length5(a0 ptr[in, syz_length_parent_struct])
+syz_test$length6(a0 ptr[in, syz_length_array_struct])
+syz_test$length7(a0 ptr[in, syz_length_array2_struct])
+syz_test$length8(a0 ptr[in, syz_length_complex_struct])
+syz_test$length9(a0 ptr[in, syz_length_vma_struct])
+
+syz_test$length10(a0 vma, a1 len[a0])
+syz_test$length11(a0 ptr[in, syz_length_large_struct], a1 len[a0])
+syz_test$length12(a0 ptr[in, syz_length_large_struct, opt], a1 len[a0])
+syz_test$length13(a0 ptr[inout, syz_length_large_struct], a1 ptr[inout, len[a0, int64]])
+syz_test$length14(a0 ptr[inout, syz_length_large_struct], a1 ptr[inout, len[a0, int64], opt])
+syz_test$length15(a0 int16, a1 len[a0])
+
+syz_length_flags = 0, 1
+
+syz_length_int_struct {
+	f0	int16
+	f1	len[f0, int16]
+}
+
+syz_length_const_struct {
+	f0	const[0, int32]
+	f1	len[f0, int32]
+}
+
+syz_length_flags_struct {
+	f0	flags[syz_length_flags, int64]
+	f1	len[f0, int64]
+}
+
+syz_length_len_struct {
+	f0	int32
+	f1	len[f0, int16]
+	f2	len[f1, int16]
+}
+
+syz_length_len2_struct {
+	f0	len[f1, int16]
+	f1	len[f0, int16]
+}
+
+syz_length_parent_struct {
+	f0	int16
+	f1	len[parent, int16]
+}
+
+syz_length_array_struct {
+	f0	array[int16, 4]
+	f1	len[f0, int16]
+}
+
+syz_length_array2_struct {
+	f0	array[int16, 4]
+	f1	bytesize[f0, int16]
+}
+
+syz_length_complex_inner_struct {
+	f0	int8
+	f1	len[f0, int8]
+	f2	len[parent, int16]
+	f3	array[int32, 3]
+}
+
+syz_length_complex_struct {
+	f0	len[parent, int64]
+	f1	syz_length_complex_inner_struct
+	f2	array[syz_length_complex_inner_struct, 1]
+	f3	len[f1, int32]
+	f4	len[f2, int16]
+	f5	array[int16]
+}
+
+syz_length_vma_struct {
+	f0	vma
+	f1	len[f0, int64]
+}
+
+syz_length_large_struct {
+	f0	int64
+	f1	int64
+	f2	array[int32, 8]
+}

--- a/sysparser/lexer.go
+++ b/sysparser/lexer.go
@@ -90,13 +90,13 @@ func Parse(in io.Reader) *Description {
 					if len(str.Flds) <= 1 {
 						failf("union %v has only %v fields, need at least 2", str.Name, len(str.Flds))
 					}
-					fields := make(map[string]bool)
-					for _, f := range str.Flds {
-						if fields[f[0]] {
-							failf("duplicate filed %v in struct/union %v", f[0], str.Name)
-						}
-						fields[f[0]] = true
+				}
+				fields := make(map[string]bool)
+				for _, f := range str.Flds {
+					if fields[f[0]] {
+						failf("duplicate field %v in struct/union %v", f[0], str.Name)
 					}
+					fields[f[0]] = true
 				}
 				structs[str.Name] = *str
 				str = nil
@@ -177,6 +177,13 @@ func Parse(in io.Reader) *Description {
 					callName := name
 					if idx := strings.IndexByte(callName, '$'); idx != -1 {
 						callName = callName[:idx]
+					}
+					fields := make(map[string]bool)
+					for _, a := range args {
+						if fields[a[0]] {
+							failf("duplicate arg %v in syscall %v", a[0], name)
+						}
+						fields[a[0]] = true
 					}
 					syscalls = append(syscalls, Syscall{name, callName, args, ret})
 				case '=':


### PR DESCRIPTION
1. Allow `len` type to be used to denote the size of any other field
2. Update all `len` fields correctly after mutation

These changes invalidate the corpus, since its format is changed. The old corpus should be removed.