### PR TITLE
sys/linux: fix cdrom rules description && clarification on how to run

### DIFF
--- a/executor/syscalls_linux.h
+++ b/executor/syscalls_linux.h
@@ -2,7 +2,7 @@
 
 #if defined(__i386__) || 0
 #define GOARCH "386"
-#define SYZ_REVISION "364c0466af55878a451d03bbf22f45852bcec1a0"
+#define SYZ_REVISION "a6661142b93c11db8d1d1253914e00ca5eb5504b"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -1946,7 +1946,7 @@ call_t syscalls[] = {
 
 #if defined(__x86_64__) || 0
 #define GOARCH "amd64"
-#define SYZ_REVISION "34877cabdba599dec5cfcdaf6a3f78dfe8af5cab"
+#define SYZ_REVISION "ef630c1493604d9e7a11a50322a48378defe8d2e"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -3942,7 +3942,7 @@ call_t syscalls[] = {
 
 #if defined(__arm__) || 0
 #define GOARCH "arm"
-#define SYZ_REVISION "3e7f1693d65a9c120f55ffe695d40e6dc50d83e9"
+#define SYZ_REVISION "b79014bd05edc06999bb4b6c7ef39ac45440abab"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -5895,7 +5895,7 @@ call_t syscalls[] = {
 
 #if defined(__aarch64__) || 0
 #define GOARCH "arm64"
-#define SYZ_REVISION "7fe8b3bb2d53395bfd16e16e39995ff9a22b534f"
+#define SYZ_REVISION "3f4434724cfe38d2510fb0e8848e65720bce8f86"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -7820,7 +7820,7 @@ call_t syscalls[] = {
 
 #if defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__) || 0
 #define GOARCH "ppc64le"
-#define SYZ_REVISION "ace22c31a6cf8dbfb5b916023e433cb78dde774a"
+#define SYZ_REVISION "fe5564af087a50bc8d72c0df149c667a8cd62d8e"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912

--- a/sys/linux/cdrom.txt
+++ b/sys/linux/cdrom.txt
@@ -1,6 +1,18 @@
 # Copyright 2018 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+# For fuzzing with qemu you need to enable cdrom option and provide an iso image.
+# For example: in "vm" section of syzkaller configuration
+# "vm" : {
+#     ...
+#     "cmdline": " -cdrom /.../ubuntu-18.04-desktop-amd64.iso "
+# }
+# In the kernel CONFIG_CDROM should be enabled.
+#
+# For more effective fuzzing one might want to disable
+# CDROMEJECT && CDROMEJECT_SW.
+# "disable_syscalls" : [ "ioctl$CDROMEJECT*" ]
+
 include <linux/cdrom.h>
 include <uapi/linux/cdrom.h>
 
@@ -52,7 +64,7 @@ ioctl$CDROM_LOCKDOOR(fd fd_cdrom, cmd const[CDROM_LOCKDOOR], lock boolptr)
 ioctl$CDROM_DEBUG(fd fd_cdrom, cmd const[CDROM_DEBUG], debug boolptr)
 ioctl$CDROM_GET_CAPABILITY(fd fd_cdrom, cmd const[CDROM_GET_CAPABILITY])
 
-ioctl$CDROMAUDIOBUFSIZ(fd fd_cdrom, cmd const[CDROMAUDIOBUFSIZ], val intptr)
+ioctl$CDROMAUDIOBUFSIZ(fd fd_cdrom, cmd const[CDROMAUDIOBUFSIZ], val int32)
 
 ioctl$DVD_READ_STRUCT(fd fd_cdrom, cmd const[DVD_READ_STRUCT], arg ptr[inout, dvd_struct])
 ioctl$DVD_WRITE_STRUCT(fd fd_cdrom, cmd const[DVD_READ_STRUCT], arg ptr[in, dvd_struct])
