### PR TITLE
Add missing bits needed for FreeBSD support in syz-ci.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -76,6 +76,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		{"akaros", "amd64", []string{"qemu"}, akaros{}},
 		{"openbsd", "amd64", []string{"gce", "vmm"}, openbsd{}},
 		{"netbsd", "amd64", []string{"gce", "qemu"}, netbsd{}},
+		{"freebsd", "amd64", []string{"gce", "qemu"}, freebsd{}},
 	}
 	for _, s := range supported {
 		if targetOS == s.OS && targetArch == s.arch {

--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -1,0 +1,87 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+type freebsd struct{}
+
+func (ctx freebsd) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
+	cmdlineFile, sysctlFile string, config []byte) error {
+	confFile := fmt.Sprintf("%v/sys/%v/conf/SYZKALLER", kernelDir, targetArch)
+
+	if config == nil {
+		config = []byte(`
+include "./GENERIC"
+
+ident		SYZKALLER
+options 	COVERAGE
+options 	KCOV
+`)
+	}
+	if err := osutil.WriteFile(confFile, config); err != nil {
+		return err
+	}
+
+	objDir := filepath.Join(outputDir, "obj")
+	if err := ctx.make(kernelDir, objDir, "kernel-toolchain"); err != nil {
+		return err
+	}
+	if err := ctx.make(kernelDir, objDir, "buildkernel", "KERNCONF=SYZKALLER"); err != nil {
+		return err
+	}
+
+	for _, s := range []struct{ dir, src, dst string }{
+		{userspaceDir, "image", "image"},
+		{userspaceDir, "key", "key"},
+	} {
+		fullSrc := filepath.Join(s.dir, s.src)
+		fullDst := filepath.Join(outputDir, s.dst)
+		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
+			return fmt.Errorf("failed to copy %v -> %v: %v", fullSrc, fullDst, err)
+		}
+	}
+
+	script := fmt.Sprintf(`
+set -eux
+md=$(sudo mdconfig -a -t vnode image)
+tmpdir=$(mktemp -d)
+sudo mount /dev/${md}p3 $tmpdir
+
+sudo MAKEOBJDIRPREFIX=$(pwd)/obj make -C %s installkernel KERNCONF=SYZKALLER DESTDIR=$tmpdir
+
+sudo umount $tmpdir
+sudo mdconfig -d -u ${md#md}
+`, kernelDir)
+
+	if debugOut, err := osutil.RunCmd(10*time.Minute, outputDir, "/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("error copying kernel: %v\n%v", err, debugOut)
+	}
+	return nil
+}
+
+func (ctx freebsd) clean(kernelDir, targetArch string) error {
+	// Builds are non-incremental for now, so we don't need to do anything here.
+	return nil
+}
+
+func (ctx freebsd) make(kernelDir string, objDir string, makeArgs ...string) error {
+	args := append([]string{
+		fmt.Sprintf("MAKEOBJDIRPREFIX=%v", objDir),
+		"make",
+		"-C", kernelDir,
+		"-j", strconv.Itoa(runtime.NumCPU()),
+	}, makeArgs...)
+	_, err := osutil.RunCmd(3*time.Hour, kernelDir, "sh", "-c", strings.Join(args, " "))
+	return err
+}

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -60,7 +60,7 @@ no options SVS
 			return fmt.Errorf("failed to copy %v -> %v: %v", fullSrc, fullDst, err)
 		}
 	}
