### PR TITLE
executor: move syz_execute_func after os imports.

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -379,6 +379,22 @@ static uint16 csum_inet_digest(struct csum_inet* csum)
 }
 #endif
 
+#if GOOS_akaros
+#include "common_akaros.h"
+#elif GOOS_freebsd || GOOS_netbsd || GOOS_openbsd
+#include "common_bsd.h"
+#elif GOOS_fuchsia
+#include "common_fuchsia.h"
+#elif GOOS_linux
+#include "common_linux.h"
+#elif GOOS_test
+#include "common_test.h"
+#elif GOOS_windows
+#include "common_windows.h"
+#else
+#error "unknown OS"
+#endif
+
 #if SYZ_EXECUTOR || __NR_syz_execute_func
 // syz_execute_func(text ptr[in, text[taget]])
 static long syz_execute_func(volatile long text)
@@ -398,22 +414,6 @@ static long syz_execute_func(volatile long text)
 	NONFAILING(((void (*)(void))(text))());
 	return 0;
 }
-#endif
-
-#if GOOS_akaros
-#include "common_akaros.h"
-#elif GOOS_freebsd || GOOS_netbsd || GOOS_openbsd
-#include "common_bsd.h"
-#elif GOOS_fuchsia
-#include "common_fuchsia.h"
-#elif GOOS_linux
-#include "common_linux.h"
-#elif GOOS_test
-#include "common_test.h"
-#elif GOOS_windows
-#include "common_windows.h"
-#else
-#error "unknown OS"
 #endif
 
 #if SYZ_THREADED

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -361,20 +361,6 @@ static uint16 csum_inet_digest(struct csum_inet* csum)
 }
 #endif
 
-#if SYZ_EXECUTOR || __NR_syz_execute_func
-static long syz_execute_func(volatile long text)
-{
-	volatile long p[8] = {0};
-	(void)p;
-#if GOARCH_amd64
-	asm volatile("" ::"r"(0l), "r"(1l), "r"(2l), "r"(3l), "r"(4l), "r"(5l), "r"(6l),
-		     "r"(7l), "r"(8l), "r"(9l), "r"(10l), "r"(11l), "r"(12l), "r"(13l));
-#endif
-	NONFAILING(((void (*)(void))(text))());
-	return 0;
-}
-#endif
-
 #if GOOS_akaros
 
 #include <ros/syscall.h>
@@ -4545,6 +4531,20 @@ static int do_sandbox_none(void)
 
 #else
 #error "unknown OS"
+#endif
+
+#if SYZ_EXECUTOR || __NR_syz_execute_func
+static long syz_execute_func(volatile long text)
+{
+	volatile long p[8] = {0};
+	(void)p;
+#if GOARCH_amd64
+	asm volatile("" ::"r"(0l), "r"(1l), "r"(2l), "r"(3l), "r"(4l), "r"(5l), "r"(6l),
+		     "r"(7l), "r"(8l), "r"(9l), "r"(10l), "r"(11l), "r"(12l), "r"(13l));
+#endif
+	NONFAILING(((void (*)(void))(text))());
+	return 0;
+}
 #endif
 
 #if SYZ_THREADED


### PR DESCRIPTION
This commit moves the definition of the `syz_execute_func` after the
block of code that imports all the OS specific common headers.

This is required because after commit
dfd3394d42ddd333c68cf355273b312da8c65a51 `syz_execute_func` started
using the `NONFAILING` macro, which is defined in those header files for
each OS.

I also ran `make generate`.

TEST=I only tested that the executor works for Fuchsia with:

```shell
$ make executor TARGETOS=fuchsia TARGETARCH=amd64 SOURCEDIR=~/fuchsia
```
