### PR TITLE
Use gcc version number instead svn revision

### DIFF
--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -27,7 +27,7 @@ If you encounter any troubles, check the [troubleshooting](/docs/troubleshooting
 ### C Compiler
 
 Syzkaller is a coverage-guided fuzzer and therefore it needs the kernel to be built with coverage support, which requires a recent GCC version.
-Coverage support was submitted to GCC in revision `231296`, released in GCC v6.0.
+Coverage support was submitted to GCC, released in GCC 6.1.0 or later.
 
 ### Linux Kernel
 


### PR DESCRIPTION
svn commit 231296 matches commit d29e939c63b71 ("Add fuzzing coverage support") in the gcc git. The change is part of gcc 6.1.0.
Replace the svn commit number with a gcc version which everyone can easily compare.
Related links: https://github.com/torvalds/linux/commit/58f4df3c1bde999574d3e66b20eb7ee796a2647e#diff-4552954e64a20391a1a3b5fd3e494bc3

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
