### PR TITLE
adb: add debug level to ALERT for UART detector

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -185,7 +185,7 @@ func findConsoleImpl(adb, dev string) (string, error) {
 	}
 	time.Sleep(500 * time.Millisecond)
 	unique := fmt.Sprintf(">>>%v<<<", dev)
-	cmd := osutil.Command(adb, "-s", dev, "shell", "echo", "\"", unique, "\"", ">", "/dev/kmsg")
+	cmd := osutil.Command(adb, "-s", dev, "shell", "echo", "\"<1>", unique, "\"", ">", "/dev/kmsg")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to run adb shell: %v\n%s", err, out)
 	}


### PR DESCRIPTION
Hi,

While getting my syzkaller setup ready, I realized that the auto detection of UART assume that the UART display all the level of printk. Which is not the case on my setup.

Adding the ALERT tag to the echo in kmsg to ensure proper detection

******


The UART output may filter lower level messages.
This ensure proper detection of the unique ID

Signed-off-by: Jean-Baptiste Théou <jb@essential.com>
