### PR TITLE
dashboard/config: enable witness on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -3,3 +3,5 @@ include "arch/amd64/conf/GENERIC.MP"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
+option WITNESS
+option WITNESS_WATCH


### PR DESCRIPTION
Lets give this another try now that larger kernels can boot.