### PR TITLE
docs: require arm64 build for fuchsia

### DIFF
--- a/docs/fuchsia.md
+++ b/docs/fuchsia.md
@@ -9,6 +9,13 @@ fx set x64 --packages garnet/packages/products/sshd
 fx full-build
 ```
 
+You need to build fuchsia for both arm64 and amd64:
+
+```
+fx set arm64 --packages garnet/packages/products/sshd
+fx full-build
+```
+
 To update descriptions run:
 ```
 make extract TARGETOS=fuchsia SOURCEDIR=/path/to/fuchsia/checkout


### PR DESCRIPTION
I am adding a note in the fuchsia docs to specify that the caller should also build fuchsia for arm64. This is because the make extract command will call generate_fidl for TARGETARCH amd64 and arm64. If you happen to have an old tree for arm64, your amd64 changes might be overwritten by the arm64 ones.
