### PR TITLE
Call initialize_devlink_ports only when a device has been created

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -653,9 +653,10 @@ static void netdevsim_add(unsigned int addr, unsigned int port_count)
 	char buf[16];
 
 	sprintf(buf, "%u %u", addr, port_count);
-	write_file("/sys/bus/netdevsim/new_device", buf);
-	snprintf(buf, sizeof(buf), "netdevsim%d", addr);
-	initialize_devlink_ports("netdevsim", buf, "netdevsim");
+	if (write_file("/sys/bus/netdevsim/new_device", buf)) {
+		snprintf(buf, sizeof(buf), "netdevsim%d", addr);
+		initialize_devlink_ports("netdevsim", buf, "netdevsim");
+	}
 }
 
 // We test in a separate namespace, which does not have any network devices initially (even lo).

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1676,9 +1676,10 @@ static void netdevsim_add(unsigned int addr, unsigned int port_count)
 	char buf[16];
 
 	sprintf(buf, "%u %u", addr, port_count);
-	write_file("/sys/bus/netdevsim/new_device", buf);
-	snprintf(buf, sizeof(buf), "netdevsim%d", addr);
-	initialize_devlink_ports("netdevsim", buf, "netdevsim");
+	if (write_file("/sys/bus/netdevsim/new_device", buf)) {
+		snprintf(buf, sizeof(buf), "netdevsim%d", addr);
+		initialize_devlink_ports("netdevsim", buf, "netdevsim");
+	}
 }
 static void initialize_netdevices(void)
 {


### PR DESCRIPTION
gVisor doesn't support netdevsim and NETLINK_GENERIC.
Without this fix, sys-executor always fails:

E openat(AT_FDCWD, /sys/bus/netdevsim/new_device, ...)
X openat(AT_FDCWD, /sys/bus/netdevsim/new_device, ...) = 0x0 errno=2
E socket(AF_NETLINK, SOCK_RAW|0x0, NETLINK_GENERIC)
X socket(AF_NETLINK, SOCK_RAW|0x0, NETLINK_GENERIC) = 0x0 errno=93
E write(0x2 host:[3], "socket(AF_NETLINK) failed\n", 0x1a)
X write(0x2 host:[3], ..., 0x1a) = 0x1a (2.767µs)
E write(0x2 host:[3], " (errno 93)\n", 0xc)
X write(0x2 host:[3], ..., 0xc) = 0xc (2.729µs)
E exit_group(0x43)
X exit_group(0x43) = 0x0 (900ns)

Cc: @jpirko 
Fixes: f350e2dc1f59 ("executor: rename devlink port netdevices to defined names")