### PR TITLE
dashboard/app: remove duplicate code inside bug.html template

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -25,75 +25,8 @@ Page with details about a single bug.
 	{{end}}
 	First crash: {{formatLateness $.Now $.Bug.FirstTime}}, last: {{formatLateness $.Now $.Bug.LastTime}}<br>
 
-	{{with $bisect := .BisectCause}}<br>
-		{{if $bisect.ErrorLink}}
-			<b>Bisection: {{link $bisect.ErrorLink "error"}}
-			({{link $bisect.LogLink "bisect log"}})</b><br>
-		{{else if $bisect.Commit}}{{with $com := $bisect.Commit}}
-			<b>Bisection: introduced by
-			({{link $bisect.LogLink "bisect log"}}):</b><br>
-			<br><span class="mono">
-			commit {{$com.Hash}}<br>
-			Author: {{$com.Author}}<br>
-			Date:   {{formatKernelTime $com.Date}}<br>
-			<br>
-			&nbsp;&nbsp;{{$com.Title}}<br>
-			</span><br>
-		{{end}}{{else if $bisect.Commits}}{{with $bisect.Commits}}
-			<b>Bisection: the first bad commit could be any of
-			({{link $bisect.LogLink "bisect log"}}):</b><br>
-			<br><span class="mono">
-			{{range $com := $bisect.Commits}}
-				&nbsp;&nbsp;{{formatTagHash $com.Hash}} {{$com.Title}}<br>
-			{{end}}
-			</span><br>
-		{{end}}{{else}}
-			<b>Bisection: the bug happens on the oldest tested release
-			({{link $bisect.LogLink "bisect log"}})</b><br>
-		{{end}}
-		Tree: <span title="{{$bisect.Manager}}">{{$bisect.KernelAlias}}</span><br>
-		{{if $bisect.CrashLogLink}}
-			Crash: {{link $bisect.CrashReportLink $bisect.CrashTitle}} ({{link $bisect.CrashLogLink "log"}})<br>
-		{{end}}
-		Repro: {{optlink $bisect.Crash.ReproCLink "C"}}
-			{{optlink $bisect.Crash.ReproSyzLink "syz"}}
-			{{optlink $bisect.Crash.KernelConfigLink ".config"}}<br>
-	{{end}}
-
-	{{with $bisect := .BisectFix}}<br>
-		{{if $bisect.ErrorLink}}
-			<b>Bisection: {{link $bisect.ErrorLink "error"}}
-			({{link $bisect.LogLink "bisect log"}})</b><br>
-		{{else if $bisect.Commit}}{{with $com := $bisect.Commit}}
-			<b>Bisection: fixed by
-			({{link $bisect.LogLink "bisect log"}}):</b><br>
-			<br><span class="mono">
-			commit {{$com.Hash}}<br>
-			Author: {{$com.Author}}<br>
-			Date:   {{formatKernelTime $com.Date}}<br>
-			<br>
-			&nbsp;&nbsp;{{$com.Title}}<br>
-			</span><br>
-		{{end}}{{else if $bisect.Commits}}{{with $bisect.Commits}}
-			<b>Bisection: the fix commit could be any of
-			({{link $bisect.LogLink "bisect log"}}):</b><br>
-			<br><span class="mono">
-			{{range $com := $bisect.Commits}}
-				&nbsp;&nbsp;{{formatTagHash $com.Hash}} {{$com.Title}}<br>
-			{{end}}
-			</span><br>
-		{{end}}{{else}}
-			<b>Bisection: the bug occurs on the newest tested release
-			({{link $bisect.LogLink "bisect log"}})</b><br>
-		{{end}}
-		Tree: <span title="{{$bisect.Manager}}">{{$bisect.KernelAlias}}</span><br>
-		{{if $bisect.CrashLogLink}}
-			Crash: {{link $bisect.CrashReportLink $bisect.CrashTitle}} ({{link $bisect.CrashLogLink "log"}})<br>
-		{{end}}
-		Repro: {{optlink $bisect.Crash.ReproCLink "C"}}
-			{{optlink $bisect.Crash.ReproSyzLink "syz"}}
-			{{optlink $bisect.Crash.KernelConfigLink ".config"}}<br>
-	{{end}}
+	{{template "bisect_results" .BisectCause}}
+	{{template "bisect_results" .BisectFix}}
 
 	{{template "bug_list" .DupOf}}
 	{{template "bug_list" .Dups}}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -223,3 +223,54 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	</span>
 {{end}}
 {{end}}
+
+{{/* Show bisection results */}}
+{{define "bisect_results"}}
+{{if .}}
+	{{$causeJob := 1}}
+	{{$fixJob := 2}}
+	{{if .ErrorLink}}
+		<b>Bisection: {{link .ErrorLink "error"}}
+		({{link .LogLink "bisect log"}})</b><br>
+	{{else if .Commit}}
+		{{if eq .Type $causeJob}}
+			<b>Bisection: introduced by
+		{{else if eq .Type $fixJob}}
+			<b>Bisection: fixed by
+		{{end}}
+		({{link .LogLink "bisect log"}}):</b><br>
+		<br><span class="mono">
+		commit {{.Commit.Hash}}<br>
+		Author: {{.Commit.Author}}<br>
+		Date:   {{formatKernelTime .Commit.Date}}<br>
+		<br>
+		&nbsp;&nbsp;{{.Commit.Title}}<br>
+		</span><br>
+	{{else if .Commits}}
+		{{if eq .Type $causeJob}}
+			<b>Bisection: the cause commit could be any of
+		{{else if eq .Type $fixJob}}
+			<b>Bisection: the fix commit could be any of
+		{{end}}
+		({{link .LogLink "bisect log"}}):</b><br>
+		<br><span class="mono">
+		{{range $com := .Commits}}
+			&nbsp;&nbsp;{{formatTagHash $com.Hash}} {{$com.Title}}<br>
+		{{end}}
+	{{else}}
+		{{if eq .Type $causeJob}}
+			<b>Bisection: the bug happens on the oldest tested release
+		{{else if eq .Type $fixJob}}
+			<b>Bisection: the fix commit could be any of
+		{{end}}
+		</span><br>
+	{{end}}
+	Tree: <span title="{{.Manager}}">{{.KernelAlias}}</span><br>
+	{{if .CrashLogLink}}
+		Crash: {{link .CrashReportLink .CrashTitle}} ({{link .CrashLogLink "log"}})<br>
+		Repro: {{optlink .Crash.ReproCLink "C"}}
+		{{optlink .Crash.ReproSyzLink "syz"}}
+		{{optlink .Crash.KernelConfigLink ".config"}}<br>
+	{{end}}
+{{end}}
+{{end}}


### PR DESCRIPTION
* Introduce "bisect_results" inside templates.html to take in a uiJob and shows its contents.
* Modify bug.html to use "bisect_results" to show BisectCause and BisectFix uiJob.