### PR TITLE
pkg/build/fuchsia: Enable KASAN by default.

### DIFF
--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -44,6 +44,7 @@ func (fu fuchsia) build(params *Params) error {
 		"--args", fmt.Sprintf(`syzkaller_dir="%s"`, syzDir),
 		"--with-base", "//bundles:tools",
 		"--with-base", "//src/testing/fuzzing/syzkaller",
+		"--variant", "kasan",
 	); err != nil {
 		return err
 	}
@@ -64,7 +65,7 @@ func (fu fuchsia) build(params *Params) error {
 	for src, dst := range map[string]string{
 		"out/" + arch + "/obj/build/images/fvm.blk": "image",
 		".ssh/pkey": "key",
-		"out/" + arch + ".zircon/kernel-" + arch + "-clang/obj/kernel/zircon.elf": "obj/zircon.elf",
+		"out/" + arch + ".zircon/kernel-" + arch + "-kasan/obj/kernel/zircon.elf": "obj/zircon.elf",
 		"out/" + arch + ".zircon/multiboot.bin":                                   "kernel",
 		"out/" + arch + "/fuchsia-ssh.zbi":                                        "initrd",
 	} {


### PR DESCRIPTION
This commit makes syzkaller build the kasan variant of fuchsia by
default.

Support for kernel address sanitizer has landed in fuchsia since commit
`54c5edfc37afe7294256552cefefca64c6ce7e94`[0].

[0]: https://fxrev.dev/383323

