### PR TITLE
sys/syz-extract: broken on OpenBSD

### DIFF
--- a/sys/openbsd/ipc.txt
+++ b/sys/openbsd/ipc.txt
@@ -13,8 +13,6 @@ resource ipc[int32]: 0, 0xffffffffffffffff
 
 # TODO: describe ipc syscall
 
-define SYS___semctl50	295
-
 resource ipc_msq[ipc]
 msgget(key proc[2039379027, 4], flags flags[msgget_flags]) ipc_msq
 msgget$private(key const[IPC_PRIVATE], flags flags[msgget_flags]) ipc_msq

--- a/sys/syz-extract/openbsd.go
+++ b/sys/syz-extract/openbsd.go
@@ -84,7 +84,7 @@ func (*openbsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 	params := &extractParams{
 		AddSource: "#include <sys/syscall.h>",
 	}
-	res, undeclared, err := extract(info, "gcc", args, params)
+	res, undeclared, err := extract(info, "cc", args, params)
 	for orig, compats := range compatNames {
 		for _, compat := range compats {
 			if undeclared[orig] && !undeclared[compat] {


### PR DESCRIPTION
While working on something else, I noticed that syz-extract was currently broken on OpenBSD. Best reviewed commit by commit.