### PR TITLE
executor: don't exit if NETLINK_GENERIC isnt' supported

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -881,8 +881,10 @@ static void netlink_wireguard_setup(void)
 	int id, err;
 
 	sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
-	if (sock == -1)
-		fail("socket(AF_NETLINK) failed\n");
+	if (sock == -1) {
+		debug("socket(AF_NETLINK) failed: %s\n", strerror(errno));
+		return;
+	}
 
 	id = netlink_wireguard_id_get(&nlmsg, sock);
 	if (id == -1)

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1900,8 +1900,10 @@ static void netlink_wireguard_setup(void)
 	int id, err;
 
 	sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
-	if (sock == -1)
-		fail("socket(AF_NETLINK) failed\n");
+	if (sock == -1) {
+		debug("socket(AF_NETLINK) failed: %s\n", strerror(errno));
+		return;
+	}
 
 	id = netlink_wireguard_id_get(&nlmsg, sock);
 	if (id == -1)


### PR DESCRIPTION
NETLINK_GENERIC isn't supported in gVisor.

Fixes: c5ed587f4af5 ("wireguard: setup some initial devices in a triangle")
