### PR TITLE
modify name of private key file

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -176,6 +176,7 @@ Booting the kernel.
 After that you should be able to ssh to QEMU instance in another terminal:
 ``` bash
 ssh -i $IMAGE/ssh/id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
+ssh -i $IMAGE/wheezy.id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
 ```
 
 If this fails with "too many tries", ssh may be passing default keys before


### PR DESCRIPTION
In the context, there is no one file called id_rsa. From the suggested script, the generated private key file is "wheezy.id_rsa". And the path is directly in the root directory of `$IMAGE`.
