### PR TITLE
prog: fix checksum dependencies

### DIFF
--- a/prog/checksum.go
+++ b/prog/checksum.go
@@ -105,6 +105,9 @@ func calcChecksumsCall(c *Call) (map[Arg]CsumInfo, map[Arg]struct{}) {
 			info = composePseudoCsumIPv6(csummedArg, ipSrcAddr, ipDstAddr, protocol)
 		}
 		csumMap[arg] = info
+		csumUses[csummedArg] = struct{}{}
+		csumUses[ipSrcAddr] = struct{}{}
+		csumUses[ipDstAddr] = struct{}{}
 	}
 
 	return csumMap, csumUses

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -427,6 +427,28 @@ func TestSerializeForExec(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"test$csum_ipv4_tcp(&(0x7f0000000000)={{0x0, 0x1, 0x2}, {{0x0}, \"ab\"}})",
+			[]uint64{
+				execInstrCopyin, dataOffset + 0, execArgConst, 2, 0x0,
+				execInstrCopyin, dataOffset + 2, execArgConst, 4 | 1<<8, 0x1,
+				execInstrCopyin, dataOffset + 6, execArgConst, 4 | 1<<8, 0x2,
+				execInstrCopyin, dataOffset + 10, execArgConst, 2, 0x0,
+				execInstrCopyin, dataOffset + 12, execArgData, 1, 0xab,
+
+				execInstrCopyin, dataOffset + 10, execArgCsum, 2, ExecArgCsumInet, 5,
+				ExecArgCsumChunkData, dataOffset + 2, 4,
+				ExecArgCsumChunkData, dataOffset + 6, 4,
+				ExecArgCsumChunkConst, 0x0600, 2,
+				ExecArgCsumChunkConst, 0x0300, 2,
+				ExecArgCsumChunkData, dataOffset + 10, 3,
+				execInstrCopyin, dataOffset + 0, execArgCsum, 2, ExecArgCsumInet, 1,
+				ExecArgCsumChunkData, dataOffset + 0, 10,
+				callID("test$csum_ipv4_tcp"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrEOF,
+			},
+			nil,
+		},
 	}
 
 	buf := make([]byte, ExecBufferSize)


### PR DESCRIPTION
Make pseudo checksums depend (via csumUses) on the arg it requires for
calculation. Otherwise we fail to assign addrs to those args during encoding
for execution. Also add a test.
