### PR TITLE
executor: fix remote coverage area size

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -91,7 +91,7 @@ static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
 	memset(&arg, 0, sizeof(arg));
 	arg.trace_mode = kcov_mode;
 	// Coverage buffer size of remote threads.
-	arg.area_size = kExtraCoverSize * (is_kernel_64_bit ? 8 : 4);
+	arg.area_size = kExtraCoverSize;
 	arg.num_handles = 1;
 	arg.handles[0] = kcov_remote_handle_usb(procid + 1);
 	arg.common_handle = procid + 1;


### PR DESCRIPTION
It should be in number of words not in bytes.
