### PR TITLE
pkg/build: update fuchsia build commands.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -21,9 +21,10 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 		return fmt.Errorf("unsupported fuchsia arch %v", targetArch)
 	}
 	arch := sysTarget.KernelHeaderArch
-	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "set", arch,
+	product := fmt.Sprintf("%s.%s", "core", arch)
+	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "set", product,
 		"--args", `extra_authorized_keys_file="//.ssh/authorized_keys"`,
-		"--board", "boards/x64.gni", "--product", "products/core.gni"); err != nil {
+		"--build-dir", "out/"+arch); err != nil {
 		return err
 	}
 	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "clean-build"); err != nil {


### PR DESCRIPTION
This CL changes the invocation of the `fx set` command to match the new
format[0].

This change involves removing "board" and "product" flags. Instead, now one has to use
`fx set product.board` to get the same result. In the case of syzkaller,
this would be "core.${ARCH}" where arch could be x64 or arm64.

Also, the default build directory now is `out/default`, and for now, it
is still not possible to have multiple archs built altogether. I set the
build directory manually to `out/${ARCH}` (as was before). This would
allow syzkaller to also build the kernel for arm if required.

[0]: https://fuchsia.googlesource.com/fuchsia/+/b814211ab33eeb4e8f02962d5c81d042b2464ac7

TEST=Tested this in syz-manager and deployed it and tested it in syz-ci. It worked.
