### PR TITLE
prog: fix restoration of default arguments

### DIFF
--- a/prog/prog.go
+++ b/prog/prog.go
@@ -273,7 +273,11 @@ func defaultArg(t sys.Type) Arg {
 	case *sys.ResourceType:
 		return resultArg(t, nil, typ.Desc.Type.Default())
 	case *sys.BufferType:
-		return dataArg(t, nil)
+		var data []byte
+		if typ.Kind == sys.BufferString && typ.Length != 0 {
+			data = make([]byte, typ.Length)
+		}
+		return dataArg(t, data)
 	case *sys.ArrayType:
 		return groupArg(t, nil)
 	case *sys.StructType:
@@ -281,17 +285,17 @@ func defaultArg(t sys.Type) Arg {
 		for _, field := range typ.Fields {
 			inner = append(inner, defaultArg(field))
 		}
-		return groupArg(t, nil)
+		return groupArg(t, inner)
 	case *sys.UnionType:
 		return unionArg(t, defaultArg(typ.Options[0]), typ.Options[0])
 	case *sys.VmaType:
-		return pointerArg(t, 0, 0, 0, nil)
+		return pointerArg(t, 0, 0, 1, nil)
 	case *sys.PtrType:
 		var res Arg
 		if !t.Optional() {
 			res = defaultArg(typ.Type)
 		}
-		return pointerArg(t, 0, 0, 1, res)
+		return pointerArg(t, 0, 0, 0, res)
 	default:
 		panic("unknown arg type")
 	}

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -5,6 +5,7 @@ package prog
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -40,6 +41,21 @@ func TestDefault(t *testing.T) {
 	for _, meta := range sys.CallMap {
 		for _, t := range meta.Args {
 			defaultArg(t)
+		}
+	}
+}
+
+func TestDefaultCallArgs(t *testing.T) {
+	initTest(t)
+	for _, meta := range sys.CallMap {
+		// Ensure that we can restore all arguments of all calls.
+		prog := fmt.Sprintf("%v()", meta.Name)
+		p, err := Deserialize([]byte(prog))
+		if err != nil {
+			t.Fatalf("failed to restore default args in prog %q: %v", prog, err)
+		}
+		if len(p.Calls) != 1 || p.Calls[0].Meta.Name != meta.Name {
+			t.Fatalf("restored bad program from prog %q: %q", prog, p.Serialize())
 		}
 	}
 }


### PR DESCRIPTION
Currently fails on:
 - pointers
 - VMAs
 - structs
 - fixed-size structs