### PR TITLE
dashboard/config: enable POOL_DEBUG on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -3,6 +3,7 @@ include "arch/amd64/conf/GENERIC.MP"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
+option POOL_DEBUG
 option WITNESS
 option WITNESS_LOCKTRACE
 option WITNESS_WATCH

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -3,3 +3,4 @@ include "arch/amd64/conf/GENERIC"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
+option POOL_DEBUG


### PR DESCRIPTION
POOL_DEBUG is disabled during release, but we want it unconditionally
enabled.