### PR TITLE
dashboard/app: allow reporting of BisectFix results

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -551,17 +551,14 @@ func pollCompletedJobs(c context.Context, typ string) ([]*dashapi.BugReport, err
 			log.Criticalf(c, "no reporting for job %v", extJobID(keys[i]))
 			continue
 		}
-		// TODO: this is temporary and will be removed once support for sending
-		// JobBisectFix result emails is implemented.
-		if job.Type == JobBisectFix {
-			continue
-		}
 		reporting := config.Namespaces[job.Namespace].ReportingByName(job.Reporting)
 		if reporting.Config.Type() != typ {
 			continue
 		}
 		// TODO: this is temporal for gradual bisection rollout.
 		// Notify only about successful bisection for now.
+		// Note: If BisectFix results in a crash on HEAD, no notification is sent out. The following
+		// check also accounts for that condition.
 		if !appengine.IsDevAppServer() && job.Type != JobTestPatch && len(job.Commits) != 1 {
 			continue
 		}
@@ -675,6 +672,7 @@ func bisectFromJob(c context.Context, rep *dashapi.BugReport, job *Job) *dashapi
 		LogLink:         externalLink(c, textLog, job.Log),
 		CrashLogLink:    externalLink(c, textCrashLog, job.CrashLog),
 		CrashReportLink: externalLink(c, textCrashReport, job.CrashReport),
+		Fix:             job.Type == JobBisectFix,
 	}
 	for _, com := range job.Commits {
 		bisect.Commits = append(bisect.Commits, &dashapi.Commit{

--- a/dashboard/app/mail_bisect_result.txt
+++ b/dashboard/app/mail_bisect_result.txt
@@ -1,27 +1,33 @@
-{{if .BisectCause.Commit}}syzbot has bisected this bug to:
+{{with $br := .}}{{with $bisect := selectBisect .}}{{if $bisect.Commit}}{{if $bisect.Fix}}syzbot suspects this bug was fixed by commit:
+{{else}}syzbot has bisected this bug to:
+{{end}}
+commit {{$bisect.Commit.Hash}}
+Author: {{$bisect.Commit.AuthorName}} <{{$bisect.Commit.Author}}>
+Date:   {{formatKernelTime $bisect.Commit.Date}}
 
-commit {{.BisectCause.Commit.Hash}}
-Author: {{.BisectCause.Commit.AuthorName}} <{{.BisectCause.Commit.Author}}>
-Date:   {{formatKernelTime .BisectCause.Commit.Date}}
-
-    {{.BisectCause.Commit.Title}}
-{{else if .BisectCause.Commits}}Bisection is inconclusive: the first bad commit could be any of:
-{{range $com := .BisectCause.Commits}}
+    {{$bisect.Commit.Title}}
+{{else if $bisect.Commits}}Bisection is inconclusive: the {{if $bisect.Fix}}fix{{else}}first bad{{end}} commit could be any of:
+{{range $com := $bisect.Commits}}
 {{formatShortHash $com.Hash}} {{$com.Title}}{{end}}
-{{else}}Bisection is inconclusive: the bug happens on the oldest tested release.
+{{else}}Bisection is inconclusive: the bug happens on the {{if $bisect.Fix}}latest{{else}}oldest{{end}} tested release.
 {{end}}
-bisection log:  {{.BisectCause.LogLink}}
-start commit:   {{formatShortHash .KernelCommit}} {{formatCommitTableTitle .KernelCommitTitle}}
-git tree:       {{.KernelRepoAlias}}
-{{if .BisectCause.CrashReportLink}}final crash:    {{.BisectCause.CrashReportLink}}
-{{end}}{{if .BisectCause.CrashLogLink}}console output: {{.BisectCause.CrashLogLink}}
-{{end}}{{if .KernelConfigLink}}kernel config:  {{.KernelConfigLink}}
-{{end}}dashboard link: {{.Link}}
-{{if .UserSpaceArch}}userspace arch: {{.UserSpaceArch}}
-{{end}}{{if .ReproSyzLink}}syz repro:      {{.ReproSyzLink}}
-{{end}}{{if .ReproCLink}}C reproducer:   {{.ReproCLink}}
-{{end}}{{if .BisectCause.Commit}}
-Reported-by: {{.CreditEmail}}
-Fixes: {{formatTagHash .BisectCause.Commit.Hash}} ("{{.BisectCause.Commit.Title}}")
-{{end}}
+bisection log:  {{$bisect.LogLink}}
+start commit:   {{formatShortHash $br.KernelCommit}} {{formatCommitTableTitle $br.KernelCommitTitle}}
+git tree:       {{$br.KernelRepoAlias}}
+{{if $bisect.CrashReportLink}}final crash:    {{$bisect.CrashReportLink}}
+{{end}}{{if $bisect.CrashLogLink}}console output: {{$bisect.CrashLogLink}}
+{{end}}{{if $br.KernelConfigLink}}kernel config:  {{$br.KernelConfigLink}}
+{{end}}dashboard link: {{$br.Link}}
+{{if $br.UserSpaceArch}}userspace arch: {{$br.UserSpaceArch}}
+{{end}}{{if $br.ReproSyzLink}}syz repro:      {{$br.ReproSyzLink}}
+{{end}}{{if $br.ReproCLink}}C reproducer:   {{$br.ReproCLink}}
+{{end}}{{if $bisect.Fix}}
+If the bisection result looks correct, please reply with:
+
+#syz fix: fix-commit-title
+{{else}}{{if $bisect.Commit}}
+Reported-by: {{$br.CreditEmail}}
+Fixes: {{formatTagHash $bisect.Commit.Hash}} ("{{$bisect.Commit.Title}}")
+{{end}}{{end}}
 For information about bisection process see: https://goo.gl/tpsmEJ#bisection
+{{end}}{{end}}

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -269,6 +269,10 @@ func incomingMail(c context.Context, r *http.Request) error {
 		log.Warningf(c, "failed to parse email: %v", err)
 		return nil
 	}
+	// Ignore any incoming emails from syzbot itself.
+	if ownEmail(c) == msg.From {
+		return nil
+	}
 	log.Infof(c, "received email: subject %q, from %q, cc %q, msg %q, bug %q, cmd %q, link %q",
 		msg.Subject, msg.From, msg.Cc, msg.MessageID, msg.BugID, msg.Command, msg.Link)
 	if msg.Command == email.CmdFix && msg.CommandArgs == "exact-commit-title" {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -332,6 +332,7 @@ type BisectResult struct {
 	LogLink         string
 	CrashLogLink    string
 	CrashReportLink string
+	Fix             bool
 }
 
 type BugUpdate struct {

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -51,6 +51,14 @@ var Funcs = template.FuncMap{
 	"formatTagHash":          formatTagHash,
 	"formatCommitTableTitle": formatCommitTableTitle,
 	"formatList":             formatStringList,
+	"selectBisect":           selectBisect,
+}
+
+func selectBisect(rep *dashapi.BugReport) *dashapi.BisectResult {
+	if rep.BisectFix != nil {
+		return rep.BisectFix
+	}
+	return rep.BisectCause
 }
 
 func link(url, text string) template.HTML {


### PR DESCRIPTION
* Modify mail_bisect_result.txt to allow for sending fix bisection results.
* Modify BisectResult to have a Fix field; introduce selectBisect for use within the template for choosing between BisectCause/BisectFix fields.
* Modify bisectFromJob() to return BisectResult with Fix field set if relevant.
* Modify the tests inside bisect_test.go to account for bisect fix related reporting emails.
* Modify incomingMail() to ignore any emails from syzbot itself.