### PR TITLE
sys/targets/targets.go: Support cross compilation on linux

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -184,7 +184,10 @@ var List = map[string]map[string]*Target{
 			PtrSize:     8,
 			PageSize:    4 << 10,
 			CFlags:      []string{"-m64"},
-			CrossCFlags: []string{"-m64", "-static"},
+			CrossCFlags: []string{"-m64", "-static"
+				"--sysroot", os.ExpandEnv("${SOURCEDIR}../dest/"),
+			},
+			CCompiler:   os.ExpandEnv("${SOURCEDIR}../tools/bin/x86_64--netbsd-g++"),
 		},
 	},
 	"openbsd": {
@@ -303,6 +306,7 @@ var oses = map[string]osCommon{
 		CPP:                    "g++",
 	},
 	"netbsd": {
+		BuildOS:                "linux",
 		SyscallNumbers:         true,
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      true,


### PR DESCRIPTION

This adds the support for compiling executor on linux systems.
Perquisites :
./build.sh -m amd64 -T ../tools tools (To build the tools)
./build.sh -m amd64 -T ../tools -D ../dest distribution (To build the distribution)
Compile with SOURCEDIR pointing to src/ 