### PR TITLE
osutil: Added stubs for missing Darwin osutil routines.

### DIFF
--- a/pkg/osutil/osutil_darwin.go
+++ b/pkg/osutil/osutil_darwin.go
@@ -10,7 +10,29 @@ import (
 	"os/exec"
 )
 
+func HandleInterrupts(shutdown chan struct{}) {
+}
+
+func UmountAll(dir string) {
+}
+
 func prolongPipe(r, w *os.File) {
+}
+
+func CreateMemMappedFile(size int) (f *os.File, mem []byte, err error) {
+    return nil, nil, fmt.Errorf("CreateMemMappedFile is not implemented")
+}
+
+func CloseMemMappedFile(f *os.File, mem []byte) error {
+    return fmt.Errorf("CloseMemMappedFile is not implemented")
+}
+
+func ProcessExitStatus(ps *os.ProcessState) int {
+    return ps.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+func ProcessSignal(p *os.Process, sig int) bool {
+    return false
 }
 
 func Sandbox(cmd *exec.Cmd, user, net bool) error {


### PR DESCRIPTION
Added stubs for missing Darwin osutil routines.
These were copy-pasted from the Windows osutil routines.

These were preventing `go get` from succeeding:

```
go get github.com/google/syzkaller/...

# github.com/google/syzkaller/pkg/ipc
../go-root-syzkaller/src/github.com/google/syzkaller/pkg/ipc/ipc.go:634:2: undefined: osutil.UmountAll
```