### PR TITLE
vm/vmimpl: Don't show ktr, but uma on FreeBSD

### DIFF
--- a/vm/vmimpl/freebsd.go
+++ b/vm/vmimpl/freebsd.go
@@ -22,7 +22,7 @@ func DiagnoseFreeBSD(w io.Writer) ([]byte, bool) {
 		"ps",
 		"show all locks",
 		"show malloc",
-		"show ktr",
+		"show uma",
 	}
 	for _, c := range commands {
 		w.Write([]byte(c + "\n"))


### PR DESCRIPTION
Right now, kernels are not build with KTR support, so don't
run show ktr. Add showing information about zones like vmstat -z
would show.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
