### PR TITLE
enable fuzzing on armhf

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Siddharth Muralee
 Dan Robertson
 Mark Johnston
 Mellanox Technologies
+Cody Holliday

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -47,3 +47,4 @@ Dan Robertson
 Mark Johnston
 Mellanox Technologies
  Noa Osherovich
+Cody Holliday

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -156,7 +156,7 @@ var List = map[string]map[string]*Target{
 			PageSize:         4 << 10,
 			CFlags:           []string{"-D__LINUX_ARM_ARCH__=6", "-m32", "-D__ARM_EABI__"},
 			CrossCFlags:      []string{"-D__LINUX_ARM_ARCH__=6", "-march=armv6", "-static"},
-			CCompilerPrefix:  "arm-linux-gnueabihf-",
+			CCompilerPrefix:  "arm-linux-gnueabi-",
 			KernelArch:       "arm",
 			KernelHeaderArch: "arm",
 		},


### PR DESCRIPTION
This fixes issues with targeting a 32 bit armhf machine. 

I notice before a user was testing on their Raspberry Pi Zero. Should armhf be a separate target?

sys/targets/targets.go: Bump armv6 to armv7 in arm target to enable compilation for armhf architecture.
pkg/host/host_linux.go: When running an unsupported architecture for kallsyms parsing, return instead of panic during kallsyms support check.