### PR TITLE
Fix make repro failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(NOSTATIC), 0)
 	STATIC_FLAG=-static
 endif
 
-.PHONY: all format clean manager fuzzer executor execprog mutate prog2c stress extract generate
+.PHONY: all format clean manager fuzzer executor execprog mutate prog2c stress extract generate repro
 
 all:
 	$(MAKE) generate


### PR DESCRIPTION
`make all-tools` won't make `syz-repro` because `repro` isn't PHONY rule