### PR TITLE
tools/create-openbsd-gce-ci.sh: explicitly specify sets location

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -111,6 +111,7 @@ Use (A)uto layout, (E)dit auto layout, or create (C)ustom layout = auto
 URL to autopartitioning template for disklabel = file://disklabel.template
 Set name(s) = +* -x* -game* done
 Directory does not contain SHA256.sig. Continue without verification = yes
+Location of sets = cd0
 EOF
 
 # Disklabel template.


### PR DESCRIPTION
The previous default must have changed resulting in an apparent
failure to install siteXX.tgz. The observable symptom was:
`Package installation failed. Inspect install_log.`

Diagnosis and suggested fix by @mptre.
