### PR TITLE
syz-extract: fix printf conditional in template

### DIFF
--- a/sys/syz-extract/fetch.go
+++ b/sys/syz-extract/fetch.go
@@ -146,7 +146,7 @@ var srcTemplate = template.Must(template.New("").Parse(`
 
 {{.AddSource}}
 
-{{.DeclarePrintf}}
+{{if .DeclarePrintf}}
 int printf(const char *format, ...);
 {{end}}
 


### PR DESCRIPTION
commit 3520854be0e7 ("syz-extract: select declaring printf or not")
broke 'make extract' because it introduced invalid syntax in a text
template.  Fix it.