### PR TITLE
sys/targets: use a different SYZ_DATA_OFFSET for 32-bit FreeBSD

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -203,9 +203,11 @@ var List = map[string]map[string]*Target{
 			NeedSyscallDefine: dontNeedSyscallDefine,
 		},
 		"386": {
-			VMArch:            "amd64",
-			PtrSize:           4,
-			PageSize:          4 << 10,
+			VMArch:   "amd64",
+			PtrSize:  4,
+			PageSize: 4 << 10,
+			// The default DataOffset doesn't work with 32-bit
+			// FreeBSD and using ld.lld due to collisions.
 			DataOffset:        256 << 20,
 			Int64Alignment:    4,
 			CCompiler:         "clang",

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -206,6 +206,7 @@ var List = map[string]map[string]*Target{
 			VMArch:            "amd64",
 			PtrSize:           4,
 			PageSize:          4 << 10,
+			DataOffset:        256 << 20,
 			Int64Alignment:    4,
 			CCompiler:         "clang",
 			CFlags:            []string{"-m32"},
@@ -447,7 +448,9 @@ func initTarget(target *Target, OS, arch string) {
 	if target.NeedSyscallDefine == nil {
 		target.NeedSyscallDefine = needSyscallDefine
 	}
-	target.DataOffset = 512 << 20
+	if target.DataOffset == 0 {
+		target.DataOffset = 512 << 20
+	}
 	target.NumPages = (16 << 20) / target.PageSize
 	sourceDir := os.Getenv("SOURCEDIR_" + strings.ToUpper(OS))
 	if sourceDir == "" {


### PR DESCRIPTION
It seems that the value used on all platforms (512 << 20) does
not work on 32-bit FreeBSD when using the clang tools.
Try (256 << 20) instead.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