@@ -68,9 +80,9 @@ cdrom_output_buffer {
 }
 
 cdrom_read {
-	cdread_lba	intptr
+	cdread_lba	int32
 	cdread_bufaddr	ptr[out, array[int8]]
-	cdread_buflen	len[cdread_bufaddr, intptr]
+	cdread_buflen	len[cdread_bufaddr, int32]
 }
 
 cdrom_msf {
@@ -115,7 +127,7 @@ cdrom_tocentry {
 
 cdrom_addr [
 	msf	cdrom_msf0
-	lba	intptr
+	lba	int32
 ]
 
 cdrom_msf0 {
@@ -127,7 +139,7 @@ cdrom_msf0 {
 cdrom_read_audio {
 	addr		cdrom_addr
 	addr_format	flags[cdrom_format, int8]
-	nframes		bytesize[buf, intptr[1:CD_FRAMES]]
+	nframes		bytesize[buf, int32[1:CD_FRAMES]]
 	buf		ptr[out, array[int8]]
 }
 
@@ -160,7 +172,7 @@ cdrom_mcn {
 }
 
 cdrom_blk {
-	from	intptr
+	from	int32
 	len	int16
 }
 
@@ -207,14 +219,14 @@ dvd_copyright {
 dvd_disckey {
 	type	const[DVD_STRUCT_DISCKEY, int8]
 
-	agid	intptr:2
+	agid	int32:2
 	value	array[int8, 2048]
 }
 
 dvd_bca {
 	type	const[DVD_STRUCT_BCA, int8]
 
-	len	len[value, intptr]
+	len	len[value, int32]
 	value	array[int8, 188]
 }
 
@@ -222,7 +234,7 @@ dvd_manufact {
 	type		const[DVD_STRUCT_MANUFACT, int8]
 
 	layer_num	int8[0:3]
-	len		len[value, intptr]
+	len		len[value, int32]
 	value		array[int8, 2048]
 }
 
@@ -245,12 +257,12 @@ type dvd_challenge array[int8, 10]
 
 dvd_lu_send_agid {
 	type	const[DVD_LU_SEND_AGID, int8]
-	agid	intptr:2
+	agid	int32:2
 }
 
 dvd_host_send_challenge {
 	type	const[DVD_HOST_SEND_CHALLENGE, int8]
-	agid	intptr:2
+	agid	int32:2
 
 	chal	dvd_challenge
 }
@@ -259,34 +271,34 @@ dvd_send_key_type = DVD_LU_SEND_KEY1, DVD_HOST_SEND_KEY2
 
 dvd_send_key {
 	type	flags[dvd_send_key_type, int8]
-	agid	intptr:2
+	agid	int32:2
 
 	key	dvd_key
 }
 
 dvd_lu_send_challenge {
 	type	const[DVD_LU_SEND_CHALLENGE, int8]
-	agid	intptr:2
+	agid	int32:2
 
 	chal	dvd_challenge
 }
 
 dvd_lu_send_title_key {
 	type		const[DVD_LU_SEND_TITLE_KEY, int8]
-	agid		intptr:2
+	agid		int32:2
 
 	title_key	dvd_key
-	lba		intptr
-	cpm		intptr:1
-	cp_sec		intptr:1
-	cgms		intptr:2
+	lba		int32
+	cpm		int32:1
+	cp_sec		int32:1
+	cgms		int32:2
 }
 
 dvd_lu_send_asf {
 	type	const[DVD_LU_SEND_ASF, int8]
-	agid	intptr:2
+	agid	int32:2
 
-	asf	intptr:1
+	asf	int32:1
 }
 
 dvd_host_send_rpcstate {
@@ -305,12 +317,12 @@ dvd_lu_send_rpcstate {
 cdrom_generic_command {
 	cmd		array[int8, CDROM_PACKET_SIZE]
 	buffer		ptr[inout, array[int8]]
-	buflen		len[buffer, intptr]
-	stat		intptr
+	buflen		len[buffer, int32]
+	stat		int32
 	sense		ptr[inout, request_sense]
 	data_direction	flags[cdrom_data_direction, int8]
-	quiet		intptr
-	timeout		intptr
+	quiet		int32
+	timeout		int32
 	reserved	ptr[out, array[intptr, 1]]
 }
 

--- a/sys/linux/gen/386.go
+++ b/sys/linux/gen/386.go
@@ -1002,14 +1002,14 @@ var structDescs_386 = []*KeyedStruct{
 	}}},
 	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0"}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4}}},
 	}}},
 	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4, ArgDir: 2}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0", Dir: 2}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
 	}}},
 	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 8}, Fields: []Type{
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "from", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "from", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int16", FldName: "len", TypeSize: 2}}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1017,12 +1017,12 @@ var structDescs_386 = []*KeyedStruct{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "cmd", TypeSize: 12, ArgDir: 2}, Kind: 1, RangeBegin: 12, RangeEnd: 12},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buffer", TypeSize: 4}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 2, IsVarlen: true}}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 4, ArgDir: 2}}, Buf: "buffer"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "sense", TypeSize: 4}, Type: &StructType{Key: StructKey{Name: "request_sense", Dir: 2}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_data_direction", FldName: "data_direction", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "reserved", TypeSize: 4}, Type: &ArrayType{TypeCommon: TypeCommon{TypeName: "array", TypeSize: 4, ArgDir: 1}, Type: &IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", TypeSize: 4, ArgDir: 1}}}, Kind: 1, RangeBegin: 1, RangeEnd: 1}},
 	}}},
 	{Key: StructKey{Name: "cdrom_mcn", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_mcn", TypeSize: 14, ArgDir: 1}, Fields: []Type{
@@ -1628,19 +1628,19 @@ var structDescs_386 = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 2},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 2},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 1},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1683,18 +1683,18 @@ var structDescs_386 = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 8},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1708,13 +1708,13 @@ var structDescs_386 = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 7},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "title_key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
 	}}},
 	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 4},
