### PR TITLE
expand  parameter "-incdirfile" for bin/syz-extract

### DIFF
--- a/syz-extract/extract.go
+++ b/syz-extract/extract.go
@@ -165,6 +165,7 @@ func readLines(path string) ([]string, error) {
 	return lines, scanner.Err()
 }
 
+
 type NameValue struct {
 	name string
 	val  uint64

--- a/syz-extract/fetch.go
+++ b/syz-extract/fetch.go
@@ -130,7 +130,12 @@ func runCompiler(arch string, vals []string, includes []string, defines map[stri
 		"-I" + *flagLinux,
 		"-include", *flagLinux + "/include/linux/kconfig.h",
 	}...)
-
+	
+	if custIncludeDirList != nil {
+		for _, incDir := range custIncludeDirList {
+			args = append(args,"-I" + *flagLinux +"/"+incDir)
+		}
+	}
 	cmd := exec.Command("gcc", args...)
 	cmd.Stdin = strings.NewReader(src)
 	out, err = cmd.CombinedOutput()


### PR DESCRIPTION
usage:
   ~/work/src/github.com/google/syzkaller$ bin/syz-extract -arch arm64 -linux "kernel" -linuxbld "out" -incdirfile "cust_include/modulexxx_inc.txt" sys/test.txt

   the content of cust_include/modulexxx_inc.txt,start with kernel dir:
      xxx/include_path_1
      xxx/xxx/include_path_2

   bin/syz-extract read in the content of incdirfile,add -Ikernel/xxx/include_path_1  -Ikernel/xxx/xxx/include_path_2 to compile cmd 
   
This is for modules which have customized  include paths