### PR TITLE
travis: switch to Go 1.9+1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 dist: trusty
 
 go:
-  - 1.8
-  - 1.9rc1
+  - "1.9"
+  - "1.10"
 
 before_install:
   - echo $PATH


### PR DESCRIPTION
1.9 is available for a long time, no point in testing in 1.9rc1.
1.10 is already released too.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
