### PR TITLE
pkg/build: Add support to build the NetBSD kernel with KMSan

### DIFF
--- a/dashboard/config/netbsd-kmsan.config
+++ b/dashboard/config/netbsd-kmsan.config
@@ -1,0 +1,15 @@
+include "arch/amd64/conf/GENERIC"
+
+options         DEBUG
+options         LOCKDEBUG
+
+makeoptions     KMSAN=1
+options         KMSAN
+no options      SVS
+no options      MODULAR
+no options      MODULAR_DEFAULT_AUTOLOAD
+options         POOL_QUARANTINE
+options         KMSAN_PANIC
+
+makeoptions     KCOV=1
+options         KCOV

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -29,16 +29,32 @@ func (ctx netbsd) build(params *Params) error {
 		return err
 	}
 	// Build tools before building kernel
-	if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-		"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "tools"); err != nil {
-		return err
+	if strings.HasSuffix(params.Compiler, "gcc") {
+		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
+			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "tools"); err != nil {
+			return err
+		}
+
+		// Build kernel
+		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
+			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "kernel="+kernelName); err != nil {
+			return err
+		}
+	} else {
+		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
+			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", 
+			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "tools"); err != nil {
+			return err
+		}
+
+		// Build kernel
+		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
+			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
+			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "kernel="+kernelName); err != nil {
+			return err
+		}
 	}
 
-	// Build kernel
-	if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-		"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "kernel="+kernelName); err != nil {
-		return err
-	}
 	for _, s := range []struct{ dir, src, dst string }{
 		{compileDir, "netbsd.gdb", "obj/netbsd.gdb"},
 		{params.UserspaceDir, "image", "image"},

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -29,7 +29,7 @@ func (ctx netbsd) build(params *Params) error {
 		return err
 	}
 	// Build tools before building kernel
-	if strings.HasSuffix(params.Compiler, "gcc") {
+	if strings.HasSuffix(params.Compiler, "g++") {
 		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
 			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "tools"); err != nil {
 			return err
@@ -40,7 +40,7 @@ func (ctx netbsd) build(params *Params) error {
 			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "kernel="+kernelName); err != nil {
 			return err
 		}
-	} else {
+	} else if strings.HasSuffix(params.Compiler, "clang++") {
 		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
 			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "tools"); err != nil {

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -42,7 +42,7 @@ func (ctx netbsd) build(params *Params) error {
 		}
 	} else {
 		if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", 
+			"-U", "-u", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "tools"); err != nil {
 			return err
 		}

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -176,8 +176,8 @@ var netbsdOopses = append([]*oops{
 				fmt:    "ASan: Unauthorized Access in %[1]v",
 			},
 			{
-			    title:  compile("MSan: Uninitialized"),
-		        report: compile(`MSan: Uninitialized (?:.*\n)+(?:kmsan|__msan).*\n(.*)\(`),
+				title:  compile("MSan: Uninitialized"),
+				report: compile(`MSan: Uninitialized (?:.*\n)+(?:kmsan|__msan).*\n(.*)\(`),
 				fmt:    "MSan: Uninitialized Memory in %[1]v",
 			},
 		},

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -175,6 +175,11 @@ var netbsdOopses = append([]*oops{
 				report: compile(`ASan: Unauthorized Access (?:.*\n)+(?:kasan|__asan).*\n(.*)\(`),
 				fmt:    "ASan: Unauthorized Access in %[1]v",
 			},
+			{
+			    title:  compile("MSan: Uninitialized"),
+		        report: compile(`MSan: Uninitialized (?:.*\n)+(?:kmsan|__msan).*\n(.*)\(`),
+				fmt:    "MSan: Uninitialized Memory in %[1]v",
+			},
 		},
 		[]*regexp.Regexp{},
 	},


### PR DESCRIPTION

KMSan requires building the kernel with Clang. 

I have made a rough patch which uses the Compiler parameter in the mgrconfig.