### PR TITLE
dashboard/app: separate To and Cc in emails

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 // Params is input arguments for the Image function.
@@ -93,6 +94,8 @@ type KernelError struct {
 	Report      []byte
 	Output      []byte
 	Maintainers []string
+	Cc          []string
+	Recipients  []vcs.RecipientInfo
 	guiltyFile  string
 }
 
@@ -195,7 +198,7 @@ func extractRootCause(err error, OS, kernelSrc string) error {
 		if err != nil {
 			kernelErr.Output = append(kernelErr.Output, err.Error()...)
 		}
-		kernelErr.Maintainers = maintainers
+		kernelErr.Recipients = maintainers
 	}
 	return kernelErr
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/vcs"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -50,8 +51,12 @@ type Report struct {
 	Corrupted bool
 	// CorruptedReason contains reason why the report is marked as corrupted.
 	CorruptedReason string
-	// Maintainers is list of maintainer emails (filled in by Symbolize).
+	// Maintainers is a list of maintainer emails (filled in by Symbolize).
 	Maintainers []string
+	// Cc is a list of less important emails (filled in by Symbolize).
+	Cc []string
+	// Recipients is a list of RecipientInfo with Email, Real Name, and type.
+	Recipients []vcs.RecipientInfo
 	// guiltyFile is the source file that we think is to blame for the crash  (filled in by Symbolize).
 	guiltyFile string
 	// reportPrefixLen is length of additional prefix lines that we added before actual crash report.

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -75,6 +75,7 @@ type Commit struct {
 	Author     string
 	AuthorName string
 	CC         []string
+	Recipients []RecipientInfo
 	Tags       []string
 	Parents    []string
 	Date       time.Time

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -5,6 +5,8 @@ package vcs
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCanonicalizeCommit(t *testing.T) {
@@ -153,5 +155,37 @@ func TestCommitLink(t *testing.T) {
 		if link != test.CommitLink {
 			t.Errorf("URL: %v\nhash: %v\nwant: %v\ngot:  %v", test.URL, test.Hash, test.CommitLink, link)
 		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	lines := []string{"Masahiro Yamada <masahiroy@kernel.org> " +
+		"(maintainer:KERNEL BUILD + files below scripts/ (unless mai...)",
+		"Michal Marek <michal.lkml@markovi.net>" +
+			"(maintainer:KERNEL BUILD + files below scripts/ (unless mai...)",
+		"linux-kbuild@vger.kernel.org" +
+			"(open list:KERNEL BUILD + files below scripts/ (unless mai...)",
+		"linux-kernel@vger.kernel.org (open list)"}
+	maintainers := []RecipientInfo{{"masahiroy@kernel.org",
+		"Masahiro Yamada",
+		"(maintainer:KERNEL BUILD + files below scripts/ (unless mai...)",
+		true},
+		{"michal.lkml@markovi.net",
+			"Michal Marek",
+			"(maintainer:KERNEL BUILD + files below scripts/ (unless mai...)", true},
+		{"linux-kbuild@vger.kernel.org",
+			"",
+			"(open list:KERNEL BUILD + files below scripts/ (unless mai...)",
+			true},
+		{"linux-kernel@vger.kernel.org",
+			"",
+			"(open list)",
+			false}}
+
+	if diff := cmp.Diff(ParseMaintainers(lines), maintainers); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := cmp.Diff(ParseMaintainers([]string{}), []RecipientInfo{}); diff != "" {
+		t.Fatal(diff)
 	}
 }


### PR DESCRIPTION
Separate people to To and Cc groups for emails. More important people as
maintainers and supporters are on To and lists such linux-kernel and
syzkaller-bugs are on Cc.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
