### PR TITLE
ipc: Use default TempDir location for syzkaller testdirs.

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -529,7 +529,7 @@ type callReply struct {
 */
 
 func makeCommand(pid int, bin []string, config *Config, inFile *os.File, outFile *os.File) (*command, error) {
-	dir, err := ioutil.TempDir("./", "syzkaller-testdir")
+	dir, err := ioutil.TempDir("", "syzkaller-testdir")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %v", err)
 	}


### PR DESCRIPTION
Fuchsia has opinions about which filesystems should be read-only,
read-write, etc, and in particular, it's pretty unhappy about making a
temporary directory in the same place as wherever you're running
syzkaller from.

Changing this to use TempDir's "default" behavior doesn't seem like it
should cause any major problems for other OSes, but I could be wrong!
If so, perhaps we should add a if GOOS == fuchsia switch of some sort?
Please let me know, thanks.