### PR TITLE
executor: fix printing null master in netlink_device_change

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -377,7 +377,7 @@ static void netlink_device_change(struct nlmsg* nlmsg, int sock, const char* nam
 	if (macsize)
 		netlink_attr(nlmsg, IFLA_ADDRESS, mac, macsize);
 	int err = netlink_send(nlmsg, sock);
-	debug("netlink: device %s up master %s: %s\n", name, master, strerror(err));
+	debug("netlink: device %s up master %s: %s\n", name, master ? master : "NULL", strerror(err));
 	(void)err;
 }
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2575,7 +2575,7 @@ static void netlink_device_change(struct nlmsg* nlmsg, int sock, const char* nam
 	if (macsize)
 		netlink_attr(nlmsg, IFLA_ADDRESS, mac, macsize);
 	int err = netlink_send(nlmsg, sock);
-	debug("netlink: device %s up master %s: %s\n", name, master, strerror(err));
+	debug("netlink: device %s up master %s: %s\n", name, master ? master : "NULL", strerror(err));
 	(void)err;
 }
 #endif


### PR DESCRIPTION
The issues is only present with verbose debugging enabled.

```
executor/common_linux.h: In function ‘void netlink_device_change(nlmsg*, int, const char*, bool, const char*, const void*, int, const char*)’:
executor/common_linux.h:380:7: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  380 |  debug("netlink: device %s up master %s: %s\n", name, master, strerror(err));
```
