### PR TITLE
prog: Fix page fault for syz-stress users.

### DIFF
--- a/prog/resources.go
+++ b/prog/resources.go
@@ -105,7 +105,6 @@ func (target *Target) TransitivelyEnabledCalls(enabled map[*Syscall]bool) (map[*
 	}
 	for {
 		n := len(supported)
-		haveGettime := supported[target.SyscallMap["clock_gettime"]]
 		for c := range supported {
 			cantCreate := ""
 			var resourceCtors []*Syscall
@@ -122,16 +121,6 @@ func (target *Target) TransitivelyEnabledCalls(enabled map[*Syscall]bool) (map[*
 					resourceCtors = ctors[res.Desc.Name]
 					break
 				}
-			}
-			// We need to support structs as resources,
-			// but for now we just special-case timespec/timeval.
-			if cantCreate == "" && !haveGettime {
-				ForeachType(c, func(typ Type) {
-					if a, ok := typ.(*StructType); ok && a.Dir() != DirOut && (a.Name() == "timespec" || a.Name() == "timeval") {
-						cantCreate = a.Name()
-						resourceCtors = []*Syscall{target.SyscallMap["clock_gettime"]}
-					}
-				})
 			}
 			if cantCreate != "" {
 				delete(supported, c)


### PR DESCRIPTION
In resources.go, haveGettime is False when SyscallMap["clock_gettime"]
is nil.

In this code, there's a branch that's entered only if haveGettime is
False, which appends SyscallMap["clock_gettime"] to resourceCtors.  That
is, it appends <nil> to resourceCtors, and then subsequently attempts to
iterate through resourceCtors and dereference the .Name of each
item--that is, it attempts to <nil>.Name.

This was causing a page fault on Fuchsia.  I'm uncertain how this was
supposed to work; since it seems to me that any code that actually
enters the 'if cantCreate == "" && !haveGetttime' branch is doomed to
fail similarly, I've simply removed that whole section.  If there's a
different way to handle the timespec/timeval special-case, I'm open to
the suggestion.