### PR TITLE
ipc: add ProgInfo struct

### DIFF
--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -103,11 +103,11 @@ func TestExecute(t *testing.T) {
 			if failed {
 				t.Fatalf("program failed:\n%s", output)
 			}
-			if len(info) == 0 {
+			if len(info.Calls) == 0 {
 				t.Fatalf("no calls executed:\n%s", output)
 			}
-			if info[0].Errno != 0 {
-				t.Fatalf("simple call failed: %v\n%s", info[0].Errno, output)
+			if info.Calls[0].Errno != 0 {
+				t.Fatalf("simple call failed: %v\n%s", info.Calls[0].Errno, output)
 			}
 			if len(output) != 0 {
 				t.Fatalf("output on empty program")
@@ -152,12 +152,12 @@ func TestParallel(t *testing.T) {
 				err = fmt.Errorf("program failed:\n%s", output)
 				return
 			}
-			if len(info) == 0 {
+			if len(info.Calls) == 0 {
 				err = fmt.Errorf("no calls executed:\n%s", output)
 				return
 			}
-			if info[0].Errno != 0 {
-				err = fmt.Errorf("simple call failed: %v\n%s", info[0].Errno, output)
+			if info.Calls[0].Errno != 0 {
+				err = fmt.Errorf("simple call failed: %v\n%s", info.Calls[0].Errno, output)
 				return
 			}
 			if len(output) != 0 {

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -124,6 +124,6 @@ type RunTestDoneArgs struct {
 	Name   string
 	ID     int
 	Output []byte
-	Info   [][]ipc.CallInfo
+	Info   []*ipc.ProgInfo
 	Error  string
 }

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -384,10 +384,10 @@ func (fuzzer *Fuzzer) corpusSignalDiff(sign signal.Signal) signal.Signal {
 	return fuzzer.corpusSignal.Diff(sign)
 }
 
-func (fuzzer *Fuzzer) checkNewSignal(p *prog.Prog, info []ipc.CallInfo) (calls []int) {
+func (fuzzer *Fuzzer) checkNewSignal(p *prog.Prog, info *ipc.ProgInfo) (calls []int) {
 	fuzzer.signalMu.RLock()
 	defer fuzzer.signalMu.RUnlock()
-	for i, inf := range info {
+	for i, inf := range info.Calls {
 		diff := fuzzer.maxSignal.DiffRaw(inf.Signal, signalPrio(p.Target, p.Calls[i], &inf))
 		if diff.Empty() {
 			continue

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -237,16 +237,16 @@ func checkSimpleProgram(args *checkArgs) error {
 	if failed {
 		return fmt.Errorf("program failed:\n%s", output)
 	}
-	if len(info) == 0 {
+	if len(info.Calls) == 0 {
 		return fmt.Errorf("no calls executed:\n%s", output)
 	}
-	if info[0].Errno != 0 {
-		return fmt.Errorf("simple call failed: %+v\n%s", info[0], output)
+	if info.Calls[0].Errno != 0 {
+		return fmt.Errorf("simple call failed: %+v\n%s", info.Calls[0], output)
 	}
-	if args.ipcConfig.Flags&ipc.FlagSignal != 0 && len(info[0].Signal) < 2 {
+	if args.ipcConfig.Flags&ipc.FlagSignal != 0 && len(info.Calls[0].Signal) < 2 {
 		return fmt.Errorf("got no coverage:\n%s", output)
 	}
-	if len(info[0].Signal) < 1 {
+	if len(info.Calls[0].Signal) < 1 {
 		return fmt.Errorf("got no fallback coverage:\n%s", output)
 	}
 	return nil

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -148,7 +148,7 @@ func (ctx *Context) execute(pid int, env *ipc.Env, entry *prog.LogEntry) {
 		log.Logf(0, "result: failed=%v hanged=%v err=%v\n\n%s",
 			failed, hanged, err, output)
 	}
-	if len(info) != 0 {
+	if len(info.Calls) != 0 {
 		ctx.printCallResults(info)
 		if *flagHints {
 			ctx.printHints(entry.P, info)
@@ -173,8 +173,8 @@ func (ctx *Context) logProgram(pid int, p *prog.Prog, callOpts *ipc.ExecOpts) {
 	ctx.logMu.Unlock()
 }
 
-func (ctx *Context) printCallResults(info []ipc.CallInfo) {
-	for i, inf := range info {
+func (ctx *Context) printCallResults(info *ipc.ProgInfo) {
+	for i, inf := range info.Calls {
 		if inf.Flags&ipc.CallExecuted == 0 {
 			continue
 		}
@@ -193,13 +193,13 @@ func (ctx *Context) printCallResults(info []ipc.CallInfo) {
 	}
 }
 
-func (ctx *Context) printHints(p *prog.Prog, info []ipc.CallInfo) {
+func (ctx *Context) printHints(p *prog.Prog, info *ipc.ProgInfo) {
 	ncomps, ncandidates := 0, 0
 	for i := range p.Calls {
 		if *flagOutput {
 			fmt.Printf("call %v:\n", i)
 		}
-		comps := info[i].Comps
+		comps := info.Calls[i].Comps
 		for v, args := range comps {
 			ncomps += len(args)
 			if *flagOutput {
@@ -220,8 +220,8 @@ func (ctx *Context) printHints(p *prog.Prog, info []ipc.CallInfo) {
 	log.Logf(0, "ncomps=%v ncandidates=%v", ncomps, ncandidates)
 }
 
-func (ctx *Context) dumpCoverage(coverFile string, info []ipc.CallInfo) {
-	for i, inf := range info {
+func (ctx *Context) dumpCoverage(coverFile string, info *ipc.ProgInfo) {
+	for i, inf := range info.Calls {
 		log.Logf(0, "call #%v: signal %v, coverage %v", i, len(inf.Signal), len(inf.Cover))
 		if len(inf.Cover) == 0 {
 			continue


### PR DESCRIPTION
This patch add a new struct `ProgInfo` that for now holds info about each call in a program `[]CallInfo`, but in the future will be expanded with remote coverage info. Update all the callers to use the new interface as well.