### PR TITLE
tools: add custom udev rules to generated images

### DIFF
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -96,6 +96,8 @@ for i in {0..31}; do
 		sudo tee -a disk.mnt/etc/udev/50-binder.rules
 done
 
+echo 'ATTR{name}=="vim2m", SYMLINK+="vim2m"' | sudo tee -a disk.mnt/etc/udev/rules.d/50-udev-default.rules
+
 echo "kernel.printk = 7 4 1 3" | sudo tee -a disk.mnt/etc/sysctl.conf
 echo "debug.exception-trace = 0" | sudo tee -a disk.mnt/etc/sysctl.conf
 SYZ_SYSCTL_FILE="${SYZ_SYSCTL_FILE:-}"

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -145,6 +145,10 @@ for i in {0..31}; do
 		sudo tee -a disk.mnt/etc/udev/50-binder.rules
 done
 
+# Add udev rules for custom drivers.
+# Create a /dev/vim2m symlink for the device managed by the vim2m driver
+echo 'ATTR{name}=="vim2m", SYMLINK+="vim2m"' | sudo tee -a disk.mnt/etc/udev/rules.d/50-udev-default.rules
+
 # sysctls
 echo "kernel.printk = 7 4 1 3" | sudo tee -a disk.mnt/etc/sysctl.conf
 echo "debug.exception-trace = 0" | sudo tee -a disk.mnt/etc/sysctl.conf

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -119,6 +119,10 @@ if [ $PERF = "true" ]; then
     rm -r $DIR/tmp/linux
 fi
 
+# Add udev rules for custom drivers.
+# Create a /dev/vim2m symlink for the device managed by the vim2m driver
+echo 'ATTR{name}=="vim2m", SYMLINK+="vim2m"' | sudo tee -a $DIR/etc/udev/rules.d/50-udev-default.rules
+
 # Build a disk image
 dd if=/dev/zero of=$RELEASE.img bs=1M seek=$SEEK count=1
 sudo mkfs.ext4 -F $RELEASE.img


### PR DESCRIPTION
Add a default udev rule file to the image creation process in
create-gce-image.sh and create-image.sh.

This change creates a default rule to make udev create a custom-named
symlink for the specific vim2m device.