### PR TITLE
pkg/report: fix report extraction

### DIFF
--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -71,7 +71,7 @@ func (ctx *freebsd) Parse(output []byte) *Report {
 	if oops == nil {
 		return nil
 	}
-	rep.Title, _, _ = extractDescription(output[rep.StartPos:], oops)
+	rep.Title, _ = extractDescription(output[rep.StartPos:], oops)
 	return rep
 }
 

--- a/pkg/report/linux_test.go
+++ b/pkg/report/linux_test.go
@@ -633,59 +633,104 @@ r0 = ioctl$KVM_CREATE_VM(0xffffffffffffffff, 0xae01, 0x0)
 [ 1722.511384] BUG: sleeping function called from invalid context at include/linux/wait.h:1095 
 [ 1722.511384] in_atomic(): 1, irqs_disabled(): 0, pid: 3658, name: syz-fuzzer 
 `, `BUG: sleeping function called from invalid context at include/linux/wait.h:LINE `, true,
-		},
-
-		// TODO: broken: https://github.com/google/syzkaller/issues/457
-		/* {
-					`
-		[  277.780013] INFO: rcu_sched self-detected stall on CPU
-		[  277.781045] INFO: rcu_sched detected stalls on CPUs/tasks:
-		[  277.781153] 	1-...: (65000 ticks this GP) idle=395/140000000000001/0 softirq=122875/122875 fqs=16248
-		[  277.781197] 	(detected by 0, t=65002 jiffies, g=72940, c=72939, q=1777)
-		[  277.781212] Sending NMI from CPU 0 to CPUs 1:
-		[  277.782014] NMI backtrace for cpu 1
-		[  277.782014] CPU: 1 PID: 12579 Comm: syz-executor0 Not tainted 4.11.0-rc3+ #71
-		[  277.782014] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
-		[  277.782014] task: ffff8801d379e140 task.stack: ffff8801cd590000
-		[  277.782014] RIP: 0010:io_serial_in+0x6b/0x90
-		[  277.782014] RSP: 0018:ffff8801dbf066a0 EFLAGS: 00000002
-		[  277.782014] RAX: dffffc0000000000 RBX: 00000000000003fd RCX: 0000000000000000
-		[  277.782014] RDX: 00000000000003fd RSI: 0000000000000005 RDI: ffffffff87020018
-		[  277.782014] RBP: ffff8801dbf066b0 R08: 0000000000000003 R09: 0000000000000001
-		[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: ffffffff8701ffe0
-		[  277.782014] R13: 0000000000000020 R14: fffffbfff0e04041 R15: fffffbfff0e04005
-		[  277.782014] FS:  00007fce6fc10700(0000) GS:ffff8801dbf00000(0000) knlGS:0000000000000000
-		[  277.782014] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
-		[  277.782014] CR2: 000000002084fffc CR3: 00000001c4500000 CR4: 00000000001406e0
-		[  277.782014] Call Trace:
-		[  277.782014]  <IRQ>
-		[  277.782014]  wait_for_xmitr+0x89/0x1c0
-		[  277.782014]  ? wait_for_xmitr+0x1c0/0x1c0
-		[  277.782014]  serial8250_console_putchar+0x1f/0x60
-		[  277.782014]  uart_console_write+0x57/0xe0
-		[  277.782014]  serial8250_console_write+0x423/0x840
-		[  277.782014]  ? check_noncircular+0x20/0x20
-		[  277.782014]  hrtimer_interrupt+0x1c2/0x5e0
-		[  277.782014]  local_apic_timer_interrupt+0x6f/0xe0
-		[  277.782014]  smp_apic_timer_interrupt+0x71/0xa0
-		[  277.782014]  apic_timer_interrupt+0x93/0xa0
-		[  277.782014] RIP: 0010:debug_lockdep_rcu_enabled.part.19+0xf/0x60
-		[  277.782014] RSP: 0018:ffff8801cd596778 EFLAGS: 00000202 ORIG_RAX: ffffffffffffff10
-		[  277.782014] RAX: dffffc0000000000 RBX: 1ffff10039ab2cf7 RCX: ffffc90001758000
-		[  277.782014] RDX: 0000000000000004 RSI: ffffffff840561f1 RDI: ffffffff852a75c0
-		[  277.782014] RBP: ffff8801cd596780 R08: 0000000000000001 R09: 0000000000000000
-		[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: 1ffff10039ab2d1b
-		[  277.782014] R13: ffff8801c44d1880 R14: ffff8801cd596918 R15: ffff8801d9b47840
-		[  277.782014]  </IRQ>
-		[  277.782014]  ? __write_space+0x5b1/0x920
-		[  277.782014]  debug_lockdep_rcu_enabled+0x77/0x90
-		[  292.742848] sctp: [Deprecated]: syz-executor0 (pid 22154) Use of int in max_burst socket option deprecated.
-		[  277.782014]  __sctp_write_space+0x5b6/0x920
-		[  277.782014]  ? __sctp_write_space+0x3f7/0x920
-		[  277.782014]  ? sctp_transport_lookup_process+0x190/0x190
-		[  277.782014]  ? trace_hardirqs_on_thunk+0x1a/0x1c
-		`, `INFO: rcu detected stall in __sctp_write_space`, false,
-				},*/{
+		}, {
+			`
+[  277.780013] INFO: rcu_sched self-detected stall on CPU
+[  277.781045] INFO: rcu_sched detected stalls on CPUs/tasks:
+[  277.781153] 	1-...: (65000 ticks this GP) idle=395/140000000000001/0 softirq=122875/122875 fqs=16248
+[  277.781197] 	(detected by 0, t=65002 jiffies, g=72940, c=72939, q=1777)
+[  277.781212] Sending NMI from CPU 0 to CPUs 1:
+[  277.782014] NMI backtrace for cpu 1
+[  277.782014] CPU: 1 PID: 12579 Comm: syz-executor0 Not tainted 4.11.0-rc3+ #71
+[  277.782014] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[  277.782014] task: ffff8801d379e140 task.stack: ffff8801cd590000
+[  277.782014] RIP: 0010:io_serial_in+0x6b/0x90
+[  277.782014] RSP: 0018:ffff8801dbf066a0 EFLAGS: 00000002
+[  277.782014] RAX: dffffc0000000000 RBX: 00000000000003fd RCX: 0000000000000000
+[  277.782014] RDX: 00000000000003fd RSI: 0000000000000005 RDI: ffffffff87020018
+[  277.782014] RBP: ffff8801dbf066b0 R08: 0000000000000003 R09: 0000000000000001
+[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: ffffffff8701ffe0
+[  277.782014] R13: 0000000000000020 R14: fffffbfff0e04041 R15: fffffbfff0e04005
+[  277.782014] FS:  00007fce6fc10700(0000) GS:ffff8801dbf00000(0000) knlGS:0000000000000000
+[  277.782014] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  277.782014] CR2: 000000002084fffc CR3: 00000001c4500000 CR4: 00000000001406e0
+[  277.782014] Call Trace:
+[  277.782014]  <IRQ>
+[  277.782014]  wait_for_xmitr+0x89/0x1c0
+[  277.782014]  ? wait_for_xmitr+0x1c0/0x1c0
+[  277.782014]  serial8250_console_putchar+0x1f/0x60
+[  277.782014]  uart_console_write+0x57/0xe0
+[  277.782014]  serial8250_console_write+0x423/0x840
+[  277.782014]  ? check_noncircular+0x20/0x20
+[  277.782014]  hrtimer_interrupt+0x1c2/0x5e0
+[  277.782014]  local_apic_timer_interrupt+0x6f/0xe0
+[  277.782014]  smp_apic_timer_interrupt+0x71/0xa0
+[  277.782014]  apic_timer_interrupt+0x93/0xa0
+[  277.782014] RIP: 0010:debug_lockdep_rcu_enabled.part.19+0xf/0x60
+[  277.782014] RSP: 0018:ffff8801cd596778 EFLAGS: 00000202 ORIG_RAX: ffffffffffffff10
+[  277.782014] RAX: dffffc0000000000 RBX: 1ffff10039ab2cf7 RCX: ffffc90001758000
+[  277.782014] RDX: 0000000000000004 RSI: ffffffff840561f1 RDI: ffffffff852a75c0
+[  277.782014] RBP: ffff8801cd596780 R08: 0000000000000001 R09: 0000000000000000
+[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: 1ffff10039ab2d1b
+[  277.782014] R13: ffff8801c44d1880 R14: ffff8801cd596918 R15: ffff8801d9b47840
+[  277.782014]  </IRQ>
+[  277.782014]  ? __write_space+0x5b1/0x920
+[  277.782014]  debug_lockdep_rcu_enabled+0x77/0x90
+[  277.782014]  __sctp_write_space+0x5b6/0x920
+[  277.782014]  ? __sctp_write_space+0x3f7/0x920
+[  277.782014]  ? sctp_transport_lookup_process+0x190/0x190
+[  277.782014]  ? trace_hardirqs_on_thunk+0x1a/0x1c
+`, `INFO: rcu detected stall in __sctp_write_space`, false,
+		}, {
+			`
+[  277.780013] INFO: rcu_sched self-detected stall on CPU
+[  277.781045] INFO: rcu_sched detected stalls on CPUs/tasks:
+[  277.781153] 	1-...: (65000 ticks this GP) idle=395/140000000000001/0 softirq=122875/122875 fqs=16248
+[  277.781197] 	(detected by 0, t=65002 jiffies, g=72940, c=72939, q=1777)
+[  277.781212] Sending NMI from CPU 0 to CPUs 1:
+[  277.782014] NMI backtrace for cpu 1
+[  277.782014] CPU: 1 PID: 12579 Comm: syz-executor0 Not tainted 4.11.0-rc3+ #71
+[  277.782014] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[  277.782014] task: ffff8801d379e140 task.stack: ffff8801cd590000
+[  277.782014] RIP: 0010:io_serial_in+0x6b/0x90
+[  277.782014] RSP: 0018:ffff8801dbf066a0 EFLAGS: 00000002
+[  277.782014] RAX: dffffc0000000000 RBX: 00000000000003fd RCX: 0000000000000000
+[  277.782014] RDX: 00000000000003fd RSI: 0000000000000005 RDI: ffffffff87020018
+[  277.782014] RBP: ffff8801dbf066b0 R08: 0000000000000003 R09: 0000000000000001
+[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: ffffffff8701ffe0
+[  277.782014] R13: 0000000000000020 R14: fffffbfff0e04041 R15: fffffbfff0e04005
+[  277.782014] FS:  00007fce6fc10700(0000) GS:ffff8801dbf00000(0000) knlGS:0000000000000000
+[  277.782014] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  277.782014] CR2: 000000002084fffc CR3: 00000001c4500000 CR4: 00000000001406e0
+[  277.782014] Call Trace:
+[  277.782014]  <IRQ>
+[  277.782014]  wait_for_xmitr+0x89/0x1c0
+[  277.782014]  ? wait_for_xmitr+0x1c0/0x1c0
+[  277.782014]  serial8250_console_putchar+0x1f/0x60
+[  277.782014]  uart_console_write+0x57/0xe0
+[  277.782014]  serial8250_console_write+0x423/0x840
+[  277.782014]  ? check_noncircular+0x20/0x20
+[  277.782014]  hrtimer_interrupt+0x1c2/0x5e0
+[  277.782014]  local_apic_timer_interrupt+0x6f/0xe0
+[  277.782014]  smp_apic_timer_interrupt+0x71/0xa0
+[  277.782014]  apic_timer_interrupt+0x93/0xa0
+[  277.782014] RIP: 0010:debug_lockdep_rcu_enabled.part.19+0xf/0x60
+[  277.782014] RSP: 0018:ffff8801cd596778 EFLAGS: 00000202 ORIG_RAX: ffffffffffffff10
+[  277.782014] RAX: dffffc0000000000 RBX: 1ffff10039ab2cf7 RCX: ffffc90001758000
+[  277.782014] RDX: 0000000000000004 RSI: ffffffff840561f1 RDI: ffffffff852a75c0
+[  277.782014] RBP: ffff8801cd596780 R08: 0000000000000001 R09: 0000000000000000
+[  277.782014] R10: dffffc0000000000 R11: ffffffff867ba200 R12: 1ffff10039ab2d1b
+[  277.782014] R13: ffff8801c44d1880 R14: ffff8801cd596918 R15: ffff8801d9b47840
+[  277.782014]  </IRQ>
+[  277.782014]  ? __write_space+0x5b1/0x920
+[  277.782014]  debug_lockdep_rcu_enabled+0x77/0x90
+[  292.742848] sctp: [Deprecated]: syz-executor0 (pid 22154) Use of int in max_burst socket option deprecated.
+[  277.782014]  __sctp_write_space+0x5b6/0x920
+[  277.782014]  ? __sctp_write_space+0x3f7/0x920
+[  277.782014]  ? sctp_transport_lookup_process+0x190/0x190
+[  277.782014]  ? trace_hardirqs_on_thunk+0x1a/0x1c
+`, `INFO: rcu detected stall`, false,
+		}, {
 			`
 [ 1722.511384] INFO: rcu_preempt detected stalls on CPUs/tasks: { 2} (detected by 0, t=65008 jiffies, g=48068, c=48067, q=7339)
 `, `INFO: rcu detected stall`, true,
@@ -1734,8 +1779,7 @@ Booting the kernel.
 [    1.971945] Kernel memory protection disabled.
 `, `unexpected kernel reboot`, false,
 		},
-		// TODO: broken: https://github.com/google/syzkaller/issues/457
-		//{`BUG: executor-detected bug`, `BUG: executor-detected bug`, false},
+		{`BUG: executor-detected bug`, `BUG: executor-detected bug`, false},
 		{`INFO:`, `INFO:`, true},
 	}
 	testParse(t, "linux", tests)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -128,7 +128,7 @@ func matchOops(line []byte, oops *oops, ignores []*regexp.Regexp) int {
 	return match
 }
 
-func extractDescription(output []byte, oops *oops) (desc string, report []byte, format oopsFormat) {
+func extractDescription(output []byte, oops *oops) (desc string, format oopsFormat) {
 	startPos := -1
 	for _, f := range oops.formats {
 		match := f.title.FindSubmatchIndex(output)
@@ -144,14 +144,11 @@ func extractDescription(output []byte, oops *oops) (desc string, report []byte, 
 			args = append(args, string(output[match[i]:match[i+1]]))
 		}
 		desc = fmt.Sprintf(f.fmt, args...)
-		report = output[startPos:]
 		format = f
 	}
 	if len(desc) == 0 {
 		pos := bytes.Index(output, oops.header)
 		if pos == -1 {
-			// TODO: broken: https://github.com/google/syzkaller/issues/457
-			// panic(fmt.Sprintf("non matching oops for %q in:\n%s", oops.header, output))
 			return
 		}
 		end := bytes.IndexByte(output[pos:], '\n')
@@ -161,7 +158,6 @@ func extractDescription(output []byte, oops *oops) (desc string, report []byte, 
 			end += pos
 		}
 		desc = string(output[pos:end])
-		report = output[pos:]
 	}
 	if len(desc) > 0 && desc[len(desc)-1] == '\r' {
 		desc = desc[:len(desc)-1]

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -151,15 +151,17 @@ func MonitorExecution(outc <-chan []byte, errc <-chan error, reporter report.Rep
 		if rep == nil {
 			panic(fmt.Sprintf("reporter.ContainsCrash/Parse disagree:\n%s", output[matchPos:]))
 		}
-		start := rep.StartPos + matchPos - beforeContext
+		start := matchPos + rep.StartPos - beforeContext
 		if start < 0 {
 			start = 0
 		}
-		end := rep.EndPos + matchPos + afterContext
+		end := matchPos + rep.EndPos + afterContext
 		if end > len(output) {
 			end = len(output)
 		}
 		rep.Output = output[start:end]
+		rep.StartPos += matchPos - start
+		rep.EndPos += matchPos - start
 		return rep
 	}
 


### PR DESCRIPTION
Try extracting report from console output only first. If that doesn't work, try extracting it from the whole log.

Add regexp for executor printed BUGs.

Optimize regexps for rcu detected stalls.

Update rep.StartPos and rep.EndPos in vm/vm.go as well as rep.Output.

Fixes #457