### PR TITLE
executor: add 'racedebug' option for syz-execprog

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -546,7 +546,6 @@ static void loop(void)
 			close(kOutPipeFd);
 #endif
 			execute_one();
-			debug("worker exiting\n");
 #if SYZ_HAVE_RESET_TEST
 			reset_test();
 #endif
@@ -596,7 +595,7 @@ static void loop(void)
 			if (current_time_ms() - start < 5 * 1000)
 				continue;
 #endif
-			debug("killing\n");
+			debug("killing hanging pid %d\n", pid);
 			kill_and_wait(pid, &status);
 			break;
 		}

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1928,7 +1928,6 @@ retry:
 		}
 		int i;
 		for (i = 0;; i++) {
-			debug("unlink(%s)\n", filename);
 			if (unlink(filename) == 0)
 				break;
 			if (errno == EPERM) {
@@ -1956,7 +1955,6 @@ retry:
 	closedir(dp);
 	int i;
 	for (i = 0;; i++) {
-		debug("rmdir(%s)\n", dir);
 		if (rmdir(dir) == 0)
 			break;
 		if (i < 100) {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -3389,7 +3389,6 @@ retry:
 		}
 		int i;
 		for (i = 0;; i++) {
-			debug("unlink(%s)\n", filename);
 			if (unlink(filename) == 0)
 				break;
 			if (errno == EPERM) {
@@ -3416,7 +3415,6 @@ retry:
 	closedir(dp);
 	int i;
 	for (i = 0;; i++) {
-		debug("rmdir(%s)\n", dir);
 		if (rmdir(dir) == 0)
 			break;
 		if (i < 100) {
@@ -4029,7 +4027,6 @@ static void loop(void)
 			close(kOutPipeFd);
 #endif
 			execute_one();
-			debug("worker exiting\n");
 #if SYZ_HAVE_RESET_TEST
 			reset_test();
 #endif
@@ -4064,7 +4061,7 @@ static void loop(void)
 			if (current_time_ms() - start < 5 * 1000)
 				continue;
 #endif
-			debug("killing\n");
+			debug("killing hanging pid %d\n", pid);
 			kill_and_wait(pid, &status);
 			break;
 		}


### PR DESCRIPTION
Sometimes race conditions are reproduced by syz-execprog and are not
reproduced by the programs generated with syz-prog2c. In such cases
it's very helpful to know when exactly the fuzzing syscalls are executed.

Unfortunately, adding timestamps to the output of the original 'debug'
option doesn't work. This option provides very verbose output, which
slows down executor and breaks the repro.

So let's add the 'racedebug' option for syz-execprog, which provides the
limited debug output with timestamps from executor.

Signed-off-by: Alexander Popov <alex.popov@linux.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
