### PR TITLE
[executor/fuchsia] update fdio import path.

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -4,7 +4,7 @@
 // This file is shared between executor and csource package.
 
 #include <fcntl.h>
-#include <lib/fdio/util.h>
+#include <lib/fdio/directory.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdlib.h>

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -743,7 +743,7 @@ static int do_sandbox_setuid(void)
 #elif GOOS_fuchsia
 
 #include <fcntl.h>
-#include <lib/fdio/util.h>
+#include <lib/fdio/directory.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdlib.h>


### PR DESCRIPTION
The Fuchsia team is going to remove the `lib/fdio/util.h` library. They
have already moved all the functions to new header files.

I have seen that fuchsia uses `fdio_service_connect`, which has been
moved to the `lib/fdio/directory.h` header file.

This commit just changes the import path in the fuchsia executor, and in
the corresponding generated go file (I made that change by running `make
generate`).
