### PR TITLE
config: use reflect to enumerate all known fields

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,3 +14,11 @@ func TestUnknown(t *testing.T) {
 		t.Fatalf("unknown field is not detected (%v)", err)
 	}
 }
+
+func TestReflectUnknown(t *testing.T) {
+	data := `{"http": "localhost:56741","ParsedIgnores": [], "Odroid_Hub_Bus": "bus"}`
+	_, _, err := parse([]byte(data))
+	if err == nil || err.Error() != "unknown field 'ParsedIgnores' in config" {
+		t.Fatalf("unknown field is not detected (%v)", err)
+	}
+}


### PR DESCRIPTION
use reflect to enumerate all known fields rather than do it manually,
when change `Config`, there is no need to change `checkUnknownFields` at the same time.
