### PR TITLE
Revert "dashboard/config: enable POOL_DEBUG on OpenBSD (#1113)"

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -3,7 +3,6 @@ include "arch/amd64/conf/GENERIC.MP"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
-option POOL_DEBUG
 option WITNESS
 option WITNESS_LOCKTRACE
 option WITNESS_WATCH

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -3,4 +3,3 @@ include "arch/amd64/conf/GENERIC"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
-option POOL_DEBUG


### PR DESCRIPTION
This reverts commit 2fbd3aa9043e84cdce8328e5084a1fecc6ec5be3.

This unbreaks the build:
```
/syzkaller/managers/main/kernel/sys/arch/amd64/conf/SYZKALLER
/syzkaller/managers/main/kernel/sys/arch/amd64/conf/SYZKALLER:6: already have options `POOL_DEBUG'
```
