### PR TITLE
prog: support bytesizeN for vma

### DIFF
--- a/executor/syscalls_linux.h
+++ b/executor/syscalls_linux.h
@@ -2,7 +2,7 @@
 
 #if defined(__i386__) || 0
 #define GOARCH "386"
-#define SYZ_REVISION "8dc5f192fbf31c44b7149a447dbc4ab3c52ce8dc"
+#define SYZ_REVISION "43937fcc0d2e1383553adc7881a7d3a395a3513f"
 #define __NR_syz_emit_ethernet 1000000
 #define __NR_syz_extract_tcp_res 1000001
 #define __NR_syz_fuse_mount 1000002
@@ -1513,7 +1513,7 @@ call_t syscalls[] = {
 
 #if defined(__x86_64__) || 0
 #define GOARCH "amd64"
-#define SYZ_REVISION "3c393f727fed32893cfa9465a4c114d2845d98f8"
+#define SYZ_REVISION "008ee2d3dbbfb6e31a49cedbeb0ab9943855c1c8"
 #define __NR_syz_emit_ethernet 1000000
 #define __NR_syz_extract_tcp_res 1000001
 #define __NR_syz_fuse_mount 1000002
@@ -3085,7 +3085,7 @@ call_t syscalls[] = {
 
 #if defined(__arm__) || 0
 #define GOARCH "arm"
-#define SYZ_REVISION "1371837664b1cb11a212e1f3748c10ec134ac955"
+#define SYZ_REVISION "12aefb8014c1fd1a13e7ee577e359879d150f795"
 #define __NR_syz_emit_ethernet 1000000
 #define __NR_syz_extract_tcp_res 1000001
 #define __NR_syz_fuse_mount 1000002
@@ -4606,7 +4606,7 @@ call_t syscalls[] = {
 
 #if defined(__aarch64__) || 0
 #define GOARCH "arm64"
-#define SYZ_REVISION "bda6cbc1306d682ce492d85f185d1ecbc8cd14d1"
+#define SYZ_REVISION "e7138e8c5e93e0a6430b9e3f97dcef689a8843c2"
 #define __NR_syz_emit_ethernet 1000000
 #define __NR_syz_extract_tcp_res 1000001
 #define __NR_syz_fuse_mount 1000002
@@ -6107,7 +6107,7 @@ call_t syscalls[] = {
 
 #if defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__) || 0
 #define GOARCH "ppc64le"
-#define SYZ_REVISION "7181d499c27790d50391729214f690d6c6339313"
+#define SYZ_REVISION "a2e427aec88bd889613c169210a83bd19d58d43f"
 #define __NR_syz_emit_ethernet 1000000
 #define __NR_syz_extract_tcp_res 1000001
 #define __NR_syz_fuse_mount 1000002

--- a/prog/mutation_test.go
+++ b/prog/mutation_test.go
@@ -23,7 +23,7 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func TestMutate(t *testing.T) {
+func TestMutateRandom(t *testing.T) {
 	target, rs, iters := initTest(t)
 next:
 	for i := 0; i < iters; i++ {
@@ -36,12 +36,17 @@ next:
 			p1.Mutate(rs, 10, nil, nil)
 			data := p.Serialize()
 			if !bytes.Equal(data0, data) {
-				t.Fatalf("program changed after clone/mutate\noriginal:\n%s\n\nnew:\n%s\n", data0, data)
+				t.Fatalf("program changed after clone/mutate\noriginal:\n%s\n\nnew:\n%s\n",
+					data0, data)
 			}
 			data1 := p1.Serialize()
-			if !bytes.Equal(data, data1) {
-				continue next
+			if bytes.Equal(data, data1) {
+				continue
 			}
+			if _, err := target.Deserialize(data1); err != nil {
+				t.Fatalf("Deserialize failed after Mutate: %v\n%s", err, data1)
+			}
+			continue next
 		}
 		t.Fatalf("mutation does not change program:\n%s", data0)
 	}

--- a/prog/size_test.go
+++ b/prog/size_test.go
@@ -26,7 +26,7 @@ func TestAssignSizeRandom(t *testing.T) {
 			target.assignSizesCall(call)
 		}
 		if data1 := p.Serialize(); !bytes.Equal(data0, data1) {
-			t.Fatalf("different lens assigned, initial: %v, new: %v", data0, data1)
+			t.Fatalf("different lens assigned, initial:\n%s\nnew:\n%s", data0, data1)
 		}
 	}
 }
@@ -78,8 +78,8 @@ func TestAssignSize(t *testing.T) {
 			"syz_test$length9(&(0x7f000001f000)={&(0x7f0000000000/0x5000)=nil, 0x5000})",
 		},
 		{
-			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, 0x0000)",
-			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, 0x5000)",
+			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, 0x0000, 0x0000, 0x0000, 0x0000)",
+			"syz_test$length10(&(0x7f0000000000/0x5000)=nil, 0x5000, 0x5000, 0x2800, 0x1400)",
 		},
 		{
 			"syz_test$length11(&(0x7f0000000000)={0xff, 0xff, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]}, 0x00)",

--- a/sys/linux/386.go
+++ b/sys/linux/386.go
@@ -13680,6 +13680,9 @@ var syscalls_386 = []*Syscall{
 	{ID: 1417, NR: 1000008, Name: "syz_test$length10", CallName: "syz_test", Args: []Type{
 		&VmaType{TypeCommon: TypeCommon{TypeName: "vma", FldName: "a0", TypeSize: 4}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "a1", TypeSize: 4}}, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "a2", TypeSize: 4}}, ByteSize: 1, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize2", FldName: "a3", TypeSize: 4}}, ByteSize: 2, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize4", FldName: "a4", TypeSize: 4}}, ByteSize: 4, Buf: "a0"},
 	}},
 	{ID: 1418, NR: 1000008, Name: "syz_test$length11", CallName: "syz_test", Args: []Type{
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "a0", TypeSize: 4}, Type: &StructType{Key: StructKey{Name: "syz_length_large_struct"}}},
@@ -17029,4 +17032,4 @@ var consts_386 = []ConstValue{
 	{Name: "__WNOTHREAD", Value: 536870912},
 }
 
