### PR TITLE
Change email address for reporting bugs

### DIFF
--- a/docs/linux/reporting_kernel_bugs.md
+++ b/docs/linux/reporting_kernel_bugs.md
@@ -3,7 +3,7 @@
 Before reporting a bug make sure nobody else already reported it. The easiest way to do this is to search through the [syzkaller mailing list](https://groups.google.com/forum/#!forum/syzkaller) for key frames present in the kernel stack traces.
 
 Please report found bugs to the Linux kernel maintainers.
-To find out the list of maintainers responsible for a particular kernel subsystem, use the [get_maintainer.pl](https://github.com/torvalds/linux/blob/master/scripts/get_maintainer.pl) script: `./scripts/get_maintainer.pl -f guilty_file.c`. Please add `syzkaller@googlegroups.com` to the CC list.
+To find out the list of maintainers responsible for a particular kernel subsystem, use the [get_maintainer.pl](https://github.com/torvalds/linux/blob/master/scripts/get_maintainer.pl) script: `./scripts/get_maintainer.pl -f guilty_file.c`. Please add `syzkaller-bugs@googlegroups.com` to the CC list.
 Make sure to mention the exact kernel branch and revision where the bug occured.
 Many kernel mailing lists reject HTML formatted messages, so use the plain text mode when sending the report.
 


### PR DESCRIPTION
I believe they should go to the bugs list, not the main list, now.
