### PR TITLE
manager: Fix default value for 'sandbox'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,8 @@ following keys in its top-level object:
  - `sshkey`: Location (on the host machine) of a root SSH identity to use for communicating with
    the virtual machine.
  - `sandbox` : Sandboxing mode, the following modes are supported:
-     - "none": don't do anything special (has false positives, e.g. due to killing init)
-     - "setuid": impersonate into user nobody (65534), default
+     - "none": don't do anything special (has false positives, e.g. due to killing init), default
+     - "setuid": impersonate into user nobody (65534)
      - "namespace": use namespaces to drop privileges
        (requires a kernel built with `CONFIG_NAMESPACES`, `CONFIG_UTS_NS`,
        `CONFIG_USER_NS`, `CONFIG_PID_NS` and `CONFIG_NET_NS`)

--- a/syz-manager/mgrconfig/mgrconfig.go
+++ b/syz-manager/mgrconfig/mgrconfig.go
@@ -139,7 +139,7 @@ func defaultValues() *Config {
 		SSHUser:   "root",
 		Cover:     true,
 		Reproduce: true,
-		Sandbox:   "none",
+		Sandbox:   "setuid",
 		RPC:       ":0",
 		Procs:     1,
 	}

--- a/syz-manager/mgrconfig/mgrconfig.go
+++ b/syz-manager/mgrconfig/mgrconfig.go
@@ -59,8 +59,8 @@ type Config struct {
 	Procs int `json:"procs"`
 
 	// Type of sandbox to use during fuzzing:
-	// "none": don't do anything special (has false positives, e.g. due to killing init)
-	// "setuid": impersonate into user nobody (65534), default
+	// "none": don't do anything special (has false positives, e.g. due to killing init), default
+	// "setuid": impersonate into user nobody (65534)
 	// "namespace": create a new namespace for fuzzer using CLONE_NEWNS/CLONE_NEWNET/CLONE_NEWPID/etc,
 	//	requires building kernel with CONFIG_NAMESPACES, CONFIG_UTS_NS, CONFIG_USER_NS,
 	//	CONFIG_PID_NS and CONFIG_NET_NS.
@@ -139,7 +139,7 @@ func defaultValues() *Config {
 		SSHUser:   "root",
 		Cover:     true,
 		Reproduce: true,
-		Sandbox:   "setuid",
+		Sandbox:   "none",
 		RPC:       ":0",
 		Procs:     1,
 	}


### PR DESCRIPTION
The docs and code comments state in several places that 'setuid' is the default sandbox value.  

However, the default is currently 'none'.  

Fix the default to be in-line with what the docs say.
