### PR TITLE
pkg/report: add initial symbolize suppport to OpenBSD

### DIFF
--- a/pkg/report/akaros.go
+++ b/pkg/report/akaros.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type akaros struct {
@@ -20,12 +21,13 @@ type akaros struct {
 	objfile string
 }
 
-func ctorAkaros(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorAkaros(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &akaros{
 		ignores: ignores,
 	}
 	if kernelObj != "" {
-		ctx.objfile = filepath.Join(kernelObj, "akaros-kernel-64b")
+		ctx.objfile = filepath.Join(kernelObj, target.KernelObject)
 	}
 	return ctx, nil, nil
 }

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -6,6 +6,8 @@ package report
 import (
 	"bytes"
 	"regexp"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type freebsd struct {
@@ -14,7 +16,8 @@ type freebsd struct {
 	ignores   []*regexp.Regexp
 }
 
-func ctorFreebsd(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorFreebsd(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &freebsd{
 		kernelSrc: kernelSrc,
 		kernelObj: kernelObj,

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/ianlancetaylor/demangle"
 )
 
@@ -38,12 +39,13 @@ var (
 	}
 )
 
-func ctorFuchsia(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorFuchsia(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &fuchsia{
 		ignores: ignores,
 	}
 	if kernelObj != "" {
-		ctx.obj = filepath.Join(kernelObj, "zircon.elf")
+		ctx.obj = filepath.Join(kernelObj, target.KernelObject)
 	}
 	suppressions := []string{
 		"fatal exception: process /tmp/syz-fuzzer", // OOM presumably

--- a/pkg/report/fuzz.go
+++ b/pkg/report/fuzz.go
@@ -49,7 +49,8 @@ var fuzzReporters = func() []Reporter {
 			continue
 		}
 		cfg := &mgrconfig.Config{
-			TargetOS: os,
+			TargetOS:   os,
+			TargetArch: "amd64",
 		}
 		reporter, err := NewReporter(cfg)
 		if err != nil {

--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -6,13 +6,16 @@ package report
 import (
 	"bytes"
 	"regexp"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type gvisor struct {
 	ignores []*regexp.Regexp
 }
 
-func ctorGvisor(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorGvisor(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &gvisor{
 		ignores: ignores,
 	}

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type linux struct {
@@ -32,11 +33,11 @@ type linux struct {
 	eoi                   []byte
 }
 
-func ctorLinux(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
-	vmlinux := ""
+func ctorLinux(target *targets.Target, kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
 	var symbols map[string][]symbolizer.Symbol
+	vmlinux := ""
 	if kernelObj != "" {
-		vmlinux = filepath.Join(kernelObj, "vmlinux")
+		vmlinux = filepath.Join(kernelObj, target.KernelObject)
 		var err error
 		symbols, err = symbolizer.ReadSymbols(vmlinux)
 		if err != nil {

--- a/pkg/report/linux_test.go
+++ b/pkg/report/linux_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestLinuxIgnores(t *testing.T) {
 	cfg := &mgrconfig.Config{
-		TargetOS: "linux",
+		TargetOS:   "linux",
+		TargetArch: "amd64",
 	}
 	reporter, err := NewReporter(cfg)
 	if err != nil {

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -5,6 +5,8 @@ package report
 
 import (
 	"regexp"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type netbsd struct {
@@ -13,7 +15,8 @@ type netbsd struct {
 	ignores   []*regexp.Regexp
 }
 
-func ctorNetbsd(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorNetbsd(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &netbsd{
 		kernelSrc: kernelSrc,
 		kernelObj: kernelObj,

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"bytes"
 	"regexp"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type openbsd struct {
@@ -15,7 +17,8 @@ type openbsd struct {
 	ignores   []*regexp.Regexp
 }
 
-func ctorOpenbsd(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorOpenbsd(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &openbsd{
 		kernelSrc: kernelSrc,
 		kernelObj: kernelObj,

--- a/pkg/report/openbsd_test.go
+++ b/pkg/report/openbsd_test.go
@@ -1,0 +1,89 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package report
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/symbolizer"
+)
+
+func TestOpenbsdSymbolizeLine(t *testing.T) {
+	tests := []struct {
+		line   string
+		result string
+	}{
+		// Normal symbolization.
+		{
+			"closef(ffffffff,ffffffff) at closef+0xaf\n",
+			"closef(ffffffff,ffffffff) at closef+0xaf kern_descrip.c:1241\n",
+		},
+		// Inlined frames.
+		{
+			"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22\n",
+			"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22 sleep_finish_timeout kern_synch.c:336 [inline]\n" +
+				"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22 kern_synch.c:157\n",
+		},
+		// Missing symbol.
+		{
+			"foo(ffffffff,ffffffff) at foo+0x1e",
+			"foo(ffffffff,ffffffff) at foo+0x1e",
+		},
+	}
+	symbols := map[string][]symbolizer.Symbol{
+		"closef": {
+			{Addr: 0x815088a0, Size: 0x12f},
+		},
+		"sleep_finish_all": {
+			{Addr: 0x81237520, Size: 0x173},
+		},
+	}
+	symb := func(bin string, pc uint64) ([]symbolizer.Frame, error) {
+		if bin != "bsd.gdb" {
+			return nil, fmt.Errorf("unknown pc 0x%x", pc)
+		}
+
+		switch pc & 0xffffffff {
+		case 0x8150894f:
+			return []symbolizer.Frame{
+				{
+					File: "/usr/src/kern_descrip.c",
+					Line: 1241,
+					Func: "closef",
+				},
+			}, nil
+		case 0x81237542:
+			return []symbolizer.Frame{
+				{
+					Func:   "sleep_finish_timeout",
+					File:   "/usr/src/kern_synch.c",
+					Line:   336,
+					Inline: true,
+				},
+				{
+					Func: "sleep_finish_all",
+					File: "/usr/src/kern_synch.c",
+					Line: 157,
+				},
+			}, nil
+		default:
+			return nil, fmt.Errorf("unknown pc 0x%x", pc)
+		}
+	}
+	obsd := openbsd{
+		kernelSrc:    "/usr/src",
+		kernelObj:    "/usr/src/sys/arch/amd64/compile/SYZKALLER/obj",
+		kernelObject: "bsd.gdb",
+		symbols:      symbols,
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			result := obsd.symbolizeLine(symb, []byte(test.line))
+			if test.result != string(result) {
+				t.Errorf("want %q\n\t     get %q", test.result, string(result))
+			}
+		})
+	}
+}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -255,7 +255,8 @@ func forEachFile(t *testing.T, dir string, fn func(t *testing.T, reporter Report
 			t.Fatal(err)
 		}
 		cfg := &mgrconfig.Config{
-			TargetOS: os,
+			TargetOS:   os,
+			TargetArch: "amd64",
 		}
 		reporter, err := NewReporter(cfg)
 		if err != nil {

--- a/pkg/report/stub.go
+++ b/pkg/report/stub.go
@@ -5,6 +5,8 @@ package report
 
 import (
 	"regexp"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type stub struct {
@@ -13,7 +15,8 @@ type stub struct {
 	ignores   []*regexp.Regexp
 }
 
-func ctorStub(kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorStub(target *targets.Target, kernelSrc, kernelObj string,
+	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &stub{
 		kernelSrc: kernelSrc,
 		kernelObj: kernelObj,

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	flagOS        = flag.String("os", runtime.GOOS, "target os")
+	flagArch      = flag.String("arch", runtime.GOARCH, "target arch")
 	flagKernelSrc = flag.String("kernel_src", ".", "path to kernel sources")
 	flagKernelObj = flag.String("kernel_obj", ".", "path to kernel build/obj dir")
 )
@@ -28,9 +29,10 @@ func main() {
 		os.Exit(1)
 	}
 	cfg := &mgrconfig.Config{
-		TargetOS:  *flagOS,
-		KernelObj: *flagKernelObj,
-		KernelSrc: *flagKernelSrc,
+		TargetOS:   *flagOS,
+		TargetArch: *flagArch,
+		KernelObj:  *flagKernelObj,
+		KernelSrc:  *flagKernelSrc,
 	}
 	reporter, err := report.NewReporter(cfg)
 	if err != nil {


### PR DESCRIPTION
```
$ cat before.txt
ddb{1}> trace
db_enter() at db_enter+0xa
panic() at panic+0x147
__assert(ffffffff81521464,ffff8000211ab3d0,ffff8000210a39e0,ffff800000038e80) at __assert+0x24
_kernel_lock(ffff8000210a39e0,ffff8000211a6000) at _kernel_lock+0x125
pageflttrap() at pageflttrap+0x6c
kerntrap(9) at kerntrap+0x8d
alltraps_kern(6,ffff800000ad6000,ffffffffffffffff,0,9,ffff8000210a39e0) at alltraps_kern+0x7b
ptsignal(2829,ffff8000210a39e0,ffff8000210b7630) at ptsignal+0x115
mi_switch() at mi_switch+0x1fb
sleep_finish(1,ffff8000211ab660) at sleep_finish+0xd3
sleep_finish_all(ffff8000211ab660,32) at sleep_finish_all+0x22
tsleep(ffff8000210a39e0,3,0,ffff8000210b76f8) at tsleep+0x142
single_thread_set(ffff8000210a39e0,ffff8000210a39e0,0) at single_thread_set+0x28b
exit1(ffff8000210a39e0,9,0) at exit1+0x84
postsig(100,ffff8000210a39e0) at postsig+0x3ea
userret(0) at userret+0x11b
syscall(0) at syscall+0x54d
Xsyscall(6,58,1739cadc000,53,0,1739cad9900) at Xsyscall+0x128
end of kernel
end trace frame: 0x173e57df590, count: -18
$ cat after.txt
ddb{1}> trace
db_enter() at db_enter+0xa sys/arch/amd64/amd64/db_interface.c:399
panic() at panic+0x147 sys/kern/subr_prf.c:208
__assert(ffffffff81521464,ffff8000211ab3d0,ffff8000210a39e0,ffff800000038e80) at __assert+0x24 sys/kern/subr_prf.c:155
_kernel_lock(ffff8000210a39e0,ffff8000211a6000) at _kernel_lock+0x125 sys/kern/kern_lock.c:63
pageflttrap() at pageflttrap+0x6c sys/arch/amd64/amd64/trap.c:163
kerntrap(9) at kerntrap+0x8d sys/arch/amd64/amd64/trap.c:294
alltraps_kern(6,ffff800000ad6000,ffffffffffffffff,0,9,ffff8000210a39e0) at alltraps_kern+0x7b
ptsignal(2829,ffff8000210a39e0,ffff8000210b7630) at ptsignal+0x115 sys/kern/kern_sig.c:944
mi_switch() at mi_switch+0x1fb sys/kern/sched_bsd.c:392
sleep_finish(1,ffff8000211ab660) at sleep_finish+0xd3 sys/kern/kern_synch.c:312
sleep_finish_all(ffff8000211ab660,32) at sleep_finish_all+0x22 sleep_finish_timeout sys/kern/kern_synch.c:336 [inline]
sleep_finish_all(ffff8000211ab660,32) at sleep_finish_all+0x22 sys/kern/kern_synch.c:157
tsleep(ffff8000210a39e0,3,0,ffff8000210b76f8) at tsleep+0x142
single_thread_set(ffff8000210a39e0,ffff8000210a39e0,0) at single_thread_set+0x28b single_thread_wait sys/kern/kern_sig.c:2051 [inline]
single_thread_set(ffff8000210a39e0,ffff8000210a39e0,0) at single_thread_set+0x28b sys/kern/kern_sig.c:2042
exit1(ffff8000210a39e0,9,0) at exit1+0x84 sys/kern/kern_exit.c:137
postsig(100,ffff8000210a39e0) at postsig+0x3ea sigexit sys/kern/kern_sig.c:1500 [inline]
postsig(100,ffff8000210a39e0) at postsig+0x3ea sys/kern/kern_sig.c:1432
userret(0) at userret+0x11b sys/kern/kern_sig.c:1882
syscall(0) at syscall+0x54d mi_syscall_return sys/sys/syscall_mi.h:122 [inline]
syscall(0) at syscall+0x54d sys/arch/amd64/amd64/trap.c:605
Xsyscall(6,58,1739cadc000,53,0,1739cad9900) at Xsyscall+0x128
end of kernel
end trace frame: 0x173e57df590, count: -18
```