### PR TITLE
Add -moduledir option

### DIFF
--- a/sys/syz-extract/akaros.go
+++ b/sys/syz-extract/akaros.go
@@ -31,6 +31,7 @@ func (*akaros) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 		"-DROS_KERNEL",
 		"-I", filepath.Join(dir, "kern", "include"),
 		"-I", filepath.Join(dir, "user", "parlib", "include"),
+		"-I", filepath.Join(arch.moduleDir, "include"),
 	}
 	for _, incdir := range info.Incdirs {
 		args = append(args, "-I"+filepath.Join(dir, incdir))

--- a/sys/syz-extract/extract.go
+++ b/sys/syz-extract/extract.go
@@ -24,6 +24,7 @@ var (
 	flagOS        = flag.String("os", "", "target OS")
 	flagBuild     = flag.Bool("build", false, "regenerate arch-specific kernel headers")
 	flagSourceDir = flag.String("sourcedir", "", "path to kernel source checkout dir")
+	flagModuleDir = flag.String("moduledir", "", "path to kernel module source checkout dir")
 	flagBuildDir  = flag.String("builddir", "", "path to kernel build dir")
 	flagArch      = flag.String("arch", "", "comma-separated list of arches to generate (all by default)")
 )
@@ -31,6 +32,7 @@ var (
 type Arch struct {
 	target    *targets.Target
 	sourceDir string
+	moduleDir string
 	buildDir  string
 	build     bool
 	files     []*File
@@ -178,6 +180,7 @@ func createArches(OS string, archArray, files []string) ([]*Arch, error) {
 		arch := &Arch{
 			target:    target,
 			sourceDir: *flagSourceDir,
+			moduleDir: *flagModuleDir,
 			buildDir:  buildDir,
 			build:     *flagBuild,
 			done:      make(chan bool),

--- a/sys/syz-extract/freebsd.go
+++ b/sys/syz-extract/freebsd.go
@@ -45,6 +45,7 @@ func (*freebsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 		"-I", filepath.Join(arch.sourceDir, "sys"),
 		"-I", filepath.Join(arch.sourceDir, "sys", "sys"),
 		"-I", filepath.Join(arch.sourceDir, "sys", "amd64"),
+		"-I", filepath.Join(arch.moduleDir, "include"),
 		"-I", arch.buildDir,
 	}
 	for _, incdir := range info.Incdirs {

--- a/sys/syz-extract/linux.go
+++ b/sys/syz-extract/linux.go
@@ -111,6 +111,7 @@ func (*linux) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uint
 		"-I" + buildDir + "/arch/" + headerArch + "/include/generated",
 		"-I" + buildDir + "/include",
 		"-I" + sourceDir + "/include",
+		"-I" + arch.moduleDir + "/include",
 		"-I" + sourceDir + "/arch/" + headerArch + "/include/uapi",
 		"-I" + buildDir + "/arch/" + headerArch + "/include/generated/uapi",
 		"-I" + sourceDir + "/include/uapi",

--- a/sys/syz-extract/netbsd.go
+++ b/sys/syz-extract/netbsd.go
@@ -62,6 +62,7 @@ func (*netbsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 		"-I", filepath.Join(arch.sourceDir, "common", "include"),
 		"-I", filepath.Join(arch.sourceDir, "sys", "compat", "linux", "common"),
 		"-I", filepath.Join(arch.sourceDir, "include"),
+		"-I", filepath.Join(arch.moduleDir, "include"),
 		"-I", arch.buildDir,
 	}
 	for _, incdir := range info.Incdirs {

--- a/sys/syz-extract/openbsd.go
+++ b/sys/syz-extract/openbsd.go
@@ -47,6 +47,7 @@ func (*openbsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 		"-I", filepath.Join(arch.sourceDir, "sys", "arch", "amd64"),
 		"-I", filepath.Join(arch.sourceDir, "common", "include"),
 		"-I", filepath.Join(arch.sourceDir, "sys", "compat", "linux", "common"),
+		"-I", filepath.Join(arch.moduleDir, "include"),
 		"-I", arch.buildDir,
 	}
 	for _, incdir := range info.Incdirs {

--- a/sys/syz-extract/trusty.go
+++ b/sys/syz-extract/trusty.go
@@ -29,6 +29,7 @@ func (*trusty) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 		"-fmessage-length=0",
 		"-I", filepath.Join(dir, "external", "lk", "include", "shared"),
 		"-I", filepath.Join(dir, "trusty", "user", "base", "include"),
+		"-I", filepath.Join(arch.moduleDir, "include"),
 	}
 	for _, incdir := range info.Incdirs {
 		args = append(args, "-I"+filepath.Join(dir, incdir))


### PR DESCRIPTION
Kernel modules are in different directories in some cases,
so to include the headers in the module dir, the moduledir flag is added

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