-	return CopyKernelToDisk(targetArch, vmType, outputDir, filepath.Join(compileDir, "netbsd"))
+	return ctx.copyKernelToDisk(targetArch, vmType, outputDir, filepath.Join(compileDir, "netbsd"))
 }
 
 func (ctx netbsd) clean(kernelDir, targetArch string) error {
@@ -70,7 +70,7 @@ func (ctx netbsd) clean(kernelDir, targetArch string) error {
 }
 
 // Copy the compiled kernel to the qemu disk image using ssh.
-func CopyKernelToDisk(targetArch, vmType, outputDir, kernel string) error {
+func (ctx netbsd) copyKernelToDisk(targetArch, vmType, outputDir, kernel string) error {
 	vmConfig := `
 {
 	"snapshot": false,

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -51,7 +51,7 @@ func (ctx openbsd) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 		}
 	}
 	if vmType == "gce" {
-		return CopyFilesToImage(
+		return ctx.copyFilesToImage(
 			filepath.Join(userspaceDir, "overlay"), outputDir)
 	}
 	return nil
@@ -71,7 +71,7 @@ func (ctx openbsd) make(kernelDir string, args ...string) error {
 	return err
 }
 
-// CopyFilesToImage populates the filesystem image in outputDir with
+// copyFilesToImage populates the filesystem image in outputDir with
 // run-specific files. The kernel is copied as /bsd and if overlayDir
 // exists, its contents are copied into corresponding files in the
 // image.
@@ -79,7 +79,7 @@ func (ctx openbsd) make(kernelDir string, args ...string) error {
 // Ideally a user space tool capable of understanding FFS should
 // interpret FFS inside the image file, but vnd(4) device would do in
 // a pinch.
-func CopyFilesToImage(overlayDir, outputDir string) error {
+func (ctx openbsd) copyFilesToImage(overlayDir, outputDir string) error {
 	script := fmt.Sprintf(`set -eux
 OVERLAY="%s"
 # Cleanup in case something failed before.

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -102,6 +102,11 @@ var freebsdOopses = []*oops{
 				title: compile("panic: ffs_write: type {{ADDR}} [0-9]+ \\([0-9]+,[0-9]+\\)"),
 				fmt:   "panic: ffs_write: type ADDR X (Y,Z)",
 			},
+			{
+				title: compile("panic: ([a-zA-Z]+[a-zA-Z0-9_]*\\(\\)) of destroyed (mutex|rmlock|rwlock|sx) @ " +
+					"/.*/(sys/.*:[0-9]+)"),
+				fmt: "panic: %[1]v of destroyed %[2]v at %[3]v",
+			},
 		},
 		[]*regexp.Regexp{},
 	},

--- a/pkg/report/testdata/freebsd/report/4
+++ b/pkg/report/testdata/freebsd/report/4
@@ -1,0 +1,19 @@
+TITLE: panic: mtx_lock() of destroyed mutex at sys/kern/sys_socket.c:LINE
+
+login: panic: mtx_lock() of destroyed mutex @ /mnt/go/src/github.com/google/syzkaller/bin/managers/freebsd/kernel/sys/kern/sys_socket.c:316
+cpuid = 0
+time = 1552095166
+KDB: stack backtrace:
+db_trace_self_wrapper() at db_trace_self_wrapper+0x47/frame 0xfffffe004b9db650
+vpanic() at vpanic+0x1e0/frame 0xfffffe004b9db6b0
+panic() at panic+0x43/frame 0xfffffe004b9db710
+__mtx_lock_flags() at __mtx_lock_flags+0x1e2/frame 0xfffffe004b9db770
+soo_stat() at soo_stat+0x13b/frame 0xfffffe004b9db7b0
+kern_fstat() at kern_fstat+0xe9/frame 0xfffffe004b9db800
+freebsd11_fstat() at freebsd11_fstat+0x2b/frame 0xfffffe004b9db980
+amd64_syscall() at amd64_syscall+0x436/frame 0xfffffe004b9dbab0
+fast_syscall_common() at fast_syscall_common+0x101/frame 0xfffffe004b9dbab0
+--- syscall (198, FreeBSD ELF64, nosys), rip = 0x412f5a, rsp = 0x7fffdffdcf38, rbp = 0x2 ---
+KDB: enter: panic
+[ thread pid 820 tid 100190 ]
+Stopped at      kdb_enter+0x6a: movq    $0,kdb_why

--- a/pkg/vcs/freebsd.go
+++ b/pkg/vcs/freebsd.go
@@ -1,0 +1,31 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"fmt"
+	"io"
+)
+
+type freebsd struct {
+	*git
+}
+
+func newFreeBSD(vm, dir string) *freebsd {
+	return &freebsd{
+		git: newGit(dir),
+	}
+}
+
+func (ctx *freebsd) ExtractFixTagsFromCommits(baseCommit, email string) ([]*Commit, error) {
+	return ctx.git.ExtractFixTagsFromCommits(baseCommit, email)
+}
+
+func (ctx *freebsd) Bisect(bad, good string, trace io.Writer, pred func() (BisectResult, error)) (*Commit, error) {
+	return nil, fmt.Errorf("not implemented for freebsd")
+}
+
+func (ctx *freebsd) PreviousReleaseTags(commit string) ([]string, error) {
+	return nil, fmt.Errorf("not implemented for freebsd")
+}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -90,6 +90,8 @@ func NewRepo(os, vm, dir string) (Repo, error) {
 		return newOpenBSD(vm, dir), nil
 	case "netbsd":
 		return newNetBSD(vm, dir), nil
+	case "freebsd":
+		return newFreeBSD(vm, dir), nil
 	}
 	return nil, fmt.Errorf("vcs is unsupported for %v", os)
 }


### PR DESCRIPTION
This is a minimal set of changes that I've used to get syz-ci to manage FreeBSD targets.

For now the FreeBSD bits in pkg/build only support building on FreeBSD. In the next several months I hope that we will be able to support cross-compilation on Linux.

To run syz-ci, I used the latest 13-current GCE image from freebsd-org-cloud-dev. The gmake, go, git and gcc packages must be installed. To create the base image used for FreeBSD workers, download the latest raw image from [1]. Boot it using qemu:

```
$ sudo pkg install qemu
$ mv FreeBSD-13.0-CURRENT-amd64.raw image
$ qemu-system-x86_64 -hda image
```

When the boot menu pops up, hit "3" to get to the loader prompt, and enter 'set console="comconsole"' and then 'boot' at the prompt. Once booted, add 'console="comconsole"' to /boot/loader.conf, add 'sshd_enable="YES"' to /etc/rc.conf, and enable root logins in /etc/ssh/sshd_config. Configure an ssh key.  That preparation should be sufficient to enable booting in GCE.

[1] http://ftp.freebsd.org/pub/FreeBSD/snapshots/VM-IMAGES/13.0-CURRENT/amd64/Latest/