### PR TITLE
Revert "vm/gvisor: replace signal panic with log"

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -190,7 +190,7 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	args := []string{
 		"-root", inst.rootDir,
 		"-watchdog-action=panic",
-		"-trace-signal=12",
+		"-panic-signal=12",
 		"-network=none",
 		"-debug",
 	}


### PR DESCRIPTION
This reverts commit c3b10a5d6a7b19ff2d35305aa175519fe6d62e8f.

This is no longer necessary now that #875 is fixed. This feature was
added to runsc just for syzkaller. Now we can remove it.

If we want non-fatal Diagnose back, we can use the existing `runsc debug
--stacks` with some additional log plumbing.