### PR TITLE
Add sudo for mkfs.ext4

### DIFF
--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -29,7 +29,7 @@ cat ssh/id_rsa.pub | sudo tee wheezy/root/.ssh/authorized_keys
 
 # Build a disk image
 dd if=/dev/zero of=wheezy.img bs=1M seek=1023 count=1
-mkfs.ext4 -F wheezy.img
+sudo mkfs.ext4 -F wheezy.img
 sudo mkdir -p /mnt/wheezy
 sudo mount -o loop wheezy.img /mnt/wheezy
 sudo cp -a wheezy/. /mnt/wheezy/.


### PR DESCRIPTION
Since mkfs.ext4 is in /sbin/ and this directory is usually not in the PATH of a normal user, this command fails.
I've tried this on Debian Wheezy/Jessie and on Ubuntu Trusty