### PR TITLE
openbsd: remove shorten report logic

### DIFF
--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -70,9 +70,6 @@ func (ctx *openbsd) Parse(output []byte) *Report {
 		return nil
 	}
 	rep.Output = output
-	if report := ctx.shortenReport(rep.Report); len(report) != 0 {
-		rep.Report = report
-	}
 	return rep
 }
 
@@ -140,19 +137,6 @@ func (ctx *openbsd) symbolizeLine(symbFunc func(bin string, pc uint64) ([]symbol
 		symbolized = append(symbolized, modified...)
 	}
 	return symbolized
-}
-
-func (ctx *openbsd) shortenReport(report []byte) []byte {
-	out := new(bytes.Buffer)
-	for s := bufio.NewScanner(bytes.NewReader(report)); s.Scan(); {
-		line := s.Bytes()
-		out.Write(line)
-		// Kernel splits lines at 79 column.
-		if len(line) != 79 {
-			out.WriteByte('\n')
-		}
-	}
-	return out.Bytes()
 }
 
 var openbsdOopses = []*oops{

--- a/pkg/report/testdata/openbsd/report/6
+++ b/pkg/report/testdata/openbsd/report/6
@@ -7,10 +7,8 @@ TITLE: pool: double put: lockfpl
 panic() at panic+0x147
 pool_do_put(ffffff001692bd18,ffffffff81ec0850) at pool_do_put+0x2e2
 pool_put(ffffff0016933440,ffff80000e3793e8) at pool_put+0x37
-lf_advlock(40,ffffff001dc251c8,2,ffff80000e3793e8,ffffffff81df26c0,200000040) a
-t lf_advlock+0x270
-VOP_ADVLOCK(ffffff0015a96da8,ffff80000e2a3080,3,ffffff001f7ca350,3) at VOP_ADVL
-OCK+0x67
+lf_advlock(40,ffffff001dc251c8,2,ffff80000e3793e8,ffffffff81df26c0,200000040) at lf_advlock+0x270
+VOP_ADVLOCK(ffffff0015a96da8,ffff80000e2a3080,3,ffffff001f7ca350,3) at VOP_ADVLOCK+0x67
 closef(ffff80000e2a3080,ffffff001f7ca350) at closef+0xaf
 fdfree(ffff80000e27c008) at fdfree+0x98
 exit1(ffff80000e3795c0,ffff80000e2a3080,ffff80000e27c008) at exit1+0x226
@@ -26,10 +24,8 @@ TITLE: pool: double put: lockfpl
 panic() at panic+0x147
 pool_do_put(ffffff001692bd18,ffffffff81ec0850) at pool_do_put+0x2e2
 pool_put(ffffff0016933440,ffff80000e3793e8) at pool_put+0x37
-lf_advlock(40,ffffff001dc251c8,2,ffff80000e3793e8,ffffffff81df26c0,200000040) a
-t lf_advlock+0x270
-VOP_ADVLOCK(ffffff0015a96da8,ffff80000e2a3080,3,ffffff001f7ca350,3) at VOP_ADVL
-OCK+0x67
+lf_advlock(40,ffffff001dc251c8,2,ffff80000e3793e8,ffffffff81df26c0,200000040) at lf_advlock+0x270
+VOP_ADVLOCK(ffffff0015a96da8,ffff80000e2a3080,3,ffffff001f7ca350,3) at VOP_ADVLOCK+0x67
 closef(ffff80000e2a3080,ffffff001f7ca350) at closef+0xaf
 fdfree(ffff80000e27c008) at fdfree+0x98
 exit1(ffff80000e3795c0,ffff80000e2a3080,ffff80000e27c008) at exit1+0x226

--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -43,6 +43,7 @@ EOF
 
 cat >etc/sysctl.conf <<EOF
 ddb.max_line=0
+ddb.max_width=0
 hw.smt=1
 EOF
 

--- a/vm/vmimpl/openbsd.go
+++ b/vm/vmimpl/openbsd.go
@@ -15,7 +15,8 @@ import (
 func DiagnoseOpenBSD(w io.Writer) bool {
 	commands := []string{
 		"",
-		"set $lines = 0", // disable pagination
+		"set $lines = 0",    // disable pagination
+		"set $maxwidth = 0", // disable line continuation
 		"show panic",
 		"trace",
 		"show registers",


### PR DESCRIPTION
A line length of 79 in the ddb output does not necessarily imply that the
following line is a continuation of the current line. Since there's no way
to distinguish between ordinary and continuation lines, it could end up
corrupting the report by joining two lines that are [disjoint](https://syzkaller.appspot.com/bug?extid=03f7377a9848d7d008c9)

Instead, disable line wrapping in ddb. If we want some kind of wrapping in
the future it's easier done by pkg/report.