### PR TITLE
docs/linux: add references to syzkaller build instructions

### DIFF
--- a/docs/linux/setup_linux-host_android-device_arm64-kernel.md
+++ b/docs/linux/setup_linux-host_android-device_arm64-kernel.md
@@ -3,6 +3,8 @@
 Prerequisites:
  - Android Serial Cable or [Suzy-Q](https://chromium.googlesource.com/chromiumos/platform/ec/+/master/docs/case_closed_debugging.md) device to capture console output is preferable but optional. syzkaller can work with normal USB cable as well, but that can be somewhat unreliable and turn lots of crashes into "lost connection to test machine" crashes with no additional info.
 
+- Build syzkaller as described [here](/docs/contributing.md).
+
 In case you have old Android `/dev/ion` driver:
 
 ```sh

--- a/docs/linux/setup_linux-host_isolated.md
+++ b/docs/linux/setup_linux-host_isolated.md
@@ -55,6 +55,8 @@ and ssh usage will reuse it.
 
 ## Syzkaller
 
+Build syzkaller as described [here](/docs/contributing.md).
+
 Use the following config:
 ```
 {

--- a/docs/linux/setup_linux-host_qemu-vm_arm-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_arm-kernel.md
@@ -104,8 +104,13 @@ ssh should succeed.
 
 # syzkaller
 
-Build `syzkaller` with `make TARGETARCH=arm`. Create manager config `arm.cfg`
-similar to the following one (changing paths as necessary):
+Build syzkaller as described [here](/docs/contributing.md), with `arm` target:
+
+```
+make TARGETOS=linux TARGETARCH=arm
+```
+
+Create manager config `arm.cfg` similar to the following one (changing paths as necessary):
 
 ```
 {

--- a/docs/linux/setup_linux-host_qemu-vm_arm64-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_arm64-kernel.md
@@ -120,7 +120,13 @@ Reboot the machine, and ensure that you can ssh from host to guest as.
 
 ## Build syzkaller
 
-    make TARGETARCH=arm64 [CC=/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-g++]
+Build syzkaller as described [here](/docs/contributing.md), with `arm64` target:
+
+```
+CC=gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-g++
+make TARGETARCH=arm64
+```
+
 
 ## Modify your config file and start off syzkaller
 

--- a/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
+++ b/docs/linux/setup_ubuntu-host_android-device_arm32-kernel.md
@@ -17,7 +17,8 @@ If feasible, recompile and reinstall the Linux kernel with any debugging options
 
 ## Build syzkaller executables
 
-Run make. 
+Build syzkaller as described [here](/docs/contributing.md), with `arm` target:
+
 ```
 make TARGETOS=linux TARGETARCH=arm
 ```

--- a/docs/linux/setup_ubuntu-host_odroid-c2-board_arm64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_odroid-c2-board_arm64-kernel.md
@@ -278,7 +278,8 @@ Now make sure you can ssh with the key:
 ssh -i ./ssh/id_rsa root@172.16.0.31
 ```
 
-Build syzkaller with `odroid` build tag:
+Build syzkaller as described [here](/docs/contributing.md), with `odroid` build tag:
+
 ``` bash
 make GOTAGS=odroid TARGETARCH=arm64
 ```

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -4,7 +4,7 @@ These are the instructions on how to fuzz the x86-64 kernel in a QEMU with Ubunt
 
 ## GCC
 
-Get the latest compiler from [this](/docs/syzbot.md#crash-does-not-reproduce) list and unpack into `$GCC`.
+Use the latest compiler from your distro or get the one from [this](/docs/syzbot.md#crash-does-not-reproduce) list and unpack into `$GCC`.
 
 Now you should have GCC binaries in `$GCC/bin/`:
 ``` bash
@@ -158,7 +158,8 @@ kill $(cat vm.pid)
 
 ## syzkaller
 
-Create a manager config like the following, replacing the environment
+Build syzkaller as described [here](/docs/contributing.md). Then
+create a manager config like the following, replacing the environment
 variables `$GOPATH`, `$KERNEL` and `$IMAGE` with their actual values.
 ```
 {


### PR DESCRIPTION
In the various linux build instructions, add pointers to the main
doc with instructions for building syzkaller.

These instructions were present before commit d23e90a7b44b ("all:
switch to Go 1.12"). They were duplicated across files. Since the
commit the instructions are in one place. Make it easier to find
them from the platform-specific setup guides.

Also clarify in the x86_64 guide that using a precompiled compiler
from the supplied list is optional if the distribution provided
compiler is recent enough. Before commit d28f4ce ("Update
setup_ubuntu-host_qemu-vm_x86-64-kernel.md") the file had explicit
build instructions. Those are no longer needed.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
