### PR TITLE
sys/targets: add ASAN compiler flag to optional

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -385,6 +385,7 @@ var (
 	optionalCFlags = map[string]bool{
 		"-static":                 true, // some distributions don't have static libraries
 		"-Wunused-const-variable": true, // gcc 5 does not support this flag
+		"-fsanitize=address":      true, // some OSes don't have ASAN
 	}
 )
 


### PR DESCRIPTION
*BSD GCC doesn't have ASAN.