### PR TITLE
executor: unbreak on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ executor:
 ifeq ($(BUILDOS),$(NATIVEBUILDOS))
 	mkdir -p ./bin/$(TARGETOS)_$(TARGETARCH)
 	$(CC) -o ./bin/$(TARGETOS)_$(TARGETARCH)/syz-executor$(EXE) executor/executor.cc \
-		-pthread -Wall -Wframe-larger-than=8192 -Wparentheses -Werror -O2 $(ADDCFLAGS) $(CFLAGS) \
-		-DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1  -DGIT_REVISION=\"$(REV)\"
+		-pthread -Wall -Wframe-larger-than=8192 -Wparentheses -Wunused-const-variable -Werror -O2 \
+		$(ADDCFLAGS) $(CFLAGS) -DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1  -DGIT_REVISION=\"$(REV)\"
 else
 	$(info ************************************************************************************)
 	$(info Building executor for ${TARGETOS} is not supported on ${BUILDOS}. Executor will not be built.)

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #if SYZ_EXECUTOR
+const int kExtraCoverSize = 256 << 10;
 struct cover_t;
 static void cover_reset(cover_t* cov);
 #endif

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -58,7 +58,6 @@ const int kOutPipeFd = kMaxFd - 2; // remapped from stdout
 const int kCoverFd = kOutPipeFd - kMaxThreads;
 const int kMaxArgs = 9;
 const int kCoverSize = 256 << 10;
-const int kExtraCoverSize = 256 << 10;
 const int kFailStatus = 67;
 const int kRetryStatus = 69;
 const int kErrorStatus = 68;

--- a/pkg/csource/build.go
+++ b/pkg/csource/build.go
@@ -39,7 +39,8 @@ func build(target *prog.Target, src []byte, file string) (string, error) {
 	}
 
 	flags := []string{
-		"-Wall", "-Werror", "-O1", "-o", bin, "-pthread",
+		"-Wall", "-Werror", "-Wparentheses", "-Wunused-const-variable",
+		"-O1", "-o", bin, "-pthread",
 		"-DGOOS_" + target.OS + "=1",
 		"-DGOARCH_" + target.Arch + "=1",
 	}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -975,6 +975,7 @@ static int do_sandbox_none(void)
 #include <unistd.h>
 
 #if SYZ_EXECUTOR
+const int kExtraCoverSize = 256 << 10;
 struct cover_t;
 static void cover_reset(cover_t* cov);
 #endif


### PR DESCRIPTION
Commit b5df78dc ("all: support extra coverage") broke the executor on OpenBSD:

```
executor/executor.cc:61:11: error: unused variable 'kExtraCoverSize' [-Werror,-Wunused-const-variable]
const int kExtraCoverSize = 256 << 10;
```