### PR TITLE
dashboard/config: enable KQUEUE_DEBUG on OpenBSD

### DIFF
--- a/dashboard/config/openbsd-syzkaller.mp
+++ b/dashboard/config/openbsd-syzkaller.mp
@@ -2,6 +2,7 @@ include "arch/amd64/conf/GENERIC.MP"
 
 pseudo-device kcov 1
 
+option KQUEUE_DEBUG
 option LOCKF_DIAGNOSTIC
 option SPLASSERT_WATCH
 option VFSLCKDEBUG

--- a/dashboard/config/openbsd-syzkaller.sp
+++ b/dashboard/config/openbsd-syzkaller.sp
@@ -2,6 +2,7 @@ include "arch/amd64/conf/GENERIC"
 
 pseudo-device kcov 1
 
+option KQUEUE_DEBUG
 option LOCKF_DIAGNOSTIC
 option SPLASSERT_WATCH
 option VFSLCKDEBUG


### PR DESCRIPTION
Recently introduced used to validate correctness of kqueue event lists.