### PR TITLE
executor: make errors during thread creation non-fatal

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -281,9 +281,9 @@ typedef struct {
 static void event_init(event_t* ev)
 {
 	if (pthread_mutex_init(&ev->mu, 0))
-		fail("pthread_mutex_init failed");
+		exitf("pthread_mutex_init failed");
 	if (pthread_cond_init(&ev->cv, 0))
-		fail("pthread_cond_init failed");
+		exitf("pthread_cond_init failed");
 	ev->state = 0;
 }
 

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -263,9 +263,9 @@ typedef struct {
 static void event_init(event_t* ev)
 {
 	if (pthread_mutex_init(&ev->mu, 0))
-		fail("pthread_mutex_init failed");
+		exitf("pthread_mutex_init failed");
 	if (pthread_cond_init(&ev->cv, 0))
-		fail("pthread_cond_init failed");
+		exitf("pthread_cond_init failed");
 	ev->state = 0;
 }
 


### PR DESCRIPTION
On OpenBSD, the executor sometimes manages to set the memory resource
limit 0 causing any following memory allocation to fail. Since threads
are potentially created from such a thread which cannot allocate any
memory, the executor will exit non-zero which in turn will cause
false-positive panics to be reported. For more info see the
discussion in PR #1243.

Instead, make any errors during thread creation non-fatal. If the
executor runs of out available threads it will exit zero.