### PR TITLE
sys: support ptr64 type

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -30,8 +30,9 @@ rest of the type-options are type-specific:
 	reference to flags description (see below)
 "array": a variable/fixed-length array, type-options:
 	type of elements, optional size (fixed "5", or ranged "5:10", boundaries inclusive)
-"ptr": a pointer to an object, type-options:
+"ptr"/"ptr64": a pointer to an object, type-options:
 	type of the object; direction (in/out/inout)
+	ptr64 has size of 8 bytes regardless of target pointer size
 "buffer": a pointer to a memory buffer (like read/write buffer argument), type-options:
 	direction (in/out/inout)
 "string": a zero-terminated memory buffer (no pointer indirection implied), type-options:

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -133,6 +133,10 @@ s6 {
 	f1	int8
 } [align_foo]			### bad struct s6 alignment foo
 
+s7 {
+	f1	ptr64[in, int32]
+}
+
 u3 [
 	f1	int8
 	f2	int32

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -74,11 +74,15 @@ var typeInt = &typeDesc{
 }
 
 var typePtr = &typeDesc{
-	Names:    []string{"ptr"},
+	Names:    []string{"ptr", "ptr64"},
 	CanBeArg: true,
 	Args:     []namedArg{{"direction", typeArgDir}, {"type", typeArgType}},
 	Gen: func(comp *compiler, t *ast.Type, args []*ast.Type, base sys.IntTypeCommon) sys.Type {
 		base.ArgDir = sys.DirIn // pointers are always in
+		base.TypeSize = comp.ptrSize
+		if t.Ident == "ptr64" {
+			base.TypeSize = 8
+		}
 		return &sys.PtrType{
 			TypeCommon: base.TypeCommon,
 			Type:       comp.genType(args[1], "", genDir(args[0]), false),


### PR DESCRIPTION
ptr64 is like ptr, but always takes 8 bytes of space.
Needed for some APIs. Unfortunately, most of these APIs
use buffer type, so we can't use ptr64 immidiately.