### PR TITLE
syz/syz-extract: Update Fuchsia extractor with current Fuchsia paths.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Google Inc.
  Willem de Bruijn
  Eric Biggers
  Atul Prakash
+ Julia Hansbrough
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ ifeq ("$(TARGETOS)", "fuchsia")
 	export CGO_ENABLED=1
 	NOSTATIC = 1
 	ifeq ("$(TARGETARCH)", "amd64")
-		ADDCFLAGS = --target=x86_64-fuchsia -lfdio -lzircon --sysroot $(SOURCEDIR)/out/build-zircon/build-zircon-pc-x86-64/sysroot -I $(SOURCEDIR)/out/build-zircon/build-zircon-pc-x86-64
+		ADDCFLAGS = --target=x86_64-fuchsia -lfdio -lzircon --sysroot $(SOURCEDIR)/out/build-zircon/build-user-x86-64/sysroot -I $(SOURCEDIR)/out/build-zircon/build-user-x86-64
 	else ifeq ("$(TARGETARCH)", "arm64")
-		ADDCFLAGS = --target=aarch64-fuchsia -lfdio -lzircon --sysroot $(SOURCEDIR)/out/build-zircon/build-zircon-pc-arm64/sysroot -I $(SOURCEDIR)/out/build-zircon/build-zircon-pc-arm64
+		ADDCFLAGS = --target=aarch64-fuchsia -lfdio -lzircon --sysroot $(SOURCEDIR)/out/build-zircon/build-user-arm64/sysroot -I $(SOURCEDIR)/out/build-zircon/build-user-arm64
 	endif
 endif
 

--- a/sys/syz-extract/fuchsia.go
+++ b/sys/syz-extract/fuchsia.go
@@ -26,7 +26,7 @@ func (*fuchsia) prepareArch(arch *Arch) error {
 func (*fuchsia) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uint64, map[string]bool, error) {
 	dir := arch.sourceDir
 	cc := filepath.Join(dir, "buildtools", "linux-x64", "clang", "bin", "clang")
-	includeDir := filepath.Join(dir, "out", "build-zircon", "build-zircon-pc-x86-64", "sysroot", "include")
+	includeDir := filepath.Join(dir, "out", "build-zircon", "build-user-x86-64", "sysroot", "include")
 	args := []string{"-fmessage-length=0", "-I" + includeDir}
 	for _, incdir := range info.Incdirs {
 		args = append(args, "-I"+filepath.Join(dir, incdir))


### PR DESCRIPTION
A change in Zircon a while back moved around where sysroots are located
in Fuchsia; this update will allow for proper extraction.