@@ -1745,7 +1745,7 @@ var structDescs_386 = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_send_key_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
@@ -19698,7 +19698,7 @@ var syscalls_386 = []*Syscall{
 	{NR: 54, Name: "ioctl$CDROMAUDIOBUFSIZ", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "cmd", TypeSize: 4}}, Val: 21378},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "val", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "val", TypeSize: 4}}},
 	}},
 	{NR: 54, Name: "ioctl$CDROMCLOSETRAY", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
@@ -33656,4 +33656,4 @@ var consts_386 = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_386 = "364c0466af55878a451d03bbf22f45852bcec1a0"
+const revision_386 = "a6661142b93c11db8d1d1253914e00ca5eb5504b"

--- a/sys/linux/gen/arm.go
+++ b/sys/linux/gen/arm.go
@@ -1007,14 +1007,14 @@ var structDescs_arm = []*KeyedStruct{
 	}}},
 	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0"}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4}}},
 	}}},
 	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4, ArgDir: 2}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0", Dir: 2}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
 	}}},
 	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 8}, Fields: []Type{
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "from", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "from", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int16", FldName: "len", TypeSize: 2}}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1022,12 +1022,12 @@ var structDescs_arm = []*KeyedStruct{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "cmd", TypeSize: 12, ArgDir: 2}, Kind: 1, RangeBegin: 12, RangeEnd: 12},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buffer", TypeSize: 4}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 2, IsVarlen: true}}},
 		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 4, ArgDir: 2}}, Buf: "buffer"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "sense", TypeSize: 4}, Type: &StructType{Key: StructKey{Name: "request_sense", Dir: 2}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_data_direction", FldName: "data_direction", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "reserved", TypeSize: 4}, Type: &ArrayType{TypeCommon: TypeCommon{TypeName: "array", TypeSize: 4, ArgDir: 1}, Type: &IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", TypeSize: 4, ArgDir: 1}}}, Kind: 1, RangeBegin: 1, RangeEnd: 1}},
 	}}},
 	{Key: StructKey{Name: "cdrom_mcn", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_mcn", TypeSize: 14, ArgDir: 1}, Fields: []Type{
@@ -1633,19 +1633,19 @@ var structDescs_arm = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 2},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 2},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 1},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1688,18 +1688,18 @@ var structDescs_arm = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 8},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
@@ -1713,13 +1713,13 @@ var structDescs_arm = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 7},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "title_key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
 	}}},
 	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 4},
@@ -1750,7 +1750,7 @@ var structDescs_arm = []*KeyedStruct{
 	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_send_key_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
@@ -19581,7 +19581,7 @@ var syscalls_arm = []*Syscall{
 	{NR: 54, Name: "ioctl$CDROMAUDIOBUFSIZ", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "cmd", TypeSize: 4}}, Val: 21378},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "val", TypeSize: 4}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "val", TypeSize: 4}}},
 	}},
 	{NR: 54, Name: "ioctl$CDROMCLOSETRAY", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
@@ -33523,4 +33523,4 @@ var consts_arm = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_arm = "3e7f1693d65a9c120f55ffe695d40e6dc50d83e9"
+const revision_arm = "b79014bd05edc06999bb4b6c7ef39ac45440abab"

--- a/sys/linux/gen/arm64.go
+++ b/sys/linux/gen/arm64.go
@@ -1007,30 +1007,31 @@ var structDescs_arm64 = []*KeyedStruct{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cap_version", FldName: "var", TypeSize: 4}}, Vals: []uint64{429392688, 537333798, 537396514}},
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "pid", FldName: "pid", TypeSize: 4}},
 	}}},
