### PR TITLE
executor: fix clang-tidy warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(NOSTATIC), 0)
 	STATIC_FLAG=-static
 endif
 
-.PHONY: all format clean manager fuzzer executor execprog mutate prog2c stress extract generate repro
+.PHONY: all format tidy clean manager fuzzer executor execprog mutate prog2c stress extract generate repro
 
 all:
 	go install ./syz-manager ./syz-fuzzer
@@ -64,6 +64,10 @@ bin/syz-sysgen: sysgen/*.go sysparser/*.go
 format:
 	go fmt ./...
 	clang-format --style=file -i executor/*.cc executor/*.h tools/kcovtrace/*.c
+
+# A single check is enabled for now. But it's always fixable and proved to be useful.
+tidy:
+	clang-tidy -quiet -header-filter=.* -checks=-*,misc-definitions-in-headers -warnings-as-errors=* executor/*.cc
 
 presubmit:
 	$(MAKE) generate

--- a/csource/csource.go
+++ b/csource/csource.go
@@ -175,6 +175,10 @@ func Write(p *prog.Prog, opts Options) ([]byte, error) {
 func generateTestFunc(w io.Writer, opts Options, calls []string, name string) {
 	if !opts.Threaded && !opts.Collide {
 		fmt.Fprintf(w, "void %v()\n{\n", name)
+		if opts.Debug {
+			// Use debug to avoid: error: ‘debug’ defined but not used.
+			fmt.Fprintf(w, "\tdebug(\"%v\\n\");\n", name)
+		}
 		if opts.Repro {
 			fmt.Fprintf(w, "\tsyscall(SYS_write, 1, \"executing program\\n\", strlen(\"executing program\\n\"));\n")
 		}
@@ -198,6 +202,10 @@ func generateTestFunc(w io.Writer, opts Options, calls []string, name string) {
 		fmt.Fprintf(w, "\tlong i;\n")
 		fmt.Fprintf(w, "\tpthread_t th[%v];\n", 2*len(calls))
 		fmt.Fprintf(w, "\n")
+		if opts.Debug {
+			// Use debug to avoid: error: ‘debug’ defined but not used.
+			fmt.Fprintf(w, "\tdebug(\"%v\\n\");\n", name)
+		}
 		if opts.Repro {
 			fmt.Fprintf(w, "\tsyscall(SYS_write, 1, \"executing program\\n\", strlen(\"executing program\\n\"));\n")
 		}
@@ -387,7 +395,7 @@ func preprocessCommonHeader(opts Options, handled map[string]int, useBitmasks, u
 	if useBitmasks {
 		defines = append(defines, "SYZ_USE_BITMASKS")
 	}
-	if useBitmasks {
+	if useChecksums {
 		defines = append(defines, "SYZ_USE_CHECKSUMS")
 	}
 	switch opts.Sandbox {

--- a/executor/syscalls.h
+++ b/executor/syscalls.h
@@ -15,7 +15,7 @@ struct call_t {
 };
 
 #if defined(__x86_64__) || 0
-call_t syscalls[] = {
+static call_t syscalls[] = {
     {"accept", 43},
     {"accept$alg", 43},
     {"accept$ax25", 43},
@@ -1524,7 +1524,7 @@ call_t syscalls[] = {
 #endif
 
 #if defined(__aarch64__) || 0
-call_t syscalls[] = {
+static call_t syscalls[] = {
     {"accept", 202},
     {"accept$alg", 202},
     {"accept$ax25", 202},
@@ -3033,7 +3033,7 @@ call_t syscalls[] = {
 #endif
 
 #if defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__) || 0
-call_t syscalls[] = {
+static call_t syscalls[] = {
     {"accept", 330},
     {"accept$alg", 330},
     {"accept$ax25", 330},

--- a/sysgen/syscallnr.go
+++ b/sysgen/syscallnr.go
@@ -94,7 +94,7 @@ struct call_t {
 
 {{range $arch := $.Archs}}
 #if {{range $cdef := $arch.CARCH}}defined({{$cdef}}) || {{end}}0
-call_t syscalls[] = {
+static call_t syscalls[] = {
 {{range $c := $arch.Calls}}	{"{{$c.Name}}", {{$c.NR}}},
 {{end}}
 };


### PR DESCRIPTION
A single check is enabled for now (misc-definitions-in-headers).
But it's always fixable and found 2 bugs in csource.