### PR TITLE
prog: Fix page fault for syz-stress users.

### DIFF
--- a/prog/resources.go
+++ b/prog/resources.go
@@ -125,7 +125,7 @@ func (target *Target) TransitivelyEnabledCalls(enabled map[*Syscall]bool) (map[*
 			}
 			// We need to support structs as resources,
 			// but for now we just special-case timespec/timeval.
-			if cantCreate == "" && !haveGettime {
+			if cantCreate == "" && !haveGettime && target.SyscallMap["clock_gettime"] != nil {
 				ForeachType(c, func(typ Type) {
 					if a, ok := typ.(*StructType); ok && a.Dir() != DirOut && (a.Name() == "timespec" || a.Name() == "timeval") {
 						cantCreate = a.Name()


### PR DESCRIPTION
In resources.go, haveGettime is False when SyscallMap["clock_gettime"]
is nil.

In this code, there's a branch that's entered only if Gettime is False,
which appends SyscallMap["clock_gettime"] to resourceCtors.  That is, it
appends nil to resourceCtors, then iterates through resourceCtors and
tries to dereference the .Name of each time, in this case, nil.Name.

This was causing a page fault on Fuchsia.

I'm not certain how the "standard" flow is supposed to work, since it
seems like any code that enters the `if cantCreate == "" && !haveGettime`
should fail... but removing that section causes test failures, so let's
just enforce that SyscallMap["clock_gettime"] is non-nil.

If there's a better way to solve this, I'm open to suggestions, I'm not
super-sure how the transitively-enabled syscall stuff is supposed to
work :)

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
