### PR TITLE
pkg/repro: fix null-ptr-deref when res is nil

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -180,7 +180,9 @@ func (ctx *context) repro(entries []*prog.LogEntry, crashStart int) (*Result, er
 		return nil, nil
 	}
 	defer func() {
-		res.Opts.Repro = false
+		if res != nil {
+			res.Opts.Repro = false
+		}
 	}()
 	res, err = ctx.minimizeProg(res)
 	if err != nil {


### PR DESCRIPTION
res can become nil if one of the repro routines fails with an error.