### PR TITLE
executor, host, csource: Add support to enable KCSAN

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -704,6 +704,9 @@ int main(void)
 #if SYZ_FAULT_INJECTION
 	setup_fault();
 #endif
+#if SYZ_ENABLE_KCSAN
+	setup_kcsan();
+#endif
 
 #if SYZ_HANDLE_SEGV
 	install_segv_handler();

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2778,3 +2778,11 @@ static void setup_binfmt_misc()
 	write_file("/proc/sys/fs/binfmt_misc/register", ":syz1:M:1:\x02::./file0:POC");
 }
 #endif
+
+#if SYZ_EXECUTOR || SYZ_ENABLE_KCSAN
+static void setup_kcsan()
+{
+	if (!write_file("/proc/kcsaninfo", "on"))
+		fail("failed to enable KCSAN");
+}
+#endif

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -181,4 +181,5 @@ static feature_t features[] = {
     {"leak", setup_leak},
     {"fault", setup_fault},
     {"binfmt_misc", setup_binfmt_misc},
+    {"kcsan", setup_kcsan},
 };

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -94,6 +94,7 @@ func defineList(p, mmapProg *prog.Prog, opts Options) (defines []string) {
 		"SYZ_RESET_NET_NAMESPACE":           opts.EnableNetReset,
 		"SYZ_ENABLE_BINFMT_MISC":            opts.EnableBinfmtMisc,
 		"SYZ_ENABLE_CLOSE_FDS":              opts.EnableCloseFds,
+		"SYZ_ENABLE_KCSAN":                  opts.EnableKCSAN,
 		"SYZ_USE_TMP_DIR":                   opts.UseTmpDir,
 		"SYZ_HANDLE_SEGV":                   opts.HandleSegv,
 		"SYZ_REPRO":                         opts.Repro,

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -5193,6 +5193,14 @@ static void setup_binfmt_misc()
 }
 #endif
 
+#if SYZ_EXECUTOR || SYZ_ENABLE_KCSAN
+static void setup_kcsan()
+{
+	if (!write_file("/proc/kcsaninfo", "on"))
+		fail("failed to enable KCSAN");
+}
+#endif
+
 #elif GOOS_test
 
 #include <stdlib.h>
@@ -5670,6 +5678,9 @@ int main(void)
 #endif
 #if SYZ_FAULT_INJECTION
 	setup_fault();
+#endif
+#if SYZ_ENABLE_KCSAN
+	setup_kcsan();
 #endif
 
 #if SYZ_HANDLE_SEGV

--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	EnableCgroups    bool `json:"cgroups,omitempty"`
 	EnableBinfmtMisc bool `json:"binfmt_misc,omitempty"`
 	EnableCloseFds   bool `json:"close_fds"`
+	EnableKCSAN      bool `json:"kcsan,omitempty"`
 
 	UseTmpDir  bool `json:"tmpdir,omitempty"`
 	HandleSegv bool `json:"segv,omitempty"`
@@ -121,7 +122,10 @@ func (opts Options) checkLinuxOnly(OS string) error {
 		return fmt.Errorf("option EnableBinfmtMisc is not supported on %v", OS)
 	}
 	if opts.EnableCloseFds {
-		return fmt.Errorf("EnableCloseFds is not supported on %v", OS)
+		return fmt.Errorf("option EnableCloseFds is not supported on %v", OS)
+	}
+	if opts.EnableKCSAN {
+		return fmt.Errorf("option EnableKCSAN is not supported on %v", OS)
 	}
 	if opts.Sandbox == sandboxNamespace ||
 		(opts.Sandbox == sandboxSetuid && !(OS == openbsd || OS == freebsd || OS == netbsd)) ||

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -75,6 +75,7 @@ const (
 	FeatureLeakChecking
 	FeatureNetworkInjection
 	FeatureNetworkDevices
+	FeatureKCSAN
 	numFeatures
 )
 
@@ -106,6 +107,7 @@ func Check(target *prog.Target) (*Features, error) {
 		FeatureLeakChecking:               {Name: "leak checking", Reason: unsupported},
 		FeatureNetworkInjection:           {Name: "net packet injection", Reason: unsupported},
 		FeatureNetworkDevices:             {Name: "net device setup", Reason: unsupported},
+		FeatureKCSAN:                      {Name: "concurrency sanitizer", Reason: unsupported},
 	}
 	switch target.OS {
 	case "akaros", "fuchsia", "test":
@@ -141,6 +143,9 @@ func Setup(target *prog.Target, features *Features, featureFlags csource.Feature
 	}
 	if target.OS == "linux" && featureFlags["binfmt_misc"].Enabled {
 		args = append(args, "binfmt_misc")
+	}
+	if features[FeatureKCSAN].Enabled {
+		args = append(args, "kcsan")
 	}
 	_, err := osutil.RunCmd(time.Minute, "", executor, args...)
 	return err

--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -395,6 +395,7 @@ func init() {
 	checkFeature[FeatureLeakChecking] = checkLeakChecking
 	checkFeature[FeatureNetworkInjection] = checkNetworkInjection
 	checkFeature[FeatureNetworkDevices] = unconditionallyEnabled
+	checkFeature[FeatureKCSAN] = checkKCSAN
 }
 
 func checkCoverage() string {
@@ -553,6 +554,13 @@ func checkUSBInjection() string {
 func checkDebugFS() string {
 	if err := osutil.IsAccessible("/sys/kernel/debug"); err != nil {
 		return "debugfs is not enabled or not mounted"
+	}
+	return ""
+}
+
+func checkKCSAN() string {
+	if err := osutil.IsAccessible("/proc/kcsaninfo"); err != nil {
+		return err.Error()
 	}
 	return ""
 }

--- a/tools/syz-prog2c/prog2c.go
+++ b/tools/syz-prog2c/prog2c.go
@@ -87,6 +87,7 @@ func main() {
 		EnableCgroups:    features["cgroups"].Enabled,
 		EnableBinfmtMisc: features["binfmt_misc"].Enabled,
 		EnableCloseFds:   features["close_fds"].Enabled,
+		EnableKCSAN:      features["kcsan"].Enabled,
 		UseTmpDir:        *flagUseTmpDir,
 		HandleSegv:       *flagHandleSegv,
 		Repro:            false,


### PR DESCRIPTION
By default, the current KCSAN .config does not enable KCSAN during boot,
since we encounter races during boot which would prevent syzkaller from
ever executing.

This adds support to detect if KCSAN is available, and enables it on the
fuzzer host.


---

Tested and works. Let me know if anything is missing. Thanks!