### PR TITLE
pkg/ipc: support C compiler in non-standard location

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -585,7 +585,6 @@ func makeCommand(pid int, bin []string, config *Config, inFile, outFile *os.File
 	if inFile != nil && outFile != nil {
 		cmd.ExtraFiles = []*os.File{inFile, outFile}
 	}
-	cmd.Env = []string{}
 	cmd.Dir = dir
 	cmd.Stdin = outrp
 	cmd.Stdout = inwp


### PR DESCRIPTION
If C compiler is installed e.g. in /opt then
we have to import LD_LIBRARY_PATH.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
