### PR TITLE
sys/targets: fix mknod neutralize for netbsd

### DIFF
--- a/sys/targets/common.go
+++ b/sys/targets/common.go
@@ -100,7 +100,8 @@ func (arch *UnixNeutralizer) Neutralize(c *prog.Call) {
 		if c.Meta.CallName == "mknodat" {
 			pos = 2
 		}
-		if _, ok := c.Args[pos+1].Type().(*prog.ProcType); ok {
+		switch c.Args[pos+1].Type().(type) {
+		case *prog.ProcType, *prog.ResourceType:
 			return
 		}
 		mode := c.Args[pos].(*prog.ConstArg)


### PR DESCRIPTION
mknod on netbsd can now also accept a resource for the last arg.
Fix that and add a test that will catch such things more reliably.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
