### PR TITLE
pkg/report: fix other NetBSD corrupted reports

### DIFF
--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -44,9 +44,9 @@ var netbsdOopses = []*oops{
 		[]byte("fault in supervisor mode"),
 		[]oopsFormat{
 			{
-				title:  compile("fatal (?:page|protection) fault in supervisor mode"),
-				report: compile(`fatal (?:page|protection) fault in supervisor mode(?:.*\n)+?--- trap.*?\n(.*?)\(`),
-				fmt:    "page fault in %[1]v",
+				title:  compile("fatal (page|protection|integer divide) fault in supervisor mode"),
+				report: compile(`fatal (page|protection|integer divide) fault in supervisor mode(?:.*\n)+?.*trap.*?\n.*?\](.*?)\(`),
+				fmt:    "%[1]v fault in %[2]v",
 			},
 		},
 		[]*regexp.Regexp{},
@@ -61,7 +61,7 @@ var netbsdOopses = []*oops{
 			},
 			{
 				title:  compile("panic: lock error"),
-				report: compile(`panic: lock error:(?:.*\n)+?.*?Begin traceback.*?\n(?:.*(?:panic|printf|lockdebug|abort|mutex).*\n)*(.*?)\(`),
+				report: compile(`panic: lock error:(?:.*\n)+?.*?Begin traceback.*?\n(?:.*(?:panic|printf|lockdebug|abort|mutex).*\n)*.*?\](.*?)\(`),
 				fmt:    "lock error in %[1]v",
 			},
 		},

--- a/pkg/report/testdata/netbsd/report/0
+++ b/pkg/report/testdata/netbsd/report/0
@@ -1,43 +1,21 @@
 TITLE: page fault in shm_delete_mapping
 
-uvm_fault(0xffffe4007e04a180, 0x0, 1) -> e
-fatal page fault in supervisor mode
-trap type 6 code 0 rip 0xffffffff809bfb5e cs 0x8 rflags 0x10282 cr2 0 ilevel 0 rsp 0xffffe40043f6fdb0
-curlwp 0xffffe40075d40960 pid 2741.3 lowest kstack 0xffffe40043f6c2c0
-panic: trap
-cpu2: Begin traceback...
-vpanic() at netbsd:vpanic+0x140
-snprintf() at netbsd:snprintf
-trap() at netbsd:trap+0xc4c
---- trap (number 6) ---
-shm_delete_mapping() at netbsd:shm_delete_mapping+0x46
-sys_shmat() at netbsd:sys_shmat+0x25c
-sys___syscall() at netbsd:sys___syscall+0x58
-syscall() at netbsd:syscall+0x1d8
---- syscall (number 198) ---
-765edba3f45a:
-cpu2: End traceback...
+[  32.0706954] fatal page fault in supervisor mode
+[  32.0706954] trap type 6 code 0 rip 0xffffffff80ee1709 cs 0x8 rflags 0x10287 cr2 0xffff900000000000 ilevel 0 rsp 0xffffc4816eaf7c98
+[  32.0706954] curlwp 0xffffc48011fc61c0 pid 767.2 lowest kstack 0xffffc4816eaf02c0
+[  32.0706954] panic: trap
+[  32.0706954] cpu1: Begin traceback...
+[  32.0817608] vpanic() at netbsd:vpanic+0x214
+[  32.0817608] snprintf() at netbsd:snprintf
+[  32.0817608] startlwp() at netbsd:startlwp
+[  32.0928709] alltraps() at netbsd:alltraps+0xb2
+[  32.1039814] shm_delete_mapping() at netbsd:shm_delete_mapping+0x7f
+[  32.1150915] sys_shmat() at netbsd:sys_shmat+0x4b5
+[  32.1262011] sys___syscall() at netbsd:sys___syscall+0xe2
+[  32.1262011] syscall() at netbsd:syscall+0x30e
+[  32.1373117] --- syscall (number 198) ---
+[  32.1373117] 775e9043f4aa:
+[  32.1484219] cpu1: End traceback...
 
-dumping to dev 0,1 (offset=8, size=524157):
-dump 113 112 111 110 109 Skipping crash dump on recursive panic
-panic: wddump: polled command has been queued
-cpu2: Begin traceback...
-vpanic() at netbsd:vpanic+0x140
-snprintf() at netbsd:snprintf
-wddump() at netbsd:wddump+0x295
-dumpsys_seg() at netbsd:dumpsys_seg+0xf3
-dump_seg_iter() at netbsd:dump_seg_iter+0xd2
-dodumpsys() at netbsd:dodumpsys+0x24b
-dumpsys() at netbsd:dumpsys+0x1d
-vpanic() at netbsd:vpanic+0x149
-snprintf() at netbsd:snprintf
-trap() at netbsd:trap+0xc4c
---- trap (number 6) ---
-shm_delete_mapping() at netbsd:shm_delete_mapping+0x46
-sys_shmat() at netbsd:sys_shmat+0x25c
-sys___syscall() at netbsd:sys___syscall+0x58
-syscall() at netbsd:syscall+0x1d8
---- syscall (number 198) ---
-765edba3f45a:
-cpu2: End traceback...
-rebooting...
+[  32.1484219] dumping to dev 4,1 (offset=0, size=0): not possible
+[  32.1595325] rebooting...

