### PR TITLE
tools/*openbsd*: use nc from base instead of curl from package

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -48,12 +48,15 @@ EOF
 
 cat >etc/rc.local <<EOF
 (
-  /usr/local/bin/curl -H "Metadata-Flavor: Google" \
-     "http://metadata.google.internal/computeMetadata/v1/instance/hostname" \
-     > /etc/myname.gce \
+  nc metadata.google.internal 80 <<EOF2 | tail -n1 > /etc/myname.gce \
   && echo >> /etc/myname.gce \
   && mv /etc/myname{.gce,} \
   && hostname \$(cat /etc/myname)
+GET /computeMetadata/v1/instance/hostname HTTP/1.0
+Host: metadata.google.internal
+Metadata-Flavor: Google
+
+EOF2
   set -eux
 
   echo "starting syz-ci"

--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -52,12 +52,15 @@ EOF
 
 cat >etc/rc.local <<EOF
 (
-  /usr/local/bin/curl -H "Metadata-Flavor: Google" \
-     "http://metadata.google.internal/computeMetadata/v1/instance/hostname" \
-     > /etc/myname.gce \
+  nc metadata.google.internal 80 <<EOF2 | tail -n1 > /etc/myname.gce \
   && echo >> /etc/myname.gce \
   && mv /etc/myname{.gce,} \
   && hostname \$(cat /etc/myname)
+GET /computeMetadata/v1/instance/hostname HTTP/1.0
+Host: metadata.google.internal
+Metadata-Flavor: Google
+
+EOF2
 )
 EOF
 


### PR DESCRIPTION
This worked fine for ci machine but gce workers have no packages.