### PR TITLE
repro: speedup bisection for flaky crashes

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -631,6 +631,12 @@ func (ctx *context) bisectProgs(progs []*prog.LogEntry, pred func([]*prog.LogEnt
 
 	guilty := [][]*prog.LogEntry{progs}
 again:
+	if len(guilty) > 8 {
+		// This is usually the case for flaky crashes. Continuing bisection at this
+		// point would just take a lot of time and likely produce no result.
+		ctx.reproLog(3, "bisect: too many guilty chunks, aborting")
+		return nil, nil
+	}
 	ctx.reproLog(3, "bisect: guilty chunks: %v", chunksToStr(guilty))
 	for i, chunk := range guilty {
 		if len(chunk) == 1 {

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -60,6 +60,10 @@ func TestBisect(t *testing.T) {
 			}
 			return guilty == numGuilty, nil
 		})
+		if numGuilty > 8 && len(progs) == 0 {
+			// Bisection has been aborted.
+			continue
+		}
 		if len(progs) != numGuilty {
 			t.Fatalf("bisect test failed: wrong number of guilty progs: got: %v, want: %v", len(progs), numGuilty)
 		}


### PR DESCRIPTION
Limit the amount of bisection chunks to 8. Going over this value probably
means that we are bisection a flaky crash, and continuing bisection would
just take a lot of time and likely produce no result.
