### PR TITLE
prog: don't mutate mmap() calls too often

### DIFF
--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -57,6 +57,11 @@ func (p *Prog) Mutate(rs rand.Source, ncalls int, ct *ChoiceTable, corpus []*Pro
 				retry = true
 				continue
 			}
+			// Mutating mmap() arguments almost certainly doesn't give us new coverage.
+			if c.Meta.Name == "mmap" && r.nOutOf(99, 100) {
+				retry = true
+				continue
+			}
 			s := analyze(ct, p, c)
 			for stop := false; !stop; stop = r.oneOf(3) {
 				args, bases := mutationArgs(c)


### PR DESCRIPTION
Due to https://github.com/google/syzkaller/issues/316 there're too many
mmap() calls in the programs, and syzkaller is spending quite a bit of
time mutating them. Most of the time changing mmap() calls won't give
us new coverage, so let's not do it too often.