-const revision_386 = "8dc5f192fbf31c44b7149a447dbc4ab3c52ce8dc"
+const revision_386 = "43937fcc0d2e1383553adc7881a7d3a395a3513f"

--- a/sys/linux/amd64.go
+++ b/sys/linux/amd64.go
@@ -14178,6 +14178,9 @@ var syscalls_amd64 = []*Syscall{
 	{ID: 1478, NR: 1000008, Name: "syz_test$length10", CallName: "syz_test", Args: []Type{
 		&VmaType{TypeCommon: TypeCommon{TypeName: "vma", FldName: "a0", TypeSize: 8}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "a1", TypeSize: 8}}, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "a2", TypeSize: 8}}, ByteSize: 1, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize2", FldName: "a3", TypeSize: 8}}, ByteSize: 2, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize4", FldName: "a4", TypeSize: 8}}, ByteSize: 4, Buf: "a0"},
 	}},
 	{ID: 1479, NR: 1000008, Name: "syz_test$length11", CallName: "syz_test", Args: []Type{
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "a0", TypeSize: 8}, Type: &StructType{Key: StructKey{Name: "syz_length_large_struct"}}},
@@ -17560,4 +17563,4 @@ var consts_amd64 = []ConstValue{
 	{Name: "__WNOTHREAD", Value: 536870912},
 }
 
-const revision_amd64 = "3c393f727fed32893cfa9465a4c114d2845d98f8"
+const revision_amd64 = "008ee2d3dbbfb6e31a49cedbeb0ab9943855c1c8"

--- a/sys/linux/arm.go
+++ b/sys/linux/arm.go
@@ -13604,6 +13604,9 @@ var syscalls_arm = []*Syscall{
 	{ID: 1429, NR: 1000008, Name: "syz_test$length10", CallName: "syz_test", Args: []Type{
 		&VmaType{TypeCommon: TypeCommon{TypeName: "vma", FldName: "a0", TypeSize: 4}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "a1", TypeSize: 4}}, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "a2", TypeSize: 4}}, ByteSize: 1, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize2", FldName: "a3", TypeSize: 4}}, ByteSize: 2, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize4", FldName: "a4", TypeSize: 4}}, ByteSize: 4, Buf: "a0"},
 	}},
 	{ID: 1430, NR: 1000008, Name: "syz_test$length11", CallName: "syz_test", Args: []Type{
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "a0", TypeSize: 4}, Type: &StructType{Key: StructKey{Name: "syz_length_large_struct"}}},
@@ -16897,4 +16900,4 @@ var consts_arm = []ConstValue{
 	{Name: "__WNOTHREAD", Value: 536870912},
 }
 
