### PR TITLE
gce: rename MetaGeneration to Metageneration

### DIFF
--- a/syz-gce/syz-gce.go
+++ b/syz-gce/syz-gce.go
@@ -467,7 +467,7 @@ func (a *GCSImageAction) Poll() (string, error) {
 	}
 	a.handle = f.If(storage.Conditions{
 		GenerationMatch:     attrs.Generation,
-		MetagenerationMatch: attrs.MetaGeneration,
+		MetagenerationMatch: attrs.Metageneration,
 	})
 	return attrs.Updated.Format(time.RFC1123Z), nil
 }


### PR DESCRIPTION
syz-gce/syz-gce.go:470: attrs.MetaGeneration undefined (type *"cloud.google.com/go/storage".ObjectAttrs has no field or method MetaGeneration, but does have Metageneration