### PR TITLE
Fix coverage reporting on FreeBSD

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -96,7 +96,10 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 	var d templateData
 	for f, covered := range fileSet(covered, uncovered) {
 		remain := filepath.Clean(strings.TrimPrefix(f, prefix))
-		if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {
+		// On FreeBSD, some files are in the kernel build directory.
+		if rg.OS == "freebsd" && f[0] != '/' {
+			f = filepath.Join(rg.objDir, remain)
+		} else if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {
 			f = filepath.Join(rg.srcDir, remain)
 		}
 		lines, err := parseFile(f)

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -108,7 +108,7 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 		}
 		lines, err := parseFile(f)
 		var buf bytes.Buffer
-		var coverage int
+		var coverage = 0
 		var mode string
 		if err != nil {
 			if rg.OS == "freebsd" {
@@ -123,7 +123,6 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 				return err
 			}
 		} else {
-			coverage = 0
 			for i, ln := range lines {
 				if len(covered) > 0 && covered[0].line == i+1 {
 					if covered[0].covered {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -22,8 +22,10 @@ import (
 
 type ReportGenerator struct {
 	vmlinux  string
+	objDir   string
 	srcDir   string
 	arch     string
+	OS       string
 	symbols  []symbol
 	coverPCs []uint64
 }
@@ -39,11 +41,13 @@ type coverage struct {
 	covered bool
 }
 
-func MakeReportGenerator(vmlinux, srcDir, arch string) (*ReportGenerator, error) {
+func MakeReportGenerator(vmlinux, objDir, srcDir, arch, OS string) (*ReportGenerator, error) {
 	rg := &ReportGenerator{
 		vmlinux: vmlinux,
+		objDir:  objDir,
 		srcDir:  srcDir,
 		arch:    arch,
+		OS:      OS,
 	}
 	if err := rg.readSymbols(); err != nil {
 		return nil, err

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -98,7 +98,7 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 		// On FreeBSD, some files are in the kernel build directory.
 		// These files either start with "./" or contain "/./".
 		if rg.OS == "freebsd" {
-			f = f[strings.LastIndex(f, "/./") + 1:]
+			f = f[strings.LastIndex(f, "/./")+1:]
 		}
 		remain := filepath.Clean(strings.TrimPrefix(f, prefix))
 		if rg.OS == "freebsd" && strings.HasPrefix(f, "./") {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -96,7 +96,7 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 	var d templateData
 	for f, covered := range fileSet(covered, uncovered) {
 		// On FreeBSD, some files are in the kernel build directory.
-		// These files either start with "./" or contain "/./".
+		// The filenames either start with "./" or contain "/./".
 		if rg.OS == "freebsd" {
 			f = f[strings.LastIndex(f, "/./")+1:]
 		}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -260,7 +260,7 @@ func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, 
 						break
 					}
 				}
-				if (prefix == "") {
+				if prefix == "" {
 					break
 				}
 				prefix = prefix[:i]

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -248,16 +248,20 @@ func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, 
 		if prefix == "" {
 			prefix = frame.File
 		} else {
-			i := 0
-			for ; i < len(prefix) && i < len(frame.File); i++ {
-				if prefix[i] != frame.File[i] {
+			// On FreeBSD, don't consider files which are present
+			// in the objDir directory.
+			if rg.OS != "freebsd" || (len(frame.File) > 0 && frame.File[0] == '/') {
+				i := 0
+				for ; i < len(prefix) && i < len(frame.File); i++ {
+					if prefix[i] != frame.File[i] {
+						break
+					}
+				}
+				if (prefix == "") {
 					break
 				}
+				prefix = prefix[:i]
 			}
-			if (prefix == "") {
-				break
-			}
-			prefix = prefix[:i]
 		}
 
 	}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -97,7 +97,7 @@ func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncover
 	for f, covered := range fileSet(covered, uncovered) {
 		remain := filepath.Clean(strings.TrimPrefix(f, prefix))
 		// On FreeBSD, some files are in the kernel build directory.
-		if rg.OS == "freebsd" && f[0] != '/' {
+		if rg.OS == "freebsd" && strings.HasPrefix(f, "./") {
 			f = filepath.Join(rg.objDir, remain)
 		} else if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {
 			f = filepath.Join(rg.srcDir, remain)
@@ -253,7 +253,7 @@ func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, 
 		} else {
 			// On FreeBSD, don't consider files which are present
 			// in the objDir directory.
-			if rg.OS != "freebsd" || (len(frame.File) > 0 && frame.File[0] == '/') {
+			if rg.OS != "freebsd" || !strings.HasPrefix(frame.File, "./") {
 				i := 0
 				for ; i < len(prefix) && i < len(frame.File); i++ {
 					if prefix[i] != frame.File[i] {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -238,6 +238,9 @@ func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, 
 					break
 				}
 			}
+			if (prefix == "") {
+				break
+			}
 			prefix = prefix[:i]
 		}
 

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -235,6 +235,10 @@ func (rg *ReportGenerator) uncoveredPcsInFuncs(pcs []uint64) []uint64 {
 	return uncoveredPCs
 }
 
+func isInObjDir(name string) bool {
+	return strings.HasPrefix(name, "./")
+}
+
 func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, error) {
 	symb := symbolizer.NewSymbolizer()
 	defer symb.Close()
@@ -253,7 +257,7 @@ func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, 
 		} else {
 			// On FreeBSD, don't consider files which are present
 			// in the objDir directory.
-			if rg.OS != "freebsd" || !strings.HasPrefix(frame.File, "./") {
+			if rg.OS != "freebsd" || !isInObjDir(frame.File) {
 				i := 0
 				for ; i < len(prefix) && i < len(frame.File); i++ {
 					if prefix[i] != frame.File[i] {

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -31,7 +31,7 @@ func initCover(kernelObj, kernelObjName, kernelSrc, arch, OS string) error {
 	}
 	vmlinux := filepath.Join(kernelObj, kernelObjName)
 	var err error
-	reportGenerator, err = cover.MakeReportGenerator(vmlinux, kernelSrc, arch)
+	reportGenerator, err = cover.MakeReportGenerator(vmlinux, kernelObj, kernelSrc, arch, OS)
 	if err != nil {
 		return err
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -61,7 +61,7 @@ func main() {
 		failf("%v", err)
 	}
 	kernelObj := filepath.Join(*flagKernelObj, target.KernelObject)
-	rg, err := cover.MakeReportGenerator(kernelObj, *flagKernelSrc, *flagArch)
+	rg, err := cover.MakeReportGenerator(kernelObj, *flagKernelObj, *flagKernelSrc, *flagArch, *flagOS)
 	if err != nil {
 		failf("%v", err)
 	}


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
On FreeBSD one has to provide two variable in the config file:

1.  `"kernel_src": "/usr/home/tuexen/head/sys/"` provides a path on to the kernel sources and
2. `"kernel_obj": "/usr/obj/usr/home/tuexen/head/amd64.amd64/sys/SYZKALLER/"` provides a path to the kernel build directory containing the kernel binary and generated source files.