### PR TITLE
executor: fix strncpy compile error

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -645,7 +645,7 @@ static uintptr_t syz_open_dev(uintptr_t a0, uintptr_t a1, uintptr_t a2)
 		// syz_open_dev(dev strconst, id intptr, flags flags[open_flags]) fd
 		char buf[1024];
 		char* hash;
-		NONFAILING(strncpy(buf, (char*)a0, sizeof(buf)));
+		NONFAILING(strncpy(buf, (char*)a0, sizeof(buf) - 1));
 		buf[sizeof(buf) - 1] = 0;
 		while ((hash = strchr(buf, '#'))) {
 			*hash = '0' + (char)(a1 % 10); // 10 devices should be enough for everyone.

--- a/pkg/csource/linux_common.go
+++ b/pkg/csource/linux_common.go
@@ -765,7 +765,7 @@ static uintptr_t syz_open_dev(uintptr_t a0, uintptr_t a1, uintptr_t a2)
 	} else {
 		char buf[1024];
 		char* hash;
-		NONFAILING(strncpy(buf, (char*)a0, sizeof(buf)));
+		NONFAILING(strncpy(buf, (char*)a0, sizeof(buf) - 1));
 		buf[sizeof(buf) - 1] = 0;
 		while ((hash = strchr(buf, '#'))) {
 			*hash = '0' + (char)(a1 % 10);


### PR DESCRIPTION
gcc8 is stricter when dealing with strings and strncpy and demands that
the size of the actual string to be copied to be explicitly smaller than
the size of the destination, just to make sure the NULL terminator is
taken into considerantion. This patch fixes the issue.

Signed-off-by: Ioana Ciornei <ciorneiioana@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
