### PR TITLE
.github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# For reference see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+*		@dvyukov
+*.py		@xairy
+*fuchsia*	@mvanotti
+*freebsd*	@markjdb @tuexen
+*netbsd*	@krytarowski @R3x
+*openbsd*	@blackgnezdo @mptre


### PR DESCRIPTION
This should automatically assign reviewers/cc corresponding developers.
Add codeowners for OSes for which we have committers.

For details see:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
