### PR TITLE
Modify name of private key file as id_rsa does not exist in the context

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -175,7 +175,7 @@ Booting the kernel.
 
 After that you should be able to ssh to QEMU instance in another terminal:
 ``` bash
-ssh -i $IMAGE/ssh/id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
+ssh -i $IMAGE/wheezy.id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
 ```
 
 If this fails with "too many tries", ssh may be passing default keys before
@@ -218,7 +218,7 @@ variables `$GOPATH`, `$KERNEL` and `$IMAGE` with their actual values.
 	"workdir": "$GOPATH/src/github.com/google/syzkaller/workdir",
 	"kernel_obj": "$KERNEL",
 	"image": "$IMAGE/wheezy.img",
-	"sshkey": "$IMAGE/ssh/id_rsa",
+	"sshkey": "$IMAGE/wheezy.id_rsa",
 	"syzkaller": "$GOPATH/src/github.com/google/syzkaller",
 	"procs": 8,
 	"type": "qemu",


### PR DESCRIPTION
In the context, there is no one file called id_rsa. From [the suggested script](https://github.com/google/syzkaller/blob/master/tools/create-image.sh) to generate wheezy qemu image, we could see the private key is "wheezy.id_rsa". And the path is directly in the root directory of $IMAGE.