--- a/pkg/report/testdata/netbsd/report/2
+++ b/pkg/report/testdata/netbsd/report/2
@@ -1,4 +1,5 @@
 TITLE: page fault in callout_halt
+CORRUPTED: Y
 
 login: uvm_fault(0xfffffe807d0068b0, 0x0, 1) -> e
 fatal page fault in supervisor mode

--- a/pkg/report/testdata/netbsd/report/2
+++ b/pkg/report/testdata/netbsd/report/2
@@ -1,25 +1,21 @@
-TITLE: page fault in callout_halt
-CORRUPTED: Y
+TITLE: page fault in shm_delete_mapping
 
-login: uvm_fault(0xfffffe807d0068b0, 0x0, 1) -> e
-fatal page fault in supervisor mode
-trap type 6 code 0 rip 0xffffffff8095a148 cs 0x8 rflags 0x286 cr2 0 ilevel 0x8 rsp 0xffff800044a61df0
-curlwp 0xfffffe807b5a8ba0 pid 11957.2 lowest kstack 0xffff800044a5f2c0
-panic: trap
-cpu1: Begin traceback...
-vpanic() at netbsd:vpanic+0x15d
-snprintf() at netbsd:snprintf
-trap() at netbsd:trap+0xa00
---- trap (number 6) ---
-callout_halt() at netbsd:callout_halt+0x1b
-timer_settime() at netbsd:timer_settime+0x26
-dosetitimer() at netbsd:dosetitimer+0x204
-sys___setitimer50() at netbsd:sys___setitimer50+0xaa
-sys___syscall() at netbsd:sys___syscall+0x71
-syscall() at netbsd:syscall+0x1ec
---- syscall (number 198) ---
-72f43183f4aa:
-cpu1: End traceback...
+[  32.0706954] fatal page fault in supervisor mode
+[  32.0706954] trap type 6 code 0 rip 0xffffffff80ee1709 cs 0x8 rflags 0x10287 cr2 0xffff900000000000 ilevel 0 rsp 0xffffc4816eaf7c98
+[  32.0706954] curlwp 0xffffc48011fc61c0 pid 767.2 lowest kstack 0xffffc4816eaf02c0
+[  32.0706954] panic: trap
+[  32.0706954] cpu1: Begin traceback...
+[  32.0817608] vpanic() at netbsd:vpanic+0x214
+[  32.0817608] snprintf() at netbsd:snprintf
+[  32.0817608] startlwp() at netbsd:startlwp
+[  32.0928709] alltraps() at netbsd:alltraps+0xb2
+[  32.1039814] shm_delete_mapping() at netbsd:shm_delete_mapping+0x7f
+[  32.1150915] sys_shmat() at netbsd:sys_shmat+0x4b5
+[  32.1262011] sys___syscall() at netbsd:sys___syscall+0xe2
+[  32.1262011] syscall() at netbsd:syscall+0x30e
+[  32.1373117] --- syscall (number 198) ---
+[  32.1373117] 775e9043f4aa:
+[  32.1484219] cpu1: End traceback...
 
-dumping to dev 19,1 (offset=0, size=0): not possible
-rebooting...
+[  32.1484219] dumping to dev 4,1 (offset=0, size=0): not possible
+[  32.1595325] rebooting...

--- a/pkg/report/testdata/netbsd/report/3
+++ b/pkg/report/testdata/netbsd/report/3
@@ -1,4 +1,4 @@
-TITLE: page fault in callout_halt
+TITLE: page fault in do_sys_accept
 
 [ 401.9356239] fatal page fault in supervisor mode
 [ 401.9475401] trap type 6 code 0x2 rip 0xffffffff8022b8cc cs 0x8 rflags 0x10246 cr2 0 ilevel 0 rsp 0xffff9f816eefba88

--- a/pkg/report/testdata/netbsd/report/3
+++ b/pkg/report/testdata/netbsd/report/3
@@ -1,23 +1,21 @@
 TITLE: page fault in callout_halt
 
