### PR TITLE
ppc64le fixes

### DIFF
--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -65,6 +65,8 @@ func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, st
 			re = regexp.MustCompile(` T (__ia32_|__x64_)?sys_([^\n]+)\n`)
 		case "arm64":
 			re = regexp.MustCompile(` T (__arm64_)?sys_([^\n]+)\n`)
+		case "ppc64le":
+			re = regexp.MustCompile(` T ()?sys_([^\n]+)\n`)
 		default:
 			panic("unsupported arch for kallsyms parsing")
 		}

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -119,7 +119,7 @@ var archConfigs = map[string]*archConfig{
 	"linux/ppc64le": {
 		Qemu:      "qemu-system-ppc64",
 		TargetDir: "/",
-		QemuArgs:  "-enable-kvm",
+		QemuArgs:  "-enable-kvm -vga none",
 		CmdLine:   linuxCmdline,
 	},
 	"freebsd/amd64": {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -119,6 +119,7 @@ var archConfigs = map[string]*archConfig{
 	"linux/ppc64le": {
 		Qemu:      "qemu-system-ppc64",
 		TargetDir: "/",
+		QemuArgs:  "-enable-kvm",
 		CmdLine:   linuxCmdline,
 	},
 	"freebsd/amd64": {


### PR DESCRIPTION
Miscellaneous fixes that I needed to get syzkaller working with kcov on ppc64le.

These have been lightly tested on a POWER8 KVM host I have access to. The kernel support for kcov hasn't landed upstream yet but I've sent a patch.