### PR TITLE
vm/gvisor: replace signal panic with log

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -190,7 +190,7 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	args := []string{
 		"-root", inst.rootDir,
 		"-watchdog-action=panic",
-		"-panic-signal=12",
+		"-trace-signal=12",
 		"-network=none",
 		"-debug",
 	}


### PR DESCRIPTION
Diagnose currently sends the panic signal to generate a traceback for
additional context.

However, Diagnose is also called in otherwise successful scenarios
(vm.Instance.MonitorExecution -> vm.monitor.extractError). Triggering a
panic will make this successful scenario look like a failure.

We could simply suppress this panic, but 1) that means we never shutdown
cleanly (not important, but ugly), and 2) we're less likely to detect
delayed crashes since we kill the sandbox immediately (that's what
MonitorExecution is checking for).

Instead, switch from -panic-signal to -trace-signal, which simply logs a
traceback without exiting. This option was added to runsc in
https://github.com/google/gvisor/commit/24c1158b9c21f7f8b7126e810d623a518422052e.

The other uses of Diagnose will always generate a report regardless of
an additional panic, so we're not losing any reports.