### PR TITLE
tools/create-openbsd-vmm-worker.sh: set location to cd0

### DIFF
--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -108,6 +108,7 @@ Use (A)uto layout, (E)dit auto layout, or create (C)ustom layout = auto
 URL to autopartitioning template for disklabel = file://disklabel.template
 Set name(s) = -* +bsd +bsd.mp +base* +site* done
 Directory does not contain SHA256.sig. Continue without verification = yes
+Location of sets = cd0
 EOF
 
 # Disklabel template.


### PR DESCRIPTION
Improves consistency (and speed).
