### PR TITLE
Makefile: enable -Wunused-const-variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,7 @@ executor:
 ifeq ($(BUILDOS),$(NATIVEBUILDOS))
 	mkdir -p ./bin/$(TARGETOS)_$(TARGETARCH)
 	$(CC) -o ./bin/$(TARGETOS)_$(TARGETARCH)/syz-executor$(EXE) executor/executor.cc \
-		-pthread -Wall -Wframe-larger-than=8192 -Wparentheses -Werror -O2 $(ADDCFLAGS) $(CFLAGS) \
-		-DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1  -DGIT_REVISION=\"$(REV)\"
+		$(ADDCFLAGS) $(CFLAGS) -DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1  -DGIT_REVISION=\"$(REV)\"
 else
 	$(info ************************************************************************************)
 	$(info Building executor for ${TARGETOS} is not supported on ${BUILDOS}. Executor will not be built.)

--- a/pkg/csource/build.go
+++ b/pkg/csource/build.go
@@ -39,7 +39,7 @@ func build(target *prog.Target, src []byte, file string) (string, error) {
 	}
 
 	flags := []string{
-		"-Wall", "-Werror", "-O1", "-o", bin, "-pthread",
+		"-o", bin,
 		"-DGOOS_" + target.OS + "=1",
 		"-DGOARCH_" + target.Arch + "=1",
 	}


### PR DESCRIPTION
See discussion in PR #942.
Extend support for optional flags in sys/targets
as this flag is not supported by gcc 5.
Make flags consistent across Makefile and pkg/csource.