### PR TITLE
pkg/bisect: add initial testing support for cause bisection

### DIFF
--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -1,0 +1,133 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package bisect
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/vcs"
+)
+
+// testEnv will implement instance.BuilderTester. This allows us to
+// set bisect.env.inst to a testEnv object.
+type testEnv struct {
+	repo *vcs.TestRepo
+	r    vcs.Repo
+	t    *testing.T
+	// TODO: add a "fix bool" here so that Test() can return results according to
+	// whether fix/cause bisection is happening.
+}
+
+func (env *testEnv) BuildSyzkaller(repo, commit string) error {
+	return nil
+}
+
+func (env *testEnv) BuildKernel(compilerBin, userspaceDir, cmdlineFile, sysctlFile string,
+	kernelConfig []byte) (string, error) {
+	return "", nil
+}
+
+func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]error, error) {
+	hc, err := env.r.HeadCommit()
+	if err != nil {
+		env.t.Fatal(err)
+	}
+	// For cause bisection, if newer than or equal to 602, it crashes.
+	// -- 602 is the cause commit.
+	// TODO: for fix bisection(check env.fix), if older than 602, it crashes.
+	// -- 602 is the fix commit.
+	val, err := strconv.Atoi(hc.Title)
+	if err != nil {
+		env.t.Fatalf("invalid commit title: %v", val)
+	}
+	if val >= 602 {
+		var errors []error
+		for i := 0; i < numVMs; i++ {
+			errors = append(errors, &instance.CrashError{
+				Report: &report.Report{
+					Title: fmt.Sprintf("crashes at %v", hc.Title),
+				},
+			})
+		}
+		return errors, nil
+	}
+	var errors []error
+	for i := 0; i < numVMs; i++ {
+		errors = append(errors, nil)
+	}
+	return errors, nil
+}
+
+// TestBisectCause tests that bisection returns the correct cause
+// commit.
+func TestBisectCause(t *testing.T) {
+	t.Parallel()
+	build.CompilerIdentity = func(_ string) (string, error) {
+		return "unused-compiler-identity", nil
+	}
+	baseDir, err := ioutil.TempDir("", "syz-git-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(baseDir)
+	originRepo := vcs.CreateTestRepo(t, baseDir, "originRepo")
+	for rv := 4; rv < 10; rv++ {
+		for i := 0; i < 6; i++ {
+			originRepo.CommitChange(fmt.Sprintf("%v", rv*100+i))
+			if i == 0 {
+				originRepo.SetTag(fmt.Sprintf("v%v.0", rv))
+			}
+		}
+	}
+	repo := vcs.CloneTestRepo(t, baseDir, "repo", originRepo)
+	r, err := vcs.NewRepo("test", "64", repo.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := r.HeadCommit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{
+		Fix:   false,
+		Trace: new(bytes.Buffer),
+		Manager: mgrconfig.Config{
+			TargetOS:     "test",
+			TargetVMArch: "64",
+			Type:         "qemu",
+			KernelSrc:    repo.Dir,
+		},
+		Kernel: KernelConfig{
+			Commit: head.Hash,
+			Repo:   originRepo.Dir,
+		},
+	}
+	inst := &testEnv{
+		repo: repo,
+		r:    r,
+		t:    t,
+	}
+	commits, rep, err := runImpl(cfg, r, r.(vcs.Bisecter), inst)
+	if err != nil {
+		t.Fatalf("returned error: '%v'", err)
+	}
+	if len(commits) != 1 {
+		t.Fatalf("Got %d commits: %v", len(commits), commits)
+	}
+	if commits[0].Title != "602" {
+		t.Fatalf("Expected commit '602' got '%v'", commits[0].Title)
+	}
+	if rep == nil {
+		t.Fatal("returned rep==nil, report should not be empty")
+	}
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -79,6 +79,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		{"openbsd", "amd64", []string{"gce", "vmm"}, openbsd{}},
 		{"netbsd", "amd64", []string{"gce", "qemu"}, netbsd{}},
 		{"freebsd", "amd64", []string{"gce", "qemu"}, freebsd{}},
+		{"test", "64", []string{"qemu"}, testBuilder{}},
 	}
 	for _, s := range supported {
 		if targetOS == s.OS && targetArch == s.arch {
@@ -92,7 +93,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 	return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
 }
 
-func CompilerIdentity(compiler string) (string, error) {
+var CompilerIdentity = func(compiler string) (string, error) {
 	if compiler == "" {
 		return "", nil
 	}

--- a/pkg/build/testlinux.go
+++ b/pkg/build/testlinux.go
@@ -1,0 +1,16 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+// TypeBuilder implements the builder interface.
+type testBuilder struct{}
+
+func (tb testBuilder) build(targetArch, vmType, kernelDir, outputDir, compiler, userspaceDir,
+	cmdlineFile, sysctlFile string, config []byte) error {
+	return nil
+}
+
+func (tb testBuilder) clean(string, string) error {
+	return nil
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -450,3 +450,27 @@ func (git *git) bisectInconclusive(output []byte) ([]*Commit, error) {
 	}
 	return commits, nil
 }
+
+func (git *git) previousReleaseTags(commit string, self bool) ([]string, error) {
+	var tags []string
+	if self {
+		output, err := git.git("tag", "--list", "--points-at", commit, "--merged", commit, "v*.*")
+		if err != nil {
+			return nil, err
+		}
+		tags, err = gitParseReleaseTags(output)
+		if err != nil {
+			return nil, err
+		}
+	}
+	output, err := git.git("tag", "--no-contains", commit, "--merged", commit, "v*.*")
+	if err != nil {
+		return nil, err
+	}
+	tags1, err := gitParseReleaseTags(output)
+	if err != nil {
+		return nil, err
+	}
+	tags = append(tags, tags1...)
+	return tags, nil
+}

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -31,30 +31,10 @@ func newLinux(dir string) *linux {
 }
 
 func (ctx *linux) PreviousReleaseTags(commit string) ([]string, error) {
-	return ctx.previousReleaseTags(commit, false)
-}
-
-func (ctx *linux) previousReleaseTags(commit string, self bool) ([]string, error) {
-	var tags []string
-	if self {
-		output, err := ctx.git.git("tag", "--list", "--points-at", commit, "--merged", commit, "v*.*")
-		if err != nil {
-			return nil, err
-		}
-		tags, err = gitParseReleaseTags(output)
-		if err != nil {
-			return nil, err
-		}
-	}
-	output, err := ctx.git.git("tag", "--no-contains", commit, "--merged", commit, "v*.*")
+	tags, err := ctx.git.previousReleaseTags(commit, false)
 	if err != nil {
 		return nil, err
 	}
-	tags1, err := gitParseReleaseTags(output)
-	if err != nil {
-		return nil, err
-	}
-	tags = append(tags, tags1...)
 	for i, tag := range tags {
 		if tag == "v4.0" {
 			// Initially we tried to stop at 3.8 because:

--- a/pkg/vcs/test_util.go
+++ b/pkg/vcs/test_util.go
@@ -1,0 +1,116 @@
+package vcs
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+const (
+	userEmail           = `test@syzkaller.com`
+	userName            = `Test Syzkaller`
+	extractFixTagsEmail = `"syzbot" <syzbot@my.mail.com>`
+)
+
+type testWriter testing.T
+
+func (t *testWriter) Write(data []byte) (int, error) {
+	(*testing.T)(t).Log(string(data))
+	return len(data), nil
+}
+
+type TestRepo struct {
+	t       *testing.T
+	Dir     string
+	name    string
+	Commits map[string]map[string]*Commit
+	repo    *git
+}
+
+func (repo *TestRepo) git(args ...string) {
+	if _, err := osutil.RunCmd(time.Minute, repo.Dir, "git", args...); err != nil {
+		repo.t.Fatal(err)
+	}
+}
+
+func MakeTestRepo(t *testing.T, dir string) *TestRepo {
+	if err := osutil.MkdirAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	ignoreCC := map[string]bool{
+		"stable@vger.kernel.org": true,
+	}
+	repo := &TestRepo{
+		t:       t,
+		Dir:     dir,
+		name:    filepath.Base(dir),
+		Commits: make(map[string]map[string]*Commit),
+		repo:    newGit(dir, ignoreCC),
+	}
+	repo.git("init")
+	repo.git("config", "--add", "user.email", userEmail)
+	repo.git("config", "--add", "user.name", userName)
+	return repo
+}
+
+func (repo *TestRepo) CommitFileChange(branch, change string) {
+	id := fmt.Sprintf("%v-%v-%v", repo.name, branch, change)
+	file := filepath.Join(repo.Dir, "file")
+	if err := osutil.WriteFile(file, []byte(id)); err != nil {
+		repo.t.Fatal(err)
+	}
+	repo.git("add", file)
+	repo.git("commit", "-m", id)
+	if repo.Commits[branch] == nil {
+		repo.Commits[branch] = make(map[string]*Commit)
+	}
+	com, err := repo.repo.HeadCommit()
+	if err != nil {
+		repo.t.Fatal(err)
+	}
+	repo.Commits[branch][change] = com
+}
+
+func (repo *TestRepo) CommitChange(description string) {
+	repo.git("commit", "--allow-empty", "-m", description)
+}
+
+func (repo *TestRepo) SetTag(tag string) {
+	repo.git("tag", tag)
+}
+
+func CreateTestRepo(t *testing.T, baseDir, name string) *TestRepo {
+	repo := MakeTestRepo(t, filepath.Join(baseDir, name))
+	repo.git("checkout", "-b", "master")
+	repo.CommitFileChange("master", "0")
+	for _, branch := range []string{"branch1", "branch2"} {
+		repo.git("checkout", "-b", branch, "master")
+		repo.CommitFileChange(branch, "0")
+		repo.CommitFileChange(branch, "1")
+	}
+	repo.git("checkout", "master")
+	repo.CommitFileChange("master", "1")
+	return repo
+}
+
+func CloneTestRepo(t *testing.T, baseDir string, name string, originRepo *TestRepo) *TestRepo {
+	dir := filepath.Join(baseDir, name)
+	if err := osutil.MkdirAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	ignoreCC := map[string]bool{
+		"stable@vger.kernel.org": true,
+	}
+	repo := &TestRepo{
+		t:       t,
+		Dir:     dir,
+		name:    filepath.Base(dir),
+		Commits: make(map[string]map[string]*Commit),
+		repo:    newGit(dir, ignoreCC),
+	}
+	repo.git("clone", originRepo.Dir, repo.Dir)
+	return repo
+}

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -1,0 +1,23 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+type testos struct {
+	*git
+}
+
+func newTestos(dir string) *testos {
+	return &testos{
+		git: newGit(dir, nil),
+	}
+}
+
+func (ctx *testos) PreviousReleaseTags(commit string) ([]string, error) {
+	return ctx.git.previousReleaseTags(commit, false)
+}
+func (ctx *testos) EnvForCommit(commit string, kernelConfig []byte) (*BisectEnv, error) {
+	return &BisectEnv{
+		Compiler: "test-compiler-dont-use",
+	}, nil
+}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -104,6 +104,8 @@ func NewRepo(os, vm, dir string) (Repo, error) {
 		return newNetBSD(vm, dir), nil
 	case "freebsd":
 		return newFreeBSD(vm, dir), nil
+	case "test":
+		return newTestos(dir), nil
 	}
 	return nil, fmt.Errorf("vcs is unsupported for %v", os)
 }

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -120,7 +120,7 @@ func main() {
 	}
 }
 
-func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env *instance.Env, com *vcs.Commit) {
+func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.BuilderTester, com *vcs.Commit) {
 	bisectEnv, err := bisecter.EnvForCommit(com.Hash, kernelConfig)
 	if err != nil {
 		fail(err)


### PR DESCRIPTION
(note: incomplete change)
    
Refactor existing code as follows:
* Move reusable test utility functions from git_repo_test.go to pkg/vcs/test_util.go and make them exported.
* Split Run() into Run()+runImpl().
* Change type of bisect.go:env.inst to `instance.BuilderTester`. Change usage inside syz-testbuild/testbuild.go accordingly.
* Move most of linux.PreviousReleaseTags() into vcs/git.go as git.previousReleaseTags().
    
Introduce the following changes:
* instance.BuilderTester is an interface with methods
        BuildSyzkaller()
        BuildKernel()
        Test()
NewEnv() now returns this interface.
* type testEnv implements instance.BuilderTester.
* type testBuilder implements builder interface. Add a entry into table inside pkg/build/build.go:getBuilder() to return testBuilder object.
