### PR TITLE
pkg/build: update zircon build directory.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -34,9 +34,9 @@ func (fu fuchsia) build(targetArch, vmType, kernelDir, outputDir, compiler, user
 	for src, dst := range map[string]string{
 		"out/" + arch + "/obj/build/images/fvm.blk": "image",
 		".ssh/pkey": "key",
-		"out/build-zircon/kernel-" + arch + "-gcc/obj/kernel/zircon.elf": "obj/zircon.elf",
-		"out/build-zircon/multiboot.bin":                                 "kernel",
-		"out/" + arch + "/fuchsia.zbi":                                   "initrd",
+		"out/" + arch + ".zircon/kernel-" + arch + "-gcc/obj/kernel/zircon.elf": "obj/zircon.elf",
+		"out/" + arch + ".zircon/multiboot.bin":                                 "kernel",
+		"out/" + arch + "/fuchsia.zbi":                                          "initrd",
 	} {
 		fullSrc := filepath.Join(kernelDir, filepath.FromSlash(src))
 		fullDst := filepath.Join(outputDir, filepath.FromSlash(dst))


### PR DESCRIPTION
Recently, fuchsia changed the build directory for zircon, now instead of
build-zircon, we have arch.zircon, where arch is x64 or arm64.
