### PR TITLE
Add controls for executor aborts and output

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Google Inc.
  David Drysdale
  Vishwath Mohan
  Billy Lau
+ Michael Pratt
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -181,14 +181,14 @@ func main() {
 
 	kmemleakInit()
 
-	flags, timeout, err := ipc.DefaultFlags()
+	config, err := ipc.DefaultConfig()
 	if err != nil {
 		panic(err)
 	}
 	if _, ok := calls[sys.CallMap["syz_emit_ethernet"]]; ok {
-		flags |= ipc.FlagEnableTun
+		config.Flags |= ipc.FlagEnableTun
 	}
-	noCover = flags&ipc.FlagSignal == 0
+	noCover = config.Flags&ipc.FlagSignal == 0
 	leakCallback := func() {
 		if atomic.LoadUint32(&allTriaged) != 0 {
 			// Scan for leaks once in a while (it is damn slow).
@@ -203,7 +203,7 @@ func main() {
 	needPoll <- struct{}{}
 	envs := make([]*ipc.Env, *flagProcs)
 	for pid := 0; pid < *flagProcs; pid++ {
-		env, err := ipc.MakeEnv(*flagExecutor, timeout, flags, pid)
+		env, err := ipc.MakeEnv(*flagExecutor, pid, config)
 		if err != nil {
 			panic(err)
 		}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -56,14 +56,14 @@ func main() {
 		return
 	}
 
-	flags, timeout, err := ipc.DefaultFlags()
+	config, err := ipc.DefaultConfig()
 	if err != nil {
 		Fatalf("%v", err)
 	}
-	needCover := flags&ipc.FlagSignal != 0
+	needCover := config.Flags&ipc.FlagSignal != 0
 	dedupCover := true
 	if *flagCoverFile != "" {
-		flags |= ipc.FlagSignal
+		config.Flags |= ipc.FlagSignal
 		needCover = true
 		dedupCover = false
 	}
@@ -75,7 +75,7 @@ func main() {
 		}
 	}
 	if handled["syz_emit_ethernet"] {
-		flags |= ipc.FlagEnableTun
+		config.Flags |= ipc.FlagEnableTun
 	}
 
 	var wg sync.WaitGroup
@@ -89,7 +89,7 @@ func main() {
 		pid := p
 		go func() {
 			defer wg.Done()
-			env, err := ipc.MakeEnv(*flagExecutor, timeout, flags, pid)
+			env, err := ipc.MakeEnv(*flagExecutor, pid, config)
 			if err != nil {
 				Fatalf("failed to create ipc env: %v", err)
 			}
@@ -126,7 +126,7 @@ func main() {
 					if failed {
 						fmt.Printf("BUG: executor-detected bug:\n%s", output)
 					}
-					if flags&ipc.FlagDebug != 0 || err != nil {
+					if config.Flags&ipc.FlagDebug != 0 || err != nil {
 						fmt.Printf("result: failed=%v hanged=%v err=%v\n\n%s", failed, hanged, err, output)
 					}
 					if *flagCoverFile != "" {

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -50,7 +50,7 @@ func main() {
 	prios := prog.CalculatePriorities(corpus)
 	ct := prog.BuildChoiceTable(prios, calls)
 
-	flags, timeout, err := ipc.DefaultFlags()
+	config, err := ipc.DefaultConfig()
 	if err != nil {
 		Fatalf("%v", err)
 	}
@@ -58,7 +58,7 @@ func main() {
 	for pid := 0; pid < *flagProcs; pid++ {
 		pid := pid
 		go func() {
-			env, err := ipc.MakeEnv(*flagExecutor, timeout, flags, pid)
+			env, err := ipc.MakeEnv(*flagExecutor, pid, config)
 			if err != nil {
 				Fatalf("failed to create execution environment: %v", err)
 			}


### PR DESCRIPTION
This PR contains two related commits providing additional control over the execution of the executor.

The first adds an 'abort' signal which is used to ask the executor to exit. When wrapping the executor in an external sandbox, providing a graceful shutdown mechanism may allow the sandbox to out additional debugging information. If the executor fails to gracefully shut down it is sent a SIGKILL.

The second allows control over the the executor output buffer. An external sandbox may output many more logs, making 128k insufficient to provide full context for the failure. The current buffering mechanism isn't ideal for a large buffer size, but it is fine for now.