### PR TITLE
Visit root node during typedef checks

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -22,9 +22,9 @@ type Node interface {
 	Info() (pos Pos, typ string, name string)
 	// Clone makes a deep copy of the node.
 	Clone() Node
-	// Walk calls callback cb for all child nodes of this node.
+	// walk calls callback cb for all child nodes of this node.
 	// Note: it's not recursive. Use Recursive helper for recursive walk.
-	Walk(cb func(Node))
+	walk(cb func(Node))
 }
 
 // Top-level AST nodes:

--- a/pkg/ast/walk.go
+++ b/pkg/ast/walk.go
@@ -15,7 +15,7 @@ func Recursive(cb func(Node)) func(Node) {
 	var rec func(Node)
 	rec = func(n Node) {
 		cb(n)
-		n.Walk(rec)
+		n.walk(rec)
 	}
 	return rec
 }
@@ -23,32 +23,32 @@ func Recursive(cb func(Node)) func(Node) {
 func PostRecursive(cb func(Node)) func(Node) {
 	var rec func(Node)
 	rec = func(n Node) {
-		n.Walk(rec)
+		n.walk(rec)
 		cb(n)
 	}
 	return rec
 }
 
-func (n *NewLine) Walk(cb func(Node)) {}
-func (n *Comment) Walk(cb func(Node)) {}
-func (n *Ident) Walk(cb func(Node))   {}
-func (n *String) Walk(cb func(Node))  {}
-func (n *Int) Walk(cb func(Node))     {}
+func (n *NewLine) walk(cb func(Node)) {}
+func (n *Comment) walk(cb func(Node)) {}
+func (n *Ident) walk(cb func(Node))   {}
+func (n *String) walk(cb func(Node))  {}
+func (n *Int) walk(cb func(Node))     {}
 
-func (n *Include) Walk(cb func(Node)) {
+func (n *Include) walk(cb func(Node)) {
 	cb(n.File)
 }
 
-func (n *Incdir) Walk(cb func(Node)) {
+func (n *Incdir) walk(cb func(Node)) {
 	cb(n.Dir)
 }
 
-func (n *Define) Walk(cb func(Node)) {
+func (n *Define) walk(cb func(Node)) {
 	cb(n.Name)
 	cb(n.Value)
 }
 
-func (n *Resource) Walk(cb func(Node)) {
+func (n *Resource) walk(cb func(Node)) {
 	cb(n.Name)
 	cb(n.Base)
 	for _, v := range n.Values {
@@ -56,7 +56,7 @@ func (n *Resource) Walk(cb func(Node)) {
 	}
 }
 
-func (n *TypeDef) Walk(cb func(Node)) {
+func (n *TypeDef) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, a := range n.Args {
 		cb(a)
@@ -69,7 +69,7 @@ func (n *TypeDef) Walk(cb func(Node)) {
 	}
 }
 
-func (n *Call) Walk(cb func(Node)) {
+func (n *Call) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, f := range n.Args {
 		cb(f)
@@ -79,7 +79,7 @@ func (n *Call) Walk(cb func(Node)) {
 	}
 }
 
-func (n *Struct) Walk(cb func(Node)) {
+func (n *Struct) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, f := range n.Fields {
 		cb(f)
@@ -92,27 +92,27 @@ func (n *Struct) Walk(cb func(Node)) {
 	}
 }
 
-func (n *IntFlags) Walk(cb func(Node)) {
+func (n *IntFlags) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, v := range n.Values {
 		cb(v)
 	}
 }
 
-func (n *StrFlags) Walk(cb func(Node)) {
+func (n *StrFlags) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, v := range n.Values {
 		cb(v)
 	}
 }
 
-func (n *Type) Walk(cb func(Node)) {
+func (n *Type) walk(cb func(Node)) {
 	for _, t := range n.Args {
 		cb(t)
 	}
 }
 
-func (n *Field) Walk(cb func(Node)) {
+func (n *Field) walk(cb func(Node)) {
 	cb(n.Name)
 	cb(n.Type)
 	for _, c := range n.Comments {

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -942,7 +942,7 @@ func (comp *compiler) instantiate(templ ast.Node, params []*ast.Ident, args []*a
 	}
 	argUsed := make(map[string]bool)
 	err0 := comp.errors
-	templ.Walk(ast.PostRecursive(func(n ast.Node) {
+	ast.PostRecursive(func(n ast.Node) {
 		templArg, ok := n.(*ast.Type)
 		if !ok {
 			return
@@ -972,7 +972,7 @@ func (comp *compiler) instantiate(templ ast.Node, params []*ast.Ident, args []*a
 				col.Pos = concreteArg.Pos
 			}
 		}
-	}))
+	})(templ)
 	for _, param := range params {
 		if !argUsed[param.Name] {
 			comp.error(argMap[param.Name].Pos,

--- a/pkg/compiler/testdata/all.txt
+++ b/pkg/compiler/testdata/all.txt
@@ -224,6 +224,7 @@ type templ_struct4 templ_struct3
 type templ_struct5 templ_struct0[C1, templ_struct0[C2, int8]]
 type templ_struct6 templ_struct0[C1, templ_struct2[C2]]
 type templ_union union_with_templ_struct
+type templ_base3[BASE] BASE
 
 foo$templ0(a templ0[42, int8])
 foo$templ1(a ptr[in, templ_struct0[C2, int8]])
@@ -234,6 +235,7 @@ foo$templ5(a ptr[in, templ_struct1[3]])
 foo$templ6(a ptr[in, templ_struct4])
 foo$templ7(a ptr[in, templ_struct5], b ptr[in, templ_struct6], c ptr[in, templ_union], d ptr[in, type3])
 foo$templ8(a ptr[in, templ_templ_use])
+foo$templ9(a ptr[in, templ_base3[int64]])
 
 # Structs.
 


### PR DESCRIPTION
This pull request fixes a bug in typedef checks: the root node was never visited. `Node.Walk()` is also unexported as `ast.Recursive` and `ast.PostRecursive` should be used instead to prevent this error from happening.