### PR TITLE
Added a retry clause when doing battery check in adb.go

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -259,7 +259,7 @@ func (inst *instance) checkBatteryLevel() error {
 		minLevel      = 20
 		requiredLevel = 30
 	)
-	val, err := inst.getBatteryLevel()
+	val, err := inst.getBatteryLevel(3)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func (inst *instance) checkBatteryLevel() error {
 		if !vm.SleepInterruptible(time.Minute) {
 			return nil
 		}
-		val, err = inst.getBatteryLevel()
+		val, err = inst.getBatteryLevel(0)
 		if err != nil {
 			return err
 		}
@@ -283,10 +283,20 @@ func (inst *instance) checkBatteryLevel() error {
 	return nil
 }
 
-func (inst *instance) getBatteryLevel() (int, error) {
+func (inst *instance) getBatteryLevel(numRetry int) (int, error) {
 	out, err := inst.adb("shell", "dumpsys battery | grep level:")
-	if err != nil {
-		return 0, err
+
+	// allow for retrying for devices that does not boot up so fast
+	for ; numRetry >= 0 && err != nil; numRetry-- {
+		if numRetry > 0 {
+			// sleep for 5 seconds before retrying
+			time.Sleep(5 * time.Second)
+			out, err = inst.adb("shell", "dumpsys battery | grep level:")
+		} else {
+			if err != nil {
+				return 0, err
+			}
+		}
 	}
 	val := 0
 	for _, c := range out {


### PR DESCRIPTION
Some devices may not boot up fast enough when battery check
is done as it currently is in adb.go. Therefore,
getBatteryLevel() is modified to take in a parameter to determine
the number of times to retry before giving up.

Tested on slower-to-boot devices and resolved the scenario where
"failed to create instance: adb [shell dumpsys battery | grep level:] failed: exit status 1
Can't find service: battery" error occurs.