### PR TITLE
executor: enable cgroup/cpuset memory pressure calc.

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2406,6 +2406,7 @@ static void setup_cgroups()
 		debug("mount(cgroup cpu) failed: %d\n", errno);
 	}
 	write_file("/syzcgroup/cpu/cgroup.clone_children", "1");
+	write_file("/syzcgroup/cpu/cpuset.memory_pressure_enabled", "1");
 	if (chmod("/syzcgroup/cpu", 0777)) {
 		debug("chmod(/syzcgroup/cpu) failed: %d\n", errno);
 	}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6862,6 +6862,7 @@ static void setup_cgroups()
 		debug("mount(cgroup cpu) failed: %d\n", errno);
 	}
 	write_file("/syzcgroup/cpu/cgroup.clone_children", "1");
+	write_file("/syzcgroup/cpu/cpuset.memory_pressure_enabled", "1");
 	if (chmod("/syzcgroup/cpu", 0777)) {
 		debug("chmod(/syzcgroup/cpu) failed: %d\n", errno);
 	}


### PR DESCRIPTION
Enable the cpuset.memory_pressure_enabled flag in the root cpuset.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
