### PR TITLE
cover: add code coverage for fuchsia.

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -945,6 +945,7 @@ void copyout_call_results(thread_t* th)
 	}
 }
 
+#if !GOOS_fuchsia
 void write_call_output(thread_t* th, bool finished)
 {
 	uint32 reserrno = 999;
@@ -1013,6 +1014,7 @@ void write_call_output(thread_t* th, bool finished)
 		      th->call_index, th->call_num, reserrno, finished, blocked);
 #endif
 }
+#endif
 
 void write_extra_output()
 {

--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -6,10 +6,75 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <zircon/process.h>
 #include <zircon/status.h>
 #include <zircon/syscalls.h>
 
-#include "nocover.h"
+#define MAX_COVSZ (1ULL << 20)
+
+// In x86_64, sancov stores the return address - 1.
+// We add 1 so the stored value points to a valid pc.
+static const uint64_t kPcFixup = 1;
+
+struct cover_ctx_t {
+	uint64_t cover_data_raw[MAX_COVSZ];
+	uint32_t cover_data_truncated[MAX_COVSZ];
+	zx_handle_t covcount_vmo;
+};
+
+static __thread cover_ctx_t cover;
+
+static void cover_open(cover_t* cov, bool extra)
+{
+}
+
+static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
+{
+	zx_status_t status = zx_coverage_control(zx_thread_self(), 1, &cover.covcount_vmo);
+	if (status != ZX_OK) {
+		fail("failed to enable coverage. err: %d", status);
+	}
+}
+
+static void cover_reset(cover_t* cov)
+{
+	zx_status_t status = zx_coverage_control(zx_thread_self(), 2, nullptr);
+
+	if (status != ZX_OK) {
+	  fail("failed to reset coverage. err: %d", status);
+	}
+}
+
+static void cover_collect(cover_t* cov)
+{
+zx_status_t status;
+	uint64_t cov_count;
+	status = zx_vmo_read(cover.covcount_vmo, &cov_count, 0, sizeof(cov_count));
+	if (status != ZX_OK) {
+	fail("failed to read kcov size: %d", status);
+}
+	if (cov_count > MAX_COVSZ - 1) {
+	  cov_count = MAX_COVSZ - 1;
+	}
+
+	debug("coverage size: %zu\n", cov_count);
+
+	status = zx_vmo_read(cover.covcount_vmo, cover.cover_data_raw, sizeof(uint64_t), cov_count * sizeof(uint64_t));
+	if (status != ZX_OK) {
+	fail("failed to read kcov data: %d",status);
+}
+
+	for (size_t i = 0; i < cov_count; i++) {
+		cover.cover_data_truncated[i] = static_cast<uint32_t>((cover.cover_data_raw[i] + kPcFixup) & 0xFFFFFFFF);
+	}
+
+	cov->size = cov_count;
+	cov->data = reinterpret_cast<char*>(cover.cover_data_truncated);
+}
+
+static void cover_protect(cover_t* cov)
+{
+}
 
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
@@ -39,4 +104,55 @@ static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 	if (res == 0xffffffff)
 		res = (intptr_t)-1;
 	return res;
+}
+
+void write_call_output(thread_t* th, bool finished)
+{
+	uint32 reserrno = 999;
+	const bool blocked = th != last_scheduled;
+	uint32 call_flags = call_flag_executed | (blocked ? call_flag_blocked : 0);
+	if (finished) {
+		reserrno = th->res != -1 ? 0 : th->reserrno;
+		call_flags |= call_flag_finished |
+			      (th->fault_injected ? call_flag_fault_injected : 0);
+	}
+	call_reply reply;
+	reply.header.magic = kOutMagic;
+	reply.header.done = 0;
+	reply.header.status = 0;
+	reply.call_index = th->call_index;
+	reply.call_num = th->call_num;
+	reply.reserrno = reserrno;
+	reply.flags = call_flags;
+	reply.signal_size = 0;
+	reply.cover_size = 0;
+	reply.comps_size = 0;
+	if (flag_coverage) {
+		reply.signal_size = th->cov.size;
+		if (flag_collect_cover) {
+			reply.cover_size = th->cov.size;
+		}
+	}
+	if (write(kOutPipeFd, &reply, sizeof(reply)) != sizeof(reply))
+		fail("control pipe call write failed");
+
+	if (flag_coverage) {
+		// In Fuchsia, coverage is collected by instrumenting edges instead of
+		// basic blocks. This means that the signal that syzkaller
+		// understands is the same as the coverage PCs.
+		ssize_t wrote = write(kOutPipeFd, th->cov.data, th->cov.size * sizeof(uint32_t));
+		if (wrote != sizeof(uint32_t) * th->cov.size) {
+			fail("signals table write failed. Wrote %zd", wrote);
+		}
+		if (!flag_collect_cover) {
+			return;
+		}
+		wrote = write(kOutPipeFd, th->cov.data, th->cov.size * sizeof(uint32_t));
+		if (wrote != sizeof(uint32_t) * th->cov.size) {
+			fail("coverage table write failed. Wrote %zd", wrote);
+		}
+	}
+
+	debug_verbose("out: index=%u num=%u errno=%d finished=%d blocked=%d\n",
+		      th->call_index, th->call_num, reserrno, finished, blocked);
 }

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -27,6 +27,7 @@ type ReportGenerator struct {
 	srcDir   string
 	buildDir string
 	objDir   string
+	OS       string
 	symbols  []symbol
 	pcs      map[uint64][]symbolizer.Frame
 }