-login: fatal protection fault in supervisor mode
-trap type 4 code 0 rip 0xffffffff8095a148 cs 0x8 rflags 0x286 cr2 0x7 ilevel 0x8 rsp 0xffff800044b07df0
-curlwp 0xfffffe807a6ed500 pid 1223.2 lowest kstack 0xffff800044b052c0
-panic: trap
-cpu0: Begin traceback...
-vpanic() at netbsd:vpanic+0x15d
-snprintf() at netbsd:snprintf
-trap() at netbsd:trap+0xa00
---- trap (number 4) ---
-callout_halt() at netbsd:callout_halt+0x1b
-timer_settime() at netbsd:timer_settime+0x26
-dosetitimer() at netbsd:dosetitimer+0x204
-sys___setitimer50() at netbsd:sys___setitimer50+0xaa
-sys___syscall() at netbsd:sys___syscall+0x71
-syscall() at netbsd:syscall+0x1ec
---- syscall (number 198) ---
-736f9e23f4aa:
-cpu0: End traceback...
+[ 401.9356239] fatal page fault in supervisor mode
+[ 401.9475401] trap type 6 code 0x2 rip 0xffffffff8022b8cc cs 0x8 rflags 0x10246 cr2 0 ilevel 0 rsp 0xffff9f816eefba88
+[ 401.9599592] curlwp 0xffff9f8012ee9500 pid 25040.2 lowest kstack 0xffff9f816eef42c0
+[ 401.9675001] panic: trap
+[ 401.9675001] cpu0: Begin traceback...
+[ 401.9756945] vpanic() at netbsd:vpanic+0x214
+[ 401.9857023] snprintf() at netbsd:snprintf
+[ 401.9957128] startlwp() at netbsd:startlwp
+[ 402.0057261] alltraps() at netbsd:alltraps+0xb2
+[ 402.0157399] do_sys_accept() at netbsd:do_sys_accept+0x2f4
+[ 402.0257549] sys_paccept() at netbsd:sys_paccept+0x11c
+[ 402.0357684] sys___syscall() at netbsd:sys___syscall+0xe2
+[ 402.0457858] syscall() at netbsd:syscall+0x348
+[ 402.0457858] --- syscall (number 198) ---
+[ 402.0588888] 7cdccb23f4aa:
+[ 402.0588888] cpu0: End traceback...
 
-dumping to dev 19,1 (offset=0, size=0): not possible
-rebooting...
+[ 402.0668525] dumping to dev 4,1 (offset=0, size=0): not possible
+[ 402.0668525] rebooting...

--- a/pkg/report/testdata/netbsd/report/4
+++ b/pkg/report/testdata/netbsd/report/4
@@ -1,27 +1,21 @@
-TITLE: page fault in vmem_alloc
+TITLE: integer divide fault in vmem_alloc
 
-login: uvm_fault(0xfffffe807be892f8, 0x0, 1) -> e
-fatal page fault in supervisor mode
-trap type 6 code 0 rip 0xffffffff809774b3 cs 0x8 rflags 0x246 cr2 0x36 ilevel 0 rsp 0xffff800044ab3c50
-curlwp 0xfffffe807c62b040 pid 27514.2 lowest kstack 0xffff800044ab12c0
-panic: trap
-cpu0: Begin traceback...
-vpanic() at netbsd:vpanic+0x15d
-snprintf() at netbsd:snprintf
-trap() at netbsd:trap+0xa00
---- trap (number 6) ---
-vmem_alloc() at netbsd:vmem_alloc+0x3e
-uvm_km_kmem_alloc() at netbsd:uvm_km_kmem_alloc+0x46
-kmem_intr_alloc() at netbsd:kmem_intr_alloc+0x6d
-ufs_readdir() at netbsd:ufs_readdir+0xdd
-VOP_READDIR() at netbsd:VOP_READDIR+0x5c
-vn_readdir() at netbsd:vn_readdir+0xd8
-sys___getdents30() at netbsd:sys___getdents30+0x75
-sys___syscall() at netbsd:sys___syscall+0x71
-syscall() at netbsd:syscall+0x1ec
---- syscall (number 198) ---
-75e993c3f4aa:
-cpu0: End traceback...
+[  31.6002559] fatal integer divide fault in supervisor mode
+[  31.6002559] trap type 8 code 0 rip 0xffffffff80ee4614 cs 0x8 rflags 0x10246 cr2 0x20000540 ilevel 0x8 rsp 0xffff98816dabfd40
+[  31.6002559] curlwp 0xffff98800de018a0 pid 0.5 lowest kstack 0xffff98816dab82c0
+[  31.6002559] panic: trap
+[  31.6002559] cpu0: Begin traceback...
+[  31.6002559] vpanic() at netbsd:vpanic+0x214
+[  31.6002559] snprintf() at netbsd:snprintf
+[  31.6002559] startlwp() at netbsd:startlwp
+[  31.6002559] alltraps() at netbsd:alltraps+0xb2
+[  31.6002559] callout_softclock() at netbsd:callout_softclock+0x237
+[  31.6002559] softint_dispatch() at netbsd:softint_dispatch+0x23e
+[  31.6002559] DDB lost frame for netbsd:Xsoftintr+0x5a, trying 0xffff98816dabfff0
+[  31.6002559] Xsoftintr() at netbsd:Xsoftintr+0x5a
+[  31.6002559] --- interrupt ---
+[  31.6002559] 0:
+[  31.6002559] cpu0: End traceback...
 
