### PR TITLE
Adapt switching to user nobody to be more portable on BSDs

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -5,6 +5,7 @@
 
 #include <unistd.h>
 
+#include <pwd.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
@@ -345,13 +346,17 @@ static int do_sandbox_setuid(void)
 	initialize_tun(procid);
 #endif
 
-	const int nobody = 65534;
+	char pwbuf[1024];
+	struct passwd *pw, pwres;
+	if (getpwnam_r("nobody", &pwres, pwbuf, sizeof(pwbuf), &pw) != 0 || !pw)
+		fail("getpwnam_r(\"nobody\") failed");
+
 	if (setgroups(0, NULL))
 		fail("failed to setgroups");
-	if (setresgid(nobody, nobody, nobody))
-		fail("failed to setresgid");
-	if (setresuid(nobody, nobody, nobody))
-		fail("failed to setresuid");
+	if (setgid(pw->pw_gid))
+		fail("failed to setgid");
+	if (setuid(pw->pw_uid))
+		fail("failed to setuid");
 
 	loop();
 	doexit(1);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -394,6 +394,7 @@ void child()
 
 #include <unistd.h>
 
+#include <pwd.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
@@ -710,13 +711,17 @@ static int do_sandbox_setuid(void)
 	initialize_tun(procid);
 #endif
 
-	const int nobody = 65534;
+	char pwbuf[1024];
+	struct passwd *pw, pwres;
+	if (getpwnam_r("nobody", &pwres, pwbuf, sizeof(pwbuf), &pw) != 0 || !pw)
+		fail("getpwnam_r(\"nobody\") failed");
+
 	if (setgroups(0, NULL))
 		fail("failed to setgroups");
-	if (setresgid(nobody, nobody, nobody))
-		fail("failed to setresgid");
-	if (setresuid(nobody, nobody, nobody))
-		fail("failed to setresuid");
+	if (setgid(pw->pw_gid))
+		fail("failed to setgid");
+	if (setuid(pw->pw_uid))
+		fail("failed to setuid");
 
 	loop();
 	doexit(1);


### PR DESCRIPTION
NetBSD uses different uid/gid than FreeBSD/OpenBSD for the user
nobody. Instead of hardcoding the values, retrieve it from the
password entry database.

While there, switch to setuid(2) and setgid(2) calls as they are
good enough and portable. setresgid(2) and setresuid(2) aren't
available on NetBSD.
