### PR TITLE
tools: add syz-expand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,9 @@ trace2syz:
 usbgen:
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-usbgen github.com/google/syzkaller/tools/syz-usbgen
 
+expand:
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-expand github.com/google/syzkaller/tools/syz-expand
+
 # `extract` extracts const files from various kernel sources, and may only
 # re-generate parts of files.
 extract: bin/syz-extract

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -46,19 +46,31 @@ func TestDefaultCallArgs(t *testing.T) {
 	}
 }
 
-func TestSerialize(t *testing.T) {
+func testSerialize(t *testing.T, verbose bool) {
 	target, rs, iters := initTest(t)
 	for i := 0; i < iters; i++ {
 		p := target.Generate(rs, 10, nil)
-		data := p.Serialize()
-		p1, err := target.Deserialize(data, NonStrict)
+		var data []byte
+		mode := NonStrict
+		if verbose {
+			data = p.SerializeVerbose()
+			mode = Strict
+		} else {
+			data = p.Serialize()
+		}
+		p1, err := target.Deserialize(data, mode)
 		if err != nil {
 			t.Fatalf("failed to deserialize program: %v\n%s", err, data)
 		}
 		if p1 == nil {
 			t.Fatalf("deserialized nil program:\n%s", data)
 		}
-		data1 := p1.Serialize()
+		var data1 []byte
+		if verbose {
+			data1 = p1.SerializeVerbose()
+		} else {
+			data1 = p1.Serialize()
+		}
 		if len(p.Calls) != len(p1.Calls) {
 			t.Fatalf("different number of calls")
 		}
@@ -66,6 +78,14 @@ func TestSerialize(t *testing.T) {
 			t.Fatalf("program changed after serialize/deserialize\noriginal:\n%s\n\nnew:\n%s\n", data, data1)
 		}
 	}
+}
+
+func TestSerialize(t *testing.T) {
+	testSerialize(t, false)
+}
+
+func TestSerializeVerbose(t *testing.T) {
+	testSerialize(t, true)
 }
 
 func TestVmaType(t *testing.T) {

--- a/tools/syz-expand/expand.go
+++ b/tools/syz-expand/expand.go
@@ -1,0 +1,52 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Parses a program and prints it including all default values.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+
+	"github.com/google/syzkaller/prog"
+	_ "github.com/google/syzkaller/sys"
+)
+
+var (
+	flagOS     = flag.String("os", runtime.GOOS, "target os")
+	flagArch   = flag.String("arch", runtime.GOARCH, "target arch")
+	flagProg   = flag.String("prog", "", "file with program to expand")
+	flagStrict = flag.Bool("strict", false, "parse input program in strict mode")
+)
+
+func main() {
+	flag.Parse()
+	if *flagProg == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+	target, err := prog.GetTarget(*flagOS, *flagArch)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(1)
+	}
+	data, err := ioutil.ReadFile(*flagProg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read prog file: %v\n", err)
+		os.Exit(1)
+	}
+	mode := prog.NonStrict
+	if *flagStrict {
+		mode = prog.Strict
+	}
+	p, err := target.Deserialize(data, mode)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to deserialize the program: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s", p.SerializeVerbose())
+}


### PR DESCRIPTION
The syz-expand tools allows to parse a program and print it including all
the default values. This is mainly useful for debugging, like doing manual
program modifications while trying to come up with a reproducer for some
particular kernel behavior.
