### PR TITLE
syz-manager: add simple email support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Jean-Baptiste Cayrou
 Yuzhe Han
 Utkarsh Anand
 Tobias Klauser
+Tim Tianyang Chen

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,3 +25,4 @@ Yuzhe Han
 Thomas Garnier
 Utkarsh Anand
 Tobias Klauser
+Tim Tianyang Chen

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@ invocation time with the `-config` option.  This configuration can be based on t
 following keys in its top-level object:
 
  - `http`: URL that will display information about the running `syz-manager` process.
+ - `email_addr`: Optional email address to receive notifications when bugs are encountered for the first time.
+   Mailx is the only supported mailer. Please set it up prior to using this function.
  - `workdir`: Location of a working directory for the `syz-manager` process. Outputs here include:
      - `<workdir>/crashes/*`: crash output files (see [Crash Reports](#crash-reports))
      - `<workdir>/corpus.db`: corpus with interesting programs

--- a/syz-manager/mgrconfig/mgrconfig.go
+++ b/syz-manager/mgrconfig/mgrconfig.go
@@ -34,6 +34,8 @@ type Config struct {
 	Hub_Addr   string
 	Hub_Key    string
 
+	Email_Addr string // syz-manager will send crash emails to this address using mailx (optional)
+
 	Dashboard_Client string
 	Dashboard_Addr   string
 	Dashboard_Key    string


### PR DESCRIPTION
Users can specify an email address to reveive notifications when a
bug is discovered for the first time, without setting up a full fledged
dashboard. The supported mailer is mailx.

Signed-off-by: Tim Tianyang Chen <soapcn@gmail.com>