### PR TITLE
Make it possible to generate coverage reports on FreeBSD.

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -302,7 +302,7 @@ var oses = map[string]osCommon{
 		SyscallPrefix:          "SYS_",
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
-		KernelObject:           "kernel.debug",
+		KernelObject:           "kernel.full",
 		CPP:                    "g++",
 	},
 	"netbsd": {


### PR DESCRIPTION
A couple of minor changes; the main difference is that we now copy kernel.full out of the object tree.

With the FreeBSD diff posted here I get working coverage reports: https://reviews.freebsd.org/D19633
Assuming that lands, syzbot will be able to generate coverage reports once it pulls the update.