### PR TITLE
pkg/instance: use gmake on FreeBSD as on OpenBSD

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -399,7 +399,7 @@ func ExecprogCmd(execprog, executor, OS, arch, sandbox string, repeat, threaded,
 }
 
 var MakeBin = func() string {
-	if runtime.GOOS == "openbsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "openbsd" {
 		return "gmake"
 	}
 	return "make"


### PR DESCRIPTION
We could probably do this for *bsd, but this change is what I was able to test.