### PR TITLE
dashboard/app: show fix bisections on bug web UI

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -37,45 +37,12 @@ Page with details about a single bug.
 	<textarea id="log_textarea" readonly rows="25" wrap=off>{{printf "%s" .SampleReport}}</textarea><br>
 	{{end}}
 
-	<table class="list_table">
-		<caption>All crashes ({{.Bug.NumCrashes}}):</caption>
-		<thead>
-		<tr>
-			<th><a onclick="return sortTable(this, 'Manager', textSort)" href="#">Manager</a></th>
-			<th><a onclick="return sortTable(this, 'Time', textSort, true)" href="#">Time</a></th>
-			<th><a onclick="return sortTable(this, 'Kernel', textSort)" href="#">Kernel</a></th>
-			<th><a onclick="return sortTable(this, 'Commit', textSort)" href="#">Commit</a></th>
-			<th><a onclick="return sortTable(this, 'Syzkaller', textSort)" href="#">Syzkaller</a></th>
-			<th><a onclick="return sortTable(this, 'Config', textSort)" href="#">Config</a></th>
-			<th><a onclick="return sortTable(this, 'Log', textSort)" href="#">Log</a></th>
-			<th><a onclick="return sortTable(this, 'Report', reproSort)" href="#">Report</a></th>
-			<th><a onclick="return sortTable(this, 'Syz repro', reproSort)" href="#">Syz repro</a></th>
-			<th><a onclick="return sortTable(this, 'C repro', textSort)" href="#">C repro</a></th>
-			{{if $.HasMaintainers}}
-			<th><a onclick="return sortTable(this, 'Maintainers', textSort)" href="#">Maintainers</a></th>
-			{{end}}
-		</tr>
-		</thead>
-		<tbody>
-		{{range $c := $.Crashes}}
-			<tr>
-				<td class="manager">{{$c.Manager}}</td>
-				<td class="time">{{formatTime $c.Time}}</td>
-				<td class="kernel" title="{{$c.KernelAlias}}">{{$c.KernelAlias}}</td>
-				<td class="tag" title="{{$c.KernelCommit}}
-{{formatTime $c.KernelCommitDate}}">{{link $c.KernelCommitLink (formatShortHash $c.KernelCommit)}}</td>
-				<td class="tag">{{link $c.SyzkallerCommitLink (formatShortHash $c.SyzkallerCommit)}}</td>
-				<td class="config">{{if $c.KernelConfigLink}}<a href="{{$c.KernelConfigLink}}">.config</a>{{end}}</td>
-				<td class="repro">{{if $c.LogLink}}<a href="{{$c.LogLink}}">log</a>{{end}}</td>
-				<td class="repro">{{if $c.ReportLink}}<a href="{{$c.ReportLink}}">report</a>{{end}}</td>
-				<td class="repro">{{if $c.ReproSyzLink}}<a href="{{$c.ReproSyzLink}}">syz</a>{{end}}</td>
-				<td class="repro">{{if $c.ReproCLink}}<a href="{{$c.ReproCLink}}">C</a>{{end}}</td>
-				{{if $.HasMaintainers}}
-				<td class="maintainers" title="{{$c.Maintainers}}">{{$c.Maintainers}}</td>
-				{{end}}
-			</tr>
-		{{end}}
-		</tbody>
-	</table>
+	{{if .FixBisections}}
+	{{if .FixBisections.Crashes}}
+		{{template "crash_list" .FixBisections}}
+	{{end}}
+	{{end}}
+
+	{{template "crash_list" .Crashes}}
 </body>
 </html>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -232,6 +232,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{end}}
 {{end}}
 
+{{/* Bisection result, invoked with *uiJob */}}
 {{/* Show bisection results */}}
 {{define "bisect_results"}}
 {{if .}}
@@ -281,5 +282,52 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{optlink .Crash.ReproSyzLink "syz"}}
 		{{optlink .Crash.KernelConfigLink ".config"}}<br>
 	{{end}}
+{{end}}
+{{end}}
+
+{{/* List of fixing commits, invoked with *uiCrashTable */}}
+{{/* Show crashes */}}
+{{define "crash_list"}}
+{{if .}}
+<table class="list_table">
+	<caption>{{.Caption}}</caption>
+		<thead>
+		<tr>
+			<th><a onclick="return sortTable(this, 'Manager', textSort)" href="#">Manager</a></th>
+			<th><a onclick="return sortTable(this, 'Time', textSort, true)" href="#">Time</a></th>
+			<th><a onclick="return sortTable(this, 'Kernel', textSort)" href="#">Kernel</a></th>
+			<th><a onclick="return sortTable(this, 'Commit', textSort)" href="#">Commit</a></th>
+			<th><a onclick="return sortTable(this, 'Syzkaller', textSort)" href="#">Syzkaller</a></th>
+			<th><a onclick="return sortTable(this, 'Config', textSort)" href="#">Config</a></th>
+			<th><a onclick="return sortTable(this, 'Log', textSort)" href="#">Log</a></th>
+			<th><a onclick="return sortTable(this, 'Report', reproSort)" href="#">Report</a></th>
+			<th><a onclick="return sortTable(this, 'Syz repro', reproSort)" href="#">Syz repro</a></th>
+			<th><a onclick="return sortTable(this, 'C repro', textSort)" href="#">C repro</a></th>
+			{{if .HasMaintainers}}
+			<th><a onclick="return sortTable(this, 'Maintainers', textSort)" href="#">Maintainers</a></th>
+			{{end}}
+		</tr>
+		</thead>
+		<tbody>
+		{{range $b := .Crashes}}
+		<tr>
+			<td class="manager">{{$b.Manager}}</td>
+			<td class="time">{{formatTime $b.Time}}</td>
+			<td class="kernel" title="{{$b.KernelAlias}}">{{$b.KernelAlias}}</td>
+			<td class="tag" title="{{$b.KernelCommit}}
+	{{formatTime $b.KernelCommitDate}}">{{link $b.KernelCommitLink (formatShortHash $b.KernelCommit)}}</td>
+			<td class="tag">{{link $b.SyzkallerCommitLink (formatShortHash $b.SyzkallerCommit)}}</td>
+			<td class="config">{{if $b.KernelConfigLink}}<a href="{{$b.KernelConfigLink}}">.config</a>{{end}}</td>
+			<td class="repro">{{if $b.LogLink}}<a href="{{$b.LogLink}}">log</a>{{end}}</td>
+			<td class="repro">{{if $b.ReportLink}}<a href="{{$b.ReportLink}}">report</a>{{end}}</td>
+			<td class="repro">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}</td>
+			<td class="repro">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
+			{{if $.HasMaintainers}}
+			<td class="maintainers" title="{{$b.Maintainers}}">{{$b.Maintainers}}</td>
+			{{end}}
+		</tr>
+		{{end}}
+		</tbody>
+</table>
 {{end}}
 {{end}}


### PR DESCRIPTION
When fix bisections fail due to crash on HEAD, the LastTime of the bug is updated so that fix bisection will be retried. However, this change alone might cause confusion to the viewer as there is no information on the UI about what the crash corresponding to LastTime is.

Fix this by listing all fix bisections if the bug.BisectFix is set to BisectNot.

Closes: #1366 