### PR TITLE
syz-dash: move patch parsing to pkg/kernel

### DIFF
--- a/pkg/kernel/patch.go
+++ b/pkg/kernel/patch.go
@@ -1,7 +1,7 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package dash
+package kernel
 
 import (
 	"bufio"
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func parsePatch(text string) (title string, diff string, err error) {
+func ParsePatch(text string) (title string, diff string, err error) {
 	s := bufio.NewScanner(strings.NewReader(text))
 	parsingDiff := false
 	diffStarted := false

--- a/pkg/kernel/patch_test.go
+++ b/pkg/kernel/patch_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package dash
+package kernel
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 func TestParsePatch(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {
-			title, diff, err := parsePatch(test.text)
+			title, diff, err := ParsePatch(test.text)
 			if err != nil {
 				t.Fatalf("failed to parse patch: %v", err)
 			}

--- a/syz-dash/handler.go
+++ b/syz-dash/handler.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/syzkaller/pkg/kernel"
 	"appengine"
 	ds "appengine/datastore"
 	"appengine/user"
@@ -412,7 +413,7 @@ func handleBug(c appengine.Context, w http.ResponseWriter, r *http.Request) erro
 		}
 		dropCached(c)
 	case "Add patch":
-		title, diff, err := parsePatch(r.FormValue("patch"))
+		title, diff, err := kernel.ParsePatch(r.FormValue("patch"))
 		if err != nil {
 			return fmt.Errorf("failed to parse patch: %v", err)
 		}


### PR DESCRIPTION
Patch parsing is not dashboard-specific and can
be reused by other programs.