### PR TITLE
docs/linux: fix example qemu command

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ Google Inc.
  Michael A. Specter
  Jann Horn
  Andy Nguyen
+ Matt Morehouse
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -127,8 +127,8 @@ qemu-system-x86_64 \
 	-smp 2 \
 	-kernel $KERNEL/arch/x86/boot/bzImage \
 	-append "console=ttyS0 root=/dev/sda earlyprintk=serial"\
-	-drive file=$IMAGE/stretch.img,format=raw
-	-net -net user,host=10.0.2.10,hostfwd=tcp:127.0.0.1:10021-:22 \
+	-drive file=$IMAGE/stretch.img,format=raw \
+	-net user,host=10.0.2.10,hostfwd=tcp:127.0.0.1:10021-:22 \
 	-net nic,model=e1000 \
 	-enable-kvm \
 	-nographic \


### PR DESCRIPTION
Fixes a couple typos that prevent copy-paste.