### PR TITLE
pkg/csource: annotate syscalls using comments in C reproducers

### DIFF
--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -239,7 +239,12 @@ func (ctx *context) emitCall(w *bytes.Buffer, call prog.ExecCall, ci int, haveCo
 		}
 		fmt.Fprintf(w, "0")
 	}
-	fmt.Fprintf(w, ");\n")
+	fmt.Fprintf(w, ");")
+	comment := ctx.target.AnnotateCall(call)
+	if len(comment) != 0 {
+		fmt.Fprintf(w, " /* %s */", comment)
+	}
+	fmt.Fprintf(w, "\n")
 	if trace {
 		cast := ""
 		if !native && !strings.HasPrefix(callName, "syz_") {

--- a/prog/target.go
+++ b/prog/target.go
@@ -31,6 +31,11 @@ type Target struct {
 	// SanitizeCall neutralizes harmful calls.
 	SanitizeCall func(c *Call)
 
+	// AnnotateCall annotates a syscall invocation in C reproducers.
+	// The returned string will be placed inside a comment except for the
+	// empty string which will omit the comment.
+	AnnotateCall func(c ExecCall) string
+
 	// SpecialTypes allows target to do custom generation/mutation for some struct's and union's.
 	// Map key is struct/union name for which custom generation/mutation is required.
 	// Map value is custom generation/mutation function that will be called
@@ -106,6 +111,7 @@ func AllTargets() []*Target {
 
 func (target *Target) lazyInit() {
 	target.SanitizeCall = func(c *Call) {}
+	target.AnnotateCall = func(c ExecCall) string { return "" }
 	target.initTarget()
 	target.initArch(target)
 	target.ConstMap = nil // currently used only by initArch


### PR DESCRIPTION
Providing additional info, especially regarding syscall arguments, in reproducers
can be helpful. An example is device numbers passed to mknod(2).

This commit introduces an optional annotate function on a per target basis.

Example for the OpenBSD target:

```
  $ cat prog.in
  mknod(0x0, 0x0, 0x4503)
  getpid()
  $ syz-prog2c -prog prog.in
  int main(void)
  {
    syscall(SYS_mmap, 0x20000000, 0x1000000, 3, 0x1012, -1, 0, 0);
    syscall(SYS_mknod, 0, 0, 0x4503); /* major = 69, minor = 3 */
    syscall(SYS_getpid);
    return 0;
  }
```

Testing would be nice, but I couldn't figure out how-to go from `Prog` to `ExecCall`.