### PR TITLE
ipc: fix ProgInfo usage

### DIFF
--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -122,7 +122,7 @@ func (proc *Proc) triageInput(item *WorkTriage) {
 	notexecuted := 0
 	for i := 0; i < signalRuns; i++ {
 		info := proc.executeRaw(proc.execOptsCover, item.p, StatTriage)
-		if len(info.Calls) == 0 || len(info.Calls[item.call].Signal) == 0 ||
+		if info == nil || len(info.Calls) == 0 || len(info.Calls[item.call].Signal) == 0 ||
 			item.info.Errno == 0 && info.Calls[item.call].Errno != 0 {
 			// The call was not executed or failed.
 			notexecuted++
@@ -146,7 +146,7 @@ func (proc *Proc) triageInput(item *WorkTriage) {
 			func(p1 *prog.Prog, call1 int) bool {
 				for i := 0; i < minimizeAttempts; i++ {
 					info := proc.execute(proc.execOptsNoCollide, p1, ProgNormal, StatMinimize)
-					if len(info.Calls) == 0 || len(info.Calls[call1].Signal) == 0 {
+					if info == nil || len(info.Calls) == 0 || len(info.Calls[call1].Signal) == 0 {
 						continue // The call was not executed.
 					}
 					inf := info.Calls[call1]

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -148,7 +148,7 @@ func (ctx *Context) execute(pid int, env *ipc.Env, entry *prog.LogEntry) {
 		log.Logf(0, "result: failed=%v hanged=%v err=%v\n\n%s",
 			failed, hanged, err, output)
 	}
-	if len(info.Calls) != 0 {
+	if info == nil || len(info.Calls) != 0 {
 		ctx.printCallResults(info)
 		if *flagHints {
 			ctx.printHints(entry.P, info)


### PR DESCRIPTION
We used to use `len([]CallInfo)` to check both, whether the slice is `nil` or whether its length is zero. Since `ProgInfo` is not a slice, we need a separate check for nil.
