### PR TITLE
pkg/csource: remove /bin/bash assumption

### DIFF
--- a/pkg/csource/gen.sh
+++ b/pkg/csource/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2018 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 


### PR DESCRIPTION
OpenBSD and probably other BSDs does not ship with /bin/bash. This particular script runs fine with regular /bin/sh.