### PR TITLE
Generate a const array

### DIFF
--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -151,6 +151,24 @@ func TestSerializeForExec(t *testing.T) {
 				instrEOF,
 			},
 		},
+		{
+			"syz_test$bufconst0(&(0x7f0000000000)={\"776c616e3000\", 0x43})",
+			[]uint64{
+				instrCopyin, dataOffset + 0, argData, 6, 0x00306e616c77,
+				instrCopyin, dataOffset + 6, argConst, 2, 0x43,
+				callID("syz_test$bufconst0"), 1, argConst, ptrSize, dataOffset,
+				instrEOF,
+			},
+		},
+		{
+			"syz_test$bufconst1(&(0x7f0000000000)={\"776c616e00\", 0x43})",
+			[]uint64{
+				instrCopyin, dataOffset + 0, argData, 5, 0x006e616c77,
+				instrCopyin, dataOffset + 6, argConst, 2, 0x43,
+				callID("syz_test$bufconst1"), 1, argConst, ptrSize, dataOffset,
+				instrEOF,
+			},
+		},
 	}
 
 	for i, test := range tests {

--- a/sys/README.md
+++ b/sys/README.md
@@ -45,8 +45,10 @@ rest of the type-options are type-specific:
 	"buffer": a pointer to a memory buffer (like read/write buffer argument), type-options:
 		direction (in/out/inout)
 	"string": a pointer to a memory buffer, similar to buffer[in]
-	"strconst": a pointer to a constant string, type-options:
-		the underlying string (for example "/dev/dsp")
+	"bufconst": an embed constant string (terminating \x00 byte is automatically appended to the string),
+		type-options: string value (for example "wlan0")
+	"strconst": a pointer to a constant string (terminating \x00 byte is automatically appended to the string),
+		shortcut for ptr[in, bufconst["str"]], type-options: the underlying string (for example "/dev/dsp")
 	"filename": a file/link/dir name
 	"fileoff": offset within a file, type-options:
 		argname of the file

--- a/sys/test.txt
+++ b/sys/test.txt
@@ -187,3 +187,18 @@ syz_end_var_struct {
 	f1	const[0x42, int32be]
 	f2	flags[syz_end_flags, int64be]
 } [packed]
+
+# Const buffer type
+
+syz_test$bufconst0(a0 ptr[in, syz_bufconst])
+syz_test$bufconst1(a0 ptr[in, syz_bufconst_align])
+
+syz_bufconst {
+	f0	bufconst["wlan0"]
+	f1	int16
+}
+
+syz_bufconst_align {
+	f0	bufconst["wlan"]
+	f1	int16
+}

--- a/sysgen/sysgen.go
+++ b/sysgen/sysgen.go
@@ -501,6 +501,11 @@ func generateArg(
 			failf("wrong number of arguments for %v arg %v, want %v, got %v", typ, name, want, len(a))
 		}
 		fmt.Fprintf(out, "PtrType{%v, Dir: %v, Type: StrConstType{%v, Val: \"%v\"}}", common(), fmtDir("in"), common(), a[0]+"\\x00")
+	case "bufconst":
+		if want := 1; len(a) != want {
+			failf("wrong number of arguments for %v arg %v, want %v, got %v", typ, name, want, len(a))
+		}
+		fmt.Fprintf(out, "StrConstType{%v, Val: \"%v\"}", common(), a[0]+"\\x00")
 	case "int8", "int16", "int32", "int64", "intptr", "int16be", "int32be", "int64be", "intptrbe":
 		canBeArg = true
 		size, bigEndian := decodeIntType(typ)


### PR DESCRIPTION
Use bufconst to generate a const string. Fix issue 62
