### PR TITLE
prog: introduce Field type

### DIFF
--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -323,7 +323,7 @@ func (comp *compiler) checkLenType(t0, t *ast.Type, parents []parentDesc,
 		warned[parentName] = true
 		return
 	}
-	_, args, _ := comp.getArgsBase(t, "", isArg)
+	_, args, _ := comp.getArgsBase(t, isArg)
 	for i, arg := range args {
 		argDesc := desc.Args[i]
 		if argDesc.Type == typeArgLenTarget {
@@ -522,7 +522,7 @@ func (comp *compiler) collectUsedType(structs, flags, strflags map[string]bool, 
 		}
 		return
 	}
-	_, args, _ := comp.getArgsBase(t, "", isArg)
+	_, args, _ := comp.getArgsBase(t, isArg)
 	for i, arg := range args {
 		if desc.Args[i].Type == typeArgType {
 			comp.collectUsedType(structs, flags, strflags, arg, desc.Args[i].IsArg)
@@ -603,7 +603,7 @@ func (comp *compiler) checkTypeCtors(t *ast.Type, dir prog.Dir, isArg bool,
 	if desc == typePtr {
 		dir = genDir(t.Args[0])
 	}
-	_, args, _ := comp.getArgsBase(t, "", isArg)
+	_, args, _ := comp.getArgsBase(t, isArg)
 	for i, arg := range args {
 		if desc.Args[i].Type == typeArgType {
 			comp.checkTypeCtors(arg, dir, desc.Args[i].IsArg, ctors, checked)
@@ -684,7 +684,7 @@ func (comp *compiler) recurseField(checked map[string]bool, t *ast.Type, path []
 		comp.checkStructRecursion(checked, comp.structs[t.Ident], path)
 		return
 	}
-	_, args, base := comp.getArgsBase(t, "", false)
+	_, args, base := comp.getArgsBase(t, false)
 	if desc == typePtr && base.IsOptional {
 		return // optional pointers prune recursion
 	}
@@ -774,7 +774,7 @@ func (comp *compiler) checkType(ctx checkCtx, t *ast.Type, flags checkFlags) {
 		return
 	}
 	if desc.Check != nil {
-		_, args, base := comp.getArgsBase(t, "", flags&checkIsArg != 0)
+		_, args, base := comp.getArgsBase(t, flags&checkIsArg != 0)
 		desc.Check(comp, t, args, base)
 	}
 }
@@ -1098,12 +1098,12 @@ func (comp *compiler) checkVarlens() {
 }
 
 func (comp *compiler) isVarlen(t *ast.Type) bool {
-	desc, args, _ := comp.getArgsBase(t, "", false)
+	desc, args, _ := comp.getArgsBase(t, false)
 	return desc.Varlen != nil && desc.Varlen(comp, t, args)
 }
 
 func (comp *compiler) isZeroSize(t *ast.Type) bool {
-	desc, args, _ := comp.getArgsBase(t, "", false)
+	desc, args, _ := comp.getArgsBase(t, false)
 	return desc.ZeroSize != nil && desc.ZeroSize(comp, t, args)
 }
 

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -249,13 +249,13 @@ func (comp *compiler) getTypeDesc(t *ast.Type) *typeDesc {
 	return nil
 }
 
-func (comp *compiler) getArgsBase(t *ast.Type, field string, isArg bool) (*typeDesc, []*ast.Type, prog.IntTypeCommon) {
+func (comp *compiler) getArgsBase(t *ast.Type, isArg bool) (*typeDesc, []*ast.Type, prog.IntTypeCommon) {
 	desc := comp.getTypeDesc(t)
 	if desc == nil {
 		panic(fmt.Sprintf("no type desc for %#v", *t))
 	}
 	args, opt := removeOpt(t)
-	com := genCommon(t.Ident, field, sizeUnassigned, opt != nil)
+	com := genCommon(t.Ident, sizeUnassigned, opt != nil)
 	base := genIntCommon(com, 0, false)
 	if desc.NeedBase {
 		base.TypeSize = comp.ptrSize
@@ -305,7 +305,7 @@ func (comp *compiler) foreachType(n0 ast.Node,
 
 func (comp *compiler) foreachSubType(t *ast.Type, isArg bool,
 	cb func(*ast.Type, *typeDesc, []*ast.Type, prog.IntTypeCommon)) {
-	desc, args, base := comp.getArgsBase(t, "", isArg)
+	desc, args, base := comp.getArgsBase(t, isArg)
 	cb(t, desc, args, base)
 	for i, arg := range args {
 		if desc.Args[i].Type == typeArgType {

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -162,7 +162,7 @@ var typePtr = &typeDesc{
 		}
 		return &prog.PtrType{
 			TypeCommon: base.TypeCommon,
-			Elem:       comp.genType(args[1], "", 0),
+			Elem:       comp.genType(args[1], 0),
 			ElemDir:    genDir(args[0]),
 		}
 	},
@@ -212,7 +212,7 @@ var typeArray = &typeDesc{
 		return comp.isZeroSize(args[0])
 	},
 	Gen: func(comp *compiler, t *ast.Type, args []*ast.Type, base prog.IntTypeCommon) prog.Type {
-		elemType := comp.genType(args[0], "", 0)
+		elemType := comp.genType(args[0], 0)
 		kind, begin, end := prog.ArrayRandLen, uint64(0), uint64(0)
 		if len(args) > 1 {
 			kind, begin, end = prog.ArrayRangeLen, args[1].Value, args[1].Value
@@ -696,7 +696,7 @@ var typeFmt = &typeDesc{
 		{Name: "value", Type: typeArgType, IsArg: true},
 	},
 	Check: func(comp *compiler, t *ast.Type, args []*ast.Type, base prog.IntTypeCommon) {
-		desc, _, _ := comp.getArgsBase(args[1], "", true)
+		desc, _, _ := comp.getArgsBase(args[1], true)
 		switch desc {
 		case typeResource, typeInt, typeLen, typeFlags, typeProc:
 		default:
@@ -718,7 +718,7 @@ var typeFmt = &typeDesc{
 			format = prog.FormatStrOct
 			size = 23
 		}
-		typ := comp.genType(args[1], "", comp.ptrSize)
+		typ := comp.genType(args[1], comp.ptrSize)
 		switch t := typ.(type) {
 		case *prog.ResourceType:
 			t.ArgFormat = format
@@ -767,7 +767,7 @@ func init() {
 			baseType = r.Base
 			r = comp.resources[r.Base.Ident]
 		}
-		baseProgType := comp.genType(baseType, "", 0)
+		baseProgType := comp.genType(baseType, 0)
 		base.TypeSize = baseProgType.Size()
 		return &prog.ResourceType{
 			TypeCommon: base.TypeCommon,
@@ -829,13 +829,11 @@ func init() {
 		if s.IsUnion {
 			return &prog.UnionType{
 				Key:        key,
-				FldName:    base.FldName,
 				StructDesc: desc,
 			}
 		}
 		return &prog.StructType{
 			Key:        key,
-			FldName:    base.FldName,
 			StructDesc: desc,
 		}
 	}

--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -166,11 +166,11 @@ var (
 func isSupportedSyzkall(sandbox string, c *prog.Syscall) (bool, string) {
 	switch c.CallName {
 	case "syz_open_dev":
-		if _, ok := c.Args[0].(*prog.ConstType); ok {
+		if _, ok := c.Args[0].Type.(*prog.ConstType); ok {
 			// This is for syz_open_dev$char/block.
 			return true, ""
 		}
-		fname, ok := extractStringConst(c.Args[0])
+		fname, ok := extractStringConst(c.Args[0].Type)
 		if !ok {
 			panic("first open arg is not a pointer to string const")
 		}
@@ -249,7 +249,7 @@ func isSupportedSyzkall(sandbox string, c *prog.Syscall) (bool, string) {
 		if ok, reason := onlySandboxNone(sandbox); !ok {
 			return ok, reason
 		}
-		fstype, ok := extractStringConst(c.Args[0])
+		fstype, ok := extractStringConst(c.Args[0].Type)
 		if !ok {
 			panic("syz_mount_image arg is not string")
 		}
@@ -306,7 +306,7 @@ func onlySandboxNoneOrNamespace(sandbox string) (bool, string) {
 }
 
 func isSupportedSocket(c *prog.Syscall) (bool, string) {
-	af, ok := c.Args[0].(*prog.ConstType)
+	af, ok := c.Args[0].Type.(*prog.ConstType)
 	if !ok {
 		panic("socket family is not const")
 	}
@@ -320,14 +320,14 @@ func isSupportedSocket(c *prog.Syscall) (bool, string) {
 	if err == syscall.EAFNOSUPPORT {
 		return false, "socket family is not supported (EAFNOSUPPORT)"
 	}
-	proto, ok := c.Args[2].(*prog.ConstType)
+	proto, ok := c.Args[2].Type.(*prog.ConstType)
 	if !ok {
 		return true, ""
 	}
 	var typ uint64
-	if arg, ok := c.Args[1].(*prog.ConstType); ok {
+	if arg, ok := c.Args[1].Type.(*prog.ConstType); ok {
 		typ = arg.Val
-	} else if arg, ok := c.Args[1].(*prog.FlagsType); ok {
+	} else if arg, ok := c.Args[1].Type.(*prog.FlagsType); ok {
 		typ = arg.Vals[0]
 	} else {
 		return true, ""
@@ -344,7 +344,7 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 	var fd int
 	var err error
 
-	fname, ok := extractStringConst(c.Args[1])
+	fname, ok := extractStringConst(c.Args[1].Type)
 	if !ok || len(fname) == 0 || fname[0] != '/' {
 		return true, ""
 	}
@@ -352,7 +352,7 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 	modes := []int{syscall.O_RDONLY, syscall.O_WRONLY, syscall.O_RDWR}
 
 	// Attempt to extract flags from the syscall description
-	if mode, ok := c.Args[2].(*prog.ConstType); ok {
+	if mode, ok := c.Args[2].Type.(*prog.ConstType); ok {
 		modes = []int{int(mode.Val)}
 	}
 
@@ -370,7 +370,7 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 }
 
 func isSupportedMount(c *prog.Syscall, sandbox string) (bool, string) {
-	fstype, ok := extractStringConst(c.Args[2])
+	fstype, ok := extractStringConst(c.Args[2].Type)
 	if !ok {
 		panic(fmt.Sprintf("%v: filesystem is not string const", c.Name))
 	}

--- a/prog/any_test.go
+++ b/prog/any_test.go
@@ -61,12 +61,12 @@ func TestSquash(t *testing.T) {
 			if target.ArgContainsAny(ptrArg) {
 				t.Fatalf("arg is already squashed")
 			}
-			target.squashPtr(ptrArg, true)
+			target.squashPtr(ptrArg)
 			if !target.ArgContainsAny(ptrArg) {
 				t.Fatalf("arg is not squashed")
 			}
 			p1 := strings.TrimSpace(string(p.Serialize()))
-			target.squashPtr(ptrArg, true)
+			target.squashPtr(ptrArg)
 			p2 := strings.TrimSpace(string(p.Serialize()))
 			if p1 != p2 {
 				t.Fatalf("double squash changed program:\n%v\nvs:\n%v", p1, p2)

--- a/prog/hints_test.go
+++ b/prog/hints_test.go
@@ -295,7 +295,7 @@ func TestHintsCheckDataArg(t *testing.T) {
 			res := make(map[string]bool)
 			// Whatever type here. It's just needed to pass the
 			// dataArg.Type().Dir() == DirIn check.
-			typ := &ArrayType{TypeCommon{"", "", 0, false, true}, nil, 0, 0, 0}
+			typ := &ArrayType{TypeCommon{"", 0, false, true}, nil, 0, 0, 0}
 			dataArg := MakeDataArg(typ, DirIn, []byte(test.in))
 			checkDataArg(dataArg, test.comps, func() {
 				res[string(dataArg.Data())] = true

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -234,10 +234,11 @@ func (arg *GroupArg) fixedInnerSize() bool {
 type UnionArg struct {
 	ArgCommon
 	Option Arg
+	Index  int // Index of the selected option in the union type.
 }
 
-func MakeUnionArg(t Type, dir Dir, opt Arg) *UnionArg {
-	return &UnionArg{ArgCommon: ArgCommon{typ: t, dir: dir}, Option: opt}
+func MakeUnionArg(t Type, dir Dir, opt Arg, index int) *UnionArg {
+	return &UnionArg{ArgCommon: ArgCommon{typ: t, dir: dir}, Option: opt, Index: index}
 }
 
 func (arg *UnionArg) Size() uint64 {

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -601,15 +601,15 @@ func (target *Target) DataMmapProg() *Prog {
 	}
 }
 
-func (r *randGen) generateArgs(s *state, types []Type, dir Dir) ([]Arg, []*Call) {
+func (r *randGen) generateArgs(s *state, fields []Field, dir Dir) ([]Arg, []*Call) {
 	var calls []*Call
-	args := make([]Arg, len(types))
+	args := make([]Arg, len(fields))
 
 	// Generate all args. Size args have the default value 0 for now.
-	for i, typ := range types {
-		arg, calls1 := r.generateArg(s, typ, dir)
+	for i, field := range fields {
+		arg, calls1 := r.generateArg(s, field.Type, dir)
 		if arg == nil {
-			panic(fmt.Sprintf("generated arg is nil for type '%v', types: %+v", typ.Name(), types))
+			panic(fmt.Sprintf("generated arg is nil for field '%v', fields: %+v", field.Type.Name(), fields))
 		}
 		args[i] = arg
 		calls = append(calls, calls1...)
@@ -797,9 +797,10 @@ func (a *StructType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*
 }
 
 func (a *UnionType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*Call) {
-	optType := a.Fields[r.Intn(len(a.Fields))]
+	index := r.Intn(len(a.Fields))
+	optType := a.Fields[index].Type
 	opt, calls := r.generateArg(s, optType, dir)
-	return MakeUnionArg(a, dir, opt), calls
+	return MakeUnionArg(a, dir, opt, index), calls
 }
 
 func (a *PtrType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*Call) {

--- a/prog/size.go
+++ b/prog/size.go
@@ -14,7 +14,8 @@ const (
 	SyscallRef = "syscall"
 )
 
-func (target *Target) assignSizes(args []Arg, parentsMap map[Arg]Arg, syscallArgs []Arg, autos map[Arg]bool) {
+func (target *Target) assignSizes(args []Arg, fields []Field, parentsMap map[Arg]Arg,
+	syscallArgs []Arg, syscallFields []Field, autos map[Arg]bool) {
 	for _, arg := range args {
 		if arg = InnerArg(arg); arg == nil {
 			continue // Pointer to optional len field, no need to fill in value.
@@ -31,19 +32,26 @@ func (target *Target) assignSizes(args []Arg, parentsMap map[Arg]Arg, syscallArg
 		}
 		a := arg.(*ConstArg)
 		if typ.Path[0] == SyscallRef {
-			target.assignSize(a, nil, typ.Path[1:], syscallArgs, parentsMap)
+			target.assignSize(a, nil, typ.Path[1:], syscallArgs, syscallFields, parentsMap)
 		} else {
-			target.assignSize(a, a, typ.Path, args, parentsMap)
+			target.assignSize(a, a, typ.Path, args, fields, parentsMap)
 		}
 	}
 }
 
-func (target *Target) assignSize(dst *ConstArg, pos Arg, path []string, args []Arg, parentsMap map[Arg]Arg) {
+func (target *Target) assignSizeStruct(dst *ConstArg, buf Arg, path []string, parentsMap map[Arg]Arg) {
+	arg := buf.(*GroupArg)
+	typ := arg.Type().(*StructType)
+	target.assignSize(dst, buf, path, arg.Inner, typ.Fields, parentsMap)
+}
+
+func (target *Target) assignSize(dst *ConstArg, pos Arg, path []string, args []Arg,
+	fields []Field, parentsMap map[Arg]Arg) {
 	elem := path[0]
 	path = path[1:]
 	var offset uint64
-	for _, buf := range args {
-		if elem != buf.Type().FieldName() {
+	for i, buf := range args {
+		if elem != fields[i].Name {
 			offset += buf.Size()
 			continue
 		}
@@ -58,39 +66,39 @@ func (target *Target) assignSize(dst *ConstArg, pos Arg, path []string, args []A
 			dst.Val = 0 // target is an optional pointer
 			return
 		}
-		if len(path) == 0 {
-			dst.Val = target.computeSize(buf, offset, dst.Type().(*LenType))
-		} else {
-			target.assignSize(dst, buf, path, buf.(*GroupArg).Inner, parentsMap)
+		if len(path) != 0 {
+			target.assignSizeStruct(dst, buf, path, parentsMap)
+			return
 		}
+		dst.Val = target.computeSize(buf, offset, dst.Type().(*LenType))
 		return
 	}
 	if elem == ParentRef {
 		buf := parentsMap[pos]
-		if len(path) == 0 {
-			dst.Val = target.computeSize(buf, noOffset, dst.Type().(*LenType))
-		} else {
-			target.assignSize(dst, buf, path, buf.(*GroupArg).Inner, parentsMap)
+		if len(path) != 0 {
+			target.assignSizeStruct(dst, buf, path, parentsMap)
+			return
 		}
+		dst.Val = target.computeSize(buf, noOffset, dst.Type().(*LenType))
 		return
 	}
 	for buf := parentsMap[pos]; buf != nil; buf = parentsMap[buf] {
 		if elem != buf.Type().TemplateName() {
 			continue
 		}
-		if len(path) == 0 {
-			dst.Val = target.computeSize(buf, noOffset, dst.Type().(*LenType))
-		} else {
-			target.assignSize(dst, buf, path, buf.(*GroupArg).Inner, parentsMap)
+		if len(path) != 0 {
+			target.assignSizeStruct(dst, buf, path, parentsMap)
+			return
 		}
+		dst.Val = target.computeSize(buf, noOffset, dst.Type().(*LenType))
 		return
 	}
-	var argNames []string
-	for _, arg := range args {
-		argNames = append(argNames, arg.Type().FieldName())
+	var fieldNames []string
+	for _, field := range fields {
+		fieldNames = append(fieldNames, field.Name)
 	}
-	panic(fmt.Sprintf("len field %q references non existent field %q, pos=%q/%q, argsMap: %+v",
-		dst.Type().FieldName(), elem, pos.Type().Name(), pos.Type().FieldName(), argNames))
+	panic(fmt.Sprintf("len field %q references non existent field %q, pos=%q, argsMap: %v, path: %v",
+		dst.Type().Name(), elem, pos.Type().Name(), fieldNames, path))
 }
 
 const noOffset = ^uint64(0)
@@ -121,7 +129,7 @@ func (target *Target) computeSize(arg Arg, offset uint64, lenType *LenType) uint
 	}
 }
 
-func (target *Target) assignSizesArray(args []Arg, autos map[Arg]bool) {
+func (target *Target) assignSizesArray(args []Arg, fields []Field, autos map[Arg]bool) {
 	parentsMap := make(map[Arg]Arg)
 	for _, arg := range args {
 		ForeachSubArg(arg, func(arg Arg, _ *ArgCtx) {
@@ -132,29 +140,29 @@ func (target *Target) assignSizesArray(args []Arg, autos map[Arg]bool) {
 			}
 		})
 	}
-	target.assignSizes(args, parentsMap, args, autos)
+	target.assignSizes(args, fields, parentsMap, args, fields, autos)
 	for _, arg := range args {
 		ForeachSubArg(arg, func(arg Arg, _ *ArgCtx) {
-			if _, ok := arg.Type().(*StructType); ok {
-				target.assignSizes(arg.(*GroupArg).Inner, parentsMap, args, autos)
+			if typ, ok := arg.Type().(*StructType); ok {
+				target.assignSizes(arg.(*GroupArg).Inner, typ.Fields, parentsMap, args, fields, autos)
 			}
 		})
 	}
 }
 
 func (target *Target) assignSizesCall(c *Call) {
-	target.assignSizesArray(c.Args, nil)
+	target.assignSizesArray(c.Args, c.Meta.Args, nil)
 }
 
-func (r *randGen) mutateSize(arg *ConstArg, parent []Arg) bool {
+func (r *randGen) mutateSize(arg *ConstArg, parent []Arg, fields []Field) bool {
 	typ := arg.Type().(*LenType)
 	elemSize := typ.BitSize / 8
 	if elemSize == 0 {
 		elemSize = 1
 		// TODO(dvyukov): implement path support for size mutation.
 		if len(typ.Path) == 1 {
-			for _, field := range parent {
-				if typ.Path[0] != field.Type().FieldName() {
+			for i, field := range parent {
+				if typ.Path[0] != fields[i].Name {
 					continue
 				}
 				if inner := InnerArg(field); inner != nil {

--- a/prog/target.go
+++ b/prog/target.go
@@ -187,12 +187,12 @@ func restoreLinks(syscalls []*Syscall, resources []*ResourceDesc, structs []*Key
 	for _, desc := range structs {
 		keyedStructs[desc.Key] = desc.Desc
 		for i := range desc.Desc.Fields {
-			unref(&desc.Desc.Fields[i], types)
+			unref(&desc.Desc.Fields[i].Type, types)
 		}
 	}
 	for _, c := range syscalls {
 		for i := range c.Args {
-			unref(&c.Args[i], types)
+			unref(&c.Args[i].Type, types)
 		}
 		if c.Ret != nil {
 			unref(&c.Ret, types)
@@ -262,7 +262,7 @@ func (g *Gen) GenerateSpecialArg(typ Type, dir Dir, pcalls *[]*Call) Arg {
 func (g *Gen) generateArg(typ Type, dir Dir, pcalls *[]*Call, ignoreSpecial bool) Arg {
 	arg, calls := g.r.generateArgImpl(g.s, typ, dir, ignoreSpecial)
 	*pcalls = append(*pcalls, calls...)
-	g.r.target.assignSizesArray([]Arg{arg}, nil)
+	g.r.target.assignSizesArray([]Arg{arg}, []Field{{Name: "", Type: arg.Type()}}, nil)
 	return arg
 }
 

--- a/sys/linux/init.go
+++ b/sys/linux/init.go
@@ -295,8 +295,8 @@ func (arch *arch) generateTimespec(g *prog.Gen, typ0 prog.Type, dir prog.Dir, ol
 	case g.NOutOf(1, 4):
 		// Now for relative, past for absolute.
 		arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
-			prog.MakeResultArg(typ.Fields[0], dir, nil, 0),
-			prog.MakeResultArg(typ.Fields[1], dir, nil, 0),
+			prog.MakeResultArg(typ.Fields[0].Type, dir, nil, 0),
+			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, 0),
 		})
 	case g.NOutOf(1, 3):
 		// Few ms ahead for relative, past for absolute
@@ -308,37 +308,37 @@ func (arch *arch) generateTimespec(g *prog.Gen, typ0 prog.Type, dir prog.Dir, ol
 			nsec /= 1e3
 		}
 		arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
-			prog.MakeResultArg(typ.Fields[0], dir, nil, 0),
-			prog.MakeResultArg(typ.Fields[1], dir, nil, nsec),
+			prog.MakeResultArg(typ.Fields[0].Type, dir, nil, 0),
+			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, nsec),
 		})
 	case g.NOutOf(1, 2):
 		// Unreachable fututre for both relative and absolute
 		arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
-			prog.MakeResultArg(typ.Fields[0], dir, nil, 2e9),
-			prog.MakeResultArg(typ.Fields[1], dir, nil, 0),
+			prog.MakeResultArg(typ.Fields[0].Type, dir, nil, 2e9),
+			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, 0),
 		})
 	default:
 		// Few ms ahead for absolute.
 		meta := arch.clockGettimeSyscall
-		ptrArgType := meta.Args[1].(*prog.PtrType)
+		ptrArgType := meta.Args[1].Type.(*prog.PtrType)
 		argType := ptrArgType.Elem.(*prog.StructType)
 		tp := prog.MakeGroupArg(argType, prog.DirOut, []prog.Arg{
-			prog.MakeResultArg(argType.Fields[0], prog.DirOut, nil, 0),
-			prog.MakeResultArg(argType.Fields[1], prog.DirOut, nil, 0),
+			prog.MakeResultArg(argType.Fields[0].Type, prog.DirOut, nil, 0),
+			prog.MakeResultArg(argType.Fields[1].Type, prog.DirOut, nil, 0),
 		})
 		var tpaddr prog.Arg
 		tpaddr, calls = g.Alloc(ptrArgType, prog.DirIn, tp)
 		gettime := &prog.Call{
 			Meta: meta,
 			Args: []prog.Arg{
-				prog.MakeConstArg(meta.Args[0], prog.DirIn, arch.CLOCK_REALTIME),
+				prog.MakeConstArg(meta.Args[0].Type, prog.DirIn, arch.CLOCK_REALTIME),
 				tpaddr,
 			},
 			Ret: prog.MakeReturnArg(meta.Ret),
 		}
 		calls = append(calls, gettime)
-		sec := prog.MakeResultArg(typ.Fields[0], dir, tp.Inner[0].(*prog.ResultArg), 0)
-		nsec := prog.MakeResultArg(typ.Fields[1], dir, tp.Inner[1].(*prog.ResultArg), 0)
+		sec := prog.MakeResultArg(typ.Fields[0].Type, dir, tp.Inner[0].(*prog.ResultArg), 0)
+		nsec := prog.MakeResultArg(typ.Fields[1].Type, dir, tp.Inner[1].(*prog.ResultArg), 0)
 		msec := timeout1
 		if g.NOutOf(1, 2) {
 			msec = timeout2

--- a/sys/linux/init_alg.go
+++ b/sys/linux/init_alg.go
@@ -12,25 +12,25 @@ import (
 func (arch *arch) generateSockaddrAlg(g *prog.Gen, typ0 prog.Type, dir prog.Dir, old prog.Arg) (
 	arg prog.Arg, calls []*prog.Call) {
 	typ := typ0.(*prog.StructType)
-	family := g.GenerateArg(typ.Fields[0], dir, &calls)
+	family := g.GenerateArg(typ.Fields[0].Type, dir, &calls)
 	// There is very little point in generating feat/mask,
 	// because that can only fail otherwise correct bind.
-	feat := prog.MakeConstArg(typ.Fields[2], dir, 0)
-	mask := prog.MakeConstArg(typ.Fields[3], dir, 0)
+	feat := prog.MakeConstArg(typ.Fields[2].Type, dir, 0)
+	mask := prog.MakeConstArg(typ.Fields[3].Type, dir, 0)
 	if g.NOutOf(1, 1000) {
-		feat = g.GenerateArg(typ.Fields[2], dir, &calls).(*prog.ConstArg)
-		mask = g.GenerateArg(typ.Fields[3], dir, &calls).(*prog.ConstArg)
+		feat = g.GenerateArg(typ.Fields[2].Type, dir, &calls).(*prog.ConstArg)
+		mask = g.GenerateArg(typ.Fields[3].Type, dir, &calls).(*prog.ConstArg)
 	}
 	algType, algName := generateAlgName(g.Rand())
 	// Extend/truncate type/name to their fixed sizes.
-	algTypeData := fixedSizeData(algType, typ.Fields[1].Size())
-	algNameData := fixedSizeData(algName, typ.Fields[4].Size())
+	algTypeData := fixedSizeData(algType, typ.Fields[1].Type.Size())
+	algNameData := fixedSizeData(algName, typ.Fields[4].Type.Size())
 	arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
 		family,
-		prog.MakeDataArg(typ.Fields[1], dir, algTypeData),
+		prog.MakeDataArg(typ.Fields[1].Type, dir, algTypeData),
 		feat,
 		mask,
-		prog.MakeDataArg(typ.Fields[4], dir, algNameData),
+		prog.MakeDataArg(typ.Fields[4].Type, dir, algNameData),
 	})
 	return
 }
@@ -61,7 +61,7 @@ func generateAlgNameStruct(g *prog.Gen, typ0 prog.Type, dir prog.Dir, algTyp int
 	algName := generateAlg(g.Rand(), algTyp)
 	algNameData := fixedSizeData(algName, typ.Fields[0].Size())
 	arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
-		prog.MakeDataArg(typ.Fields[0], dir, algNameData),
+		prog.MakeDataArg(typ.Fields[0].Type, dir, algNameData),
 	})
 	return
 }

--- a/sys/linux/init_vusb.go
+++ b/sys/linux/init_vusb.go
@@ -171,9 +171,10 @@ func (arch *arch) generateUsbHidDeviceDescriptor(g *prog.Gen, typ0 prog.Type, di
 }
 
 func patchGroupArg(arg prog.Arg, index int, field string, value uint64) {
-	fieldArg := arg.(*prog.GroupArg).Inner[index].(*prog.ConstArg)
-	if fieldArg.Type().FieldName() != field {
-		panic(fmt.Sprintf("bad field, expected %v, found %v", field, fieldArg.Type().FieldName()))
+	a := arg.(*prog.GroupArg)
+	typ := a.Type().(*prog.StructType)
+	if field != typ.Fields[index].Name {
+		panic(fmt.Sprintf("bad field, expected %v, found %v", field, typ.Fields[index].Name))
 	}
-	fieldArg.Val = value
+	a.Inner[index].(*prog.ConstArg).Val = value
 }

--- a/sys/targets/common.go
+++ b/sys/targets/common.go
@@ -22,19 +22,19 @@ func MakePosixMmap(target *prog.Target, exec, contain bool) func() []*prog.Call 
 	const invalidFD = ^uint64(0)
 	makeMmap := func(addr, size, prot uint64) *prog.Call {
 		args := []prog.Arg{
-			prog.MakeVmaPointerArg(meta.Args[0], prog.DirIn, addr, size),
-			prog.MakeConstArg(meta.Args[1], prog.DirIn, size),
-			prog.MakeConstArg(meta.Args[2], prog.DirIn, prot),
-			prog.MakeConstArg(meta.Args[3], prog.DirIn, flags),
-			prog.MakeResultArg(meta.Args[4], prog.DirIn, nil, invalidFD),
+			prog.MakeVmaPointerArg(meta.Args[0].Type, prog.DirIn, addr, size),
+			prog.MakeConstArg(meta.Args[1].Type, prog.DirIn, size),
+			prog.MakeConstArg(meta.Args[2].Type, prog.DirIn, prot),
+			prog.MakeConstArg(meta.Args[3].Type, prog.DirIn, flags),
+			prog.MakeResultArg(meta.Args[4].Type, prog.DirIn, nil, invalidFD),
 		}
 		i := len(args)
 		// Some targets have a padding argument between fd and offset.
 		if len(meta.Args) > 6 {
-			args = append(args, prog.MakeConstArg(meta.Args[i], prog.DirIn, 0))
+			args = append(args, prog.MakeConstArg(meta.Args[i].Type, prog.DirIn, 0))
 			i++
 		}
-		args = append(args, prog.MakeConstArg(meta.Args[i], prog.DirIn, 0))
+		args = append(args, prog.MakeConstArg(meta.Args[i].Type, prog.DirIn, 0))
 		return &prog.Call{
 			Meta: meta,
 			Args: args,
@@ -61,8 +61,8 @@ func MakeSyzMmap(target *prog.Target) func() []*prog.Call {
 			{
 				Meta: meta,
 				Args: []prog.Arg{
-					prog.MakeVmaPointerArg(meta.Args[0], prog.DirIn, 0, size),
-					prog.MakeConstArg(meta.Args[1], prog.DirIn, size),
+					prog.MakeVmaPointerArg(meta.Args[0].Type, prog.DirIn, 0, size),
+					prog.MakeConstArg(meta.Args[1].Type, prog.DirIn, size),
 				},
 				Ret: prog.MakeReturnArg(meta.Ret),
 			},

--- a/sys/windows/init.go
+++ b/sys/windows/init.go
@@ -35,10 +35,10 @@ func (arch *arch) makeMmap() []*prog.Call {
 		{
 			Meta: meta,
 			Args: []prog.Arg{
-				prog.MakeVmaPointerArg(meta.Args[0], prog.DirIn, 0, size),
-				prog.MakeConstArg(meta.Args[1], prog.DirIn, size),
-				prog.MakeConstArg(meta.Args[2], prog.DirIn, arch.MEM_COMMIT|arch.MEM_RESERVE),
-				prog.MakeConstArg(meta.Args[3], prog.DirIn, arch.PAGE_EXECUTE_READWRITE),
+				prog.MakeVmaPointerArg(meta.Args[0].Type, prog.DirIn, 0, size),
+				prog.MakeConstArg(meta.Args[1].Type, prog.DirIn, size),
+				prog.MakeConstArg(meta.Args[2].Type, prog.DirIn, arch.MEM_COMMIT|arch.MEM_RESERVE),
+				prog.MakeConstArg(meta.Args[3].Type, prog.DirIn, arch.PAGE_EXECUTE_READWRITE),
 			},
 			Ret: prog.MakeReturnArg(meta.Ret),
 		},

--- a/tools/syz-trace2syz/proggen/call_selector.go
+++ b/tools/syz-trace2syz/proggen/call_selector.go
@@ -141,7 +141,7 @@ func (cs *openCallSelector) Select(call *parser.Syscall) *prog.Syscall {
 func (cs *openCallSelector) matchOpen(meta *prog.Syscall, call *parser.Syscall) (bool, int) {
 	straceFileArg := call.Args[openDiscriminatorArgs[call.CallName]]
 	straceBuf := straceFileArg.(*parser.BufferType).Val
-	syzFileArg := meta.Args[openDiscriminatorArgs[meta.CallName]]
+	syzFileArg := meta.Args[openDiscriminatorArgs[meta.CallName]].Type
 	if _, ok := syzFileArg.(*prog.PtrType); !ok {
 		return false, -1
 	}
@@ -186,7 +186,7 @@ func (cs *defaultCallSelector) matchCall(meta *prog.Syscall, call *parser.Syscal
 		if i >= len(meta.Args) || i >= len(call.Args) {
 			return -1
 		}
-		typ := meta.Args[i]
+		typ := meta.Args[i].Type
 		arg := call.Args[i]
 		switch t := typ.(type) {
 		case *prog.ConstType:

--- a/tools/syz-trace2syz/proggen/generate_unions.go
+++ b/tools/syz-trace2syz/proggen/generate_unions.go
@@ -14,7 +14,7 @@ import (
 func (ctx *context) genSockaddrStorage(syzType *prog.UnionType, dir prog.Dir, straceType parser.IrType) prog.Arg {
 	field2Opt := make(map[string]int)
 	for i, field := range syzType.Fields {
-		field2Opt[field.FieldName()] = i
+		field2Opt[field.Name] = i
 	}
 	idx := 0
 	switch strType := straceType.(type) {
@@ -44,14 +44,14 @@ func (ctx *context) genSockaddrStorage(syzType *prog.UnionType, dir prog.Dir, st
 	default:
 		log.Fatalf("unable to parse sockaddr_storage. Unsupported type: %#v", strType)
 	}
-	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx], dir, straceType))
+	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx].Type, dir, straceType), idx)
 }
 
 func (ctx *context) genSockaddrNetlink(syzType *prog.UnionType, dir prog.Dir, straceType parser.IrType) prog.Arg {
 	var idx = 2
 	field2Opt := make(map[string]int)
 	for i, field := range syzType.Fields {
-		field2Opt[field.FieldName()] = i
+		field2Opt[field.Name] = i
 	}
 	switch a := straceType.(type) {
 	case *parser.GroupType:
@@ -74,7 +74,7 @@ func (ctx *context) genSockaddrNetlink(syzType *prog.UnionType, dir prog.Dir, st
 			}
 		}
 	}
-	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx], dir, straceType))
+	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx].Type, dir, straceType), idx)
 }
 
 func (ctx *context) genIfrIfru(syzType *prog.UnionType, dir prog.Dir, straceType parser.IrType) prog.Arg {
@@ -83,5 +83,5 @@ func (ctx *context) genIfrIfru(syzType *prog.UnionType, dir prog.Dir, straceType
 	case parser.Constant:
 		idx = 2
 	}
-	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx], dir, straceType))
+	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[idx].Type, dir, straceType), idx)
 }

--- a/tools/syz-trace2syz/proggen/proggen.go
+++ b/tools/syz-trace2syz/proggen/proggen.go
@@ -115,7 +115,7 @@ func (ctx *context) genCall() *prog.Call {
 		if i < len(straceCall.Args) {
 			strArg = straceCall.Args[i]
 		}
-		res := ctx.genArg(syzCall.Meta.Args[i], prog.DirIn, strArg)
+		res := ctx.genArg(syzCall.Meta.Args[i].Type, prog.DirIn, strArg)
 		syzCall.Args = append(syzCall.Args, res)
 	}
 	ctx.genResult(syzCall.Meta.Ret, straceCall.Ret)
@@ -218,7 +218,7 @@ func (ctx *context) genStruct(syzType *prog.StructType, dir prog.Dir, traceType 
 			return ret
 		}
 		for i := range syzType.Fields {
-			if prog.IsPad(syzType.Fields[i]) {
+			if prog.IsPad(syzType.Fields[i].Type) {
 				args = append(args, syzType.Fields[i].DefaultArg(dir))
 				continue
 			}
@@ -228,7 +228,7 @@ func (ctx *context) genStruct(syzType *prog.StructType, dir prog.Dir, traceType 
 			if j >= len(a.Elems) {
 				args = append(args, syzType.Fields[i].DefaultArg(dir))
 			} else {
-				args = append(args, ctx.genArg(syzType.Fields[i], dir, a.Elems[j]))
+				args = append(args, ctx.genArg(syzType.Fields[i].Type, dir, a.Elems[j]))
 			}
 			j++
 		}
@@ -253,7 +253,7 @@ func (ctx *context) recurseStructs(syzType *prog.StructType, dir prog.Dir, trace
 	// only consider structs with one non-padded field
 	numFields := 0
 	for _, field := range syzType.Fields {
-		if prog.IsPad(field) {
+		if prog.IsPad(field.Type) {
 			continue
 		}
 		numFields++
@@ -266,7 +266,7 @@ func (ctx *context) recurseStructs(syzType *prog.StructType, dir prog.Dir, trace
 		return nil, false
 	}
 	// first field needs to be a struct
-	switch t := syzType.Fields[0].(type) {
+	switch t := syzType.Fields[0].Type.(type) {
 	case *prog.StructType:
 		var args []prog.Arg
 		// first element and traceType should have the same number of elements
@@ -301,7 +301,7 @@ func (ctx *context) genUnionArg(syzType *prog.UnionType, dir prog.Dir, straceTyp
 	case "ifr_ifru":
 		return ctx.genIfrIfru(syzType, dir, straceType)
 	}
-	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[0], dir, straceType))
+	return prog.MakeUnionArg(syzType, dir, ctx.genArg(syzType.Fields[0].Type, dir, straceType), 0)
 }
 
 func (ctx *context) genBuffer(syzType *prog.BufferType, dir prog.Dir, traceType parser.IrType) prog.Arg {


### PR DESCRIPTION
Remvoe FieldName from Type and add a separate Field type
that holds field name. Use Field for struct fields, union options
and syscalls arguments, only these really have names.

Reduces size of sys/linux/gen/amd64.go from 5665583 to 5201321 (-8.2%).
Allows to not create new type for squashed any pointer.
But main advantages will follow, e.g. removing StructDesc,
using TypeRef in Arg, etc.

Update #1580