### PR TITLE
Makefile: change go binary path for fuchsia.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ TARGETGOARCH := $(TARGETVMARCH)
 
 ifeq ("$(TARGETOS)", "fuchsia")
 	# SOURCEDIR should point to fuchsia checkout.
-	GO = "$(SOURCEDIR)/scripts/devshell/go"
+	GO = "$(SOURCEDIR)/tools/devshell/contrib/go"
 endif
 
 GITREV=$(shell git rev-parse HEAD)


### PR DESCRIPTION
Recently[0][1], fuchsia moved some of the tools out of `//scripts`, into the
`//tools` directory. The go script was moved into
`//tools/devshell/contrib/go`.

This commit modifies the Makefile so that it references to the new go
binary.

[0]: https://fuchsia-review.googlesource.com/c/fuchsia/+/267708/
[1]: https://fuchsia-review.googlesource.com/c/fuchsia/+/267908/