### PR TITLE
Preliminary Clang support for Linux in syz-extract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ ifeq ("$(TARGETOS)", "trusty")
 	TARGETGOARCH := $(HOSTARCH)
 endif
 
+SYZ_CLANG ?= 0
+
 .PHONY: all host target \
 	manager runtest fuzzer executor \
 	ci hub \
@@ -196,7 +198,7 @@ ifeq ($(TARGETOS),fuchsia)
 	$(MAKE) generate_fidl TARGETARCH=arm64
 else
 endif
-	bin/syz-extract -build -os=$(TARGETOS) -sourcedir=$(SOURCEDIR) $(FILES)
+	bin/syz-extract -build -os=$(TARGETOS) -sourcedir=$(SOURCEDIR) -use_clang=$(SYZ_CLANG) $(FILES)
 
 bin/syz-extract:
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o $@ ./sys/syz-extract

--- a/pkg/compiler/fuzz.go
+++ b/pkg/compiler/fuzz.go
@@ -22,6 +22,6 @@ func Fuzz(data []byte) int {
 }
 
 var (
-	fuzzTarget = targets.Get("test", "64")
+	fuzzTarget = targets.Get("test", "64", "default")
 	fuzzConsts = map[string]uint64{"A": 1, "B": 2, "C": 3, "SYS_A": 4, "SYS_B": 5, "SYS_C": 6}
 )

--- a/sys/syz-extract/extract.go
+++ b/sys/syz-extract/extract.go
@@ -27,6 +27,7 @@ var (
 	flagIncludes  = flag.String("includedirs", "", "path to other kernel source include dirs separated by commas")
 	flagBuildDir  = flag.String("builddir", "", "path to kernel build dir")
 	flagArch      = flag.String("arch", "", "comma-separated list of arches to generate (all by default)")
+	flagUseClang  = flag.Bool("use_clang", false, "compile with Clang instead of the default compiler")
 )
 
 type Arch struct {
@@ -34,6 +35,7 @@ type Arch struct {
 	sourceDir   string
 	includeDirs string
 	buildDir    string
+	useClang    bool
 	build       bool
 	files       []*File
 	err         error
@@ -170,7 +172,11 @@ func createArches(OS string, archArray, files []string) ([]*Arch, error) {
 			buildDir = *flagSourceDir
 		}
 
-		target := targets.Get(OS, archStr)
+		compiler := "default"
+		if *flagUseClang {
+			compiler = "clang"
+		}
+		target := targets.Get(OS, archStr, compiler)
 		if target == nil {
 			return nil, fmt.Errorf("unknown arch: %v", archStr)
 		}
@@ -180,6 +186,7 @@ func createArches(OS string, archArray, files []string) ([]*Arch, error) {
 			sourceDir:   *flagSourceDir,
 			includeDirs: *flagIncludes,
 			buildDir:    buildDir,
+			useClang:    *flagUseClang,
 			build:       *flagBuild,
 			done:        make(chan bool),
 		}

--- a/tools/syz-env/env.go
+++ b/tools/syz-env/env.go
@@ -36,7 +36,7 @@ func impl() ([]Var, error) {
 	targetOS := or(os.Getenv("TARGETOS"), hostOS)
 	targetArch := or(os.Getenv("TARGETARCH"), hostArch)
 	targetVMArch := or(os.Getenv("TARGETVMARCH"), targetArch)
-	target := targets.Get(targetOS, targetArch)
+	target := targets.Get(targetOS, targetArch, "default")
 	if target == nil {
 		return nil, fmt.Errorf("unknown target %v/%v", targetOS, targetArch)
 	}


### PR DESCRIPTION
Constant extraction with Clang allows the user to not install all the
necessary cross-compilers for every platform. Everything needed is a
Clang binary configured for "AArch64;ARM;Mips;PowerPC;X86" and the
respective binutils packages.

This patch adds a -clangdir flag to syz-extract, which lets the user
pass the path to a directory containing `clang` and `ld.lld` binaries.
When running `make extract`, this path can be supplied via the CLANGDIR env
variable.

Differences between a Clang and a GCC build:
 - Clang needs a --target argument instead of -march. Luckily, the
   target is equal to target.CCompilerPrefix without the trailing dash;
 - We need to set CC=$CLANGDIR/clang and LD=$CLANGDIR/ld.lld (for certain
   arches) in the kernel `make` invocation.

Signed-off-by: Alexander Potapenko <glider@google.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
