### PR TITLE
openbsd: run on gce

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -71,10 +71,8 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		return fuchsia{}, nil
 	case targetOS == "akaros" && targetArch == "amd64" && vmType == "qemu":
 		return akaros{}, nil
-	case targetOS == "openbsd" && targetArch == "amd64":
-		return openbsd{
-			useGCE: vmType == "gce",
-		}, nil
+	case targetOS == "openbsd" && targetArch == "amd64" && (vmType == "gce" || vmType == "vmm"):
+		return openbsd{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -71,8 +71,10 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		return fuchsia{}, nil
 	case targetOS == "akaros" && targetArch == "amd64" && vmType == "qemu":
 		return akaros{}, nil
-	case targetOS == "openbsd" && targetArch == "amd64" && vmType == "vmm":
-		return openbsd{}, nil
+	case targetOS == "openbsd" && targetArch == "amd64":
+		return openbsd{
+			kernelInImage: vmType == "gce",
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -73,7 +73,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		return akaros{}, nil
 	case targetOS == "openbsd" && targetArch == "amd64":
 		return openbsd{
-			kernelInImage: vmType == "gce",
+			useGCE: vmType == "gce",
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -28,11 +28,11 @@ func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 	if err := ctx.make(compileDir, "all"); err != nil {
 		return err
 	}
-	for _, s := range []struct { dir, src, dst string } {
-		{compileDir, "obj/bsd",     "kernel"},
+	for _, s := range []struct{ dir, src, dst string }{
+		{compileDir, "obj/bsd", "kernel"},
 		{compileDir, "obj/bsd.gdb", "obj/bsd.gdb"},
-		{userspaceDir, "image",     "image"},
-		{userspaceDir, "key",       "key"},
+		{userspaceDir, "image", "image"},
+		{userspaceDir, "key", "key"},
 	} {
 		fullSrc := filepath.Join(s.dir, s.src)
 		fullDst := filepath.Join(outputDir, s.dst)

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -92,7 +92,11 @@ func (ctx openbsd) make(kernelDir string, args ...string) error {
 // implement this directly, but vnd(4) device would do in a pinch.
 // Assumes that the outputDir contains the appropriately named files.
 func CopyKernelToImage(outputDir string) error {
-	script := `
+	script := `set -eux
+# Cleanup in case something failed before.
+doas umount /altroot || true
+doas vnconfig -u vnd0 || true
+
 doas /sbin/vnconfig vnd0 image
 doas mount /dev/vnd0a /altroot
 doas cp kernel /altroot/bsd

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -14,9 +14,8 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 )
 
-type openbsd struct{
+type openbsd struct {
 	useGCE bool
-
 }
 
 func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -56,7 +56,9 @@ func (ctx openbsd) configure(confDir, compileDir, kernelName string, useGCE bool
 	baseConfig := "GENERIC"
 	if useGCE {
 		// GCE supports multiple CPUs.
-		baseConfig = "GENERIC.MP"
+		// TODO(gnezdo): Switch to GENERIC.mp once kernel crash is solved.
+		// http://openbsd-archive.7691.n7.nabble.com/option-kcov-GENERIC-MP-gt-silent-crash-tc355807.html
+		baseConfig = "GENERIC"
 	}
 	conf := []byte(fmt.Sprintf(`
 include "arch/amd64/conf/%v"

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -28,16 +28,16 @@ func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 	if err := ctx.make(compileDir, "all"); err != nil {
 		return err
 	}
-
-	for src, dst := range map[string]string{
-		filepath.Join(compileDir, "obj/bsd"):     "kernel",
-		filepath.Join(compileDir, "obj/bsd.gdb"): "obj/bsd.gdb",
-		filepath.Join(userspaceDir, "image"):     "image",
-		filepath.Join(userspaceDir, "key"):       "key",
+	for _, s := range []struct { dir, src, dst string } {
+		{compileDir, "obj/bsd",     "kernel"},
+		{compileDir, "obj/bsd.gdb", "obj/bsd.gdb"},
+		{userspaceDir, "image",     "image"},
+		{userspaceDir, "key",       "key"},
 	} {
-		fullDst := filepath.Join(outputDir, dst)
-		if err := osutil.CopyFile(src, fullDst); err != nil {
-			return fmt.Errorf("failed to copy %v -> %v: %v", src, fullDst, err)
+		fullSrc := filepath.Join(s.dir, s.src)
+		fullDst := filepath.Join(outputDir, s.dst)
+		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
+			return fmt.Errorf("failed to copy %v -> %v: %v", fullSrc, fullDst, err)
 		}
 	}
 	return nil

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 )
 
-type openbsd struct {}
+type openbsd struct{}
 
 func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
 	cmdlineFile, sysctlFile string, config []byte) error {

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -56,7 +56,7 @@ func (ctx openbsd) configure(confDir, compileDir, kernelName string, useGCE bool
 	baseConfig := "GENERIC"
 	if useGCE {
 		// GCE supports multiple CPUs.
-		// TODO(gnezdo): Switch to GENERIC.mp once kernel crash is solved.
+		// TODO(gnezdo): Switch to GENERIC.MP once kernel crash is solved.
 		// http://openbsd-archive.7691.n7.nabble.com/option-kcov-GENERIC-MP-gt-silent-crash-tc355807.html
 		baseConfig = "GENERIC"
 	}

--- a/t/t.go
+++ b/t/t.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+import "github.com/google/syzkaller/pkg/build"
+
+func main() {
+	fmt.Printf("Error %v\n", build.CopyKernelToImage("."))
+}

--- a/t/t.go
+++ b/t/t.go
@@ -1,8 +1,0 @@
-package main
-
-import "fmt"
-import "github.com/google/syzkaller/pkg/build"
-
-func main() {
-	fmt.Printf("Error %v\n", build.CopyKernelToImage("."))
-}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -100,7 +100,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.GCEImage == "" {
 		cfg.GCEImage = env.Name
 		gcsImage := filepath.Join(cfg.GCSPath, env.Name+"-image.tar.gz")
-		log.Logf(0, "uploading image to %v...", gcsImage)
+		log.Logf(0, "uploading image %v to %v...", env.Image, gcsImage)
 		if err := uploadImageToGCS(env.Image, gcsImage); err != nil {
 			return nil, err
 		}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -436,15 +436,10 @@ func uploadImageToGCS(localImage, gcsImage string) error {
 		Mode:     0640,
 		Size:     localStat.Size(),
 		ModTime:  time.Now(),
-		// This is hacky but we actually need these large uids.
-		// GCE understands only the old GNU tar format and
-		// there is no direct way to force tar package to use GNU format.
-		// But these large numbers force tar to switch to GNU format.
-		Uid:   100000000,
-		Gid:   100000000,
 		Uname: "syzkaller",
 		Gname: "syzkaller",
 	}
+	setGNUFormat(tarHeader)
 	if err := tarWriter.WriteHeader(tarHeader); err != nil {
 		return fmt.Errorf("failed to write image tar header: %v", err)
 	}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -436,8 +436,8 @@ func uploadImageToGCS(localImage, gcsImage string) error {
 		Mode:     0640,
 		Size:     localStat.Size(),
 		ModTime:  time.Now(),
-		Uname: "syzkaller",
-		Gname: "syzkaller",
+		Uname:    "syzkaller",
+		Gname:    "syzkaller",
 	}
 	setGNUFormat(tarHeader)
 	if err := tarWriter.WriteHeader(tarHeader); err != nil {

--- a/vm/gce/tar_go1.10.go
+++ b/vm/gce/tar_go1.10.go
@@ -1,0 +1,11 @@
+// +build go1.10
+
+package gce
+
+import (
+	"archive/tar"
+)
+
+func setGNUFormat(hdr *tar.Header) {
+	hdr.Format = tar.FormatGNU
+}

--- a/vm/gce/tar_go1.10.go
+++ b/vm/gce/tar_go1.10.go
@@ -1,3 +1,6 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 // +build go1.10
 
 package gce

--- a/vm/gce/tar_go1.9.go
+++ b/vm/gce/tar_go1.9.go
@@ -1,0 +1,16 @@
+// +build !go1.10
+
+package gce
+
+import (
+	"archive/tar"
+)
+
+func setGNUFormat(hdr *tar.Header) {
+	// This is hacky but we actually need these large uids.
+	// GCE understands only the old GNU tar format and prior to Go 1.10
+	// there is no direct way to force tar package to use GNU format.
+	// But these large numbers force tar to switch to GNU format.
+	hdr.Uid = 100000000
+	hdr.Gid = 100000000
+}

--- a/vm/gce/tar_go1.9.go
+++ b/vm/gce/tar_go1.9.go
@@ -1,3 +1,6 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 // +build !go1.10
 
 package gce

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -54,7 +54,7 @@ type BootErrorer interface {
 // (i.e. creation of instances out-of-thin-air). Overcommit is used during image
 // and patch testing in syz-ci when it just asks for more than specified in config
 // instances. Generally virtual machines (qemu, gce) support overcommit,
-// while physical machines (adb, isolated) do not. Strictly saying, we should
+// while physical machines (adb, isolated) do not. Strictly speaking, we should
 // never use overcommit and use only what's specified in config, because we
 // override resource limits specified in config (e.g. can OOM). But it works and
 // makes lots of things much simpler.

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -33,8 +33,8 @@ type Instance interface {
 	// Copy copies a hostSrc file into VM and returns file name in VM.
 	Copy(hostSrc string) (string, error)
 
-	// Forward setups forwarding from within VM to host port port
-	// and returns address to use in VM.
+	// Forward sets up forwarding from within VM to the given tcp
+	// port on the host and returns the address to use in VM.
 	Forward(port int) (string, error)
 
 	// Run runs cmd inside of the VM (think of ssh cmd).

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -127,7 +127,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 
 	if err := inst.Boot(); err != nil {
 		// Cleans up if Boot fails.
-                inst.Close()
+		inst.Close()
 		return nil, err
 	}
 

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -125,18 +125,12 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		return nil, err
 	}
 
-	closeInst := inst
-	defer func() {
-		if closeInst != nil {
-			closeInst.Close()
-		}
-	}()
-
 	if err := inst.Boot(); err != nil {
+		// Cleans up if Boot fails.
+                inst.Close()
 		return nil, err
 	}
 
-	closeInst = nil
 	return inst, nil
 }
 


### PR DESCRIPTION
This is working to the point of uploading a built tar file. The failure at that point is not actionable:
```
2018/11/24 21:18:02 GCE initialized: running on ci-openbsd-1, internal IP 10.128.0.105, project syzkaller, zone us-central1-c, net https://www.googleapis.com/compute/beta/projects/syzkaller/global/networks/default/https://www.googleapis.com/compute/beta/projects/syzkaller/regions/us-central1/subnetworks/default                                         
2018/11/24 21:18:02 uploading image /syzkaller/managers/main/latest.tmp/image to syzkaller/ci-openbsd-main-test-image.tar.gz...                                                 
2018/11/24 21:18:51 creating GCE image ci-openbsd-main-test...
2018/11/24 21:19:02 ci-openbsd-main: failed to create VM pool: failed to create GCE image: create image operation failed: &{Code:INVALID_IMAGE_TAR Location: Message:The tar archive is not a valid image. ForceSendFields:[] NullFields:[]}.
```

The same error can be seen directly:
```
% gcloud compute --project=syzkaller images create ci-openbsd-test-image --source-uri=https://storage.googleapis.com/syzkaller/ci-openbsd-main-test-image.tar.gz

ERROR: (gcloud.compute.images.create) Could not fetch resource:
 - The tar archive is not a valid image.
``` 

The file seems to have the contents I expected:
```
% gsutil cp gs://syzkaller/ci-openbsd-main-test-image.tar.gz /tmp                                                                                   ~/s/syzkaller@gnezdo  9:19PM
Copying gs://syzkaller/ci-openbsd-main-test-image.tar.gz...
\ [1 files][234.1 MiB/234.1 MiB]                                                
Operation completed over 1 objects/234.1 MiB.                                    
% tar zvtf /tmp/ci-openbsd-main-test-image.tar.gz
-rw-r----- syzkaller/syzkaller 1073741824 2018-11-24 21:18 disk.raw
```

Something is clearly not happy inside GCE and observability is lacking. 

Fixes #738 #740