### PR TITLE
executor: fix a USB define on NetBSD

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -12,8 +12,10 @@
 #include <sys/syscall.h>
 
 #if GOOS_netbsd
-#if SYZ_EXECUTOR || SYZ_USB
+#if SYZ_EXECUTOR || __NR_syz_usb_connect
 #include "common_usb_netbsd.h"
+#endif
+#if SYZ_EXECUTOR || SYZ_USB
 static void setup_usb(void)
 {
 	if (chmod("/dev/vhci", 0666))

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -410,7 +410,7 @@ void child()
 #include <sys/syscall.h>
 
 #if GOOS_netbsd
-#if SYZ_EXECUTOR || SYZ_USB
+#if SYZ_EXECUTOR || __NR_syz_usb_connect
 
 #include <dev/usb/usb.h>
 #include <dev/usb/usbhid.h>
@@ -1560,6 +1560,8 @@ static volatile long syz_usb_disconnect(volatile long a0)
 }
 #endif
 
+#endif
+#if SYZ_EXECUTOR || SYZ_USB
 static void setup_usb(void)
 {
 	if (chmod("/dev/vhci", 0666))


### PR DESCRIPTION
`SYZ_USB` must be for `setup_usb()` only, got it wrong the first time