### PR TITLE
Update Fuchsia docs; change "key" to "sshkey".

### DIFF
--- a/docs/fuchsia.md
+++ b/docs/fuchsia.md
@@ -12,7 +12,7 @@ fx full-build
 You need to build fuchsia for both arm64 and amd64:
 
 ```
-fx set arm64 --packages garnet/packages/products/sshd
+fx set arm64 --args 'extra_authorized_keys_file="//.ssh/authorized_keys"' --packages garnet/packages/products/sshd --product garnet/products/default.gni
 fx full-build
 ```
 
@@ -39,8 +39,8 @@ Run `syz-manager` with a config along the lines of:
 	"workdir": "/workdir.fuchsia",
 	"kernel_obj": "/fuchsia/out/build-zircon/build-x64",
 	"syzkaller": "/syzkaller",
-	"image": "/fuchsia/out/x64/out/build/images/fvm.blk",
-	"sshkey": "/fuchsia/out/x64/ssh-keys/id_ed25519",
+	"image": "/fuchsia/out/x64/obj/build/images/fvm.blk",
+	"sshkey": ".ssh/pkey",
 	"reproduce": false,
 	"cover": false,
 	"procs": 8,
@@ -49,8 +49,9 @@ Run `syz-manager` with a config along the lines of:
 		"count": 10,
 		"cpu": 4,
 		"mem": 2048,
-		"kernel": "/fuchsia/out/build-zircon/build-x64/zircon.bin",
-		"initrd": "/fuchsia/out/x64/bootdata-blob.bin"
+                "obj/zircon.elf": "out/build-zircon/build-x64/zircon.elf"
+		"kernel": "/fuchsia/out/build-zircon/build-x64/multiboot.bin",
+		"initrd": "/fuchsia/out/x64/fuchsia.zbi"
 	}
 }
 ```

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -14,6 +14,9 @@ import (
 
 type fuchsia struct{}
 
+// PLEASE NOTE: changes to this function should also be reflected in
+// docs/fuchsia.md, so that manual testing instructions are always up-to-date.
+
 func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
 	cmdlineFile, sysctlFile string, config []byte) error {
 	sysTarget := targets.Get("fuchsia", targetArch)
@@ -28,7 +31,7 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 	}
 	for src, dst := range map[string]string{
 		"out/" + arch + "/obj/build/images/fvm.blk": "image",
-		".ssh/pkey":                                 "key",
+		".ssh/pkey":                                 "sshkey",
 		"out/build-zircon/build-" + arch + "/zircon.elf":    "obj/zircon.elf",
 		"out/build-zircon/build-" + arch + "/multiboot.bin": "kernel",
 		"out/" + arch + "/fuchsia.zbi":                      "initrd",


### PR DESCRIPTION
Docs for configuring Syzkaller for Fuchsia were out of date; now fixing.

Also: changed "key" to "sshkey", because this was causing breaking behavior when I tried to test it locally (config.go:checkUnknownFieldsRec didn't recognize the key for some reason), and because "sshkey" provides greater consistency with how other configs handle this anyway.