### PR TITLE
executor: fix regression on OpenBSD

### DIFF
--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -17,7 +17,14 @@
 
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
-	if (mmap(data, data_size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE | MAP_FIXED, -1, 0) != data)
+#if GOOS_openbsd
+	// W^X not allowed by default on OpenBSD.
+	int prot = PROT_READ | PROT_WRITE;
+#else
+	int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+#endif
+
+	if (mmap(data, data_size, prot, MAP_ANON | MAP_PRIVATE | MAP_FIXED, -1, 0) != data)
 		fail("mmap of data segment failed");
 
 	// Some minimal sandboxing.


### PR DESCRIPTION
 OpenBSD does not allow write and exec mappings by default.

Since the OpenBSD target does not make use of syz_execute_func yet, just drop
PROT_EXEC for now.

Supporting write and exec would require one to edit /etc/fstab during
installation.