### PR TITLE
vm/adb: disable kptr_restrict for Android

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -112,6 +112,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	if _, err := inst.adb("shell", "rm -Rf /data/syzkaller*"); err != nil {
 		return nil, err
 	}
+	inst.adb("shell", "echo 0 > /proc/sys/kernel/kptr_restrict")
 	closeInst = nil
 	return inst, nil
 }


### PR DESCRIPTION
echo 0 to kptr_restrict in /proc/sys/kernel to unhide
kernel pointers when fuzzing for more reliable crash
dedup and easier debugging when analyzing crash.