@@ -47,6 +48,7 @@ func MakeReportGenerator(target *targets.Target, kernelObject, srcDir, buildDir 
 		srcDir:   srcDir,
 		buildDir: buildDir,
 		objDir:   filepath.Dir(kernelObject),
+		OS:       target.OS,
 		pcs:      make(map[uint64][]symbolizer.Frame),
 	}
 	errc := make(chan error)
@@ -168,6 +170,16 @@ func (rg *ReportGenerator) generate(w io.Writer, progs []Prog, files map[string]
 	for fname, file := range files {
 		remain := ""
 		switch {
+		case rg.OS == "fuchsia":
+			// Fuchsia uses paths relative to the build directory (and, currently, sometimes
+			// absolute paths).
+			// For example: ../../zircon/kernel/dev/pcie/pcie_root.cc
+			// We add an extra ../../.. to the objDir to reach this root build directory
+			// from the kernel object directory.
+			if !filepath.IsAbs(fname) {
+				fname = filepath.Clean(filepath.Join(rg.objDir, "..", "..", "..", fname))
+			}
+			remain = strings.TrimPrefix(fname, rg.buildDir)
 		case strings.HasPrefix(fname, rg.objDir):
 			// Assume the file was built there.
 			remain = filepath.Clean(strings.TrimPrefix(fname, rg.objDir))
@@ -223,7 +235,7 @@ func (rg *ReportGenerator) generate(w io.Writer, progs []Prog, files map[string]
 		}
 		lines, err := parseFile(fname)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to parse file %q: %v", fname, err)
 		}
 		var buf bytes.Buffer
 		for i, ln := range lines {
@@ -378,6 +390,7 @@ func objdumpAndSymbolize(target *targets.Target, obj string) ([]symbolizer.Frame
 		cmd.Process.Kill()
 		cmd.Wait()
 	}()
+
 	s := bufio.NewScanner(stdout)
 	callInsns, traceFuncs := archCallInsn(target)
 	var pcs []uint64
@@ -495,8 +508,17 @@ func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
 	}
 }
 
+// archCallInsn returns a pair of lists of byte-arrays which are useful to
+// detect calls to the coverage instrumentation in objdump disassembly.
+// The first list contains string representations of call instructions in that
+// architecture.
+// The second one is a list of instrumentation function names (e.g.
+// <__sanitizer_cov_trace_pc>).
+// Callers could check each line in an objdump disassembly and look for all
+// call instructions that contain the second string.
 func archCallInsn(target *targets.Target) ([][]byte, [][]byte) {
-	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>")}
+	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>"),
+		[]byte(" <__sanitizer_cov_trace_pc_guard>")}
 	switch target.Arch {
 	case "amd64":
 		// ffffffff8100206a:       callq  ffffffff815cc1d0 <__sanitizer_cov_trace_pc>

--- a/pkg/host/features.go
+++ b/pkg/host/features.go
@@ -67,6 +67,11 @@ func Check(target *prog.Target) (*Features, error) {
 		FeatureUSBEmulation:     {Name: "USB emulation", Reason: unsupported},
 	}
 	if noHostChecks(target) {
+		// TODO(1603): HostFuzzer Mode checks have to be run on syz-executor.
+		if target.OS == "fuchsia" {
+			res[FeatureCoverage].Enabled = true
+			res[FeatureCoverage].Reason = "pending on-target detection, assumed to be available."
+		}
 		return res, nil
 	}
 	for n, check := range checkFeature {

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -438,7 +438,7 @@ func fuchsiaCFlags(arch, clangArch string) []string {
 		"-lfdio",
 		"-lzircon",
 		"--sysroot", out + "/zircon_toolchain/obj/zircon/public/sysroot/sysroot",
-		"-I", sourceDirVar + "/zircon/system/ulib/fdio/include",
+		"-I", sourceDirVar + "/sdk/lib/fdio/include",
 		"-I", sourceDirVar + "/zircon/system/ulib/fidl/include",
 		"-I", sourceDirVar + "/src/lib/ddk/include",
 		"-I", out + "/fidling/gen/sdk/fidl/fuchsia.device",


### PR DESCRIPTION
**NOTE** This CL is not ready to be merged, but we would like to get feedback on the approach. The CL still needs to wait for the KCOV support in fuchsia to land.

This CL contains code changes in syzkaller to support extracting code
coverage information from Fuchsia.

Changes in Syz-Executor:

Basically, everything is implemented in `executor_fuchsia.h`, the
function `write_call_output` was reimplemented as to not break other
OSes implementations (fuchsia processes coverage signal differently).

Coverage is extracted from the kernel as a VMO. This VMO contains a
table of uint64_t with the number of hits for each pc.
The mapping Index->PC is stored in `/boot/kernel/data/zircon.elf.1.sancov`.

`cover_enable` starts collecting coverage for the current thread, and
creates a VMO to store said coverage.

`cover_reset` takes a snapshot of the current coverage.
`cover_collect` takes another snpashot of the current coverage, and sets
`cov->data` as an array containing all the pcs whose count differ from
the last snapshot.

`write_call_output` is similar to the regular in syzkaller for other OSes,
except that it includes the coverage data and signal (signal == coverage
data for the fuchsia case, as fuchsia covers all edges instead of basic
blocks).

The coverage obtained from Fuchsia is in Sancov format. For x86_64,
the PC is set to the return address of the sanitizer_cov_trace_pc_guard
function - 1 (this is because in x86 instruction size is variable). To
make syzkaller understand the PC, we just increase the value by 1, so
now it points to the return address directly. The difference between
"the call instruction" and "the instruction after the call" should not
matter for syzkaller, as coverage wise it should be the same.

Changes in Syz-Manager:

Coverage collection is always enabled in target os is Fuchsia.

The IPC package now supports reading signal, coverage and comparisons
from IPC and not only shared memory.

Coverage Reports include a functionality to see a source-code overlay,
using addr2line to match the filename. In the case of fuchsia builds,
the path returned by addr2line is a relative path based on the build
directory. Syzkaller now assumes that if that file path is relative, it
is relative to the build directory.

Calls to the coverage functions were matched by comparing the function
name (`__sanitizer_cov_trace_pc`). In fuchsia, we use
`__sanitizer_cov_trace_pc_guard`. This commit adapts the archCallInsn to
return a slice containing both values.

This work has been done in pair-programming with eep@google.com
