### PR TITLE
executor/fuchsia: Don't map memory as executable.

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <utime.h>
 #include <zircon/process.h>
+#include <zircon/status.h>
 #include <zircon/syscalls.h>
 
 #if SYZ_EXECUTOR || __NR_get_root_resource
@@ -50,7 +51,7 @@ static zx_status_t update_exception_thread_regs(zx_handle_t exception)
 	zx_handle_t thread;
 	zx_status_t status = zx_exception_get_thread(exception, &thread);
 	if (status != ZX_OK) {
-		debug("zx_exception_get_thread failed: %d\n", status);
+		debug("zx_exception_get_thread failed: %s (%d)\n", zx_status_get_string(status), status);
 		return status;
 	}
 
@@ -58,8 +59,8 @@ static zx_status_t update_exception_thread_regs(zx_handle_t exception)
 	status = zx_thread_read_state(thread, ZX_THREAD_STATE_GENERAL_REGS,
 				      &regs, sizeof(regs));
 	if (status != ZX_OK) {
-		debug("zx_thread_read_state failed: %d (%d)\n",
-		      (int)sizeof(regs), status);
+		debug("zx_thread_read_state failed: %d %s (%d)\n",
+		      (int)sizeof(regs), zx_status_get_string(status), status);
 	} else {
 #if GOARCH_amd64
 		regs.rip = (uint64)(void*)&segv_handler;
@@ -70,7 +71,7 @@ static zx_status_t update_exception_thread_regs(zx_handle_t exception)
 #endif
 		status = zx_thread_write_state(thread, ZX_THREAD_STATE_GENERAL_REGS, &regs, sizeof(regs));
 		if (status != ZX_OK) {
-			debug("zx_thread_write_state failed: %d\n", status);
+			debug("zx_thread_write_state failed: %s (%d)\n", zx_status_get_string(status), status);
 		}
 	}
 
@@ -84,7 +85,7 @@ static void* ex_handler(void* arg)
 	for (int i = 0; i < 10000; i++) {
 		zx_status_t status = zx_object_wait_one(exception_channel, ZX_CHANNEL_READABLE, ZX_TIME_INFINITE, NULL);
 		if (status != ZX_OK) {
-			debug("zx_object_wait_one failed: %d\n", status);
+			debug("zx_object_wait_one failed: %s (%d)\n", zx_status_get_string(status), status);
 			continue;
 		}
 
@@ -92,20 +93,20 @@ static void* ex_handler(void* arg)
 		zx_handle_t exception;
 		status = zx_channel_read(exception_channel, 0, &info, &exception, sizeof(info), 1, NULL, NULL);
 		if (status != ZX_OK) {
-			debug("zx_channel_read failed: %d\n", status);
+			debug("zx_channel_read failed: %s (%d)\n", zx_status_get_string(status), status);
 			continue;
 		}
 
 		debug("got exception: type=%d tid=%llu\n", info.type, (unsigned long long)(info.tid));
 		status = update_exception_thread_regs(exception);
 		if (status != ZX_OK) {
-			debug("failed to update exception thread registers: %d\n", status);
+			debug("failed to update exception thread registers: %s (%d)\n", zx_status_get_string(status), status);
 		}
 
 		uint32 state = ZX_EXCEPTION_STATE_HANDLED;
 		status = zx_object_set_property(exception, ZX_PROP_EXCEPTION_STATE, &state, sizeof(state));
 		if (status != ZX_OK) {
-			debug("zx_object_set_property(ZX_PROP_EXCEPTION_STATE) failed: %d\n", status);
+			debug("zx_object_set_property(ZX_PROP_EXCEPTION_STATE) failed: %s (%d)\n", zx_status_get_string(status), status);
 		}
 		zx_handle_close(exception);
 	}
@@ -118,7 +119,7 @@ static void install_segv_handler(void)
 	zx_status_t status;
 	zx_handle_t exception_channel;
 	if ((status = zx_task_create_exception_channel(zx_process_self(), 0, &exception_channel)) != ZX_OK)
-		fail("zx_task_create_exception_channel failed: %d", status);
+		fail("zx_task_create_exception_channel failed: %s (%d)", zx_status_get_string(status), status);
 	pthread_t th;
 	if (pthread_create(&th, 0, ex_handler, (void*)(long)exception_channel))
 		fail("pthread_create failed");
@@ -190,30 +191,24 @@ long syz_mmap(size_t addr, size_t size)
 	zx_info_vmar_t info;
 	zx_status_t status = zx_object_get_info(root, ZX_INFO_VMAR, &info, sizeof(info), 0, 0);
 	if (status != ZX_OK) {
-		debug("zx_object_get_info(ZX_INFO_VMAR) failed: %d", status);
+		debug("zx_object_get_info(ZX_INFO_VMAR) failed: %s (%d)", zx_status_get_string(status), status);
 		return status;
 	}
 	zx_handle_t vmo;
 	status = zx_vmo_create(size, 0, &vmo);
 	if (status != ZX_OK) {
-		debug("zx_vmo_create failed with: %d\n", status);
+		debug("zx_vmo_create failed: %s (%d)\n", zx_status_get_string(status), status);
 		return status;
 	}
-	status = zx_vmo_replace_as_executable(vmo, ZX_HANDLE_INVALID, &vmo);
-	if (status != ZX_OK) {
-		debug("zx_vmo_replace_as_executable failed with: %d\n", status);
-		// Don't need to zx_handle_close(vmo) because
-		// zx_vmo_replace_as_executable already invalidates it.
-		return status;
-	}
+
 	uintptr_t mapped_addr;
-	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE | ZX_VM_FLAG_PERM_EXECUTE,
+	status = zx_vmar_map(root, ZX_VM_FLAG_SPECIFIC_OVERWRITE | ZX_VM_FLAG_PERM_READ | ZX_VM_FLAG_PERM_WRITE,
 			     addr - info.base, vmo, 0, size,
 			     &mapped_addr);
 
 	zx_status_t close_vmo_status = zx_handle_close(vmo);
 	if (close_vmo_status != ZX_OK) {
-		debug("zx_handle_close(vmo) failed with: %d\n", close_vmo_status);
+		debug("zx_handle_close(vmo) failed with: %s (%d)\n", zx_status_get_string(close_vmo_status), close_vmo_status);
 	}
 	return status;
 }

--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <zircon/status.h>
 #include <zircon/syscalls.h>
 
 #include "nocover.h"
@@ -14,7 +15,7 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
 	zx_status_t status = syz_mmap((size_t)data, data_size);
 	if (status != ZX_OK)
-		fail("mmap of data segment failed with: %d", status);
+		fail("mmap of data segment failed: %s (%d)", zx_status_get_string(status), status);
 }
 
 static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])


### PR DESCRIPTION
Fuchsia has strict controls over who can map memory as executable.
Refactoring syz-executor to be able to do that involves a non trivial
amount of work: it needs to run as a fuchsia component and replace stdin
for some other mechanism to communicate with syz-fuzzer (probably a fidl
service and a thin client that proxies stdin/stdout to syz-fuzzer via
ssh).

Mapping memory as executable doesn't seem to be used or needed in
syz-executor at all. After talking with Dmitry, he mentioned that it was
used in a deprecated feature: `syz_execute_func` which would execute
random code. It also allows more scenarios during fuzzing.

For now, I'm removing that option to allow syzkaller continue fuzzing.

This change also refactors all of the error messages adding a string
representation of the `zx_status_t` in error logs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
