### PR TITLE
pkg/vcs: handle git commits without a body

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -160,6 +160,15 @@ func (git *git) getCommit(commit string) (*Commit, error) {
 	return gitParseCommit(output, nil, nil, git.ignoreCC)
 }
 
+func isEmpty(lines [][]byte) bool {
+	for _, line := range lines {
+		if len(line) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func gitParseCommit(output, user, domain []byte, ignoreCC map[string]bool) (*Commit, error) {
 	lines := bytes.Split(output, []byte{'\n'})
 	if len(lines) < 4 || len(lines[0]) != 40 {
@@ -173,7 +182,12 @@ func gitParseCommit(output, user, domain []byte, ignoreCC map[string]bool) (*Com
 	cc := make(map[string]bool)
 	cc[strings.ToLower(string(lines[2]))] = true
 	var tags []string
-	for _, line := range lines[5:] {
+	bodyLines := lines[5:]
+	if isEmpty(bodyLines) {
+		// Body is empty, use summary instead.
+		bodyLines = [][]byte{lines[1]}
+	}
+	for _, line := range bodyLines {
 		if user != nil {
 			userPos := bytes.Index(line, user)
 			if userPos != -1 {

--- a/pkg/vcs/git_repo_test.go
+++ b/pkg/vcs/git_repo_test.go
@@ -281,6 +281,13 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 		cc:     []string{"gregkh@linuxfoundation.org", userEmail, "zaitcev@redhat.com"},
 		tags:   []string{"f9831b881b3e849829fc"},
 	},
+	{
+		description: `Do more sanity checks when accepting socket addresses in routing messages from user land. Reported-by: syzbot+638dbf7851da8e255af5@my.mail.com`,
+		title:       "Do more sanity checks when accepting socket addresses in routing messages from user land. Reported-by: syzbot+638dbf7851da8e255af5@my.mail.com",
+		author:      userEmail,
+		cc:          []string{userEmail},
+		tags:        []string{"638dbf7851da8e255af5"},
+	},
 }
 
 func TestBisect(t *testing.T) {


### PR DESCRIPTION
OpenBSD uses cvs and does not enforce the standard Git convention for
commit messages of putting a summary followed by a new line and body.
If such commit[1] contains a `Reported-by` header, it's currently not
detected. Instead, if the body is empty try to extract data from the
commit summary.

[1] https://github.com/openbsd/src/commit/bdbfbec5cea84d24d6a598cf1e63dbdb10e8331a