### PR TITLE
Include generate_fidl as part of the `extract` step.

### DIFF
--- a/docs/fuchsia.md
+++ b/docs/fuchsia.md
@@ -48,13 +48,9 @@ Run `syz-manager` with a config along the lines of:
 
 ## How to generate syscall description for FIDL
 
-Use `generate_fidl` target to automatically generate syscall descriptions for all the supported FIDL files.
+Syscall descriptions for FIDL are automatically generated as part of `make extract` as described above.
 
-```bash
-make generate_fidl TARGETARCH=amd64 SOURCEDIR=/path/to/fuchsia/checkout
-```
-
-To manually generate syscall description for a given `.fidl` file, use the following instruction.
+However, if you wish to manually generate syscall descriptions for a given `.fidl` file, do the following.
 
 FIDL files should first be compiled into FIDL intermediate representation (JSON) files using `fidlc`:
 

--- a/sys/fuchsia/fidlgen/main.go
+++ b/sys/fuchsia/fidlgen/main.go
@@ -52,7 +52,7 @@ func main() {
 		sourceDir,
 		"out",
 		arch,
-		fmt.Sprintf("host_%s", arch),
+		"host_x64",
 		"fidlgen",
 	)
 	if !osutil.IsExist(fidlgenPath) {


### PR DESCRIPTION
Anytime we're running `make extract/generate` with Fuchsia as a target, we
probably want to update FIDL descriptions too, so we don't fall behind
what upstream is up to.

This includes generate_fidl as part of the `make generate` workflow.