### PR TITLE
tools/syz-symbolize: add report mode

### DIFF
--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -14,7 +14,9 @@ import (
 )
 
 var (
-	flagLinux = flag.String("linux", "", "path to linux")
+	flagKernelSrc = flag.String("kernel_src", "", "path to kernel sources")
+	flagKernelObj = flag.String("kernel_obj", "", "path to kernel build dir")
+	flagReport    = flag.Bool("report", false, "extract report from the log")
 )
 
 func main() {
@@ -24,18 +26,43 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
+	if *flagKernelSrc == "" {
+		*flagKernelSrc = *flagKernelObj
+	}
 	text, err := ioutil.ReadFile(flag.Args()[0])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open input file: %v\n", err)
 		os.Exit(1)
 	}
-	if console := report.ExtractConsoleOutput(text); len(console) != 0 {
-		text = console
+	if *flagReport {
+		desc, text, _, _ := report.Parse(text, nil)
+		text, err = report.Symbolize(filepath.Join(*flagKernelObj, "vmlinux"), text, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to symbolize: %v\n", err)
+			os.Exit(1)
+		}
+		guiltyFile := report.ExtractGuiltyFile(text)
+		fmt.Printf("%v\n\n", desc)
+		os.Stdout.Write(text)
+		fmt.Printf("\n")
+		fmt.Printf("guilty file: %v\n", guiltyFile)
+		if guiltyFile != "" {
+			maintainers, err := report.GetMaintainers(*flagKernelSrc, guiltyFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to get maintainers: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("maintainers: %v\n", maintainers)
+		}
+	} else {
+		if console := report.ExtractConsoleOutput(text); len(console) != 0 {
+			text = console
+		}
+		text, err = report.Symbolize(filepath.Join(*flagKernelObj, "vmlinux"), text, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to symbolize: %v\n", err)
+			os.Exit(1)
+		}
+		os.Stdout.Write(text)
 	}
-	text, err = report.Symbolize(filepath.Join(*flagLinux, "vmlinux"), text, nil)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to symbolize: %v\n", err)
-		os.Exit(1)
-	}
-	os.Stdout.Write(text)
 }


### PR DESCRIPTION
Currently syz-symbolize symbolizes whole input file.
Add a new mode (controlled with -report flag) when
it prints report as would be extracted by syz-manager.