-	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 8}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0"}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 8, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4, ArgDir: 2}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0", Dir: 2}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 16}, Fields: []Type{
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "from", TypeSize: 8}}},
+	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 8}, Fields: []Type{
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "from", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int16", FldName: "len", TypeSize: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "cdrom_generic_command", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_generic_command", TypeSize: 80, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_generic_command", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_generic_command", TypeSize: 64, ArgDir: 2}, Fields: []Type{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "cmd", TypeSize: 12, ArgDir: 2}, Kind: 1, RangeBegin: 12, RangeEnd: 12},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buffer", TypeSize: 8}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 2, IsVarlen: true}}},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 8, ArgDir: 2}}, Buf: "buffer"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "stat", TypeSize: 8, ArgDir: 2}}},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 4, ArgDir: 2}}, Buf: "buffer"},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "sense", TypeSize: 8}, Type: &StructType{Key: StructKey{Name: "request_sense", Dir: 2}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_data_direction", FldName: "data_direction", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "quiet", TypeSize: 8, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "timeout", TypeSize: 8, ArgDir: 2}}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "reserved", TypeSize: 8}, Type: &ArrayType{TypeCommon: TypeCommon{TypeName: "array", TypeSize: 8, ArgDir: 1}, Type: &IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", TypeSize: 8, ArgDir: 1}}}, Kind: 1, RangeBegin: 1, RangeEnd: 1}},
 	}}},
 	{Key: StructKey{Name: "cdrom_mcn", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_mcn", TypeSize: 14, ArgDir: 1}, Fields: []Type{
@@ -1063,23 +1064,24 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdmsf_frame1", TypeSize: 1}}},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 2640}, Type: &ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", TypeSize: 1}}}, Kind: 1, RangeBegin: 2640, RangeEnd: 2640},
 	}}},
-	{Key: StructKey{Name: "cdrom_multisession", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_multisession", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_multisession", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_multisession", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&UnionType{Key: StructKey{Name: "cdrom_addr", Dir: 2}, FldName: "addr"},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "xa_flag", TypeSize: 1, ArgDir: 2}}, Kind: 2, RangeEnd: 1},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "addr_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "cdrom_output_buffer", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_output_buffer", TypeSize: 2646, ArgDir: 1}, Fields: []Type{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 2646, ArgDir: 1}, Kind: 1, RangeBegin: 2646, RangeEnd: 2646},
 	}}},
-	{Key: StructKey{Name: "cdrom_read_audio"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_read_audio", TypeSize: 32}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_read_audio"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_read_audio", TypeSize: 24}, Fields: []Type{
 		&UnionType{Key: StructKey{Name: "cdrom_addr"}, FldName: "addr"},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "addr_format", TypeSize: 1}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "nframes", TypeSize: 8}}, BitSize: 8, Buf: "buf"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "nframes", TypeSize: 4}}, BitSize: 8, Buf: "buf"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buf", TypeSize: 8}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 1, IsVarlen: true}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_subchnl", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_subchnl", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_subchnl", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_subchnl", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "cdsc_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdsc_audiostatus", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdsc_adr", TypeSize: 1, ArgDir: 2}, BitfieldLen: 4, BitfieldMdl: true}},
@@ -1096,15 +1098,15 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdti_trk1", TypeSize: 1}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdti_ind1", TypeSize: 1}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_tocentry", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tocentry", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_tocentry", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tocentry", TypeSize: 12, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_track", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_adr", TypeSize: 1, ArgDir: 2}, BitfieldLen: 4, BitfieldMdl: true}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_ctrl", TypeSize: 1, ArgDir: 2}, BitfieldOff: 4, BitfieldLen: 4}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "cdte_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 5}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 1}}, IsPad: true},
 		&UnionType{Key: StructKey{Name: "cdrom_addr", Dir: 2}, FldName: "cdte_addr"},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_datamode", TypeSize: 1, ArgDir: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "cdrom_tochdr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tochdr", TypeSize: 2, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdth_trk0", TypeSize: 1, ArgDir: 2}}},
