### PR TITLE
tools: update to Debian stretch

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -105,8 +105,8 @@ Install debootstrap:
 sudo apt-get install debootstrap
 ```
 
-Use [this script](https://github.com/google/syzkaller/blob/master/tools/create-image.sh) to create a minimal Debian-wheezy Linux image.
-The result should be `$IMAGE/wheezy.img` disk image.
+Use [this script](https://github.com/google/syzkaller/blob/master/tools/create-image.sh) to create a minimal Debian-stretch Linux image.
+The result should be `$IMAGE/stretch.img` disk image.
 
 Sometimes it's useful to have some additional packages and tools available in the VM even though they are not required to run syzkaller.
 The instructions to install some useful tools are below.
@@ -114,22 +114,22 @@ They should obviously be executed before packing the `.img` file.
 
 To install other packages (not required to run syzkaller):
 ``` bash
-sudo chroot wheezy /bin/bash -c "apt-get update; apt-get install -y curl tar time strace gcc make sysbench git vim screen usbutils"
+sudo chroot stretch /bin/bash -c "apt-get update; apt-get install -y curl tar time strace gcc make sysbench git vim screen usbutils"
 ```
 
 To install Trinity (not required to run syzkaller):
 ``` bash
-sudo chroot wheezy /bin/bash -c "mkdir -p ~; cd ~/; wget https://github.com/kernelslacker/trinity/archive/v1.5.tar.gz -O trinity-1.5.tar.gz; tar -xf trinity-1.5.tar.gz"
-sudo chroot wheezy /bin/bash -c "cd ~/trinity-1.5 ; ./configure.sh ; make -j16 ; make install"
+sudo chroot stretch /bin/bash -c "mkdir -p ~; cd ~/; wget https://github.com/kernelslacker/trinity/archive/v1.5.tar.gz -O trinity-1.5.tar.gz; tar -xf trinity-1.5.tar.gz"
+sudo chroot stretch /bin/bash -c "cd ~/trinity-1.5 ; ./configure.sh ; make -j16 ; make install"
 ```
 
 To install perf (not required to run syzkaller):
 ``` bash
-cp -r $KERNEL wheezy/tmp/
-sudo chroot wheezy /bin/bash -c "apt-get update; apt-get install -y flex bison python-dev libelf-dev libunwind7-dev libaudit-dev libslang2-dev libperl-dev binutils-dev liblzma-dev libnuma-dev"
-sudo chroot wheezy /bin/bash -c "cd /tmp/linux/tools/perf/; make"
-sudo chroot wheezy /bin/bash -c "cp /tmp/linux/tools/perf/perf /usr/bin/"
-rm -r wheezy/tmp/linux
+cp -r $KERNEL stretch/tmp/
+sudo chroot stretch /bin/bash -c "apt-get update; apt-get install -y flex bison python-dev libelf-dev libunwind7-dev libaudit-dev libslang2-dev libperl-dev binutils-dev liblzma-dev libnuma-dev"
+sudo chroot stretch /bin/bash -c "cd /tmp/linux/tools/perf/; make"
+sudo chroot stretch /bin/bash -c "cp /tmp/linux/tools/perf/perf /usr/bin/"
+rm -r stretch/tmp/linux
 ```
 
 ## QEMU
@@ -144,7 +144,7 @@ Make sure the kernel boots and `sshd` starts:
 qemu-system-x86_64 \
   -kernel $KERNEL/arch/x86/boot/bzImage \
   -append "console=ttyS0 root=/dev/sda debug earlyprintk=serial slub_debug=QUZ"\
-  -hda $IMAGE/wheezy.img \
+  -hda $IMAGE/stretch.img \
   -net user,hostfwd=tcp::10021-:22 -net nic \
   -enable-kvm \
   -nographic \
@@ -217,8 +217,8 @@ variables `$GOPATH`, `$KERNEL` and `$IMAGE` with their actual values.
 	"http": "127.0.0.1:56741",
 	"workdir": "$GOPATH/src/github.com/google/syzkaller/workdir",
 	"kernel_obj": "$KERNEL",
-	"image": "$IMAGE/wheezy.img",
-	"sshkey": "$IMAGE/wheezy.id_rsa",
+	"image": "$IMAGE/stretch.img",
+	"sshkey": "$IMAGE/stretch.id_rsa",
 	"syzkaller": "$GOPATH/src/github.com/google/syzkaller",
 	"procs": 8,
 	"type": "qemu",

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -2,13 +2,13 @@
 # Copyright 2016 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-# create-image.sh creates a minimal Debian-wheezy Linux image suitable for syzkaller.
+# create-image.sh creates a minimal Debian Linux image suitable for syzkaller.
 
 set -eux
 
-# Create a minimal Debian-wheezy distributive as a directory.
-RELEASE=wheezy
-DIR=wheezy
+# Create a minimal Debian distribution in a directory.
+RELEASE=stretch
+DIR=stretch
 sudo rm -rf $DIR
 mkdir -p $DIR
 sudo debootstrap --include=openssh-server,curl,tar,gcc,libc6-dev,time,strace,sudo,less,psmisc,selinux-utils,policycoreutils,checkpolicy,selinux-policy-default $RELEASE $DIR
@@ -17,6 +17,7 @@ sudo debootstrap --include=openssh-server,curl,tar,gcc,libc6-dev,time,strace,sud
 sudo sed -i '/^root/ { s/:x:/::/ }' $DIR/etc/passwd
 echo 'T0:23:respawn:/sbin/getty -L ttyS0 115200 vt100' | sudo tee -a $DIR/etc/inittab
 printf '\nauto eth0\niface eth0 inet dhcp\n' | sudo tee -a $DIR/etc/network/interfaces
+echo '/dev/root / ext4 defaults 0 0' | sudo tee -a $DIR/etc/fstab
 echo 'debugfs /sys/kernel/debug debugfs defaults 0 0' | sudo tee -a $DIR/etc/fstab
 echo 'binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc defaults 0 0' | sudo tee -a $DIR/etc/fstab
 echo "kernel.printk = 7 4 1 3" | sudo tee -a $DIR/etc/sysctl.conf


### PR DESCRIPTION
This updates the image creation tool to use Debian stretch (current stable)
instead of wheezy, which is very out of date. The only change needed here
was a hint to systemd to make the root filesystem read-write after booting.
Documentation has also been updated.
