### PR TITLE
pkg/report: Handle powerpc stack traces correctly

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -652,7 +652,7 @@ var linuxStallAnchorFrames = []*regexp.Regexp{
 
 var (
 	linuxSymbolizeRe = regexp.MustCompile(`(?:\[\<(?:[0-9a-f]+)\>\])?[ \t]+(?:[0-9]+:)?([a-zA-Z0-9_.]+)\+0x([0-9a-f]+)/0x([0-9a-f]+)`)
-	stackFrameRe     = regexp.MustCompile(`^ *(?:\[\<(?:[0-9a-f]+)\>\])?[ \t]+(?:[0-9]+:)?([a-zA-Z0-9_.]+)\+0x([0-9a-f]+)/0x([0-9a-f]+)`)
+	stackFrameRe     = regexp.MustCompile(`^ *(?:\[\<?(?:[0-9a-f]+)\>?\] ?){0,2}[ \t]+(?:[0-9]+:)?([a-zA-Z0-9_.]+)\+0x([0-9a-f]+)/0x([0-9a-f]+)`)
 	linuxRcuStall    = compile("INFO: rcu_(?:preempt|sched|bh) (?:self-)?detected(?: expedited)? stall")
 	linuxRipFrame    = compile(`IP: (?:(?:[0-9]+:)?(?:{{PC}} +){0,2}{{FUNC}}|[0-9]+:0x[0-9a-f]+|(?:[0-9]+:)?{{PC}} +\[< *\(null\)>\] +\(null\)|[0-9]+: +\(null\))`)
 )
@@ -675,7 +675,7 @@ var linuxStackKeywords = []*regexp.Regexp{
 var linuxStackParams = &stackParams{
 	stackStartRes: linuxStackKeywords,
 	frameRes: []*regexp.Regexp{
-		compile("^ +(?:{{PC}} )?{{FUNC}}"),
+		compile("^ *(?:{{PC}} ){0,2}{{FUNC}}"),
 	},
 	skipPatterns: []string{
 		"__sanitizer",

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -258,7 +258,7 @@ var parseStackTrace *regexp.Regexp
 
 func compile(re string) *regexp.Regexp {
 	re = strings.Replace(re, "{{ADDR}}", "0x[0-9a-f]+", -1)
-	re = strings.Replace(re, "{{PC}}", "\\[\\<(?:0x)?[0-9a-f]+\\>\\]", -1)
+	re = strings.Replace(re, "{{PC}}", "\\[\\<?(?:0x)?[0-9a-f]+\\>?\\]", -1)
 	re = strings.Replace(re, "{{FUNC}}", "([a-zA-Z0-9_]+)(?:\\.|\\+)", -1)
 	re = strings.Replace(re, "{{SRC}}", "([a-zA-Z0-9-_/.]+\\.[a-z]+:[0-9]+)", -1)
 	return regexp.MustCompile(re)

--- a/pkg/report/testdata/linux/report/379
+++ b/pkg/report/testdata/linux/report/379
@@ -1,0 +1,28 @@
+TITLE: INFO: task hung in __switch_to
+
+[ 2435.283131] INFO: task syz-executor.0:18224 blocked for more than 143 seconds.
+[ 2435.283923]       Not tainted 5.1.0-rc3 #1
+[ 2435.284345] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+[ 2435.285150] syz-executor.0  D12048 18224   2776 0x00040008
+[ 2435.285727] Call Trace:
+[ 2435.285992] [c000000049a87530] [c000000049a875a0] 0xc000000049a875a0 (unreliable)
+[ 2435.286794] [c000000049a87710] [c0000000000286fc] __switch_to+0x43c/0x6d0
+[ 2435.287514] [c000000049a87780] [c000000001385b4c] __schedule+0x3cc/0xed0
+[ 2435.288206] [c000000049a87860] [c0000000013866a0] schedule+0x50/0xd0
+[ 2435.288863] [c000000049a87880] [c00000000138d5ec] schedule_timeout+0x36c/0x810
+[ 2435.289608] [c000000049a879a0] [c0000000013876ec] wait_for_common+0xfc/0x220
+[ 2435.290343] [c000000049a87a10] [c0000000005f7dc8] exit_aio+0x188/0x2a0
+[ 2435.291308] [c000000049a87ad0] [c00000000016556c] mmput+0xbc/0x260
+[ 2435.293006] [c000000049a87b00] [c000000000175ea4] do_exit+0x484/0x1300
+[ 2435.293971] [c000000049a87be0] [c000000000176e44] do_group_exit+0x84/0x130
+[ 2435.295804] [c000000049a87c20] [c000000000191df8] get_signal+0x218/0xfe0
+[ 2435.297295] [c000000049a87d10] [c00000000002b0d0] do_notify_resume+0x220/0x640
+[ 2435.299010] [c000000049a87e20] [c00000000000e644] ret_from_except_lite+0x70/0x74
+[ 2435.300711] 
+[ 2435.300711] Showing all locks held in the system:
+[ 2435.302138] 1 lock held by khungtaskd/342:
+[ 2435.302643]  #0: 000000007cacd2b6 (rcu_read_lock){....}, at: debug_show_all_locks+0x28/0x260
+[ 2435.303702] 1 lock held by in:imklog/2546:
+[ 2435.304409] 
+[ 2435.304571] =============================================
+[ 2435.304571] 

--- a/pkg/report/testdata/linux/report/380
+++ b/pkg/report/testdata/linux/report/380
@@ -1,0 +1,17 @@
+TITLE: WARNING in assert_slb_presence
+
+[   38.771258] WARNING: CPU: 1 PID: 4057 at arch/powerpc/mm/slb.c:79 assert_slb_presence+0x2c/0x70
+[   38.772382] Kernel panic - not syncing: panic_on_warn set ...
+[   38.773114] CPU: 1 PID: 4057 Comm: syz-executor.4 Not tainted 5.1.0-rc3-00035-g8ed86627f715 #7
+[   38.774151] Call Trace:
+[   38.774455] [c00000003ae5b800] [c00000000135c19c] dump_stack+0x128/0x1cc (unreliable)
+[   38.775425] [c00000003ae5b860] [c00000000016ab98] panic+0x1cc/0x534
+[   38.776168] [c00000003ae5b900] [c00000000016a9cc] panic+0x0/0x534
+[   38.776919] [c00000003ae5b9a0] [c00000000135a500] report_bug+0x150/0x270
+[   38.777744] [c00000003ae5ba40] [c0000000000392d4] program_check_exception+0x344/0x4f0
+[   38.778694] [c00000003ae5bac0] [c0000000000090a4] program_check_common+0x184/0x190
+[   38.779614] --- interrupt: 700 at assert_slb_presence+0x2c/0x70
+[   38.779614]     LR = slb_insert_entry+0x19c/0x2d0
+[   38.780881] [c00000003ae5bdc0] [0000000000000000]           (null) (unreliable)
+[   38.781783] [c00000003ae5bdf0] [c00000000009651c] do_slb_fault+0x10c/0x250
+[   38.782631] [c00000003ae5be20] [c0000000000088f8] data_access_slb_common+0x138/0x190


### PR DESCRIPTION
powerpc stack traces are printed a bit differently from x86 stack traces.
Adjust the regexes accordingly to cope with this format.

Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>
