### PR TITLE
Do not call setrlimit(2) for RLIMIT_AS

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -280,9 +280,11 @@ static void sandbox_common()
 
 	// Some minimal sandboxing.
 	struct rlimit rlim;
-#ifndef GOOS_openbsd
+#ifdef GOOS_freebsd
 	// Documented bug in OpenBSD.
-	// This causes frequent random aborts on netbsd. Reason unknown.
+	// This causes frequent random aborts. Reason unknown.
+
+	// This also causes ENOMEM on NetBSD during early init.
 	rlim.rlim_cur = rlim.rlim_max = 128 << 20;
 	setrlimit(RLIMIT_AS, &rlim);
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -647,7 +647,7 @@ static void sandbox_common()
 	if (setsid() == -1)
 		fail("setsid failed");
 	struct rlimit rlim;
-#ifndef GOOS_openbsd
+#ifdef GOOS_freebsd
 	rlim.rlim_cur = rlim.rlim_max = 128 << 20;
 	setrlimit(RLIMIT_AS, &rlim);
 #endif


### PR DESCRIPTION
Setting the limit caused abnormal failure during early init on NetBSD.