### PR TITLE
prog: add support for riscv64

### DIFF
--- a/prog/little_endian.go
+++ b/prog/little_endian.go
@@ -1,7 +1,7 @@
 // Copyright 2020 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// +build amd64 386 arm64 arm mips64le ppc64le
+// +build amd64 386 arm64 arm mips64le ppc64le riscv64
 
 package prog
 


### PR DESCRIPTION
This will allow to run `make TARGETVMARCH=riscv64`.

h/t Munich RISC-V meetup talk by @bjoto