### PR TITLE
sys/openbsd: revert avoid /dev/fd node creation

### DIFF
--- a/sys/openbsd/init.go
+++ b/sys/openbsd/init.go
@@ -25,40 +25,19 @@ type arch struct {
 	S_IFCHR uint64
 }
 
-const (
-	mknodMode = 0
-	mknodDev  = 1
-
-	// openbsd:src/etc/etc.amd64/MAKEDEV
-	devFdMajor  = 22
-	devNullDevT = 0x0202
-)
-
-func major(dev uint64) uint64 {
-	// openbsd:src/sys/sys/types.h
-	return (dev >> 8) & 0xff
-}
-
 func (arch *arch) SanitizeCall(c *prog.Call) {
-	argStart := 1
+	// Prevent vnodes of type VBAD from being created. Such vnodes will
+	// likely trigger assertion errors by the kernel.
+	pos := 1
 	switch c.Meta.CallName {
 	case "mknodat":
-		argStart = 2
+		pos = 2
 		fallthrough
 	case "mknod":
-		// Prevent vnodes of type VBAD from being created. Such vnodes will
-		// likely trigger assertion errors by the kernel.
-		mode := c.Args[argStart+mknodMode].(*prog.ConstArg)
+		mode := c.Args[pos].(*prog.ConstArg)
 		if mode.Val&arch.S_IFMT == arch.S_IFMT {
 			mode.Val &^= arch.S_IFMT
 			mode.Val |= arch.S_IFCHR
-		}
-		// Prevent /dev/fd/X devices from getting created. They interfere
-		// with kcov data collection and cause corpus explosion.
-		// https://groups.google.com/d/msg/syzkaller/_IRWeAjVoy4/Akl2XMZTDAAJ
-		mode = c.Args[argStart+mknodDev].(*prog.ConstArg)
-		if major(mode.Val) == devFdMajor {
-			mode.Val = devNullDevT
 		}
 	default:
 		arch.unix.SanitizeCall(c)


### PR DESCRIPTION
This reverts commit 77c702cf1a02ef4bb695e9daa9339afb3cbd5d89.

A proper fix has instead been committed to [OpenBSD](https://github.com/openbsd/src/commit/650b9bc3abafbd3178268c3cae5b7a240d7f32b7).

See #932 for further details.