### PR TITLE
My branch with arm32 support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Google Inc.
  Zach Riggle
  Willem de Bruijn
  Eric Biggers
+ Atul Prakash
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ arch:
 	env TARGETOS=linux TARGETARCH=arm64 $(MAKE) target
 	env GOOG=linux GOARCH=ppc64le go install github.com/google/syzkaller/syz-fuzzer
 	env TARGETOS=linux TARGETARCH=ppc64le $(MAKE) target
-	# executor build on arm fails with:
-	# Error: alignment too large: 15 assumed
+	env GOOG=linux GOARCH=arm go install github.com/google/syzkaller/syz-fuzzer
+	env TARGETOS=linux TARGETARCH=arm $(MAKE) target
 	env GOOG=linux GOARCH=arm64 go install github.com/google/syzkaller/syz-fuzzer
 	env TARGETOS=linux TARGETARCH=arm64 TARGETVMARCH=arm $(MAKE) target
 	# executor build on 386 on travis fails with:

--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -7,6 +7,7 @@ Instructions for a particular VM type or kernel arch can be found on these pages
 - [Setup: Ubuntu host, Odroid C2 board, arm64 kernel](setup_ubuntu-host_odroid-c2-board_arm64-kernel.md)
 - [Setup: Linux host, QEMU vm, arm64 kernel](setup_linux-host_qemu-vm_arm64-kernel.md)
 - [Setup: Linux host, Android device, arm64 kernel](setup_linux-host_android-device_arm64-kernel.md)
+- [Setup: Ubuntu host, Android device, arm32 kernel](setup_ubuntu-host_android-device_arm32-kernel.md)
 - [Setup: Linux isolated host](setup_linux-host_isolated.md)
 
 ## Install

--- a/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
+++ b/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
@@ -1,0 +1,83 @@
+# Setup: Ubuntu host, arm32 kernel on an Android device
+
+This document will detail the steps involved in setting up a syzkaller instance fuzzing an ARM32 linux kernel on an Android (or Android Things) device. This is a work-in-progress at this time and being provided to spur further development. Some features of syzkaller may not yet work on ARM32. For example, not all debugging and test coverage features are available in the Linux kernel for ARM32, limiting the efficacy of syskaller in finding bugs fast. These instructions help set up syzkaller to be a basic fuzzer that does not rely on test coverage data from the kernel. 
+
+## Install Android and Linux kernel on an ARM32 device
+
+Follow the instructions for the ARM32 board to install Android or 
+Android Things and make sure the device boots properly.
+
+Set up the adb bridge so that adb and fastboot work.
+
+Setup a serial port, following the instructions for your board so that you can monitor any messages from the kernel.
+
+These were tested on an NXP Pico-Pi-IMX7D following the instructions [here](https://developer.android.com/things/hardware/developer-kits.html).
+
+If feasible, recompile and reinstall the Linux kernel with any debugging options available on your board.
+
+## Install Go
+
+Install Go as follows:
+``` bash
+wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz
+tar -xf go1.9.2.linux-amd64.tar.gz
+mv go goroot
+export PATH=`pwd`/go/bin:$PATH
+mkdir gopath
+export GOPATH=`pwd`/gopath
+```
+
+## Build syzkaller code
+
+### Initialize a working directory and set up environment variables
+
+Create a working directory. Also make sure GOROOT, GOPATH, and optionally NDKARM are defined and exported as instructed earlier. 
+
+``` bash
+go get -u -d github.com/google/syzkaller/...
+cd gopath/src/github.com/google/syzkaller/
+mkdir workdir 
+```
+
+### Build syzkaller executables
+
+Run make. 
+```
+make TARGETOS=linux TARGETARCH=arm
+```
+As an alternative, is possible to use the Android NDK toolchain to build syz-executor.
+To do that, one way is to create an Android.mk file and and Application.mk file
+and to use the Android NDK's ndk-build program to build syz-executor from executor/executor_linux.cc. The clang cross-compiler, which is
+part of the Android NDK, is going to be needed for a successful build.
+
+### Create a manager configuration file
+
+Create a manager config myboard.cfg, replacing the environment
+variables `$GOPATH`, `$VMLINUX` (path to vmlinux for the ARM32 board), and `$DEVICES` (the device ID for your board as reported by adb devices) with their actual values. Change any other flags as needed for your ARM board.
+```
+{
+	"target": "linux/arm",
+	"http": "127.0.0.1:56741",
+	"workdir": "$GOPATH/src/github.com/google/syzkaller/workdir",
+	"vmlinux": "$KERNEL/vmlinux",
+	"syzkaller": "$GOPATH/src/github.com/google/syzkaller",
+	"sandbox": none,
+	"procs": 1,
+	"type": "adb",
+	"cover": false, 
+	"vm": {
+		"devices": [$DEVICES],
+		"battery_check": false
+	}
+}
+```
+
+Run syzkaller manager:
+``` bash
+./bin/syz-manager -config=myboard.cfg
+```
+
+Now syzkaller should be running, you can check manager status with your web browser at `127.0.0.1:56741`.
+
+If you get issues after `syz-manager` starts, consider running it with the `-debug` flag.
+Also see [this page](troubleshooting.md) for troubleshooting tips.


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
Hello, this are some edits to better support ARM32 devices. It is targeted at Android, but should also help with support for ARM32/Linux in general. Key files that changed are executor/executor_linux.cc. In addition, some edits are made to vm/adb/adb.go because the ARM32 board that I was testing with lacked a battery. Now, adb.go supports battery-less devices. Other changes are mostly around Make process for ARM32/Android and in adding documentation.