### PR TITLE
vm/gvisor: use runsc debug --stacks to diagnose

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -405,6 +405,6 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	return vmimpl.Multiplex(adb, merger, tty, timeout, stop, inst.closed, inst.debug)
 }
 
-func (inst *instance) Diagnose() bool {
-	return false
+func (inst *instance) Diagnose() ([]byte, bool) {
+	return nil, false
 }

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -366,11 +366,11 @@ func waitForConsoleConnect(merger *vmimpl.OutputMerger) error {
 	}
 }
 
-func (inst *instance) Diagnose() bool {
+func (inst *instance) Diagnose() ([]byte, bool) {
 	if inst.env.OS == "openbsd" {
-		return vmimpl.DiagnoseOpenBSD(inst.consolew)
+		return nil, vmimpl.DiagnoseOpenBSD(inst.consolew)
 	}
-	return false
+	return nil, false
 }
 
 func (pool *Pool) getSerialPortOutput(name, gceKey string) ([]byte, error) {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -327,9 +327,9 @@ func (inst *instance) guestProxy() (*os.File, error) {
 	return guestSock, nil
 }
 
-func (inst *instance) Diagnose() bool {
+func (inst *instance) Diagnose() ([]byte, bool) {
 	osutil.Run(time.Minute, inst.runscCmd("debug", "-signal=12", inst.name))
-	return true
+	return nil, true
 }
 
 func init() {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -190,7 +190,6 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	args := []string{
 		"-root", inst.rootDir,
 		"-watchdog-action=panic",
-		"-trace-signal=12",
 		"-network=none",
 		"-debug",
 	}
@@ -328,8 +327,11 @@ func (inst *instance) guestProxy() (*os.File, error) {
 }
 
 func (inst *instance) Diagnose() ([]byte, bool) {
-	osutil.Run(time.Minute, inst.runscCmd("debug", "-signal=12", inst.name))
-	return nil, true
+	b, err := osutil.Run(time.Minute, inst.runscCmd("debug", "-stacks", inst.name))
+	if err != nil {
+		b = append(b, []byte(fmt.Sprintf("\n\nError collecting stacks: %v", err))...)
+	}
+	return b, false
 }
 
 func init() {

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -303,8 +303,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	return vmimpl.Multiplex(cmd, merger, dmesg, timeout, stop, inst.closed, inst.debug)
 }
 
-func (inst *instance) Diagnose() bool {
-	return false
+func (inst *instance) Diagnose() ([]byte, bool) {
+	return nil, false
 }
 
 func splitTargetPort(addr string) (string, int, error) {

--- a/vm/kvm/kvm.go
+++ b/vm/kvm/kvm.go
@@ -287,8 +287,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	return outputC, errorC, nil
 }
 
-func (inst *instance) Diagnose() bool {
-	return false
+func (inst *instance) Diagnose() ([]byte, bool) {
+	return nil, false
 }
 
 const script = `#! /bin/bash

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -512,12 +512,12 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	return inst.merger.Output, errc, nil
 }
 
-func (inst *instance) Diagnose() bool {
+func (inst *instance) Diagnose() ([]byte, bool) {
 	select {
 	case inst.diagnose <- true:
 	default:
 	}
-	return false
+	return nil, false
 }
 
 // nolint: lll

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -43,10 +43,13 @@ type Instance interface {
 	// Command is terminated after timeout. Send on the stop chan can be used to terminate it earlier.
 	Run(timeout time.Duration, stop <-chan bool, command string) (outc <-chan []byte, errc <-chan error, err error)
 
-	// Diagnose forces VM to dump additional debugging info
-	// (e.g. sending some sys-rq's or SIGABORT'ing a Go program).
-	// Returns true if it did anything.
-	Diagnose() bool
+	// Diagnose retrieves additional debugging info from the VM (e.g. by
+	// sending some sys-rq's or SIGABORT'ing a Go program).
+	//
+	// Optionally returns (some or all) of the info directly. If wait ==
+	// true, the caller must wait for the VM to output info directly to its
+	// log.
+	Diagnose() (diagnosis []byte, wait bool)
 
 	// Close stops and destroys the VM.
 	Close()

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -310,8 +310,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	return inst.merger.Output, errc, nil
 }
 
-func (inst *instance) Diagnose() bool {
-	return vmimpl.DiagnoseOpenBSD(inst.consolew)
+func (inst *instance) Diagnose() ([]byte, bool) {
+	return nil, vmimpl.DiagnoseOpenBSD(inst.consolew)
 }
 
 // Run the given vmctl(8) command and wait for it to finish.


### PR DESCRIPTION
This requires plumbing the result into the kernel logs, which is actually quite simple.

This replaces #891.