### PR TITLE
executor: add missing includes

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -471,6 +471,7 @@ const int kInitNetNsFd = 239; // see kMaxFd
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI || SYZ_NET_DEVICES
 
 #include <linux/genetlink.h>
+#include <stdbool.h>
 
 #define DEVLINK_FAMILY_NAME "devlink"
 
@@ -600,6 +601,8 @@ error:
 }
 
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI
+#include <fcntl.h>
+
 static void initialize_devlink_pci(void)
 {
 #if SYZ_EXECUTOR

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1496,6 +1496,7 @@ const int kInitNetNsFd = 239;
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI || SYZ_NET_DEVICES
 
 #include <linux/genetlink.h>
+#include <stdbool.h>
 
 #define DEVLINK_FAMILY_NAME "devlink"
 
@@ -1625,6 +1626,8 @@ error:
 }
 
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI
+#include <fcntl.h>
+
 static void initialize_devlink_pci(void)
 {
 #if SYZ_EXECUTOR


### PR DESCRIPTION
Fix for #1508

stdbool.h is required by initialize_devlink_ports(): true define.
fcntl.h is required by initialize_devlink_pci(): O_RDONLY define.

Signed-off-by: Denis Efremov <efremov@linux.com>