-dumping to dev 19,1 (offset=0, size=0): not possible
-rebooting...
+[  31.6002559] dumping to dev 4,1 (offset=0, size=0): not possible
+[  31.6002559] rebooting...

--- a/pkg/report/testdata/netbsd/report/4
+++ b/pkg/report/testdata/netbsd/report/4
@@ -1,4 +1,4 @@
-TITLE: integer divide fault in vmem_alloc
+TITLE: integer divide fault in callout_softclock
 
 [  31.6002559] fatal integer divide fault in supervisor mode
 [  31.6002559] trap type 8 code 0 rip 0xffffffff80ee4614 cs 0x8 rflags 0x10246 cr2 0x20000540 ilevel 0x8 rsp 0xffff98816dabfd40

--- a/pkg/report/testdata/netbsd/report/5
+++ b/pkg/report/testdata/netbsd/report/5
@@ -1,4 +1,4 @@
-TITLE: lock error in do_sys_accept 
+TITLE: lock error in do_sys_accept
 
 [ 157.5698093] panic: lock error: Mutex: mutex_vector_exit,761: assertion failed: MUTEX_OWNER(mtx->mtx_owner) == curthread: lock 0xffffc200130971c0 cpu 0 lwp 0xffffc20012ccd320
 [ 157.5924708] cpu0: Begin traceback...

--- a/pkg/report/testdata/netbsd/report/5
+++ b/pkg/report/testdata/netbsd/report/5
@@ -1,27 +1,18 @@
-TITLE: lock error in key_attach_wrapper
+TITLE: lock error in do_sys_accept 
 
-login: Mutex error: mutex_vector_enter,552: locking against myself
+[ 157.5698093] panic: lock error: Mutex: mutex_vector_exit,761: assertion failed: MUTEX_OWNER(mtx->mtx_owner) == curthread: lock 0xffffc200130971c0 cpu 0 lwp 0xffffc20012ccd320
+[ 157.5924708] cpu0: Begin traceback...
+[ 157.5977590] vpanic() at netbsd:vpanic+0x214
+[ 157.6109214] snprintf() at netbsd:snprintf
+[ 157.6251928] lockdebug_abort() at netbsd:lockdebug_abort+0x14c
+[ 157.6394641] mutex_vector_exit() at netbsd:mutex_vector_exit+0x1bc
+[ 157.6543582] do_sys_accept() at netbsd:do_sys_accept+0x346
+[ 157.6690586] sys_paccept() at netbsd:sys_paccept+0x11c
+[ 157.6839301] sys___syscall() at netbsd:sys___syscall+0xe2
+[ 157.6965505] syscall() at netbsd:syscall+0x348
+[ 157.7124393] --- syscall (number 198) ---
+[ 157.7250907] 77dca383f4aa:
+[ 157.7250907] cpu0: End traceback...
 
-lock address : 0xfffffe807fbf8780
-current cpu  :                  0
-current lwp  : 0xfffffe807aefd4c0
-owner field  : 0xfffffe807aefd4c0 wait/spin:                0/0
-
-panic: lock error: Mutex: mutex_vector_enter,552: locking against myself: lock 0xfffffe807fbf8780 cpu 0 lwp 0xfffffe807aefd4c0
-cpu0: Begin traceback...
-vpanic() at netbsd:vpanic+0x15d
-snprintf() at netbsd:snprintf
-lockdebug_abort() at netbsd:lockdebug_abort+0x6e
-mutex_vector_enter() at netbsd:mutex_vector_enter+0x2c2
-key_attach_wrapper() at netbsd:key_attach_wrapper+0x6d
-socreate() at netbsd:socreate+0x167
-makesocket() at netbsd:makesocket+0x35
-sys_socketpair() at netbsd:sys_socketpair+0xb1
-sys___syscall() at netbsd:sys___syscall+0x71
-syscall() at netbsd:syscall+0x1ec
---- syscall (number 198) ---
-72415443f4aa:
-cpu0: End traceback...
-
-dumping to dev 19,1 (offset=0, size=0): not possible
-rebooting...
+[ 157.7250907] dumping to dev 4,1 (offset=0, size=0): not possible
+[ 157.7250907] rebooting...


### PR DESCRIPTION

Some reports for page fault in supervisor mode do not go into a trap and hence get corrupted.
example - https://syzkaller.appspot.com/text?tag=CrashReport&x=136887a2c00000 and
https://syzkaller.appspot.com/text?tag=CrashReport&x=10836513200000