### PR TITLE
adb: executor: Revert to adb reboot

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -133,11 +133,6 @@ uint64_t cover_dedup(thread_t* th, uint64_t n);
 
 int main(int argc, char** argv)
 {
-	if (argc == 2 && strcmp(argv[1], "reboot") == 0) {
-		reboot(LINUX_REBOOT_CMD_RESTART);
-		return 0;
-	}
-
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
 	if (mmap(&input_data[0], kMaxInput, PROT_READ, MAP_PRIVATE | MAP_FIXED, kInFd, 0) != &input_data[0])
 		fail("mmap of input file failed");

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -217,11 +217,12 @@ func (inst *instance) repair() error {
 	// Assume that the device is in a bad state initially and reboot it.
 	// Ignore errors, maybe we will manage to reboot it anyway.
 	inst.waitForSsh()
-	// adb reboot episodically hangs, so we use a more reliable way.
-	// Ignore errors because all other adb commands hang as well
-	// and the binary can already be on the device.
-	inst.adb("push", inst.cfg.Executor, "/data/syz-executor")
-	if _, err := inst.adb("shell", "/data/syz-executor", "reboot"); err != nil {
+	// History: adb reboot episodically hangs, so we used a more reliable way:
+	// using syz-executor to issue reboot syscall. However, this has stopped
+	// working, probably due to the introduction of seccomp. Therefore,
+	// we revert this to `adb shell reboot` in the meantime, until a more
+	// reliable solution can be sought out.
+	if _, err := inst.adb("shell", "reboot"); err != nil {
 		return err
 	}
 	// Now give it another 5 minutes to boot.


### PR DESCRIPTION
Using `adb shell syz-executor reboot` to reboot devices has stopped
working with the recent Android update, probably due to the intro
of seccomp. I have reverted the device reboot logic to use `adb
shell reboot` although it can be flaky at times so that we can
continue to fuzz on devices, until a more reliable solution can be
sought out.