### PR TITLE
target: support of big-endian architectures

### DIFF
--- a/pkg/kd/kd_test.go
+++ b/pkg/kd/kd_test.go
@@ -1,6 +1,8 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+// +build !s390x
+
 package kd
 
 import (

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -200,6 +200,7 @@ nextSandbox:
 		properties := map[string]bool{
 			"arch=" + ctx.Target.Arch: true,
 			"sandbox=" + sandbox:      true,
+			"littleendian":            ctx.Target.LittleEndian,
 		}
 		for _, threaded := range []bool{false, true} {
 			name := name

--- a/prog/target.go
+++ b/prog/target.go
@@ -13,13 +13,14 @@ import (
 
 // Target describes target OS/arch pair.
 type Target struct {
-	OS         string
-	Arch       string
-	Revision   string // unique hash representing revision of the descriptions
-	PtrSize    uint64
-	PageSize   uint64
-	NumPages   uint64
-	DataOffset uint64
+	OS           string
+	Arch         string
+	Revision     string // unique hash representing revision of the descriptions
+	PtrSize      uint64
+	PageSize     uint64
+	NumPages     uint64
+	DataOffset   uint64
+	LittleEndian bool
 
 	Syscalls  []*Syscall
 	Resources []*ResourceDesc

--- a/sys/syz-extract/akaros.go
+++ b/sys/syz-extract/akaros.go
@@ -43,6 +43,7 @@ func (*akaros) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 	}
 	params := &extractParams{
 		DeclarePrintf: true,
+		TargetEndian:  arch.target.HostEndian,
 	}
 	return extract(info, "gcc", args, params)
 }

--- a/sys/syz-extract/fetch.go
+++ b/sys/syz-extract/fetch.go
@@ -24,6 +24,7 @@ type extractParams struct {
 	DeclarePrintf  bool
 	DefineGlibcUse bool // workaround for incorrect flags to clang for fuchsia.
 	ExtractFromELF bool
+	TargetEndian   binary.ByteOrder
 }
 
 func extract(info *compiler.ConstInfo, cc string, args []string, params *extractParams) (
@@ -76,7 +77,7 @@ func extract(info *compiler.ConstInfo, cc string, args []string, params *extract
 
 	var flagVals []uint64
 	if data.ExtractFromELF {
-		flagVals, err = extractFromELF(bin)
+		flagVals, err = extractFromELF(bin, params.TargetEndian)
 	} else {
 		flagVals, err = extractFromExecutable(bin)
 	}
@@ -146,7 +147,7 @@ func extractFromExecutable(binFile string) ([]uint64, error) {
 	return vals, nil
 }
 
-func extractFromELF(binFile string) ([]uint64, error) {
+func extractFromELF(binFile string, targetEndian binary.ByteOrder) ([]uint64, error) {
 	f, err := os.Open(binFile)
 	if err != nil {
 		return nil, err
@@ -164,7 +165,7 @@ func extractFromELF(binFile string) ([]uint64, error) {
 			return nil, err
 		}
 		vals := make([]uint64, len(data)/8)
-		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &vals); err != nil {
+		if err := binary.Read(bytes.NewReader(data), targetEndian, &vals); err != nil {
 			return nil, err
 		}
 		return vals, nil

--- a/sys/syz-extract/freebsd.go
+++ b/sys/syz-extract/freebsd.go
@@ -59,6 +59,7 @@ func (*freebsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 	params := &extractParams{
 		AddSource:     "#include <sys/syscall.h>",
 		DeclarePrintf: true,
+		TargetEndian:  arch.target.HostEndian,
 	}
 	return extract(info, "gcc", args, params)
 }

--- a/sys/syz-extract/fuchsia.go
+++ b/sys/syz-extract/fuchsia.go
@@ -44,6 +44,7 @@ func (*fuchsia) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 	params := &extractParams{
 		DeclarePrintf:  true,
 		DefineGlibcUse: true,
+		TargetEndian:   arch.target.HostEndian,
 	}
 	return extract(info, cc, args, params)
 }

--- a/sys/syz-extract/linux.go
+++ b/sys/syz-extract/linux.go
@@ -179,6 +179,7 @@ func (*linux) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uint
 	params := &extractParams{
 		AddSource:      "#include <asm/unistd.h>",
 		ExtractFromELF: true,
+		TargetEndian:   arch.target.HostEndian,
 	}
 	cc := arch.target.CCompiler
 	res, undeclared, err := extract(info, cc, args, params)

--- a/sys/syz-extract/netbsd.go
+++ b/sys/syz-extract/netbsd.go
@@ -92,7 +92,8 @@ func (*netbsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 		}
 	}
 	params := &extractParams{
-		AddSource: "#include <sys/syscall.h>",
+		AddSource:    "#include <sys/syscall.h>",
+		TargetEndian: arch.target.HostEndian,
 	}
 	res, undeclared, err := extract(info, "gcc", args, params)
 	for orig, compats := range compatNames {

--- a/sys/syz-extract/openbsd.go
+++ b/sys/syz-extract/openbsd.go
@@ -82,7 +82,8 @@ func (*openbsd) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]ui
 		}
 	}
 	params := &extractParams{
-		AddSource: "#include <sys/syscall.h>",
+		AddSource:    "#include <sys/syscall.h>",
+		TargetEndian: arch.target.HostEndian,
 	}
 	res, undeclared, err := extract(info, "cc", args, params)
 	for orig, compats := range compatNames {

--- a/sys/syz-extract/trusty.go
+++ b/sys/syz-extract/trusty.go
@@ -41,6 +41,7 @@ func (*trusty) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uin
 	}
 	params := &extractParams{
 		DeclarePrintf: true,
+		TargetEndian:  arch.target.HostEndian,
 	}
 	return extract(info, "gcc", args, params)
 }

--- a/sys/syz-extract/windows.go
+++ b/sys/syz-extract/windows.go
@@ -20,6 +20,7 @@ func (*windows) prepareArch(arch *Arch) error {
 func (*windows) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uint64, map[string]bool, error) {
 	params := &extractParams{
 		DeclarePrintf: true,
+		TargetEndian:  arch.target.HostEndian,
 	}
 	return extract(info, "cl", nil, params)
 }

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -199,12 +199,12 @@ func generate(target *targets.Target, prg *compiler.Prog, consts map[string]uint
 	fmt.Fprintf(out, "func init() {\n")
 	fmt.Fprintf(out, "\tRegisterTarget(&Target{"+
 		"OS: %q, Arch: %q, Revision: revision_%v, PtrSize: %v, "+
-		"PageSize: %v, NumPages: %v, DataOffset: %v, Syscalls: syscalls_%v, "+
+		"PageSize: %v, NumPages: %v, DataOffset: %v, LittleEndian: %v, Syscalls: syscalls_%v, "+
 		"Resources: resources_%v, Consts: consts_%v}, "+
 		"types_%v, InitTarget)\n}\n\n",
 		target.OS, target.Arch, target.Arch, target.PtrSize,
 		target.PageSize, target.NumPages, target.DataOffset,
-		target.Arch, target.Arch, target.Arch, target.Arch)
+		target.LittleEndian, target.Arch, target.Arch, target.Arch, target.Arch)
 
 	fmt.Fprintf(out, "var resources_%v = ", target.Arch)
 	serializer.Write(out, prg.Resources)

--- a/sys/test/test/align0_be
+++ b/sys/test/test/align0_be
@@ -1,6 +1,6 @@
 # 32_shmem has 4-byte alignment for int64 and everything goes havoc.
-# requires: -arch=32_shmem littleendian
+# requires: -arch=32_shmem -littleendian
 
-syz_compare(&AUTO="010000000200000003000400000000000500000000000000", 0x18, &AUTO=@align0={0x1, 0x2, 0x3, 0x4, 0x5}, AUTO)
+syz_compare(&AUTO="000100000000000203000004000000000000000000000005", 0x18, &AUTO=@align0={0x1, 0x2, 0x3, 0x4, 0x5}, AUTO)
 syz_compare(&AUTO="", 0x18, &AUTO=@align0={0x0, 0x0, 0x0, 0x0, 0x0}, 0x17) # EBADF
 syz_compare(&AUTO="", 0x18, &AUTO=@align0={0x1, 0x0, 0x0, 0x0, 0x0}, AUTO) # EINVAL

--- a/sys/test/test/bf
+++ b/sys/test/test/bf
@@ -1,5 +1,5 @@
 # 32_shmem has 4-byte alignment for int64 and everything goes havoc.
-# requires: -arch=32_shmem
+# requires: -arch=32_shmem littleendian
 
 syz_compare(&AUTO="ab03000000000000cdcdcdcdcdcdcdcdebffff03ab0303abaa00000000000000", 0x20, &AUTO=@bf0={0xabab, 0xcdcdcdcdcdcdcdcd, 0xabab, 0xffff, 0xffffff, 0xabab, 0xabab, 0xaaa}, AUTO)
 syz_compare(&AUTO="dcfcde563422f10e", 0x8, &AUTO=@bf2={0x0abc, 0x0bcd, 0xcdef, 0x123456, 0x78ef12}, AUTO)

--- a/sys/test/test/bf2
+++ b/sys/test/test/bf2
@@ -1,5 +1,5 @@
 # 32_shmem has 4-byte alignment for int64 and everything goes havoc.
-# requires: -arch=32_shmem
+# requires: -arch=32_shmem littleendian
 
 syz_compare(&AUTO="1200000034067800", AUTO, &AUTO=@bf4={0x12, {0x34, 0x56, 0x78}}, AUTO)
 syz_compare(&AUTO="1200000034060000", AUTO, &AUTO=@bf5={0x12, {0x34, 0x56}}, AUTO)

--- a/sys/test/test/nla
+++ b/sys/test/test/nla
@@ -1,3 +1,5 @@
+# requires: littleendian
+
 syz_compare(&AUTO="0500aa0055000000", AUTO, &AUTO=@nla=[@a0={AUTO, AUTO, 0x55, ''}], AUTO)
 syz_compare(&AUTO="0600bb0055550000", AUTO, &AUTO=@nla=[@a1={AUTO, AUTO, 0x5555, ''}], AUTO)
 syz_compare(&AUTO="0800cc0055555555", AUTO, &AUTO=@nla=[@a2={AUTO, AUTO, 0x55555555, ''}], AUTO)


### PR DESCRIPTION
* Introduce the new target flag 'LittleEndian' which specifies
  of which endianness the target is.
* Introduce the new requires flag 'littleendian' for tests to
  selectively enable/disable tests on either little-endian architectures
  or big-endian ones.
* Disable KD unit test on s390x architecture because the test
  works only on little-endian architecture.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
