### PR TITLE
executor: Improve used terminology

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3496,15 +3496,16 @@ static void setup_kcsan()
 }
 
 #if SYZ_EXECUTOR // currently only used by executor
-static void setup_kcsan_filterlist(char** frames, int nframes, bool ignore)
+static void setup_kcsan_filterlist(char** frames, int nframes, bool suppress)
 {
 	int fd = open(KCSAN_DEBUGFS_FILE, O_WRONLY);
 	if (fd == -1)
 		fail("failed to open(\"%s\")", KCSAN_DEBUGFS_FILE);
 
-	const char* const filtertype = ignore ? "blacklist" : "whitelist";
-	printf("adding functions to KCSAN %s: ", filtertype);
-	dprintf(fd, "%s\n", filtertype);
+	printf("%s KCSAN reports in functions: ",
+	       suppress ? "suppressing" : "only showing");
+	if (!suppress)
+		dprintf(fd, "whitelist\n");
 	for (int i = 0; i < nframes; ++i) {
 		printf("'%s' ", frames[i]);
 		dprintf(fd, "!%s\n", frames[i]);

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -346,7 +346,7 @@ int main(int argc, char** argv)
 	}
 	if (argc >= 2 && strcmp(argv[1], "setup_kcsan_filterlist") == 0) {
 #if SYZ_HAVE_KCSAN
-		setup_kcsan_filterlist(argv + 2, argc - 2, /*ignore=*/true);
+		setup_kcsan_filterlist(argv + 2, argc - 2, /*suppress=*/true);
 #else
 		fail("KCSAN is not implemented");
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -8343,15 +8343,16 @@ static void setup_kcsan()
 }
 
 #if SYZ_EXECUTOR
-static void setup_kcsan_filterlist(char** frames, int nframes, bool ignore)
+static void setup_kcsan_filterlist(char** frames, int nframes, bool suppress)
 {
 	int fd = open(KCSAN_DEBUGFS_FILE, O_WRONLY);
 	if (fd == -1)
 		fail("failed to open(\"%s\")", KCSAN_DEBUGFS_FILE);
 
-	const char* const filtertype = ignore ? "blacklist" : "whitelist";
-	printf("adding functions to KCSAN %s: ", filtertype);
-	dprintf(fd, "%s\n", filtertype);
+	printf("%s KCSAN reports in functions: ",
+	       suppress ? "suppressing" : "only showing");
+	if (!suppress)
+		dprintf(fd, "whitelist\n");
 	for (int i = 0; i < nframes; ++i) {
 		printf("'%s' ", frames[i]);
 		dprintf(fd, "!%s\n", frames[i]);


### PR DESCRIPTION
Improve used terminology by using better verbs to express the effect of
the whitelist/blacklist.

This follows TSAN's terminology which uses "suppress" to refer to the effect of its blacklist: https://clang.llvm.org/docs/ThreadSanitizer.html#blacklist

This also changes executor to exclusively show respectful log messages,
and as per recent conversion, converts the last such case.
