### PR TITLE
pkg/report: Add better ASan bug parsing for NetBSD 

### DIFF
--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -73,7 +73,7 @@ var netbsdOopses = []*oops{
 			{
 				title:  compile("ASan: Unauthorized Access"),
 				report: compile(`ASan: Unauthorized Access .*\[.*,(.*),(?:.*\n)+?.*? sys_(.*)\<`),
-				fmt:    "ASan: Unauthorized %[1]v in %[2]v syscall",
+				fmt:    "ASan: Unauthorized Access in %[2]v syscall",
 			},
 		},
 		[]*regexp.Regexp{},

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -71,8 +71,9 @@ var netbsdOopses = []*oops{
 		[]byte("ASan:"),
 		[]oopsFormat{
 			{
-				title: compile("ASan:"),
-				fmt:   "ASan bug",
+				title:  compile("ASan: Unauthorized Access"),
+				report: compile(`ASan: Unauthorized Access .*\[.*,(.*),(?:.*\n)+?.*? sys_(.*)\<`),
+				fmt:    "ASan: Unauthorized %[1]v in %[2]v syscall",
 			},
 		},
 		[]*regexp.Regexp{},

--- a/pkg/report/testdata/netbsd/report/12
+++ b/pkg/report/testdata/netbsd/report/12
@@ -1,2 +1,0 @@
-
-login: Jan  1 00:00:00 localhost postfix/pickup[596]: panic: event_init: unable to initialize

--- a/pkg/report/testdata/netbsd/report/6
+++ b/pkg/report/testdata/netbsd/report/6
@@ -1,17 +1,10 @@
-TITLE: ASan bug
+TITLE: ASan: Unauthorized write in pipe syscall
 
-login: [  97.7755351] kASan: Unauthorized Access In 0xffffffff80a5449c: Addr 0xffffc480049666bc [4 bytes, read]
-[  97.7755351] #0 0xffffffff80a5449c in in6_print <netbsd>
-[  97.7856191] #1 0xffffffff80a54b21 in sin6_print <netbsd>
-[  97.7856191] #2 0xffffffff80f23b2f in sockaddr_checklen <netbsd>
-[  97.7955816] #3 0xffffffff80f23bd0 in sockaddr_alloc <netbsd>
-[  97.7955816] #4 0xffffffff80f23d35 in sockaddr_dup <netbsd>
-[  97.7955816] #5 0xffffffff81035d9a in rtcache_setdst <netbsd>
-[  97.8056417] #6 0xffffffff81036197 in rtcache_lookup2 <netbsd>
-[  97.8056417] #7 0xffffffff80a5526b in in6_selectroute <netbsd>
-[  97.8056417] #8 0xffffffff80a556d5 in in6_selectsrc <netbsd>
-[  97.8159029] #9 0xffffffff80a7cf93 in rip6_connect_wrapper <netbsd>
-[  97.8159029] #10 0xffffffff80f3e2eb in do_sys_connect <netbsd>
-[  97.8257126] #11 0xffffffff80f3e513 in sys_connect <netbsd>
-[  97.8257126] #12 0xffffffff80e92599 in sys___syscall <netbsd>
-[  97.8257126] #13 0xffffffff80263338 in syscall <netbsd>
+[  21.8948097] ASan: Unauthorized Access In 0xffffffff80e88b87: Addr 0xffffd58012f95ee8 [8 bytes, write, RedZonePartial]
+[  21.9058826] #0 0xffffffff80e88b87 in file_ctor <netbsd>
+[  21.9058826] #1 0xffffffff80f16f69 in pool_cache_get_slow <netbsd>
+[  21.9058826] #2 0xffffffff80f18fbc in pool_cache_get_paddr <netbsd>
+[  21.9058826] #3 0xffffffff80e8ba24 in fd_allocfile <netbsd>
+[  21.9160732] #4 0xffffffff80f391e5 in pipe1 <netbsd>
+[  21.9160732] #5 0xffffffff80f2f206 in sys_pipe <netbsd>
+[  21.9160732] #6 0xffffffff80265c1e in syscall <netbsd>

--- a/pkg/report/testdata/netbsd/report/6
+++ b/pkg/report/testdata/netbsd/report/6
@@ -1,4 +1,4 @@
-TITLE: ASan: Unauthorized write in pipe syscall
+TITLE: ASan: Unauthorized Access in pipe syscall
 
 [  21.8948097] ASan: Unauthorized Access In 0xffffffff80e88b87: Addr 0xffffd58012f95ee8 [8 bytes, write, RedZonePartial]
 [  21.9058826] #0 0xffffffff80e88b87 in file_ctor <netbsd>

--- a/pkg/report/testdata/netbsd/report/7
+++ b/pkg/report/testdata/netbsd/report/7
@@ -1,18 +1,2 @@
-TITLE: ASan bug
 
-login: [ 161.8124298] kASan: Unauthorized Access In 0xffffffff80a5449c: Addr 0xffffc9000495f6f4 [4 bytes, read]
-[ 161.8223936] #0 0xffffffff80a5449c in in6_print <netbsd>
-[ 161.8223936] #1 0xffffffff80a54b21 in sin6_print <netbsd>
-[ 161.8324951] #2 0xffffffff80f23b2f in sockaddr_checklen <netbsd>
-[ 161.8324951] #3 0xffffffff80f23bd0 in sockaddr_alloc <netbsd>
-[ 161.8324951] #4 0xffffffff80f23d35 in sockaddr_dup <netbsd>
-[ 161.8424679] #5 0xffffffff81035d9a in rtcache_setdst <netbsd>
-[ 161.8424679] #6 0xffffffff81036197 in rtcache_lookup2 <netbsd>
-[ 161.8525790] #7 0xffffffff80a5526b in in6_selectroute <netbsd>
-[ 161.8525790] #8 0xffffffff80a556d5 in in6_selectsrc <netbsd>
-[ 161.8525790] #9 0xffffffff80a7e004 in rip6_output <netbsd>
-[ 161.8625254] #10 0xffffffff80a7ea57 in rip6_send_wrapper <netbsd>
-[ 161.8625254] #11 0xffffffff80f34284 in sosend <netbsd>
-[ 161.8625254] #12 0xffffffff80f3ed39 in do_sys_sendmsg_so <netbsd>
-[ 161.8728803] #13 0xffffffff80f3f172 in do_sys_sendmsg <netbsd>
-[ 161.8728803] #14 0xffffffff80f3f3e7 in sys_sendmsg <netbsd>
+login: Jan  1 00:00:00 localhost postfix/pickup[596]: panic: event_init: unable to initialize


### PR DESCRIPTION

Now report bugs in the format : 
ASan: Unauthorized (read|write) in (x) syscall