### PR TITLE
pkg/report: ignore exceeded race limits

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -27,6 +27,7 @@ func ctorGvisor(cfg *config) (Reporter, []string, error) {
 		"panic: failed to start executor binary",
 		"panic: executor failed: pthread_create failed",
 		"panic: error mapping run data: error mapping runData: cannot allocate memory",
+		"race: limit on 8128 simultaneously alive goroutines is exceeded, dying",
 		"ERROR: ThreadSanitizer", // Go race failing due to OOM.
 		"FATAL: ThreadSanitizer",
 	}


### PR DESCRIPTION
If syzkaller creates >8128 active threads, then we will exceed this goroutine limit.
