### PR TITLE
all: add optional close_fds feature to reproducers

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -483,6 +483,9 @@ again:
 	}
 	for (i = 0; i < 100 && __atomic_load_n(&running, __ATOMIC_RELAXED); i++)
 		sleep_ms(1);
+#if SYZ_HAVE_CLOSE_FDS
+	close_fds();
+#endif
 #if SYZ_COLLIDE
 	if (!collide) {
 		collide = 1;
@@ -571,8 +574,8 @@ static void loop(void)
 			close(kOutPipeFd);
 #endif
 			execute_one();
-#if SYZ_HAVE_RESET_TEST
-			reset_test();
+#if SYZ_HAVE_CLOSE_FDS && !SYZ_THREADED
+			close_fds();
 #endif
 			doexit(0);
 #endif
@@ -659,6 +662,9 @@ void loop(void)
 #endif
 {
 	/*SYSCALLS*/
+#if SYZ_HAVE_CLOSE_FDS && !SYZ_THREADED && !SYZ_REPEAT
+	close_fds();
+#endif
 }
 #endif
 
@@ -690,6 +696,10 @@ int main(void)
 			use_temporary_dir();
 #endif
 			/*SANDBOX_FUNC*/
+#if SYZ_HAVE_CLOSE_FDS && !SYZ_THREADED && !SYZ_REPEAT && !SYZ_SANDBOX_NONE && \
+    !SYZ_SANDBOX_SETUID && !SYZ_SANDBOX_NAMESPACE && !SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
+			close_fds();
+#endif
 #if SYZ_PROCS
 		}
 	}

--- a/executor/common.h
+++ b/executor/common.h
@@ -9,7 +9,7 @@
 // - NORETURN/PRINTF/debug are removed
 // - exitf/fail are replaced with exit
 // - uintN types are replaced with uintN_t
-// - [[FOO]] placeholders are replaced by actual values
+// - /*FOO*/ placeholders are replaced by actual values
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -457,7 +457,7 @@ static void loop(void)
 	int collide = 0;
 again:
 #endif
