### PR TITLE
pkg/build: update fuchsia build commands.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -21,9 +21,12 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 		return fmt.Errorf("unsupported fuchsia arch %v", targetArch)
 	}
 	arch := sysTarget.KernelHeaderArch
-	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "clean-build", arch,
+	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "set", arch,
 		"--args", `extra_authorized_keys_file="//.ssh/authorized_keys"`,
 		"--board", "boards/x64.gni", "--product", "products/core.gni"); err != nil {
+		return err
+	}
+	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "clean-build"); err != nil {
 		return err
 	}
 	for src, dst := range map[string]string{


### PR DESCRIPTION
This CL splits the fx commands into two: one that runs `fx set` setting
the same arguments as before, and another one right after, running `fx
clean-build` to build fuchsia.

Recently[0], fuchsia made it impossible to run `fx clean-build`
specifying the arguments. Instead, one should run `fx set` before.

The benefit is that `clean-build` now preserves the build arguments
across runs. For syzkaller, it doesn't change anything though.

[0]: https://fuchsia-review.googlesource.com/c/fuchsia/+/262674
