### PR TITLE
enable kallsyms parsing on arm

### DIFF
--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -82,7 +82,7 @@ func parseKallsyms(kallsyms []byte, arch string) map[string]bool {
 	switch arch {
 	case "386", "amd64":
 		re = regexp.MustCompile(` T (__ia32_|__x64_)?sys_([^\n]+)\n`)
-	case "arm64":
+	case "arm", "arm64":
 		re = regexp.MustCompile(` T (__arm64_)?sys_([^\n]+)\n`)
 	case "ppc64le":
 		re = regexp.MustCompile(` T ()?sys_([^\n]+)\n`)

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -94,6 +94,19 @@ c0000000011ed050 T __se_sys_accept4
 			`),
 			[]string{"bind", "listen", "accept4"},
 		},
+		{
+			"arm",
+			[]byte(`
+c037c67c T __se_sys_setfsuid
+c037c694 T __sys_setfsgid
+c037c790 T sys_setfsgid
+c037c790 T __se_sys_setfsgid
+c037c7a8 T sys_getpid
+c037c7d0 T sys_gettid
+c037c7f8 T sys_getppid
+			`),
+			[]string{"setfsgid", "getpid", "gettid", "getppid"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
pkg/host/host_linux.go: Add "arm" to kallsyms support test.
pkg/host/host_test.go: TestKallsymsParse(): Add entry to test arm kallsyms parsing support.
