### PR TITLE
executor: don't fallthrough in switches in fuchsia

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -226,10 +226,13 @@ static long syz_future_time(volatile long when)
 	switch (when) {
 	case 0:
 		delta_ms = 5;
+		break;
 	case 1:
 		delta_ms = 30;
+		break;
 	default:
 		delta_ms = 10000;
+		break;
 	}
 	zx_time_t now = zx_clock_get(ZX_CLOCK_MONOTONIC);
 	return now + delta_ms * 1000 * 1000;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -969,10 +969,13 @@ static long syz_future_time(volatile long when)
 	switch (when) {
 	case 0:
 		delta_ms = 5;
+		break;
 	case 1:
 		delta_ms = 30;
+		break;
 	default:
 		delta_ms = 10000;
+		break;
 	}
 	zx_time_t now = zx_clock_get(ZX_CLOCK_MONOTONIC);
 	return now + delta_ms * 1000 * 1000;


### PR DESCRIPTION
This commit modifies the common_fuchsia.h file changing the behavior of
the `syz_future_time function`. Before, the function used to have a switch
case that would fallthrough, making it always set the delta_ms to 10000.
The fix is to add a `break;` statement after each switch case.