### PR TITLE
syz-ci: fix error reporting for syzupdater.

### DIFF
--- a/syz-ci/syzupdater.go
+++ b/syz-ci/syzupdater.go
@@ -290,7 +290,7 @@ func (upd *SyzUpdater) uploadBuildError(commit *vcs.Commit, buildErr error) {
 		log.Logf(0, "not uploading build error: no dashboard")
 		return
 	}
-	dash := dashapi.New(upd.dashboardAddr, upd.mgrcfg.DashboardClient, upd.mgrcfg.DashboardKey)
+	dash := dashapi.New(upd.mgrcfg.DashboardClient, upd.dashboardAddr, upd.mgrcfg.DashboardKey)
 	var title string
 	var output []byte
 	if verbose, ok := buildErr.(*osutil.VerboseError); ok {


### PR DESCRIPTION
syzupdater fails to report build errors because it is constructing the
dashapi client with the wrong parameters (it is mixing dashboardAddr
with dashboardClient).

This commit swaps the order of those parameters in syzupdater's
uploadBuildError function.

Fixes #1044 