### PR TITLE
pkg/build: fix getBuilder for fuchsia.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -71,8 +71,8 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 	}{
 		{"linux", "amd64", []string{"gvisor"}, gvisor{}},
 		{"linux", "amd64", []string{"gce", "qemu"}, linux{}},
-		{"fuchsia", "amd64", []string{"gce"}, fuchsia{}},
-		{"fuchsia", "arm64", []string{"gce"}, fuchsia{}},
+		{"fuchsia", "amd64", []string{"qemu"}, fuchsia{}},
+		{"fuchsia", "arm64", []string{"qemu"}, fuchsia{}},
 		{"akaros", "amd64", []string{"qemu"}, akaros{}},
 		{"openbsd", "amd64", []string{"gce", "vmm"}, openbsd{}},
 		{"netbsd", "amd64", []string{"gce", "qemu"}, netbsd{}},


### PR DESCRIPTION
This CL changes the supported vmType for fuchsia to be QEMU, instead of
GCE.

This was broken by commit b4e5a74e4, which changed the behavior of
getBuilder. It was part of a 6-commit PR trying to add support for
FreeBSD.

That commit has caused syzkaller to stop being able to build the fuchsia
image, getting the following error:

`kernel build failed: unsupported image type fuchsia/amd64/qemu`