### PR TITLE
execprog: fix executing with fault injection

### DIFF
--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -303,6 +303,12 @@ func createConfig(target *prog.Target, entries []*prog.LogEntry,
 		execOpts.FaultCall = *flagFaultCall
 		execOpts.FaultNth = *flagFaultNth
 	}
+	for _, entry := range entries {
+		if entry.Fault {
+			config.Flags |= ipc.FlagEnableFault
+			break
+		}
+	}
 	handled := make(map[string]bool)
 	for _, entry := range entries {
 		for _, call := range entry.P.Calls {


### PR DESCRIPTION
If the fault injection flags are not provided, but the log contains a
fault injection like this:

2017/08/12 17:16:04 executing program 5 (fault-call:4 fault-nth:5):

we fail to enable fault injection in ipc.Config. Fix it.
