### PR TITLE
[fuchsia] Fix typo in Fuchsia build.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -21,10 +21,9 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 		return fmt.Errorf("unsupported fuchsia arch %v", targetArch)
 	}
 	arch := sysTarget.KernelHeaderArch
-	// TODO check if set-layer required?
 	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "clean-build", arch,
-		"--packages", "garnet/packages/products/sshd", "--args",
-		"'extra_authorized_keys_file=\"//.ssh/authorized_keys\"'"); err != nil {
+		"--packages", "garnet/packages/products/sshd",
+		"--args=extra_authorized_keys_file=\"//.ssh/authorized_keys\""); err != nil {
 		return err
 	}
 	for src, dst := range map[string]string{


### PR DESCRIPTION
Hey--so I *don't* know a particularly efficient way to test syz-ci right
now.

There's no good config I can find for just running it locally, and I
couldn't find any good unit tests for this function in particular, and
running it manually on a ci server isn't super-appealing since I'd have
to clobber the configuration there to point to my repo instead of the
canonical repo, pull from there, etc.

Do you have any good ideas for testing this before it rolls out?  In
particular I want the invocation to look exactly like:

./scripts/fx set x64 --packages garnet/packages/products/sshd --args 'extra_authorized_keys_file="//.ssh/authorized_keys"'

I thought I'd escaped it properly last time, but, since I couldn't test
it, clearly I goofed.  I *think* this does the right thing but I'd love
a sanity check.  Thanks!