### PR TITLE
vm/vmm: use derived disks for VMs

### DIFF
--- a/docs/openbsd/setup.md
+++ b/docs/openbsd/setup.md
@@ -68,7 +68,7 @@ $ make -C compile/SYZKALLER
 2. Create disk image:
 
    ```sh
-   $ vmctl create "$VMIMG" -s 4G
+   $ vmctl create "qcow2:$VMIMG" -s 4G
    ```
 
 3. Install VM:


### PR DESCRIPTION
As a result, the boot time is significantly improved since there's no longer any
need to copy the complete disk.

This feature was recently committed to OpenBSD-current. Any existing base image
used must be recreated, this time using the qcow2 disk format.