### PR TITLE
all: cleanup executor/ipc interaction

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -226,7 +226,8 @@ int main(int argc, char** argv)
 	// ptrace(PTRACE_SEIZE, 1, 0, 0x100040)
 	// This is unfortunate, but I don't have a better solution than ignoring it for now.
 	exitf("loop exited with status %d", status);
-	return 0;
+	// Unreachable.
+	return 1;
 }
 
 void loop()

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"regexp"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -29,8 +28,6 @@ var (
 	flagProcs    = flag.Int("procs", 2*runtime.NumCPU(), "number of parallel processes")
 	flagLogProg  = flag.Bool("logprog", false, "print programs before execution")
 	flagGenerate = flag.Bool("generate", true, "generate new programs, otherwise only mutate corpus")
-
-	failedRe = regexp.MustCompile("runtime error: |panic: |Panic: ")
 
 	statExec uint64
 	gate     *ipc.Gate
@@ -105,11 +102,10 @@ func execute(pid int, env *ipc.Env, p *prog.Prog) {
 	if err != nil {
 		fmt.Printf("failed to execute executor: %v\n", err)
 	}
-	paniced := failedRe.Match(output)
-	if failed || hanged || paniced || err != nil {
+	if failed || hanged || err != nil {
 		fmt.Printf("PROGRAM:\n%s\n", p.Serialize())
 	}
-	if failed || hanged || paniced || err != nil || *flagOutput {
+	if failed || hanged || err != nil || *flagOutput {
 		os.Stdout.Write(output)
 	}
 }


### PR DESCRIPTION
This is mostly a cleanup change with little functional change.

Most notably, this removes kErrorStatus from the executor, which the
executor never returns anymore. This has the cascading effect of
removing the failed return from ipc.Env.Exec, which was only returned in
the case of kErrorStatus.

In ipc.command.exec, remove the status fallback from the pipe to the
exit status. Once the executor is serving, it always writes the status
over the pipe; anything else is an error.

Remove the panic check in syz-stress, which is no longer needed.