### PR TITLE
pkg/cover: add test for report generation

### DIFF
--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -1,0 +1,152 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// It may or may not work on other OSes.
+// If you test on another OS and it works, enable it.
+// +build linux
+
+package cover
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/symbolizer"
+	_ "github.com/google/syzkaller/sys"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type Test struct {
+	Name   string
+	CFlags []string
+	Progs  []Prog
+	Result string
+}
+
+func TestReportGenerator(t *testing.T) {
+	tests := []Test{
+		{
+			Name:   "no-coverage",
+			CFlags: []string{"-g"},
+			Result: `.* doesn't contain coverage callbacks '.*__sanitizer_cov_trace_pc>\]' \(set CONFIG_KCOV=y\)`,
+		},
+		{
+			Name:   "no-debug-info",
+			CFlags: []string{"-fsanitize-coverage=trace-pc"},
+			Result: `.* doesn't have debug info \(set CONFIG_DEBUG_INFO=y\)`,
+		},
+		{
+			Name:   "no-pcs",
+			CFlags: []string{"-fsanitize-coverage=trace-pc", "-g"},
+			Result: `no coverage collected so far`,
+		},
+		{
+			Name:   "bad-pcs",
+			CFlags: []string{"-fsanitize-coverage=trace-pc", "-g"},
+			Progs:  []Prog{{Data: "data", PCs: []uint64{0x1, 0x2}}},
+			Result: `coverage \(2\) doesn't match coverage callbacks`,
+		},
+		{
+			Name:   "good",
+			CFlags: []string{"-fsanitize-coverage=trace-pc", "-g"},
+		},
+	}
+	t.Parallel()
+	for os, arches := range targets.List {
+		if os == "test" {
+			continue
+		}
+		for _, target := range arches {
+			target := targets.Get(target.OS, target.Arch)
+			if target.BuildOS != runtime.GOOS {
+				continue
+			}
+			t.Run(target.OS+"-"+target.Arch, func(t *testing.T) {
+				t.Parallel()
+				if target.BrokenCompiler != "" {
+					t.Skip("skipping the test due to broken cross-compiler:\n" + target.BrokenCompiler)
+				}
+				for _, test := range tests {
+					test := test
+					t.Run("no-coverage", func(t *testing.T) {
+						t.Parallel()
+						testReportGenerator(t, target, test)
+					})
+				}
+			})
+		}
+	}
+}
+
+func testReportGenerator(t *testing.T, target *targets.Target, test Test) {
+	rep, err := generateReport(t, target, test)
+	if err != nil {
+		if test.Result == "" {
+			t.Fatalf("expected no error, but got:\n%v", err)
+		}
+		if !regexp.MustCompile(test.Result).MatchString(err.Error()) {
+			t.Fatalf("expected error %q, but got:\n%v", test.Result, err)
+		}
+		return
+	}
+	if test.Result != "" {
+		t.Fatalf("got no error, but expected %q", test.Result)
+	}
+	_ = rep
+}
+
+func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, error) {
+	src, err := osutil.TempFile("syz-cover-test-src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(src)
+	if err := osutil.WriteFile(src, []byte(`
+void __sanitizer_cov_trace_pc() {}
+int main() {}
+`)); err != nil {
+		t.Fatal(err)
+	}
+	bin, err := osutil.TempFile("syz-cover-test-bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(bin)
+	flags := append(append([]string{
+		"-o", bin,
+		"-x", "c", src,
+	}, target.CFlags...), test.CFlags...)
+	if _, err := osutil.RunCmd(time.Hour, "", target.CCompiler, flags...); err != nil {
+		t.Fatal(err)
+	}
+	rg, err := MakeReportGenerator(target, bin, filepath.Dir(src), filepath.Dir(src))
+	if err != nil {
+		return nil, err
+	}
+	if test.Result == "" {
+		text, err := symbolizer.ReadTextSymbols(bin)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if nmain := len(text["main"]); nmain != 1 {
+			t.Fatalf("got %v main symbols", nmain)
+		}
+		main := text["main"][0]
+		var pcs []uint64
+		for off := 0; off < main.Size; off++ {
+			pcs = append(pcs, main.Addr+uint64(off))
+		}
+		test.Progs = append(test.Progs, Prog{Data: "main", PCs: pcs})
+	}
+	out := new(bytes.Buffer)
+	if err := rg.Do(out, test.Progs); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -218,8 +218,7 @@ func (mgr *Manager) httpCover(w http.ResponseWriter, r *http.Request) {
 	}
 	// Note: initCover is executed without mgr.mu because it takes very long time
 	// (but it only reads config and it protected by initCoverOnce).
-	if err := initCover(mgr.cfg.KernelObj, mgr.sysTarget.KernelObject,
-		mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc, mgr.cfg.TargetVMArch, mgr.cfg.TargetOS); err != nil {
+	if err := initCover(mgr.sysTarget, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -234,7 +233,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 		inp := mgr.corpus[sig]
 		progs = append(progs, cover.Prog{
 			Data: string(inp.Prog),
-			PCs:  coverToPCs(inp.Cover, mgr.cfg.TargetVMArch),
+			PCs:  coverToPCs(mgr.sysTarget, inp.Cover),
 		})
 	} else {
 		call := r.FormValue("call")
@@ -244,7 +243,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request) {
 			}
 			progs = append(progs, cover.Prog{
 				Data: string(inp.Prog),
-				PCs:  coverToPCs(inp.Cover, mgr.cfg.TargetVMArch),
+				PCs:  coverToPCs(mgr.sysTarget, inp.Cover),
 			})
 		}
 	}
@@ -391,8 +390,7 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 	// Note: initCover is executed without mgr.mu because it takes very long time
 	// (but it only reads config and it protected by initCoverOnce).
-	if err := initCover(mgr.cfg.KernelObj, mgr.sysTarget.KernelObject, mgr.cfg.KernelSrc,
-		mgr.cfg.KernelBuildSrc, mgr.cfg.TargetArch, mgr.cfg.TargetOS); err != nil {
+	if err := initCover(mgr.sysTarget, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc); err != nil {
 		http.Error(w, initCoverError.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -407,7 +405,7 @@ func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 	for pc := range cov {
 		covArray = append(covArray, pc)
 	}
-	pcs := coverToPCs(covArray, mgr.cfg.TargetVMArch)
+	pcs := coverToPCs(mgr.sysTarget, covArray)
 	sort.Slice(pcs, func(i, j int) bool {
 		return pcs[i] < pcs[j]
 	})

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -125,9 +125,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	sysTarget := targets.Get(cfg.TargetOS, cfg.TargetArch)
+	sysTarget := targets.Get(cfg.TargetOS, cfg.TargetVMArch)
 	if sysTarget == nil {
-		log.Fatalf("unsupported OS/arch: %v/%v", cfg.TargetOS, cfg.TargetArch)
+		log.Fatalf("unsupported OS/arch: %v/%v", cfg.TargetOS, cfg.TargetVMArch)
 	}
 	syscalls, err := mgrconfig.ParseEnabledSyscalls(target, cfg.EnabledSyscalls, cfg.DisabledSyscalls)
 	if err != nil {

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -66,7 +66,7 @@ func main() {
 		failf("%v", err)
 	}
 	kernelObj := filepath.Join(*flagKernelObj, target.KernelObject)
-	rg, err := cover.MakeReportGenerator(kernelObj, *flagKernelSrc, *flagKernelBuildSrc, *flagArch)
+	rg, err := cover.MakeReportGenerator(target, kernelObj, *flagKernelSrc, *flagKernelBuildSrc)
 	if err != nil {
 		failf("%v", err)
 	}


### PR DESCRIPTION
Test various combinations of no debug info,
no coverage instrumentation, no PCs, bad PCs, good PCs,
and what errors we produce for these.
Also implement support for cross-arch reports:
prefix objdump with cross-compile prefix
(e.g. aarch64-linux-gnu-objdump instead of objdump).