### PR TITLE
executor: provide explicit values for usb_raw_event_type

### DIFF
--- a/executor/common_usb.h
+++ b/executor/common_usb.h
@@ -85,9 +85,9 @@ struct usb_raw_init {
 };
 
 enum usb_raw_event_type {
-	USB_RAW_EVENT_INVALID,
-	USB_RAW_EVENT_CONNECT,
-	USB_RAW_EVENT_CONTROL,
+	USB_RAW_EVENT_INVALID = 0,
+	USB_RAW_EVENT_CONNECT = 1,
+	USB_RAW_EVENT_CONTROL = 2,
 };
 
 struct usb_raw_event {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2172,9 +2172,9 @@ struct usb_raw_init {
 };
 
 enum usb_raw_event_type {
-	USB_RAW_EVENT_INVALID,
-	USB_RAW_EVENT_CONNECT,
-	USB_RAW_EVENT_CONTROL,
+	USB_RAW_EVENT_INVALID = 0,
+	USB_RAW_EVENT_CONNECT = 1,
+	USB_RAW_EVENT_CONTROL = 2,
 };
 
 struct usb_raw_event {


### PR DESCRIPTION
To match the kernel uapi headers.