### PR TITLE
prog: try to nullify pointers when minimizing

### DIFF
--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -121,10 +121,19 @@ func (typ *UnionType) minimize(ctx *minimizeArgsCtx, arg Arg, path string) bool 
 }
 
 func (typ *PtrType) minimize(ctx *minimizeArgsCtx, arg Arg, path string) bool {
-	// TODO: try to remove optional ptrs
 	a := arg.(*PointerArg)
 	if a.Res == nil {
 		return false
+	}
+	if !ctx.triedPaths[path+"->"] {
+		removeArg(a.Res)
+		replaceArg(a, MakeSpecialPointerArg(a.Type(), 0))
+		ctx.target.assignSizesCall(ctx.call)
+		if ctx.pred(ctx.p, ctx.callIndex0) {
+			*ctx.p0 = ctx.p
+		}
+		ctx.triedPaths[path+"->"] = true
+		return true
 	}
 	return ctx.do(a.Res, path)
 }

--- a/prog/minimization_test.go
+++ b/prog/minimization_test.go
@@ -47,7 +47,7 @@ func TestMinimize(t *testing.T) {
 				return len(p.Calls) == 2 && p.Calls[0].Meta.Name == "mmap" && p.Calls[1].Meta.Name == "pipe2"
 			},
 			"mmap(&(0x7f0000000000/0x1000)=nil, 0x1000, 0x0, 0x10, 0xffffffffffffffff, 0x0)\n" +
-				"pipe2(&(0x7f0000000000), 0x0)\n",
+				"pipe2(0x0, 0x0)\n",
 			1,
 		},
 		// Remove two dependent calls.
@@ -80,7 +80,7 @@ func TestMinimize(t *testing.T) {
 				return p.String() == "mmap-write-sched_yield"
 			},
 			"mmap(&(0x7f0000000000/0x1000)=nil, 0x1000, 0x0, 0x10, 0xffffffffffffffff, 0x0)\n" +
-				"write(0xffffffffffffffff, &(0x7f0000000000), 0x0)\n" +
+				"write(0xffffffffffffffff, 0x0, 0x0)\n" +
 				"sched_yield()\n",
 			2,
 		},
@@ -95,8 +95,28 @@ func TestMinimize(t *testing.T) {
 				return p.String() == "mmap-write-sched_yield"
 			},
 			"mmap(&(0x7f0000000000/0x1000)=nil, 0x1000, 0x0, 0x10, 0xffffffffffffffff, 0x0)\n" +
-				"write(0xffffffffffffffff, &(0x7f0000000000), 0x0)\n" +
+				"write(0xffffffffffffffff, 0x0, 0x0)\n" +
 				"sched_yield()\n",
+			-1,
+		},
+		// Minimize pointer.
+		{
+			"pipe2(&(0x7f0000001000)={0xffffffffffffffff, 0xffffffffffffffff}, 0x0)\n",
+			-1,
+			func(p *Prog, callIndex int) bool {
+				return len(p.Calls) == 1 && p.Calls[0].Meta.Name == "pipe2"
+			},
+			"pipe2(0x0, 0x0)\n",
+			-1,
+		},
+		// Minimize pointee.
+		{
+			"pipe2(&(0x7f0000001000)={0xffffffffffffffff, 0xffffffffffffffff}, 0x0)\n",
+			-1,
+			func(p *Prog, callIndex int) bool {
+				return len(p.Calls) == 1 && p.Calls[0].Meta.Name == "pipe2" && p.Calls[0].Args[0].(*PointerArg).Address != 0
+			},
+			"pipe2(&(0x7f0000001000), 0x0)\n",
 			-1,
 		},
 	}


### PR DESCRIPTION
This patch changes minimization routines to try assigning a.Res to nil for each pointer arg.
