### PR TITLE
pkg/csource: remove duplicate check

### DIFF
--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -175,9 +175,6 @@ func DefaultOpts(cfg *mgrconfig.Config) Options {
 	if cfg.Sandbox == "" || cfg.Sandbox == "setuid" {
 		opts.EnableNetReset = false
 	}
-	if cfg.Sandbox == "" || cfg.Sandbox == "setuid" {
-		opts.EnableNetReset = false
-	}
 	if err := opts.Check(cfg.TargetOS); err != nil {
 		panic(fmt.Sprintf("DefaultOpts created bad opts: %v", err))
 	}


### PR DESCRIPTION
Remove a check that was mistakenly added with devlink_pci feature and is
duplicate of the existing check.