### PR TITLE
sys/fuchsia: add Go script that generates fidl descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ generate_go: bin/syz-sysgen format_cpp
 generate_sys: bin/syz-sysgen
 	bin/syz-sysgen
 
+generate_fidl:
+	$(GO) generate ./sys/fuchsia
+	$(MAKE) format_sys
+
 bin/syz-sysgen:
 	$(GO) build $(GOHOSTFLAGS) -o $@ ./sys/syz-sysgen
 

--- a/docs/fuchsia.md
+++ b/docs/fuchsia.md
@@ -48,6 +48,14 @@ Run `syz-manager` with a config along the lines of:
 
 ## How to generate syscall description for FIDL
 
+Use `generate_fidl` target to automatically generate syscall descriptions for all the supported FIDL files.
+
+```bash
+make generate_fidl TARGETARCH=amd64 SOURCEDIR=/path/to/fuchsia/checkout
+```
+
+To manually generate syscall description for a given `.fidl` file, use the following instruction.
+
 FIDL files should first be compiled into FIDL intermediate representation (JSON) files using `fidlc`:
 
 ```bash

--- a/sys/fuchsia/fidlgen/main.go
+++ b/sys/fuchsia/fidlgen/main.go
@@ -1,0 +1,78 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+var zirconLibs = []string{
+	"fuchsia-process",
+	"fuchsia-io",
+}
+
+func main() {
+	targetArch := os.Getenv("TARGETARCH")
+	target := targets.Get("fuchsia", targetArch)
+	if target == nil {
+		failf("unknown TARGETARCH %s", targetArch)
+	}
+	arch := target.KernelHeaderArch
+
+	sourceDir := os.Getenv("SOURCEDIR")
+	if !osutil.IsExist(sourceDir) {
+		failf("cannot find SOURCEDIR %s", sourceDir)
+	}
+
+	fidlgenPath := filepath.Join(
+		sourceDir,
+		"out",
+		arch,
+		fmt.Sprintf("host_%s", arch),
+		"fidlgen",
+	)
+	if !osutil.IsExist(fidlgenPath) {
+		failf("cannot find fidlgen %s", fidlgenPath)
+	}
+
+	for _, lib := range zirconLibs {
+		jsonPath := filepath.Join(
+			sourceDir,
+			"out",
+			arch,
+			"fidling/gen/zircon/public/fidl",
+			lib,
+			fmt.Sprintf("%s.fidl.json", lib),
+		)
+
+		if !osutil.IsExist(jsonPath) {
+			failf("cannot find %s", jsonPath)
+		}
+
+		txtPath := strings.Replace(lib, "fuchsia-", "fidl_", 1)
+		_, err := osutil.RunCmd(time.Minute, "",
+			fidlgenPath,
+			"-generators", "syzkaller",
+			"-json", jsonPath,
+			"-output-base", txtPath,
+			"-include-base", txtPath,
+		)
+
+		if err != nil {
+			failf("fidlgen failed: %v\n", err)
+		}
+	}
+}
+
+func failf(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, msg+"\n", args...)
+	os.Exit(1)
+}

--- a/sys/fuchsia/init.go
+++ b/sys/fuchsia/init.go
@@ -1,6 +1,8 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:generate go run fidlgen/main.go
+
 package fuchsia
 
 import (


### PR DESCRIPTION
This adds a Go script `sys/fuchsia/fidlgen/main.go`, which invokes `fidlgen` to automatically generate syscall description of all the currently supported FIDL files. `var zirconLibs` can later be extended to support generation of syscall descriptions for more FIDL files. What's blocking other FIDL files from being compiled is references to structs defined in other FIDL libraries.

Once most of the FIDL files can be compiled by the FIDL syzkaller backend, we may want to add a new rule to the Fuchsia build system, which simplifies this script into a single command that invokes that rule.