### PR TITLE
targets: Use OS=linux when GOOS=android

### DIFF
--- a/prog/target.go
+++ b/prog/target.go
@@ -72,6 +72,9 @@ func RegisterTarget(target *Target, initArch func(target *Target)) {
 }
 
 func GetTarget(OS, arch string) (*Target, error) {
+	if OS == "android" {
+		OS = "linux"
+	}
 	key := OS + "/" + arch
 	target := targets[key]
 	if target == nil {

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -302,8 +302,12 @@ func init() {
 			initTarget(target, OS, arch)
 		}
 	}
+	goos := runtime.GOOS
+	if goos == "android" {
+		goos = "linux"
+	}
 	for _, target := range List["test"] {
-		target.CCompiler = List[runtime.GOOS][runtime.GOARCH].CCompiler
+		target.CCompiler = List[goos][runtime.GOARCH].CCompiler
 	}
 }
 


### PR DESCRIPTION
This avoids the issue of "android" not having any registered configurations
or syscalls / ioctls / etc, when built with GOOS=android.

This occurs when building in Google3, since --config=android_arm64 selects
the Android toolchain.

This supercedes #758 which was much more complex than it needed to be.

Per the feedback there, I've used `GetTarget` as the main hook point, and removed many of the changes which were only needed due to  unnecessary changes in `targets.go`.