### PR TITLE
syz-runtest: disable csource tests for HostFuzzer targets

### DIFF
--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -222,6 +222,13 @@ func (ctx *Context) generatePrograms(progs chan *RunRequest) error {
 						}
 						ctx.produceTest(progs, req, name, properties, requires, results)
 					}
+
+					if sysTarget.HostFuzzer {
+						// For HostFuzzer mode, we need to cross-compile
+						// and copy the binary to the target system.
+						continue
+					}
+
 					name := name
 					properties["C"] = true
 					properties["executor"] = false


### PR DESCRIPTION
HostFuzzer targets require that we cross-compile the csource tests and
then copy them to the target system. The code to copy files is
currently missing from syz-runtest; also, at least for Fuchsia (which
uses HostFuzzer mode), cross-compiling is non-trivial.