### PR TITLE
tools/syz-execprog: remove dead code

### DIFF
--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -309,12 +309,6 @@ func createConfig(target *prog.Target, entries []*prog.LogEntry,
 			break
 		}
 	}
-	handled := make(map[string]bool)
-	for _, entry := range entries {
-		for _, call := range entry.P.Calls {
-			handled[call.Meta.CallName] = true
-		}
-	}
 	if featuresFlags["tun"].Enabled && features[host.FeatureNetworkInjection].Enabled {
 		config.Flags |= ipc.FlagEnableTun
 	}


### PR DESCRIPTION
handled looks no use in the `createConfig` function.