### PR TITLE
syz-manager: Improve the computation of getVMOffset() on FreeBSD

### DIFF
--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -248,7 +248,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
-		mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, cov); err != nil {
+		mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, mgr.cfg.TargetOS, cov); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -400,7 +400,7 @@ func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 
 	initCoverOnce.Do(func() {
 		initCoverError = initCover(mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
-			mgr.cfg.KernelSrc, mgr.cfg.TargetArch)
+			mgr.cfg.KernelSrc, mgr.cfg.TargetArch, mgr.cfg.TargetOS)
 	})
 	if initCoverError != nil {
 		http.Error(w, initCoverError.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
On FreeBSD getVMOffset() always returned 0 instead of 0xffffffff.
This breaks the usage of addr2line. For now, just return always
0xffffffff on FreeBSD, since a more sophisticated logic doesn't
seem to be required by now.

Thanks to Dmitry for pointing out that this functions provides
the prefix address.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
