### PR TITLE
Makefile: fix Android builds

### DIFF
--- a/docs/linux/setup_linux-host_android-device_arm64-kernel.md
+++ b/docs/linux/setup_linux-host_android-device_arm64-kernel.md
@@ -2,14 +2,12 @@
 
 Prerequisites:
  - go1.8+ toolchain (can be downloaded from [here](https://golang.org/dl/))
- - Android NDK (tested with r15 on API24) (can be downloaded from [here](https://developer.android.com/ndk/downloads/index.html))
-     + Set the `$NDK` environment variable to point at it
  - Android Serial Cable or [Suzy-Q](https://chromium.googlesource.com/chromiumos/platform/ec/+/master/docs/case_closed_debugging.md) device to capture console output is preferable but optional. syzkaller can work with normal USB cable as well, but that can be somewhat unreliable and turn lots of crashes into "lost connection to test machine" crashes with no additional info.
 
  - Build syzkaller
 
 ```sh
-$ NDK=/path/to/android/ndk make TARGETOS=android TARGETARCH=arm64
+$ make TARGETOS=linux TARGETARCH=arm64
 ```
 
  - Create config with `"type": "adb"` and specify adb devices to use. For example:

--- a/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
+++ b/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
@@ -21,7 +21,6 @@ Install Go as follows:
 ``` bash
 wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz
 tar -xf go1.9.2.linux-amd64.tar.gz
-mv go goroot
 export PATH=`pwd`/go/bin:$PATH
 mkdir gopath
 export GOPATH=`pwd`/gopath
@@ -31,7 +30,7 @@ export GOPATH=`pwd`/gopath
 
 ### Initialize a working directory and set up environment variables
 
-Create a working directory. Also make sure GOROOT, GOPATH, and optionally NDKARM are defined and exported as instructed earlier. 
+Create a working directory. Also make sure GOROOT, GOPATH are defined and exported as instructed earlier.
 
 ``` bash
 go get -u -d github.com/google/syzkaller/...
@@ -45,10 +44,6 @@ Run make.
 ```
 make TARGETOS=linux TARGETARCH=arm
 ```
-As an alternative, is possible to use the Android NDK toolchain to build syz-executor.
-To do that, one way is to create an Android.mk file and and Application.mk file
-and to use the Android NDK's ndk-build program to build syz-executor from executor/executor_linux.cc. The clang cross-compiler, which is
-part of the Android NDK, is going to be needed for a successful build.
 
 ### Create a manager configuration file
 


### PR DESCRIPTION
There are 2 known problems with current Android support:
1. It does not work with newer NDK
(happens on every NDK update).
2. Dynamic Go binaries do not start on Android emulator.

Drop special Android support and just build static linux binaries.

For context see:
https://groups.google.com/forum/#!msg/syzkaller/etg1ZJmTMzg/NYE-yjxxAQAJ
https://groups.google.com/d/msg/syzkaller/8KjCYWslTFY/1oTXn5tTAgAJ

Fixes #478