### PR TITLE
pkg/cover: fix prefix computation

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -23,6 +23,7 @@ import (
 type ReportGenerator struct {
 	vmlinux  string
 	srcDir   string
+	buildDir string
 	arch     string
 	symbols  []symbol
 	coverPCs []uint64
@@ -39,11 +40,12 @@ type coverage struct {
 	covered bool
 }
 
-func MakeReportGenerator(vmlinux, srcDir, arch string) (*ReportGenerator, error) {
+func MakeReportGenerator(vmlinux, srcDir, buildDir, arch string) (*ReportGenerator, error) {
 	rg := &ReportGenerator{
-		vmlinux: vmlinux,
-		srcDir:  srcDir,
-		arch:    arch,
+		vmlinux:  vmlinux,
+		srcDir:   srcDir,
+		buildDir: buildDir,
+		arch:     arch,
 	}
 	if err := rg.readSymbols(); err != nil {
 		return nil, err
@@ -61,7 +63,7 @@ func (rg *ReportGenerator) Do(w io.Writer, pcs []uint64) error {
 	for i, pc := range pcs {
 		pcs[i] = PreviousInstructionPC(rg.arch, pc)
 	}
-	covered, prefix, err := rg.symbolize(pcs)
+	covered, err := rg.symbolize(pcs)
 	if err != nil {
 		return err
 	}
@@ -69,20 +71,20 @@ func (rg *ReportGenerator) Do(w io.Writer, pcs []uint64) error {
 		return fmt.Errorf("'%s' does not have debug info (set CONFIG_DEBUG_INFO=y)", rg.vmlinux)
 	}
 	uncoveredPCs := rg.uncoveredPcsInFuncs(pcs)
-	uncovered, prefix2, err := rg.symbolize(uncoveredPCs)
+	uncovered, err := rg.symbolize(uncoveredPCs)
 	if err != nil {
 		return err
 	}
-	if len(uncoveredPCs) != 0 {
-		prefix = combinePrefix(prefix, prefix2)
-	}
-	return rg.generate(w, prefix, covered, uncovered)
+	return rg.generate(w, covered, uncovered)
 }
 
-func (rg *ReportGenerator) generate(w io.Writer, prefix string, covered, uncovered []symbolizer.Frame) error {
+func (rg *ReportGenerator) generate(w io.Writer, covered, uncovered []symbolizer.Frame) error {
 	var d templateData
 	for f, covered := range fileSet(covered, uncovered) {
-		remain := filepath.Clean(strings.TrimPrefix(f, prefix))
+		if strings.HasPrefix(f, rg.buildDir) {
+			return fmt.Errorf("Kernel object returned a path '%s' that doesn't match with the specified build dir '%s'", f, rg.buildDir)
+		}
+		remain := filepath.Clean(strings.TrimPrefix(f, rg.buildDir))
 		if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {
 			f = filepath.Join(rg.srcDir, remain)
 		}
@@ -219,39 +221,20 @@ func (rg *ReportGenerator) uncoveredPcsInFuncs(pcs []uint64) []uint64 {
 	return uncoveredPCs
 }
 
-func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, string, error) {
+func (rg *ReportGenerator) symbolize(pcs []uint64) ([]symbolizer.Frame, error) {
 	symb := symbolizer.NewSymbolizer()
 	defer symb.Close()
 
 	frames, err := symb.SymbolizeArray(rg.vmlinux, pcs)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	prefix := ""
 	for i := range frames {
 		frame := &frames[i]
 		frame.PC--
-		if prefix == "" {
-			prefix = frame.File
-		} else {
-			prefix = combinePrefix(prefix, frame.File)
-			if prefix == "" {
-				break
-			}
-		}
 	}
-	return frames, prefix, nil
-}
-
-func combinePrefix(prefix, prefix2 string) string {
-	i := 0
-	for ; i < len(prefix) && i < len(prefix2); i++ {
-		if prefix[i] != prefix2[i] {
-			break
-		}
-	}
-	return prefix[:i]
+	return frames, nil
 }
 
 func parseFile(fn string) ([][]byte, error) {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -81,13 +81,15 @@ func (rg *ReportGenerator) Do(w io.Writer, pcs []uint64) error {
 func (rg *ReportGenerator) generate(w io.Writer, covered, uncovered []symbolizer.Frame) error {
 	var d templateData
 	for f, covered := range fileSet(covered, uncovered) {
-		if strings.HasPrefix(f, rg.buildDir) {
+		if !strings.HasPrefix(f, rg.buildDir) {
 			return fmt.Errorf("path '%s' doesn't match build dir '%s'", f, rg.buildDir)
 		}
+
+		// Trim the existing build dir
 		remain := filepath.Clean(strings.TrimPrefix(f, rg.buildDir))
-		if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {
-			f = filepath.Join(rg.srcDir, remain)
-		}
+
+		// Add the current kernel source dir
+		f = filepath.Join(rg.srcDir, remain)
 		lines, err := parseFile(f)
 		if err != nil {
 			return err

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -82,7 +82,7 @@ func (rg *ReportGenerator) generate(w io.Writer, covered, uncovered []symbolizer
 	var d templateData
 	for f, covered := range fileSet(covered, uncovered) {
 		if strings.HasPrefix(f, rg.buildDir) {
-			return fmt.Errorf("Kernel object returned a path '%s' that doesn't match with the specified build dir '%s'", f, rg.buildDir)
+			return fmt.Errorf("path '%s' doesn't match build dir '%s'", f, rg.buildDir)
 		}
 		remain := filepath.Clean(strings.TrimPrefix(f, rg.buildDir))
 		if rg.srcDir != "" && !strings.HasPrefix(remain, rg.srcDir) {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	KernelObj string `json:"kernel_obj"`
 	// Kernel source directory (if not set defaults to KernelObj).
 	KernelSrc string `json:"kernel_src,omitempty"`
+	// Location of the driectory where the kernel was built (if not set defaults to KernelSrc)
+	KernelBuildSrc string `json:"kernel_build_src"`
 	// Arbitrary optional tag that is saved along with crash reports (e.g. branch/commit).
 	Tag string `json:"tag,omitempty"`
 	// Location of the disk image file.

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -111,6 +111,9 @@ func Complete(cfg *Config) error {
 		cfg.KernelSrc = cfg.KernelObj // assume in-tree build by default
 	}
 	cfg.KernelSrc = osutil.Abs(cfg.KernelSrc)
+	if cfg.KernelBuildSrc == "" {
+		cfg.KernelBuildSrc = cfg.KernelSrc
+	}
 	if cfg.HubClient != "" && (cfg.Name == "" || cfg.HubAddr == "" || cfg.HubKey == "") {
 		return fmt.Errorf("hub_client is set, but name/hub_addr/hub_key is empty")
 	}

--- a/pkg/report/akaros.go
+++ b/pkg/report/akaros.go
@@ -21,7 +21,7 @@ type akaros struct {
 	objfile string
 }
 
-func ctorAkaros(target *targets.Target, kernelSrc, kernelObj string,
+func ctorAkaros(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &akaros{
 		ignores: ignores,

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -11,17 +11,17 @@ import (
 )
 
 type freebsd struct {
-	kernelSrc string
-	kernelObj string
-	ignores   []*regexp.Regexp
+	kernelBuildSrc string
+	kernelObj      string
+	ignores        []*regexp.Regexp
 }
 
-func ctorFreebsd(target *targets.Target, kernelSrc, kernelObj string,
+func ctorFreebsd(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &freebsd{
-		kernelSrc: kernelSrc,
-		kernelObj: kernelObj,
-		ignores:   ignores,
+		kernelBuildSrc: kernelBuildSrc,
+		kernelObj:      kernelObj,
+		ignores:        ignores,
 	}
 	return ctx, nil, nil
 }

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -39,7 +39,7 @@ var (
 	}
 )
 
-func ctorFuchsia(target *targets.Target, kernelSrc, kernelObj string,
+func ctorFuchsia(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &fuchsia{
 		ignores: ignores,

--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -14,7 +14,7 @@ type gvisor struct {
 	ignores []*regexp.Regexp
 }
 
-func ctorGvisor(target *targets.Target, kernelSrc, kernelObj string,
+func ctorGvisor(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &gvisor{
 		ignores: ignores,

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -21,6 +21,7 @@ import (
 
 type linux struct {
 	kernelSrc             string
+	kernelBuildSrc        string
 	kernelObj             string
 	vmlinux               string
 	symbols               map[string][]symbolizer.Symbol
@@ -35,7 +36,7 @@ type linux struct {
 	eoi                   []byte
 }
 
-func ctorLinux(target *targets.Target, kernelSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
+func ctorLinux(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string, ignores []*regexp.Regexp) (Reporter, []string, error) {
 	var symbols map[string][]symbolizer.Symbol
 	vmlinux := ""
 	if kernelObj != "" {
@@ -47,11 +48,12 @@ func ctorLinux(target *targets.Target, kernelSrc, kernelObj string, ignores []*r
 		}
 	}
 	ctx := &linux{
-		kernelSrc: kernelSrc,
-		kernelObj: kernelObj,
-		vmlinux:   vmlinux,
-		symbols:   symbols,
-		ignores:   ignores,
+		kernelSrc:      kernelSrc,
+		kernelBuildSrc: kernelBuildSrc,
+		kernelObj:      kernelObj,
+		vmlinux:        vmlinux,
+		symbols:        symbols,
+		ignores:        ignores,
 	}
 	ctx.consoleOutputRe = regexp.MustCompile(`^(?:\*\* [0-9]+ printk messages dropped \*\* )?(?:.* login: )?(?:\<[0-9]+\>)?\[ *[0-9]+\.[0-9]+\](\[ *(?:C|T)[0-9]+\])? `)
 	ctx.questionableRes = []*regexp.Regexp{

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -337,14 +337,13 @@ func (ctx *linux) Symbolize(rep *Report) error {
 func (ctx *linux) symbolize(rep *Report) error {
 	symb := symbolizer.NewSymbolizer()
 	defer symb.Close()
-	strip := ctx.stripPrefix(symb)
 	var symbolized []byte
 	s := bufio.NewScanner(bytes.NewReader(rep.Report))
 	prefix := rep.reportPrefixLen
 	for s.Scan() {
 		line := append([]byte{}, s.Bytes()...)
 		line = append(line, '\n')
-		newLine := symbolizeLine(symb.Symbolize, ctx.symbols, ctx.vmlinux, strip, line)
+		newLine := symbolizeLine(symb.Symbolize, ctx.symbols, ctx.vmlinux, ctx.kernelBuildSrc, line)
 		if prefix > len(symbolized) {
 			prefix += len(newLine) - len(line)
 		}
@@ -353,33 +352,6 @@ func (ctx *linux) symbolize(rep *Report) error {
 	rep.Report = symbolized
 	rep.reportPrefixLen = prefix
 	return nil
-}
-
-func (ctx *linux) stripPrefix(symb *symbolizer.Symbolizer) string {
-	// Vmlinux may have been moved, so check if we can find debug info
-	// for some known functions and infer correct strip prefix from it.
-	knownSymbols := []struct {
-		symbol string
-		file   string
-	}{
-		{"__sanitizer_cov_trace_pc", "kernel/kcov.c"},
-		{"__asan_load1", "mm/kasan/kasan.c"},
-		{"start_kernel", "init/main.c"},
-	}
-	for _, s := range knownSymbols {
-		for _, covSymb := range ctx.symbols[s.symbol] {
-			frames, _ := symb.Symbolize(ctx.vmlinux, covSymb.Addr)
-			if len(frames) > 0 {
-				file := frames[len(frames)-1].File
-				if idx := strings.Index(file, s.file); idx != -1 {
-					return file[:idx]
-				}
-			}
-		}
-	}
-	// Strip vmlinux location from all paths.
-	strip, _ := filepath.Abs(ctx.vmlinux)
-	return filepath.Dir(strip) + string(filepath.Separator)
 }
 
 func symbolizeLine(symbFunc func(bin string, pc uint64) ([]symbolizer.Frame, error),

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -17,11 +17,12 @@ import (
 )
 
 type netbsd struct {
-	kernelSrc    string
-	kernelObj    string
-	kernelObject string
-	symbols      map[string][]symbolizer.Symbol
-	ignores      []*regexp.Regexp
+	kernelSrc      string
+	kernelBuildSrc string
+	kernelObj      string
+	kernelObject   string
+	symbols        map[string][]symbolizer.Symbol
+	ignores        []*regexp.Regexp
 }
 
 var (
@@ -33,7 +34,7 @@ var (
 	}
 )
 
-func ctorNetbsd(target *targets.Target, kernelSrc, kernelObj string,
+func ctorNetbsd(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	var symbols map[string][]symbolizer.Symbol
 	ignores = append(ignores, regexp.MustCompile("event_init: unable to initialize")) // postfix output
@@ -47,11 +48,12 @@ func ctorNetbsd(target *targets.Target, kernelSrc, kernelObj string,
 		}
 	}
 	ctx := &netbsd{
-		kernelSrc:    kernelSrc,
-		kernelObj:    kernelObj,
-		kernelObject: kernelObject,
-		symbols:      symbols,
-		ignores:      ignores,
+		kernelSrc:      kernelSrc,
+		kernelBuildSrc: kernelBuildSrc,
+		kernelObj:      kernelObj,
+		kernelObject:   kernelObject,
+		symbols:        symbols,
+		ignores:        ignores,
 	}
 	return ctx, nil, nil
 }
@@ -134,7 +136,7 @@ func (ctx *netbsd) symbolizeLine(symbFunc func(bin string, pc uint64) ([]symboli
 	// and line numbers.
 	for _, frame := range frames {
 		file := frame.File
-		file = strings.TrimPrefix(file, ctx.kernelSrc)
+		file = strings.TrimPrefix(file, ctx.kernelBuildSrc)
 		file = strings.TrimPrefix(file, "/")
 		info := fmt.Sprintf(" %v:%v", file, frame.Line)
 		modified := append([]byte{}, line...)

--- a/pkg/report/netbsd_test.go
+++ b/pkg/report/netbsd_test.go
@@ -82,11 +82,11 @@ func TestNetbsdSymbolizeLine(t *testing.T) {
 		}
 	}
 	nbsd := netbsd{
-		kernelSrc:    "netbsd/src",
-		kernelBuildSrc:    "netbsd/src",
-		kernelObj:    "/netbsd/src/obj/sys/arch/amd64/compile/GENERIC",
-		kernelObject: "netbsd.gdb",
-		symbols:      symbols,
+		kernelSrc:      "netbsd/src",
+		kernelBuildSrc: "netbsd/src",
+		kernelObj:      "/netbsd/src/obj/sys/arch/amd64/compile/GENERIC",
+		kernelObject:   "netbsd.gdb",
+		symbols:        symbols,
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/report/netbsd_test.go
+++ b/pkg/report/netbsd_test.go
@@ -83,6 +83,7 @@ func TestNetbsdSymbolizeLine(t *testing.T) {
 	}
 	nbsd := netbsd{
 		kernelSrc:    "netbsd/src",
+		kernelBuildSrc:    "netbsd/src",
 		kernelObj:    "/netbsd/src/obj/sys/arch/amd64/compile/GENERIC",
 		kernelObject: "netbsd.gdb",
 		symbols:      symbols,

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -17,11 +17,12 @@ import (
 )
 
 type openbsd struct {
-	kernelSrc    string
-	kernelObj    string
-	kernelObject string
-	symbols      map[string][]symbolizer.Symbol
-	ignores      []*regexp.Regexp
+	kernelSrc      string
+	kernelBuildSrc string
+	kernelObj      string
+	kernelObject   string
+	symbols        map[string][]symbolizer.Symbol
+	ignores        []*regexp.Regexp
 }
 
 var (
@@ -33,7 +34,7 @@ var (
 	}
 )
 
-func ctorOpenbsd(target *targets.Target, kernelSrc, kernelObj string,
+func ctorOpenbsd(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	var symbols map[string][]symbolizer.Symbol
 	kernelObject := ""
@@ -46,11 +47,12 @@ func ctorOpenbsd(target *targets.Target, kernelSrc, kernelObj string,
 		}
 	}
 	ctx := &openbsd{
-		kernelSrc:    kernelSrc,
-		kernelObj:    kernelObj,
-		kernelObject: kernelObject,
-		symbols:      symbols,
-		ignores:      ignores,
+		kernelSrc:      kernelSrc,
+		kernelBuildSrc: kernelBuildSrc,
+		kernelObj:      kernelObj,
+		kernelObject:   kernelObject,
+		symbols:        symbols,
+		ignores:        ignores,
 	}
 	return ctx, nil, nil
 }
@@ -124,7 +126,7 @@ func (ctx *openbsd) symbolizeLine(symbFunc func(bin string, pc uint64) ([]symbol
 	var symbolized []byte
 	for _, frame := range frames {
 		file := frame.File
-		file = strings.TrimPrefix(file, ctx.kernelSrc)
+		file = strings.TrimPrefix(file, ctx.kernelBuildSrc)
 		file = strings.TrimPrefix(file, "/")
 		info := fmt.Sprintf(" %v:%v", file, frame.Line)
 		modified := append([]byte{}, line...)

--- a/pkg/report/openbsd_test.go
+++ b/pkg/report/openbsd_test.go
@@ -82,11 +82,11 @@ func TestOpenbsdSymbolizeLine(t *testing.T) {
 		}
 	}
 	obsd := openbsd{
-		kernelSrc:    "/usr/src",
-		kernelBuildSrc:    "/usr/src",
-		kernelObj:    "/usr/src/sys/arch/amd64/compile/SYZKALLER/obj",
-		kernelObject: "bsd.gdb",
-		symbols:      symbols,
+		kernelSrc:      "/usr/src",
+		kernelBuildSrc: "/usr/src",
+		kernelObj:      "/usr/src/sys/arch/amd64/compile/SYZKALLER/obj",
+		kernelObject:   "bsd.gdb",
+		symbols:        symbols,
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/report/openbsd_test.go
+++ b/pkg/report/openbsd_test.go
@@ -83,6 +83,7 @@ func TestOpenbsdSymbolizeLine(t *testing.T) {
 	}
 	obsd := openbsd{
 		kernelSrc:    "/usr/src",
+		kernelBuildSrc:    "/usr/src",
 		kernelObj:    "/usr/src/sys/arch/amd64/compile/SYZKALLER/obj",
 		kernelObject: "bsd.gdb",
 		symbols:      symbols,

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -98,7 +98,7 @@ func NewReporter(cfg *mgrconfig.Config) (Reporter, error) {
 	if target == nil && typ != "gvisor" {
 		return nil, fmt.Errorf("unknown target %v/%v", cfg.TargetOS, cfg.TargetArch)
 	}
-	rep, suppressions, err := ctor(target, cfg.KernelSrc, cfg.KernelObj, ignores)
+	rep, suppressions, err := ctor(target, cfg.KernelSrc, cfg.KernelBuildSrc, cfg.KernelObj, ignores)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ var ctors = map[string]fn{
 	"windows": ctorStub,
 }
 
-type fn func(*targets.Target, string, string, []*regexp.Regexp) (Reporter, []string, error)
+type fn func(*targets.Target, string, string, string, []*regexp.Regexp) (Reporter, []string, error)
 
 func compileRegexps(list []string) ([]*regexp.Regexp, error) {
 	compiled := make([]*regexp.Regexp, len(list))

--- a/pkg/report/stub.go
+++ b/pkg/report/stub.go
@@ -15,7 +15,7 @@ type stub struct {
 	ignores   []*regexp.Regexp
 }
 
-func ctorStub(target *targets.Target, kernelSrc, kernelObj string,
+func ctorStub(target *targets.Target, kernelSrc, kernelBuildSrc, kernelObj string,
 	ignores []*regexp.Regexp) (Reporter, []string, error) {
 	ctx := &stub{
 		kernelSrc: kernelSrc,

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -39,7 +39,8 @@ func initCover(kernelObj, kernelObjName, kernelSrc, kernelBuildSrc, arch, OS str
 	return err
 }
 
-func generateCoverHTML(w io.Writer, kernelObj, kernelObjName, kernelSrc, arch, kernelBuildSrc, OS string, cov cover.Cover) error {
+func generateCoverHTML(w io.Writer, kernelObj, kernelObjName, kernelSrc, arch,
+	kernelBuildSrc, OS string, cov cover.Cover) error {
 	if len(cov) == 0 {
 		return fmt.Errorf("no coverage data available")
 	}

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -25,13 +25,13 @@ var (
 	reportGenerator   *cover.ReportGenerator
 )
 
-func initCover(kernelObj, kernelObjName, kernelSrc, arch, OS string) error {
+func initCover(kernelObj, kernelObjName, kernelSrc, kernelBuildSrc, arch, OS string) error {
 	if kernelObj == "" {
 		return fmt.Errorf("kernel_obj is not specified")
 	}
 	vmlinux := filepath.Join(kernelObj, kernelObjName)
 	var err error
-	reportGenerator, err = cover.MakeReportGenerator(vmlinux, kernelSrc, arch)
+	reportGenerator, err = cover.MakeReportGenerator(vmlinux, kernelSrc, kernelBuildSrc, arch)
 	if err != nil {
 		return err
 	}
@@ -39,11 +39,11 @@ func initCover(kernelObj, kernelObjName, kernelSrc, arch, OS string) error {
 	return err
 }
 
-func generateCoverHTML(w io.Writer, kernelObj, kernelObjName, kernelSrc, arch, OS string, cov cover.Cover) error {
+func generateCoverHTML(w io.Writer, kernelObj, kernelObjName, kernelSrc, arch, kernelBuildSrc, OS string, cov cover.Cover) error {
 	if len(cov) == 0 {
 		return fmt.Errorf("no coverage data available")
 	}
-	initCoverOnce.Do(func() { initCoverError = initCover(kernelObj, kernelObjName, kernelSrc, arch, OS) })
+	initCoverOnce.Do(func() { initCoverError = initCover(kernelObj, kernelObjName, kernelSrc, kernelBuildSrc, arch, OS) })
 	if initCoverError != nil {
 		return initCoverError
 	}

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -265,7 +265,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := generateCoverHTML(w, mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
-		mgr.cfg.KernelSrc, mgr.cfg.TargetVMArch, mgr.cfg.TargetOS, cov); err != nil {
+		mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc, mgr.cfg.TargetVMArch, mgr.cfg.TargetOS, cov); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -417,7 +417,7 @@ func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 
 	initCoverOnce.Do(func() {
 		initCoverError = initCover(mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
-			mgr.cfg.KernelSrc, mgr.cfg.TargetArch, mgr.cfg.TargetOS)
+			mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc, mgr.cfg.TargetArch, mgr.cfg.TargetOS)
 	})
 	if initCoverError != nil {
 		http.Error(w, initCoverError.Error(), http.StatusInternalServerError)

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -37,7 +37,6 @@ func main() {
 		flagOS             = flag.String("os", runtime.GOOS, "target os")
 		flagArch           = flag.String("arch", runtime.GOARCH, "target arch")
 		flagKernelSrc      = flag.String("kernel_src", "", "path to kernel sources")
-		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
 		flagKernelBuildSrc = flag.String("kernel_build_src", "", "path to kernel image's build dir (optional)")
 		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
 	)

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -34,10 +34,12 @@ import (
 
 func main() {
 	var (
-		flagOS        = flag.String("os", runtime.GOOS, "target os")
-		flagArch      = flag.String("arch", runtime.GOARCH, "target arch")
-		flagKernelSrc = flag.String("kernel_src", "", "path to kernel sources")
-		flagKernelObj = flag.String("kernel_obj", "", "path to kernel build/obj dir")
+		flagOS             = flag.String("os", runtime.GOOS, "target os")
+		flagArch           = flag.String("arch", runtime.GOARCH, "target arch")
+		flagKernelSrc      = flag.String("kernel_src", "", "path to kernel sources")
+		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
+		flagKernelBuildSrc = flag.String("kernel_build_src", "", "path to kernel image's build dir (optional)")
+		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
 	)
 	flag.Parse()
 
@@ -52,6 +54,9 @@ func main() {
 	if *flagKernelObj == "" {
 		*flagKernelObj = *flagKernelSrc
 	}
+	if *flagKernelBuildSrc == "" {
+		*flagKernelBuildSrc = *flagKernelSrc
+	}
 	target := targets.Get(*flagOS, *flagArch)
 	if target == nil {
 		failf("unknown target %v/%v", *flagOS, *flagArch)
@@ -61,7 +66,7 @@ func main() {
 		failf("%v", err)
 	}
 	kernelObj := filepath.Join(*flagKernelObj, target.KernelObject)
-	rg, err := cover.MakeReportGenerator(kernelObj, *flagKernelSrc, *flagArch)
+	rg, err := cover.MakeReportGenerator(kernelObj, *flagKernelSrc, *flagKernelBuildSrc, *flagArch)
 	if err != nil {
 		failf("%v", err)
 	}


### PR DESCRIPTION

1. Added a new config parameter - KernelBuildSrc (Defaults to KernelSrc if not added)
2. Now trims prefixes in pkg/cover based on KernelBuildSrc
3. Pass the KernelBuildSrc to all the pkg/report constructors
4. Modify the report shortening to be based on KernelBuildSrc instead of KernelSrc 

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
