### PR TITLE
Squash "unused variable" error.

### DIFF
--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -12,6 +12,7 @@
 
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
+	(void)kExtraCoverSize;
 	if (syz_mmap((size_t)data, data_size) != ZX_OK)
 		fail("mmap of data segment failed");
 }


### PR DESCRIPTION
Newer versions of syz-executor cannot be compiled for Fuchsia because
the kExtraCoverSize variable is included but never used, and thus
-Werror complains.

I did the "lazy" thing and simply added a (void)kExtraCoverSize line,
partially because I'm confused--while this fixes the error for building
Fuchsia locally, Fuchsia seems (?) to be building successfully on syz-ci
upstream (at least, it claims to be building with a much more recent
commit than the one that introduced kExtraCoverSize), which suggests
either I'm doing something wrong or the dashboard's doing something
wrong.

Furthermore, if Fuchsia *is* actually having this problem, and I'm not
confused, then *everyone* except Linux should be having this problem,
which doesn't *seem* to be the case based on the dashboards.

Dmitry, do you have any idea what might be happening?  This commit does
fix my problem but I want to be sure I'm not diverging from what the CI
bots do in some drastic way.