### PR TITLE
fuzzit.sh: migrate syzkaller to new org and introduce regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 workdir*
 
 bin/
+
+# jetbrains goland
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 dist: xenial
-
+services:
+  - docker
 go:
   - "1.11"
   - "1.12"
@@ -34,8 +35,16 @@ after_failure:
 
 jobs:
   include:
-    - stage: fuzzit.dev
-      if: branch = master AND type IN (push)
+    - stage: fuzzit.dev (regression)
+      if: branch = master AND type IN (pull_request)
       go: 1.12.x
       script:
-        - ./fuzzit.sh
+        - ./fuzzit.sh regression
+
+    - stage: fuzzit.dev (fuzzing)
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      env:
+        secure: "TEXvLRUk/cmNwksHLTihVVyBWoU76EhAXkCCdLbn1FtfqCOzzMnQm02oUYcufLrVWIuVDUEUa9Tq+BrS2LGN2oTJEzk8bdQxeiztiRwbPocRLY3y3BNWWk89Vvu/eC/nPPoeRKZ7k3VZDbAk/+cPyXNMVaxBO7rwMqrne90txgTunX9V7U9Rr7b2phECBEF+riWtO3kWumZZG9qGq6NRmEcsoMOHgF2WGmxeAkAaU8xKdYOYbbUIns3cSf+bGWnFKOxSDkVDOOyKxdAc6OufejbGU4rjspty6ueXaoL69Rq5+7GOUflqLTMO8WUhpc65DPY3+9G2iH1p7U4v10Vk2V6qbQw83DDeucjSH23zIbNkjjYHSV5IMNwAMcEG5fwANfmnmQeVQCJJkwRBZufD1T+CLf9gqVldLG9qUGPI+ySli2J0oVAQ1rvMhKgR44Ipb3FQm0XBYhYXa3i08ojVXEtG8PNGHgrmOJnhUzC/BA+m9QKncxqMuISsBdlRnuU37DD0HeHZ6NTWvGy7gv2mhnCHc7AWuveBsc3XDvSfK8U3tB9LxS2OdRKWQdhnJBKowjAZ55lvTP0AgagQL+mPBQ7qJ2N8OT/oDRtN6tkY+DIEi8JTie0XOitNbY9AaF4hRFcixpesthvTEdOzx//mURXZXiPYQwyrjf9u1dwEpfA="
+      script:
+        - ./fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # syzkaller - kernel fuzzer
 
 [![Build Status](https://travis-ci.org/google/syzkaller.svg?branch=master)](https://travis-ci.org/google/syzkaller)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=syzkaller=master)](https://fuzzit.dev)
 [![Go Report Card](https://goreportcard.com/badge/github.com/google/syzkaller)](https://goreportcard.com/report/github.com/google/syzkaller)
 [![Coverage Status](https://codecov.io/gh/google/syzkaller/graph/badge.svg)](https://codecov.io/gh/google/syzkaller)
 [![GoDoc](https://godoc.org/github.com/google/syzkaller?status.svg)](https://godoc.org/github.com/google/syzkaller)

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -2,6 +2,7 @@
 # Copyright 2019 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+
 # Helper script for working with fuzzit.dev
 # https://github.com/fuzzitdev/example-go
 
@@ -10,16 +11,21 @@ set -eux
 function target {
 	go-fuzz-build -libfuzzer -func $3 -o fuzzer.a $2
 	clang -fsanitize=fuzzer fuzzer.a -o fuzzer
-	./fuzzit create job --type fuzzing --branch $TRAVIS_BRANCH --revision $TRAVIS_COMMIT $1 ./fuzzer
+	./fuzzit create job $LOCAL --type fuzzing --branch $TRAVIS_BRANCH --revision $TRAVIS_COMMIT syzkaller/$1 ./fuzzer
 }
 
 go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
-wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v1.2.7/fuzzit_Linux_x86_64
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.12/fuzzit_Linux_x86_64
 chmod a+x fuzzit
-./fuzzit auth ${FUZZIT_API_KEY}
+if [ "$1" = "fuzzing" ]; then
+    ./fuzzit auth ${FUZZIT_API_KEY}
+    export LOCAL=""
+else
+    export LOCAL="--local"
+fi
 
-target QOmcj5QL4FVtUWV2UmhG ./prog/test FuzzDeserialize
-target ddurE2yrDlqpklLYgNc6 ./prog/test FuzzParseLog
-target 4A7DVc22Gni7tUtZBc19 ./pkg/compiler Fuzz
-target YMCIxz61XkKWaB4jmiS5 ./pkg/report Fuzz
-target 1d75bUDf9zNQz1HgHyM0 ./tools/syz-trace2syz/proggen Fuzz
+target syzkaller-prog-deserialize ./prog/test FuzzDeserialize
+target syzkaller-prog-parselog ./prog/test FuzzParseLog
+target syzkaller-compiler ./pkg/compiler Fuzz
+target syzkaller-report ./pkg/report Fuzz
+target syzkaller-trace2syz ./tools/syz-trace2syz/proggen Fuzz


### PR DESCRIPTION
The fuzzers now run on every new code that is pushed to master

Regression using the generated corpus from the above step is
run locally in the travis. This should fail the travis if new
or old bugs are introduce and thus help catch bugs earlier.

To reproduce locally you can run

./fuzzit create job --local syzkaller/target-name $PATH_TO_LIBFUZZER_TARGET

@dvyukov 

