### PR TITLE
pkg/build/openbsd: always make clean to manage config in tree

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -1,5 +1,2 @@
 include "arch/amd64/conf/GENERIC.MP"
 pseudo-device kcov 1
-option WITNESS
-option WITNESS_WATCH
-option LOCKF_DIAGNOSTIC

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -1,5 +1,2 @@
 include "arch/amd64/conf/GENERIC"
 pseudo-device kcov 1
-option WITNESS
-option WITNESS_WATCH
-option LOCKF_DIAGNOSTIC

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -33,7 +33,7 @@ func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 	if err := osutil.WriteFile(filepath.Join(compileDir, "Makefile"), makefile); err != nil {
 		return err
 	}
-	for _, tgt := range []string{"obj", "config", "all"} {
+	for _, tgt := range []string{"clean", "obj", "config", "all"} {
 		if err := ctx.make(compileDir, tgt); err != nil {
 			return err
 		}
@@ -57,7 +57,11 @@ func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 }
 
 func (ctx openbsd) clean(kernelDir string) error {
-	return ctx.make(kernelDir, "", "clean")
+	// Building clean is fast enough and incremental builds in face of
+	// changing config files don't work. Instead of optimizing for the
+	// case where humans have to think, let's bludgeon it with a
+	// machine.
+	return nil
 }
 
 func (ctx openbsd) make(kernelDir string, args ...string) error {


### PR DESCRIPTION
clean build barely takes 3 minutes end-to-end on our CI machine.

Undo debug options which caused prevented kernels from booting on GCE.

@mptre FYI