### PR TITLE
dashboard/config: enable VFSLCKDEBUG on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -4,6 +4,7 @@ pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
 option SPLASSERT_WATCH
+option VFSLCKDEBUG
 option WITNESS
 option WITNESS_LOCKTRACE
 option WITNESS_WATCH

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -4,3 +4,4 @@ pseudo-device kcov 1
 
 option LOCKF_DIAGNOSTIC
 option SPLASSERT_WATCH
+option VFSLCKDEBUG


### PR DESCRIPTION
In order to assert that vnodes are locked when needed.