### PR TITLE
executor: adjust waiting time for all usb syzcalls

### DIFF
--- a/executor/common_usb.h
+++ b/executor/common_usb.h
@@ -411,8 +411,6 @@ reply:
 	debug("syz_usb_control_io: reply length = %d\n", response.inner.length);
 	usb_fuzzer_ep0_write(fd, (struct usb_fuzzer_ep_io*)&response);
 
-	sleep_ms(200);
-
 	return 0;
 }
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2121,8 +2121,6 @@ reply:
 	debug("syz_usb_control_io: reply length = %d\n", response.inner.length);
 	usb_fuzzer_ep0_write(fd, (struct usb_fuzzer_ep_io*)&response);
 
-	sleep_ms(200);
-
 	return 0;
 }
 #endif


### PR DESCRIPTION
Allow 2000 ms of waiting time for syz_usb_connect and and the same time for
the whole program is this syzkall is present. Allow 200 ms of waiting time
for syz_usb_disconnect. Remove sleep from syz_usb_control_io.
