### PR TITLE
Disable executor/gen.go for NetBSD

### DIFF
--- a/executor/gen.go
+++ b/executor/gen.go
@@ -1,7 +1,7 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// +build !openbsd
+// +build !openbsd !netbsd
 
 //go:generate bash -c "gcc kvm_gen.cc kvm.S -o kvm_gen && ./kvm_gen > kvm.S.h && rm ./kvm_gen"
 


### PR DESCRIPTION
kvm is Linux specific.