### PR TITLE
vm/qemu: Improve debug output.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Chi Pham
 Anton Lindqvist
 Greg Steuck
 Shankara Pailoor
+Michael Tuexen

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,3 +38,4 @@ Joey Jiao
 Anton Lindqvist
 Tobin Harding
 Shankara Pailoor
+Michael Tuexen

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -74,7 +74,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 1000 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 1000]", cfg.Count)
 	}
-	if env.Debug {
+	if env.Debug && cfg.Count > 1 {
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if cfg.MachineType == "" {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/config"
+	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/vm/vmimpl"
 )
@@ -59,7 +60,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
 	if env.Debug && cfg.Count > 1 {
-		fmt.Errorf("limiting number of VMs from %v to 1 in debug mode", cfg.Count)
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if !osutil.IsExist(env.Image) {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -58,7 +58,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
-	if env.Debug {
+	if env.Debug && cfg.Count > 1 {
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if !osutil.IsExist(env.Image) {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -59,7 +59,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
 	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
+		fmt.Errorf("limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if !osutil.IsExist(env.Image) {

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -62,7 +62,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 			return nil, fmt.Errorf("bad target %q: %v", target, err)
 		}
 	}
-	if env.Debug {
+	if env.Debug && len(cfg.Targets) > 1 {
+		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", cfg.Count)
 		cfg.Targets = cfg.Targets[:1]
 	}
 	pool := &Pool{

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -63,7 +63,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		}
 	}
 	if env.Debug && len(cfg.Targets) > 1 {
-		fmt.Errorf("limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
+		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
 		cfg.Targets = cfg.Targets[:1]
 	}
 	pool := &Pool{

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -63,7 +63,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		}
 	}
 	if env.Debug && len(cfg.Targets) > 1 {
-		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", cfg.Count)
+		fmt.Errorf("limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
 		cfg.Targets = cfg.Targets[:1]
 	}
 	pool := &Pool{

--- a/vm/kvm/kvm.go
+++ b/vm/kvm/kvm.go
@@ -67,7 +67,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
-	if env.Debug {
+	if env.Debug && cfg.Count > 1 {
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if env.Image != "" {

--- a/vm/kvm/kvm.go
+++ b/vm/kvm/kvm.go
@@ -68,7 +68,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
 	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
+		fmt.Errorf("limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if env.Image != "" {

--- a/vm/kvm/kvm.go
+++ b/vm/kvm/kvm.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/config"
+	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/vm/vmimpl"
 )
@@ -68,7 +69,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
 	if env.Debug && cfg.Count > 1 {
-		fmt.Errorf("limiting number of VMs from %v to 1 in debug mode", cfg.Count)
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if env.Image != "" {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -180,7 +180,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
-	if env.Debug {
+	if env.Debug && cfg.Count > 1 {
+		log.Logf(0, "Limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if _, err := exec.LookPath(cfg.Qemu); err != nil {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -181,7 +181,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
 	}
 	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "Limiting number of VMs from %v to 1 in debug mode", cfg.Count)
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if _, err := exec.LookPath(cfg.Qemu); err != nil {

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -69,7 +69,8 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1-128]", cfg.Count)
 	}
-	if env.Debug {
+	if env.Debug && cfg.Count > 1 {
+		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
 		cfg.Count = 1
 	}
 	if cfg.Mem < 128 || cfg.Mem > 1048576 {


### PR DESCRIPTION
When running in debug mode, the number of VMs is reduced to 1.
State this in the debug output.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
