### PR TITLE
executor: enable KVM generator only on AMD64 arch

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -62,3 +62,4 @@ Collabora
 Dipanjan Das
 Daimeng Wang
 Jukka Kaartinen
+Alexander Egorenkov

--- a/executor/gen.go
+++ b/executor/gen.go
@@ -1,7 +1,7 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// +build !freebsd,!openbsd,!netbsd
+// +build amd64,!freebsd,!openbsd,!netbsd
 
 //go:generate bash -c "gcc kvm_gen.cc kvm.S -o kvm_gen && ./kvm_gen > kvm.S.h && rm ./kvm_gen"
 


### PR DESCRIPTION
Executor KVM generator works only on amd64 linux machines.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
