### PR TITLE
pkg/report: fix error in report symbolization

### DIFF
--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -27,7 +27,7 @@ type netbsd struct {
 var (
 	netbsdSymbolizeRe = []*regexp.Regexp{
 		// stack
-		regexp.MustCompile(` at ([A-Za-z0-9_]+)\+0x([0-9a-f]+)`),
+		regexp.MustCompile(` at netbsd:([A-Za-z0-9_]+)\+0x([0-9a-f]+)`),
 		// witness
 		regexp.MustCompile(`#[0-9]+ +([A-Za-z0-9_]+)\+0x([0-9a-f]+)`),
 	}

--- a/pkg/report/netbsd_test.go
+++ b/pkg/report/netbsd_test.go
@@ -17,19 +17,19 @@ func TestNetbsdSymbolizeLine(t *testing.T) {
 	}{
 		// Normal symbolization.
 		{
-			"closef(ffffffff,ffffffff) at closef+0xaf\n",
-			"closef(ffffffff,ffffffff) at closef+0xaf kern_descrip.c:1241\n",
+			"closef(ffffffff,ffffffff) at netbsd:closef+0xaf\n",
+			"closef(ffffffff,ffffffff) at netbsd:closef+0xaf kern_descrip.c:1241\n",
 		},
 		// Inlined frames.
 		{
-			"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22\n",
-			"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22 sleep_finish_timeout kern_synch.c:336 [inline]\n" +
-				"sleep_finish_all(ffffffff,32) at sleep_finish_all+0x22 kern_synch.c:157\n",
+			"sleep_finish_all(ffffffff,32) at netbsd:sleep_finish_all+0x22\n",
+			"sleep_finish_all(ffffffff,32) at netbsd:sleep_finish_all+0x22 sleep_finish_timeout kern_synch.c:336 [inline]\n" +
+				"sleep_finish_all(ffffffff,32) at netbsd:sleep_finish_all+0x22 kern_synch.c:157\n",
 		},
 		// Missing symbol.
 		{
-			"foo(ffffffff,ffffffff) at foo+0x1e",
-			"foo(ffffffff,ffffffff) at foo+0x1e",
+			"foo(ffffffff,ffffffff) at netbsd:foo+0x1e",
+			"foo(ffffffff,ffffffff) at netbsd:foo+0x1e",
 		},
 		// Witness symbolization.
 		{


### PR DESCRIPTION

missed a 'netbsd:' in front of function names for symbolization.
 
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
