### PR TITLE
syz-manager: add detailed coverage logging

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -58,3 +58,4 @@ Christoph Paasch
 Collabora
  André Almeida
 Dipanjan Das
+Daimeng Wang

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -215,13 +215,15 @@ func RunManager(cfg *mgrconfig.Config, target *prog.Target, sysTarget *targets.T
 			mgr.fuzzingTime += diff * time.Duration(atomic.LoadUint32(&mgr.numFuzzing))
 			executed := mgr.stats.execTotal.get()
 			crashes := mgr.stats.crashes.get()
-			signal := mgr.stats.corpusSignal.get()
+			corpusCover := mgr.stats.corpusCover.get()
+			corpusSignal := mgr.stats.corpusSignal.get()
+			maxSignal := mgr.stats.maxSignal.get()
 			mgr.mu.Unlock()
 			numReproducing := atomic.LoadUint32(&mgr.numReproducing)
 			numFuzzing := atomic.LoadUint32(&mgr.numFuzzing)
 
-			log.Logf(0, "VMs %v, executed %v, cover %v, crashes %v, repro %v",
-				numFuzzing, executed, signal, crashes, numReproducing)
+			log.Logf(0, "VMs %v, executed %v, corpus cover %v, corpus signal %v, max signal %v, crashes %v, repro %v",
+				numFuzzing, executed, corpusCover, corpusSignal, maxSignal, crashes, numReproducing)
 		}
 	}()
 

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -270,6 +270,7 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 	newMaxSignal := serv.maxSignal.Diff(a.MaxSignal.Deserialize())
 	if !newMaxSignal.Empty() {
 		serv.maxSignal.Merge(newMaxSignal)
+		serv.stats.maxSignal.set(len(serv.maxSignal))
 		for _, f1 := range serv.fuzzers {
 			if f1 == f {
 				continue

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -27,6 +27,7 @@ type Stats struct {
 	hubRecvReproDrop Stat
 	corpusCover      Stat
 	corpusSignal     Stat
+	maxSignal        Stat
 
 	mu         sync.Mutex
 	namedStats map[string]uint64
@@ -44,6 +45,7 @@ func (stats *Stats) all() map[string]uint64 {
 		"exec total":     stats.execTotal.get(),
 		"cover":          stats.corpusCover.get(),
 		"signal":         stats.corpusSignal.get(),
+		"max signal":     stats.maxSignal.get(),
 	}
 	if stats.haveHub {
 		m["hub: send prog add"] = stats.hubSendProgAdd.get()


### PR DESCRIPTION
Originally, syz-manager confusingly logs corpusSignal as "cover".
Change syz-manager's logging to output corpusSignal, corpusCover and maxSignal.
Add a field in Stats to store maxSignal.
