### PR TITLE
sys/targets: Disable PIE/ASLR when building tests

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -69,10 +69,11 @@ func Get(OS, arch string) *Target {
 var List = map[string]map[string]*Target{
 	"test": {
 		"64": {
-			PtrSize:     8,
-			PageSize:    4 << 10,
-			CFlags:      []string{"-m64"},
-			CrossCFlags: []string{"-m64", "-fsanitize=address"},
+			PtrSize:  8,
+			PageSize: 4 << 10,
+			CFlags:   []string{"-m64"},
+			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le
+			CrossCFlags: []string{"-m64", "-fsanitize=address", "-no-pie"},
 			osCommon: osCommon{
 				SyscallNumbers:         true,
 				SyscallPrefix:          "SYS_",
@@ -81,10 +82,11 @@ var List = map[string]map[string]*Target{
 			},
 		},
 		"64_fork": {
-			PtrSize:     8,
-			PageSize:    8 << 10,
-			CFlags:      []string{"-m64"},
-			CrossCFlags: []string{"-m64", "-fsanitize=address"},
+			PtrSize:  8,
+			PageSize: 8 << 10,
+			CFlags:   []string{"-m64"},
+			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le
+			CrossCFlags: []string{"-m64", "-fsanitize=address", "-no-pie"},
 			osCommon: osCommon{
 				SyscallNumbers:         true,
 				SyscallPrefix:          "SYS_",


### PR DESCRIPTION
Due to issues with ASLR + ASan on ppc64le (see #1446), add the -no-pie
flag to the test target so tests will pass.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>

-----

@RashmicaG has tested this, it works around our problems for now