### PR TITLE
don't crash on syz_mmap failures in fuchsia + send output of syz-executor for non-forkserver oses.

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -172,8 +172,10 @@ long syz_mmap(size_t addr, size_t size)
 	zx_handle_t root = zx_vmar_root_self();
 	zx_info_vmar_t info;
 	zx_status_t status = zx_object_get_info(root, ZX_INFO_VMAR, &info, sizeof(info), 0, 0);
-	if (status != ZX_OK)
-		fail("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
+	if (status != ZX_OK) {
+		debug("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
+		return status;
+	}
 	zx_handle_t vmo;
 	status = zx_vmo_create(size, 0, &vmo);
 	if (status != ZX_OK) {
@@ -181,8 +183,10 @@ long syz_mmap(size_t addr, size_t size)
 		return status;
 	}
 	status = zx_vmo_replace_as_executable(vmo, ZX_HANDLE_INVALID, &vmo);
-	if (status != ZX_OK)
+	if (status != ZX_OK) {
+		debug("zx_vmo_replace_as_executable failed with: %d\n", status);
 		return status;
+	}
 	uintptr_t mapped_addr;
 	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
 			     addr - info.base, vmo, 0, size,

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -938,8 +938,10 @@ long syz_mmap(size_t addr, size_t size)
 	zx_handle_t root = zx_vmar_root_self();
 	zx_info_vmar_t info;
 	zx_status_t status = zx_object_get_info(root, ZX_INFO_VMAR, &info, sizeof(info), 0, 0);
-	if (status != ZX_OK)
-		fail("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
+	if (status != ZX_OK) {
+		debug("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
+		return status;
+	}
 	zx_handle_t vmo;
 	status = zx_vmo_create(size, 0, &vmo);
 	if (status != ZX_OK) {
@@ -947,8 +949,10 @@ long syz_mmap(size_t addr, size_t size)
 		return status;
 	}
 	status = zx_vmo_replace_as_executable(vmo, ZX_HANDLE_INVALID, &vmo);
-	if (status != ZX_OK)
+	if (status != ZX_OK) {
+		debug("zx_vmo_replace_as_executable failed with: %d\n", status);
 		return status;
+	}
 	uintptr_t mapped_addr;
 	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
 			     addr - info.base, vmo, 0, size,

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -584,9 +584,6 @@ func makeCommand(pid int, bin []string, config *Config, inFile, outFile *os.File
 	if config.Flags&FlagDebug != 0 {
 		close(c.readDone)
 		cmd.Stderr = os.Stdout
-	} else if config.Flags&FlagUseForkServer == 0 {
-		close(c.readDone)
-		// TODO: read out output after execution failure.
 	} else {
 		cmd.Stderr = wp
 		go func(c *command) {


### PR DESCRIPTION
syz_mmap is a pseudo-syscall that can be used by syzkaller in fuzzing
programs, however, it is also used to setup the environment for
syz-executor. syz-executor already checks the return value[0] when it is
used for setting up the environment, so it doesn't make sense for the
function to crash (most probably, in a fuzzing program it will be called
with arguments that would make it fail).

The previous behavior was causing a bunch of "Lost connection to test
machine" syzkaller crashes which were meaningless. An example of a
program in which syz_mmap would crash would be any program in which the
handle to the root vmar is closed before calling syz_mmap.

The other change reuses the logic for sending the output back from
syz-executor to syz-fuzzer that forkserver oses use: reading it
periodically. This will be useful for debugging issues in Fuchsia that
does not support forkserver yet.


[0]:
https://github.com/google/syzkaller/blob/a60cb4cd840ce786236a00480e8bb1025e0c5fef/executor/executor_fuchsia.h#L15

