### PR TITLE
Adding Support for .txt file openat

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ Google Inc.
  Julia Hansbrough
  Dan Austin
  Victor Hsieh
+ Michael A. Specter
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -312,6 +312,9 @@ func isSupportedSocket(c *prog.Syscall) (bool, string) {
 }
 
 func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
+	var fd int
+	var err error
+
 	fname, ok := extractStringConst(c.Args[1])
 	if !ok || len(fname) == 0 || fname[0] != '/' {
 		return true, ""
@@ -325,7 +328,7 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 	}
 
 	for _, mode := range modes {
-		fd, err := syscall.Open(fname, mode, 0)
+		fd, err = syscall.Open(fname, mode, 0)
 		if fd != -1 {
 			syscall.Close(fd)
 		}

--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -317,53 +317,21 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 		return true, ""
 	}
 
-	// Test 1: try to extract the correct flags
-	constFlags, ok := c.Args[2].(*prog.ConstType)
-	if ok {
-		// flag exists and is const
-		fd, err := syscall.Open(fname, int(constFlags.Val), 0)
+	modes := []int{syscall.O_RDONLY, syscall.O_WRONLY, syscall.O_RDWR}
+
+	// Attempt to extract flags from the syscall description
+	if mode, ok := c.Args[2].(*prog.ConstType); ok {
+		modes = []int{int(mode.Val)}
+	}
+
+	for _, mode := range modes {
+		fd, err := syscall.Open(fname, mode, 0)
 		if fd != -1 {
 			syscall.Close(fd)
 		}
 		if err == nil {
 			return true, ""
-		} else {
-			out := fmt.Sprintf("open(%v) failed: %v, const declared but fails %d", fname, err, int(constFlags.Val))
-			return false, out
 		}
-	}
-
-	// Test 2: try O_RDONLY, O_WRONLY, O_RDWR
-	// O_RDONLY
-	fd, err := syscall.Open(fname, syscall.O_RDONLY, 0)
-	if fd != -1 {
-		syscall.Close(fd)
-	}
-	if err == nil {
-		return true, ""
-	}
-
-	// ENOENT occurs when the file itself doesn't exist
-	if err == syscall.ENOENT {
-		return false, fmt.Sprintf("open(%v) failed: %v", fname, err)
-	}
-
-	// O_WRONLY
-	fd, err = syscall.Open(fname, syscall.O_WRONLY, 0)
-	if fd != -1 {
-		syscall.Close(fd)
-	}
-	if err == nil {
-		return true, ""
-	}
-
-	// O_RDWR
-	fd, err = syscall.Open(fname, syscall.O_RDWR, 0)
-	if fd != -1 {
-		syscall.Close(fd)
-	}
-	if err == nil {
-		return true, ""
 	}
 
 	return false, fmt.Sprintf("open(%v) failed: %v", fname, err)


### PR DESCRIPTION
A nontrivial number of drivers require specific flags to openat. This pull request updates host_linux.go to first check if the openat has a constant that is specified by the .txt file, then attempts O_RDONLY, O_WRONLY, and O_RDWR.


