### PR TITLE
pkg/report: Add oopses for gVisor stuck tasks and watchdog.

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -175,4 +175,37 @@ var gvisorOopses = append([]*oops{
 		},
 		[]*regexp.Regexp{},
 	},
+	{
+		[]byte("Sentry detected"),
+		[]oopsFormat{
+			{
+				title:        compile("Sentry detected (.*) stuck tasks(s):(.*)"),
+				fmt:          "Sentry detected %[1]v stuck tasks(s)",
+				noStackTrace: true,
+			},
+		},
+		[]*regexp.Regexp{},
+	},
+	{
+		[]byte("Watchdog.Start() not called"),
+		[]oopsFormat{
+			{
+				title:        compile("Watchdog.Start() not called within (.*)"),
+				fmt:          "Watchdog.Start() not called within %[1]v:%[2]v",
+				noStackTrace: true,
+			},
+		},
+		[]*regexp.Regexp{},
+	},
+	{
+		[]byte("Watchdog goroutine is stuck"),
+		[]oopsFormat{
+			{
+				title:        compile("Watchdog goroutine is stuck:(.*)"),
+				fmt:          "Watchdog goroutine is stuck:%[1]v",
+				noStackTrace: true,
+			},
+		},
+		[]*regexp.Regexp{},
+	},
 }, commonOopses...)

--- a/pkg/report/testdata/gvisor/report/25
+++ b/pkg/report/testdata/gvisor/report/25
@@ -1,0 +1,42 @@
+TITLE: Sentry detected 1 stuck task(s):
+
+W0610 22:12:59.791982  105709 log.go:338] Sentry detected 1 stuck task(s):
+	Task tid: 1 (0x1), entered RunSys state 25s ago.
+Search for '(*Task).run(0x..., 0x<tid>)' in the stack dump to find the offending goroutine:
+goroutine 15 [running]:
+gvisor.dev/gvisor/pkg/log.Stacks(0xc000142001, 0x4ed822, 0xc00051ebf0, 0xc00051ebf8)
+	pkg/log/log.go:314 +0xa5
+gvisor.dev/gvisor/pkg/log.TracebackAll(0xc0000a0160, 0xad, 0x0, 0x0, 0x0)
+	pkg/log/log.go:337 +0x2a
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).doAction(0xc000316280, 0x0, 0x1, 0xc00051ed70)
+	pkg/sentry/watchdog/watchdog.go:349 +0xdf
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).report(0xc000316280, 0xc00030b950, 0xc000140001, 0x5d2b65080)
+	pkg/sentry/watchdog/watchdog.go:327 +0x311
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).runTurn(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:308 +0x4b1
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).loop(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:243 +0x42
+created by gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).Start
+	pkg/sentry/watchdog/watchdog.go:194 +0x1b7
+
+goroutine 81 [sleep]:
+time.Sleep(0x34630b8a000)
+	GOROOT/src/runtime/time.go:188 +0xba
+gvisor.dev/gvisor/pkg/sentry/syscalls/linux.openAt(0xc000140000, 0x3ffffff9c, 0x7f0f49821428, 0x80000, 0x0, 0xc000782a80, 0x200000003)
+	pkg/sentry/syscalls/linux/sys_file.go:137 +0x40
+gvisor.dev/gvisor/pkg/sentry/syscalls/linux.Openat(0xc000140000, 0xffffff9c, 0x7f0f49821428, 0x80000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x19d48, ...)
+	pkg/sentry/syscalls/linux/sys_file.go:488 +0xb4
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).executeSyscall(0xc000140000, 0x101, 0xffffff9c, 0x7f0f49821428, 0x80000, 0x0, 0x0, 0x0, 0x0, 0xf9cc80, ...)
+	pkg/sentry/kernel/task_syscall.go:170 +0x122
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).doSyscallInvoke(0xc000140000, 0x101, 0xffffff9c, 0x7f0f49821428, 0x80000, 0x0, 0x0, 0x0, 0x0, 0x0)
+	pkg/sentry/kernel/task_syscall.go:305 +0x66
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).doSyscallEnter(0xc000140000, 0x101, 0xffffff9c, 0x7f0f49821428, 0x80000, 0x0, 0x0, 0x0, 0xc00011e900, 0x1)
+	pkg/sentry/kernel/task_syscall.go:265 +0x96
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).doSyscall(0xc000140000, 0x2, 0xc000119080)
+	pkg/sentry/kernel/task_syscall.go:240 +0x15c
+gvisor.dev/gvisor/pkg/sentry/kernel.(*runApp).execute(0x0, 0xc000140000, 0x1115680, 0x0)
+	pkg/sentry/kernel/task_run.go:259 +0xec8
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).run(0xc000140000, 0x1)
+	pkg/sentry/kernel/task_run.go:92 +0x18b
+created by gvisor.dev/gvisor/pkg/sentry/kernel.(*Task).Start
+	pkg/sentry/kernel/task_start.go:318 +0xfe

