### PR TITLE
Update configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,4 +40,6 @@ following keys in its top-level object:
      - `cpu`: Number of CPUs to simulate in the VM (*not currently used*).
      - `mem`: Amount of memory (in MiB) for the VM; this is passed as the `-m` option to `qemu-system-x86_64`.
 
-See also [config.go](/pkg/mgrconfig/mgrconfig.go) for all config parameters.
+See also:
+ - [config.go](/pkg/mgrconfig/mgrconfig.go) for all config parameters;
+ - [qemu.go](/vm/qemu/qemu.go) for all vm parameters.


### PR DESCRIPTION
docs: add link for all supported qemu arguments.

VM parameters are not defined in config.go. At first i was confused for the lack of support of initrd option, but them noticed, that vm parameter are parsed in qemu.go instead.
