### PR TITLE
tools/syz-trace2syz/proggen: append 0 to string buffers

### DIFF
--- a/tools/syz-trace2syz/proggen/proggen.go
+++ b/tools/syz-trace2syz/proggen/proggen.go
@@ -287,9 +287,9 @@ func (ctx *context) genBuffer(syzType *prog.BufferType, traceType parser.IrType)
 	default:
 		log.Fatalf("unsupported type for buffer: %#v", traceType)
 	}
-	// strace always drops the null byte for strings but we only need to add it back for filenames
+	// strace always drops the null byte for buffer types but we only need to add it back for filenames and strings
 	switch syzType.Kind {
-	case prog.BufferFilename:
+	case prog.BufferFilename, prog.BufferString:
 		bufVal = append(bufVal, '\x00')
 	}
 	if !syzType.Varlen() {

--- a/tools/syz-trace2syz/proggen/proggen_test.go
+++ b/tools/syz-trace2syz/proggen/proggen_test.go
@@ -163,6 +163,13 @@ connect(3, {sa_family=2, sin_port=17812, sin_addr=0x7f000001}, 16) = 0
 r0 = socket$inet_tcp(0x2, 0x1, 0x0)
 connect$inet(r0, &(0x7f0000000000)={0x2, 0x4594, @rand_addr=0x7f000001}, 0x10)
 `,
+		}, {`
+open("\x2f\x64\x65\x76\x2f\x73\x6e\x64\x2f\x73\x65\x71", 0) = 3
+fsetxattr(3, "\x73\x65\x63\x75\x72\x69\x74\x79\x2e\x73\x65\x6c\x69\x6e\x75\x78","\x73\x79\x73", 4, 0) = 0
+`, `
+r0 = open(&(0x7f0000000000)='/dev/snd/seq\x00', 0x0, 0x0)
+fsetxattr(r0, &(0x7f0000000040)=@known='security.selinux\x00', &(0x7f0000000080)='sys\x00', 0x4, 0x0)
+`,
 		},
 	}
 	target, err := prog.GetTarget("linux", "amd64")


### PR DESCRIPTION
String buffers get the null byte added during generation. This means we need to add the null byte explicitly in trace2syz.