--- a/pkg/report/testdata/gvisor/report/26
+++ b/pkg/report/testdata/gvisor/report/26
@@ -1,0 +1,38 @@
+TITLE: Watchdog.Start() not called within 30s:
+
+W0610 22:17:15.468562  107732 log.go:338] Watchdog.Start() not called within 30s:
+goroutine 31 [running]:
+gvisor.dev/gvisor/pkg/log.Stacks(0xc00039ae01, 0x4ec95a, 0xc0003b8ea0, 0xc00039ae30)
+	pkg/log/log.go:314 +0xa5
+gvisor.dev/gvisor/pkg/log.TracebackAll(0xc0000a6150, 0x26, 0x0, 0x0, 0x0)
+	pkg/log/log.go:337 +0x2a
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).doAction(0xc000316280, 0x1, 0x0, 0xc00039af90)
+	pkg/sentry/watchdog/watchdog.go:355 +0x2ca
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).waitForStart(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:231 +0x1ab
+created by gvisor.dev/gvisor/pkg/sentry/watchdog.New
+	pkg/sentry/watchdog/watchdog.go:171 +0x1ba
+
+goroutine 1 [semacquire]:
+sync.runtime_Semacquire(0xc0003281c4)
+	GOROOT/src/runtime/sema.go:56 +0x42
+sync.(*WaitGroup).Wait(0xc0003281c4)
+	GOROOT/src/sync/waitgroup.go:130 +0x64
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Kernel).WaitExited(...)
+	pkg/sentry/kernel/kernel.go:1240
+gvisor.dev/gvisor/runsc/boot.(*Loader).WaitExit(0xc00037c000, 0x0, 0x0)
+	runsc/boot/loader.go:998 +0x38
+gvisor.dev/gvisor/runsc/cmd.(*Boot).Execute(0xc00015e360, 0x1126800, 0xc000052008, 0xc000166420, 0xc00017b440, 0x2, 0x2, 0x0)
+	runsc/cmd/boot.go:265 +0x73f
+github.com/google/subcommands.(*Commander).Execute(0xc00011a000, 0x1126800, 0xc000052008, 0xc00017b440, 0x2, 0x2, 0x0)
+	external/com_github_google_subcommands/subcommands.go:200 +0x2f9
+github.com/google/subcommands.Execute(...)
+	external/com_github_google_subcommands/subcommands.go:481
+main.main()
+	runsc/main.go:334 +0x1a28
+
+goroutine 6 [chan receive, locked to thread]:
+gvisor.dev/gvisor/pkg/sentry/platform/ptrace.newSubprocess.func1(0xfdac68, 0xc00007c0c0, 0xc00007c120)
+	pkg/sentry/platform/ptrace/subprocess.go:175 +0x18f
+created by gvisor.dev/gvisor/pkg/sentry/platform/ptrace.newSubprocess
+	pkg/sentry/platform/ptrace/subprocess.go:159 +0x13b

