### PR TITLE
openbsd: include process information into crashes

### DIFF
--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -325,6 +325,8 @@ func (inst *instance) Diagnose() bool {
 		"show panic",
 		"trace",
 		"show registers",
+		"show proc",
+		"ps",
 	}
 	for _, c := range commands {
 		inst.consolew.Write([]byte(c + "\n"))


### PR DESCRIPTION
@mptre, WDYT?