### PR TITLE
tools/syz-trace2syz: adding missing copyright headers

### DIFF
--- a/tools/syz-trace2syz/proggen/context.go
+++ b/tools/syz-trace2syz/proggen/context.go
@@ -1,3 +1,6 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 package proggen
 
 import (

--- a/tools/syz-trace2syz/proggen/return_cache.go
+++ b/tools/syz-trace2syz/proggen/return_cache.go
@@ -1,3 +1,6 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 package proggen
 
 import (


### PR DESCRIPTION
Adding missing copyright headers to return_cache.go and context.go
