### PR TITLE
Support ppc64le kernel builds

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -72,6 +72,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 	}{
 		{"linux", "amd64", []string{"gvisor"}, gvisor{}},
 		{"linux", "amd64", []string{"gce", "qemu"}, linux{}},
+		{"linux", "ppc64le", []string{"qemu"}, linux{}},
 		{"fuchsia", "amd64", []string{"qemu"}, fuchsia{}},
 		{"fuchsia", "arm64", []string{"qemu"}, fuchsia{}},
 		{"akaros", "amd64", []string{"qemu"}, akaros{}},

--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -25,7 +25,7 @@ type linux struct{}
 
 func (linux linux) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
 	cmdlineFile, sysctlFile string, config []byte) error {
-	if err := linux.buildKernel(kernelDir, outputDir, compiler, config); err != nil {
+	if err := linux.buildKernel(targetArch, kernelDir, outputDir, compiler, config); err != nil {
 		return err
 	}
 	if err := linux.createImage(targetArch, vmType, kernelDir, outputDir, userspaceDir, cmdlineFile,
@@ -35,7 +35,7 @@ func (linux linux) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 	return nil
 }
 
-func (linux) buildKernel(kernelDir, outputDir, compiler string, config []byte) error {
+func (linux) buildKernel(targetArch, kernelDir, outputDir, compiler string, config []byte) error {
 	configFile := filepath.Join(kernelDir, ".config")
 	if err := osutil.WriteFile(configFile, config); err != nil {
 		return fmt.Errorf("failed to write config file: %v", err)
@@ -59,9 +59,18 @@ func (linux) buildKernel(kernelDir, outputDir, compiler string, config []byte) e
 	if err := osutil.CopyFile(configFile, outputConfig); err != nil {
 		return err
 	}
-	// We build only bzImage as we currently don't use modules.
+	// We build only zImage/bzImage as we currently don't use modules.
 	cpu := strconv.Itoa(runtime.NumCPU())
-	cmd = osutil.Command("make", "bzImage", "-j", cpu, "CC="+compiler)
+
+	var target string
+	switch targetArch {
+	case "386", "amd64":
+		target = "bzImage"
+	case "ppc64le":
+		target = "zImage"
+	}
+	cmd = osutil.Command("make", target, "-j", cpu, "CC="+compiler)
+
 	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return err
 	}
@@ -87,8 +96,16 @@ func (linux) createImage(targetArch, vmType, kernelDir, outputDir, userspaceDir,
 	if err := osutil.WriteExecFile(scriptFile, []byte(createImageScript)); err != nil {
 		return fmt.Errorf("failed to write script file: %v", err)
 	}
-	bzImage := filepath.Join(kernelDir, filepath.FromSlash("arch/x86/boot/bzImage"))
-	cmd := osutil.Command(scriptFile, userspaceDir, bzImage, targetArch)
+
+	var kernelImage string
+	switch targetArch {
+	case "386", "amd64":
+		kernelImage = "arch/x86/boot/bzImage"
+	case "ppc64le":
+		kernelImage = "arch/powerpc/boot/zImage.pseries"
+	}
+	kernelImagePath := filepath.Join(kernelDir, filepath.FromSlash(kernelImage))
+	cmd := osutil.Command(scriptFile, userspaceDir, kernelImagePath, targetArch)
 	cmd.Dir = tempDir
 	cmd.Env = append([]string{}, os.Environ()...)
 	cmd.Env = append(cmd.Env,

--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -28,7 +28,8 @@ func (linux linux) build(targetArch, vmType, kernelDir, outputDir, compiler, use
 	if err := linux.buildKernel(kernelDir, outputDir, compiler, config); err != nil {
 		return err
 	}
-	if err := linux.createImage(vmType, kernelDir, outputDir, userspaceDir, cmdlineFile, sysctlFile); err != nil {
+	if err := linux.createImage(targetArch, vmType, kernelDir, outputDir, userspaceDir, cmdlineFile,
+		sysctlFile); err != nil {
 		return err
 	}
 	return nil
@@ -76,7 +77,7 @@ func (linux) buildKernel(kernelDir, outputDir, compiler string, config []byte) e
 	return nil
 }
 
-func (linux) createImage(vmType, kernelDir, outputDir, userspaceDir, cmdlineFile, sysctlFile string) error {
+func (linux) createImage(targetArch, vmType, kernelDir, outputDir, userspaceDir, cmdlineFile, sysctlFile string) error {
 	tempDir, err := ioutil.TempDir("", "syz-build")
 	if err != nil {
 		return err
@@ -87,7 +88,7 @@ func (linux) createImage(vmType, kernelDir, outputDir, userspaceDir, cmdlineFile
 		return fmt.Errorf("failed to write script file: %v", err)
 	}
 	bzImage := filepath.Join(kernelDir, filepath.FromSlash("arch/x86/boot/bzImage"))
-	cmd := osutil.Command(scriptFile, userspaceDir, bzImage)
+	cmd := osutil.Command(scriptFile, userspaceDir, bzImage, targetArch)
 	cmd.Dir = tempDir
 	cmd.Env = append([]string{}, os.Environ()...)
 	cmd.Env = append(cmd.Env,

--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -10,13 +10,24 @@ set -eux
 CLEANUP=""
 trap 'eval " $CLEANUP"' EXIT
 
+IMG_ARCH="${3:-amd64}"
+
 if [ ! -e $1/sbin/init ]; then
-	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage"
+	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage [arch]"
 	exit 1
 fi
 
-if [ "$(basename $2)" != "bzImage" ]; then
-	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage"
+case "$IMG_ARCH" in
+	386|amd64)
+		KERNEL_IMAGE_BASENAME=bzImage
+		;;
+	ppc64le)
+		KERNEL_IMAGE_BASENAME=zImage.pseries
+		;;
+esac
+
+if [ "$(basename $2)" != "$KERNEL_IMAGE_BASENAME" ]; then
+	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage [arch]"
 	exit 1
 fi
 
@@ -53,8 +64,18 @@ elif [ "$BLOCK_DEVICE" == "nbd" ]; then
 	sudo qemu-nbd -c $DISKDEV --format=raw disk.raw
 	CLEANUP="sudo qemu-nbd -d $DISKDEV; $CLEANUP"
 fi
-echo -en "o\nn\np\n1\n\n\na\nw\n" | sudo fdisk $DISKDEV
-PARTDEV=$DISKDEV"p1"
+
+case "$IMG_ARCH" in
+	386|amd64)
+		echo -en "o\nn\np\n1\n\n\na\nw\n" | sudo fdisk $DISKDEV
+		PARTDEV=$DISKDEV"p1"
+		;;
+	ppc64le)
+		echo -en "g\nn\n1\n2048\n16383\nt\n7\nn\n2\n\n\nw\n" | sudo fdisk $DISKDEV
+		PARTDEV=$DISKDEV"p2"
+		;;
+esac
+
 until [ -e $PARTDEV ]; do sleep 1; done
 sudo -E mkfs.ext4 -O ^resize_inode,^has_journal,ext_attr,extents,huge_file,flex_bg,dir_nlink,sparse_super $PARTDEV
 mkdir -p disk.mnt
@@ -99,7 +120,9 @@ if [ "$SYZ_CMDLINE_FILE" != "" ]; then
 	CMDLINE=$(awk '{printf("%s ", $0)}' $SYZ_CMDLINE_FILE)
 fi
 
-cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
+case "$IMG_ARCH" in
+386|amd64)
+	cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
 terminal_input console
 terminal_output console
 set timeout=0
@@ -115,5 +138,22 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 $CMDLINE
 }
 EOF
-sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
+	sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
+	;;
+ppc64le)
+	cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
+terminal_input console
+terminal_output console
+set timeout=0
+menuentry 'linux' --class gnu-linux --class gnu --class os {
+	insmod gzio
+	insmod part_gpt
+	insmod ext2
+	set root='(ieee1275/disk,gpt2)'
+	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 $CMDLINE
+}
+EOF
+	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"
+	;;
+esac
 `

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -14,7 +14,7 @@
 #   sudo apt-get install grub-efi
 #
 # Usage:
-#   ./create-gce-image.sh /dir/with/user/space/system /path/to/bzImage
+#   ./create-gce-image.sh /dir/with/user/space/system /path/to/{zImage,bzImage} [arch]
 #
 # SYZ_VM_TYPE env var controls type of target test machine. Supported values:
 # - qemu (default)
@@ -50,13 +50,24 @@ set -eux
 CLEANUP=""
 trap 'eval " $CLEANUP"' EXIT
 
+IMG_ARCH="${3:-amd64}"
+
 if [ ! -e $1/sbin/init ]; then
-	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage"
+	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage [arch]"
 	exit 1
 fi
 
-if [ "$(basename $2)" != "bzImage" ]; then
-	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage"
+case "$IMG_ARCH" in
+	386|amd64)
+		KERNEL_IMAGE_BASENAME=bzImage
+		;;
+	ppc64le)
+		KERNEL_IMAGE_BASENAME=zImage.pseries
+		;;
+esac
+
+if [ "$(basename $2)" != "$KERNEL_IMAGE_BASENAME" ]; then
+	echo "usage: create-gce-image.sh /dir/with/user/space/system /path/to/bzImage [arch]"
 	exit 1
 fi
 
@@ -101,8 +112,19 @@ elif [ "$BLOCK_DEVICE" == "nbd" ]; then
 	sudo qemu-nbd -c $DISKDEV --format=raw disk.raw
 	CLEANUP="sudo qemu-nbd -d $DISKDEV; $CLEANUP"
 fi
-echo -en "o\nn\np\n1\n\n\na\nw\n" | sudo fdisk $DISKDEV
-PARTDEV=$DISKDEV"p1"
+
+case "$IMG_ARCH" in
+	386|amd64)
+		echo -en "o\nn\np\n1\n\n\na\nw\n" | sudo fdisk $DISKDEV
+		PARTDEV=$DISKDEV"p1"
+		;;
+	ppc64le)
+		# Create a small PowerPC PReP boot partition, and a Linux partition for the rest
+		echo -en "g\nn\n1\n2048\n16383\nt\n7\nn\n2\n\n\nw\n" | sudo fdisk $DISKDEV
+		PARTDEV=$DISKDEV"p2"
+		;;
+esac
+
 until [ -e $PARTDEV ]; do sleep 1; done
 sudo -E mkfs.ext4 -O ^resize_inode,^has_journal,ext_attr,extents,huge_file,flex_bg,dir_nlink,sparse_super $PARTDEV
 mkdir -p disk.mnt
@@ -148,7 +170,9 @@ if [ "$SYZ_CMDLINE_FILE" != "" ]; then
 	CMDLINE=$(awk '{printf("%s ", $0)}' $SYZ_CMDLINE_FILE)
 fi
 
-cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
+case "$IMG_ARCH" in
+386|amd64)
+	cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
 terminal_input console
 terminal_output console
 set timeout=0
@@ -169,4 +193,24 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 $CMDLINE
 }
 EOF
-sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
+	sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
+	;;
+ppc64le)
+	cat << EOF | sudo tee disk.mnt/boot/grub/grub.cfg
+terminal_input console
+terminal_output console
+set timeout=0
+# rodata=n: mark_rodata_ro becomes very slow with KASAN (lots of PGDs)
+# panic=86400: prevents kernel from rebooting so that we don't get reboot output in all crash reports
+# debug is not set as it produces too much output
+menuentry 'linux' --class gnu-linux --class gnu --class os {
+	insmod gzio
+	insmod part_gpt
+	insmod ext2
+	set root='(ieee1275/disk,gpt2)'
+	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 $CMDLINE
+}
+EOF
+	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"
+	;;
+esac


### PR DESCRIPTION
See #1084.

This currently uses the existing approach of installing a kernel into the disk image. Right now we only use qemu with ppc64le, which means we could load the kernel directly rather than needing to recreate the disk image for each kernel build which would be more efficient. But that's a project for a later time.