### PR TITLE
vm/gvisor: support forwarding on IPv6

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -310,7 +310,7 @@ func (inst *instance) guestProxy() (*os.File, error) {
 	}
 	hostSock := os.NewFile(uintptr(socks[0]), "host unix proxy")
 	guestSock := os.NewFile(uintptr(socks[1]), "guest unix proxy")
-	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%v", inst.port))
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%v", inst.port))
 	if err != nil {
 		conn.Close()
 		hostSock.Close()


### PR DESCRIPTION
Dialing with "tcp" allows use of IPv4 or IPv6, and Listen in instance.inst.testInstance() may do either.

However, by hard-coding "127.0.0.1" here we force v4. Using "localhost" allows whichever is default.
