### PR TITLE
sys/targets: fix tests when building on FreeBSD

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -433,7 +433,7 @@ func init() {
 					// Ensure clang does not complain about it.
 					target.CFlags = append(target.CFlags, "-Wno-unused-command-line-argument")
 					// When building executor for the test OS, clang needs
-					// to link against the c++ library.
+					// to link against the libc++ library.
 					target.CFlags = append(target.CFlags, "-lc++")
 				}
 			}

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -195,8 +195,8 @@ var List = map[string]map[string]*Target{
 		"amd64": {
 			PtrSize:           8,
 			PageSize:          4 << 10,
-			CCompiler:         "c++",
-			CFlags:            []string{"-m64", "-static"},
+			CCompiler:         "clang",
+			CFlags:            []string{"-m64"},
 			NeedSyscallDefine: dontNeedSyscallDefine,
 		},
 		"386": {
@@ -204,8 +204,8 @@ var List = map[string]map[string]*Target{
 			PtrSize:           4,
 			PageSize:          4 << 10,
 			Int64Alignment:    4,
-			CCompiler:         "c++",
-			CFlags:            []string{"-m32", "-static"},
+			CCompiler:         "clang",
+			CFlags:            []string{"-m32"},
 			NeedSyscallDefine: dontNeedSyscallDefine,
 		},
 	},
@@ -344,6 +344,8 @@ var oses = map[string]osCommon{
 		ExecutorUsesShmem:      true,
 		ExecutorUsesForkServer: true,
 		KernelObject:           "kernel.full",
+		CPP:                    "g++",
+		cflags:                 []string{"-static", "-lc++"},
 	},
 	"netbsd": {
 		BuildOS:                "linux",
@@ -425,6 +427,12 @@ func init() {
 			if host := List[goos][runtime.GOARCH]; host != nil {
 				target.CCompiler = host.CCompiler
 				target.CPP = host.CPP
+				if goos == "freebsd" {
+					// For some configurations -no-pie is passed to the compiler,
+					// which is not used by clang.
+					// Ensure clang does not complain about it.
+					target.CFlags = append(target.CFlags, "-Wno-unused-command-line-argument")
+				}
 			}
 		}
 		target.BuildOS = goos

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -432,6 +432,9 @@ func init() {
 					// which is not used by clang.
 					// Ensure clang does not complain about it.
 					target.CFlags = append(target.CFlags, "-Wno-unused-command-line-argument")
+					// When building executor for the test OS, clang needs
+					// to link against the c++ library.
+					target.CFlags = append(target.CFlags, "-lc++")
 				}
 			}
 		}


### PR DESCRIPTION
gmake test is failing on FreeBSD since switching to clang.

To address this:
* use g++ as the C preprocessor for now.
* use a C compiler for compiling C sources and add -lc++ when
  compiling executor.cc. Without this, clang warns about
  using a C++ compiler for compiling C code.
* some test configs add -no-pie, which is not used by clang.
  Add -Wno-unused-command-line-argument to silence a warning
* when test compiling, clang warns about remove_dir() in
  executor/common.h. It wants static inline void remove_dir()
  instead of static void remove_dir(). Silence this warning
  by adding -Wno-unneeded-internal-declaration

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
