### PR TITLE
docs: add the link of manager config file used in the syz-repro

### DIFF
--- a/docs/reproducing_crashes.md
+++ b/docs/reproducing_crashes.md
@@ -17,7 +17,7 @@ Now, run `syz-prog2c` tool on the program. It will give you executable C source.
 
 If the crash is not reproducible with `-threaded/collide=0` flags, then you need this last step. You can think of threaded/collide mode as if each syscall is executed in its own thread. To mode such execution mode, move individual syscalls into separate threads. You can see an example here: https://groups.google.com/d/msg/syzkaller/fHZ42YrQM-Y/Z4Xf-BbUDgAJ.
 
-This process is automated to some degree in the `syz-repro` utility. You need to give it your manager config and a crash report file:
+This process is automated to some degree in the `syz-repro` utility. You need to give it your manager config and a crash report file. And you can refer to the [example config file](https://github.com/google/syzkaller/blob/master/pkg/mgrconfig/testdata/qemu.cfg).
 ```
 ./syz-repro -config my.cfg crash-qemu-1-1455745459265726910
 ```


### PR DESCRIPTION
I did not find any link for the manager config used in `syz-repro`. After searching in the repo, I found one example config in the pkg/mgrconfig/testdata. If there is already one link in the docs, feel free to ignore this PR.
BTW, what's the base file address for the configuration option(e.g., kernel_obj)? Is the base address of `qemu.cfg` when you run `syz-repro`.