### PR TITLE
sys/openbsd: make SanitizeCall() idempotent

### DIFF
--- a/sys/openbsd/init.go
+++ b/sys/openbsd/init.go
@@ -22,31 +22,20 @@ type arch struct {
 }
 
 func (arch *arch) SanitizeCall(c *prog.Call) {
-	arch.unix.SanitizeCall(c)
-
 	// Prevent vnodes of type VBAD from being created. Such vnodes will
 	// likely trigger assertion errors by the kernel.
-	// TODO(dvyukov): this is disabled for now because TestSanitizeRandom fails.
-	if false {
-		pos := 1
-		switch c.Meta.CallName {
-		case "mknodat":
-			pos = 2
-			fallthrough
-		case "mknod":
-			mode := c.Args[pos].(*prog.ConstArg)
-			if mode.Val&arch.unix.S_IFMT != arch.unix.S_IFMT {
-				return
-			}
-			saneMode := mode.Val & ^arch.unix.S_IFMT
-			switch {
-			case mode.Val&arch.unix.S_IFCHR == arch.unix.S_IFCHR:
-				mode.Val = saneMode | arch.unix.S_IFCHR
-			case mode.Val&arch.unix.S_IFBLK == arch.unix.S_IFBLK:
-				mode.Val = saneMode | arch.unix.S_IFBLK
-			case mode.Val&arch.unix.S_IFIFO == arch.unix.S_IFIFO:
-				mode.Val = saneMode | arch.unix.S_IFIFO
-			}
+	pos := 1
+	switch c.Meta.CallName {
+	case "mknodat":
+		pos = 2
+		fallthrough
+	case "mknod":
+		mode := c.Args[pos].(*prog.ConstArg)
+		if mode.Val&arch.unix.S_IFMT == arch.unix.S_IFMT {
+			mode.Val &^= arch.unix.S_IFMT
+			mode.Val |= arch.unix.S_IFCHR
 		}
+	default:
+		arch.unix.SanitizeCall(c)
 	}
 }


### PR DESCRIPTION
On OpenBSD, the vnode type for a device node of type S_IFMT is interpreted as
VBAD. Such vnodes often causes assertion failures inside kernel producing noisy
crashes. The goal of the OpenBSD specific SanitizeCall() is to prevent such
device nodes from being created. The S_IFMT constant is a mask covering all
possible device types, thus covering both character and block devices. Therefore
when the fuzzer generates a mknod{,at}() syscall with the S_IFMT type we cannot
known if the intent was to create a block or character device. Therefore
simplify the code to create a character device under such circumstances.

The observed failure is caused by the interaction between the OpenBSD specific
SanitizeCall() and the Unix one. The Unix sanitizer will not modify the mode
argument if it contains the S_IFMT mask. But on the second invocation when the
mode no longer contains S_IFMT it will modify it, causing a different program
to be produced. Therefore only delegate to the Unix sanitizer if the syscall is
not equal to mknod{,at}().

Regression introduces in commit b771b17e ("Add mandatory OpenBSD bits (#689)").