### PR TITLE
Re-enable ASAN-ified Fuchsia builds.

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -179,10 +179,9 @@ long syz_mmap(size_t addr, size_t size)
 	if (status != ZX_OK)
 		return status;
 	uintptr_t mapped_addr;
-	status = zx_vmar_map(root, addr - info.base, vmo, 0, size,
-			     ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ |
-				 ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
-			     &mapped_addr);
+	status = zx_vmar_map(root, ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE |
+		         ZX_VM_FLAG_PERM_EXECUTE,
+				 0, vmo, 0, size, &mapped_addr);
 	return status;
 }
 #endif

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -22,7 +22,7 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 	}
 	arch := sysTarget.KernelHeaderArch
 	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "clean-build", arch,
-		"--packages", "garnet/packages/products/sshd"); err != nil {
+		"--packages", "garnet/packages/products/sshd", "--variant", "asan"); err != nil {
 		return err
 	}
 	for src, dst := range map[string]string{

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -204,6 +204,7 @@ var List = map[string]map[string]*Target{
 				"-L", os.ExpandEnv("${SOURCEDIR}/out/x64/x64-shared"),
 				"-L", os.ExpandEnv("${SOURCEDIR}/out/x64/sdks/zircon_sysroot/arch/x64/sysroot/lib"),
 				"-L", os.ExpandEnv("${SOURCEDIR}/out/build-zircon/build-x64/system/ulib/driver"),
+				"-fsanitize=address",
 			},
 		},
 		"arm64": {


### PR DESCRIPTION
Previously, ASAN was disabled due to a "library not found" issue.

The root cause of this problem: when Fuchsia is built with ASAN entirely
enabled, there are some non-ASAN-ified common libraries that are *not*
built (because they're no longer needed by the system). Unfortunately,
Syzkaller depended on such libraries existing, leading to the "not
found" problem.

There are three possible solutions: (1) move Syzkaller in-tree for full
packaging support, (2) build *almost* all of the system with ASAN to
allow the correct libraries to get picked up (brittle), or (3) build Syzkaller
itself with ASAN.

This commit chooses approach (3) for now, for simplicity, though this
seems like an indication that (1) may be worth pursuing again in the future;
maintaining this separate builds is beginning to be a pain point.

Once this was resolved, a further issue was unmasked: when ASAN is
enabled, the address layout of various components of the system were
altered, s.t. the hardcoded SYZ_DATA_OFFSET address was no longer
overwritable.

Since I couldn't find any description in the code wrt the importance of
the SYZ_DATA_OFFSET, I changed zx_map_vmar to simply choose the
appropriate offset on its own.  If the SYZ_DATA_OFFSET has some
functional importance I'm unaware of, let me know and I'll update the
commit to handle that case.

(Also, the ordering for zx_vmar_map's arguments has changed, so I
updated that accordingly.)