### PR TITLE
.gitattributes: hide generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+executor/defs.h linguist-generated
+sys/*/gen/*.go  linguist-generated


### PR DESCRIPTION
This pull request hides all generated files in pull requests, until #1291 is addressed. This feature is documented on [the github-linguist repository](https://github.com/github/linguist#generated-code). You can preview this change on [a small fork I created](https://github.com/pchaigno/syzkaller-tmp/pull/2).

