### PR TITLE
pkg/build: update env variables for akaros

### DIFF
--- a/pkg/build/akaros.go
+++ b/pkg/build/akaros.go
@@ -123,8 +123,7 @@ func (ctx akaros) cmd(kernelDir, runDir string, bin string, args ...string) erro
 	cmd.Env = append(cmd.Env, []string{
 		"MAKE_JOBS=" + strconv.Itoa(runtime.NumCPU()),
 		"AKAROS_ROOT=" + kernelDir,
-		"AKAROS_XCC_ROOT=" + filepath.Join(kernelDir, "toolchain", "x86_64-ucb-akaros-gcc"),
-		"X86_64_INSTDIR=" + filepath.Join(kernelDir, "toolchain", "x86_64-ucb-akaros-gcc"),
+		"AKAROS_TOOLCHAINS=" + filepath.Join(kernelDir, "toolchain"),
 		"PATH=" + filepath.Join(kernelDir, "toolchain", "x86_64-ucb-akaros-gcc", "bin") +
 			string(filepath.ListSeparator) + os.Getenv("PATH"),
 	}...)


### PR DESCRIPTION
* Remove the environment variable: AKAROS_XCC_ROOT
(refer to commit: brho/akaros bdab8c3a)
* Add environment variable AKAROS_TOOLCHAINS which
points to the parent directory of the old AKAROS_XCC_ROOT.
(refer to commit: brho/akaro 62ec5c3c)
* Add "$AKAROS_TOOLCHAINS/x86_64-ucb-akaros-gcc/bin" to PATH.

Signed-off-by: Aditya Basu <mitthu@google.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