@@ -1608,7 +1610,7 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "seq", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "signal", TypeSize: 4}}, Kind: 2, RangeEnd: 65},
 	}}},
-	{Key: StructKey{Name: "dvd_authinfo", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_authinfo", TypeSize: 40, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_authinfo", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_authinfo", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_authinfo_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 2, 3, 7, 8, 1, 4, 9, 10, 10}},
 		&StructType{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, FldName: "lsa"},
 		&StructType{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, FldName: "hsc"},
@@ -1620,19 +1622,17 @@ var structDescs_arm64 = []*KeyedStruct{
 		&StructType{Key: StructKey{Name: "dvd_host_send_rpcstate", Dir: 2}, FldName: "hrpcs"},
 		&StructType{Key: StructKey{Name: "dvd_lu_send_rpcstate", Dir: 2}, FldName: "lrpcs"},
 	}}},
-	{Key: StructKey{Name: "dvd_bca"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 208}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_bca"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 196}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 188}, Kind: 1, RangeBegin: 188, RangeEnd: 188},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "dvd_bca", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 208, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_bca", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 196, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8, ArgDir: 2}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4, ArgDir: 2}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 188, ArgDir: 2}, Kind: 1, RangeBegin: 188, RangeEnd: 188},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_copyright"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_copyright", TypeSize: 4}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 1},
@@ -1646,24 +1646,24 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cpst", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "rmi", TypeSize: 1, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 2},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 2},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 32, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 1},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_host_send_rpcstate", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_rpcstate", TypeSize: 2, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 11},
@@ -1701,23 +1701,23 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "end_sector", TypeSize: 4, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "end_sector_l0", TypeSize: 4, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 8},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "asf", TypeSize: 8, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 32, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_rpcstate", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_rpcstate", TypeSize: 3, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "type", TypeSize: 1, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
@@ -1726,29 +1726,29 @@ var structDescs_arm64 = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "region_mask", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "rpc_scheme", TypeSize: 1, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 40, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 7},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "title_key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cpm", TypeSize: 8, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cp_sec", TypeSize: 8, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cgms", TypeSize: 8, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
 	}}},
-	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 4},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "layer_num", TypeSize: 1}}, Kind: 2, RangeEnd: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_manufact", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_manufact", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 4},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "layer_num", TypeSize: 1, ArgDir: 2}}, Kind: 2, RangeEnd: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8, ArgDir: 2}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4, ArgDir: 2}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_physical"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_physical", TypeSize: 84}, Fields: []Type{
@@ -1763,14 +1763,14 @@ var structDescs_arm64 = []*KeyedStruct{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "layer", TypeSize: 80, ArgDir: 2}, Type: &StructType{Key: StructKey{Name: "dvd_layer", Dir: 2}}, Kind: 1, RangeBegin: 4, RangeEnd: 4},
 	}}},
-	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_send_key_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 4}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "dvd_struct"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_struct"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2056}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_struct_type", FldName: "type", TypeSize: 1}}, Vals: []uint64{0, 1, 2, 3, 4}},
 		&StructType{Key: StructKey{Name: "dvd_physical"}, FldName: "physical"},
 		&StructType{Key: StructKey{Name: "dvd_copyright"}, FldName: "copyright"},
@@ -1778,7 +1778,7 @@ var structDescs_arm64 = []*KeyedStruct{
 		&StructType{Key: StructKey{Name: "dvd_bca"}, FldName: "bca"},
 		&StructType{Key: StructKey{Name: "dvd_manufact"}, FldName: "manufact"},
 	}}},
