### PR TITLE
docs: Use 'stretch' in ssh command

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ Ondrej Mosnacek
 Daniel Borkmann
 Joey Jiao
 Anton Lindqvist
+Tobin Harding

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -175,7 +175,7 @@ Booting the kernel.
 
 After that you should be able to ssh to QEMU instance in another terminal:
 ``` bash
-ssh -i $IMAGE/wheezy.id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
+ssh -i $IMAGE/stretch.id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
 ```
 
 If this fails with "too many tries", ssh may be passing default keys before


### PR DESCRIPTION
Recently Debian image was updated to be 'stretch' from 'wheezy'.  The
ssh command got missed.

Update the ssh command to use 'stretch' instead of 'wheezy'.

Signed-off-by: Tobin C. Harding <me@tobin.cc>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
