### PR TITLE
qemu: support advanced hard drive configurations

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -36,17 +36,17 @@ type Config struct {
 	Kernel string `json:"kernel"`
 	// Additional command line options for the booting kernel, for example `root=/dev/sda1`.
 	// Can only be specified with kernel.
-	Cmdline     string `json:"cmdline"`
-	Initrd      string `json:"initrd"`       // linux initial ramdisk. (optional)
+	Cmdline string `json:"cmdline"`
+	Initrd  string `json:"initrd"` // linux initial ramdisk. (optional)
 	// qemu image device.
 	// The default value "hda" is transformed to "-hda image" for qemu.
 	// The modern way of describing qemu hard disks is supported, so the value
 	// "drive index=0,media=disk,file=" is transformed to "-drive index=0,media=disk,file=image"
 	// for qemu.
 	ImageDevice string `json:"image_device"`
-	CPU         int    `json:"cpu"`          // number of VM CPUs
-	Mem         int    `json:"mem"`          // amount of VM memory in MiB
-	Snapshot    bool   `json:"snapshot"`     // For building kernels without -snapshot (for pkg/build)
+	CPU         int    `json:"cpu"`      // number of VM CPUs
+	Mem         int    `json:"mem"`      // amount of VM memory in MiB
+	Snapshot    bool   `json:"snapshot"` // For building kernels without -snapshot (for pkg/build)
 }
 
 type Pool struct {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -38,7 +38,12 @@ type Config struct {
 	// Can only be specified with kernel.
 	Cmdline     string `json:"cmdline"`
 	Initrd      string `json:"initrd"`       // linux initial ramdisk. (optional)
-	ImageDevice string `json:"image_device"` // qemu image device (hda by default)
+	// qemu image device.
+	// The default value "hda" is transformed to "-hda image" for qemu.
+	// The modern way of describing qemu hard disks is supported, so the value
+	// "drive index=0,media=disk,file=" is transformed to "-drive index=0,media=disk,file=image"
+	// for qemu.
+	ImageDevice string `json:"image_device"`
 	CPU         int    `json:"cpu"`          // number of VM CPUs
 	Mem         int    `json:"mem"`          // amount of VM memory in MiB
 	Snapshot    bool   `json:"snapshot"`     // For building kernels without -snapshot (for pkg/build)
@@ -341,9 +346,15 @@ func (inst *instance) boot() error {
 			"-device", "virtio-9p-pci,fsdev=fsdev0,mount_tag=/dev/root",
 		)
 	} else if inst.image != "" {
-		args = append(args,
-			"-"+inst.cfg.ImageDevice, inst.image,
-		)
+		// inst.cfg.ImageDevice can contain spaces
+		imgline := strings.Split(inst.cfg.ImageDevice, " ")
+		imgline[0] = "-" + imgline[0]
+		if strings.HasSuffix(imgline[len(imgline)-1], "file=") {
+			imgline[len(imgline)-1] = imgline[len(imgline)-1] + inst.image
+		} else {
+			imgline = append(imgline, inst.image)
+		}
+		args = append(args, imgline...)
 		if inst.cfg.Snapshot {
 			args = append(args, "-snapshot")
 		}


### PR DESCRIPTION
Currently the 'image_device' config option in qemu.go doesn't properly
support the modern '-drive' argument for describing qemu hard disks.

In fact the various old ways to define qemu drives all boil down to
the common form '-drive if=TYPE,bus=BUS,unit=UNIT,OPTS...'

For example '-hda img' is equivalent to '-drive index=0,media=disk,file=img'.

Let's make the 'image_device' config option support both forms.

Signed-off-by: Alexander Popov <alex.popov@linux.com>
