### PR TITLE
syz-manager: Support kernelSrc and vmlinux from different tree

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,3 +33,4 @@ Mitchell Horne
 Denis Efremov
 Ondrej Mosnacek
 Daniel Borkmann
+Joey Jiao

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -70,7 +70,7 @@ func initCover(kernelObj, arch string) error {
 	return err
 }
 
-func generateCoverHTML(w io.Writer, kernelObj, arch string, cov cover.Cover) error {
+func generateCoverHTML(w io.Writer, kernelObj, kernelSrc, arch string, cov cover.Cover) error {
 	if len(cov) == 0 {
 		return fmt.Errorf("no coverage data available")
 	}
@@ -106,6 +106,10 @@ func generateCoverHTML(w io.Writer, kernelObj, arch string, cov cover.Cover) err
 
 	var d templateData
 	for f, covered := range fileSet(coveredFrames, uncoveredFrames) {
+		remain := strings.TrimPrefix(f, prefix)
+		if kernelSrc != "" {
+			f = filepath.Join(kernelSrc, remain)
+		}
 		lines, err := parseFile(f)
 		if err != nil {
 			return err
@@ -130,7 +134,7 @@ func generateCoverHTML(w io.Writer, kernelObj, arch string, cov cover.Cover) err
 				buf.Write([]byte{'\n'})
 			}
 		}
-		f = filepath.Clean(strings.TrimPrefix(f, prefix))
+		f = filepath.Clean(remain)
 		d.Files = append(d.Files, &templateFile{
 			ID:       hash.String([]byte(f)),
 			Name:     f,

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -231,7 +231,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.cfg.TargetVMArch, cov); err != nil {
+	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, cov); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
If vmlinux built from different tree from kernelSrc, cover page will failed to
show. So match only the path without prefix.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
