### PR TITLE
pkg/report: revert bucketing MAX_STACK_TRACE_ENTRIES reports

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -967,11 +967,6 @@ var linuxOopses = []*oops{
 				},
 			},
 			{
-				title: compile("BUG: MAX_STACK_TRACE_ENTRIES too low!"),
-				fmt:   "BUG: MAX_STACK_TRACE_ENTRIES too low in %[1]v",
-				stack: warningStackFmt("save_trace", "mark_lock"),
-			},
-			{
 				title: compile("BUG: using __this_cpu_([a-z_]+)\\(\\) in preemptible"),
 				fmt:   "BUG: using __this_cpu_%[1]v() in preemptible code in %[2]v",
 				stack: &stackFmt{

--- a/pkg/report/testdata/linux/report/403
+++ b/pkg/report/testdata/linux/report/403
@@ -1,4 +1,4 @@
-TITLE: BUG: MAX_STACK_TRACE_ENTRIES too low in ucma_close
+TITLE: BUG: MAX_STACK_TRACE_ENTRIES too low!
 
 [  185.416858][  T809] BUG: MAX_STACK_TRACE_ENTRIES too low!
 [  185.422408][  T809] turning off the locking correctness validator.

--- a/pkg/report/testdata/linux/report/404
+++ b/pkg/report/testdata/linux/report/404
@@ -1,4 +1,4 @@
-TITLE: BUG: MAX_STACK_TRACE_ENTRIES too low in scsi_remove_host
+TITLE: BUG: MAX_STACK_TRACE_ENTRIES too low!
 
 [ 3167.402179][T32668] BUG: MAX_STACK_TRACE_ENTRIES too low!
 [ 3167.407738][T32668] turning off the locking correctness validator.


### PR DESCRIPTION
MAX_STACK_TRACE_ENTRIES crash reports caused by a particular issues can come
from any part of the kernel, so bucketing them based on the stack trace is
pointless and only creates duplicate bug reports.
