### PR TITLE
pkg/vcs: Unset various git environment variables when invoking git

### DIFF
--- a/pkg/vcs/git_test_util.go
+++ b/pkg/vcs/git_test_util.go
@@ -25,7 +25,11 @@ type TestRepo struct {
 }
 
 func (repo *TestRepo) Git(args ...string) {
-	if _, err := osutil.RunCmd(time.Minute, repo.Dir, "git", args...); err != nil {
+	cmd := osutil.Command("git", args...)
+	cmd.Dir = repo.Dir
+	cmd.Env = filterEnv()
+
+	if _, err := osutil.Run(time.Minute, cmd); err != nil {
 		repo.t.Fatal(err)
 	}
 }

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -167,8 +167,13 @@ func CheckCommitHash(hash string) bool {
 }
 
 func runSandboxed(dir, command string, args ...string) ([]byte, error) {
+	return runSandboxedEnv(dir, command, nil, args...)
+}
+
+func runSandboxedEnv(dir, command string, env []string, args ...string) ([]byte, error) {
 	cmd := osutil.Command(command, args...)
 	cmd.Dir = dir
+	cmd.Env = env
 	if err := osutil.Sandbox(cmd, true, false); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If you try to run git-using tests while the GIT_DIR environment variable
(and GIT_WORK_TREE, etc) happens to be set, the tests are going to do fun
and exciting things on a repository that isn't the test repository it tries
to set up.

As it turns out, if you try to run "make test" using git rebase -x, you'll
end up with GIT_DIR set to the syzkaller tree. Hilarity ensues.

Unset GIT_DIR, GIT_WORK_TREE and a few other environment variables when
invoking git - that way it'll default to looking at the working directory
that we have given it, which is what we expect.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>