### PR TITLE
syz-manager, syz-hub: share repros between managers via hub

### DIFF
--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -155,3 +155,13 @@ func WriteFile(filename string, data []byte) error {
 func WriteExecFile(filename string, data []byte) error {
 	return ioutil.WriteFile(filename, data, DefaultExecPerm)
 }
+
+// Return all files in a directory.
+func ListDir(dir string) ([]string, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Readdirnames(-1)
+}

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -74,18 +74,23 @@ type HubConnectArgs struct {
 
 type HubSyncArgs struct {
 	// see HubConnectArgs.
-	Client  string
-	Key     string
-	Manager string
+	Client     string
+	Key        string
+	Manager    string
+	NeedRepros bool
 	// Programs added to corpus since last sync or connect.
 	Add [][]byte
-	// Hashed of programs removed from corpus since last sync or connect.
+	// Hashes of programs removed from corpus since last sync or connect.
 	Del []string
+	// Repros found since last sync.
+	Repros [][]byte
 }
 
 type HubSyncRes struct {
 	// Set of programs from other managers.
-	Inputs [][]byte
+	Progs [][]byte
+	// Set of repros from other managers.
+	Repros [][]byte
 	// Number of remaining pending programs,
 	// if >0 manager should do sync again.
 	More int

--- a/syz-hub/http.go
+++ b/syz-hub/http.go
@@ -38,17 +38,22 @@ func (hub *Hub) httpSummary(w http.ResponseWriter, r *http.Request) {
 	total := UIManager{
 		Name:   "total",
 		Corpus: len(hub.st.Corpus.Records),
+		Repros: len(hub.st.Repros.Records),
 	}
 	for name, mgr := range hub.st.Managers {
 		total.Added += mgr.Added
 		total.Deleted += mgr.Deleted
 		total.New += mgr.New
+		total.SentRepros += mgr.SentRepros
+		total.RecvRepros += mgr.RecvRepros
 		data.Managers = append(data.Managers, UIManager{
-			Name:    name,
-			Corpus:  len(mgr.Corpus.Records),
-			Added:   mgr.Added,
-			Deleted: mgr.Deleted,
-			New:     mgr.New,
+			Name:       name,
+			Corpus:     len(mgr.Corpus.Records),
+			Added:      mgr.Added,
+			Deleted:    mgr.Deleted,
+			New:        mgr.New,
+			SentRepros: mgr.SentRepros,
+			RecvRepros: mgr.RecvRepros,
 		})
 	}
 	sort.Sort(UIManagerArray(data.Managers))
@@ -70,11 +75,14 @@ type UISummaryData struct {
 }
 
 type UIManager struct {
-	Name    string
-	Corpus  int
-	Added   int
-	Deleted int
-	New     int
+	Name       string
+	Corpus     int
+	Added      int
+	Deleted    int
+	New        int
+	Repros     int
+	SentRepros int
+	RecvRepros int
 }
 
 type UIManagerArray []UIManager
@@ -102,6 +110,9 @@ var summaryTemplate = compileTemplate(`
 		<th>Added</th>
 		<th>Deleted</th>
 		<th>New</th>
+		<th>Repros</th>
+		<th>Sent</th>
+		<th>Recv</th>
 	</tr>
 	{{range $m := $.Managers}}
 	<tr>
@@ -110,6 +121,9 @@ var summaryTemplate = compileTemplate(`
 		<td>{{$m.Added}}</td>
 		<td>{{$m.Deleted}}</td>
 		<td>{{$m.New}}</td>
+		<td>{{$m.Repros}}</td>
+		<td>{{$m.SentRepros}}</td>
+		<td>{{$m.RecvRepros}}</td>
 	</tr>
 	{{end}}
 </table>

--- a/syz-hub/state/state_test.go
+++ b/syz-hub/state/state_test.go
@@ -4,13 +4,16 @@
 package state
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestState(t *testing.T) {
-	dir, err := ioutil.TempDir("", "syz-gce-state-test")
+	dir, err := ioutil.TempDir("", "syz-hub-state-test")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -24,4 +27,88 @@ func TestState(t *testing.T) {
 	if err == nil {
 		t.Fatalf("synced with unconnected manager")
 	}
+	calls := []string{"read", "write"}
+	if err := st.Connect("foo", false, calls, nil); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	_, _, err = st.Sync("foo", nil, nil)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+}
+
+func TestRepro(t *testing.T) {
+	dir, err := ioutil.TempDir("", "syz-hub-state-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	st, err := Make(dir)
+	if err != nil {
+		t.Fatalf("failed to make state: %v", err)
+	}
+
+	if err := st.Connect("foo", false, []string{"open", "read", "write"}, nil); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if err := st.Connect("bar", false, []string{"open", "read", "close"}, nil); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	checkPendingRepro(t, st, "foo", "")
+	checkPendingRepro(t, st, "bar", "")
+
+	if err := st.AddRepro("foo", []byte("open()")); err != nil {
+		t.Fatalf("AddRepro failed: %v", err)
+	}
+	checkPendingRepro(t, st, "foo", "")
+	checkPendingRepro(t, st, "bar", "open()")
+	checkPendingRepro(t, st, "bar", "")
+
+	// This repro is already present.
+	if err := st.AddRepro("bar", []byte("open()")); err != nil {
+		t.Fatalf("AddRepro failed: %v", err)
+	}
+	if err := st.AddRepro("bar", []byte("read()")); err != nil {
+		t.Fatalf("AddRepro failed: %v", err)
+	}
+	if err := st.AddRepro("bar", []byte("open()\nread()")); err != nil {
+		t.Fatalf("AddRepro failed: %v", err)
+	}
+	// This does not satisfy foo's call set.
+	if err := st.AddRepro("bar", []byte("close()")); err != nil {
+		t.Fatalf("AddRepro failed: %v", err)
+	}
+	checkPendingRepro(t, st, "bar", "")
+
+	// Check how persistence works.
+	st, err = Make(dir)
+	if err != nil {
+		t.Fatalf("failed to make state: %v", err)
+	}
+	if err := st.Connect("foo", false, []string{"open", "read", "write"}, nil); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if err := st.Connect("bar", false, []string{"open", "read", "close"}, nil); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	checkPendingRepro(t, st, "bar", "")
+	checkPendingRepro(t, st, "foo", "read()")
+	checkPendingRepro(t, st, "foo", "open()\nread()")
+	checkPendingRepro(t, st, "foo", "")
+}
+
+func checkPendingRepro(t *testing.T, st *State, name, result string) {
+	repro, err := st.PendingRepro(name)
+	if err != nil {
+		t.Fatalf("\n%v: PendingRepro failed: %v", caller(1), err)
+	}
+	if string(repro) != result {
+		t.Fatalf("\n%v: PendingRepro returned %q, want %q", caller(1), string(repro), result)
+	}
+}
+
+func caller(skip int) string {
+	_, file, line, _ := runtime.Caller(skip + 1)
+	return fmt.Sprintf("%v:%v", filepath.Base(file), line)
 }

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -292,7 +292,7 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 
 func collectCrashes(workdir string) ([]*UICrashType, error) {
 	crashdir := filepath.Join(workdir, "crashes")
-	dirs, err := readdirnames(crashdir)
+	dirs, err := osutil.ListDir(crashdir)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func readCrash(workdir, dir string, full bool) *UICrashType {
 	modTime := stat.ModTime()
 	descFile.Close()
 
-	files, err := readdirnames(filepath.Join(crashdir, dir))
+	files, err := osutil.ListDir(filepath.Join(crashdir, dir))
 	if err != nil {
 		return nil
 	}
@@ -393,15 +393,6 @@ func readCrash(workdir, dir string, full bool) *UICrashType {
 		Triaged:     triaged,
 		Crashes:     crashes,
 	}
-}
-
-func readdirnames(dir string) ([]string, error) {
-	f, err := os.Open(dir)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	return f.Readdirnames(-1)
 }
 
 func trimNewLines(data []byte) []byte {


### PR DESCRIPTION
Currently hub allows managers to exchange programs from corpus.
But reproducers are not exchanged and we don't know if a crash
happens on other managers as well or not.

Allow hub to exchange reproducers.

Reproducers are stored in a separate db file with own sequence numbers.
This allows to throttle distribution of reproducers to managers,
so that they are not overloaded with reproducers and don't lose them on restarts.

Based on patch by Andrey Konovalov:
https://github.com/google/syzkaller/pull/325

Fixes #282