--- a/pkg/report/testdata/gvisor/report/27
+++ b/pkg/report/testdata/gvisor/report/27
@@ -1,0 +1,42 @@
+TITLE: Watchdog goroutine is stuck:
+
+W0610 22:24:47.286728  110123 log.go:338] Watchdog goroutine is stuck:
+goroutine 11 [running]:
+gvisor.dev/gvisor/pkg/log.Stacks(0xc00005a501, 0x48ed6a, 0xbfb0754bd1085de4, 0x5e6d69c6f)
+	pkg/log/log.go:314 +0xa5
+gvisor.dev/gvisor/pkg/log.TracebackAll(0xc00005a590, 0x1c, 0x0, 0x0, 0x0)
+	pkg/log/log.go:337 +0x2a
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).doAction(0xc000316280, 0x0, 0x0, 0xc00005a658)
+	pkg/sentry/watchdog/watchdog.go:349 +0xdf
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).reportStuckWatchdog(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:333 +0x7c
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).runTurn(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:265 +0xee
+gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).loop(0xc000316280)
+	pkg/sentry/watchdog/watchdog.go:243 +0x42
+created by gvisor.dev/gvisor/pkg/sentry/watchdog.(*Watchdog).Start
+	pkg/sentry/watchdog/watchdog.go:194 +0x1b7
+
+goroutine 1 [semacquire]:
+sync.runtime_Semacquire(0xc0003281c4)
+	GOROOT/src/runtime/sema.go:56 +0x42
+sync.(*WaitGroup).Wait(0xc0003281c4)
+	GOROOT/src/sync/waitgroup.go:130 +0x64
+gvisor.dev/gvisor/pkg/sentry/kernel.(*Kernel).WaitExited(...)
+	pkg/sentry/kernel/kernel.go:1240
+gvisor.dev/gvisor/runsc/boot.(*Loader).WaitExit(0xc00037c000, 0x0, 0x0)
+	runsc/boot/loader.go:998 +0x38
+gvisor.dev/gvisor/runsc/cmd.(*Boot).Execute(0xc00015e360, 0x11267a0, 0xc000052008, 0xc000166420, 0xc00017b440, 0x2, 0x2, 0x0)
+	runsc/cmd/boot.go:265 +0x73f
+github.com/google/subcommands.(*Commander).Execute(0xc00011a000, 0x11267a0, 0xc000052008, 0xc00017b440, 0x2, 0x2, 0x0)
+	external/com_github_google_subcommands/subcommands.go:200 +0x2f9
+github.com/google/subcommands.Execute(...)
+	external/com_github_google_subcommands/subcommands.go:481
+main.main()
+	runsc/main.go:334 +0x1a28
+
+goroutine 6 [chan receive, locked to thread]:
+gvisor.dev/gvisor/pkg/sentry/platform/ptrace.newSubprocess.func1(0xfdac68, 0xc00007c0c0, 0xc00007c120)
+	pkg/sentry/platform/ptrace/subprocess.go:175 +0x18f
+created by gvisor.dev/gvisor/pkg/sentry/platform/ptrace.newSubprocess
+	pkg/sentry/platform/ptrace/subprocess.go:159 +0x13b


### PR DESCRIPTION
gVisor has a watchdog that monitors for stuck tasks. When one is
detected, it logs all goroutine stack traces and then panics[1]. The
panic will also log goroutine stack trackes, but skips running
goroutines, which usually contain the culprite. Thus, we often miss the
offending goroutine stack in panic output.

There is a similar monitor for the watchdog itself, which detects when
the watchdog is stuck and logs all goroutine stack traces before
panicing[2].

This CL adds a two new 'oops'es for gVisor that will capture the stuck
task and stuck watchdog logs and report them. This will make it easier
to debug stuck tasks from syzkaller output.

1: https://cs.opensource.google/gvisor/gvisor/+/master:pkg/sentry/watchdog/watchdog.go;l=318;drc=b2e2a081a8a180764677111ae3c0b6179be81d31
2: https://cs.opensource.google/gvisor/gvisor/+/master:pkg/sentry/watchdog/watchdog.go;l=332;drc=b2e2a081a8a180764677111ae3c0b6179be81d31

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
