### PR TITLE
pkg/mgrconfig: allow the name of kernel to be configured

### DIFF
--- a/docs/openbsd/setup.md
+++ b/docs/openbsd/setup.md
@@ -103,6 +103,8 @@ $ cat openbsd.cfg
   "target": "openbsd/amd64",
   "http": ":10000",
   "workdir": "$HOME/go/src/github.com/google/syzkaller/workdir",
+  "kernel_obj": "/sys/arch/amd64/compile/GENERIC/obj",
+  "kernel_src": "/",
   "syzkaller": "$HOME/go/src/github.com/google/syzkaller",
   "image": "$VMDIR/syzkaller.img",
   "sshkey": "$SSKEY",

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -43,6 +43,8 @@ type osCommon struct {
 	ExecutorUsesForkServer bool
 	// Extension of executable files (notably, .exe for windows).
 	ExeExtension string
+	// Name of the kernel object file.
+	KernelObject string
 }
 
 func Get(OS, arch string) *Target {
@@ -249,41 +251,48 @@ var oses = map[string]osCommon{
 		SyscallPrefix:          "__NR_",
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
+		KernelObject:           "vmlinux",
 	},
 	"freebsd": {
 		SyscallNumbers:         true,
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
+		KernelObject:           "vmlinux",
 	},
 	"netbsd": {
 		SyscallNumbers:         true,
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
+		KernelObject:           "vmlinux",
 	},
 	"openbsd": {
 		SyscallNumbers:         true,
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
+		KernelObject:           "bsd.gdb",
 	},
 	"fuchsia": {
 		SyscallNumbers:         false,
 		ExecutorUsesShmem:      false,
 		ExecutorUsesForkServer: false,
+		KernelObject:           "vmlinux",
 	},
 	"windows": {
 		SyscallNumbers:         false,
 		ExecutorUsesShmem:      false,
 		ExecutorUsesForkServer: false,
 		ExeExtension:           ".exe",
+		KernelObject:           "vmlinux",
 	},
 	"akaros": {
 		SyscallNumbers:         true,
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      false,
 		ExecutorUsesForkServer: true,
+		KernelObject:           "vmlinux",
 	},
 }
 

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -42,11 +42,11 @@ var (
 	initCoverVMOffset uint32
 )
 
-func initCover(kernelObj, arch string) error {
+func initCover(kernelObj, kernelObjName, arch string) error {
 	if kernelObj == "" {
 		return fmt.Errorf("kernel_obj is not specified")
 	}
-	vmlinux := filepath.Join(kernelObj, "vmlinux")
+	vmlinux := filepath.Join(kernelObj, kernelObjName)
 	symbols, err := symbolizer.ReadSymbols(vmlinux)
 	if err != nil {
 		return fmt.Errorf("failed to run nm on %v: %v", vmlinux, err)
@@ -70,11 +70,11 @@ func initCover(kernelObj, arch string) error {
 	return err
 }
 
-func generateCoverHTML(w io.Writer, kernelObj, kernelSrc, arch string, cov cover.Cover) error {
+func generateCoverHTML(w io.Writer, kernelObj, kernelObjName, kernelSrc, arch string, cov cover.Cover) error {
 	if len(cov) == 0 {
 		return fmt.Errorf("no coverage data available")
 	}
-	initCoverOnce.Do(func() { initCoverError = initCover(kernelObj, arch) })
+	initCoverOnce.Do(func() { initCoverError = initCover(kernelObj, kernelObjName, arch) })
 	if initCoverError != nil {
 		return initCoverError
 	}
@@ -85,7 +85,7 @@ func generateCoverHTML(w io.Writer, kernelObj, kernelSrc, arch string, cov cover
 		prevPC := previousInstructionPC(arch, fullPC)
 		pcs = append(pcs, prevPC)
 	}
-	vmlinux := filepath.Join(kernelObj, "vmlinux")
+	vmlinux := filepath.Join(kernelObj, kernelObjName)
 	uncovered, err := uncoveredPcsInFuncs(vmlinux, pcs)
 	if err != nil {
 		return err

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -237,7 +237,8 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, cov); err != nil {
+	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
+		mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, cov); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -359,7 +360,9 @@ func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	initCoverOnce.Do(func() { initCoverError = initCover(mgr.cfg.KernelObj, mgr.cfg.TargetArch) })
+	initCoverOnce.Do(func() {
+		initCoverError = initCover(mgr.cfg.KernelObj, mgr.sysTarget.KernelObject, mgr.cfg.TargetArch)
+	})
 	if initCoverError != nil {
 		http.Error(w, initCoverError.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
With this change, I'm able to render the HTML-representation of the coverage on OpenBSD.