### PR TITLE
dashboard/app: add manager monitoring

### DIFF
--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -68,6 +68,26 @@ func formatTime(t time.Time) string {
 	return t.Format("Jan 02 15:04")
 }
 
+func formatClock(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("15:04")
+}
+
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return ""
+	}
+	days := int(d / (24 * time.Hour))
+	hours := int(d / time.Hour % 24)
+	mins := int(d / time.Minute % 60)
+	if days != 0 {
+		return fmt.Sprintf("%vd%vh", days, hours)
+	}
+	return fmt.Sprintf("%vh%vm", hours, mins)
+}
+
 func formatReproLevel(l dashapi.ReproLevel) string {
 	switch l {
 	case ReproLevelSyz:
@@ -84,6 +104,8 @@ var (
 
 	templateFuncs = template.FuncMap{
 		"formatTime":       formatTime,
+		"formatClock":      formatClock,
+		"formatDuration":   formatDuration,
 		"formatReproLevel": formatReproLevel,
 	}
 )

--- a/dashboard/app/main.html
+++ b/dashboard/app/main.html
@@ -11,11 +11,11 @@
 		</tr>
 		{{range $b := $.Bugs}}
 			<tr>
-				<td class="title"><a href="/bug?id={{$b.ID}}">{{$b.Title}}</a></td>
+				<td class="title"><a href="{{$b.Link}}">{{$b.Title}}</a></td>
 				<td class="count">{{$b.NumCrashes}}</td>
 				<td class="repro">{{formatReproLevel $b.ReproLevel}}</td>
 				<td class="time">{{formatTime $b.LastTime}}</td>
-				<td class="status">{{if $b.Link}}<a href="{{$b.Link}}">{{$b.Status}}</a>{{else}}{{$b.Status}}{{end}}</td>
+				<td class="status">{{if $b.Link}}<a href="{{$b.ExternalLink}}">{{$b.Status}}</a>{{else}}{{$b.Status}}{{end}}</td>
 				<td class="patched" title="{{$b.Commits}}">{{if $b.Commits}}{{len $b.PatchedOn}}/{{len $b.MissingOn}}{{end}}</td>
 			</tr>
 		{{end}}
@@ -40,6 +40,49 @@
 	<br><br>
 
 	<table class="list_table">
+		<caption>Managers:</caption>
+		<tr>
+			<th>Name</th>
+			<th>Last Active</th>
+			<th>Current Build</th>
+			<th>Failed Build</th>
+			<th>Today: Uptime</th>
+			<th>Fuzzing Time</th>
+			<th>Corpus</th>
+			<th>Coverage</th>
+			<th>Crashes</th>
+			<th>Execs</th>
+		</tr>
+		{{range $mgr := $.Managers}}
+			<tr>
+				<td>{{$mgr.Namespace}}/{{$mgr.Name}}</td>
+				{{if $mgr.LastActiveBad}}
+					<td style="color:#f00">{{formatTime $mgr.LastActive}}</td>
+				{{else}}
+					<td>{{formatClock $mgr.LastActive}}</td>
+				{{end}}
+				{{if $mgr.CurrentBuild}}
+					<td title="{{$mgr.CurrentBuild.KernelRepo}}/{{$mgr.CurrentBuild.KernelBranch}}/{{$mgr.CurrentBuild.KernelCommit}} (syzkaller {{$mgr.CurrentBuild.SyzkallerCommit}})">{{formatTime $mgr.CurrentBuild.Time}}</td>
+				{{else}}
+					<td></td>
+				{{end}}
+				{{if $mgr.FailedBuildBugLink}}
+					<td><a href="{{$mgr.FailedBuildBugLink}}" style="color:#f00">failed</a></td>
+				{{else}}
+					<td></td>
+				{{end}}
+				<td>{{formatDuration $mgr.CurrentUpTime}}</td>
+				<td>{{formatDuration $mgr.TotalFuzzingTime}}</td>
+				<td>{{$mgr.MaxCorpus}}</td>
+				<td>{{$mgr.MaxCover}}</td>
+				<td>{{$mgr.TotalCrashes}}</td>
+				<td>{{$mgr.TotalExecs}}</td>
+			</tr>
+		{{end}}
+	</table>
+	<br><br>
+
+	<table class="list_table">
 		<caption>Recent jobs:</caption>
 		<tr>
 			<th>Created</th>
@@ -59,7 +102,7 @@
 				<td class="time">{{formatTime $job.Started}}{{if gt $job.Attempts 1}} ({{$job.Attempts}}){{end}}</td>
 				<td class="time">{{formatTime $job.Finished}}</td>
 				<td>{{$job.User}}</td>
-				<td class="title"><a href="/bug?id={{$job.BugID}}">{{$job.BugTitle}}</a></td>
+				<td class="title"><a href="{{$job.BugLink}}">{{$job.BugTitle}}</a></td>
 				<td><a href="{{$job.PatchLink}}">patch</a></td>
 				<td>{{$job.Namespace}}/{{$job.Reporting}}</td>
 				<td>{{$job.Manager}}</td>

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -577,8 +577,7 @@ func (state *ReportingState) getEntry(now time.Time, namespace, name string) *Re
 		panic(fmt.Sprintf("requesting reporting state for %v/%v", namespace, name))
 	}
 	// Convert time to date of the form 20170125.
-	year, month, day := now.Date()
-	date := year*10000 + int(month)*100 + day
+	date := timeDate(now)
 	for i := range state.Entries {
 		ent := &state.Entries[i]
 		if ent.Namespace == namespace && ent.Name == name {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 )
 
 type Dashboard struct {
@@ -247,6 +248,23 @@ type PollRequest struct {
 
 type PollResponse struct {
 	Reports []*BugReport
+}
+
+type ManagerStatsReq struct {
+	Name string
+	// Current level:
+	UpTime time.Duration
+	Corpus uint64
+	Cover  uint64
+
+	// Delta since last sync:
+	FuzzingTime time.Duration
+	Crashes     uint64
+	Execs       uint64
+}
+
+func (dash *Dashboard) UploadManagerStats(req *ManagerStatsReq) error {
+	return dash.query("manager_stats", req, nil)
 }
 
 type (

--- a/syz-ci/testing.go
+++ b/syz-ci/testing.go
@@ -31,12 +31,13 @@ func bootInstance(mgrcfg *mgrconfig.Config) (*vm.Instance, report.Reporter, *rep
 	}
 	inst, err := vmPool.Create(0)
 	if err != nil {
-		if bootErr, ok := err.(vm.BootError); ok {
-			rep := reporter.Parse(bootErr.Output)
+		if bootErr, ok := err.(vm.BootErrorer); ok {
+			title, output := bootErr.BootError()
+			rep := reporter.Parse(output)
 			if rep == nil {
 				rep = &report.Report{
-					Title:  bootErr.Title,
-					Output: bootErr.Output,
+					Title:  title,
+					Output: output,
 				}
 			}
 			if err := reporter.Symbolize(rep); err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -37,18 +37,15 @@ type Instance struct {
 	index   int
 }
 
-type (
-	Env       vmimpl.Env
-	BootError vmimpl.BootError
-)
+type Env vmimpl.Env
 
 var (
 	Shutdown   = vmimpl.Shutdown
 	TimeoutErr = vmimpl.TimeoutErr
 )
 
-func (err BootError) Error() string {
-	return fmt.Sprintf("%v\n%s", err.Title, err.Output)
+type BootErrorer interface {
+	BootError() (string, []byte)
 }
 
 func Create(typ string, env *Env) (*Pool, error) {

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -66,6 +66,10 @@ func (err BootError) Error() string {
 	return fmt.Sprintf("%v\n%s", err.Title, err.Output)
 }
 
+func (err BootError) BootError() (string, []byte) {
+	return err.Title, err.Output
+}
+
 // Create creates a VM type that can be used to create individual VMs.
 func Create(typ string, env *Env) (Pool, error) {
 	ctor := ctors[typ]


### PR DESCRIPTION
Make it possible to monitor health and operation
of all managers from dashboard.
1. Notify dashboard about internal syz-ci errors
   (currently we don't know when/if they happen).
2. Send statistics from managers to dashboard.