### PR TITLE
pkg/host: Add stat to kallsyms rename map

### DIFF
--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -154,6 +154,7 @@ var (
 	kallsymsRenameMap  = map[string]string{
 		"umount":  "oldumount",
 		"umount2": "umount",
+		"stat":    "newstat",
 	}
 	trialMu         sync.Mutex
 	trialSupported  = make(map[uint64]bool)


### PR DESCRIPTION
On powerpc, the "stat" syscall is implemented by "sys_newstat" entry point.
This causes a test failure as we can't find "sys_stat" in kallsyms.

Add "stat" -> "newstat" to the kallsyms rename map to work around this.

Closes: #1083 ("pkg/host: TestSupportedSyscalls fails on ppc64le")
Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>

----

I've had trouble testing this on arm/arm64, so if someone else could confirm I haven't broken those that would be great.