### PR TITLE
travis: switch to ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-dist: trusty
+dist: xenial
 
 go:
   - "1.9"


### PR DESCRIPTION
14.04 has way too old gcc.
In particular this causes build failures like:
https://travis-ci.org/google/syzkaller/jobs/481342304
Switch to 16.04.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
