### PR TITLE
docs: use 'c++' to build on FreeBSD

### DIFF
--- a/docs/freebsd.md
+++ b/docs/freebsd.md
@@ -8,7 +8,7 @@ make manager fuzzer execprog TARGETOS=freebsd
 ```
 To build C `syz-executor` binary, copy `executor/*` files to a FreeBSD machine and build there with:
 ```
-gcc executor/executor_freebsd.cc -o syz-executor -O1 -lpthread -DGOOS=\"freebsd\" -DGIT_REVISION=\"CURRENT_GIT_REVISION\"
+c++ executor/executor_freebsd.cc -o syz-executor -O1 -lpthread -DGOOS=\"freebsd\" -DGIT_REVISION=\"CURRENT_GIT_REVISION\"
 ```
 Then, copy out the binary back to host into `bin/freebsd_amd64` dir.
 


### PR DESCRIPTION
Building the executor via `gcc executor/executor_freebsd.cc ...`
requires that a GCC package first be installed on the FreeBSD VM image.
The FreeBSD base system comes with Clang already installed, so we can
build via `c++ executor/executor_freebsd.cc ...` and avoid having to
install additional packages.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
