### PR TITLE
vm/gvisor: don't close conn on error

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -312,7 +312,6 @@ func (inst *instance) guestProxy() (*os.File, error) {
 	guestSock := os.NewFile(uintptr(socks[1]), "guest unix proxy")
 	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%v", inst.port))
 	if err != nil {
-		conn.Close()
 		hostSock.Close()
 		guestSock.Close()
 		return nil, err


### PR DESCRIPTION
If net.Dial returns an error, conn is nil and closing it will panic.
