### PR TITLE
sys/fuchsia add zircon-ethernet to fidlgen libs.

### DIFF
--- a/sys/fuchsia/fidlgen/main.go
+++ b/sys/fuchsia/fidlgen/main.go
@@ -25,6 +25,7 @@ var layerToLibs = map[string][]string{
 		"fuchsia-io",
 		"fuchsia-net",
 		"fuchsia-net-stack",
+		"zircon-ethernet",
 	},
 	"garnet": {
 		"fuchsia.devicesettings",


### PR DESCRIPTION
This commits adds "zircon-ethernet" to the list of fidl libraries that
fidlgen would look at. This is required because recently, a change in
fuchsia[0] added a new method to the netstack interface, that allows for
adding an EthernetInterface. One of the parameters is a
zircon.ethernet.Device, so we need to import that type for fidlgen to be
able to understand fidl_net-stack.txt.

I tested this by running:

```shell
$ make extract TARGETOS=fuchsia SOURCEDIR=${FUCHSIADIR}
$ make generate
```

[0]: https://fuchsia-review.googlesource.com/c/zircon/+/220580
