### PR TITLE
ipc: fix endianness issues

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -167,8 +167,10 @@ static void cover_reset(cover_t* cov)
 
 static void cover_collect(cover_t* cov)
 {
-	// Note: this assumes little-endian kernel.
-	cov->size = *(uint32*)cov->data;
+	if (is_kernel_64_bit)
+		cov->size = *(uint64*)cov->data;
+	else
+		cov->size = *(uint32*)cov->data;
 }
 
 static bool cover_check(uint32 pc)

--- a/executor/test.h
+++ b/executor/test.h
@@ -8,7 +8,7 @@
 static int test_copyin()
 {
 	static uint16 buf[3];
-	STORE_BY_BITMASK(uint16, , &buf[1], 0x1234, 0, 16);
+	STORE_BY_BITMASK(uint16, htole16, &buf[1], 0x1234, 0, 16);
 	unsigned char x[sizeof(buf)];
 	memcpy(x, buf, sizeof(x));
 	if (x[0] != 0 || x[1] != 0 ||
@@ -18,7 +18,7 @@ static int test_copyin()
 		       x[0], x[1], x[2], x[3], x[4], x[5]);
 		return 1;
 	}
-	STORE_BY_BITMASK(uint16, , &buf[1], 0x555a, 5, 4);
+	STORE_BY_BITMASK(uint16, htole16, &buf[1], 0x555a, 5, 4);
 	memcpy(x, buf, sizeof(x));
 	if (x[0] != 0 || x[1] != 0 ||
 	    x[2] != 0x54 || x[3] != 0x13 ||

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -4,7 +4,6 @@
 package ipc
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -439,7 +438,7 @@ func readUint32(outp *[]byte) (uint32, bool) {
 	if len(out) < 4 {
 		return 0, false
 	}
-	v := binary.LittleEndian.Uint32(out)
+	v := prog.HostEndian.Uint32(out)
 	*outp = out[4:]
 	return v, true
 }
@@ -449,7 +448,7 @@ func readUint64(outp *[]byte) (uint64, bool) {
 	if len(out) < 8 {
 		return 0, false
 	}
-	v := binary.LittleEndian.Uint64(out)
+	v := prog.HostEndian.Uint64(out)
 	*outp = out[8:]
 	return v, true
 }

--- a/prog/big_endian.go
+++ b/prog/big_endian.go
@@ -1,0 +1,10 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// +build s390x
+
+package prog
+
+import "encoding/binary"
+
+var HostEndian = binary.BigEndian

--- a/prog/decodeexec.go
+++ b/prog/decodeexec.go
@@ -203,10 +203,7 @@ func (dec *execDecoder) read() uint64 {
 	if dec.err != nil {
 		return 0
 	}
-	var v uint64
-	for i := 0; i < 8; i++ {
-		v |= uint64(dec.data[i]) << uint(i*8)
-	}
+	v := HostEndian.Uint64(dec.data)
 	dec.data = dec.data[8:]
 	return v
 }

--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -20,6 +20,8 @@
 package prog
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"sort"
 )
@@ -221,14 +223,9 @@ func (w *execContext) write(v uint64) {
 		w.eof = true
 		return
 	}
-	w.buf[0] = byte(v >> 0)
-	w.buf[1] = byte(v >> 8)
-	w.buf[2] = byte(v >> 16)
-	w.buf[3] = byte(v >> 24)
-	w.buf[4] = byte(v >> 32)
-	w.buf[5] = byte(v >> 40)
-	w.buf[6] = byte(v >> 48)
-	w.buf[7] = byte(v >> 56)
+	buf := new(bytes.Buffer)
+	binary.Write(buf, HostEndian, v)
+	copy(w.buf, buf.Bytes())
 	w.buf = w.buf[8:]
 }
 

--- a/prog/little_endian.go
+++ b/prog/little_endian.go
@@ -1,0 +1,10 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// +build amd64 386 arm64 arm mips64le ppc64le
+
+package prog
+
+import "encoding/binary"
+
+var HostEndian = binary.LittleEndian


### PR DESCRIPTION
Use native byte-order for IPC and program serialization.
This way we will be able to support both little- and big-endian
architectures.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
