### PR TITLE
vm/qemu: Allow empty qemu-args.

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -313,7 +313,9 @@ func (inst *instance) Boot() error {
 		"-serial", "stdio",
 		"-no-reboot",
 	}
-	args = append(args, strings.Split(inst.cfg.QemuArgs, " ")...)
+	if inst.cfg.QemuArgs != "" {
+		args = append(args, strings.Split(inst.cfg.QemuArgs, " ")...)
+	}
 	if inst.image == "9p" {
 		args = append(args,
 			"-fsdev", "local,id=fsdev0,path=/,security_model=none,readonly",


### PR DESCRIPTION
Allow setting qemu_args to "" in the config file. This is needed
when running qemu from the qemu-devel package on FreeBSD, which
does not support the -enable-kvm option.
Without this patch, an entry "" is added to the list of command
line parameters, which breaks the starting of the qemu instances.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
