### PR TITLE
Pass -debug flag to runsc.

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -190,6 +190,7 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 		"-watchdog-action=panic",
 		"-panic-signal=12",
 		"-network=none",
+		"-debug",
 	}
 	if inst.cfg.RunscArgs != "" {
 		args = append(args, strings.Split(inst.cfg.RunscArgs, " ")...)


### PR DESCRIPTION
As of commit 3f053259, gVisor sentry panics are no longer sent to the
stderr for "runsc run" by default, as that stderr belongs exclusively to
the application.

As a result, syzbot never sees the gVisor panic stack trace, and is only
reporting errors that occur when waiting for a dead sandbox.

Passing the "-debug" flag to runsc will make the sentry panics visible
to syzbot again.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
