### PR TITLE
docs/linux: change suggested kernel git repo

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -21,7 +21,7 @@ gcc-nm  gcov-tool   x86_64-pc-linux-gnu-gcc-nm
 Checkout Linux kernel source:
 
 ``` bash
-git clone https://github.com/torvalds/linux.git $KERNEL
+git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git $KERNEL
 ```
 
 Generate default configs:


### PR DESCRIPTION
Suggest to checkout linux kernel from kernel.org rather than from github.
github is a mirror and we don't use it ourselves and I think it's
generally not used by kernel developers. The kernel.org repo is
the canonical location.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
