### PR TITLE
sys/targets: Change CCompiler path for fuchsia.

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -243,7 +243,7 @@ var List = map[string]map[string]*Target{
 			PtrSize:          8,
 			PageSize:         4 << 10,
 			KernelHeaderArch: "x64",
-			CCompiler:        os.ExpandEnv("${SOURCEDIR}/buildtools/linux-x64/clang/bin/clang++"),
+			CCompiler:        os.ExpandEnv("${SOURCEDIR}/prebuilt/third_party/clang/linux-x64/bin/clang++"),
 			CrossCFlags: []string{
 				"-Wno-deprecated",
 				"--target=x86_64-fuchsia",
@@ -261,7 +261,7 @@ var List = map[string]map[string]*Target{
 			PtrSize:          8,
 			PageSize:         4 << 10,
 			KernelHeaderArch: "arm64",
-			CCompiler:        os.ExpandEnv("${SOURCEDIR}/buildtools/linux-x64/clang/bin/clang++"),
+			CCompiler:        os.ExpandEnv("${SOURCEDIR}/prebuilt/third_party/clang/linux-x64/bin/clang++"),
 			CrossCFlags: []string{
 				"-Wno-deprecated",
 				"--target=aarch64-fuchsia",


### PR DESCRIPTION
Recently fuchsia got rid of the buildtools/ folder, and moved some of
the stuff into the prebuilt directory.

See https://fuchsia-review.googlesource.com/c/fuchsia/+/305379 for more
info.

