### PR TITLE
Bisect the log to find multiple guilty programs

### DIFF
--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package repro
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/prog"
+)
+
+func initTest(t *testing.T) (*rand.Rand, int) {
+	iters := 1000
+	if testing.Short() {
+		iters = 100
+	}
+	seed := int64(time.Now().UnixNano())
+	rs := rand.NewSource(seed)
+	t.Logf("seed=%v", seed)
+	return rand.New(rs), iters
+}
+
+func TestBisect(t *testing.T) {
+	rd, iters := initTest(t)
+	for n := 0; n < iters; n++ {
+		var progs []*prog.LogEntry
+		numTotal := rd.Intn(300)
+		numGuilty := 0
+		for i := 0; i < numTotal; i++ {
+			var prog prog.LogEntry
+			if rd.Intn(30) == 0 {
+				prog.Proc = 42
+				numGuilty += 1
+			}
+			progs = append(progs, &prog)
+		}
+		if numGuilty == 0 {
+			var prog prog.LogEntry
+			prog.Proc = 42
+			progs = append(progs, &prog)
+			numGuilty += 1
+		}
+		progs, _ = bisectProgs(progs, "test", func(p []*prog.LogEntry) (bool, error) {
+			guilty := 0
+			for _, prog := range p {
+				if prog.Proc == 42 {
+					guilty += 1
+				}
+			}
+			return guilty == numGuilty, nil
+		})
+		if len(progs) != numGuilty {
+			t.Fatalf("bisect test failed: wrong number of guilty progs: got: %v, want: %v", len(progs), numGuilty)
+		}
+		for _, prog := range progs {
+			if prog.Proc != 42 {
+				t.Fatalf("bisect test failed: wrong program is guilty: progs: %v", progs)
+			}
+		}
+	}
+}

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -253,6 +253,8 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 	prog, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.prog"))
 	cprog, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.cprog"))
 	rep, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.report"))
+	log, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.log"))
+	stats, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.stats"))
 
 	fmt.Fprintf(w, "Syzkaller hit '%s' bug on commit %s.\n\n", trimNewLines(desc), trimNewLines(tag))
 	if len(rep) != 0 {
@@ -269,6 +271,12 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 		if len(cprog) != 0 {
 			fmt.Fprintf(w, "C reproducer:\n%s\n\n", cprog)
 		}
+	}
+	if len(stats) > 0 {
+		fmt.Fprintf(w, "Reproducing stats:\n%s\n\n", stats)
+	}
+	if len(log) > 0 {
+		fmt.Fprintf(w, "Reproducing log:\n%s\n\n", log)
 	}
 }
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -620,6 +620,10 @@ func (mgr *Manager) saveRepro(crash *Crash, res *repro.Result) {
 	if len(crash.text) > 0 {
 		ioutil.WriteFile(filepath.Join(dir, "repro.report"), []byte(crash.text), 0660)
 	}
+	ioutil.WriteFile(filepath.Join(dir, "repro.log"), res.Stats.Log, 0660)
+	stats := fmt.Sprintf("Extracting prog: %s\nMinimizing prog: %s\nSimplifying prog options: %s\nExtracting C: %s\nSimplifying C: %s\n",
+		res.Stats.ExtractProgTime, res.Stats.MinimizeProgTime, res.Stats.SimplifyProgTime, res.Stats.ExtractCTime, res.Stats.SimplifyCTime)
+	ioutil.WriteFile(filepath.Join(dir, "repro.stats"), []byte(stats), 0660)
 	var cprogText []byte
 	if res.CRepro {
 		cprog, err := csource.Write(res.Prog, res.Opts)

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -770,7 +770,7 @@ func (mgr *Manager) Check(a *CheckArgs, r *int) error {
 }
 
 func (mgr *Manager) NewInput(a *NewInputArgs, r *int) error {
-	Logf(2, "new input from %v for syscall %v (signal=%v cover=%v)", a.Name, a.Call, len(a.Signal), len(a.Cover))
+	Logf(4, "new input from %v for syscall %v (signal=%v cover=%v)", a.Name, a.Call, len(a.Signal), len(a.Cover))
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
@@ -861,7 +861,7 @@ func (mgr *Manager) Poll(a *PollArgs, r *PollRes) error {
 			}
 		}
 	}
-	Logf(2, "poll from %v: recv maxsignal=%v, send maxsignal=%v candidates=%v inputs=%v",
+	Logf(4, "poll from %v: recv maxsignal=%v, send maxsignal=%v candidates=%v inputs=%v",
 		a.Name, len(a.MaxSignal), len(r.MaxSignal), len(r.Candidates), len(r.NewInputs))
 	return nil
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -118,7 +118,7 @@ func MonitorExecution(outc <-chan []byte, errc <-chan error, needOutput bool, ig
 
 	matchPos := 0
 	const (
-		beforeContext = 256 << 10
+		beforeContext = 1024 << 10
 		afterContext  = 128 << 10
 	)
 	extractError := func(defaultError string) (string, []byte, []byte, bool, bool) {


### PR DESCRIPTION
After this change syzkaller was able to generate a reproducer for [this bug](https://groups.google.com/forum/#!topic/syzkaller/dQ0r_bHOrJk).

The following is not yet implemented:
```
// TODO: Minimize each program before concatenation.
// TODO: Return multiple programs if concatenation fails.
```

Updates #179 
