### PR TITLE
Disable checkFeature[FeatureNetworkInjection] for NetBSD

### DIFF
--- a/pkg/host/host_netbsd.go
+++ b/pkg/host/host_netbsd.go
@@ -14,5 +14,4 @@ func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, st
 func init() {
 	checkFeature[FeatureCoverage] = unconditionallyEnabled
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
-	checkFeature[FeatureNetworkInjection] = unconditionallyEnabled
 }


### PR DESCRIPTION
There is a problem with the image. Until the problem will be resolved,
disable the feature as it causes premature death of the syzbot setup.
