### PR TITLE
[RFC] Implement configuration bisection

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -29,13 +29,14 @@ type Config struct {
 }
 
 type KernelConfig struct {
-	Repo      string
-	Branch    string
-	Commit    string
-	Cmdline   string
-	Sysctl    string
-	Config    []byte
-	Userspace string
+	Repo           string
+	Branch         string
+	Commit         string
+	Cmdline        string
+	Sysctl         string
+	Config         []byte
+	BaselineConfig []byte
+	Userspace      string
 }
 
 type SyzkallerConfig struct {

--- a/pkg/vcs/linux_test.go
+++ b/pkg/vcs/linux_test.go
@@ -1,0 +1,114 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+type MinimizationTest struct {
+	config         string
+	baselineConfig string
+	// Output contains expected config option
+	expectedConfig string
+	// Minimization is expected to pass or fail
+	passing bool
+}
+
+func createTestLinuxRepo(t *testing.T) string {
+	baseDir, err := ioutil.TempDir("", "syz-config-bisect-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := CreateTestRepo(t, baseDir, "")
+	repo.CommitChange("commit")
+	repo.SetTag("v4.1")
+	err = os.MkdirAll(baseDir+"/tools/testing/ktest", 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(baseDir+"/scripts/kconfig", 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy stubbed scripts used by config bisect
+	err = osutil.CopyFile("testdata/linux/config-bisect.pl",
+		baseDir+"/tools/testing/ktest/config-bisect.pl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = osutil.CopyFile("testdata/linux/merge_config.sh",
+		baseDir+"/scripts/kconfig/merge_config.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return baseDir
+}
+
+func TestMinimizationResults(t *testing.T) {
+	tests := []MinimizationTest{
+		{
+			config:         "CONFIG_ORIGINAL=y",
+			baselineConfig: "CONFIG_FAILING=y",
+			expectedConfig: "CONFIG_ORIGINAL=y",
+			passing:        false,
+		},
+		{
+			config:         "CONFIG_ORIGINAL=y",
+			baselineConfig: "CONFIG_REPRODUCES_CRASH=y",
+			expectedConfig: "CONFIG_REPRODUCES_CRASH=y",
+			passing:        true,
+		},
+		{
+			config:         "CONFIG_ORIGINAL=y",
+			baselineConfig: "CONFIG_NOT_REPRODUCE_CRASH=y",
+			expectedConfig: "CONFIG_ORIGINAL=y",
+			passing:        true,
+		},
+		{
+			config:         configBisectTag,
+			baselineConfig: "CONFIG_NOT_REPRODUCE_CRASH=y",
+			expectedConfig: configBisectTag,
+			passing:        true,
+		},
+	}
+
+	trace := new(bytes.Buffer)
+	baseDir := createTestLinuxRepo(t)
+	repo, err := NewRepo("linux", "64", baseDir)
+	if err != nil {
+		t.Fatalf("Unable to create repository")
+	}
+	pred := func(test []byte) (BisectResult, error) {
+		if strings.Contains(string(test), "CONFIG_REPRODUCES_CRASH=y") {
+			return BisectBad, nil
+		}
+		return BisectGood, nil
+	}
+
+	minimizer, ok := repo.(ConfigMinimizer)
+	if !ok {
+		t.Fatalf("Config minimization is not implemented")
+	}
+	for _, test := range tests {
+		outConfig, err := minimizer.Minimize([]byte(test.config),
+			[]byte(test.baselineConfig), trace, pred)
+		if test.passing && err != nil {
+			t.Fatalf("Failed to run Minimize")
+		} else if test.passing && !strings.Contains(string(outConfig),
+			test.expectedConfig) {
+			t.Fatalf("Output is not expected %v vs. %v", string(outConfig),
+				test.expectedConfig)
+		}
+	}
+	t.Log(trace.String())
+}

--- a/pkg/vcs/testdata/linux/config-bisect.pl
+++ b/pkg/vcs/testdata/linux/config-bisect.pl
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2020 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+# config-bisect.pl -l ctx.git.dir -r -b ctx.git.dir kernelBaselineConfig kernelConfig
+
+if [ "$3" == "-r" ]
+then
+    baseline=`cat $6`
+    outdir=$5
+    echo $baseline > $outdir/.config
+    exit 0
+fi
+
+# config-bisect.pl -l ctx.git.dir -b ctx.git.dir kernelBaselineConfig kernelConfig verdict
+baseline=`cat $5`
+
+# Test baseline file contains string CONFIG_FAILING -> fail
+if [ "$baseline" == "CONFIG_FAILING=y" ]
+then
+    exit 1
+fi
+
+# Generate end results which "reproduces" the crash
+if [ $baseline == "CONFIG_REPRODUCES_CRASH=y" ]
+then
+    echo "%%%%%%%% FAILED TO FIND SINGLE BAD CONFIG %%%%%%%%"
+    echo "Hmm, can't make any more changes without making good == bad?"
+    echo "Difference between good (+) and bad (-)"
+    echo "REPRODUCES_CRASH n -> y"
+    echo "-DISABLED_OPTION=n"
+    echo "+ONLY_IN_ORIGINAL_OPTION=y"
+    echo "See good and bad configs for details:"
+    echo "good: /mnt/work/config_bisect_evaluation/out/config_bisect/kernel.baseline_config.tmp"
+    echo "bad:  /mnt/work/config_bisect_evaluation/out/config_bisect/kernel.config.tmp"
+    echo "%%%%%%%% FAILED TO FIND SINGLE BAD CONFIG %%%%%%%%"
+    exit 2
+fi
+
+# Generate end result which doesn't "reproduce" the crash
+if [ $baseline == "CONFIG_NOT_REPRODUCE_CRASH=y" ]
+then
+    echo "%%%%%%%% FAILED TO FIND SINGLE BAD CONFIG %%%%%%%%"
+    echo "Hmm, can't make any more changes without making good == bad?"
+    echo "Difference between good (+) and bad (-)"
+    echo "NOT_REPRODUCE_CRASH n -> y"
+    echo "See good and bad configs for details:"
+    echo "good: /mnt/work/config_bisect_evaluation/out/config_bisect/kernel.baseline_config.tmp"
+    echo "bad:  /mnt/work/config_bisect_evaluation/out/config_bisect/kernel.config.tmp"
+    echo "%%%%%%%% FAILED TO FIND SINGLE BAD CONFIG %%%%%%%%"
+    exit 2
+fi
+
+

--- a/pkg/vcs/testdata/linux/merge_config.sh
+++ b/pkg/vcs/testdata/linux/merge_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright 2020 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+# merge_config.sh -m -O outdir baseline kernelAdditionsConfig
+OUTDIR=$3
+
+echo `cat $4` > $OUTDIR/.config
+echo `cat $5` >> $OUTDIR/.config
+
+exit 0

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -3,9 +3,16 @@
 
 package vcs
 
+import (
+	"fmt"
+	"io"
+)
+
 type testos struct {
 	*git
 }
+
+var _ ConfigMinimizer = new(testos)
 
 func newTestos(dir string) *testos {
 	return &testos{
@@ -18,5 +25,13 @@ func (ctx *testos) PreviousReleaseTags(commit string) ([]string, error) {
 }
 
 func (ctx *testos) EnvForCommit(binDir, commit string, kernelConfig []byte) (*BisectEnv, error) {
-	return &BisectEnv{}, nil
+	return &BisectEnv{KernelConfig: kernelConfig}, nil
+}
+
+func (ctx *testos) Minimize(original, baseline []byte, trace io.Writer,
+	pred func(test []byte) (BisectResult, error)) ([]byte, error) {
+	if string(baseline) == "minimize-fails" {
+		return nil, fmt.Errorf("minimization failure")
+	}
+	return original, nil
 }

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -69,6 +69,10 @@ type Bisecter interface {
 	EnvForCommit(binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
 }
 
+type ConfigMinimizer interface {
+	Minimize(original, baseline []byte, trace io.Writer, pred func(test []byte) (BisectResult, error)) ([]byte, error)
+}
+
 type Commit struct {
 	Hash       string
 	Title      string

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -370,6 +370,16 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 	if err := instance.OverrideVMCount(mgrcfg, bisect.NumTests); err != nil {
 		return err
 	}
+
+	var baseline []byte
+	var err error
+	// Read possible baseline for config minimization
+	if len(mgr.mgrcfg.KernelBaselineConfig) != 0 {
+		baseline, err = ioutil.ReadFile(mgr.mgrcfg.KernelBaselineConfig)
+		if err != nil {
+			return err
+		}
+	}
 	trace := new(bytes.Buffer)
 	cfg := &bisect.Config{
 		Trace:    io.MultiWriter(trace, log.VerboseWriter(3)),
@@ -377,13 +387,14 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		Fix:      req.Type == dashapi.JobBisectFix,
 		BinDir:   jp.cfg.BisectBinDir,
 		Kernel: bisect.KernelConfig{
-			Repo:      mgr.mgrcfg.Repo,
-			Branch:    mgr.mgrcfg.Branch,
-			Commit:    req.KernelCommit,
-			Cmdline:   mgr.mgrcfg.KernelCmdline,
-			Sysctl:    mgr.mgrcfg.KernelSysctl,
-			Config:    req.KernelConfig,
-			Userspace: mgr.mgrcfg.Userspace,
+			Repo:           mgr.mgrcfg.Repo,
+			Branch:         mgr.mgrcfg.Branch,
+			Commit:         req.KernelCommit,
+			Cmdline:        mgr.mgrcfg.KernelCmdline,
+			Sysctl:         mgr.mgrcfg.KernelSysctl,
+			Config:         req.KernelConfig,
+			BaselineConfig: baseline,
+			Userspace:      mgr.mgrcfg.Userspace,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   jp.syzkallerRepo,

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -108,6 +108,8 @@ type ManagerConfig struct {
 	Compiler     string `json:"compiler"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
+	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig
+	KernelBaselineConfig string `json:"kernel_baseline_config"`
 	// File with kernel cmdline values (optional).
 	KernelCmdline string `json:"kernel_cmdline"`
 	// File with sysctl values (e.g. output of sysctl -a, optional).

--- a/syz-ci/testdata/example.cfg
+++ b/syz-ci/testdata/example.cfg
@@ -15,6 +15,7 @@
 			"compiler": "/syzkaller/gcc/bin/gcc",
 			"userspace": "/syzkaller/wheezy",
 			"kernel_config": "/syzkaller/kasan.config",
+			"kernel_baseline_config": "/syzkaller/kasan_baseline.config",
 			"manager_config": {
 				"target": "linux/amd64",
 				"sandbox": "namespace",

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -102,9 +102,11 @@ func main() {
 	loadString("syzkaller.commit", &cfg.Syzkaller.Commit)
 	loadString("kernel.commit", &cfg.Kernel.Commit)
 	loadFile("kernel.config", &cfg.Kernel.Config, true)
+	loadFile("kernel.baseline_config", &cfg.Kernel.BaselineConfig, false)
 	loadFile("repro.syz", &cfg.Repro.Syz, false)
 	loadFile("repro.c", &cfg.Repro.C, false)
 	loadFile("repro.opts", &cfg.Repro.Opts, true)
+
 	if _, err := bisect.Run(cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "bisection failed: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
First patch is adding new Syzkaller configuration option kernel_baseline_config. This option can be used to provide kernel configuration containing minimalistic set of drivers. It will be used as "good" configuration when configuration bisection is run for crash. To ge good bisection results baseline configuration should contain same debug options as "normal" configuration and have just unneeded drivers disabled.

Second patch is adding kernel configuration bisection as part of normal commit bisection. First original head with original commit is tested as earlier. Then original head is tested with configured baseline configuration (kernel_baseline_config). If crash reproduces with this baseline configuration it's used in commit bisection. If the crash doesn't reproduce then configuration bisection is run. When triggering configuration option is found provided baseline configuration is modified according the bisection results. This new configuration (kernel_minimalistic_configuration) is tested once more with current head. If crash reproduces with the generated configuration commit bisection is performed using it.

We are expecting configuration bisection to improve current commit bisection by killing "noise" caused by drivers not related to crash. It is also providing us possibility to identify which crashes certain kernel configuration is prone to.

Weaknesses in this configuration bisection implementation are mostly dervived from config_bisect.pl provided by Linux kernel and Syzkaller crash log parsing. 