### PR TITLE
Increase coverage of BPF sockmap

### DIFF
--- a/sys/linux/bpf.txt
+++ b/sys/linux/bpf.txt
@@ -96,10 +96,18 @@ bpf_map_lookup_arg {
 	flags	flags[bpf_lookup_flags, int64]
 }
 
+bpf_map_update_val [
+	buf	array[int8]
+	udp	sock_udp
+	udp6	sock_udp6
+	tcp	sock_tcp
+	tcp6	sock_tcp6
+] [varlen]
+
 bpf_map_update_arg {
 	map	fd_bpf_map
 	key	ptr64[in, array[int8]]
-	val	ptr64[in, array[int8]]
+	val	ptr64[in, bpf_map_update_val]
 	flags	flags[bpf_map_flags, int64]
 }
 

--- a/sys/linux/bpf.txt
+++ b/sys/linux/bpf.txt
@@ -400,8 +400,13 @@ bpf_obj_get {
 	file_flags	flags[bpf_open_flags, int32]
 }
 
+bpf_attach_targets [
+	cgroup	fd_cgroup[opt]
+	map	fd_bpf_map[opt]
+]
+
 bpf_attach_arg {
-	target_fd	fd_cgroup
+	target_fd	bpf_attach_targets
 	attach_bpf_fd	fd_bpf_prog
 	type		flags[bpf_attach_type, int32]
 	flags		flags[bpf_attach_flags, int32]
@@ -409,7 +414,7 @@ bpf_attach_arg {
 }
 
 bpf_detach_arg {
-	target	const[0, int32]
+	target	bpf_attach_targets
 	prog	fd_bpf_prog
 	type	flags[bpf_attach_type, int32]
 	flags	const[0, int32]


### PR DESCRIPTION
Extend the syscall definition for BPF_MAP_UPDATE_ELEM to include socket fds, which should make some paths in the sockmap code easier to discover.

Also expand BPF_PROG_ATTACH to include a BPF map fd as the target, since this is used to associate BPF programs with a sockmap.