### PR TITLE
pkg/csource: use CC env variable to determine compiler

### DIFF
--- a/pkg/csource/build.go
+++ b/pkg/csource/build.go
@@ -20,7 +20,10 @@ import (
 // lang can be "c" or "c++".
 func Build(target *prog.Target, lang, src string) (string, error) {
 	sysTarget := targets.List[target.OS][target.Arch]
-	compiler := sysTarget.CCompilerPrefix + "gcc"
+	compiler := os.Getenv("CC")
+	if compiler == "" {
+		compiler = sysTarget.CCompilerPrefix + "gcc"
+	}
 	if _, err := exec.LookPath(compiler); err != nil {
 		return "", ErrNoCompiler
 	}


### PR DESCRIPTION
The problem relates https://github.com/google/syzkaller/issues/387
You can call ```make CC=gcc``` to build syzkaller before running. Sometimes syzkaller fails to build programs at runtime since compiler is hardcoded in the sources.

This patch allows you to set the compiler through env variable
```
CC=gcc ./bin/syz-manager -config=my.cfg
```

Signed-off-by: Denis Efremov <efremov@linux.com>