-	{Key: StructKey{Name: "dvd_struct", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_struct", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_struct_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3, 4}},
 		&StructType{Key: StructKey{Name: "dvd_physical", Dir: 2}, FldName: "physical"},
 		&StructType{Key: StructKey{Name: "dvd_copyright", Dir: 2}, FldName: "copyright"},
@@ -19863,7 +19863,7 @@ var syscalls_arm64 = []*Syscall{
 	{NR: 29, Name: "ioctl$CDROMAUDIOBUFSIZ", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "cmd", TypeSize: 8}}, Val: 21378},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "val", TypeSize: 8}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "val", TypeSize: 4}}},
 	}},
 	{NR: 29, Name: "ioctl$CDROMCLOSETRAY", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
@@ -33724,4 +33724,4 @@ var consts_arm64 = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_arm64 = "7fe8b3bb2d53395bfd16e16e39995ff9a22b534f"
+const revision_arm64 = "3f4434724cfe38d2510fb0e8848e65720bce8f86"

--- a/sys/linux/gen/ppc64le.go
+++ b/sys/linux/gen/ppc64le.go
@@ -998,30 +998,31 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cap_version", FldName: "var", TypeSize: 4}}, Vals: []uint64{429392688, 537333798, 537396514}},
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "pid", FldName: "pid", TypeSize: 4}},
 	}}},
-	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 8}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_addr"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0"}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 8, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_addr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_addr", TypeSize: 4, ArgDir: 2}, Fields: []Type{
 		&StructType{Key: StructKey{Name: "cdrom_msf0", Dir: 2}, FldName: "msf"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 16}, Fields: []Type{
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "from", TypeSize: 8}}},
+	{Key: StructKey{Name: "cdrom_blk"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_blk", TypeSize: 8}, Fields: []Type{
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "from", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int16", FldName: "len", TypeSize: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "cdrom_generic_command", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_generic_command", TypeSize: 80, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_generic_command", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_generic_command", TypeSize: 64, ArgDir: 2}, Fields: []Type{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "cmd", TypeSize: 12, ArgDir: 2}, Kind: 1, RangeBegin: 12, RangeEnd: 12},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buffer", TypeSize: 8}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 2, IsVarlen: true}}},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 8, ArgDir: 2}}, Buf: "buffer"},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "stat", TypeSize: 8, ArgDir: 2}}},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "buflen", TypeSize: 4, ArgDir: 2}}, Buf: "buffer"},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "stat", TypeSize: 4, ArgDir: 2}}},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "sense", TypeSize: 8}, Type: &StructType{Key: StructKey{Name: "request_sense", Dir: 2}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_data_direction", FldName: "data_direction", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "quiet", TypeSize: 8, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "timeout", TypeSize: 8, ArgDir: 2}}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "quiet", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "timeout", TypeSize: 4, ArgDir: 2}}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "reserved", TypeSize: 8}, Type: &ArrayType{TypeCommon: TypeCommon{TypeName: "array", TypeSize: 8, ArgDir: 1}, Type: &IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", TypeSize: 8, ArgDir: 1}}}, Kind: 1, RangeBegin: 1, RangeEnd: 1}},
 	}}},
 	{Key: StructKey{Name: "cdrom_mcn", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_mcn", TypeSize: 14, ArgDir: 1}, Fields: []Type{
@@ -1054,23 +1055,24 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdmsf_frame1", TypeSize: 1}}},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 2640}, Type: &ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", TypeSize: 1}}}, Kind: 1, RangeBegin: 2640, RangeEnd: 2640},
 	}}},
-	{Key: StructKey{Name: "cdrom_multisession", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_multisession", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_multisession", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_multisession", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&UnionType{Key: StructKey{Name: "cdrom_addr", Dir: 2}, FldName: "addr"},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "xa_flag", TypeSize: 1, ArgDir: 2}}, Kind: 2, RangeEnd: 1},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "addr_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "cdrom_output_buffer", Dir: 1}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_output_buffer", TypeSize: 2646, ArgDir: 1}, Fields: []Type{
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 2646, ArgDir: 1}, Kind: 1, RangeBegin: 2646, RangeEnd: 2646},
 	}}},
-	{Key: StructKey{Name: "cdrom_read_audio"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_read_audio", TypeSize: 32}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_read_audio"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_read_audio", TypeSize: 24}, Fields: []Type{
 		&UnionType{Key: StructKey{Name: "cdrom_addr"}, FldName: "addr"},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "addr_format", TypeSize: 1}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "nframes", TypeSize: 8}}, BitSize: 8, Buf: "buf"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "bytesize", FldName: "nframes", TypeSize: 4}}, BitSize: 8, Buf: "buf"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 		&PtrType{TypeCommon: TypeCommon{TypeName: "ptr", FldName: "buf", TypeSize: 8}, Type: &BufferType{TypeCommon: TypeCommon{TypeName: "array", ArgDir: 1, IsVarlen: true}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_subchnl", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_subchnl", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_subchnl", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_subchnl", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "cdsc_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdsc_audiostatus", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdsc_adr", TypeSize: 1, ArgDir: 2}, BitfieldLen: 4, BitfieldMdl: true}},
@@ -1087,15 +1089,15 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdti_trk1", TypeSize: 1}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdti_ind1", TypeSize: 1}}},
 	}}},
