### PR TITLE
pkg/csource: fix failing syz-runtest for NetBSD

### DIFF
--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -22,7 +22,7 @@ const (
 	linux   = "linux"
 	freebsd = "freebsd"
 	openbsd = "openbsd"
-	netbsd	= "netbsd"
+	netbsd  = "netbsd"
 
 	sandboxNone                = "none"
 	sandboxSetuid              = "setuid"

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -22,6 +22,7 @@ const (
 	linux   = "linux"
 	freebsd = "freebsd"
 	openbsd = "openbsd"
+	netbsd	= "netbsd"
 
 	sandboxNone                = "none"
 	sandboxSetuid              = "setuid"

--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -105,7 +105,7 @@ func (opts Options) checkLinuxOnly(OS string) error {
 	if OS == linux {
 		return nil
 	}
-	if opts.EnableTun && !(OS == openbsd || OS == freebsd) {
+	if opts.EnableTun && !(OS == openbsd || OS == freebsd || OS == netbsd) {
 		return fmt.Errorf("option EnableTun is not supported on %v", OS)
 	}
 	if opts.EnableNetDev {
@@ -124,7 +124,7 @@ func (opts Options) checkLinuxOnly(OS string) error {
 		return fmt.Errorf("EnableCloseFds is not supported on %v", OS)
 	}
 	if opts.Sandbox == sandboxNamespace ||
-		(opts.Sandbox == sandboxSetuid && !(OS == openbsd || OS == freebsd)) ||
+		(opts.Sandbox == sandboxSetuid && !(OS == openbsd || OS == freebsd || OS == netbsd)) ||
 		opts.Sandbox == sandboxAndroidUntrustedApp {
 		return fmt.Errorf("option Sandbox=%v is not supported on %v", opts.Sandbox, OS)
 	}


### PR DESCRIPTION

Running syz-runtest for NetBSD fails due to missing check for NetBSD. This patch seems to fix the issue.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
