### PR TITLE
pkg/osutil: fix arm build

### DIFF
--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -41,7 +41,7 @@ func RemoveAll(dir string) error {
 func SystemMemorySize() uint64 {
 	var info syscall.Sysinfo_t
 	syscall.Sysinfo(&info)
-	return info.Totalram
+	return uint64(info.Totalram) //nolint:unconvert
 }
 
 func removeImmutable(fname string) error {


### PR DESCRIPTION
pkg/osutil/osutil_linux.go:44:13: cannot use info.Totalram (type uint32) as type uint64 in return argument