### PR TITLE
build: fix issue with git and relative dates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifeq ("$(shell git diff --shortstat)", "")
 else
 	REV=$(GITREV)+
 endif
-GITREVDATE=$(shell git log -n 1 --format="%ad")
+GITREVDATE=$(shell git log -n 1 --format="%aD")
 
 # Don't generate symbol table and DWARF debug info.
 # Reduces build time and binary sizes considerably.

--- a/prog/meta.go
+++ b/prog/meta.go
@@ -19,7 +19,7 @@ func init() {
 	GitRevisionBase = strings.Replace(GitRevision, "+", "", -1)
 	if gitRevisionDate != "" {
 		var err error
-		if GitRevisionDate, err = time.Parse("Mon Jan 2 15:04:05 2006 -0700", gitRevisionDate); err != nil {
+		if GitRevisionDate, err = time.Parse("Mon, 2 Jan 2006 15:04:05 -0700", gitRevisionDate); err != nil {
 			panic(err)
 		}
 	}

--- a/prog/prio.go
+++ b/prog/prio.go
@@ -221,6 +221,7 @@ func (target *Target) BuildChoiceTable(prios [][]float32, enabled map[*Syscall]b
 	if len(enabledCalls) == 0 {
 		panic(fmt.Sprintf("empty enabledCalls, len(target.Syscalls)=%v", len(target.Syscalls)))
 	}
+	sort.Sort(BySyscallID(enabledCalls))
 	run := make([][]int, len(target.Syscalls))
 	for i := range run {
 		if !enabled[target.Syscalls[i]] {

--- a/prog/types.go
+++ b/prog/types.go
@@ -21,6 +21,21 @@ type Syscall struct {
 	outputResources []*ResourceDesc
 }
 
+type BySyscallID []*Syscall
+
+func (s BySyscallID) Len() int {
+	return len(s)
+}
+
+func (s BySyscallID) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s BySyscallID) Less(i, j int) bool {
+	return s[i].ID < s[j].ID
+}
+
+
 type Dir int
 
 const (


### PR DESCRIPTION
If git is set up to display relative dates, the build succeeds but
produces binaries that panic immediately an error like:

```
panic: parsing time "30 hours ago" as "Mon Jan 2 15:04:05 2006 -0700"
```

This change forces git to return an RFC2822-compliant date string, and
updates the parser to handle that format.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
