### PR TITLE
pkg/build: Add ssh tools for fuchsia.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -24,6 +24,7 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 	product := fmt.Sprintf("%s.%s", "core", arch)
 	if _, err := osutil.RunCmd(time.Hour, kernelDir, "scripts/fx", "set", product,
 		"--args", `extra_authorized_keys_file="//.ssh/authorized_keys"`,
+		"--with-base", "//bundles:tools",
 		"--build-dir", "out/"+arch); err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit adds the "//bundles:tools" packages to the fuchsia build
used for syzkaller. This includes ssh tools, which includes scp.

Recently, Syzkaller broke for fuchsia because it was not able to find 
scp. Apparently, there was no recent change that removed scp from the 
default "core.x64" build: it has been already removed since at least a 
month. It is not clear why it broke right now.

TEST=I have tested this on syz-ci. Fuchsia is now able to pass the image
test.
