### PR TITLE
vm/gvisor: Send debug logs to stderr so they can be read by syzkaller

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -215,7 +215,9 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 		"-watchdog-action=panic",
 		"-network=none",
 		"-debug",
-		"-alsologtostderr",
+		// Send debug logs to stderr, so that they will be picked up by
+		// syzkaller. Without this, debug logs are sent to /dev/null.
+		"-debug-log=/dev/stderr",
 	}
 	if inst.cfg.RunscArgs != "" {
 		args = append(args, strings.Split(inst.cfg.RunscArgs, " ")...)


### PR DESCRIPTION
The -alsologtostderr flag is a noop if -panic-log is also set. So before
this change, debug logs were not included in the syzkaller output logs.

By setting -debug-log=/dev/stderr, all debug logs are sent to stderr,
which syzkaller scrapes and includes in the output logs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
