### PR TITLE
sys/linux: use some non-negative points on wireguard

### DIFF
--- a/sys/linux/socket_netlink_generic_wireguard.txt
+++ b/sys/linux/socket_netlink_generic_wireguard.txt
@@ -61,9 +61,9 @@ allowedip_policy_ipv6 {
 # Limit number of keys to 5 to reduce search space.
 wireguard_key [
 	z	array[const[0, int8], NOISE_PUBLIC_KEY_LEN]
-	a	array[const[0xaa, int8], NOISE_PUBLIC_KEY_LEN]
-	b	array[const[0xbb, int8], NOISE_PUBLIC_KEY_LEN]
-	c	array[const[0xcc, int8], NOISE_PUBLIC_KEY_LEN]
+	a	array[const[0x11, int8], NOISE_PUBLIC_KEY_LEN]
+	b	array[const[0x22, int8], NOISE_PUBLIC_KEY_LEN]
+	c	array[const[0x33, int8], NOISE_PUBLIC_KEY_LEN]
 	d	array[const[0xdd, int8], NOISE_PUBLIC_KEY_LEN]
 ]
 


### PR DESCRIPTION
z is low-order and will be rejected, and a, b, c, and d are all negative,
which means they'll be rejected too. That's an interesting code path, of
course, but it also prevents other more interesting code paths. This
commit changes 3 of these to be non-negative so we actually add a few
legitimate peers, while leaving one as negative for hitting that path.

Update #806 