-	for (call = 0; call < [[NUM_CALLS]]; call++) {
+	for (call = 0; call < /*NUM_CALLS*/; call++) {
 		for (thread = 0; thread < (int)(sizeof(threads) / sizeof(threads[0])); thread++) {
 			struct thread_t* th = &threads[thread];
 			if (!th->created) {
@@ -527,7 +527,7 @@ static void loop(void)
 #endif
 	int iter;
 #if SYZ_REPEAT_TIMES
-	for (iter = 0; iter < [[REPEAT_TIMES]]; iter++) {
+	for (iter = 0; iter < /*REPEAT_TIMES*/; iter++) {
 #else
 	for (iter = 0;; iter++) {
 #endif
@@ -644,12 +644,10 @@ static void loop(void)
 #endif
 #endif
 
-// clang-format off
-// clang-format badly mishandles this part, moreover different versions mishandle it differently.
 #if !SYZ_EXECUTOR
-[[SYSCALL_DEFINES]]
+/*SYSCALL_DEFINES*/
 
-[[RESULTS]]
+/*RESULTS*/
 
 #if SYZ_THREADED || SYZ_REPEAT || SYZ_SANDBOX_NONE || SYZ_SANDBOX_SETUID || SYZ_SANDBOX_NAMESPACE || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
 #if SYZ_THREADED
@@ -660,7 +658,7 @@ void execute_one(void)
 void loop(void)
 #endif
 {
-	[[SYSCALLS]]
+	/*SYSCALLS*/
 }
 #endif
 
@@ -670,7 +668,7 @@ void loop(void)
 
 int main(int argc, char** argv)
 {
-	[[MMAP_DATA]]
+	/*MMAP_DATA*/
 
 	program_name = argv[0];
 	if (argc == 2 && strcmp(argv[1], "child") == 0)
@@ -678,21 +676,20 @@ int main(int argc, char** argv)
 #else
 int main(void)
 {
-	[[MMAP_DATA]]
+	/*MMAP_DATA*/
 #endif
-		// clang-format on
 
 #if SYZ_HANDLE_SEGV
 	install_segv_handler();
 #endif
 #if SYZ_PROCS
-	for (procid = 0; procid < [[PROCS]]; procid++) {
+	for (procid = 0; procid < /*PROCS*/; procid++) {
 		if (fork() == 0) {
 #endif
 #if SYZ_USE_TMP_DIR || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
 			use_temporary_dir();
 #endif
-			[[SANDBOX_FUNC]]
+			/*SANDBOX_FUNC*/
 #if SYZ_PROCS
 		}
 	}

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2612,12 +2612,20 @@ static void setup_test()
 	flush_tun();
 #endif
 }
+#endif
 
-#define SYZ_HAVE_RESET_TEST 1
-static void reset_test()
+#if SYZ_EXECUTOR || SYZ_ENABLE_CLOSE_FDS
+#define SYZ_HAVE_CLOSE_FDS 1
+static void close_fds()
 {
+#if SYZ_EXECUTOR
+	if (!flag_enable_close_fds)
+		return;
+#endif
 	// Keeping a 9p transport pipe open will hang the proccess dead,
 	// so close all opened file descriptors.
+	// Also close all USB emulation descriptors to trigger exit from USB
+	// event loop to collect coverage.
 	int fd;
 	for (fd = 3; fd < 30; fd++)
 		close(fd);

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -119,6 +119,7 @@ static bool flag_enable_net_dev;
 static bool flag_enable_net_reset;
 static bool flag_enable_cgroups;
 static bool flag_enable_binfmt_misc;
+static bool flag_enable_close_fds;
 
 static bool flag_collect_cover;
 static bool flag_dedup_cover;
@@ -454,6 +455,7 @@ void parse_env_flags(uint64 flags)
 	flag_enable_net_reset = flags & (1 << 9);
 	flag_enable_cgroups = flags & (1 << 10);
 	flag_enable_binfmt_misc = flags & (1 << 11);
+	flag_enable_close_fds = flags & (1 << 12);
 }
 
 #if SYZ_EXECUTOR_USES_FORK_SERVER
@@ -731,6 +733,10 @@ retry:
 			write_extra_output();
 		}
 	}
+
+#if SYZ_HAVE_CLOSE_FDS
+	close_fds();
+#endif
 
 	if (flag_collide && !flag_inject_fault && !colliding && !collide) {
 		debug("enabling collider\n");

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -89,6 +89,7 @@ func defineList(p, mmapProg *prog.Prog, opts Options) (defines []string) {
 		"SYZ_ENABLE_NETDEV":                 opts.EnableNetDev,
 		"SYZ_RESET_NET_NAMESPACE":           opts.EnableNetReset,
 		"SYZ_ENABLE_BINFMT_MISC":            opts.EnableBinfmtMisc,
+		"SYZ_ENABLE_CLOSE_FDS":              opts.EnableCloseFds,
 		"SYZ_USE_TMP_DIR":                   opts.UseTmpDir,
 		"SYZ_HANDLE_SEGV":                   opts.HandleSegv,
 		"SYZ_REPRO":                         opts.Repro,

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -50,7 +50,7 @@ func createCommonHeader(p, mmapProg *prog.Prog, replacements map[string]string, 
 	}
 
 	for from, to := range replacements {
-		src = bytes.Replace(src, []byte("[["+from+"]]"), []byte(to), -1)
+		src = bytes.Replace(src, []byte("/*"+from+"*/"), []byte(to), -1)
 	}
 
 	for from, to := range map[string]string{

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -4588,7 +4588,7 @@ static void loop(void)
 	int collide = 0;
 again:
 #endif
-	for (call = 0; call < [[NUM_CALLS]]; call++) {
+	for (call = 0; call < /*NUM_CALLS*/; call++) {
 		for (thread = 0; thread < (int)(sizeof(threads) / sizeof(threads[0])); thread++) {
 			struct thread_t* th = &threads[thread];
 			if (!th->created) {
@@ -4655,7 +4655,7 @@ static void loop(void)
 #endif
 	int iter;
 #if SYZ_REPEAT_TIMES
-	for (iter = 0; iter < [[REPEAT_TIMES]]; iter++) {
+	for (iter = 0; iter < /*REPEAT_TIMES*/; iter++) {
 #else
 	for (iter = 0;; iter++) {
 #endif
@@ -4755,10 +4755,11 @@ static void loop(void)
 }
 #endif
 #endif
-#if !SYZ_EXECUTOR
-[[SYSCALL_DEFINES]]
 
-[[RESULTS]]
+#if !SYZ_EXECUTOR
+/*SYSCALL_DEFINES*/
+
+/*RESULTS*/
 
 #if SYZ_THREADED || SYZ_REPEAT || SYZ_SANDBOX_NONE || SYZ_SANDBOX_SETUID || SYZ_SANDBOX_NAMESPACE || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
 #if SYZ_THREADED
@@ -4769,7 +4770,7 @@ void execute_one(void)
 void loop(void)
 #endif
 {
-	[[SYSCALLS]]
+	/*SYSCALLS*/
 }
 #endif
 #if GOOS_akaros && SYZ_REPEAT
@@ -4777,7 +4778,7 @@ void loop(void)
 
 int main(int argc, char** argv)
 {
-	[[MMAP_DATA]]
+	/*MMAP_DATA*/
 
 	program_name = argv[0];
 	if (argc == 2 && strcmp(argv[1], "child") == 0)
@@ -4785,20 +4786,20 @@ int main(int argc, char** argv)
 #else
 int main(void)
 {
-	[[MMAP_DATA]]
+	/*MMAP_DATA*/
 #endif
 
 #if SYZ_HANDLE_SEGV
 	install_segv_handler();
 #endif
 #if SYZ_PROCS
-	for (procid = 0; procid < [[PROCS]]; procid++) {
+	for (procid = 0; procid < /*PROCS*/; procid++) {
 		if (fork() == 0) {
 #endif
 #if SYZ_USE_TMP_DIR || SYZ_SANDBOX_ANDROID_UNTRUSTED_APP
 			use_temporary_dir();
 #endif
-			[[SANDBOX_FUNC]]
+			/*SANDBOX_FUNC*/
 #if SYZ_PROCS
 		}
 	}

--- a/pkg/csource/options_test.go
+++ b/pkg/csource/options_test.go
@@ -44,6 +44,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			EnableNetReset:   true,
 			EnableCgroups:    true,
 			EnableBinfmtMisc: false,
+			EnableCloseFds:   true,
 			UseTmpDir:        true,
 			HandleSegv:       true,
 			Repro:            true,
@@ -65,6 +66,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			EnableNetReset:   true,
 			EnableCgroups:    true,
 			EnableBinfmtMisc: false,
+			EnableCloseFds:   true,
 			UseTmpDir:        true,
 			HandleSegv:       true,
 			Repro:            true,
@@ -81,6 +83,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			EnableTun:        true,
 			EnableCgroups:    false,
 			EnableBinfmtMisc: false,
+			EnableCloseFds:   true,
 			UseTmpDir:        true,
 			HandleSegv:       true,
 			Repro:            false,
@@ -97,6 +100,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			EnableTun:        true,
 			EnableCgroups:    false,
 			EnableBinfmtMisc: false,
+			EnableCloseFds:   true,
 			UseTmpDir:        true,
 			HandleSegv:       true,
 			Repro:            false,
@@ -113,6 +117,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			EnableTun:        true,
 			EnableCgroups:    true,
 			EnableBinfmtMisc: false,
+			EnableCloseFds:   true,
 			UseTmpDir:        true,
 			HandleSegv:       true,
 			Repro:            false,
@@ -208,28 +213,31 @@ func TestParseFeaturesFlags(t *testing.T) {
 		Features map[string]bool
 	}{
 		{"none", "none", true, map[string]bool{
-			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true,
+			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true, "close_fds": true,
 		}},
 		{"none", "none", false, map[string]bool{
-			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false,
+			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false, "close_fds": false,
 		}},
 		{"all", "none", true, map[string]bool{
-			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true,
+			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true, "close_fds": true,
 		}},
 		{"", "none", true, map[string]bool{
-			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false,
+			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false, "close_fds": false,
 		}},
 		{"none", "all", true, map[string]bool{
-			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false,
+			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false, "close_fds": false,
 		}},
 		{"none", "", true, map[string]bool{
-			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true,
+			"tun": true, "net_dev": true, "net_reset": true, "cgroups": true, "binfmt_misc": true, "close_fds": true,
 		}},
 		{"tun,net_dev", "none", true, map[string]bool{
-			"tun": true, "net_dev": true, "net_reset": false, "cgroups": false, "binfmt_misc": false,
+			"tun": true, "net_dev": true, "net_reset": false, "cgroups": false, "binfmt_misc": false, "close_fds": false,
 		}},
 		{"none", "cgroups,net_dev", true, map[string]bool{
-			"tun": true, "net_dev": false, "net_reset": true, "cgroups": false, "binfmt_misc": true,
+			"tun": true, "net_dev": false, "net_reset": true, "cgroups": false, "binfmt_misc": true, "close_fds": true,
+		}},
+		{"close_fds", "none", true, map[string]bool{
+			"tun": false, "net_dev": false, "net_reset": false, "cgroups": false, "binfmt_misc": false, "close_fds": true,
 		}},
 	}
 	for i, test := range tests {

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -38,6 +38,7 @@ const (
 	FlagEnableNetReset                                  // reset network namespace between programs
 	FlagEnableCgroups                                   // setup cgroups for testing
 	FlagEnableBinfmtMisc                                // setup binfmt_misc for testing
+	FlagEnableCloseFds                                  // close fds after each program
 	// Executor does not know about these:
 	FlagUseShmem      // use shared memory instead of pipes for communication
 	FlagUseForkServer // use extended protocol with handshake

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -809,6 +809,7 @@ var cSimplifies = append(progSimplifies, []Simplify{
 		opts.EnableNetReset = false
 		opts.EnableCgroups = false
 		opts.EnableBinfmtMisc = false
+		opts.EnableCloseFds = false
 		return true
 	},
 	func(opts *csource.Options) bool {
@@ -844,6 +845,15 @@ var cSimplifies = append(progSimplifies, []Simplify{
 			return false
 		}
 		opts.EnableBinfmtMisc = false
+		return true
+	},
+	func(opts *csource.Options) bool {
+		// We don't want to remove close_fds() call when repeat is enabled,
+		// since that can lead to deadlocks, see executor/common_linux.h.
+		if !opts.EnableCloseFds || opts.Repeat {
+			return false
+		}
+		opts.EnableCloseFds = false
 		return true
 	},
 	func(opts *csource.Options) bool {

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -202,6 +202,7 @@ func main() {
 	config.Flags |= ipc.FlagEnableNetReset
 	config.Flags |= ipc.FlagEnableCgroups
 	config.Flags |= ipc.FlagEnableBinfmtMisc
+	config.Flags |= ipc.FlagEnableCloseFds
 
 	if *flagRunTest {
 		runTest(target, manager, *flagName, config.Executor)

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -324,5 +324,8 @@ func createConfig(target *prog.Target, entries []*prog.LogEntry,
 	if featuresFlags["binfmt_misc"].Enabled {
 		config.Flags |= ipc.FlagEnableBinfmtMisc
 	}
+	if featuresFlags["close_fds"].Enabled {
+		config.Flags |= ipc.FlagEnableCloseFds
+	}
 	return config, execOpts
 }

--- a/tools/syz-prog2c/prog2c.go
+++ b/tools/syz-prog2c/prog2c.go
@@ -84,6 +84,7 @@ func main() {
 		EnableNetReset:   features["net_reset"].Enabled,
 		EnableCgroups:    features["cgroups"].Enabled,
 		EnableBinfmtMisc: features["binfmt_misc"].Enabled,
+		EnableCloseFds:   features["close_fds"].Enabled,
 		UseTmpDir:        *flagUseTmpDir,
 		HandleSegv:       *flagHandleSegv,
 		Repro:            false,

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -94,6 +94,9 @@ func main() {
 	if featuresFlags["binfmt_misc"].Enabled {
 		config.Flags |= ipc.FlagEnableBinfmtMisc
 	}
+	if featuresFlags["close_fds"].Enabled {
+		config.Flags |= ipc.FlagEnableCloseFds
+	}
 	gate = ipc.NewGate(2**flagProcs, nil)
 	for pid := 0; pid < *flagProcs; pid++ {
 		pid := pid


### PR DESCRIPTION
Instead of always closing open fds (number 3 to 30) after each program,
add an options called EnableCloseFds. It can be passed to syz-execprog,
syz-prog2c and syz-stress via the -enable and -disable flags. Set the
default value is true. Also minimize C repros over it.
