### PR TITLE
Add a Dtb flag for arm qemu vm type.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Workdir  string
 	Vmlinux  string
 	Kernel   string // e.g. arch/x86/boot/bzImage
+	Dtb      string
 	Tag      string // arbitrary optional tag that is saved along with crash reports (e.g. kernel branch/commit)
 	Cmdline  string // kernel command line
 	Image    string // linux image for VMs
@@ -214,6 +215,7 @@ func parse(data []byte) (*Config, map[int]bool, error) {
 	}
 	cfg.Workdir = abs(cfg.Workdir)
 	cfg.Kernel = abs(cfg.Kernel)
+	cfg.Dtb = abs(cfg.Dtb)
 	cfg.Vmlinux = abs(cfg.Vmlinux)
 	cfg.Syzkaller = abs(cfg.Syzkaller)
 	cfg.Initrd = abs(cfg.Initrd)
@@ -343,6 +345,7 @@ func CreateVMConfig(cfg *Config, index int) (*vm.Config, error) {
 		Bin:             cfg.Bin,
 		BinArgs:         cfg.Bin_Args,
 		Kernel:          cfg.Kernel,
+		Dtb:		 cfg.Dtb,
 		Cmdline:         cfg.Cmdline,
 		Image:           cfg.Image,
 		Initrd:          cfg.Initrd,
@@ -375,6 +378,7 @@ func checkUnknownFields(data []byte) (string, error) {
 		"Workdir",
 		"Vmlinux",
 		"Kernel",
+		"Dtb",
 		"Tag",
 		"Cmdline",
 		"Image",

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -188,6 +188,11 @@ func (inst *instance) Boot() error {
 			"-initrd", inst.cfg.Initrd,
 		)
 	}
+	if inst.cfg.Dtb != "" {
+         	args = append(args,
+            		"-dtb", inst.cfg.Dtb,
+        	)
+    	}
 	if inst.cfg.Kernel != "" {
 		cmdline := "console=ttyS0 vsyscall=native rodata=n oops=panic panic_on_warn=1 panic=86400" +
 			" ftrace_dump_on_oops=orig_cpu earlyprintk=serial slub_debug=UZ net.ifnames=0 biosdevname=0 " +

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -42,6 +42,7 @@ type Config struct {
 	Bin             string
 	BinArgs         string
 	Initrd          string
+	Dtb		string
 	Kernel          string
 	Cmdline         string
 	Image           string


### PR DESCRIPTION
Add a Dtb flag to config file to support "-dtb" option of arm qemu, and load custom dtb file to support new devices emulated in qemu.