-	{Key: StructKey{Name: "cdrom_tocentry", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tocentry", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "cdrom_tocentry", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tocentry", TypeSize: 12, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_track", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_adr", TypeSize: 1, ArgDir: 2}, BitfieldLen: 4, BitfieldMdl: true}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_ctrl", TypeSize: 1, ArgDir: 2}, BitfieldOff: 4, BitfieldLen: 4}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "cdrom_format", FldName: "cdte_format", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 1}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 5}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 1}}, IsPad: true},
 		&UnionType{Key: StructKey{Name: "cdrom_addr", Dir: 2}, FldName: "cdte_addr"},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdte_datamode", TypeSize: 1, ArgDir: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "cdrom_tochdr", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "cdrom_tochdr", TypeSize: 2, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cdth_trk0", TypeSize: 1, ArgDir: 2}}},
@@ -1599,7 +1601,7 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "seq", TypeSize: 4}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "signal", TypeSize: 4}}, Kind: 2, RangeEnd: 65},
 	}}},
-	{Key: StructKey{Name: "dvd_authinfo", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_authinfo", TypeSize: 40, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_authinfo", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_authinfo", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_authinfo_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 2, 3, 7, 8, 1, 4, 9, 10, 10}},
 		&StructType{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, FldName: "lsa"},
 		&StructType{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, FldName: "hsc"},
@@ -1611,19 +1613,17 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&StructType{Key: StructKey{Name: "dvd_host_send_rpcstate", Dir: 2}, FldName: "hrpcs"},
 		&StructType{Key: StructKey{Name: "dvd_lu_send_rpcstate", Dir: 2}, FldName: "lrpcs"},
 	}}},
-	{Key: StructKey{Name: "dvd_bca"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 208}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_bca"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 196}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 188}, Kind: 1, RangeBegin: 188, RangeEnd: 188},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "dvd_bca", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 208, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_bca", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_bca", TypeSize: 196, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8, ArgDir: 2}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4, ArgDir: 2}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 188, ArgDir: 2}, Kind: 1, RangeBegin: 188, RangeEnd: 188},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 4}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_copyright"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_copyright", TypeSize: 4}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 1},
@@ -1637,24 +1637,24 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "cpst", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "rmi", TypeSize: 1, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_disckey"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 2},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_disckey", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_disckey", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 2},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 32, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_host_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 1},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_host_send_rpcstate", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_host_send_rpcstate", TypeSize: 2, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 11},
@@ -1692,23 +1692,23 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "end_sector", TypeSize: 4, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "end_sector_l0", TypeSize: 4, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_agid", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_agid", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 16, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_asf", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_asf", TypeSize: 8, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 8},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "asf", TypeSize: 8, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "asf", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 1}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 32, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_challenge", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_challenge", TypeSize: 20, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "chal", TypeSize: 10, ArgDir: 2}, Kind: 1, RangeBegin: 10, RangeEnd: 10},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 	}}},
 	{Key: StructKey{Name: "dvd_lu_send_rpcstate", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_rpcstate", TypeSize: 3, ArgDir: 2}, Fields: []Type{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "type", TypeSize: 1, ArgDir: 2}, BitfieldLen: 2, BitfieldMdl: true}},
@@ -1717,29 +1717,29 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "region_mask", TypeSize: 1, ArgDir: 2}}},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "rpc_scheme", TypeSize: 1, ArgDir: 2}}},
 	}}},
-	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 40, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_lu_send_title_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_lu_send_title_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 7},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "title_key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "lba", TypeSize: 8, ArgDir: 2}}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cpm", TypeSize: 8, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cp_sec", TypeSize: 8, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "cgms", TypeSize: 8, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "lba", TypeSize: 4, ArgDir: 2}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cpm", TypeSize: 4, ArgDir: 2}, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cp_sec", TypeSize: 4, ArgDir: 2}, BitfieldOff: 1, BitfieldLen: 1, BitfieldMdl: true}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "cgms", TypeSize: 4, ArgDir: 2}, BitfieldOff: 2, BitfieldLen: 2}},
 	}}},
