### PR TITLE
pkg/host: disable NetworkInjection on NetBSD for now

### DIFF
--- a/pkg/host/host_netbsd.go
+++ b/pkg/host/host_netbsd.go
@@ -14,5 +14,5 @@ func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, st
 func init() {
 	checkFeature[FeatureCoverage] = unconditionallyEnabled
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
-	checkFeature[FeatureNetworkInjection] = unconditionallyEnabled
+	checkFeature[FeatureNetworkInjection] = "Temporarily disabled"
 }


### PR DESCRIPTION
NetworkInjection causes early exit and poor coverage, it will be re-enabled
once the issues with it are fixed.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
