### PR TITLE
vm: Get debug information when FreeBSD on panics

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -370,6 +370,9 @@ func waitForConsoleConnect(merger *vmimpl.OutputMerger) error {
 }
 
 func (inst *instance) Diagnose() ([]byte, bool) {
+	if inst.env.OS == "freebsd" {
+		return nil, vmimpl.DiagnoseFreeBSD(inst.consolew)
+	}
 	if inst.env.OS == "openbsd" {
 		return nil, vmimpl.DiagnoseOpenBSD(inst.consolew)
 	}

--- a/vm/vmimpl/freebsd.go
+++ b/vm/vmimpl/freebsd.go
@@ -1,0 +1,32 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vmimpl
+
+import (
+	"io"
+	"time"
+)
+
+// DiagnoseFreeBSD sends the debug commands to the given writer which
+// is expected to be connected to a panicked FreeBSD kernel.  If kernel
+// just hanged, we've lost connection or detected some non-panic
+// error, console still shows normal login prompt.
+func DiagnoseFreeBSD(w io.Writer) bool {
+	commands := []string{
+		"",
+		"set $lines = 0",    // disable pagination
+		"set $maxwidth = 0", // disable line continuation
+		"show registers",
+		"show proc",
+		"ps",
+		"show all locks",
+		"show malloc",
+		"show ktr",
+	}
+	for _, c := range commands {
+		w.Write([]byte(c + "\n"))
+		time.Sleep(1 * time.Second)
+	}
+	return true
+}


### PR DESCRIPTION
The FreeBSD kernel debugger can provide more information when the
kernel panics. Add support to bhybe and gce to print this information.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
