### PR TITLE
pkg/csource to work openbsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ test_race:
 clean:
 	rm -rf ./bin/
 
-# For a tupical Ubuntu/Debian distribution.
+# For a typical Ubuntu/Debian distribution.
 # We use "|| true" for apt-get install because packages are all different on different distros,
 # and we want to install at least gometalinter on Travis CI.
 install_prerequisites:

--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -20,13 +20,8 @@ static int do_sandbox_none(void)
 
 #if SYZ_EXECUTOR || __NR_syz_open_pts
 
-#if defined(__OpenBSD__)
 #include <termios.h>
 #include <util.h>
-#else
-// Needed when compiling on Linux.
-#include <pty.h>
-#endif
 
 static uintptr_t syz_open_pts(void)
 {

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -27,8 +27,7 @@ const (
 
 func createCommonHeader(p, mmapProg *prog.Prog, replacements map[string]string, opts Options) ([]byte, error) {
 	defines := defineList(p, mmapProg, opts)
-	target := mmapProg.Target
-	sysTarget := targets.Get(target.OS, target.Arch)
+	sysTarget := targets.Get(p.Target.OS, p.Target.Arch)
 	cmd := osutil.Command(sysTarget.CPreprocessor, "-nostdinc", "-undef", "-fdirectives-only", "-dDI", "-E", "-P", "-")
 	for _, def := range defines {
 		cmd.Args = append(cmd.Args, "-D"+def)

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -27,7 +27,9 @@ const (
 
 func createCommonHeader(p, mmapProg *prog.Prog, replacements map[string]string, opts Options) ([]byte, error) {
 	defines := defineList(p, mmapProg, opts)
-	cmd := osutil.Command("cpp", "-nostdinc", "-undef", "-fdirectives-only", "-dDI", "-E", "-P", "-")
+	target := mmapProg.Target
+	sysTarget := targets.Get(target.OS, target.Arch)
+	cmd := osutil.Command(sysTarget.CPreprocessor, "-nostdinc", "-undef", "-fdirectives-only", "-dDI", "-E", "-P", "-")
 	for _, def := range defines {
 		cmd.Args = append(cmd.Args, "-D"+def)
 	}

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,9 @@ func TestGenerate(t *testing.T) {
 		}
 		target := target
 		t.Run(target.OS+"/"+target.Arch, func(t *testing.T) {
+			if runtime.GOOS == "openbsd" && target.OS != "openbsd" {
+				t.Skip("broken")
+			}
 			if target.OS == "linux" && target.Arch == "arm" {
 				// This currently fails (at least with my arm-linux-gnueabihf-gcc-4.8) with:
 				// Assembler messages:

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -17,10 +16,6 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	switch runtime.GOOS {
-	case "openbsd":
-		t.Skipf("broken on %v", runtime.GOOS)
-	}
 	t.Parallel()
 	for _, target := range prog.AllTargets() {
 		switch target.OS {

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -25,7 +25,9 @@ func TestGenerate(t *testing.T) {
 		}
 		target := target
 		t.Run(target.OS+"/"+target.Arch, func(t *testing.T) {
-			if runtime.GOOS == "openbsd" && target.OS != "openbsd" {
+			// OpenBSD tests don't run except on itself
+			// and nothing else runs on OpenBSD.
+			if (runtime.GOOS == "openbsd") != (target.OS == "openbsd") {
 				t.Skip("broken")
 			}
 			if target.OS == "linux" && target.Arch == "arm" {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -413,12 +413,8 @@ static int do_sandbox_none(void)
 
 #if SYZ_EXECUTOR || __NR_syz_open_pts
 
-#if defined(__OpenBSD__)
 #include <termios.h>
 #include <util.h>
-#else
-#include <pty.h>
-#endif
 
 static uintptr_t syz_open_pts(void)
 {

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -17,10 +17,6 @@ import (
 )
 
 func Test(t *testing.T) {
-	switch runtime.GOOS {
-	case "openbsd":
-		t.Skipf("broken on %v", runtime.GOOS)
-	}
 	for _, sysTarget := range targets.List["test"] {
 		sysTarget1 := targets.Get(sysTarget.OS, sysTarget.Arch)
 		t.Run(sysTarget1.Arch, func(t *testing.T) {

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -182,13 +182,13 @@ var List = map[string]map[string]*Target{
 	},
 	"openbsd": {
 		"amd64": {
-			PtrSize:     8,
-			PageSize:    4 << 10,
-			CFlags:      []string{"-m64"},
-			CCompiler:   "c++",
+			PtrSize:   8,
+			PageSize:  4 << 10,
+			CFlags:    []string{"-m64"},
+			CCompiler: "c++",
 			// GNU CPP is installed from gcc package.
-			CPreprocessor: "/usr/local/bin/ecpp",
-			CrossCFlags: []string{"-m64", "-static", "-lutil"},
+			CPreprocessor: "ecpp",
+			CrossCFlags:   []string{"-m64", "-static", "-lutil"},
 		},
 	},
 	"fuchsia": {

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -25,6 +25,7 @@ type Target struct {
 	CrossCFlags      []string
 	CCompilerPrefix  string
 	CCompiler        string
+	CPreprocessor    string
 	KernelArch       string
 	KernelHeaderArch string
 	// NeedSyscallDefine is used by csource package to decide when to emit __NR_* defines.
@@ -185,6 +186,8 @@ var List = map[string]map[string]*Target{
 			PageSize:    4 << 10,
 			CFlags:      []string{"-m64"},
 			CCompiler:   "c++",
+			// GNU CPP is installed from gcc package.
+			CPreprocessor: "/usr/local/bin/ecpp",
 			CrossCFlags: []string{"-m64", "-static", "-lutil"},
 		},
 	},
@@ -331,6 +334,9 @@ func initTarget(target *Target, OS, arch string) {
 	}
 	if target.CCompiler == "" {
 		target.CCompiler = target.CCompilerPrefix + "gcc"
+	}
+	if target.CPreprocessor == "" {
+		target.CPreprocessor = "cpp"
 	}
 }
 

--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -30,7 +30,7 @@ rm -fr etc && mkdir -p etc
 cat >install.site <<EOF
 #!/bin/sh
 syspatch
-PKGS="bash git gmake go llvm nano wget"
+PKGS="bash gcc git gmake go llvm nano wget"
 PKG_PATH=https://${MIRROR}/pub/OpenBSD/${DOWNLOAD_VERSION}/packages/${ARCH}/ pkg_add -I \$PKGS
 PKG_PATH=http://firmware.openbsd.org/firmware/snapshots/ pkg_add vmm-firmware
 PKG_PATH= pkg_info -I \$PKGS vmm-firmware && echo pkg_add OK


### PR DESCRIPTION
A quick reproducer for bug #724  is
`go test -short github.com/google/syzkaller/pkg/csource`
It appears `-fdirectives-only` is essential to what is being tested and this forces a dependency on gcc cpp. Luckily it's not hard to arrange with pkg_add gcc and this PR.

This brings me to the next problem which seems to have something to do with my not understanding all the modalities of how artifacts are built. In particular, the tests are failing with:

```c
--- FAIL: TestGenerate (3.64s)
    --- FAIL: TestGenerate/openbsd/amd64 (0.03s)
        csource_test.go:55: seed=1541376313652063013
        --- FAIL: TestGenerate/openbsd/amd64/1/28 (0.28s)
            csource_test.go:104: opts: {Threaded:true Collide:false Repeat:true RepeatTimes:10 Procs:4 Sandbox:none Fault:false FaultCall:0 FaultNth:0 EnableTun:false UseTmpDir:true EnableCgroups:false EnableNetdev:false ResetNet:false HandleSegv:false Repro:false Trace:false}
                program:
                syz_execute_func(&(0x7f0000000000)="c481f3580f66420f3839b4eaf6d60000c4c2d5a78165566666c4a2a996e166440fed5f0a8fc8b0a3eea640d0d8660fef670ac481fc58eac4219971d4ff")
                syz_open_pts()
                
            csource_test.go:105: failed to build program:
                // autogenerated by syzkaller (https://github.com/google/syzkaller)
                
                <stdin>:8:10: fatal error: 'pty.h' file not found
                #include <pty.h>
                         ^~~~~~~
                1 error generated.
                
                compiler invocation: c++ [-Wall -Werror -O1 -g -o /tmp/syz-executor631965043 -pthread -DGOOS_openbsd=1 -DGOARCH_amd64=1 -x c - -m64 -static -lutil]
        --- FAIL: TestGenerate/openbsd/amd64/1/27 (0.18s)
            csource_test.go:104: opts: {Threaded:true Collide:true Repeat:true RepeatTimes:0 Procs:2 Sandbox:none Fault:false FaultCall:0 FaultNth:0 EnableTun:false UseTmpDir:true EnableCgroups:false EnableNetdev:false ResetNet:false HandleSegv:false Repro:true Trace:false}
                program:
                syz_execute_func(&(0x7f0000000000)="c481f3580f66420f3839b4eaf6d60000c4c2d5a78165566666c4a2a996e166440fed5f0a8fc8b0a3eea640d0d8660fef670ac481fc58eac4219971d4ff")
                syz_open_pts()

```