### PR TITLE
syz-fuzzer, executor: Add support for blacklisting data race frames

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2784,9 +2784,33 @@ static void setup_binfmt_misc()
 #endif
 
 #if SYZ_EXECUTOR || SYZ_ENABLE_KCSAN
+#define KCSAN_DEBUGFS_FILE "/sys/kernel/debug/kcsan"
+
 static void setup_kcsan()
 {
-	if (!write_file("/sys/kernel/debug/kcsan", "on"))
+	if (!write_file(KCSAN_DEBUGFS_FILE, "on"))
 		fail("failed to enable KCSAN");
 }
+
+#if SYZ_EXECUTOR // currently only used by executor
+static void setup_kcsan_filterlist(char** frames, int nframes, bool blacklist)
+{
+	int fd = open(KCSAN_DEBUGFS_FILE, O_WRONLY);
+	if (fd == -1)
+		fail("failed to open(\"%s\")", KCSAN_DEBUGFS_FILE);
+
+	const char* const filtertype = blacklist ? "blacklist" : "whitelist";
+	printf("adding functions to KCSAN %s: ", filtertype);
+	dprintf(fd, "%s\n", filtertype);
+	for (int i = 0; i < nframes; ++i) {
+		printf("'%s' ", frames[i]);
+		dprintf(fd, "!%s\n", frames[i]);
+	}
+	printf("\n");
+
+	close(fd);
+}
+
+#define SYZ_HAVE_KCSAN 1
+#endif
 #endif

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -347,6 +347,14 @@ int main(int argc, char** argv)
 #endif
 		return 0;
 	}
+	if (argc >= 2 && strcmp(argv[1], "setup_kcsan_blacklist") == 0) {
+#if SYZ_HAVE_KCSAN
+		setup_kcsan_filterlist(argv + 2, argc - 2, /*blacklist=*/true);
+#else
+		fail("KCSAN is not implemented");
+#endif
+		return 0;
+	}
 	if (argc == 2 && strcmp(argv[1], "test") == 0)
 		return run_tests();
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -62,6 +62,7 @@ const (
 	Unknown Type = iota
 	Hang
 	MemoryLeak
+	DataRace
 	UnexpectedReboot
 )
 
@@ -73,6 +74,8 @@ func (t Type) String() string {
 		return "HANG"
 	case MemoryLeak:
 		return "LEAK"
+	case DataRace:
+		return "DATARACE"
 	case UnexpectedReboot:
 		return "REBOOT"
 	default:
@@ -119,6 +122,7 @@ func NewReporter(cfg *mgrconfig.Config) (Reporter, error) {
 const (
 	unexpectedKernelReboot = "unexpected kernel reboot"
 	memoryLeakPrefix       = "memory leak in "
+	dataRacePrefix         = "KCSAN: data-race"
 )
 
 var ctors = map[string]fn{
@@ -186,6 +190,9 @@ func extractReportType(rep *Report) Type {
 	}
 	if strings.HasPrefix(rep.Title, memoryLeakPrefix) {
 		return MemoryLeak
+	}
+	if strings.HasPrefix(rep.Title, dataRacePrefix) {
+		return DataRace
 	}
 	if strings.HasPrefix(rep.Title, "INFO: rcu detected stall") ||
 		strings.HasPrefix(rep.Title, "INFO: task hung") ||

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -112,6 +112,8 @@ func parseHeaderLine(t *testing.T, test *ParseTest, ln string) {
 			test.Type = Hang
 		case MemoryLeak.String():
 			test.Type = MemoryLeak
+		case DataRace.String():
+			test.Type = DataRace
 		case UnexpectedReboot.String():
 			test.Type = UnexpectedReboot
 		default:

--- a/pkg/report/testdata/linux/report/427
+++ b/pkg/report/testdata/linux/report/427
@@ -1,4 +1,6 @@
 TITLE: KCSAN: data-race in find_next_bit / rcu_report_exp_cpu_mult
+TYPE: DATARACE
+FRAME: find_next_bit
 
 [   44.377931][    C4] ==================================================================
 [   44.379001][    C4] BUG: KCSAN: data-race in find_next_bit / rcu_report_exp_cpu_mult

--- a/pkg/report/testdata/linux/report/428
+++ b/pkg/report/testdata/linux/report/428
@@ -1,7 +1,9 @@
-TITLE: KCSAN: racing read in e1000_clean_rx_irq
+TITLE: KCSAN: data-race in e1000_clean_rx_irq
+TYPE: DATARACE
+FRAME: e1000_clean_rx_irq
 
 [   44.381409][    C4]  ==================================================================
-[   44.381969][    C4]  BUG: KCSAN: racing read in e1000_clean_rx_irq+0x551/0xb10
+[   44.381969][    C4]  BUG: KCSAN: data-race in e1000_clean_rx_irq+0x551/0xb10
 [   44.382748][    C4]  
 [   44.383468][    C4]  race at unknown origin, with read to 0xffff933db8a2ae6c of 1 bytes by interrupt on cpu 0:
 [   44.384066][    C4]   e1000_clean_rx_irq+0x551/0xb10

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -35,6 +35,7 @@ type ConnectRes struct {
 	AllSandboxes     bool
 	CheckResult      *CheckArgs
 	MemoryLeakFrames []string
+	DataRaceFrames   []string
 }
 
 type CheckArgs struct {


### PR DESCRIPTION
This adds support to add frames that have already been in data races, to
the KCSAN report blacklist.
