### PR TITLE
Deleting unnecessary code in genSockaddrStorage()

### DIFF
--- a/tools/syz-trace2syz/proggen/generate_unions.go
+++ b/tools/syz-trace2syz/proggen/generate_unions.go
@@ -14,24 +14,8 @@ func (ctx *context) genSockaddrStorage(syzType *prog.UnionType, straceType parse
 	for i, field := range syzType.Fields {
 		field2Opt[field.FieldName()] = i
 	}
-	// We currently look at the first argument of the system call
-	// To determine which option of the union we select.
-	call := ctx.currentStraceCall
-	var straceArg parser.IrType
-	switch call.CallName {
-	// May need to handle special cases.
-	case "recvfrom", "sendto":
-		straceArg = call.Args[4]
-	default:
-		if len(call.Args) >= 2 {
-			straceArg = call.Args[1]
-		} else {
-			log.Fatalf("unable identify union for sockaddr_storage for call: %s",
-				call.CallName)
-		}
-	}
 	idx := 0
-	switch strType := straceArg.(type) {
+	switch strType := straceType.(type) {
 	case *parser.GroupType:
 		socketFamily, ok := strType.Elems[0].(parser.Constant)
 		if !ok {

--- a/tools/syz-trace2syz/proggen/proggen_test.go
+++ b/tools/syz-trace2syz/proggen/proggen_test.go
@@ -211,6 +211,15 @@ connect(0xffffffffffffffff, &(0x7f0000000000)=` +
 			`@in6={0xa, 0x3039, 0x75bcd7a, @rand_addr="0012003400560078009000ab00cd00ef",` +
 			` 0xfacefeed}, 0x80)
 `,
+		}, {`
+socket(0xa, 0x2, 0) = 3
+sendto(3, "", 0, 0, {sa_family=0xa, sin6_port="\x4e\x24", sin6_flowinfo="\x00\x00\x00\x00",` +
+			` sin6_addr="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",` +
+			` sin6_scope_id=0}, 28) = -1
+`, `
+r0 = socket$inet6_udp(0xa, 0x2, 0x0)
+sendto$inet6(r0, &(0x7f0000000000), 0x0, 0x0, &(0x7f0000000040)={0xa, 0x4e24}, 0x1c)
+`,
 		},
 	}
 	target, err := prog.GetTarget("linux", "amd64")


### PR DESCRIPTION
genSockaddrStorage() determines the correct sockaddr_storage union option when we
cannot identify the system call variant. We used to have custom logic per system
call which was not tested and is actually unnecessary. This patch deletes that
code and adds a test to make sure there are no regressions.