### PR TITLE
syz-ci: send build info for failed bisections

### DIFF
--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -586,7 +586,7 @@ func TestBisectCauseAncient(t *testing.T) {
 		c.expectEQ(msg.Body, fmt.Sprintf(`Bisection is inconclusive: the bug happens on the oldest tested release.
 
 bisection log:  %[2]v
-start commit:   11111111 kernel_commit_title1
+oldest commit:  11111111 kernel_commit_title1
 git tree:       repo1 branch1
 final crash:    %[3]v
 console output: %[4]v

--- a/dashboard/app/mail_bisect_result.txt
+++ b/dashboard/app/mail_bisect_result.txt
@@ -12,7 +12,7 @@ Date:   {{formatKernelTime $bisect.Commit.Date}}
 {{else}}Bisection is inconclusive: the bug happens on the {{if $bisect.Fix}}latest{{else}}oldest{{end}} tested release.
 {{end}}
 bisection log:  {{$bisect.LogLink}}
-start commit:   {{formatShortHash $br.KernelCommit}} {{formatCommitTableTitle $br.KernelCommitTitle}}
+{{if $bisect.Commit}}start commit:   {{else if $bisect.Commits}}start commit:   {{else}}{{if $bisect.Fix}}latest commit:  {{else}}oldest commit:  {{end}}{{end}}{{formatShortHash $br.KernelCommit}} {{formatCommitTableTitle $br.KernelCommitTitle}}
 git tree:       {{$br.KernelRepoAlias}}
 {{if $bisect.CrashReportLink}}final crash:    {{$bisect.CrashReportLink}}
 {{end}}{{if $bisect.CrashLogLink}}console output: {{$bisect.CrashLogLink}}

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -397,7 +397,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		Manager: *mgrcfg,
 	}
 
-	commits, rep, err := bisect.Run(cfg)
+	commits, rep, _, err := bisect.Run(cfg)
 	resp.Log = trace.Bytes()
 	if err != nil {
 		return err

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -397,7 +397,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		Manager: *mgrcfg,
 	}
 
-	commits, rep, _, err := bisect.Run(cfg)
+	commits, rep, com, err := bisect.Run(cfg)
 	resp.Log = trace.Bytes()
 	if err != nil {
 		return err
@@ -418,6 +418,12 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		resp.CrashLog = rep.Output
 		if len(resp.Commits) != 0 {
 			resp.Commits[0].CC = append(resp.Commits[0].CC, rep.Maintainers...)
+		} else {
+			// If there is a report ahd there is no commit, it means a crash
+			// occurred on HEAD(for BisectFix) and oldest tested release(for BisectCause).
+			resp.Build.KernelCommit = com.Hash
+			resp.Build.KernelCommitDate = com.Date
+			resp.Build.KernelCommitTitle = com.Title
 		}
 	}
 	return nil

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -103,7 +103,7 @@ func main() {
 	loadFile("kernel.config", &cfg.Kernel.Config)
 	loadFile("repro.syz", &cfg.Repro.Syz)
 	loadFile("repro.opts", &cfg.Repro.Opts)
-	if _, _, err := bisect.Run(cfg); err != nil {
+	if _, _, _, err := bisect.Run(cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "bisection failed: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
When fix bisections fails due to a crash on HEAD, the dashboard needs to keep track of which commit the crash occurred at. In order to do this, send correct commit information to the dashboard.
* Modify Run() to return the commit object when a failure occurs on oldest release (for BisectCause) and latest release (for BisectFix).
* Modify bisect() to set appropriate fields in dashapi.JobDoneReq.Build (KernelCommit, KernelCommitDate, KernelCommitTitle).
* Modify the mail_bisect_result.txt template to be clearer on what BisectResult.KernelCommit represents.  Modify tests in bisect_test.go to accommodate the changes in the templates.

Closes: #1367