### PR TITLE
.travis.yml: test against go1.9rc1, tip since aliases trip gofmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: trusty
 
 go:
-  - 1.8.1
+  - 1.9rc1
 
 before_install:
   - echo $PATH


### PR DESCRIPTION
.travis.yml: use go1.9rc1 since aliases trip gofmt for vendored code
    
For https://github.com/golang/go/issues/21337.
    
Since the introduction of aliases is in Go1.9 but Go1.9 hasn't
yet been officially released, let's use go1.9rc1 which is supported
on Travis CI by their Go version getter gimme
https://github.com/travis-ci/gimme
instead of against go1.8.1. This solves the problem on which
our vendored code is updated using Go1.9* syntax but is running
against Go1.8* in Travis CI tests.