### PR TITLE
ifuzz: fix 2-byte vex decoding

### DIFF
--- a/ifuzz/decode.go
+++ b/ifuzz/decode.go
@@ -47,6 +47,7 @@ func Decode(mode int, text []byte) (int, error) {
 		prefixLen = 3
 		if text[0] == 0xc5 {
 			prefixLen = 2
+			vexMap = 1 // V0F
 		}
 		if len(text) < prefixLen {
 			return 0, fmt.Errorf("bad VEX/XOP prefix")


### PR DESCRIPTION
The intel documentation states, in section:

 2.3.6 "Instruction Operand Encoding and VEX.vvvv, ModR/M"

The following:

 "VEX.m-mmmm is only available on the 3-byte VEX. The 2-byte VEX implies
  a leading 0Fh opcode byte."

This lead the decode function to reject the following as an unknown
instruction:

 `c5 f9 6e c1 vmovd  %ecx,%xmm0`

With this fix, it correctly decodes it as a 4 byte instruction.