### PR TITLE
Update Syzkaller generated code to make check_diff happy.

### DIFF
--- a/pkg/build/akaros.go
+++ b/pkg/build/akaros.go
@@ -86,8 +86,8 @@ bash
 		return fmt.Errorf("failed to write image file: %v", err)
 	}
 	for src, dst := range map[string]string{
-		".config": "kernel.config",
-		"key":     "key",
+		".config":                    "kernel.config",
+		"key":                        "key",
 		"obj/kern/akaros-kernel":     "kernel",
 		"obj/kern/akaros-kernel-64b": "obj/akaros-kernel-64b",
 	} {

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -28,7 +28,7 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 	}
 	for src, dst := range map[string]string{
 		"out/" + arch + "/obj/build/images/fvm.blk": "image",
-		".ssh/pkey":                                 "key",
+		".ssh/pkey": "key",
 		"out/build-zircon/build-" + arch + "/zircon.elf":    "obj/zircon.elf",
 		"out/build-zircon/build-" + arch + "/multiboot.bin": "kernel",
 		"out/" + arch + "/fuchsia.zbi":                      "initrd",

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -33,12 +33,12 @@ func TestCheckRepoAddress(t *testing.T) {
 		"http://host.xz:123/path/to/repo.git/":                                  true,
 		"https://chromium.googlesource.com/chromiumos/third_party/kernel":       true,
 		"https://fuchsia.googlesource.com":                                      true,
-		"":           false,
-		"foobar":     false,
-		"linux-next": false,
-		"foo://kernel.ubuntu.com/ubuntu/ubuntu-zesty.git":    false,
-		"git://kernel/ubuntu.git":                            false,
-		"gitgit://kernel.ubuntu.com/ubuntu/ubuntu-zesty.git": false,
+		"":                                                                      false,
+		"foobar":                                                                false,
+		"linux-next":                                                            false,
+		"foo://kernel.ubuntu.com/ubuntu/ubuntu-zesty.git":                       false,
+		"git://kernel/ubuntu.git":                                               false,
+		"gitgit://kernel.ubuntu.com/ubuntu/ubuntu-zesty.git":                    false,
 	})
 }
 

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -219,11 +219,11 @@ func TestEscapingPaths(t *testing.T) {
 		"file/../../file":        true,
 		"../file":                true,
 		"./file/../../file/file": true,
-		"":          false,
-		".":         false,
-		"file":      false,
-		"./file":    false,
-		"./file/..": false,
+		"":                       false,
+		".":                      false,
+		"file":                   false,
+		"./file":                 false,
+		"./file/..":              false,
 	}
 	for path, want := range paths {
 		got := escapingFilename(path)


### PR DESCRIPTION
check_diff expects all code that results from "make generate" to be
checked in appropriately.

I had a few unrelated pull requests with failing tests, which I
*believe* (correct me if I'm wrong) was a result of the master branch I
was working on not actually being able to pass check_diff, because "make
generate" generated new code.

I'm not sure how master got in this state (if my understanding is
correct), since "make generate" is part of the presubmits.

However, it makes sense to try and get this working again, to simply my
other pull requests.

This diff is the result of simply running "make generate" on master and
adding the result to a commit.