### PR TITLE
sys: change proc arguments to the format used by const/flags/len

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -47,7 +47,7 @@ rest of the type-options are type-specific:
 "vma": a pointer to a set of pages (used as input for mmap/munmap/mremap/madvise), type-options:
 	optional number of pages (e.g. vma[7]), or a range of pages (e.g. vma[2-4])
 "proc": per process int (see description below), type-options:
-	underlying type, value range start, how many values per process
+	value range start, how many values per process, underlying type
 "text16", "text32", "text64": machine code of the specified bitness
 ```
 
@@ -171,7 +171,8 @@ The `proc` type can be used to denote per process integers.
 The idea is to have a separate range of values for each executor, so they don't interfere.
 
 The simplest example is a port number.
-The `proc[int16be, 20000, 4]` type means that we want to generate an `int16be` integer starting from `20000` and assign no more than `4` integers for each process.
+The `proc[20000, 4, int16be]` type means that we want to generate an `int16be`
+integer starting from `20000` and assign `4` values for each process.
 As a result the executor number `n` will get values in the `[20000 + n * 4, 20000 + (n + 1) * 4)` range.
 
 ## Misc

--- a/sys/key.txt
+++ b/sys/key.txt
@@ -45,6 +45,6 @@ key_desc {
 	name0	const[115, int8]
 	name1	const[121, int8]
 	name2	const[122, int8]
-	name3	proc[int8, 32, 4]
+	name3	proc[32, 4, int8]
 	name4	const[0, int8]
 }

--- a/sys/socket.txt
+++ b/sys/socket.txt
@@ -289,7 +289,7 @@ syzn_devname {
 	s	const[115, int8]
 	y	const[121, int8]
 	z	const[122, int8]
-	N	proc[int8, 48, 1]
+	N	proc[48, 1, int8]
 	z0	const[0, int8]
 }
 
@@ -696,8 +696,8 @@ ethtool_flow_ext {
 ethtool_tcpip4_spec {
 	ip4src	ipv4_addr
 	ip4dst	ipv4_addr
-	psrc	proc[int16be, 20000, 4]
-	pdst	proc[int16be, 20000, 4]
+	psrc	proc[20000, 4, int16be]
+	pdst	proc[20000, 4, int16be]
 	tos	int8
 }
 
@@ -720,8 +720,8 @@ ethtool_usrip4_spec {
 ethtool_tcpip6_spec {
 	ip6src	ipv6_addr
 	ip6dst	ipv6_addr
-	psrc	proc[int16be, 20000, 4]
-	pdst	proc[int16be, 20000, 4]
+	psrc	proc[20000, 4, int16be]
+	pdst	proc[20000, 4, int16be]
 	tclass	int8
 }
 

--- a/sys/socket_inet.txt
+++ b/sys/socket_inet.txt
@@ -19,7 +19,7 @@ sock_in_pair {
 
 sockaddr_in {
 	family	const[AF_INET, int16]
-	port	proc[int16be, 20000, 4]
+	port	proc[20000, 4, int16be]
 	addr	ipv4_addr
 	pad	array[const[0, int8], 8]
 }
@@ -116,9 +116,9 @@ xfrm_policy_shares = XFRM_SHARE_ANY, XFRM_SHARE_SESSION, XFRM_SHARE_USER, XFRM_S
 xfrm_selector {
 	daddr		xfrm_address
 	saddr		xfrm_address
-	dport		proc[int16be, 20000, 4]
+	dport		proc[20000, 4, int16be]
 	dport_mask	int16
-	sport		proc[int16be, 20000, 4]
+	sport		proc[20000, 4, int16be]
 	sport_mask	int16
 	family		flags[socket_domain, int16]
 	prefixlen_d	flags[xfrm_prefixlens, int8]

--- a/sys/socket_inet6.txt
+++ b/sys/socket_inet6.txt
@@ -20,7 +20,7 @@ sock_in6_pair {
 
 sockaddr_in6 {
 	family	const[AF_INET6, int16]
-	port	proc[int16be, 20000, 4]
+	port	proc[20000, 4, int16be]
 	flow	int32
 	addr	ipv6_addr
 	scope	int32

--- a/sys/socket_unix.txt
+++ b/sys/socket_unix.txt
@@ -43,7 +43,7 @@ sockaddr_un_file {
 sockaddr_un_abstract {
 	family	flags[unix_socket_family, int16]
 	ind	const[0, int8]
-	id	proc[int32, 20000, 4]
+	id	proc[20000, 4, int32]
 }
 
 msghdr_un {

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -662,24 +662,18 @@ func generateArg(
 		fmt.Fprintf(out, "&ConstType{%v, Val: uint64(%v)}", intCommon(size, bigEndian, bitfieldLen), a[0])
 	case "proc":
 		canBeArg = true
-		size := uint64(ptrSize)
-		bigEndian := false
-		bitfieldLen := uint64(0)
-		var valuesStart string
-		var valuesPerProc string
+		want := 2
 		if isField {
-			if want := 3; len(a) != want {
-				failf("wrong number of arguments for %v arg %v, want %v, got %v", typ, name, want, len(a))
-			}
-			size, bigEndian, bitfieldLen = decodeIntType(a[0])
-			valuesStart = a[1]
-			valuesPerProc = a[2]
-		} else {
-			if want := 2; len(a) != want {
-				failf("wrong number of arguments for %v arg %v, want %v, got %v", typ, name, want, len(a))
-			}
-			valuesStart = a[0]
-			valuesPerProc = a[1]
+			want = 3
+		}
+		if len(a) != want {
+			failf("wrong number of arguments for %v arg %v, want %v, got %v", typ, name, want, len(a))
+		}
+		valuesStart := a[0]
+		valuesPerProc := a[1]
+		size, bitfieldLen, bigEndian := uint64(ptrSize), uint64(0), false
+		if isField {
+			size, bigEndian, bitfieldLen = decodeIntType(a[2])
 		}
 		valuesStartInt, err := strconv.ParseInt(valuesStart, 10, 64)
 		if err != nil {

--- a/sys/vnet.txt
+++ b/sys/vnet.txt
@@ -31,13 +31,13 @@ include <uapi/linux/if_ether.h>
 mac_addr_local {
 # This corresponds to LOCAL_MAC ("aa:aa:aa:aa:aa:%02hx" % pid) in executor/common.h
 	a0	array[const[0xaa, int8], 5]
-	a1	proc[int8, 0, 1]
+	a1	proc[0, 1, int8]
 } [packed]
 
 mac_addr_remote {
 # This corresponds to REMOTE_MAC ("bb:bb:bb:bb:bb:%02hx" % pid) in executor/common.h
 	a0	array[const[0xbb, int8], 5]
-	a1	proc[int8, 0, 1]
+	a1	proc[0, 1, int8]
 } [packed]
 
 mac_addr [
@@ -278,7 +278,7 @@ include <net/cipso_ipv4.h>
 ipv4_addr_local {
 	a0	const[0xac, int8]
 	a1	const[0x14, int8]
-	a2	proc[int8, 0, 1]
+	a2	proc[0, 1, int8]
 	a3	const[0xaa, int8]
 } [packed]
 
@@ -286,7 +286,7 @@ ipv4_addr_local {
 ipv4_addr_remote {
 	a0	const[0xac, int8]
 	a1	const[0x14, int8]
-	a2	proc[int8, 0, 1]
+	a2	proc[0, 1, int8]
 	a3	const[0xbb, int8]
 } [packed]
 
@@ -419,7 +419,7 @@ ipv4_header {
 	ecn		int8:2
 	dscp		int8:6
 	total_len	len[ipv4_packet, int16be]
-	id		proc[int16be, 100, 4]
+	id		proc[100, 4, int16be]
 	frag_off	int16be
 # TODO: frag_off is actually 13 bits, 3 bits are flags
 	ttl		int8
@@ -457,7 +457,7 @@ ipv6_addr_local {
 	a0	const[0xfe, int8]
 	a1	const[0x80, int8]
 	a2	array[const[0x0, int8], 12]
-	a3	proc[int8, 0, 1]
+	a3	proc[0, 1, int8]
 	a4	const[0xaa, int8]
 } [packed]
 
@@ -466,7 +466,7 @@ ipv6_addr_remote {
 	a0	const[0xfe, int8]
 	a1	const[0x80, int8]
 	a2	array[const[0x0, int8], 12]
-	a3	proc[int8, 0, 1]
+	a3	proc[0, 1, int8]
 	a4	const[0xbb, int8]
 } [packed]
 
@@ -523,7 +523,7 @@ ipv6_fragment_ext_header {
 	m_flag		int8:1
 	reserved2	int8:2
 	fragment_off_lo	int8:5
-	identification	proc[int32, 100, 4]
+	identification	proc[100, 4, int32]
 } [packed]
 
 ipv6_dstopts_ext_header {
@@ -678,8 +678,10 @@ tcp_options {
 tcp_flags = 0, TCPHDR_FIN, TCPHDR_SYN, TCPHDR_RST, TCPHDR_PSH, TCPHDR_ACK, TCPHDR_URG, TCPHDR_ECE, TCPHDR_CWR, TCPHDR_SYN_ECN
 
 tcp_header {
-	src_port	proc[int16be, 20000, 4]
-	dst_port	proc[int16be, 20000, 4]
+# TODO: proc[20000, 4, int16be] is a good candidate for typedef when/if we have them.
+# I.e. typedef proc[20000, 4, int16be] sock_port
+	src_port	proc[20000, 4, int16be]
+	dst_port	proc[20000, 4, int16be]
 	seq_num		tcp_seq_num
 	ack_num		tcp_seq_num
 	ns		int8:1
@@ -709,8 +711,8 @@ tcp_payload {
 # https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
 
 udp_packet {
-	src_port	proc[int16be, 20000, 4]
-	dst_port	proc[int16be, 20000, 4]
+	src_port	proc[20000, 4, int16be]
+	dst_port	proc[20000, 4, int16be]
 	length		len[parent, int16be]
 	csum		csum[parent, pseudo, IPPROTO_UDP, int16be]
 	data		array[int8]
@@ -733,7 +735,7 @@ icmp_ipv4_header {
 	ecn		int8:2
 	dscp		int8:6
 	total_len	int16be
-	id		proc[int16be, 100, 4]
+	id		proc[100, 4, int16be]
 	frag_off	int16be
 	ttl		int8
 	protocol	flags[ipv4_types, int8]
@@ -1017,8 +1019,8 @@ include <uapi/linux/dccp.h>
 dccp_types = DCCP_PKT_REQUEST, DCCP_PKT_RESPONSE, DCCP_PKT_DATA, DCCP_PKT_ACK, DCCP_PKT_DATAACK, DCCP_PKT_CLOSEREQ, DCCP_PKT_CLOSE, DCCP_PKT_RESET, DCCP_PKT_SYNC, DCCP_PKT_SYNCACK, DCCP_PKT_INVALID
 
 dccp_header {
-	src_port	proc[int16be, 20000, 4]
-	dst_port	proc[int16be, 20000, 4]
+	src_port	proc[20000, 4, int16be]
+	dst_port	proc[20000, 4, int16be]
 	offset		bytesize4[parent, int8]
 	cscov		const[1, int8:4]
 # TODO: cscov might have other values, affects checksummed data


### PR DESCRIPTION
All other types have optional underlying type as the last argument.
Proc have it as first. This creates very irregular syntax and
complicates parsing. Make type the last argument.

Note: this is a breaking change if you have descriptions on the side.