### PR TITLE
docs: more info about resources and the "enable_sysaclls" config option

### DIFF
--- a/docs/syscall_descriptions.md
+++ b/docs/syscall_descriptions.md
@@ -106,7 +106,15 @@ more efficient.
 
 If you want to fuzz only the new subsystem that you described locally, you may
 find the `enable_syscalls` configuration parameter useful to specifically target
-the new system calls.
+the new system calls. All system calls in the `enable_syscalls` list
+will be enabled if their requirements are met (ie. if they are supported
+in the target machine and any other system calls that need to run in
+order to provide inputs for them are also enabled). You can also include
+wildcard definitions to enable multiple system calls in a single line,
+for example: `"ioctl"` will enable all the described ioctls syscalls
+that have their requirements met, ``"ioctl$UDMABUF_CREATE"`` enables
+only that particular ioctl call, ``"write$UHID_*"`` enables all write
+system calls that start with that description identifier.
 
 When updating existing syzkaller descriptions, note, that unless there's a drastic
 change in descriptions for a particular syscall, the programs that are already in

--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -170,25 +170,14 @@ listen(fd sock, backlog int32)
 Resources don't have to be necessarily returned by a syscall. They can be used as any other data type. For example:
 
 ```
-resource fd_request[fd]
+resource my_resource[int32]
 
-ioctl$MEDIA_IOC_REQUEST_ALLOC(fd fd_media, cmd const[MEDIA_IOC_REQUEST_ALLOC], arg ptr[out, fd_request])
-ioctl$VIDIOC_QBUF(fd fd_video, cmd const[VIDIOC_QBUF], arg ptr[inout, v4l2_buffer])
+request_producer(..., arg ptr[out, my_resource])
+request_consumer(..., arg ptr[inout, test_struct])
 
-v4l2_buffer {
-	index		int32
-	type		flags[v4l2_buf_type, int32]
-	bytesused	len[type, int32]
-	flags		const[V4L2_BUF_FLAG_REQUEST_FD, int32]
-	field		int32
-	timestamp	timeval
-	timecode	v4l2_timecode
-	sequence	int32
-	memory		flags[v4l2_memory, int32]
-	m		v4l2_buffer_union
-	length		int32
-	reserved2	const[0, int32]
-	request_fd	fd_request[opt]
+test_struct {
+	...
+	attr	my_resource
 }
 ```
 


### PR DESCRIPTION
  - Give some extra clarifications and examples about resources in syscall
    descriptions.
  - More details about how to use the "enable_syscalls" option.
  - Mention pseudo-syscalls in the general syscall description doc file.
