### PR TITLE
Change KCSAN info file to debugfs

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2782,7 +2782,7 @@ static void setup_binfmt_misc()
 #if SYZ_EXECUTOR || SYZ_ENABLE_KCSAN
 static void setup_kcsan()
 {
-	if (!write_file("/proc/kcsaninfo", "on"))
+	if (!write_file("/sys/kernel/debug/kcsan", "on"))
 		fail("failed to enable KCSAN");
 }
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -5196,7 +5196,7 @@ static void setup_binfmt_misc()
 #if SYZ_EXECUTOR || SYZ_ENABLE_KCSAN
 static void setup_kcsan()
 {
-	if (!write_file("/proc/kcsaninfo", "on"))
+	if (!write_file("/sys/kernel/debug/kcsan", "on"))
 		fail("failed to enable KCSAN");
 }
 #endif

--- a/pkg/host/host_linux.go
+++ b/pkg/host/host_linux.go
@@ -559,7 +559,7 @@ func checkDebugFS() string {
 }
 
 func checkKCSAN() string {
-	if err := osutil.IsAccessible("/proc/kcsaninfo"); err != nil {
+	if err := osutil.IsAccessible("/sys/kernel/debug/kcsan"); err != nil {
 		return err.Error()
 	}
 	return ""


### PR DESCRIPTION
The push of this needs to be synchronized with the update of KCSAN.

Once I merge this, I will immediately have to push the new KCSAN (which also includes blacklisting functions from reports).

A follow-up patch will add support for blacklisting functions.
