### PR TITLE
dashboard/config: enable SPLASSERT_WATCH on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -3,6 +3,7 @@ include "arch/amd64/conf/GENERIC.MP"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
+option SPLASSERT_WATCH
 option WITNESS
 option WITNESS_LOCKTRACE
 option WITNESS_WATCH

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -3,3 +3,4 @@ include "arch/amd64/conf/GENERIC"
 pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
+option SPLASSERT_WATCH


### PR DESCRIPTION
Makes interrupt priority level assertions fatal.