### PR TITLE
prog: properly remove calls when splicing progs

### DIFF
--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -29,8 +29,8 @@ func (p *Prog) Mutate(rs rand.Source, ncalls int, ct *ChoiceTable, corpus []*Pro
 			p0c := p0.Clone()
 			idx := r.Intn(len(p.Calls))
 			p.Calls = append(p.Calls[:idx], append(p0c.Calls, p.Calls[idx:]...)...)
-			if len(p.Calls) > ncalls {
-				p.Calls = p.Calls[:ncalls]
+			for i := len(p.Calls) - 1; i >= ncalls; i-- {
+				p.removeCall(i)
 			}
 		case r.nOutOf(20, 31):
 			// Insert a new call.

--- a/prog/mutation_test.go
+++ b/prog/mutation_test.go
@@ -46,6 +46,19 @@ next:
 	}
 }
 
+func TestMutateCorpus(t *testing.T) {
+	rs, iters := initTest(t)
+	var corpus []*Prog
+	for i := 0; i < 100; i++ {
+		p := Generate(rs, 10, nil)
+		corpus = append(corpus, p)
+	}
+	for i := 0; i < iters; i++ {
+		p1 := Generate(rs, 10, nil)
+		p1.Mutate(rs, 10, nil, corpus)
+	}
+}
+
 func TestMutateTable(t *testing.T) {
 	tests := [][2]string{
 		// Insert calls.
@@ -276,8 +289,9 @@ func TestMinimize(t *testing.T) {
 
 func TestMinimizeRandom(t *testing.T) {
 	rs, iters := initTest(t)
+	iters /= 10 // Long test.
 	for i := 0; i < iters; i++ {
-		p := Generate(rs, 10, nil)
+		p := Generate(rs, 5, nil)
 		Minimize(p, len(p.Calls)-1, func(p1 *Prog, callIndex int) bool {
 			if err := p1.validate(); err != nil {
 				t.Fatalf("invalid program: %v", err)
@@ -292,7 +306,7 @@ func TestMinimizeRandom(t *testing.T) {
 		}, true)
 	}
 	for i := 0; i < iters; i++ {
-		p := Generate(rs, 10, nil)
+		p := Generate(rs, 5, nil)
 		Minimize(p, len(p.Calls)-1, func(p1 *Prog, callIndex int) bool {
 			if err := p1.validate(); err != nil {
 				t.Fatalf("invalid program: %v", err)

--- a/prog/size_test.go
+++ b/prog/size_test.go
@@ -20,15 +20,13 @@ func TestAssignSizeRandom(t *testing.T) {
 		if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
 			t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
 		}
-		for try := 0; try <= 10; try++ {
-			p.Mutate(rs, 10, nil, nil)
-			data0 := p.Serialize()
-			for _, call := range p.Calls {
-				assignSizesCall(call)
-			}
-			if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
-				t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
-			}
+		p.Mutate(rs, 10, nil, nil)
+		data0 = p.Serialize()
+		for _, call := range p.Calls {
+			assignSizesCall(call)
+		}
+		if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
+			t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
 		}
 	}
 }


### PR DESCRIPTION
Use removeCall() to update use references.

Also add a test.