### PR TITLE
Makefile: fix git "modified tree" test on FreeBSD

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Yuzhe Han
 Utkarsh Anand
 Tobias Klauser
 Tim Tianyang Chen
+Ed Maste

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,3 +26,4 @@ Thomas Garnier
 Utkarsh Anand
 Tobias Klauser
 Tim Tianyang Chen
+Ed Maste

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ifeq ("$(TARGETOS)", "windows")
 endif
 
 GITREV=$(shell git rev-parse HEAD)
-ifeq ($(`git diff --shortstat`), "")
+ifeq ("$(shell git diff --shortstat)", "")
 	REV=$(GITREV)
 else
 	REV=$(GITREV)+


### PR DESCRIPTION
I'm not sure if this is due to different versions of gmake or some other
reason, but the Makefile falsely detected a modified git tree when the
first ifeq argument was unquoted. Also switch to the $(shell ... style
for consistency.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
