### PR TITLE
dashboard: sort crashes by time descending.

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -737,6 +737,10 @@ func loadCrashesForBug(c context.Context, bug *Bug) ([]*uiCrash, []byte, error) 
 		}
 		results = append(results, makeUICrash(crash, build))
 	}
+	// most recent crashes should go first.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Time.After(results[j].Time)
+	})
 	sampleReport, _, err := getText(c, textCrashReport, crashes[0].Report)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This CL changes the order in which results are returned in the
loadCrashesForBug function, by returning the crashes in time-descending
order.

The idea is that with this change, the dashboard would display the most
recent crashes on top of the table, instead of at the bottom.