### PR TITLE
Fix support for fuzzing in Android sandbox for amd64

### DIFF
--- a/executor/android/android_seccomp.h
+++ b/executor/android/android_seccomp.h
@@ -102,3 +102,23 @@ static void set_app_seccomp_filter()
 	// Will fail() if anything fails.
 	install_filter(&f);
 }
+
+#if GOARCH_amd64 || GOARCH_386
+// In bionic mkdir calls mkdirat, there is no seccomp hole for mkdir.
+int mkdir(const char* path, mode_t mode)
+{
+	return mkdirat(AT_FDCWD, path, mode);
+}
+
+// In bionic unlinkat calls mkdirat, there is no seccomp hole for rmdir.
+int rmdir(const char* path)
+{
+	return unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+}
+
+// In bionic symlink calls symlinkat, there is no seccomp hole for symlink.
+int symlink(const char* old_path, const char* new_path)
+{
+	return symlinkat(old_path, AT_FDCWD, new_path);
+}
+#endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6508,6 +6508,21 @@ static void set_app_seccomp_filter()
 	install_filter(&f);
 }
 
+#if GOARCH_amd64 || GOARCH_386
+int mkdir(const char* path, mode_t mode)
+{
+	return mkdirat(AT_FDCWD, path, mode);
+}
+int rmdir(const char* path)
+{
+	return unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+}
+int symlink(const char* old_path, const char* new_path)
+{
+	return symlinkat(old_path, AT_FDCWD, new_path);
+}
+#endif
+
 #endif
 #include <fcntl.h>
 #include <grp.h>


### PR DESCRIPTION
Bionic wrap mkdir, rmdir, and symlink and calls different syscalls
(mkdirat, unlinkat, and symlinkat).  mkdir, rmdir, and symlink are not
allowed through the seccomp filter.  This adds the wrapper functions for
amd64 and i386 only.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
