### PR TITLE
sys/linux: add MORUS and AEGIS AEAD algorithms

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,3 +31,4 @@ Ed Maste
 Sumukha PK
 Mitchell Horne
 Denis Efremov
+Ondrej Mosnacek

--- a/sys/linux/init_alg.go
+++ b/sys/linux/init_alg.go
@@ -145,6 +145,17 @@ var allAlgs = map[int][]algDesc{
 		{"generic-gcm-aesni", nil},
 		{"rfc4106(gcm(aes))", nil},
 		{"rfc4106-gcm-aesni", nil},
+		{"morus640", nil},
+		{"morus640-sse2", nil},
+		{"morus1280", nil},
+		{"morus1280-sse2", nil},
+		{"morus1280-avx2", nil},
+		{"aegis128", nil},
+		{"aegis128-aesni", nil},
+		{"aegis128l", nil},
+		{"aegis128l-aesni", nil},
+		{"aegis256", nil},
+		{"aegis256-aesni", nil},
 	},
 	ALG_BLKCIPHER: []algDesc{
 		// templates:


### PR DESCRIPTION
This adds some recently added AEAD algorithms to the Linux kernel AF_ALG fuzzer:
https://www.mail-archive.com/linux-crypto@vger.kernel.org/msg32482.html
https://www.mail-archive.com/linux-crypto@vger.kernel.org/msg32483.html