### PR TITLE
FreeBSD executor fix

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -15,7 +15,11 @@
 #define _GNU_SOURCE
 #endif
 
+#if GOOS_freebsd
+#include <sys/endian.h> // for htobe*.
+#else
 #include <endian.h> // for htobe*.
+#endif
 #include <stdint.h>
 #include <stdio.h> // for fmt arguments
 #include <stdlib.h>

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9,7 +9,11 @@ var commonHeader = `
 #define _GNU_SOURCE
 #endif
 
+#if GOOS_freebsd
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
* Fixed endian.h path in executor/common.h. Modified pkg/csource/csource_test.go to skip test for target freebsd.
* Fixed ioctl calls for FreeBSD in executor/executor_bsd.h and replaced corresponding constant definitions by sys/kcov.h include. Modified Makefile to skip executor build for FreeBSD.