### PR TITLE
executor: add support for FreeBSD's kcov

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Tobias Klauser
 Tim Tianyang Chen
 Ed Maste
 Sumukha PK
+Mitchell Horne

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,3 +29,4 @@ Tobias Klauser
 Tim Tianyang Chen
 Ed Maste
 Sumukha PK
+Mitchell Horne


### PR DESCRIPTION
This patch makes the changes necessary to support the new kcov interface in FreeBSD; allowing coverage data to be collected when syzkaller is run on this platform. The interface is intentionally very similar to that of the Linux kcov.

The changes to support this feature in FreeBSD have not been merged yet and therefore are not necessarily final. However, it is unlikely that there will be any changes to the interface itself. Those interested can visit the review for this patch [here](https://reviews.freebsd.org/D14599).