### PR TITLE
syzkaller: add reinforcement-learning-based task and seed selection

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -58,3 +58,4 @@ Christoph Paasch
 Collabora
  André Almeida
 Dipanjan Das
+Daimeng Wang

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -311,8 +311,9 @@ func (inst *inst) testInstance() error {
 		}
 	}
 
-	cmd := OldFuzzerCmd(fuzzerBin, executorCmd, "test", inst.cfg.TargetOS, inst.cfg.TargetArch, fwdAddr,
-		inst.cfg.Sandbox, 0, inst.cfg.Cover, true)
+	cmd := OldFuzzerCmd(fuzzerBin, executorCmd, "test", inst.cfg.TargetOS,
+		inst.cfg.TargetArch, fwdAddr, inst.cfg.Sandbox, 0,
+		inst.cfg.Cover, true)
 	outc, errc, err := inst.vm.Run(10*time.Minute, nil, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to run binary in VM: %v", err)
@@ -418,7 +419,7 @@ func (inst *inst) testProgram(command string, testTime time.Duration) error {
 }
 
 func FuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string, procs, verbosity int,
-	cover, debug, test, runtest bool) string {
+	cover, debug, test, runtest, mabts, mabss bool) string {
 	osArg := ""
 	if targets.Get(OS, arch).HostFuzzer {
 		// Only these OSes need the flag, because the rest assume host OS.
@@ -434,14 +435,21 @@ func FuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string, procs,
 	if verbosity != 0 {
 		verbosityArg = fmt.Sprintf(" -vv=%v", verbosity)
 	}
-	return fmt.Sprintf("%v -executor=%v -name=%v -arch=%v%v -manager=%v -sandbox=%v"+
+	ret := fmt.Sprintf("%v -executor=%v -name=%v -arch=%v%v -manager=%v -sandbox=%v"+
 		" -procs=%v -cover=%v -debug=%v -test=%v%v%v",
 		fuzzer, executor, name, arch, osArg, fwdAddr, sandbox,
 		procs, cover, debug, test, runtestArg, verbosityArg)
+	// Only add MAB args when not testing, since instance_test cannot
+	// parse new flags
+	if !test {
+		ret += fmt.Sprintf(" -mabts=%v -mabss=%v", mabts, mabss)
+	}
+	return ret
 }
 
-func OldFuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string, procs int, cover, test bool) string {
-	return FuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox, procs, 0, cover, false, test, false)
+func OldFuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string,
+	procs int, cover, test bool) string {
+	return FuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox, procs, 0, cover, false, test, false, false, false)
 }
 
 func ExecprogCmd(execprog, executor, OS, arch, sandbox string, repeat, threaded, collide bool,

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -29,8 +29,8 @@ func TestFuzzerCmd(t *testing.T) {
 	flagSandbox := flags.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace)")
 	flagDebug := flags.Bool("debug", false, "debug output from executor")
 	flagV := flags.Int("v", 0, "verbosity")
-	cmdLine := OldFuzzerCmd(os.Args[0], "/myexecutor", "myname", "linux", "386", "localhost:1234",
-		"namespace", 3, true, true)
+	cmdLine := OldFuzzerCmd(os.Args[0], "/myexecutor", "myname", "linux", "386",
+		"localhost:1234", "namespace", 3, true, true)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatal(err)

--- a/pkg/mab/mab_reward_test.go
+++ b/pkg/mab/mab_reward_test.go
@@ -1,0 +1,31 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package mab_test
+
+import (
+	"testing"
+
+	. "github.com/google/syzkaller/pkg/mab"
+)
+
+func TestRewardUpdate(t *testing.T) {
+	reward := Reward{
+		Count:      0,
+		TotalCov:   0.0,
+		TotalTime:  0.0,
+		TotalCov2:  0.0,
+		TotalTime2: 0.0,
+	}
+	reward_expected := Reward{
+		Count:      1,
+		TotalCov:   2.0,
+		TotalTime:  4.0,
+		TotalCov2:  4.0,
+		TotalTime2: 16.0,
+	}
+	reward.Update(2.0, 4.0)
+	if reward != reward_expected {
+		t.Fatal("Reward is not updated correctly")
+	}
+}

--- a/pkg/mab/result.go
+++ b/pkg/mab/result.go
@@ -1,0 +1,29 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package mab
+
+import (
+	"github.com/google/syzkaller/pkg/hash"
+)
+
+type ExecResult struct {
+	Cov       int     // Coverage gained
+	TimeExec  float64 // Executing time (s)
+	TimeTotal float64 // Total time (s)
+	Pidx      int     // If mutation, the idx of the seed program
+}
+
+type TriageResult struct {
+	CorpusCov        int
+	VerifyTime       float64
+	MinimizeCov      int
+	MinimizeTime     float64
+	MinimizeTimeSave float64
+	Source           int // 0: Gen, 1: Mut, 2: Tri
+	SourceExecTime   float64
+	SourceSig        hash.Sig
+	Pidx             int     // Index of the program in the corpus
+	Success          bool    // Whether triage produces a seed
+	TimeTotal        float64 // Total time spent
+}

--- a/pkg/mab/reward.go
+++ b/pkg/mab/reward.go
@@ -1,0 +1,70 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package mab
+
+type Reward struct {
+	Count      int
+	TotalCov   float64 // sum(cov)
+	TotalTime  float64 // sum(time)
+	TotalCov2  float64 // sum(cov * cov). Used to compute std
+	TotalTime2 float64 // sum(time * time). Used to compute std
+}
+
+type TotalReward struct {
+	// For Task Scheduling
+	EstimatedRewardGenerate float64 // Estimated reward for Generate. Used for weight deciding
+	EstimatedRewardMutate   float64 // Estimated reward for Mutate. Used for weight deciding
+	EstimatedRewardTriage   float64 // Estimated reward for Triage. Used for weight deciding
+	RawAllTasks             Reward  // Raw cov/time for all Gen/Mut/Tri. Used for computing expected time
+	RewardAllTasks          Reward  // Cov/time converted to reward for all Gen/Mut/Tri. Used for normalization
+
+	// For Seed selection
+	RawMutateOnly    Reward // Raw cov/time for mutations. Used for Nael's computation for seed selection
+	RewardMutateOnly Reward // Cov/time converted to reward for mutations only. Used for normalization
+}
+
+// Reward and time time information for each seed
+type CorpusReward struct {
+	MutateCount      int     // Number of times this seed has been mutated
+	ExecTime         float64 // Execution time
+	MutateTime       float64 // Total time of mutating this seed
+	MutateCov        float64 // Total coverage cov of mutating this seed
+	VerifyTime       float64 // Time time of verifing this seed
+	MinimizeCov      float64 // Coverage coved from minimization
+	MinimizeTime     float64 // Time time of minimization
+	MinimizeTimeSave float64 // Estimated time save due to minimization
+	MutateReward     float64 // Converted reward of mutating this seed. Coversion based on all tasks
+	MutateRewardOrig float64 // Converted reward of mutating this seed. Conversion based on mutations only
+	TriageReward     float64 // Converted reward of triaging this seed
+}
+
+func (reward *Reward) Update(cov float64, time float64) {
+	const Max = 1.0e+100 // Prevent overflow
+
+	reward.Count++
+	reward.TotalCov += cov
+	reward.TotalCov2 += cov * cov
+	reward.TotalTime += time
+	reward.TotalTime2 += time * time
+	if reward.TotalCov > Max {
+		reward.TotalCov = Max
+	}
+	if reward.TotalCov2 > Max {
+		reward.TotalCov2 = Max
+	}
+	if reward.TotalTime > Max {
+		reward.TotalTime = Max
+	}
+	if reward.TotalTime2 > Max {
+		reward.TotalTime2 = Max
+	}
+}
+
+func (reward *Reward) Remove(cov float64, time float64) {
+	reward.Count--
+	reward.TotalCov -= cov
+	reward.TotalCov2 -= cov * cov
+	reward.TotalTime -= time
+	reward.TotalTime2 -= time * time
+}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -114,4 +114,8 @@ type Config struct {
 	SyzFuzzerBin   string `json:"-"`
 	SyzExecprogBin string `json:"-"`
 	SyzExecutorBin string `json:"-"`
+
+	// MAB task selection and seed selection
+	MABTS bool `json:"mabts"`
+	MABSS bool `json:"mabss"`
 }

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -6,16 +6,26 @@
 package rpctype
 
 import (
+	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/pkg/mab"
 	"github.com/google/syzkaller/pkg/signal"
 )
+
+type RPCMABStatus struct {
+	Round        int
+	Exp31Round   int
+	Reward       mab.TotalReward
+	CorpusReward map[hash.Sig]mab.CorpusReward
+}
 
 type RPCInput struct {
 	Call   string
 	Prog   []byte
 	Signal signal.Serial
 	Cover  []uint32
+	Reward mab.CorpusReward
 }
 
 type RPCCandidate struct {
@@ -61,12 +71,14 @@ type PollArgs struct {
 	NeedCandidates bool
 	MaxSignal      signal.Serial
 	Stats          map[string]uint64
+	RPCMABStatus
 }
 
 type PollRes struct {
 	Candidates []RPCCandidate
 	NewInputs  []RPCInput
 	MaxSignal  signal.Serial
+	RPCMABStatus
 }
 
 type HubConnectArgs struct {

--- a/prog/clone.go
+++ b/prog/clone.go
@@ -9,8 +9,10 @@ import (
 
 func (p *Prog) Clone() *Prog {
 	p1 := &Prog{
-		Target: p.Target,
-		Calls:  make([]*Call, len(p.Calls)),
+		Target:       p.Target,
+		Calls:        make([]*Call, len(p.Calls)),
+		Source:       p.Source,
+		CorpusReward: p.CorpusReward,
 	}
 	newargs := make(map[*ResultArg]*ResultArg)
 	for ci, c := range p.Calls {

--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -22,6 +22,7 @@ const maxBlobLen = uint64(100 << 10)
 // ct:      ChoiceTable for syscalls.
 // corpus:  The entire corpus, including original program p.
 func (p *Prog) Mutate(rs rand.Source, ncalls int, ct *ChoiceTable, corpus []*Prog) {
+	p.Source = 1
 	r := newRand(p.Target, rs)
 	if ncalls < len(p.Calls) {
 		ncalls = len(p.Calls)

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -5,12 +5,16 @@ package prog
 
 import (
 	"fmt"
+	"github.com/google/syzkaller/pkg/mab"
 )
 
 type Prog struct {
 	Target   *Target
 	Calls    []*Call
 	Comments []string
+
+	Source       int // Gen: 0, Mut: 1, Tri: 2
+	CorpusReward mab.CorpusReward
 }
 
 type Call struct {
@@ -396,6 +400,10 @@ func (p *Prog) removeCall(idx int) {
 	}
 	copy(p.Calls[idx:], p.Calls[idx+1:])
 	p.Calls = p.Calls[:len(p.Calls)-1]
+}
+
+func (p *Prog) ResetReward() {
+	p.CorpusReward = mab.CorpusReward{}
 }
 
 func (p *Prog) sanitizeFix() {

--- a/syz-fuzzer/mab.go
+++ b/syz-fuzzer/mab.go
@@ -1,0 +1,83 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math"
+	"sync"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
+)
+
+// Time unit is important since MAB ended up converting coverage
+// gained into time, before feeding it to the exponential growth
+// algorithm. Converting time unit from ns to s can prevent overflow
+// of float64 when computing exponentials
+const (
+	MABTimeUnit = 1000000000.0
+	MABLogLevel = 4
+)
+
+type MABStatus struct {
+	fuzzer *Fuzzer
+
+	MABMu     sync.RWMutex
+	SSEnabled bool
+	TSEnabled bool
+
+	SSGamma float64
+	SSEta   float64
+	TSGamma float64
+	TSEta   float64
+
+	Round          int         // How many MAB choices have been made
+	Exp31Round     int         // Round # for Exp3.1.
+	Exp31Threshold float64     // Threshold based on Round.
+	CorpusUpdate   map[int]int // Track seed priority update
+	Reward         mab.TotalReward
+}
+
+func (status *MABStatus) GetTSWeight(lock bool) []float64 {
+	if lock {
+		status.MABMu.Lock()
+		defer status.MABMu.Unlock()
+	}
+	x := []float64{0.0, 0.0, 0.0}
+	weight := []float64{1.0, 1.0, 1.0}
+	eta := status.TSEta
+	const (
+		MABWeightThresholdMax = 1.0e+300
+		MABWeightThresholdMin = 1.0e-300
+	)
+	x[0] = eta * status.Reward.EstimatedRewardGenerate
+	x[1] = eta * status.Reward.EstimatedRewardMutate
+	x[2] = eta * status.Reward.EstimatedRewardTriage
+	log.Logf(MABLogLevel, "MABWeight %v\n", x)
+	// Compute median to prevent overflow
+	median := x[0]
+	if x[0] > x[1] {
+		if x[1] > x[2] {
+			median = x[1]
+		} else if x[0] > x[2] {
+			median = x[2]
+		}
+	} else {
+		if x[1] < x[2] {
+			median = x[1]
+		} else if x[0] < x[2] {
+			median = x[2]
+		}
+	}
+	for i := 0; i <= 2; i++ {
+		weight[i] = math.Exp(x[i] - median)
+		if weight[i] > MABWeightThresholdMax {
+			weight[i] = MABWeightThresholdMax
+		}
+		if weight[i] < MABWeightThresholdMin {
+			weight[i] = MABWeightThresholdMin
+		}
+	}
+	return weight
+}

--- a/syz-fuzzer/mab_proc.go
+++ b/syz-fuzzer/mab_proc.go
@@ -1,0 +1,123 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
+	"github.com/google/syzkaller/prog"
+)
+
+func (proc *Proc) DoGenerate() *mab.ExecResult {
+	ts0 := time.Now().UnixNano()
+	ct := proc.fuzzer.choiceTable
+	p := proc.fuzzer.target.Generate(proc.rnd, prog.RecommendedCalls, ct)
+	_, ret := proc.execute(proc.execOpts, p, ProgNormal, StatSmash)
+	ret.TimeTotal = float64(time.Now().UnixNano()-ts0) / MABTimeUnit
+	return &ret
+}
+
+func (proc *Proc) DoMutate() *mab.ExecResult {
+	ts0 := time.Now().UnixNano()
+	fuzzerSnapshot := proc.fuzzer.snapshot()
+	ct := proc.fuzzer.choiceTable
+	// MAB seed selection is integrated with chooseProgram
+	pidx, _p := fuzzerSnapshot.chooseProgram(proc.rnd)
+	p := _p.Clone()
+	p.ResetReward()
+	p.Mutate(proc.rnd, prog.RecommendedCalls, ct, fuzzerSnapshot.corpus)
+	_, ret := proc.execute(proc.execOpts, p, ProgNormal, StatFuzz)
+	ret.Pidx = pidx
+	ret.TimeTotal = float64(time.Now().UnixNano()-ts0) / MABTimeUnit
+	return &ret
+}
+
+func (proc *Proc) DoTriage() *mab.TriageResult {
+	ts0 := time.Now().UnixNano()
+	item := proc.fuzzer.workQueue.dequeue(DequeueOptionTriageOnly)
+	switch item := item.(type) {
+	case *WorkTriage:
+		{
+			ret := proc.ProcessItem(item)
+			ret.TimeTotal = float64(time.Now().UnixNano()-ts0) / MABTimeUnit
+			return ret
+		}
+	default:
+		{
+			return nil
+		}
+	}
+}
+
+func (proc *Proc) clearQueue() {
+	// Clear the work queue for all non-Triage items
+	count := 0
+	for {
+		item := proc.fuzzer.workQueue.dequeue(DequeueOptionNoTriage)
+		if item != nil {
+			count++
+			log.Logf(0, "Clearing candidate %v from work queue.\n", count)
+			proc.ProcessItem(item)
+		} else {
+			return
+		}
+	}
+}
+
+func (proc *Proc) MABLoop() {
+	// Compute weight and proba
+	weight := proc.fuzzer.MABStatus.GetTSWeight(true)
+	fuzzerSnapshot := proc.fuzzer.snapshot()
+	triageCount := 1
+	mutateCount := 1
+	if len(fuzzerSnapshot.corpus) == 0 { // Check whether mutation is an option
+		mutateCount = 0
+	}
+	proc.fuzzer.workQueue.mu.Lock() // Check whether triage is an option
+	triageQueueLen := len(proc.fuzzer.workQueue.triage)
+	triageQueueLenCandidate := len(proc.fuzzer.workQueue.triageCandidate)
+	proc.fuzzer.workQueue.mu.Unlock()
+	if triageQueueLen+triageQueueLenCandidate == 0 {
+		triageCount = 0
+	}
+	W := weight[0] + float64(mutateCount)*weight[1] + float64(triageCount)*weight[2]
+	if W == 0.0 {
+		log.Fatalf("Error total weight W = 0")
+	}
+	prGenerate := weight[0] / W
+	prMutate := weight[1] / W
+	prTriage := weight[2] / W
+	prMutateActual := float64(mutateCount) * prMutate
+	prTriageActual := float64(triageCount) * prTriage
+	// Use real weight as pr. Consider cases where triage/mutation might be unavailable
+	prTasks := []float64{prGenerate, prMutateActual, prTriageActual}
+	log.Logf(0, "MAB Probability: [%v, %v, %v]\n", prTasks[0], prTasks[1], prTasks[2])
+	// Choose
+	randNum := rand.Float64() * (prGenerate + prMutateActual + prTriageActual)
+	choice := -1
+	if randNum <= prGenerate {
+		choice = 0
+	} else if randNum > prGenerate && randNum <= prGenerate+prMutateActual {
+		choice = 1
+	} else {
+		choice = 2
+	}
+	// Handle choices
+	var r interface{}
+	if choice == 0 {
+		r = *proc.DoGenerate()
+	} else if choice == 1 {
+		r = *proc.DoMutate()
+	} else if choice == 2 {
+		r = *proc.DoTriage()
+	}
+	if r != nil {
+		log.Logf(0, "MAB Choice: %v, Result: %+v\n", choice, r)
+	}
+	// Update Weight
+	proc.fuzzer.MABStatus.UpdateWeight(choice, r, prTasks)
+}

--- a/syz-fuzzer/mab_reward.go
+++ b/syz-fuzzer/mab_reward.go
@@ -1,0 +1,88 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
+)
+
+func ComputeReward(cov float64, time float64, totalReward *mab.Reward) float64 {
+	if totalReward.TotalCov > 0 {
+		ret := cov*(totalReward.TotalTime/totalReward.TotalCov) - time
+		log.Logf(MABLogLevel, "MAB Reward: %v * %v / %v - %v = %v",
+			cov, totalReward.TotalTime,
+			totalReward.TotalCov, time,
+			ret)
+		return ret
+	}
+	return 0.0
+}
+
+func (status *MABStatus) ComputeTSReward(cov float64, time float64) float64 {
+	return ComputeReward(cov, time, &status.Reward.RawAllTasks)
+}
+
+func (status *MABStatus) ComputeSSReward(cov float64, time float64) float64 {
+	return ComputeReward(cov, time, &status.Reward.RawMutateOnly)
+}
+
+func NormalizeReward(reward float64, totalReward *mab.Reward) float64 {
+	// Use Z-score + logistic function to normalize reward to [-1,1]
+	// If there is an error, return 0.0
+	if totalReward.Count == 0 {
+		return 0.0
+	}
+	// First standardize reward using Z-score shifted to a mean of 0
+	meanX := totalReward.TotalCov / float64(totalReward.Count)
+	stdX := (totalReward.TotalCov2 / float64(totalReward.Count)) - (meanX * meanX)
+	if stdX < 0.0 {
+		log.Logf(MABLogLevel, "Error: Cannot compute std sqrt(%v)", stdX)
+		return 0.0
+	} else if stdX == 0.0 {
+		return 0.0
+	}
+	stdX = math.Sqrt(stdX)
+	// Normally, Z-score should be z = (reward - meanX) / stdX.
+	// However, we want to make sure positive reward is positive.
+	// In later stages of fuzzing, meanX is going to be negative.
+	// We don't want an "arm" with negative reward be rewarded
+	z := reward / stdX
+	// Prevent overflowing
+	if z > 16.0 {
+		return 1
+	} else if z < -16.0 {
+		return -1
+	}
+	// Next, logistic function scaled to [-1, 1]
+	x := (1.0 - math.Exp(-z)) / (1.0 + math.Exp(-z))
+	log.Logf(MABLogLevel, "MAB Normalized Reward: %v; z=%v mean=%v std=%v", x, z, meanX, stdX)
+	return x
+}
+
+func (status *MABStatus) NormalizeTSReward(reward float64) float64 {
+	return NormalizeReward(reward, &status.Reward.RewardAllTasks)
+}
+
+func (status *MABStatus) NormalizeSSReward(reward float64) float64 {
+	return NormalizeReward(reward, &status.Reward.RewardMutateOnly)
+}
+
+// Estimate reward computation, according to Exp3-IX
+func EstimateReward(reward, pr, gamma float64) float64 {
+	ret := reward / (pr + gamma)
+	log.Logf(MABLogLevel, "MAB Estimate Reward: %v / (%v + %v) = %v\n",
+		reward, pr, gamma, ret)
+	return ret
+}
+
+func (status *MABStatus) EstimateTSReward(reward, pr float64) float64 {
+	return EstimateReward(reward, pr, status.TSGamma)
+}
+
+func (status *MABStatus) EstimateSSReward(reward, pr float64) float64 {
+	return EstimateReward(reward, pr, status.SSGamma)
+}

--- a/syz-fuzzer/mab_reward_test.go
+++ b/syz-fuzzer/mab_reward_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/mab"
+)
+
+func initTestMabStatus(rawCov, rawTime, totalReward []float64) MABStatus {
+	status := MABStatus{
+		TSEnabled:      true,
+		SSEnabled:      true,
+		CorpusUpdate:   make(map[int]int),
+		TSGamma:        0.05,
+		TSEta:          0.1,
+		SSGamma:        0.05,
+		SSEta:          0.1,
+		Round:          0,
+		Exp31Round:     1,
+		Exp31Threshold: 1.0,
+		Reward:         mab.TotalReward{},
+	}
+	status.Reward.RawAllTasks.Update(rawCov, rawTime)
+	status.Reward.RewardAllTasks.Update(totalReward, 0.0)
+	return status
+}
+
+func TestRewardComputation(t *testing.T) {
+	status := initTestMabStatus([]float64{2.0, 4.0, 6.0}, []float64{0.2, 0.4, 0.6}, []float64{2.0, 4.0, 6.0})
+	reward := status.ComputeTSReward(1.0, 1.0)
+}

--- a/syz-fuzzer/mab_sync.go
+++ b/syz-fuzzer/mab_sync.go
@@ -1,0 +1,61 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/google/syzkaller/pkg/hash"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
+	"github.com/google/syzkaller/pkg/rpctype"
+)
+
+func (status *MABStatus) readMABStatus() rpctype.RPCMABStatus {
+	fuzzerStatus := rpctype.RPCMABStatus{
+		Round:        status.Round,
+		Exp31Round:   status.Exp31Round,
+		Reward:       status.Reward,
+		CorpusReward: make(map[hash.Sig]mab.CorpusReward),
+	}
+	const batchSize = 100
+	syncedCnt := 0
+	synced := make([]int, batchSize)
+	for pidx := range status.CorpusUpdate {
+		// Avoid sending too much
+		if syncedCnt >= batchSize {
+			break
+		}
+		if pidx >= 0 && pidx < len(status.fuzzer.corpus) {
+			p := status.fuzzer.corpus[pidx]
+			sig := hash.Hash(p.Serialize())
+			fuzzerStatus.CorpusReward[sig] = p.CorpusReward
+			log.Logf(MABLogLevel, "MAB Corpus Sync Send %v: %+v\n", sig.String(), p.CorpusReward)
+			synced[syncedCnt] = pidx
+			syncedCnt++
+		}
+	}
+	for i := 0; i < syncedCnt; i++ {
+		spidx := synced[i]
+		delete(status.CorpusUpdate, spidx)
+	}
+	log.Logf(MABLogLevel, "MAB Corpus Sync Pending: %v\n", len(status.CorpusUpdate))
+	return fuzzerStatus
+}
+
+func (status *MABStatus) writeMABStatus(managerStatus rpctype.RPCMABStatus) {
+	if status.Round < managerStatus.Round {
+		status.Round = managerStatus.Round
+		status.Exp31Round = managerStatus.Exp31Round
+		status.BootstrapExp31()
+		status.Reward = managerStatus.Reward
+	}
+	for sig, v := range managerStatus.CorpusReward {
+		pidx := -1
+		ok := false
+		if pidx, ok = status.fuzzer.corpusHashes[sig]; ok && pidx >= 0 && pidx < len(status.fuzzer.corpus) {
+			status.fuzzer.corpus[pidx].CorpusReward = v
+			sig := hash.Hash(status.fuzzer.corpus[pidx].Serialize())
+			log.Logf(MABLogLevel, "MAB Corpus Sync Receive %v: %+v\n", sig.String(), v)
+		}
+	}
+}

--- a/syz-fuzzer/mab_test.go
+++ b/syz-fuzzer/mab_test.go
@@ -1,0 +1,11 @@
+// Copyright 2019 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestMabSsUpdate(t *testing.T) {
+}

--- a/syz-fuzzer/mab_update.go
+++ b/syz-fuzzer/mab_update.go
@@ -1,0 +1,291 @@
+// Copyright 2015 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math"
+
+	"github.com/google/syzkaller/pkg/hash"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
+)
+
+func PreprocessResult(result interface{}) interface{} {
+	// Deal with cost outlier
+	costMax := 1000000000.0 / MABTimeUnit
+
+	switch result.(type) {
+	case mab.ExecResult:
+		{
+			_r, ok := result.(mab.ExecResult)
+			if ok {
+				if _r.TimeExec > costMax {
+					_r.TimeExec = costMax
+				} else if _r.TimeExec < 0.0 {
+					_r.TimeExec = 0.0
+				}
+			}
+			return _r
+		}
+	case mab.TriageResult:
+		{
+			_r, ok := result.(mab.TriageResult)
+			if ok {
+				if _r.VerifyTime > costMax {
+					_r.VerifyTime = costMax
+				} else if _r.VerifyTime < 0.0 {
+					_r.VerifyTime = 0.0
+				}
+				if _r.MinimizeTime > costMax {
+					_r.MinimizeTime = costMax
+				} else if _r.MinimizeTime < 0.0 {
+					_r.MinimizeTime = 0.0
+				}
+				if _r.MinimizeTimeSave > costMax || _r.MinimizeTimeSave < -costMax {
+					_r.MinimizeTimeSave = 0
+				}
+			}
+			return _r
+		}
+	default:
+		log.Fatalf("unknown result type: %#v", result)
+	}
+	return result
+}
+
+func (status *MABStatus) ResetTS() {
+	// Reset only applies to task selection
+	status.Reward.EstimatedRewardGenerate = 0.0
+	status.Reward.EstimatedRewardMutate = 0.0
+	status.Reward.EstimatedRewardTriage = 0.0
+	status.Reward.RewardAllTasks = mab.Reward{}
+}
+
+func (status *MABStatus) BootstrapExp31() {
+	status.TSGamma = math.Exp2(float64(-status.Exp31Round))
+	status.TSEta = 2.0 * status.TSGamma
+	status.Exp31Threshold = 3.0 * math.Log(3.0) * math.Exp2(2.0*float64(status.Exp31Round)) / (math.E - 1.0)
+	status.Exp31Threshold = status.Exp31Threshold - (3.0 / status.TSGamma)
+	log.Logf(MABLogLevel,
+		"MAB Exp3.1 New Round %v, Gamma: %v, Eta: %v, Threshold: %v\n",
+		status.Exp31Round, status.TSGamma, status.TSEta, status.Exp31Threshold)
+}
+
+func (status *MABStatus) UpdateSeedWeight(pidx int, reward float64) {
+	// Update estimate reward
+	status.fuzzer.corpus[pidx].CorpusReward.MutateRewardOrig += status.fuzzer.MABStatus.SSEta * reward
+	// Update corpus selection weight
+	weightThresholdMax := math.Exp(16)
+	weightThresholdMin := math.Exp(-16)
+	prio := 1.0
+	prio = math.Exp(status.fuzzer.corpus[pidx].CorpusReward.MutateRewardOrig)
+	if prio > weightThresholdMax {
+		prio = weightThresholdMax
+	}
+	if prio < weightThresholdMin {
+		prio = weightThresholdMin
+	}
+	log.Logf(MABLogLevel, "MAB Corpus %v, %v: %v -> %v",
+		pidx, status.fuzzer.corpus[pidx].CorpusReward.MutateRewardOrig,
+		status.fuzzer.corpusPrios[pidx], prio)
+	status.fuzzer.corpusPrios[pidx] = prio
+	if pidx == 0 {
+		status.fuzzer.sumPrios[pidx] = status.fuzzer.corpusPrios[pidx]
+	} else {
+		status.fuzzer.sumPrios[pidx] = status.fuzzer.sumPrios[pidx-1] + status.fuzzer.corpusPrios[pidx]
+	}
+	for i := pidx + 1; i < len(status.fuzzer.corpus); i++ {
+		status.fuzzer.sumPrios[i] = status.fuzzer.sumPrios[i-1] + status.fuzzer.corpusPrios[i]
+	}
+}
+
+func (status *MABStatus) UpdateTriageWeight(result mab.TriageResult, pr []float64) {
+	cov := float64(result.MinimizeCov)
+	timeVerify := result.VerifyTime
+	timeMinimize := result.MinimizeTime
+	timeSave := result.MinimizeTimeSave
+	pidx := result.Pidx
+	// Convert and normalize
+	reward := status.ComputeTSReward(cov, timeVerify+timeMinimize)
+	rewardNorm := status.NormalizeTSReward(reward)
+	rewardEst := status.EstimateTSReward(rewardNorm, pr[2])
+	// Update
+	status.Reward.EstimatedRewardTriage += rewardEst
+	status.Reward.RewardAllTasks.Update(reward, 0.0)
+	status.Reward.RawAllTasks.Update(cov, timeVerify+timeMinimize)
+	// If triage succeed, record for SS
+	if result.Success && pidx >= 0 && pidx < len(status.fuzzer.corpus) {
+		status.fuzzer.corpus[pidx].CorpusReward.TriageReward = rewardNorm
+		status.fuzzer.corpus[pidx].CorpusReward.MinimizeCov = float64(result.MinimizeCov)
+		status.fuzzer.corpus[pidx].CorpusReward.VerifyTime = timeVerify
+		status.fuzzer.corpus[pidx].CorpusReward.MinimizeTime = timeMinimize
+		status.fuzzer.corpus[pidx].CorpusReward.MinimizeTimeSave = timeSave
+		// Mark seed for update
+		status.CorpusUpdate[pidx] = 1
+	}
+}
+
+func (status *MABStatus) UpdateGenerateWeight(result mab.ExecResult, pr []float64) {
+	cov := float64(result.Cov)
+	time := result.TimeExec
+	// Convert and normalize
+	reward := status.ComputeTSReward(cov, time)
+	rewardNorm := status.NormalizeTSReward(reward)
+	rewardEst := status.EstimateTSReward(rewardNorm, pr[0])
+	// Update
+	status.Reward.EstimatedRewardGenerate += rewardEst
+	status.Reward.RewardAllTasks.Update(reward, 0.0)
+	status.Reward.RawAllTasks.Update(cov, time)
+}
+
+func (status *MABStatus) UpdateMutateWeight(result mab.ExecResult, pr []float64) {
+	cov := float64(result.Cov)
+	time := result.TimeExec
+	pidx := result.Pidx
+	if pidx < 0 || pidx > len(status.fuzzer.corpus) {
+		log.Logf(MABLogLevel, "MAB Error: pidx = %v out of range\n", pidx)
+		return
+	}
+	if status.TSEnabled {
+		p := status.fuzzer.corpus[pidx]
+		mutateCnt := p.CorpusReward.MutateCount
+		timeVerify := p.CorpusReward.VerifyTime
+		timeMinimize := p.CorpusReward.MinimizeTime
+		covMinimize := p.CorpusReward.MinimizeCov
+		// After this mutation, total coverage gain by mutating this seed
+		totalCovMutCur := p.CorpusReward.MutateCov + cov
+		// After this mutation, total time cost of mutating this seed
+		totalTimeMutCur := p.CorpusReward.MutateTime + time
+		// Before this mutation, reward for mutating this seed
+		rewardMutPrev := p.CorpusReward.MutateReward
+		// Before this mutation, reward for triaging this seed
+		rewardTriPrev := p.CorpusReward.TriageReward
+		timeSave := p.CorpusReward.MinimizeTimeSave
+		// Total estimated time save due to minimization
+		totalTimeSave := float64(mutateCnt) * timeSave
+		if totalTimeMutCur+timeVerify == 0.0 {
+			log.Logf(MABLogLevel,
+				"MAB Error: timeVerify(%v) + timeMut(%v) == 0\n",
+				timeVerify, totalTimeMutCur)
+			// Update raw coverage and time for future reward computation and normalization
+			status.Reward.RawAllTasks.Update(cov, time)
+			status.Reward.RawMutateOnly.Update(cov, time)
+			return
+		}
+		// Distribut gain considering minimize effect
+		// Minimize reward: Coverage/time reward + time saved
+		rewardMinimizeCov := status.ComputeTSReward(covMinimize, timeMinimize)
+		rewardMinimizeCur := rewardMinimizeCov + totalTimeSave
+		log.Logf(MABLogLevel, "MAB Assoc Minimize Reward: %v + %v * %v = %v\n",
+			rewardMinimizeCov, mutateCnt, timeSave, rewardMinimizeCur)
+		// Verification reward: Partial mutation coverage vs verification time
+		assocCovVerify := totalCovMutCur * timeVerify / (totalTimeMutCur + timeVerify)
+		rewardVerifyCur := status.ComputeTSReward(assocCovVerify, timeVerify)
+		log.Logf(MABLogLevel, "MAB Assoc Verify Reward: R((%v + %v) * %v / %v = %v, %v) = %v",
+			status.fuzzer.corpus[pidx].CorpusReward.MutateCov, cov,
+			timeVerify, totalTimeMutCur+timeVerify, assocCovVerify, timeVerify, rewardVerifyCur)
+		// Triage reward: minimize + triage
+		rewardTriageCurrent := rewardVerifyCur + rewardMinimizeCur
+		log.Logf(MABLogLevel, "MAB Triage Reward: %v + %v = %v",
+			rewardVerifyCur, rewardMinimizeCur, rewardTriageCurrent)
+		// Mutation reward: Share partial mutation coverage to verification.
+		assocCovMutCur := totalCovMutCur * totalTimeMutCur / (totalTimeMutCur + timeVerify)
+		rewardMutCur := status.ComputeTSReward(assocCovMutCur, totalTimeMutCur)
+		log.Logf(MABLogLevel,
+			"MAB Mutate Reward: R((%v + %v) * (%v + %v) / %v = %v, %v) = %v\n",
+			p.CorpusReward.MutateCov, cov, p.CorpusReward.MutateTime, time,
+			totalTimeMutCur+timeVerify, assocCovMutCur, totalTimeMutCur, rewardMutCur)
+		// Compute x
+		rewardMutDiff := rewardMutCur - rewardMutPrev
+		rewardTriDiff := rewardTriageCurrent - rewardTriPrev
+		log.Logf(MABLogLevel, "MAB Triage Reward Diff: %v - %v = %v\n",
+			rewardTriageCurrent, rewardTriPrev, rewardTriDiff)
+		log.Logf(MABLogLevel, "MAB Mutate Reward Diff: %v - %v = %v\n",
+			rewardMutCur, rewardMutPrev, rewardMutDiff)
+		rewardNormMutDiff := status.NormalizeTSReward(rewardMutDiff)
+		rewardNormTriDiff := status.NormalizeTSReward(rewardTriDiff)
+		rewardEstMut := status.EstimateTSReward(rewardNormMutDiff, pr[1])
+		// Triage might be unavailable this time, as a result, compute triage's probality as if triage is available
+		// Fortunately, we know that mutation is definitely available. Use that as an estimation
+		rewardEstTri := status.EstimateTSReward(rewardNormTriDiff, pr[1])
+		status.Reward.EstimatedRewardMutate += rewardEstMut
+		status.Reward.EstimatedRewardTriage += rewardEstTri
+		// Update program stat
+		status.fuzzer.corpus[pidx].CorpusReward.MutateCov = totalCovMutCur
+		status.fuzzer.corpus[pidx].CorpusReward.MutateTime = totalTimeMutCur
+		status.fuzzer.corpus[pidx].CorpusReward.MutateReward = rewardMutCur
+		status.fuzzer.corpus[pidx].CorpusReward.TriageReward = rewardTriageCurrent
+		// Don't use associated gain for normalization
+		rewardNoassocNorm := status.ComputeTSReward(cov, time)
+		status.Reward.RewardAllTasks.Update(rewardNoassocNorm, 0.0)
+	}
+	// Mark for update
+	status.CorpusUpdate[pidx] = 1
+	// Update for seed selection MAB
+	if status.SSEnabled {
+		rewardSS := status.ComputeSSReward(cov, time)
+		rewardSSNorm := status.NormalizeSSReward(rewardSS)
+		rewardSSEst := status.EstimateSSReward(rewardSSNorm,
+			status.fuzzer.corpusPrios[pidx]/status.fuzzer.sumPrios[len(status.fuzzer.sumPrios)-1])
+		status.UpdateSeedWeight(pidx, rewardSSEst)
+		status.Reward.RewardMutateOnly.Update(rewardSS, 0.0)
+	}
+	status.fuzzer.corpus[pidx].CorpusReward.MutateCount++
+	sig := hash.Hash(status.fuzzer.corpus[pidx].Serialize())
+	log.Logf(MABLogLevel, "MAB Mutate Count for %v(%v): %v\n",
+		pidx, sig.String(), status.fuzzer.corpus[pidx].CorpusReward.MutateCount)
+	status.Reward.RawAllTasks.Update(cov, time)
+	status.Reward.RawMutateOnly.Update(cov, time)
+}
+
+func (status *MABStatus) UpdateWeight(itemType int, result interface{}, pr []float64) {
+	// 0 = Generate, 1 = Mutate, 2 = Triage
+	if itemType < 0 || itemType > 2 || len(pr) < 3 {
+		log.Logf(MABLogLevel, "MAB Error: itemType = %v\n", itemType)
+		return
+	}
+	if pr[itemType] == 0 {
+		log.Logf(MABLogLevel, "MAB Error: pr[%v] = 0\n", itemType)
+		return
+	}
+	status.MABMu.Lock()
+
+	defer func() {
+		log.Logf(MABLogLevel, "MAB Round %v GLC: %+v\n", status.Round, status.Reward)
+		exp31Max := math.Max(status.Reward.EstimatedRewardGenerate,
+			math.Max(status.Reward.EstimatedRewardMutate,
+				status.Reward.EstimatedRewardTriage))
+		exp31Min := math.Min(status.Reward.EstimatedRewardGenerate,
+			math.Min(status.Reward.EstimatedRewardMutate,
+				status.Reward.EstimatedRewardTriage))
+		if exp31Max-exp31Min > status.Exp31Threshold ||
+			exp31Max > status.Exp31Threshold ||
+			math.Abs(exp31Min) > status.Exp31Threshold {
+			status.Exp31Round++
+			status.ResetTS()
+			status.BootstrapExp31()
+		}
+		status.MABMu.Unlock()
+	}()
+	_result := PreprocessResult(result)
+	if itemType == 0 && status.TSEnabled { // Generate
+		_r, ok := _result.(mab.ExecResult)
+		if !ok {
+			return
+		}
+		status.UpdateGenerateWeight(_r, pr)
+	} else if itemType == 1 { // Mutate
+		_r, ok := _result.(mab.ExecResult)
+		if !ok {
+			return
+		}
+		status.UpdateMutateWeight(_r, pr)
+	} else if itemType == 2 { // Triage
+		_r, ok := _result.(mab.TriageResult)
+		if !ok {
+			return
+		}
+		status.UpdateTriageWeight(_r, pr)
+	}
+}

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mab"
 	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/prog"
@@ -34,6 +36,12 @@ type RPCServer struct {
 	corpusCover  cover.Cover
 	rotator      *prog.Rotator
 	rnd          *rand.Rand
+
+	// For now we assume a single-fuzzer model
+	MABRound        int
+	MABExp31Round   int
+	MABReward       mab.TotalReward
+	MABCorpusReward map[hash.Sig]mab.CorpusReward
 }
 
 type Fuzzer struct {
@@ -66,6 +74,9 @@ func startRPCServer(mgr *Manager) (int, error) {
 		sandbox:               mgr.cfg.Sandbox,
 		fuzzers:               make(map[string]*Fuzzer),
 		rnd:                   rand.New(rand.NewSource(time.Now().UnixNano())),
+		MABRound:              0,
+		MABExp31Round:         0,
+		MABCorpusReward:       make(map[hash.Sig]mab.CorpusReward),
 	}
 	serv.batchSize = 5
 	if serv.batchSize < mgr.cfg.Procs {
@@ -232,6 +243,10 @@ func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 		return nil
 	}
 
+	// Update reward
+	sig := hash.Hash(a.RPCInput.Prog)
+	serv.MABCorpusReward[sig] = a.RPCInput.Reward
+
 	if f.rotatedSignal != nil {
 		f.rotatedSignal.Merge(inputSignal)
 	}
@@ -270,6 +285,7 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 	newMaxSignal := serv.maxSignal.Diff(a.MaxSignal.Deserialize())
 	if !newMaxSignal.Empty() {
 		serv.maxSignal.Merge(newMaxSignal)
+		serv.stats.maxSignal.set(len(serv.maxSignal))
 		for _, f1 := range serv.fuzzers {
 			if f1 == f {
 				continue
@@ -294,6 +310,17 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 		for i := 0; i < batchSize && len(f.inputs) > 0; i++ {
 			last := len(f.inputs) - 1
 			r.NewInputs = append(r.NewInputs, f.inputs[last])
+
+			// Send MAB status as well
+			sig := hash.Hash(f.inputs[last].Prog)
+			if r.CorpusReward == nil {
+				r.CorpusReward = make(map[hash.Sig]mab.CorpusReward)
+			}
+			if v, ok := serv.MABCorpusReward[sig]; ok {
+				r.CorpusReward[sig] = v
+				r.NewInputs[len(r.NewInputs)-1].Reward = v
+			}
+
 			f.inputs[last] = rpctype.RPCInput{}
 			f.inputs = f.inputs[:last]
 		}
@@ -301,7 +328,30 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 			f.inputs = nil
 		}
 	}
+	// Sync MAB status
+	serv.SyncMABStatus(&a.RPCMABStatus, &r.RPCMABStatus)
 	log.Logf(4, "poll from %v: candidates=%v inputs=%v maxsignal=%v",
 		a.Name, len(r.Candidates), len(r.NewInputs), len(r.MaxSignal.Elems))
+	return nil
+}
+
+func (serv *RPCServer) SyncMABStatus(a *rpctype.RPCMABStatus, r *rpctype.RPCMABStatus) error {
+	if a.Round > serv.MABRound {
+		serv.MABRound = a.Round
+		serv.MABExp31Round = a.Exp31Round
+		serv.MABReward = a.Reward
+		for sig, v := range a.CorpusReward {
+			serv.MABCorpusReward[sig] = v
+			log.Logf(4, "MAB Corpus Sync %v: %+v\n", sig.String(), v)
+		}
+	} else if a.Round < serv.MABRound {
+		r.Round = serv.MABRound
+		r.Exp31Round = serv.MABExp31Round
+		r.Reward = serv.MABReward
+		r.CorpusReward = make(map[hash.Sig]mab.CorpusReward)
+		for sig, v := range serv.MABCorpusReward {
+			r.CorpusReward[sig] = v
+		}
+	}
 	return nil
 }

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -27,6 +27,7 @@ type Stats struct {
 	hubRecvReproDrop Stat
 	corpusCover      Stat
 	corpusSignal     Stat
+	maxSignal        Stat
 
 	mu         sync.Mutex
 	namedStats map[string]uint64
@@ -44,6 +45,7 @@ func (stats *Stats) all() map[string]uint64 {
 		"exec total":     stats.execTotal.get(),
 		"cover":          stats.corpusCover.get(),
 		"signal":         stats.corpusSignal.get(),
+		"max signal":     stats.maxSignal.get(),
 	}
 	if stats.haveHub {
 		m["hub: send prog add"] = stats.hubSendProgAdd.get()

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -187,7 +187,7 @@ func (mgr *Manager) boot(name string, index int) (*report.Report, error) {
 	}
 	cmd := instance.FuzzerCmd(fuzzerBin, executorCmd, name,
 		mgr.cfg.TargetOS, mgr.cfg.TargetArch, fwdAddr, mgr.cfg.Sandbox, mgr.cfg.Procs, 0,
-		mgr.cfg.Cover, mgr.debug, false, true)
+		mgr.cfg.Cover, mgr.debug, false, true, mgr.cfg.MABTS, mgr.cfg.MABSS)
 	outc, errc, err := inst.Run(time.Hour, mgr.vmStop, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run fuzzer: %v", err)


### PR DESCRIPTION
Use Multi-armed-bandit(MAB) algorithm to 1) schedule generate/mutate/triage
task to run and 2) select seed to mutate.

Working on unit tests.

Detailed changes:

pkg/instance, pkg/mgrconfig: add two individual toggles of MAB task/seed
                             selection.
pkg/mab: some basic data structures that will be used.
pkg/rpctype, syz-manager: synchonization of MAB status between manager and
                          fuzzer. Useful for state restoring when fuzzer
                          crashes. Only works well on one fuzzer for now.
syz-fuzzer/mab*: core logic of MAB algorithm.
syz-fuzzer: modify existing tasks to collect coverage and timing informations.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
