### PR TITLE
Syz-manager: add simple email support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,3 +25,4 @@ Yuzhe Han
 Thomas Garnier
 Utkarsh Anand
 Tobias Klauser
+Tim Tianyang Chen

--- a/syz-manager/mgrconfig/mgrconfig.go
+++ b/syz-manager/mgrconfig/mgrconfig.go
@@ -34,6 +34,8 @@ type Config struct {
 	Hub_Addr   string
 	Hub_Key    string
 
+	Email_addr string
+
 	Dashboard_Client string
 	Dashboard_Addr   string
 	Dashboard_Key    string


### PR DESCRIPTION
Users can specify an email address to reveive notifications when a
bug is discovered the first time, without setting up a full fledged
dashboard. Supported mailer is mailx.

Signed-off-by: Tim Tianyang Chen <soapcn@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
