### PR TITLE
prog: remove StructDesc

### DIFF
--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -122,8 +122,6 @@ func TestData(t *testing.T) {
 				out := new(bytes.Buffer)
 				fmt.Fprintf(out, "\n\nRESOURCES:\n")
 				serializer.Write(out, desc.Resources)
-				fmt.Fprintf(out, "\n\nSTRUCTS:\n")
-				serializer.Write(out, desc.StructDescs)
 				fmt.Fprintf(out, "\n\nSYSCALLS:\n")
 				serializer.Write(out, desc.Syscalls)
 				if false {
@@ -188,8 +186,6 @@ s2 {
 	if p == nil {
 		t.Fatal("failed to compile")
 	}
-	got := p.StructDescs[0].Desc
-	t.Logf("got: %#v", got)
 }
 
 func TestCollectUnusedError(t *testing.T) {

--- a/prog/any.go
+++ b/prog/any.go
@@ -36,7 +36,12 @@ type anyTypes struct {
 //	resoct	fmt[oct, ANYRES64]
 // ] [varlen]
 func initAnyTypes(target *Target) {
-	target.any.union = &UnionType{}
+	target.any.union = &UnionType{
+		TypeCommon: TypeCommon{
+			TypeName: "ANYUNION",
+			IsVarlen: true,
+		},
+	}
 	target.any.array = &ArrayType{
 		TypeCommon: TypeCommon{
 			TypeName: "ANYARRAY",
@@ -89,20 +94,14 @@ func initAnyTypes(target *Target) {
 	target.any.resdec = createResource("ANYRESDEC", "int64", FormatStrDec, 20)
 	target.any.reshex = createResource("ANYRESHEX", "int64", FormatStrHex, 18)
 	target.any.resoct = createResource("ANYRESOCT", "int64", FormatStrOct, 23)
-	target.any.union.StructDesc = &StructDesc{
-		TypeCommon: TypeCommon{
-			TypeName: "ANYUNION",
-			IsVarlen: true,
-		},
-		Fields: []Field{
-			{Name: "ANYBLOB", Type: target.any.blob},
-			{Name: "ANYRES16", Type: target.any.res16},
-			{Name: "ANYRES32", Type: target.any.res32},
-			{Name: "ANYRES64", Type: target.any.res64},
-			{Name: "ANYRESDEC", Type: target.any.resdec},
-			{Name: "ANYRESHEX", Type: target.any.reshex},
-			{Name: "ANYRESOCT", Type: target.any.resoct},
-		},
+	target.any.union.Fields = []Field{
+		{Name: "ANYBLOB", Type: target.any.blob},
+		{Name: "ANYRES16", Type: target.any.res16},
+		{Name: "ANYRES32", Type: target.any.res32},
+		{Name: "ANYRES64", Type: target.any.res64},
+		{Name: "ANYRESDEC", Type: target.any.resdec},
+		{Name: "ANYRESHEX", Type: target.any.reshex},
+		{Name: "ANYRESOCT", Type: target.any.resoct},
 	}
 }
 

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -20,15 +20,13 @@ func TestGeneration(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	target, _, _ := initTest(t)
-	for _, meta := range target.Syscalls {
-		foreachType(meta, func(typ Type, ctx typeCtx) {
-			arg := typ.DefaultArg(ctx.Dir)
-			if !isDefault(arg) {
-				t.Errorf("default arg is not default: %s\ntype: %#v\narg: %#v",
-					typ, typ, arg)
-			}
-		})
-	}
+	ForeachType(target.Syscalls, func(typ Type, ctx TypeCtx) {
+		arg := typ.DefaultArg(ctx.Dir)
+		if !isDefault(arg) {
+			t.Errorf("default arg is not default: %s\ntype: %#v\narg: %#v",
+				typ, typ, arg)
+		}
+	})
 }
 
 func TestDefaultCallArgs(t *testing.T) {
@@ -203,7 +201,7 @@ func TestSpecialStructs(t *testing.T) {
 			t.Run(special, func(t *testing.T) {
 				var typ Type
 				for i := 0; i < len(target.Syscalls) && typ == nil; i++ {
-					foreachType(target.Syscalls[i], func(t Type, ctx typeCtx) {
+					ForeachCallType(target.Syscalls[i], func(t Type, ctx TypeCtx) {
 						if ctx.Dir == DirOut {
 							return
 						}

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -101,22 +101,20 @@ func TestEnabledCalls(t *testing.T) {
 func TestSizeGenerateConstArg(t *testing.T) {
 	target, rs, iters := initRandomTargetTest(t, "test", "64")
 	r := newRand(target, rs)
-	for _, c := range target.Syscalls {
-		foreachType(c, func(typ Type, ctx typeCtx) {
-			if _, ok := typ.(*IntType); !ok {
-				return
+	ForeachType(target.Syscalls, func(typ Type, ctx TypeCtx) {
+		if _, ok := typ.(*IntType); !ok {
+			return
+		}
+		bits := typ.TypeBitSize()
+		limit := uint64(1<<bits - 1)
+		for i := 0; i < iters; i++ {
+			newArg, _ := typ.generate(r, nil, ctx.Dir)
+			newVal := newArg.(*ConstArg).Val
+			if newVal > limit {
+				t.Fatalf("invalid generated value: %d. (arg bitsize: %d; max value: %d)", newVal, bits, limit)
 			}
-			bits := typ.TypeBitSize()
-			limit := uint64(1<<bits - 1)
-			for i := 0; i < iters; i++ {
-				newArg, _ := typ.generate(r, nil, ctx.Dir)
-				newVal := newArg.(*ConstArg).Val
-				if newVal > limit {
-					t.Fatalf("invalid generated value: %d. (arg bitsize: %d; max value: %d)", newVal, bits, limit)
-				}
-			}
-		})
-	}
+		}
+	})
 }
 
 func TestFlags(t *testing.T) {

--- a/prog/resources.go
+++ b/prog/resources.go
@@ -45,16 +45,14 @@ func (target *Target) calcResourceCtors(res *ResourceDesc, precise bool) []*Sysc
 func (target *Target) populateResourceCtors() {
 	// Find resources that are created by each call.
 	callsResources := make([][]*ResourceDesc, len(target.Syscalls))
-	for call, meta := range target.Syscalls {
-		foreachType(meta, func(typ Type, ctx typeCtx) {
-			switch typ1 := typ.(type) {
-			case *ResourceType:
-				if ctx.Dir != DirIn {
-					callsResources[call] = append(callsResources[call], typ1.Desc)
-				}
+	ForeachType(target.Syscalls, func(typ Type, ctx TypeCtx) {
+		switch typ1 := typ.(type) {
+		case *ResourceType:
+			if ctx.Dir != DirIn {
+				callsResources[ctx.Meta.ID] = append(callsResources[ctx.Meta.ID], typ1.Desc)
 			}
-		})
-	}
+		}
+	})
 
 	// Populate resource ctors accounting for resource compatibility.
 	for _, res := range target.Resources {
@@ -126,7 +124,7 @@ func isCompatibleResourceImpl(dst, src []string, precise bool) bool {
 
 func (target *Target) getInputResources(c *Syscall) []*ResourceDesc {
 	var resources []*ResourceDesc
-	foreachType(c, func(typ Type, ctx typeCtx) {
+	ForeachCallType(c, func(typ Type, ctx TypeCtx) {
 		if ctx.Dir == DirOut {
 			return
 		}
@@ -146,7 +144,7 @@ func (target *Target) getInputResources(c *Syscall) []*ResourceDesc {
 
 func (target *Target) getOutputResources(c *Syscall) []*ResourceDesc {
 	var resources []*ResourceDesc
-	foreachType(c, func(typ Type, ctx typeCtx) {
+	ForeachCallType(c, func(typ Type, ctx TypeCtx) {
 		switch typ1 := typ.(type) {
 		case *ResourceType:
 			if ctx.Dir != DirIn {

--- a/prog/rotation.go
+++ b/prog/rotation.go
@@ -50,7 +50,7 @@ func MakeRotator(target *Target, calls map[*Syscall]bool, rnd *rand.Rand) *Rotat
 		}
 		// VMAs and filenames are effectively resources for our purposes
 		// (but they don't have ctors).
-		foreachType(call, func(t Type, _ typeCtx) {
+		ForeachCallType(call, func(t Type, _ TypeCtx) {
 			switch a := t.(type) {
 			case *BufferType:
 				switch a.Kind {

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -189,18 +189,14 @@ func generate(target *targets.Target, prg *compiler.Prog, consts map[string]uint
 	fmt.Fprintf(out, "\tRegisterTarget(&Target{"+
 		"OS: %q, Arch: %q, Revision: revision_%v, PtrSize: %v, "+
 		"PageSize: %v, NumPages: %v, DataOffset: %v, Syscalls: syscalls_%v, "+
-		"Resources: resources_%v, Structs: structDescs_%v, Types: types_%v, Consts: consts_%v}, "+
+		"Resources: resources_%v, Types: types_%v, Consts: consts_%v}, "+
 		"InitTarget)\n}\n\n",
 		target.OS, target.Arch, target.Arch, target.PtrSize,
 		target.PageSize, target.NumPages, target.DataOffset,
-		target.Arch, target.Arch, target.Arch, target.Arch, target.Arch)
+		target.Arch, target.Arch, target.Arch, target.Arch)
 
 	fmt.Fprintf(out, "var resources_%v = ", target.Arch)
 	serializer.Write(out, prg.Resources)
-	fmt.Fprintf(out, "\n\n")
-
-	fmt.Fprintf(out, "var structDescs_%v = ", target.Arch)
-	serializer.Write(out, prg.StructDescs)
 	fmt.Fprintf(out, "\n\n")
 
 	fmt.Fprintf(out, "var syscalls_%v = ", target.Arch)


### PR DESCRIPTION
Remove StructDesc, KeyedStruct, StructKey and all associated
logic/complexity in prog and pkg/compiler.
We can now handle recursion more generically with the Ref type,
and Dir/FieldName are not a part of the type anymore.
This makes StructType/UnionType simpler and more natural.

Reduces size of sys/linux/gen/amd64.go from 5201321 to 4180861 (-20%).

Update #1580

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
