### PR TITLE
executor: move debug_dump_data() into common_linux.h

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -13,6 +13,18 @@ struct cover_t;
 static void cover_reset(cover_t* cov);
 #endif
 
+static void debug_dump_data(const char* data, int length)
+{
+	if (!flag_debug)
+		return;
+	for (int i = 0; i < length; i++) {
+		debug("%02x ", data[i] & 0xff);
+		if (i % 16 == 15)
+			debug("\n");
+	}
+	debug("\n");
+}
+
 #if SYZ_EXECUTOR || SYZ_THREADED
 #include <linux/futex.h>
 #include <pthread.h>

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -70,7 +70,6 @@ static NORETURN PRINTF void error(const char* msg, ...);
 static NORETURN PRINTF void exitf(const char* msg, ...);
 // Print debug output, does not add \n at the end of msg as opposed to the previous functions.
 static PRINTF void debug(const char* msg, ...);
-static void debug_dump_data(const char* data, int length);
 static NORETURN void doexit(int status);
 
 static void receive_execute();
@@ -1311,16 +1310,4 @@ void debug(const char* msg, ...)
 	vfprintf(stderr, msg, args);
 	va_end(args);
 	fflush(stderr);
-}
-
-void debug_dump_data(const char* data, int length)
-{
-	if (!flag_debug)
-		return;
-	for (int i = 0; i < length; i++) {
-		debug("%02x ", data[i] & 0xff);
-		if (i % 16 == 15)
-			debug("\n");
-	}
-	debug("\n");
 }

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -682,6 +682,18 @@ struct cover_t;
 static void cover_reset(cover_t* cov);
 #endif
 
+static void debug_dump_data(const char* data, int length)
+{
+	if (!flag_debug)
+		return;
+	for (int i = 0; i < length; i++) {
+		debug("%02x ", data[i] & 0xff);
+		if (i % 16 == 15)
+			debug("\n");
+	}
+	debug("\n");
+}
+
 #if SYZ_EXECUTOR || SYZ_THREADED
 #include <linux/futex.h>
 #include <pthread.h>


### PR DESCRIPTION
Compiling the executor on OpenBSD currently fails:

  executor/executor.cc:1316:6: error: unused function 'debug_dump_data'

Another approach would be to make the function non-static.