### PR TITLE
pkg/repro: don't enable features missing on the target

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -353,7 +353,8 @@ func (mgr *Manager) vmLoop() {
 				atomic.AddUint32(&mgr.numReproducing, 1)
 				log.Logf(1, "loop: starting repro of '%v' on instances %+v", crash.Title, vmIndexes)
 				go func() {
-					res, stats, err := repro.Run(crash.Output, mgr.cfg, mgr.reporter, mgr.vmPool, vmIndexes)
+					features := mgr.checkResult.Features
+					res, stats, err := repro.Run(crash.Output, mgr.cfg, features, mgr.reporter, mgr.vmPool, vmIndexes)
 					reproDone <- &ReproResult{
 						instances: vmIndexes,
 						report0:   crash.Report,

--- a/tools/syz-repro/repro.go
+++ b/tools/syz-repro/repro.go
@@ -64,7 +64,7 @@ func main() {
 	}
 	osutil.HandleInterrupts(vm.Shutdown)
 
-	res, stats, err := repro.Run(data, cfg, reporter, vmPool, vmIndexes)
+	res, stats, err := repro.Run(data, cfg, nil, reporter, vmPool, vmIndexes)
 	if err != nil {
 		log.Logf(0, "reproduction failed: %v", err)
 	}


### PR DESCRIPTION
Manager has already checked what features are present on the target.
But if we detected that, say, USB is missing, we still enabled it
in the starting csource options. This is wrong, increases configuration
minimization time and may lead to some obscure bugs.