### PR TITLE
sys/openbsd: sanitize setrlimit(RLIMIT_STACK) syscalls

### DIFF
--- a/sys/openbsd/init_test.go
+++ b/sys/openbsd/init_test.go
@@ -52,6 +52,11 @@ func TestSanitizeMknodCall(t *testing.T) {
 			`setrlimit(0x2, &(0x7f0000cc0ff0)={0x60000000, 0x80000000})`,
 		},
 		{
+			// RLIMIT_STACK
+			`setrlimit(0x3, &(0x7f0000cc0ff0)={0x1000000000, 0x1000000000})`,
+			`setrlimit(0x3, &(0x7f0000cc0ff0)={0x100000, 0x100000})`,
+		},
+		{
 			// RLIMIT_CPU
 			`setrlimit(0x0, &(0x7f0000cc0ff0)={0x1, 0x1})`,
 			`setrlimit(0x0, &(0x7f0000cc0ff0)={0x1, 0x1})`,

--- a/sys/openbsd/init_test.go
+++ b/sys/openbsd/init_test.go
@@ -9,7 +9,7 @@ import (
 	_ "github.com/google/syzkaller/sys/openbsd/gen"
 )
 
-func TestSanitizeMknodCall(t *testing.T) {
+func TestSanitizeCall(t *testing.T) {
 	target, err := prog.GetTarget("openbsd", "amd64")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Do not allow the stack to grow beyond the initial soft limit chosen by
syz-executor. Otherwise, syz-executor will most likely not be able to
perform any more heap allocations since they majoriy of memory is
reserved for the stack.

This is one of the root causes of the high amount of reported "lost
connection to test machine".