### PR TITLE
CIFuzz: Surface error logs and test case on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: bug_report
-        path: ./out/bug_report
+        name: artifacts
+        path: ./out/artifacts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: fuzzer_testcase
-        path: ./out/testcase
+        name: bug_report
+        path: ./out/bug_report
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,12 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         project-name: 'syzkaller'
-        dry-run: true
+        dry-run: false
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         fuzz-time: 600
-        dry-run: true
+        dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure()


### PR DESCRIPTION
This change to CIFuzz will notify users when a bug was found in there pull request. It will also upload a directory containing the stack trace and test case that caused to bug. Hopefully will mitigate confusion in situations like https://github.com/google/syzkaller/pull/1590 
