### PR TITLE
Parse incdir "incdir" in syscall description file to add custom include directories.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Jeremy Huang
 Shuai Bai
 Alexander Popov
 Jean-Baptiste Cayrou
+Yuzhe Han

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ Jeremy Huang
 Shuai Bai
 Alexander Popov
 Jean-Baptiste Cayrou
+Yuzhe Han

--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -159,5 +159,5 @@ As a result the executor number `n` will get values in the `[20000 + n * 4, 2000
 
 ## Misc
 
-Description files also contain `include` directives that refer to Linux kernel header files
+Description files also contain `include` directives that refer to Linux kernel header files, `incdir` directives that refer to custom Linux kernel header directories 
 and `define` directives that define symbolic constant values. See the following section for details.

--- a/sys/sysparser/lexer.go
+++ b/sys/sysparser/lexer.go
@@ -78,7 +78,6 @@ func Parse(in io.Reader) *Description {
 					incdir = append(incdir, ch)
 				}
 				p.Parse('"')
-				fmt.Printf("find incdir:[%v]\n", string(incdir))
 				incdirs = append(incdirs, string(incdir))
 			}
 			continue

--- a/sys/sysparser/lexer.go
+++ b/sys/sysparser/lexer.go
@@ -14,6 +14,7 @@ import (
 
 type Description struct {
 	Includes  []string
+	Incdirs   []string
 	Defines   map[string]string
 	Syscalls  []Syscall
 	Structs   map[string]*Struct
@@ -48,6 +49,7 @@ type Resource struct {
 func Parse(in io.Reader) *Description {
 	p := newParser(in)
 	var includes []string
+	var incdirs []string
 	defines := make(map[string]string)
 	var syscalls []Syscall
 	structs := make(map[string]*Struct)
@@ -57,7 +59,28 @@ func Parse(in io.Reader) *Description {
 	resources := make(map[string]Resource)
 	var str *Struct
 	for p.Scan() {
-		if p.EOF() || p.Char() == '#' {
+		if p.EOF() {
+			continue
+		}
+		if p.Char() == '#' {
+			p.Parse(p.Char())
+			line := p.Str()
+			if strings.HasPrefix(line, "#incdir") {
+				p.Ident()
+				p.Parse('"')
+				var incdir []byte
+				for {
+					ch := p.Char()
+					if ch == '"' {
+						break
+					}
+					p.Parse(ch)
+					incdir = append(incdir, ch)
+				}
+				p.Parse('"')
+				fmt.Printf("find incdir:[%v]\n", string(incdir))
+				incdirs = append(incdirs, string(incdir))
+			}
 			continue
 		}
 		if str != nil {
@@ -237,6 +260,7 @@ func Parse(in io.Reader) *Description {
 	sort.Sort(syscallArray(syscalls))
 	return &Description{
 		Includes:  includes,
+		Incdirs:   incdirs,
 		Defines:   defines,
 		Syscalls:  syscalls,
 		Structs:   structs,

--- a/sys/sysparser/lexer.go
+++ b/sys/sysparser/lexer.go
@@ -59,27 +59,7 @@ func Parse(in io.Reader) *Description {
 	resources := make(map[string]Resource)
 	var str *Struct
 	for p.Scan() {
-		if p.EOF() {
-			continue
-		}
-		if p.Char() == '#' {
-			p.Parse(p.Char())
-			line := p.Str()
-			if strings.HasPrefix(line, "#incdir") {
-				p.Ident()
-				p.Parse('"')
-				var incdir []byte
-				for {
-					ch := p.Char()
-					if ch == '"' {
-						break
-					}
-					p.Parse(ch)
-					incdir = append(incdir, ch)
-				}
-				p.Parse('"')
-				incdirs = append(incdirs, string(incdir))
-			}
+		if p.EOF() || p.Char() == '#' {
 			continue
 		}
 		if str != nil {
@@ -186,6 +166,19 @@ func Parse(in io.Reader) *Description {
 					failf("struct '%v' is redefined as resource", name)
 				}
 				resources[id] = Resource{id, base, vals}
+			} else if name == "incdir" {
+				p.Parse('"')
+				var incdir []byte
+				for {
+					ch := p.Char()
+					if ch == '"' {
+						break
+					}
+					p.Parse(ch)
+					incdir = append(incdir, ch)
+				}
+				p.Parse('"')
+				incdirs = append(incdirs, string(incdir))
 			} else {
 				switch ch := p.Char(); ch {
 				case '(':

--- a/sys/syz-extract/extract.go
+++ b/sys/syz-extract/extract.go
@@ -121,7 +121,7 @@ func compileConsts(arch *Arch, desc *Description) map[string]uint64 {
 		return nil
 	}
 
-	consts, err := fetchValues(arch.KernelHeaderArch, valArr, append(desc.Includes, arch.KernelInclude), desc.Defines, arch.CFlags)
+	consts, err := fetchValues(arch.KernelHeaderArch, valArr, append(desc.Includes, arch.KernelInclude), desc.Incdirs, desc.Defines, arch.CFlags)
 	if err != nil {
 		failf("%v", err)
 	}

--- a/sys/syz-extract/fetch.go
+++ b/sys/syz-extract/fetch.go
@@ -16,8 +16,8 @@ import (
 // fetchValues converts literal constants (e.g. O_APPEND) or any other C expressions
 // into their respective numeric values. It does so by builting and executing a C program
 // that prints values of the provided expressions.
-func fetchValues(arch string, vals []string, includes []string, defines map[string]string, cflags []string) (map[string]uint64, error) {
-	bin, out, err := runCompiler(arch, nil, includes, nil, cflags, nil)
+func fetchValues(arch string, vals []string, includes []string, incdirs []string, defines map[string]string, cflags []string) (map[string]uint64, error) {
+	bin, out, err := runCompiler(arch, nil, includes, incdirs, nil, cflags, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run gcc: %v\n%v", err, string(out))
 	}
@@ -29,7 +29,7 @@ func fetchValues(arch string, vals []string, includes []string, defines map[stri
 	}
 
 	undeclared := make(map[string]bool)
-	bin, out, err = runCompiler(arch, vals, includes, defines, cflags, undeclared)
+	bin, out, err = runCompiler(arch, vals, includes, incdirs, defines, cflags, undeclared)
 	if err != nil {
 		for _, errMsg := range []string{
 			"error: ‘([a-zA-Z0-9_]+)’ undeclared",
@@ -45,7 +45,7 @@ func fetchValues(arch string, vals []string, includes []string, defines map[stri
 				}
 			}
 		}
-		bin, out, err = runCompiler(arch, vals, includes, defines, cflags, undeclared)
+		bin, out, err = runCompiler(arch, vals, includes, incdirs, defines, cflags, undeclared)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run gcc: %v\n%v", err, string(out))
 		}
@@ -79,7 +79,7 @@ func fetchValues(arch string, vals []string, includes []string, defines map[stri
 	return res, nil
 }
 
-func runCompiler(arch string, vals []string, includes []string, defines map[string]string, cflags []string, undeclared map[string]bool) (bin string, out []byte, err error) {
+func runCompiler(arch string, vals []string, includes []string, incdirs []string, defines map[string]string, cflags []string, undeclared map[string]bool) (bin string, out []byte, err error) {
 	includeText := ""
 	for _, inc := range includes {
 		includeText += fmt.Sprintf("#include <%v>\n", inc)
@@ -130,7 +130,9 @@ func runCompiler(arch string, vals []string, includes []string, defines map[stri
 		"-I" + *flagLinux,
 		"-include", *flagLinux + "/include/linux/kconfig.h",
 	}...)
-
+	for _, incdir := range incdirs {
+		args = append(args, "-I" + incdir,)
+	}
 	cmd := exec.Command("gcc", args...)
 	cmd.Stdin = strings.NewReader(src)
 	out, err = cmd.CombinedOutput()

--- a/sys/syz-extract/fetch.go
+++ b/sys/syz-extract/fetch.go
@@ -131,7 +131,7 @@ func runCompiler(arch string, vals []string, includes []string, incdirs []string
 		"-include", *flagLinux + "/include/linux/kconfig.h",
 	}...)
 	for _, incdir := range incdirs {
-		args = append(args, "-I" + incdir,)
+		args = append(args, "-I" + *flagLinux + "/" + incdir,)
 	}
 	cmd := exec.Command("gcc", args...)
 	cmd.Stdin = strings.NewReader(src)


### PR DESCRIPTION
Add custom include directories with this syntax in syscall description file:
incdir "incdir"

bin/syz-extract read in the content of syscall description, add -IflagLinux/incdir to compile cmd args
This is for modules which have customized include paths
Same target with https://github.com/google/syzkaller/pull/158