### PR TITLE
sys/openbsd: sanitize mlockall syscalls

### DIFF
--- a/sys/openbsd/init.go
+++ b/sys/openbsd/init.go
@@ -42,6 +42,9 @@ const (
 	// kOutPipeFd in executor/executor.cc
 	kcovFdMinorMax = 248
 
+	// MCL_FUTURE from openbsd:src/sys/sys/mman.h
+	mclFuture uint64 = 0x2
+
 	// RLIMIT_DATA from openbsd:src/sys/sys/resource.h
 	rlimitData = 2
 	// RLIMIT_STACK from openbsd:src/sys/sys/resource.h
@@ -112,6 +115,9 @@ func (arch *arch) SanitizeCall(c *prog.Call) {
 		if devmajor(dev.Val) == 4 && devminor(dev.Val) == 2 {
 			dev.Val = devNullDevT
 		}
+	case "mlockall":
+		flags := c.Args[0].(*prog.ConstArg)
+		flags.Val &= ^mclFuture
 	case "setrlimit":
 		var rlimitMin uint64
 		var rlimitMax uint64 = math.MaxUint64

--- a/sys/openbsd/init_test.go
+++ b/sys/openbsd/init_test.go
@@ -47,6 +47,11 @@ func TestSanitizeCall(t *testing.T) {
 			`mknod(0x0, 0x0, 0x202)`,
 		},
 		{
+			// MCL_CURRENT | MCL_FUTURE
+			`mlockall(0x3)`,
+			`mlockall(0x1)`,
+		},
+		{
 			// RLIMIT_DATA
 			`setrlimit(0x2, &(0x7f0000cc0ff0)={0x0, 0x80000000})`,
 			`setrlimit(0x2, &(0x7f0000cc0ff0)={0x60000000, 0x80000000})`,


### PR DESCRIPTION
Locking down future mappings will most likely cause syz-executor to run
out of memory.

This is one of the root causes of the high amount of reported "lost
connection to test machine".