### PR TITLE
sys/openbsd: correct setrlimit resource detection

### DIFF
--- a/sys/openbsd/init.go
+++ b/sys/openbsd/init.go
@@ -49,6 +49,8 @@ const (
 	rlimitData = 2
 	// RLIMIT_STACK from openbsd:src/sys/sys/resource.h
 	rlimitStack = 3
+	// Mask covering all valid rlimit resources.
+	rlimitMask = 0xf
 )
 
 // openbsd:src/sys/sys/types.h
@@ -121,7 +123,7 @@ func (arch *arch) SanitizeCall(c *prog.Call) {
 	case "setrlimit":
 		var rlimitMin uint64
 		var rlimitMax uint64 = math.MaxUint64
-		resource := c.Args[0].(*prog.ConstArg).Val
+		resource := c.Args[0].(*prog.ConstArg).Val & rlimitMask
 		if resource == rlimitData {
 			// OpenBSD performs a strict validation of the
 			// RLIMIT_DATA soft limit during memory allocation.

--- a/sys/openbsd/init_test.go
+++ b/sys/openbsd/init_test.go
@@ -57,6 +57,11 @@ func TestSanitizeCall(t *testing.T) {
 			`setrlimit(0x2, &(0x7f0000cc0ff0)={0x60000000, 0x80000000})`,
 		},
 		{
+			// RLIMIT_DATA
+			`setrlimit(0x10000000000002, &(0x7f0000cc0ff0)={0x0, 0x80000000})`,
+			`setrlimit(0x10000000000002, &(0x7f0000cc0ff0)={0x60000000, 0x80000000})`,
+		},
+		{
 			// RLIMIT_STACK
 			`setrlimit(0x3, &(0x7f0000cc0ff0)={0x1000000000, 0x1000000000})`,
 			`setrlimit(0x3, &(0x7f0000cc0ff0)={0x100000, 0x100000})`,


### PR DESCRIPTION
The sanitizer fails to sanitize programs like the following:

```
  setrlimit(0x10000000000002, &(0x7f0000000080))
```

... due to presence of the most significant bit. Therefore mask of all
bits that cannot form a valid rlimit resource.

This is one of the root causes of the high amount of reported "lost
connection to test machine".