### PR TITLE
sys: use -march=armv6 instead of -march=armv6t2

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -155,7 +155,7 @@ var List = map[string]map[string]*Target{
 			PtrSize:          4,
 			PageSize:         4 << 10,
 			CFlags:           []string{"-D__LINUX_ARM_ARCH__=6", "-m32", "-D__ARM_EABI__"},
-			CrossCFlags:      []string{"-D__LINUX_ARM_ARCH__=6", "-march=armv6t2", "-static"},
+			CrossCFlags:      []string{"-D__LINUX_ARM_ARCH__=6", "-march=armv6", "-static"},
 			CCompilerPrefix:  "arm-linux-gnueabihf-",
 			KernelArch:       "arm",
 			KernelHeaderArch: "arm",


### PR DESCRIPTION
The latter doesn't work on Raspberry Pi Zero.
