### PR TITLE
prog: speed up resource ctors detection

### DIFF
--- a/prog/decl_test.go
+++ b/prog/decl_test.go
@@ -15,7 +15,7 @@ func TestResourceCtors(t *testing.T) {
 	testEachTarget(t, func(t *testing.T, target *Target) {
 		expectFail := false
 		for _, res := range target.Resources {
-			if len(target.calcResourceCtors(res.Kind, true)) == 0 != expectFail {
+			if len(target.calcResourceCtors(res, true)) == 0 != expectFail {
 				t.Errorf("resource %v can't be created", res.Name)
 			}
 		}

--- a/prog/target.go
+++ b/prog/target.go
@@ -168,9 +168,10 @@ func (target *Target) initTarget() {
 		})
 	}
 
+	target.populateResourceCtors()
 	target.resourceCtors = make(map[string][]*Syscall)
 	for _, res := range target.Resources {
-		target.resourceCtors[res.Name] = target.calcResourceCtors(res.Kind, false)
+		target.resourceCtors[res.Name] = target.calcResourceCtors(res, false)
 	}
 	initAnyTypes(target)
 }

--- a/prog/types.go
+++ b/prog/types.go
@@ -132,6 +132,12 @@ type ResourceDesc struct {
 	Type   Type
 	Kind   []string
 	Values []uint64
+	Ctors  []ResourceCtor
+}
+
+type ResourceCtor struct {
+	Call    int // Index in Target.Syscalls
+	Precise bool
 }
 
 type ResourceType struct {


### PR DESCRIPTION
When we build a list of resource constructors we over and over iterate through
all types in a syscall to find resource types. Speed it up by iterating only
once to build a list of constructors for each resource and then reuse it.
This significantly speeds up syz-exeprog startup time on Raspberry Pi Zero.