-const revision_arm = "1371837664b1cb11a212e1f3748c10ec134ac955"
+const revision_arm = "12aefb8014c1fd1a13e7ee577e359879d150f795"

--- a/sys/linux/arm64.go
+++ b/sys/linux/arm64.go
@@ -13665,6 +13665,9 @@ var syscalls_arm64 = []*Syscall{
 	{ID: 1413, NR: 1000008, Name: "syz_test$length10", CallName: "syz_test", Args: []Type{
 		&VmaType{TypeCommon: TypeCommon{TypeName: "vma", FldName: "a0", TypeSize: 8}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "a1", TypeSize: 8}}, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "a2", TypeSize: 8}}, ByteSize: 1, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize2", FldName: "a3", TypeSize: 8}}, ByteSize: 2, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize4", FldName: "a4", TypeSize: 8}}, ByteSize: 4, Buf: "a0"},
 	}},
 	{ID: 1414, NR: 1000008, Name: "syz_test$length11", CallName: "syz_test", Args: []Type{
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "a0", TypeSize: 8}, Type: &StructType{Key: StructKey{Name: "syz_length_large_struct"}}},
@@ -16942,4 +16945,4 @@ var consts_arm64 = []ConstValue{
 	{Name: "__WNOTHREAD", Value: 536870912},
 }
 
-const revision_arm64 = "bda6cbc1306d682ce492d85f185d1ecbc8cd14d1"
+const revision_arm64 = "e7138e8c5e93e0a6430b9e3f97dcef689a8843c2"

--- a/sys/linux/ppc64le.go
+++ b/sys/linux/ppc64le.go
@@ -13340,6 +13340,9 @@ var syscalls_ppc64le = []*Syscall{
 	{ID: 1387, NR: 1000008, Name: "syz_test$length10", CallName: "syz_test", Args: []Type{
 		&VmaType{TypeCommon: TypeCommon{TypeName: "vma", FldName: "a0", TypeSize: 8}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "a1", TypeSize: 8}}, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "a2", TypeSize: 8}}, ByteSize: 1, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize2", FldName: "a3", TypeSize: 8}}, ByteSize: 2, Buf: "a0"},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize4", FldName: "a4", TypeSize: 8}}, ByteSize: 4, Buf: "a0"},
 	}},
 	{ID: 1388, NR: 1000008, Name: "syz_test$length11", CallName: "syz_test", Args: []Type{
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "a0", TypeSize: 8}, Type: &StructType{Key: StructKey{Name: "syz_length_large_struct"}}},
@@ -16627,4 +16630,4 @@ var consts_ppc64le = []ConstValue{
 	{Name: "__WNOTHREAD", Value: 536870912},
 }
 
-const revision_ppc64le = "7181d499c27790d50391729214f690d6c6339313"
+const revision_ppc64le = "a2e427aec88bd889613c169210a83bd19d58d43f"

--- a/sys/linux/test.txt
+++ b/sys/linux/test.txt
@@ -191,7 +191,7 @@ syz_test$length7(a0 ptr[in, syz_length_array2_struct])
 syz_test$length8(a0 ptr[in, syz_length_complex_struct])
 syz_test$length9(a0 ptr[in, syz_length_vma_struct])
 
-syz_test$length10(a0 vma, a1 len[a0])
+syz_test$length10(a0 vma, a1 len[a0], a2 bytesize[a0], a3 bytesize2[a0], a4 bytesize4[a0])
 syz_test$length11(a0 ptr[in, syz_length_large_struct], a1 len[a0])
 syz_test$length12(a0 ptr[in, syz_length_large_struct, opt], a1 len[a0])
 syz_test$length13(a0 ptr[inout, syz_length_large_struct], a1 ptr[inout, len[a0, int64]])


### PR DESCRIPTION
I guess this is currently unused,
but ignoring bytesizeN for vma looks wrong.
If user asks for bytesizeN for vma, divide vma size by N.