### PR TITLE
adb: Add console logic for ttyUSB.serial

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -153,6 +153,14 @@ func findConsole(adb, dev string) string {
 }
 
 func findConsoleImpl(adb, dev string) (string, error) {
+	// Attempt to find an exact match, at /dev/ttyUSB.{SERIAL}
+	// This is something that can be set up on Linux via 'udev' rules
+	exactCon := "/dev/ttyUSB." + dev
+	if osutil.IsExist(exactCon) {
+		return exactCon, nil
+	}
+
+	// Search all consoles, as described in 'findConsole'
 	consoles, err := filepath.Glob("/dev/ttyUSB*")
 	if err != nil {
 		return "", fmt.Errorf("failed to list /dev/ttyUSB devices: %v", err)


### PR DESCRIPTION
By using UDEV rules, we can create device nodes which exist at

	/dev/ttyUSB.{android device serial}

Which makes it easier to determine which console belongs to a device.

While this is non-standard behavior, it's an inexpensive path check
and makes the lookup faster and deterministic.
