### PR TITLE
Fix checkpoint_net_namespace on Android

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Google Inc.
  Eric Biggers
  Atul Prakash
  Julia Hansbrough
+ Dan Austin
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/executor/common.h
+++ b/executor/common.h
@@ -471,7 +471,7 @@ static void loop()
 #endif
 #if GOOS_linux
 #if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
-        checkpoint_net_namespace();
+	checkpoint_net_namespace();
 #endif
 #endif
 #if SYZ_EXECUTOR && GOOS_akaros

--- a/executor/common.h
+++ b/executor/common.h
@@ -469,6 +469,11 @@ static void loop()
 	// Tell parent that we are ready to serve.
 	reply_handshake();
 #endif
+#if GOOS_linux
+#if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
+        checkpoint_net_namespace();
+#endif
+#endif
 #if SYZ_EXECUTOR && GOOS_akaros
 	// For akaros we do exec in the child process because new threads can't be created in the fork child.
 	// Thus we proxy input program over the child_pipe to the child process.

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1430,10 +1430,6 @@ static void setup_common()
 	setup_cgroups();
 	setup_binfmt_misc();
 #endif
-#if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
-	// TODO(dvukov): we do this in the wrong net namespace. Does this matter?
-	checkpoint_net_namespace();
-#endif
 }
 #endif
 

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2925,9 +2925,6 @@ static void setup_common()
 	setup_cgroups();
 	setup_binfmt_misc();
 #endif
-#if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
-	checkpoint_net_namespace();
-#endif
 }
 #endif
 
@@ -3733,6 +3730,11 @@ static void loop()
 #endif
 #if SYZ_EXECUTOR
 	reply_handshake();
+#endif
+#if GOOS_linux
+#if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
+       checkpoint_net_namespace();
+#endif
 #endif
 #if SYZ_EXECUTOR && GOOS_akaros
 	int child_pipe[2];

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -3733,7 +3733,7 @@ static void loop()
 #endif
 #if GOOS_linux
 #if SYZ_EXECUTOR || SYZ_RESET_NET_NAMESPACE
-       checkpoint_net_namespace();
+	checkpoint_net_namespace();
 #endif
 #endif
 #if SYZ_EXECUTOR && GOOS_akaros


### PR DESCRIPTION
With checkpoint_net_namespace moved to setup_common, and Android fuzzing session
terminates prematurely due to ipv4_tables not being initialized at this time.
Moving the call back to loop fixes this behavior.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
