### PR TITLE
sys: make ifindex a resource

### DIFF
--- a/sys/socket.txt
+++ b/sys/socket.txt
@@ -230,6 +230,8 @@ ifreq_ioctls = SIOCGIFNAME, SIOCSIFLINK, SIOCGIFFLAGS, SIOCSIFFLAGS, SIOCGIFADDR
 
 ioctl$sock_ifreq(fd sock, cmd flags[ifreq_ioctls], arg ptr[inout, ifreq])
 
+ioctl$sock_SIOCGIFINDEX(fd sock, cmd const[SIOCGIFINDEX], arg ptr[inout, ifreq_SIOCGIFINDEX])
+
 ioctl$sock_SIOCGIFBR(fd sock, cmd const[SIOCGIFBR], arg ptr[inout, brctl_arg])
 ioctl$sock_SIOCSIFBR(fd sock, cmd const[SIOCGIFBR], arg ptr[inout, brctl_arg])
 
@@ -258,6 +260,14 @@ ioctl$sock_SIOCSPGRP(fd sock, cmd const[SIOCSPGRP], arg ptr[in, pid])
 ioctl$sock_FIOGETOWN(fd sock, cmd const[FIOGETOWN], arg ptr[out, pid])
 ioctl$sock_SIOCGPGRP(fd sock, cmd const[SIOCGPGRP], arg ptr[out, pid])
 
+resource ifindex[int32]
+
+ifreq_SIOCGIFINDEX {
+	ifr_ifrn	devname
+	ifr_ifru	ifindex
+	pad		array[const[0, int8], 20]
+} [packed]
+
 ifreq {
 	ifr_ifrn	devname
 	ifr_ifru	ifr_ifru
@@ -271,10 +281,13 @@ syzn_devname {
 	0	const[0, int8]
 }
 
+# We could add "eth0" to this list as well, but this will affect the connection between fuzzer and manager and produce lots of "no output" crashes.
+devnames = "lo", "tunl0", "gre0", "gretap0", "ip_vti0", "ip6_vti0", "sit0", "ip6tnl0", "ip6gre0", "bond0", "dummy0", "eql", "ifb0", "ipddp0", "yam0", "bcsf0", "bcsh0", "teql0", "nr0", "rose0", "irlan0", "bpq0"
+
 devname [
 	generic         array[int8, IFNAMSIZ]
-	loopback	string["lo", IFNAMSIZ]
-	ethernet	syzn_devname
+	common		string[devnames, IFNAMSIZ]
+	syzn		syzn_devname
 ]
 
 ifr_ifru [

--- a/sys/socket_inet.txt
+++ b/sys/socket_inet.txt
@@ -124,7 +124,7 @@ xfrm_selector {
 	prefixlen_d	flags[xfrm_prefixlens, int8]
 	prefixlen_s	flags[xfrm_prefixlens, int8]
 	proto		int8
-	ifindex		int32
+	ifindex		ifindex
 	user		uid
 }
 
@@ -182,7 +182,7 @@ ip_mreq {
 ip_mreqn {
 	imr_multiaddr	ipv4_addr
 	imr_address	ipv4_addr
-	imr_ifindex	int32
+	imr_ifindex	ifindex
 }
 
 ip_mreq_source {
@@ -202,7 +202,7 @@ ip_msfilter {
 ip_msfilter_mode = MCAST_INCLUDE, MCAST_EXCLUDE
 
 in_pktinfo {
-	ipi_ifindex	int32
+	ipi_ifindex	ifindex
 	ipi_spec_dst	ipv4_addr
 	ipi_addr	ipv4_addr
 }
@@ -240,9 +240,22 @@ ioctl$sock_inet_SIOCDARP(fd sock_in, cmd const[SIOCDARP], arg ptr[in, arpreq_in]
 ioctl$sock_inet_SIOCGARP(fd sock_in, cmd const[SIOCGARP], arg ptr[inout, arpreq_in])
 ioctl$sock_inet_SIOCSARP(fd sock_in, cmd const[SIOCSARP], arg ptr[in, arpreq_in])
 
-inet_ifreq_ioctls = SIOCGIFADDR, SIOCSIFADDR, SIOCGIFBRDADDR, SIOCSIFBRDADDR, SIOCGIFNETMASK, SIOCSIFNETMASK, SIOCGIFDSTADDR, SIOCSIFDSTADDR, SIOCSIFPFLAGS, SIOCGIFPFLAGS, SIOCSIFFLAGS
+ioctl$sock_inet_SIOCGIFADDR(fd sock, cmd const[SIOCGIFADDR], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCSIFADDR(fd sock, cmd const[SIOCSIFADDR], arg ptr[inout, ifreq_in])
 
-ioctl$sock_inet_ifreq(fd sock, cmd flags[inet_ifreq_ioctls], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCGIFBRDADDR(fd sock, cmd const[SIOCGIFBRDADDR], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCSIFBRDADDR(fd sock, cmd const[SIOCSIFBRDADDR], arg ptr[inout, ifreq_in])
+
+ioctl$sock_inet_SIOCGIFNETMASK(fd sock, cmd const[SIOCGIFNETMASK], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCSIFNETMASK(fd sock, cmd const[SIOCSIFNETMASK], arg ptr[inout, ifreq_in])
+
+ioctl$sock_inet_SIOCGIFDSTADDR(fd sock, cmd const[SIOCGIFDSTADDR], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCSIFDSTADDR(fd sock, cmd const[SIOCSIFDSTADDR], arg ptr[inout, ifreq_in])
+
+ioctl$sock_inet_SIOCGIFPFLAGS(fd sock, cmd const[SIOCGIFPFLAGS], arg ptr[inout, ifreq_in])
+ioctl$sock_inet_SIOCSIFPFLAGS(fd sock, cmd const[SIOCSIFPFLAGS], arg ptr[inout, ifreq_in])
+
+ioctl$sock_inet_SIOCSIFFLAGS(fd sock, cmd const[SIOCSIFFLAGS], arg ptr[inout, ifreq_in])
 
 rt_flags = RTF_UP, RTF_GATEWAY, RTF_HOST, RTF_REINSTATE, RTF_DYNAMIC, RTF_MODIFIED, RTF_MTU, RTF_WINDOW, RTF_IRTT, RTF_REJECT
 

--- a/sys/socket_inet6.txt
+++ b/sys/socket_inet6.txt
@@ -113,8 +113,8 @@ mf6cctl {
 }
 
 ipv6_mreq {
-	multi	ipv6_addr
-	ifindex	int32
+	multi		ipv6_addr
+	ifindex		ifindex
 }
 
 in6_flowlabel_req {
@@ -153,7 +153,7 @@ group_filter_in6 {
 
 in6_pktinfo {
 	ipi6_addr	ipv6_addr
-	ipi6_ifindex	int32
+	ipi6_ifindex	ifindex
 }
 
 # IPv6 ioctls
@@ -181,11 +181,11 @@ in6_rtmsg {
 	rtmsg_metric	flags[rtmsg_metrics, int32]
 	rtmsg_info	int64
 	rtmsg_flags	flags[rtmsg_flags, int32]
-	rtmsg_ifindex	int32
+	rtmsg_ifindex	ifindex
 }
 
 in6_ifreq {
 	ifr6_addr	ipv6_addr
 	ifr6_prefixlen	int32
-	ifr6_ifindex	int32
+	ifr6_ifindex	ifindex
 }


### PR DESCRIPTION
Also split `ioctl$sock_inet_ifreq` into multple ioctls to make it possible to disable or enable particular ones.