### PR TITLE
pkg/build: add initial OpenBSD support

### DIFF
--- a/docs/openbsd/setup.md
+++ b/docs/openbsd/setup.md
@@ -6,7 +6,7 @@ In addition, the host must be running `-current`.
 Variables used throughout the instructions:
 
 - `$KERNEL` - Custom built kernel, see [Compile Kernel](#compile-kernel).
-              Defaults to `/sys/arch/amd64/compile/GENERIC/obj/bsd` if the
+              Defaults to `/sys/arch/amd64/compile/SYZKALLER/obj/bsd` if the
               instructions are honored.
 - `$SSHKEY` - Public SSH key ***without a passphrase*** used to connect to the
               VMs, it's advised to use a dedicated key.
@@ -39,11 +39,15 @@ A `GENERIC` kernel must be compiled with
 option enabled:
 
 ```sh
-$ cd /sys
-$ echo 'pseudo-device kcov 1' >arch/amd64/conf/KCOV
-$ echo 'include "arch/amd64/conf/KCOV" >>arch/amd64/conf/GENERIC
-$ make -C arch/amd64/compile/GENERIC config
-$ make -C arch/amd64/compile/GENERIC
+$ cd /sys/arch/amd64
+$ cat <<EOF >conf/SYZKALLER
+include "arch/amd64/conf/GENERIC"
+pseudo-device kcov 1
+EOF
+$ cp -R compile/GENERIC compile/SYZKALLER
+$ make -C compile/SYZKALLER obj
+$ make -C compile/SYZKALLER config
+$ make -C compile/SYZKALLER
 ```
 
 ## Create VM
@@ -103,7 +107,7 @@ $ cat openbsd.cfg
   "target": "openbsd/amd64",
   "http": ":10000",
   "workdir": "$HOME/go/src/github.com/google/syzkaller/workdir",
-  "kernel_obj": "/sys/arch/amd64/compile/GENERIC/obj",
+  "kernel_obj": "/sys/arch/amd64/compile/SYZKALLER/obj",
   "kernel_src": "/",
   "syzkaller": "$HOME/go/src/github.com/google/syzkaller",
   "image": "$VMDIR/syzkaller.img",

--- a/pkg/build/akaros.go
+++ b/pkg/build/akaros.go
@@ -94,7 +94,7 @@ bash
 		fullSrc := filepath.Join(kernelDir, filepath.FromSlash(src))
 		fullDst := filepath.Join(outputDir, filepath.FromSlash(dst))
 		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
-			return fmt.Errorf("faied to copy %v: %v", src, err)
+			return fmt.Errorf("failed to copy %v: %v", src, err)
 		}
 	}
 	return nil

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -71,6 +71,8 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		return fuchsia{}, nil
 	case targetOS == "akaros" && targetArch == "amd64" && vmType == "qemu":
 		return akaros{}, nil
+	case targetOS == "openbsd" && targetArch == "amd64" && vmType == "vmm":
+		return openbsd{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
 	}

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -35,7 +35,7 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 		fullSrc := filepath.Join(kernelDir, filepath.FromSlash(src))
 		fullDst := filepath.Join(outputDir, filepath.FromSlash(dst))
 		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
-			return fmt.Errorf("faied to copy %v: %v", src, err)
+			return fmt.Errorf("failed to copy %v: %v", src, err)
 		}
 	}
 	return nil

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -1,0 +1,80 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+type openbsd struct{}
+
+func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
+	cmdlineFile, sysctlFile string, config []byte) error {
+	const kernelName = "SYZKALLER"
+	confDir := fmt.Sprintf("%v/sys/arch/%v/conf", kernelDir, targetArch)
+	compileDir := fmt.Sprintf("%v/sys/arch/%v/compile/%v", kernelDir, targetArch, kernelName)
+
+	if err := ctx.configure(confDir, compileDir, kernelName); err != nil {
+		return err
+	}
+
+	if err := ctx.make(compileDir, "all"); err != nil {
+		return err
+	}
+
+	for src, dst := range map[string]string{
+		"obj/bsd":     "kernel",
+		"obj/bsd.gdb": "obj/bsd.gdb",
+	} {
+		fullSrc := filepath.Join(compileDir, src)
+		fullDst := filepath.Join(outputDir, dst)
+		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
+			return fmt.Errorf("failed to copy %v -> %v: %v", fullSrc, fullDst, err)
+		}
+	}
+
+	return nil
+}
+
+func (ctx openbsd) clean(kernelDir string) error {
+	return ctx.make(kernelDir, "", "clean")
+}
+
+func (ctx openbsd) configure(confDir, compileDir, kernelName string) error {
+	conf := []byte(`
+include "arch/amd64/conf/GENERIC"
+pseudo-device kcov 1
+`)
+	if err := osutil.WriteFile(filepath.Join(confDir, kernelName), conf); err != nil {
+		return err
+	}
+
+	if err := osutil.MkdirAll(compileDir); err != nil {
+		return err
+	}
+	makefile := []byte(".include \"../Makefile.inc\"\n")
+	if err := osutil.WriteFile(filepath.Join(compileDir, "Makefile"), makefile); err != nil {
+		return err
+	}
+	if err := ctx.make(compileDir, "obj"); err != nil {
+		return err
+	}
+	if err := ctx.make(compileDir, "config"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ctx openbsd) make(kernelDir string, args ...string) error {
+	args = append([]string{"-j", strconv.Itoa(runtime.NumCPU())}, args...)
+	_, err := osutil.RunCmd(10*time.Minute, kernelDir, "make", args...)
+	return err
+}


### PR DESCRIPTION
First stab at adding support for OpenBSD to `pkg/build`. Currently
limited to building a kernel with KCOV enabled.