### PR TITLE
[RFC] Provide reporting of all issues found in the log over Symbolize tool via newly added pkg/report ParseMulti i-face

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,9 @@ stress: descriptions
 db: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-db github.com/google/syzkaller/tools/syz-db
 
+symbolize:
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-symbolize github.com/google/syzkaller/tools/syz-symbolize
+
 upgrade: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-upgrade github.com/google/syzkaller/tools/syz-upgrade
 

--- a/pkg/report/akaros.go
+++ b/pkg/report/akaros.go
@@ -34,9 +34,10 @@ func (ctx *akaros) ContainsCrash(output []byte) bool {
 	return containsCrash(output, akarosOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *akaros) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *akaros) Parse(output []byte) *Report {

--- a/pkg/report/akaros.go
+++ b/pkg/report/akaros.go
@@ -34,6 +34,11 @@ func (ctx *akaros) ContainsCrash(output []byte) bool {
 	return containsCrash(output, akarosOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *akaros) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *akaros) Parse(output []byte) *Report {
 	rep := simpleLineParser(output, akarosOopses, akarosStackParams, ctx.ignores)
 	if rep == nil {

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -23,6 +23,11 @@ func (ctx *freebsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, freebsdOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *freebsd) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *freebsd) Parse(output []byte) *Report {
 	rep := &Report{
 		Output: output,

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -23,9 +23,10 @@ func (ctx *freebsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, freebsdOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *freebsd) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *freebsd) Parse(output []byte) *Report {

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -55,9 +55,10 @@ func (ctx *fuchsia) ContainsCrash(output []byte) bool {
 	return containsCrash(output, zirconOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *fuchsia) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *fuchsia) Parse(output []byte) *Report {

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -55,6 +55,11 @@ func (ctx *fuchsia) ContainsCrash(output []byte) bool {
 	return containsCrash(output, zirconOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *fuchsia) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *fuchsia) Parse(output []byte) *Report {
 	// We symbolize here because zircon output does not contain even function names.
 	symbolized := ctx.symbolize(output)

--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -39,6 +39,11 @@ func (ctx *gvisor) ContainsCrash(output []byte) bool {
 	return containsCrash(output, gvisorOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *gvisor) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *gvisor) Parse(output []byte) *Report {
 	rep := simpleLineParser(output, gvisorOopses, nil, ctx.ignores)
 	if rep == nil {

--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -39,9 +39,10 @@ func (ctx *gvisor) ContainsCrash(output []byte) bool {
 	return containsCrash(output, gvisorOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *gvisor) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *gvisor) Parse(output []byte) *Report {

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -127,9 +127,10 @@ func (ctx *linux) ContainsCrash(output []byte) bool {
 	return containsCrash(output, linuxOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *linux) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *linux) Parse(output []byte) *Report {
@@ -143,7 +144,7 @@ func (ctx *linux) Parse(output []byte) *Report {
 			StartPos: startPos,
 		}
 		endPos, reportEnd, report, prefix := ctx.findReport(output, oops, startPos, context, questionable)
-		rep.EndPos = endPos  // ! TOV: That's full span end position (not the report we would like to return now)
+		rep.EndPos = endPos // This is full span till the end of the log, not the relevant report end
 		title, corrupted, format := extractDescription(report[:reportEnd], oops, linuxStackParams)
 		if title == "" {
 			prefix = nil
@@ -153,7 +154,8 @@ func (ctx *linux) Parse(output []byte) *Report {
 				panic(fmt.Sprintf("non matching oops for %q context=%q in:\n%s\n",
 					oops.header, context, report))
 			}
-			reportEnd = rep.EndPos - rep.StartPos  // ? TOV: Added reportEnd full span as we start relying on it below
+			// Added reportEnd full span calc-n as we start relying on it below
+			reportEnd = rep.EndPos - rep.StartPos
 		}
 		rep.Title = title
 		rep.Corrupted = corrupted != ""
@@ -163,8 +165,8 @@ func (ctx *linux) Parse(output []byte) *Report {
 			rep.Report = append(rep.Report, '\n')
 		}
 		rep.reportPrefixLen = len(rep.Report)
-		// rep.Report = append(rep.Report, report...)
-		rep.Report = append(rep.Report, report[:reportEnd]...)  // ? TOV: TODO: Recheck reliability of reportEnd
+		// Reliability of reportEnd is fine. We do not need evyrything down to the end of log.
+		rep.Report = append(rep.Report, report[:reportEnd]...)
 		if !rep.Corrupted {
 			rep.Corrupted, rep.CorruptedReason = ctx.isCorrupted(title, report, format)
 		}

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -54,9 +54,10 @@ func (ctx *netbsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, netbsdOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *netbsd) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *netbsd) Parse(output []byte) *Report {

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -54,6 +54,11 @@ func (ctx *netbsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, netbsdOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *netbsd) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *netbsd) Parse(output []byte) *Report {
 	stripped := bytes.Replace(output, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 	stripped = bytes.Replace(stripped, []byte{'\n', '\r'}, []byte{'\n'}, -1)

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -56,6 +56,11 @@ func (ctx *openbsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, openbsdOopses, ctx.ignores)
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *openbsd) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *openbsd) Parse(output []byte) *Report {
 	stripped := bytes.Replace(output, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 	stripped = bytes.Replace(stripped, []byte{'\n', '\r'}, []byte{'\n'}, -1)

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -56,9 +56,10 @@ func (ctx *openbsd) ContainsCrash(output []byte) bool {
 	return containsCrash(output, openbsdOopses, ctx.ignores)
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *openbsd) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *openbsd) Parse(output []byte) *Report {

--- a/pkg/report/stub.go
+++ b/pkg/report/stub.go
@@ -18,9 +18,10 @@ func (ctx *stub) ContainsCrash(output []byte) bool {
 	panic("not implemented")
 }
 
-// TOV: Dummy i-face (unused currently, but needed for compiling)
 func (ctx *stub) ParseMulti(output []byte) []*Report {
-	return nil
+	// Dummy i-face (OS dependent) placeholder.
+	// Valuable functionality is general and kept in wrapper currently.
+	panic("Not implemented. Should not be used.")
 }
 
 func (ctx *stub) Parse(output []byte) *Report {

--- a/pkg/report/stub.go
+++ b/pkg/report/stub.go
@@ -18,6 +18,11 @@ func (ctx *stub) ContainsCrash(output []byte) bool {
 	panic("not implemented")
 }
 
+// TOV: Dummy i-face (unused currently, but needed for compiling)
+func (ctx *stub) ParseMulti(output []byte) []*Report {
+	return nil
+}
+
 func (ctx *stub) Parse(output []byte) *Report {
 	panic("not implemented")
 }

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -50,42 +50,35 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to open input file: %v\n", err)
 		os.Exit(1)
 	}
-	// rep := reporter.Parse(text)
-	// if rep == nil {
-	// 	rep = &report.Report{Report: text}
-	// } else if *flagOutDir != "" {
-	// 	saveCrash(rep, *flagOutDir)
-	// }
-	//if err := reporter.Symbolize(rep); err != nil {
 
-	repVec := reporter.ParseMulti(text)	// TOV: Var Arr of reports
+	// Vector/array of reports
+	repVec := reporter.ParseMulti(text)
 	repN := len(repVec)
-	if 0 == repN {
-		// TOV: If cannot parse, just push everything out
-		// repVec = append(repVec, &report.Report{Report: text})
-		rep := &report.Report{Report: text}  // TOV: Only one single heap goes to out
-		// TOV: There are no _fields_ to print, except for "Report", right?
-		//      How it was supposed to print that inexistent stuff then?  TODO: Check
-		//
+	if repN == 0 {
+		// If cannot parse, just push everything out. Only one single heap goes to out.
+		rep := &report.Report{Report: text}
+		// There are no _fields_ to print, except for "Report", right?
+		// How it was supposed to print that inexistent stuff then?
 		if err := reporter.Symbolize(rep); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to symbolize report: %v\n", err)
 			os.Exit(1)
 		}
+		// This should print empty fields except for the last
 		fmt.Printf("TITLE: %v\n", rep.Title)
 		fmt.Printf("CORRUPTED: %v (%v)\n", rep.Corrupted, rep.CorruptedReason)
 		fmt.Printf("MAINTAINERS: %v\n", rep.Maintainers)
 		fmt.Printf("\n")
 		os.Stdout.Write(rep.Report)
 	} else {
-		// TOV: Loop through the vector of reports
-		for i := 0;  i < repN;  i++ {
+		// Loop through the vector of reports
+		for i := 0; i < repN; i++ {
 			if *flagOutDir != "" {
-				// TOV: TODO: Once per iteration in a loop
+				// Once per iteration in a loop
 				saveCrash(repVec[i], *flagOutDir)
 			}
 			if err := reporter.Symbolize(repVec[i]); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to symbolize report: %v\n", err)
-				// TOV: Do we really have to exit in case of single report symbolizing failure?
+				// Do we really have to exit in case of single report symbolizing failure?
 				//os.Exit(1)
 			} else {
 				fmt.Printf("TITLE: %v\n", repVec[i].Title)
@@ -103,9 +96,9 @@ func saveCrash(rep *report.Report, path string) {
 	id := sig.String()
 	dir := filepath.Join(path, id)
 	osutil.MkdirAll(dir)
-	// TOV: "Title" is the only thing that bothers us here?
-	//      TODO: Why to exit on every single fail??
-	if err := osutil.WriteFile(filepath.Join(dir, "description"), []byte(rep.Title + "\n")); err != nil {
+	// "Title" is the most important thing for config bisection
+	// Do we really want to drop everything on every single write out fail? (We do not even use it now ;)
+	if err := osutil.WriteFile(filepath.Join(dir, "description"), []byte(rep.Title+"\n")); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write description: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Proposal for a new feature that allows reporting of *all issues/crashes/bugs* found in the log over _Symbolize tool_ via newly added **ParseMulti** i-face into `pkg/report`
