### PR TITLE
prog/encodingexec: pad data args with zero bytes

### DIFF
--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -275,6 +275,7 @@ func (w *execContext) writeArg(arg Arg) {
 			w.eof = true
 		} else {
 			copy(w.buf, data)
+			copy(w.buf[len(data):], make([]byte, 8))
 			w.buf = w.buf[padded:]
 		}
 	case *UnionArg:


### PR DESCRIPTION
We must pad data arguments with known values when serializing
them into the given destination buffer because it could
be reused and contain random bytes from previous use.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
