### PR TITLE
tools/syz-trace2syz: only add null-byte for prog.BufferFilename

### DIFF
--- a/tools/syz-trace2syz/parser/lex.go
+++ b/tools/syz-trace2syz/parser/lex.go
@@ -5804,6 +5804,5 @@ func ParseString(s string) string {
 		log.Logf(2, "failed to decode string: %s, with error: %s", s, err.Error())
 		decoded = []byte(strippedStr)
 	}
-	decoded = append(decoded, '\x00')
 	return string(decoded)
 }

--- a/tools/syz-trace2syz/parser/straceLex.rl
+++ b/tools/syz-trace2syz/parser/straceLex.rl
@@ -127,6 +127,5 @@ func ParseString(s string) string{
 		log.Logf(2, "failed to decode string: %s, with error: %s", s, err.Error())
 		decoded = []byte(strippedStr)
 	}
-	decoded = append(decoded, '\x00')
 	return string(decoded)
 }

--- a/tools/syz-trace2syz/proggen/proggen.go
+++ b/tools/syz-trace2syz/proggen/proggen.go
@@ -287,6 +287,11 @@ func (ctx *context) genBuffer(syzType *prog.BufferType, traceType parser.IrType)
 	default:
 		log.Fatalf("unsupported type for buffer: %#v", traceType)
 	}
+	// strace always drops the null byte for strings but we only need to add it back for filenames
+	switch syzType.Kind {
+	case prog.BufferFilename:
+		bufVal = append(bufVal, '\x00')
+	}
 	if !syzType.Varlen() {
 		size := syzType.Size()
 		for uint64(len(bufVal)) < size {

--- a/tools/syz-trace2syz/proggen/proggen_test.go
+++ b/tools/syz-trace2syz/proggen/proggen_test.go
@@ -24,14 +24,14 @@ open("file", 66) = 3
 write(3, "somedata", 8) = 8
 `, `
 r0 = open(&(0x7f0000000000)='file\x00', 0x42, 0x0)
-write(r0, &(0x7f0000000040)='somedata\x00', 0x9)
+write(r0, &(0x7f0000000040)='somedata', 0x8)
 `,
 		}, {`
 pipe([5,6]) = 0
 write(6, "\xff\xff\xfe\xff", 4) = 4
 `, `
 pipe(&(0x7f0000000000)={0xffffffffffffffff, <r0=>0xffffffffffffffff})
-write(r0, &(0x7f0000000040)="fffffeff00", 0x5)
+write(r0, &(0x7f0000000040)="fffffeff", 0x4)
 `,
 		}, {`
 pipe({0x0, 0x1}) = 0
@@ -51,13 +51,13 @@ getsockopt$inet_sctp6_SCTP_RESET_STREAMS(0xffffffffffffffff, 0x84, 0x77, &(0x7f0
 inotify_init() = 2
 open("tmp", 66) = 3
 inotify_add_watch(3, "\x2e", 0xfff) = 3
-write(3, "temp", 5) = 5
+write(3, "temp", 4) = 4
 inotify_rm_watch(2, 3) = 0
 `, `
 r0 = inotify_init()
 r1 = open(&(0x7f0000000000)='tmp\x00', 0x42, 0x0)
 r2 = inotify_add_watch(r1, &(0x7f0000000040)='.\x00', 0xfff)
-write(r1, &(0x7f0000000080)='temp\x00', 0x5)
+write(r1, &(0x7f0000000080)='temp', 0x4)
 inotify_rm_watch(r0, r2)
 `,
 		}, {`


### PR DESCRIPTION
trace2syz used to always add a null byte to strings.
This isn't correct behavior since we may end up writing null bytes to files.
The extra byte can affect system calls like ioctl$FS_IOC_ENABLE_VERITY. We now only add the byte for filenames.