### PR TITLE
vm/isolated: update isolated vm

### DIFF
--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -210,7 +210,7 @@ func (inst *instance) repair() error {
 			return err
 		}
 		log.Logf(2, "isolated: rebooted wait for comeback")
-		if err := inst.waitForSSH(3 * time.Minute); err != nil {
+		if err := inst.waitForSSH(30 * time.Minute); err != nil {
 			log.Logf(0, "isolated: machine did not comeback")
 			return err
 		}

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -55,7 +55,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, err
 	}
 	if cfg.Host == "" {
-		return nil, fmt.Errorf("config param Host is empty")
+		cfg.Host = "127.0.0.1"
 	}
 	if len(cfg.Targets) == 0 {
 		return nil, fmt.Errorf("config param targets is empty")
@@ -108,7 +108,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		return nil, err
 	}
 
-	//remount to writable
+	//Remount to writable
 	inst.ssh("mount -o remount,rw /")
 
 	// Create working dir if doesn't exist.

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -68,6 +68,11 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 			return nil, fmt.Errorf("bad target %q: %v", target, err)
 		}
 	}
+	if len(cfg.USBDevNums) > 0 {
+		if len(cfg.USBDevNums) != len(cfg.Targets) {
+			return nil, fmt.Errorf("the number of Targets and the number of USBDevNums should be same")
+		}
+	}
 	if env.Debug && len(cfg.Targets) > 1 {
 		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
 		cfg.Targets = cfg.Targets[:1]

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -28,7 +28,7 @@ type Config struct {
 	Targets      []string `json:"targets"`        // target machines: (hostname|ip)(:port)?
 	TargetDir    string   `json:"target_dir"`     // directory to copy/run on target
 	TargetReboot bool     `json:"target_reboot"`  // reboot target on repair
-	USBDevNums   []string `json:"usb_device_num"` // usb device number
+	USBDevNums   []string `json:"usb_device_num"` // /sys/bus/usb/devices/
 }
 
 type Pool struct {
@@ -71,7 +71,9 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if env.Debug && len(cfg.Targets) > 1 {
 		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
 		cfg.Targets = cfg.Targets[:1]
-		cfg.USBDevNums = cfg.USBDevNums[:1]
+		if len(cfg.USBDevNums) > 1 {
+			cfg.USBDevNums = cfg.USBDevNums[:1]
+		}
 	}
 	pool := &Pool{
 		cfg: cfg,

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -88,7 +88,6 @@ func (pool *Pool) Count() int {
 
 func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	targetAddr, targetPort, _ := splitTargetPort(pool.cfg.Targets[index])
-	
 	inst := &instance{
 		cfg:        pool.cfg,
 		os:         pool.env.OS,
@@ -195,7 +194,7 @@ func (inst *instance) repair() error {
 			log.Logf(2, "ssh return: %v", e)
 		} else if len(inst.cfg.USBDevNums) > 1 {
 			log.Logf(2, "isolated: ssh failed")
-			log.Logf(2, "isolated: trying to reboot by USB authorization")			
+			log.Logf(2, "isolated: trying to reboot by USB authorization")
 			usbAuth := fmt.Sprintf("%s%s%s", "/sys/bus/usb/devices/", inst.cfg.USBDevNums[inst.index], "/authorized")
 			err = ioutil.WriteFile(usbAuth, []byte("0"), 0)
 			if err != nil {

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -219,6 +219,9 @@ func (inst *instance) repair() error {
 			return err
 		}
 		log.Logf(2, "isolated: reboot succeeded")
+	} else {
+		log.Logf(2, "isolated: ssh failed")
+		return fmt.Errorf("SSH failed")
 	}
 	return nil
 }

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -71,9 +71,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if env.Debug && len(cfg.Targets) > 1 {
 		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
 		cfg.Targets = cfg.Targets[:1]
-		if len(cfg.Targets) > 1 && len(cfg.USBDevNums) > 1 {
-			cfg.USBDevNums = cfg.USBDevNums[:1]
-		}
+		cfg.USBDevNums = cfg.USBDevNums[:1]
 	}
 	pool := &Pool{
 		cfg: cfg,
@@ -192,7 +190,7 @@ func (inst *instance) repair() error {
 			log.Logf(2, "isolated: trying to reboot by ssh")
 			e := inst.ssh("reboot") // reboot will return an error, ignore it
 			log.Logf(2, "ssh return: %v", e)
-		} else if len(inst.cfg.USBDevNums) > 1 {
+		} else if len(inst.cfg.USBDevNums) > 0 {
 			log.Logf(2, "isolated: ssh failed")
 			log.Logf(2, "isolated: trying to reboot by USB authorization")
 			usbAuth := fmt.Sprintf("%s%s%s", "/sys/bus/usb/devices/", inst.cfg.USBDevNums[inst.index], "/authorized")


### PR DESCRIPTION
Old isolated.go cannot do hard reset the target device when the target device is stuck,
because it used SSH command to reboot.
New isolated.go can reboot the target device using USB hub,
so it can reboot the device when its kernel is crashed during fuzzing.
It also doesn't require 'CGO' like odroid.go

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
