### PR TITLE
Android sandbox fixes

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -151,14 +151,18 @@ static uint64 current_time_ms(void)
 }
 #endif
 
-#if SYZ_EXECUTOR || SYZ_USE_TMP_DIR
+#if SYZ_EXECUTOR || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP || SYZ_USE_TMP_DIR
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 static void use_temporary_dir(void)
 {
+#if SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
+	char tmpdir_template[] = "/data/data/syzkaller/syzkaller.XXXXXX";
+#else
 	char tmpdir_template[] = "./syzkaller.XXXXXX";
+#endif
 	char* tmpdir = mkdtemp(tmpdir_template);
 	if (!tmpdir)
 		fail("failed to mkdtemp");
@@ -665,7 +669,7 @@ int main(void)
 	for (procid = 0; procid < [[PROCS]]; procid++) {
 		if (fork() == 0) {
 #endif
-#if SYZ_USE_TMP_DIR
+#if SYZ_USE_TMP_DIR || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
 			use_temporary_dir();
 #endif
 			[[SANDBOX_FUNC]]

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1867,7 +1867,7 @@ static void syz_setfilecon(const char* path, const char* context)
 	if (setxattr(path, SELINUX_XATTR_NAME, context, strlen(context) + 1, 0) != 0)
 		fail("setfilecon: setxattr failed");
 
-	if (syz_getfilecon(path, new_context, sizeof(new_context)) != 0)
+	if (syz_getfilecon(path, new_context, sizeof(new_context)) <= 0)
 		fail("setfilecon: getfilecon failed");
 
 	if (strcmp(context, new_context) != 0)
@@ -1879,6 +1879,9 @@ static int do_sandbox_android_untrusted_app(void)
 {
 	setup_common();
 	sandbox_common();
+
+	if (chown(".", UNTRUSTED_APP_UID, UNTRUSTED_APP_UID) != 0)
+		fail("chmod failed");
 
 	if (setgroups(UNTRUSTED_APP_NUM_GROUPS, UNTRUSTED_APP_GROUPS) != 0)
 		fail("setgroups failed");

--- a/tools/android/Makefile
+++ b/tools/android/Makefile
@@ -1,0 +1,18 @@
+TARGET := libs/arm64-v8a/sandbox_test
+SRC := jni/sandbox_test.c
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	ndk-build
+
+push: $(TARGET)
+	adb push "$^" /data/local/tmp
+
+run: push
+	adb shell /data/local/tmp/sandbox_test
+
+clean:
+	rm -rf libs obj
+
+.PHONY: all push run

--- a/tools/android/jni/Android.mk
+++ b/tools/android/jni/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := sandbox_test
+LOCAL_SRC_FILES := sandbox_test.c
+LOCAL_C_INCLUDES := ../../
+
+include $(BUILD_EXECUTABLE)

--- a/tools/android/jni/Application.mk
+++ b/tools/android/jni/Application.mk
@@ -1,0 +1,5 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+APP_ABI:= arm64-v8a
+APP_PLATFORM:=latest

--- a/tools/android/jni/sandbox_test.c
+++ b/tools/android/jni/sandbox_test.c
@@ -1,0 +1,43 @@
+#define GOOS_linux 1
+#define SYZ_SANDBOX_ANDROID_UNTRUSTED_APP 1
+#define SYZ_USE_TMP_DIR 1
+#define fail(...)   do { dprintf(2, __VA_ARGS__); dprintf(2, "\n"); perror("errno"); exit(1); } while(0)
+#define error(...)  do { dprintf(2, __VA_ARGS__); } while(0)
+#define debug(...)  do { dprintf(2, __VA_ARGS__); } while(0)
+
+#include <stdlib.h>
+#include <string.h>
+
+void doexit(int status)
+{
+    exit(status);
+}
+
+static void loop() {
+    exit(system("id"));
+}
+
+static void use_temporary_dir(void)
+{
+#if SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
+    char tmpdir_template[] = "/data/data/syzkaller/syzkaller.XXXXXX";
+#else
+    char tmpdir_template[] = "./syzkaller.XXXXXX";
+#endif
+    char* tmpdir = mkdtemp(tmpdir_template);
+    if (!tmpdir)
+        fail("failed to mkdtemp");
+    if (chmod(tmpdir, 0777))
+        fail("failed to chmod");
+    if (chdir(tmpdir))
+        fail("failed to chdir");
+}
+
+
+
+#include "executor/common_linux.h"
+
+int main() {
+    use_temporary_dir();
+    do_sandbox_android_untrusted_app();
+}


### PR DESCRIPTION
Android: Fix sandbox implementation

My test harness for this code performed some steps that are not performed when syz-executor is invoked directy.

Specifcally, we need to operate from a directory under /data/data, and have the correct UID/GID set as the owner of the directory.

I added a simple test harness to demonstrate that it works, and ease the testing process in the future.

Test: make -C tools/android run
Test: make presubmit