### PR TITLE
kcov: some fixes for extra coverage

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -93,7 +93,7 @@ static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
 	// Coverage buffer size of remote threads.
 	arg.area_size = kExtraCoverSize * (is_kernel_64_bit ? 8 : 4);
 	arg.num_handles = 1;
-	arg.handles[0] = kcov_remote_handle_usb(procid);
+	arg.handles[0] = kcov_remote_handle_usb(procid + 1);
 	arg.common_handle = procid + 1;
 	if (ioctl(cov->fd, KCOV_REMOTE_ENABLE, &arg))
 		exitf("cover enable write trace failed");

--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -431,7 +431,7 @@ func checkCoverageFeature(feature int) (reason string) {
 		}
 	case FeatureExtraCoverage:
 		arg := KcovRemoteArg{
-			TraceMode:    uint32(linux.KCOV_TRACE_CMP),
+			TraceMode:    uint32(linux.KCOV_TRACE_PC),
 			AreaSize:     uint32(coverSize * unsafe.Sizeof(uintptr(0))),
 			NumHandles:   0,
 			CommonHandle: 0,

--- a/sys/linux/init.go
+++ b/sys/linux/init.go
@@ -83,6 +83,7 @@ func InitTarget(target *prog.Target) {
 		KCOV_ENABLE = uintptr(target.GetConst("KCOV_ENABLE"))
 		KCOV_REMOTE_ENABLE = uintptr(target.GetConst("KCOV_REMOTE_ENABLE"))
 		KCOV_DISABLE = uintptr(target.GetConst("KCOV_DISABLE"))
+		KCOV_TRACE_PC = uintptr(target.GetConst("KCOV_TRACE_PC"))
 		KCOV_TRACE_CMP = uintptr(target.GetConst("KCOV_TRACE_CMP"))
 	}
 }
@@ -93,6 +94,7 @@ var (
 	KCOV_ENABLE        uintptr
 	KCOV_REMOTE_ENABLE uintptr
 	KCOV_DISABLE       uintptr
+	KCOV_TRACE_PC      uintptr
 	KCOV_TRACE_CMP     uintptr
 )
 


### PR DESCRIPTION
Use PC tracing mode when detecting KCOV_REMOTE_ENABLE support in the kernel.

Also fix kcov_remote_handle_usb argument.
