### PR TITLE
snap

### DIFF
--- a/tools/snap/snapcraft.yaml
+++ b/tools/snap/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: syzkaller
+summary: kernel fuzzer.
+description: syzkaller is an unsupervised, coverage-guided kernel fuzzer.
+  
+grade: stable
+confinement: strict
+base: core18
+
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
+apps:
+  syzkaller:
+    command: bin/syzkaller
+    plugs:
+      - home
+      - network
+      - removable-media
+      
+
+parts:
+  syzkaller:
+    plugin: godeps
+    source: https://github.com/google/syzkaller.git
+    source-type: git
+    override-pull: |
+      git clone https://github.com/google/syzkaller.git src/github.com/google/syzkaller
+      cd src/github.com/google/syzkaller
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+    override-build: |
+      export GOPATH=$PWD
+      cd src/github.com/google/syzkaller
+      env CGO_ENABLED=0 GOOS=linux \
+      go build --ldflags "-s -w \
+        -X 'github.com/google/syzkaller/version.GitCommit=$(git rev-list -1 HEAD)' \
+        -X 'github.com/google/syzkaller/version.Version=$(git describe --tags --abbrev=0)'" \
+        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/syzkaller
+    build-snaps:
+      - go
+    build-packages:
+      - git
+      - sed


### PR DESCRIPTION
Added snapcraft.yaml to build a [snap](https://snapcraft.io/). Snap is supported across 41 Linux including Ubuntu/Debian and soon Windows 10 under the WSL2.
