### PR TITLE
sys/targets: fix fuchsiaCFlags

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -391,7 +391,7 @@ func fuchsiaCFlags(arch, clangArch string) []string {
 	out := sourceDirVar + "/out/" + arch
 	return []string{
 		"-Wno-deprecated",
-		"--target", clangArch + "-fuchsia",
+		"-target", clangArch + "-fuchsia",
 		"-ldriver",
 		"-lfdio",
 		"-lzircon",


### PR DESCRIPTION
This commit modifies the fuchsia cflags to use the short version of
the «target» flag. The previous code seemed to be broken due to lacking
an `=` after the flag name using the long version.
