### PR TITLE
[fuchsia] Update syntax for making W+X memory regions; make errors more

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -176,12 +176,16 @@ long syz_mmap(size_t addr, size_t size)
 		fail("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
 	zx_handle_t vmo;
 	status = zx_vmo_create(size, 0, &vmo);
+	if (status != ZX_OK) {
+		debug("zx_vmo_create failed with: %d", status);
+		return status;
+	}
+	status = zx_vmo_replace_as_executable(vmo, ZX_HANDLE_INVALID, &vmo);
 	if (status != ZX_OK)
 		return status;
 	uintptr_t mapped_addr;
 	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
 			     addr - info.base, vmo, 0, size,
-
 			     &mapped_addr);
 	return status;
 }

--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -12,8 +12,9 @@
 
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
-	if (syz_mmap((size_t)data, data_size) != ZX_OK)
-		fail("mmap of data segment failed");
+	zx_status_t status = syz_mmap((size_t)data, data_size);
+	if (status != ZX_OK)
+		fail("mmap of data segment failed with: %d", status);
 }
 
 static long execute_syscall(const call_t* c, long a[kMaxArgs])

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -912,12 +912,16 @@ long syz_mmap(size_t addr, size_t size)
 		fail("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
 	zx_handle_t vmo;
 	status = zx_vmo_create(size, 0, &vmo);
+	if (status != ZX_OK) {
+		debug("zx_vmo_create failed with: %d", status);
+		return status;
+	}
+	status = zx_vmo_replace_as_executable(vmo, ZX_HANDLE_INVALID, &vmo);
 	if (status != ZX_OK)
 		return status;
 	uintptr_t mapped_addr;
 	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
 			     addr - info.base, vmo, 0, size,
-
 			     &mapped_addr);
 	return status;
 }


### PR DESCRIPTION
expressive.

Fuchsia recently changed such that zx_vmar_map can't be declared
executable and writeable at the same time; use a new syscall for this
purpose.

Also made a few errors more informative.

cc @mvanotti 