### PR TITLE
dashboard/app: fix typo and change reporting description

### DIFF
--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -398,9 +398,9 @@ kernel config:  %[5]v
 dashboard link: https://testapp.appspot.com/bug?extid=%[1]v
 syz repro:      %[6]v
 
-If the bisection result looks correct, please reply with:
+If the result looks correct, please mark the bug fixed by replying with:
 
-#syz fix: fix-commit-title
+#syz fix: kernel: add a fix
 
 For information about bisection process see: https://goo.gl/tpsmEJ#bisection
 `, extBugID, bisectLogLink, bisectCrashReportLink, bisectCrashLogLink, kernelConfigLink, reproSyzLink, reproCLink))

--- a/dashboard/app/mail_bisect_result.txt
+++ b/dashboard/app/mail_bisect_result.txt
@@ -22,9 +22,9 @@ git tree:       {{$br.KernelRepoAlias}}
 {{end}}{{if $br.ReproSyzLink}}syz repro:      {{$br.ReproSyzLink}}
 {{end}}{{if $br.ReproCLink}}C reproducer:   {{$br.ReproCLink}}
 {{end}}{{if $bisect.Fix}}
-If the bisection result looks correct, please reply with:
+If the result looks correct, please mark the bug fixed by replying with:
 
-#syz fix: fix-commit-title
+#syz fix: {{$bisect.Commit.Title}}
 {{else}}{{if $bisect.Commit}}
 Reported-by: {{$br.CreditEmail}}
 Fixes: {{formatTagHash $bisect.Commit.Hash}} ("{{$bisect.Commit.Title}}")


### PR DESCRIPTION
* Fix a typo in mail_bisect_result.txt related to the "syz fix:" line.
* Improve the description to make it clearer why sending a "syz fix:" is important.
