### PR TITLE
dashboard: allow to view bugs happened on a particular manager

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -89,7 +89,7 @@ type Bug struct {
 	Reporting      []BugReporting
 	Commits        []string // titles of fixing commmits
 	CommitInfo     []Commit // additional info for commits (for historical reasons parallel array to Commits)
-	HappenedOn     []string `datastore:",noindex"` // list of managers
+	HappenedOn     []string // list of managers
 	PatchedOn      []string `datastore:",noindex"` // list of managers
 	UNCC           []string // don't CC these emails on this bug
 }

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -18,6 +18,17 @@ indexes:
 - kind: Bug
   properties:
   - name: Namespace
+  - name: HappenedOn
+
+- kind: Bug
+  properties:
+  - name: Namespace
+  - name: Status
+  - name: HappenedOn
+
+- kind: Bug
+  properties:
+  - name: Namespace
   - name: Title
   - name: Seq
     direction: desc


### PR DESCRIPTION
As a result all bugs from the ci2-upstream-usb instance can be viewed here:

https://syzkaller.appspot.com/upstream?manager=ci2-upstream-usb
