### PR TITLE
sys/linux: id field fix in v4l2_event_subscription

### DIFF
--- a/executor/syscalls_linux.h
+++ b/executor/syscalls_linux.h
@@ -2,7 +2,7 @@
 
 #if defined(__i386__) || 0
 #define GOARCH "386"
-#define SYZ_REVISION "4afefb283f9a69eab272882da97a27408e9248ac"
+#define SYZ_REVISION "2816607dc1030d54c6abf98aaa99ea7054785e51"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -1946,7 +1946,7 @@ call_t syscalls[] = {
 
 #if defined(__x86_64__) || 0
 #define GOARCH "amd64"
-#define SYZ_REVISION "4d8b8766c16cd244787689c362b69e9347ced7dc"
+#define SYZ_REVISION "4dfc7b2093255c116f8e02b3be10ddce87927081"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -3942,7 +3942,7 @@ call_t syscalls[] = {
 
 #if defined(__arm__) || 0
 #define GOARCH "arm"
-#define SYZ_REVISION "b8c5273058572a80fa1677921b69b0b3191947a5"
+#define SYZ_REVISION "ab6166ffafd1b575c22c14ae79cd813f97f13bf6"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912
@@ -5895,7 +5895,7 @@ call_t syscalls[] = {
 
 #if defined(__aarch64__) || 0
 #define GOARCH "arm64"
-#define SYZ_REVISION "db3b56a840a32603a5eee9c20d97cf9d05293022"
+#define SYZ_REVISION "1e5f965fce82c3d2a90ab9addf0a6d68379e0e15"
 #define SYZ_PAGE_SIZE 4096
 #define SYZ_NUM_PAGES 4096
 #define SYZ_DATA_OFFSET 536870912

--- a/sys/linux/gen/386.go
+++ b/sys/linux/gen/386.go
@@ -14377,7 +14377,7 @@ var structDescs_386 = []*KeyedStruct{
 	}}},
 	{Key: StructKey{Name: "v4l2_event_subscription"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription", TypeSize: 32}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_type", FldName: "type", TypeSize: 4}}, Vals: []uint64{0, 1, 2, 3, 4, 5, 6, 134217728, 134221824, 134221825, 134221826, 134221827, 134221828, 134221829, 134221830, 134221831, 134221832, 134221833, 134221834}},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "id", TypeSize: 4}}, Buf: "type"},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "id", TypeSize: 4}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription_flags", FldName: "flags", TypeSize: 4}}, Vals: []uint64{1, 2}},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 20}, Type: &ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", TypeSize: 4}}}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 	}}},
@@ -33659,4 +33659,4 @@ var consts_386 = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_386 = "4afefb283f9a69eab272882da97a27408e9248ac"
+const revision_386 = "2816607dc1030d54c6abf98aaa99ea7054785e51"

--- a/sys/linux/gen/arm.go
+++ b/sys/linux/gen/arm.go
@@ -14230,7 +14230,7 @@ var structDescs_arm = []*KeyedStruct{
 	}}},
 	{Key: StructKey{Name: "v4l2_event_subscription"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription", TypeSize: 32}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_type", FldName: "type", TypeSize: 4}}, Vals: []uint64{0, 1, 2, 3, 4, 5, 6, 134217728, 134221824, 134221825, 134221826, 134221827, 134221828, 134221829, 134221830, 134221831, 134221832, 134221833, 134221834}},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "id", TypeSize: 4}}, Buf: "type"},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "id", TypeSize: 4}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription_flags", FldName: "flags", TypeSize: 4}}, Vals: []uint64{1, 2}},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 20}, Type: &ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", TypeSize: 4}}}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 	}}},
@@ -33526,4 +33526,4 @@ var consts_arm = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_arm = "b8c5273058572a80fa1677921b69b0b3191947a5"
+const revision_arm = "ab6166ffafd1b575c22c14ae79cd813f97f13bf6"

--- a/sys/linux/gen/arm64.go
+++ b/sys/linux/gen/arm64.go
@@ -14475,7 +14475,7 @@ var structDescs_arm64 = []*KeyedStruct{
 	}}},
 	{Key: StructKey{Name: "v4l2_event_subscription"}, Desc: &StructDesc{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription", TypeSize: 32}, Fields: []Type{
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_type", FldName: "type", TypeSize: 4}}, Vals: []uint64{0, 1, 2, 3, 4, 5, 6, 134217728, 134221824, 134221825, 134221826, 134221827, 134221828, 134221829, 134221830, 134221831, 134221832, 134221833, 134221834}},
-		&LenType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "len", FldName: "id", TypeSize: 4}}, Buf: "type"},
+		&IntType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "int32", FldName: "id", TypeSize: 4}}},
 		&FlagsType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "v4l2_event_subscription_flags", FldName: "flags", TypeSize: 4}}, Vals: []uint64{1, 2}},
 		&ArrayType{TypeCommon: TypeCommon{TypeName: "array", FldName: "reserved", TypeSize: 20}, Type: &ConstType{IntTypeCommon: IntTypeCommon{TypeCommon: TypeCommon{TypeName: "const", TypeSize: 4}}}, Kind: 1, RangeBegin: 5, RangeEnd: 5},
 	}}},
@@ -33727,4 +33727,4 @@ var consts_arm64 = []ConstValue{
 	{Name: "bpf_insn_load_imm_dw", Value: 24},
 }
 
-const revision_arm64 = "db3b56a840a32603a5eee9c20d97cf9d05293022"
+const revision_arm64 = "1e5f965fce82c3d2a90ab9addf0a6d68379e0e15"

--- a/sys/linux/video4linux.txt
+++ b/sys/linux/video4linux.txt
@@ -676,7 +676,7 @@ v4l2_event_motion_det {
 
 v4l2_event_subscription {
 	type		flags[v4l2_event_type, int32]
-	id		len[type, int32]
+	id		int32
 	flags		flags[v4l2_event_subscription_flags, int32]
 	reserved	array[const[0, int32], 5]
 }


### PR DESCRIPTION
The id field in the v4l2_event_subscription structure
currently described as: id len[type, int32].

But all the documentation states is:
"id - ID of the event source. If there is no ID associated
with the event source, then set this to 0. Whether or not
an event needs an ID depends on the event type."

So, the documentation clearly states that:
1. id - is the source of an event
2. type - is the type of an event
3. for some types of events there is no source and id can be 0

According to this 'id int32' is a more accurate description of
the field.

Discussion https://github.com/google/syzkaller/issues/616
