### PR TITLE
pkg/report: add Output to Report

### DIFF
--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -34,7 +34,9 @@ func (ctx *freebsd) ContainsCrash(output []byte) bool {
 }
 
 func (ctx *freebsd) Parse(output []byte) *Report {
-	rep := new(Report)
+	rep := &Report{
+		Output: output,
+	}
 	var oops *oops
 	for pos := 0; pos < len(output); {
 		next := bytes.IndexByte(output[pos:], '\n')

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -77,7 +77,9 @@ func (ctx *linux) ContainsCrash(output []byte) bool {
 
 func (ctx *linux) Parse(output []byte) *Report {
 	output = ctx.ExtractConsoleOutput(output)
-	rep := new(Report)
+	rep := &Report{
+		Output: output,
+	}
 	var oops *oops
 	var textPrefix [][]byte
 	textLines := 0

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -34,6 +34,8 @@ type Report struct {
 	Title string
 	// Report contains whole oops text.
 	Report []byte
+	// Output contains whole raw kernel output.
+	Output []byte
 	// StartPos/EndPos denote region of output with oops message(s).
 	StartPos int
 	EndPos   int

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -339,12 +339,12 @@ func (job *Job) testProgram(inst *vm.Instance, command string, reporter report.R
 	if err != nil {
 		return false, fmt.Errorf("failed to run binary in VM: %v", err)
 	}
-	rep, output := vm.MonitorExecution(outc, errc, reporter, true)
+	rep := vm.MonitorExecution(outc, errc, reporter, true)
 	if rep == nil {
 		return false, nil
 	}
 	job.resp.CrashTitle = rep.Title
 	job.resp.CrashReport = rep.Report
-	job.resp.CrashLog = output
+	job.resp.CrashLog = rep.Output
 	return true, nil
 }

--- a/tools/syz-crush/crush.go
+++ b/tools/syz-crush/crush.go
@@ -109,7 +109,7 @@ func runInstance(cfg *mgrconfig.Config, reporter report.Reporter, vmPool *vm.Poo
 	}
 
 	log.Logf(0, "vm-%v: crushing...", index)
-	rep, output := vm.MonitorExecution(outc, errc, reporter, false)
+	rep := vm.MonitorExecution(outc, errc, reporter, false)
 	if rep == nil {
 		// This is the only "OK" outcome.
 		log.Logf(0, "vm-%v: running long enough, restarting", index)
@@ -121,7 +121,7 @@ func runInstance(cfg *mgrconfig.Config, reporter report.Reporter, vmPool *vm.Poo
 		}
 		defer f.Close()
 		log.Logf(0, "vm-%v: crashed: %v, saving to %v", index, rep.Title, f.Name())
-		f.Write(output)
+		f.Write(rep.Output)
 	}
 	return
 }


### PR DESCRIPTION
Whole raw output is indivisble part of Report,
currently we always pass Output separately along with Report.
Make Output a Report field.

Then, put whole Report into manager Crash and repro context and Result.
There is little point in passing Report as aa bunch of separate fields.