### PR TITLE
pkg/cover: Fix PreviousInstructionPC for MIPS64LE

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -436,7 +436,7 @@ func PreviousInstructionPC(arch string, pc uint64) uint64 {
 	case "ppc64le":
 		return pc - 4
 	case "mips64le":
-		return pc - 4
+		return pc - 8
 	default:
 		panic(fmt.Sprintf("unknown arch %q", arch))
 	}


### PR DESCRIPTION
PC from the target is address of "jal __sanitizer_cov_trace_pc" + 8.
E.g. case below has address ffffffff80b4eec4 in PC

ffffffff80b4eebc:       jal     ffffffff80232080 <__sanitizer_cov_trace_pc>
ffffffff80b4eec0:       nop
ffffffff80b4eec4:       move    a1,s0

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
