### PR TITLE
pkg/report: make uvm_fault parsing more strict on OpenBSD

### DIFF
--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -226,7 +226,7 @@ var openbsdOopses = append([]*oops{
 		[]*regexp.Regexp{},
 	},
 	{
-		[]byte("uvm_fault"),
+		[]byte("uvm_fault("),
 		[]oopsFormat{
 			{
 				title: compile("uvm_fault\\((?:.*\\n)+?.*Stopped at[ ]+{{ADDR}}"),

--- a/pkg/report/testdata/openbsd/report/28
+++ b/pkg/report/testdata/openbsd/report/28
@@ -1,0 +1,2 @@
+
+vmx_mprotect_ept: uvm_fault returns 14, GPA=0x200000


### PR DESCRIPTION
In order to avoid treating the following diagnostic printf as a panic[1]:

	vmx_mprotect_ept: uvm_fault returns 14, GPA=0x200000

[1] https://syzkaller.appspot.com/bug?id=25f3ef919bf9f5d8a89e13b1ba5fec8ca56334be