### PR TITLE
pkg/report: improve USB reports

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -779,6 +779,7 @@ var linuxStackParams = &stackParams{
 		"unregister_netdev",
 		"sysfs_remove",
 		"device_remove_file",
+		"tty_unregister_device",
 		"dummy_urb_enqueue",
 		"usb_kill_urb",
 		"usb_kill_anchored_urbs",

--- a/pkg/report/testdata/linux/report/422
+++ b/pkg/report/testdata/linux/report/422
@@ -1,4 +1,4 @@
-TITLE: KASAN: use-after-free Read in tty_unregister_device
+TITLE: KASAN: use-after-free Read in hso_probe
 
 [   54.689586][ T1737] ==================================================================
 [   54.697746][ T1737] BUG: KASAN: use-after-free in __mutex_lock+0xf23/0x1360


### PR DESCRIPTION
tty_unregister_device looks generic enough, add to ignore list.