-	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_manufact"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1}}, Val: 4},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "layer_num", TypeSize: 1}}, Kind: 2, RangeEnd: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
-	{Key: StructKey{Name: "dvd_manufact", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_manufact", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_manufact", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "type", TypeSize: 1, ArgDir: 2}}, Val: 4},
 		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int8", FldName: "layer_num", TypeSize: 1, ArgDir: 2}}, Kind: 2, RangeEnd: 3},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 6}}, IsPad: true},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 8, ArgDir: 2}}, Buf: "value"},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
+		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "len", TypeSize: 4, ArgDir: 2}}, Buf: "value"},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "value", TypeSize: 2048, ArgDir: 2}, Kind: 1, RangeBegin: 2048, RangeEnd: 2048},
 	}}},
 	{Key: StructKey{Name: "dvd_physical"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_physical", TypeSize: 84}, Fields: []Type{
@@ -1754,14 +1754,14 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 2}}, IsPad: true},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "layer", TypeSize: 80, ArgDir: 2}, Type: &StructType{Key: StructKey{Name: "dvd_layer", Dir: 2}}, Kind: 1, RangeBegin: 4, RangeEnd: 4},
 	}}},
-	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 24, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_send_key", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_send_key", TypeSize: 16, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_send_key_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{2, 4}},
-		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 7}}, IsPad: true},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "agid", TypeSize: 8, ArgDir: 2}, BitfieldLen: 2}},
+		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "agid", TypeSize: 4, ArgDir: 2}, BitfieldLen: 2}},
 		&BufferType{TypeCommon: TypeCommon{TypeName: "array", FldName: "key", TypeSize: 5, ArgDir: 2}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "pad", TypeSize: 3}}, IsPad: true},
 	}}},
-	{Key: StructKey{Name: "dvd_struct"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2064}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_struct"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2056}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_struct_type", FldName: "type", TypeSize: 1}}, Vals: []uint64{0, 1, 2, 3, 4}},
 		&StructType{Key: StructKey{Name: "dvd_physical"}, FldName: "physical"},
 		&StructType{Key: StructKey{Name: "dvd_copyright"}, FldName: "copyright"},
@@ -1769,7 +1769,7 @@ var structDescs_ppc64le = []*KeyedStruct{
 		&StructType{Key: StructKey{Name: "dvd_bca"}, FldName: "bca"},
 		&StructType{Key: StructKey{Name: "dvd_manufact"}, FldName: "manufact"},
 	}}},
-	{Key: StructKey{Name: "dvd_struct", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2064, ArgDir: 2}, Fields: []Type{
+	{Key: StructKey{Name: "dvd_struct", Dir: 2}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "dvd_struct", TypeSize: 2056, ArgDir: 2}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "dvd_struct_type", FldName: "type", TypeSize: 1, ArgDir: 2}}, Vals: []uint64{0, 1, 2, 3, 4}},
 		&StructType{Key: StructKey{Name: "dvd_physical", Dir: 2}, FldName: "physical"},
 		&StructType{Key: StructKey{Name: "dvd_copyright", Dir: 2}, FldName: "copyright"},
@@ -18962,7 +18962,7 @@ var syscalls_ppc64le = []*Syscall{
 	{NR: 54, Name: "ioctl$CDROMAUDIOBUFSIZ", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
 		&ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", FldName: "cmd", TypeSize: 8}}, Val: 21378},
-		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "intptr", FldName: "val", TypeSize: 8}}},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "val", TypeSize: 4}}},
 	}},
 	{NR: 54, Name: "ioctl$CDROMCLOSETRAY", CallName: "ioctl", Args: []Type{
 		&ResourceType{TypeCommon: TypeCommon{TypeName: "fd_cdrom", FldName: "fd", TypeSize: 4}},
@@ -31134,4 +31134,4 @@ var consts_ppc64le = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_ppc64le = "ace22c31a6cf8dbfb5b916023e433cb78dde774a"
+const revision_ppc64le = "fe5564af087a50bc8d72c0df149c667a8cd62d8e"


### PR DESCRIPTION
1. Comment with clarification on how to run qemu added.
2.  Description of int type fixed.

Signed-off-by: Denis Efremov <efremov@linux.com>