### PR TITLE
executor: fix type size of syscall args in Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Dan Robertson
 Mark Johnston
 Mellanox Technologies
 Cody Holliday
+JinWoo Lee

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,3 +48,4 @@ Mark Johnston
 Mellanox Technologies
  Noa Osherovich
 Cody Holliday
+JinWoo Lee

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -172,7 +172,7 @@ static const uint64 arg_csum_inet = 0;
 static const uint64 arg_csum_chunk_data = 0;
 static const uint64 arg_csum_chunk_const = 1;
 
-typedef long(SYSCALLAPI* syscall_t)(long, long, long, long, long, long, long, long, long);
+typedef intptr_t(SYSCALLAPI* syscall_t)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
 
 struct call_t {
 	const char* name;
@@ -199,8 +199,8 @@ struct thread_t {
 	int call_index;
 	int call_num;
 	int num_args;
-	long args[kMaxArgs];
-	long res;
+	intptr_t args[kMaxArgs];
+	intptr_t res;
 	uint32 reserrno;
 	bool fault_injected;
 	cover_t cov;
@@ -847,7 +847,7 @@ void handle_completion(thread_t* th)
 	if (event_isset(&th->ready) || !event_isset(&th->done) || !th->executing)
 		fail("bad thread state in completion: ready=%d done=%d executing=%d",
 		     event_isset(&th->ready), event_isset(&th->done), th->executing);
-	if (th->res != (long)-1)
+	if (th->res != (intptr_t)-1)
 		copyout_call_results(th);
 	if (!collide && !th->colliding) {
 		write_call_output(th, true);

--- a/executor/executor_akaros.h
+++ b/executor/executor_akaros.h
@@ -19,7 +19,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 	}
 }
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	return syscall(c->sys_nr, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
 }

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -31,7 +31,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 	setrlimit(RLIMIT_NOFILE, &rlim);
 }
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	if (c->call)
 		return c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);

--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -17,9 +17,9 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 		fail("mmap of data segment failed with: %d", status);
 }
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
-	long res = c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
+	intptr_t res = c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
 	if (strncmp(c->name, "zx_", 3) == 0) {
 		// Convert zircon error convention to the libc convention that executor expects.
 		// The following calls return arbitrary integers instead of error codes.
@@ -32,9 +32,9 @@ static long execute_syscall(const call_t* c, long a[kMaxArgs])
 		errno = (-res) & 0x7f;
 		return -1;
 	}
-	// We cast libc functions to signature returning long,
+	// We cast libc functions to signature returning intptr_t,
 	// as the result int -1 is returned as 0x00000000ffffffff rather than full -1.
 	if (res == 0xffffffff)
-		res = (long)-1;
+		res = (intptr_t)-1;
 	return res;
 }

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -48,7 +48,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 
 static __thread cover_t* current_cover;
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	if (c->call)
 		return c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);

--- a/executor/executor_test.h
+++ b/executor/executor_test.h
@@ -13,7 +13,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 		fail("mmap of data segment failed");
 }
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	return c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
 }

--- a/executor/executor_windows.h
+++ b/executor/executor_windows.h
@@ -12,7 +12,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 		fail("mmap of data segment failed");
 }
 
-static long execute_syscall(const call_t* c, long a[kMaxArgs])
+static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	__try {
 		return c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -96,7 +96,7 @@ func (ctx *context) generateSyscalls(calls []string, hasVars bool) string {
 	buf := new(bytes.Buffer)
 	if !opts.Threaded && !opts.Collide {
 		if hasVars || opts.Trace {
-			fmt.Fprintf(buf, "\tlong res = 0;\n")
+			fmt.Fprintf(buf, "\tintptr_t res = 0;\n")
 		}
 		if opts.Repro {
 			fmt.Fprintf(buf, "\tif (write(1, \"executing program\\n\", sizeof(\"executing program\\n\") - 1)) {}\n")
@@ -109,7 +109,7 @@ func (ctx *context) generateSyscalls(calls []string, hasVars bool) string {
 		}
 	} else {
 		if hasVars || opts.Trace {
-			fmt.Fprintf(buf, "\tlong res;")
+			fmt.Fprintf(buf, "\tintptr_t res;")
 		}
 		fmt.Fprintf(buf, "\tswitch (call) {\n")
 		for i, c := range calls {
@@ -232,7 +232,7 @@ func (ctx *context) emitCall(w *bytes.Buffer, call prog.ExecCall, ci int, haveCo
 			if native && ctx.target.PtrSize == 4 {
 				// syscall accepts args as ellipsis, resources are uint64
 				// and take 2 slots without the cast, which would be wrong.
-				val = "(long)" + val
+				val = "(intptr_t)" + val
 			}
 			fmt.Fprintf(w, "%v", val)
 		default:
@@ -249,9 +249,9 @@ func (ctx *context) emitCall(w *bytes.Buffer, call prog.ExecCall, ci int, haveCo
 	if trace {
 		cast := ""
 		if !native && !strings.HasPrefix(callName, "syz_") {
-			// Potentially we casted a function returning int to a function returning long.
-			// So instead of long -1 we can get 0x00000000ffffffff. Sign extend it to long.
-			cast = "(long)(int)"
+			// Potentially we casted a function returning int to a function returning intptr_t.
+			// So instead of intptr_t -1 we can get 0x00000000ffffffff. Sign extend it to intptr_t.
+			cast = "(intptr_t)(int)"
 		}
 		fmt.Fprintf(w, "\tfprintf(stderr, \"### call=%v errno=%%u\\n\", %vres == -1 ? errno : 0);\n", ci, cast)
 	}
@@ -264,11 +264,11 @@ func (ctx *context) emitCallName(w *bytes.Buffer, call prog.ExecCall, native boo
 	} else if strings.HasPrefix(callName, "syz_") {
 		fmt.Fprintf(w, "%v(", callName)
 	} else {
-		args := strings.Repeat(",long", len(call.Args))
+		args := strings.Repeat(",intptr_t", len(call.Args))
 		if args != "" {
 			args = args[1:]
 		}
-		fmt.Fprintf(w, "((long(*)(%v))CAST(%v))(", args, callName)
+		fmt.Fprintf(w, "((intptr_t(*)(%v))CAST(%v))(", args, callName)
 	}
 }
 
@@ -355,7 +355,7 @@ func (ctx *context) copyinVal(w *bytes.Buffer, addr, size uint64, val string, bf
 func (ctx *context) copyout(w *bytes.Buffer, call prog.ExecCall, resCopyout bool) {
 	if ctx.sysTarget.OS == "fuchsia" {
 		// On fuchsia we have real system calls that return ZX_OK on success,
-		// and libc calls that are casted to function returning long,
+		// and libc calls that are casted to function returning intptr_t,
 		// as the result int -1 is returned as 0x00000000ffffffff rather than full -1.
 		if strings.HasPrefix(call.Meta.CallName, "zx_") {
 			fmt.Fprintf(w, "\tif (res == ZX_OK)")


### PR DESCRIPTION
In Windows, long is 32-bit data type even in 64-bit architecture.
Therefore, defining arg_t and using size_t in Windows can fix it.

Using size_t since there can be a future work to support 32-bit Windows.