### PR TITLE
executor: limit stack frame size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ all:
 
 all-tools: execprog mutate prog2c stress repro upgrade
 
+# executor uses stacks of limited size, so no jumbo frames.
 executor:
-	$(CC) -o ./bin/syz-executor executor/executor.cc -pthread -Wall -O1 -g $(STATIC_FLAG) $(CFLAGS)
+	$(CC) -o ./bin/syz-executor executor/executor.cc -pthread -Wall -Wframe-larger-than=8192 -Werror -O1 -g $(STATIC_FLAG) $(CFLAGS)
 
 # Don't generate symbol table and DWARF debug info.
 # Reduces build time and binary sizes considerably.

--- a/executor/common.h
+++ b/executor/common.h
@@ -234,7 +234,9 @@ static void execute_command(const char* format, ...)
 
 int tunfd = -1;
 
-#define SYZ_TUN_MAX_PACKET_SIZE (64 << 10)
+// We just need this to be large enough to hold headers that we parse (ethernet/ip/tcp).
+// Rest of the packet (if any) will be silently truncated which is fine.
+#define SYZ_TUN_MAX_PACKET_SIZE 1000
 
 // sysgen knowns about this constant (maxPids)
 #define MAX_PIDS 32


### PR DESCRIPTION
Stack usage warning currently breaks our internal build (with 16K frame limit).
Executor uses stacks of limited size, that's another reason to not
allow frames of arbitrary size.

Limit stack frame size to 8K.
Reduce tun packet size. We don't need to read out whole packet.