### PR TITLE
dashboard/config: enable WITNESS_LOCKTRACE on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -4,4 +4,5 @@ pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
 option WITNESS
+option WITNESS_LOCKTRACE
 option WITNESS_WATCH


### PR DESCRIPTION
This option will print all lock acquisition paths once a lock violation
is identified by [witness](https://marc.info/?l=openbsd-cvs&m=154955230813384&w=2)