### PR TITLE
pkg/report: fix symbolization of old KASAN stack trace format

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -343,7 +343,7 @@ var oopses = []*oops{
 var (
 	consoleOutputRe = regexp.MustCompile(`^(?:\<[0-9]+\>)?\[ *[0-9]+\.[0-9]+\] `)
 	questionableRe  = regexp.MustCompile(`(?:\[\<[0-9a-f]+\>\])? \? +[a-zA-Z0-9_.]+\+0x[0-9a-f]+/[0-9a-f]+`)
-	symbolizeRe     = regexp.MustCompile(`(?:\[\<(?:[0-9a-f]+)\>\])? +(?:[0-9]+:)?([a-zA-Z0-9_.]+)\+0x([0-9a-f]+)/0x([0-9a-f]+)`)
+	symbolizeRe     = regexp.MustCompile(`(?:\[\<(?:[0-9a-f]+)\>\])?[ \t]+(?:[0-9]+:)?([a-zA-Z0-9_.]+)\+0x([0-9a-f]+)/0x([0-9a-f]+)`)
 	decNumRe        = regexp.MustCompile(`[0-9]{5,}`)
 	lineNumRe       = regexp.MustCompile(`(:[0-9]+)+`)
 	addrRe          = regexp.MustCompile(`[0-9a-f]{8,}`)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -970,6 +970,11 @@ func TestSymbolizeLine(t *testing.T) {
 			"    [<ffffffff84e5bea0>] do_ipv6_setsockopt.isra.7.part.3+0x101/0x2830 \n",
 			"    [<ffffffff84e5bea0>] do_ipv6_setsockopt.isra.7.part.3+0x101/0x2830 net.c:111 \n",
 		},
+		// Old KASAN frame format (with tab).
+		{
+			"[   50.419727] 	baz+0x101/0x200\n",
+			"[   50.419727] 	baz+0x101/0x200 baz.c:100\n",
+		},
 		// Inlined frames.
 		{
 			"    [<ffffffff84e5bea0>] foo+0x141/0x185\n",


### PR DESCRIPTION
Which has a tab instead of a space at the beginning of each frame in alloc and free stack traces.