### PR TITLE
fuzzer: speed up syscall support detection

### DIFF
--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -4,6 +4,7 @@
 package host
 
 import (
+	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/prog"
 )
 
@@ -11,6 +12,7 @@ import (
 // For unsupported syscalls it also returns reason as to why it is unsupported.
 func DetectSupportedSyscalls(target *prog.Target, sandbox string) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
+	log.Logf(1, "detecting supported syscalls")
 	supported := make(map[*prog.Syscall]bool)
 	unsupported := make(map[*prog.Syscall]string)
 	// Akaros does not have own host and parasitizes on some other OS.
@@ -26,7 +28,7 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string) (
 		case "syz_execute_func":
 			ok = true
 		default:
-			ok, reason = isSupported(c, sandbox)
+			ok, reason = isSupported(c, target, sandbox)
 		}
 		if ok {
 			supported[c] = true

--- a/pkg/host/host_akaros.go
+++ b/pkg/host/host_akaros.go
@@ -9,6 +9,6 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }

--- a/pkg/host/host_darwin.go
+++ b/pkg/host/host_darwin.go
@@ -7,6 +7,6 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return false, ""
 }

--- a/pkg/host/host_freebsd.go
+++ b/pkg/host/host_freebsd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }
 

--- a/pkg/host/host_fuchsia.go
+++ b/pkg/host/host_fuchsia.go
@@ -9,6 +9,6 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }

--- a/pkg/host/host_netbsd.go
+++ b/pkg/host/host_netbsd.go
@@ -7,6 +7,6 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }

--- a/pkg/host/host_openbsd.go
+++ b/pkg/host/host_openbsd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }
 

--- a/pkg/host/host_windows.go
+++ b/pkg/host/host_windows.go
@@ -7,6 +7,6 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-func isSupported(c *prog.Syscall, sandbox string) (bool, string) {
+func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {
 	return true, ""
 }

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -101,6 +101,7 @@ func convertTestReq(target *prog.Target, req *rpctype.RunTestPollRes) *runtest.R
 }
 
 func checkMachine(args *checkArgs) (*rpctype.CheckArgs, error) {
+	log.Logf(0, "checking machine...")
 	// Machine checking can be very slow on some machines (qemu without kvm, KMEMLEAK linux, etc),
 	// so print periodic heartbeats for vm.MonitorExecution so that it does not decide that we are dead.
 	done := make(chan bool)
@@ -254,6 +255,7 @@ func checkSimpleProgram(args *checkArgs) error {
 
 func buildCallList(target *prog.Target, enabledCalls []int, sandbox string) (
 	enabled []int, disabled []rpctype.SyscallReason, err error) {
+	log.Logf(0, "building call list...")
 	calls := make(map[*prog.Syscall]bool)
 	if len(enabledCalls) != 0 {
 		for _, n := range enabledCalls {


### PR DESCRIPTION
Right now syz-fuzzer does a search through /proc/kallsyms for each syscall
to check whether it's supported. Do one search instead and save the results
to a map. This speeds up syscall detection ~60 times when testing arm64 kernel
on x86. Also add another search pattern for arm64 and add some logging.
