### PR TITLE
dashboard, syz-ci: add blacklist for bisection results

### DIFF
--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -541,7 +541,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 }
 
 func TestBisectWrong(t *testing.T) {
-	// Test bisection results with 	BisectResultMerge/BisectResultNoop flags set.
+	// Test bisection results with BisectResultMerge/BisectResultNoop flags set.
 	// If any of these set, the result must not be reported separately,
 	// as part of bug report during upstreamming, nor should affect CC list.
 	c := NewCtx(t)
@@ -549,7 +549,7 @@ func TestBisectWrong(t *testing.T) {
 
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		var flags dashapi.JobDoneFlags
 		switch i {
 		case 0:
@@ -561,6 +561,8 @@ func TestBisectWrong(t *testing.T) {
 			flags = dashapi.BisectResultMerge | dashapi.BisectResultNoop
 		case 4:
 			flags = dashapi.BisectResultRelease
+		case 5:
+			flags = dashapi.BisectResultBlacklist
 		default:
 			t.Fatalf("assign flags")
 		}

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -206,6 +206,7 @@ const (
 	BisectResultMerge JobFlags = 1 << iota
 	BisectResultNoop
 	BisectResultRelease
+	BisectResultBlacklist
 )
 
 func (job *Job) isUnreliableBisect() bool {
@@ -216,7 +217,8 @@ func (job *Job) isUnreliableBisect() bool {
 	// it is considered an unreliable/wrong result and should not be reported in emails.
 	return job.Flags&BisectResultMerge != 0 ||
 		job.Flags&BisectResultNoop != 0 ||
-		job.Flags&BisectResultRelease != 0
+		job.Flags&BisectResultRelease != 0 ||
+		job.Flags&BisectResultBlacklist != 0
 }
 
 // Text holds text blobs (crash logs, reports, reproducers, etc).

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -177,9 +177,10 @@ const (
 type JobDoneFlags int64
 
 const (
-	BisectResultMerge   JobDoneFlags = 1 << iota // bisected to a merge commit
-	BisectResultNoop                             // commit does not affect resulting kernel binary
-	BisectResultRelease                          // commit is a kernel release
+	BisectResultMerge     JobDoneFlags = 1 << iota // bisected to a merge commit
+	BisectResultNoop                               // commit does not affect resulting kernel binary
+	BisectResultRelease                            // commit is a kernel release
+	BisectResultBlacklist                          // commit is blacklisted, see syz-ci/jobs.go
 )
 
 func (dash *Dashboard) JobPoll(req *JobPollReq) (*JobPollResp, error) {


### PR DESCRIPTION
Currently only ignores the commit that adds the Raw Gadget interface.

Requested here:
https://groups.google.com/g/syzkaller-bugs/c/sZUeGC3Fh-o/m/t_5cKPrMAQAJ
