### PR TITLE
prog: reuse defaultArg

### DIFF
--- a/prog/prog.go
+++ b/prog/prog.go
@@ -292,7 +292,7 @@ func defaultArg(t sys.Type) Arg {
 		return pointerArg(t, 0, 0, 1, nil)
 	case *sys.PtrType:
 		var res Arg
-		if !t.Optional() {
+		if !t.Optional() && t.Dir() != sys.DirOut {
 			res = defaultArg(typ.Type)
 		}
 		return pointerArg(t, 0, 0, 0, res)

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -608,26 +608,14 @@ func (r *randGen) generateArg(s *state, typ sys.Type) (arg Arg, calls []*Call) {
 		// in subsequent calls. For the same reason we do generate pointer/array/struct
 		// output arguments (their elements can be referenced in subsequent calls).
 		switch typ.(type) {
-		case *sys.IntType, *sys.FlagsType, *sys.ConstType, *sys.ProcType:
-			return constArg(typ, typ.Default()), nil
-		case *sys.VmaType:
-			return pointerArg(typ, 0, 0, 0, nil), nil
-		case *sys.ResourceType:
-			return resultArg(typ, nil, typ.Default()), nil
+		case *sys.IntType, *sys.FlagsType, *sys.ConstType, *sys.ProcType,
+			*sys.VmaType, *sys.ResourceType:
+			return defaultArg(typ), nil
 		}
 	}
 
 	if typ.Optional() && r.oneOf(5) {
-		switch typ.(type) {
-		case *sys.PtrType:
-			return pointerArg(typ, 0, 0, 0, nil), nil
-		case *sys.BufferType:
-			panic("impossible") // parent PtrType must be Optional instead
-		case *sys.VmaType:
-			return pointerArg(typ, 0, 0, 0, nil), nil
-		default:
-			return constArg(typ, typ.Default()), nil
-		}
+		return defaultArg(typ), nil
 	}
 
 	// Allow infinite recursion for optional pointers.


### PR DESCRIPTION
Reuse defaultArg in generateArg. There is code that does the same.
Also, don't generate pointer value for output arguments.