### PR TITLE
prog/alloc: align address allocation for aligned[addr]

### DIFF
--- a/pkg/compiler/gen.go
+++ b/pkg/compiler/gen.go
@@ -296,7 +296,7 @@ func (comp *compiler) layoutStructFields(t *prog.StructType, varlen, packed bool
 		f := field.Type
 		fieldAlign := uint64(1)
 		if !packed {
-			fieldAlign = comp.typeAlign(f)
+			fieldAlign = f.Alignment()
 			if structAlign < fieldAlign {
 				structAlign = fieldAlign
 			}
@@ -422,58 +422,6 @@ func setBitfieldOffset(t prog.Type, v uint64) {
 func setBitfieldUnitOffset(t prog.Type, v uint64) {
 	_, _, p := bitfieldFields(t)
 	*p = v
-}
-
-func (comp *compiler) typeAlign(t0 prog.Type) uint64 {
-	switch t0.Format() {
-	case prog.FormatNative, prog.FormatBigEndian:
-	case prog.FormatStrDec, prog.FormatStrHex, prog.FormatStrOct:
-		return 1
-	default:
-		panic("unknown binary format")
-	}
-	if prog.IsPad(t0) {
-		return 1
-	}
-	switch t := t0.(type) {
-	case *prog.ConstType, *prog.IntType, *prog.LenType, *prog.FlagsType, *prog.ProcType,
-		*prog.CsumType, *prog.PtrType, *prog.VmaType, *prog.ResourceType:
-		align := t0.UnitSize()
-		if align == 8 && comp.target.Int64Alignment != 0 {
-			align = comp.target.Int64Alignment
-		}
-		return align
-	case *prog.BufferType:
-		return 1
-	case *prog.ArrayType:
-		return comp.typeAlign(t.Elem)
-	case *prog.StructType:
-		n := comp.structs[t.TypeName]
-		attrs := comp.parseAttrs(structAttrs, n, n.Attrs)
-		if align := attrs[attrAlign]; align != 0 {
-			return align // overrided by user attribute
-		}
-		if attrs[attrPacked] != 0 {
-			return 1
-		}
-		align := uint64(0)
-		for _, f := range t.Fields {
-			if a := comp.typeAlign(f.Type); align < a {
-				align = a
-			}
-		}
-		return align
-	case *prog.UnionType:
-		align := uint64(0)
-		for _, f := range t.Fields {
-			if a := comp.typeAlign(f.Type); align < a {
-				align = a
-			}
-		}
-		return align
-	default:
-		panic(fmt.Sprintf("unknown type: %#v", t))
-	}
 }
 
 func genPad(size uint64) prog.Field {

--- a/prog/alloc.go
+++ b/prog/alloc.go
@@ -51,13 +51,18 @@ func (ma *memAlloc) noteAlloc(addr0, size0 uint64) {
 	}
 }
 
-func (ma *memAlloc) alloc(r *randGen, size0 uint64) uint64 {
+// alloc returns the next free address of size0 with respect to the given alignment.
+func (ma *memAlloc) alloc(r *randGen, size0, alignment0 uint64) uint64 {
 	if size0 == 0 {
 		size0 = 1
 	}
+	if alignment0 == 0 {
+		alignment0 = 1
+	}
 	size := (size0 + memAllocGranule - 1) / memAllocGranule
+	alignment := (alignment0 + memAllocGranule - 1) / memAllocGranule
 	end := ma.size - size
-	for start := uint64(0); start <= end; start++ {
+	for start := uint64(0); start <= end; start += alignment {
 		empty := true
 		for i := uint64(0); i < size; i++ {
 			if ma.get(start + i) {
@@ -72,7 +77,7 @@ func (ma *memAlloc) alloc(r *randGen, size0 uint64) uint64 {
 		}
 	}
 	ma.bankruptcy()
-	return ma.alloc(r, size0)
+	return ma.alloc(r, size0, alignment0)
 }
 
 func (ma *memAlloc) bankruptcy() {

--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -1017,7 +1017,7 @@ func (p *parser) fixupAutos(prog *Prog) {
 				_ = s
 			case *PtrType:
 				a := arg.(*PointerArg)
-				a.Address = s.ma.alloc(nil, a.Res.Size())
+				a.Address = s.ma.alloc(nil, a.Res.Size(), a.Res.Type().Alignment())
 			default:
 				panic(fmt.Sprintf("unsupported auto type %T", typ))
 			}

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -336,7 +336,7 @@ func (r *randGen) randString(s *state, t *BufferType) []byte {
 }
 
 func (r *randGen) allocAddr(s *state, typ Type, dir Dir, size uint64, data Arg) *PointerArg {
-	return MakePointerArg(typ, dir, s.ma.alloc(r, size), data)
+	return MakePointerArg(typ, dir, s.ma.alloc(r, size, data.Type().Alignment()), data)
 }
 
 func (r *randGen) allocVMA(s *state, typ Type, dir Dir, numPages uint64) *PointerArg {

--- a/prog/target.go
+++ b/prog/target.go
@@ -305,14 +305,12 @@ func (pg *Builder) Append(c *Call) error {
 	return nil
 }
 
-func (pg *Builder) Allocate(size uint64) uint64 {
-	return pg.ma.alloc(nil, size)
+func (pg *Builder) Allocate(size, alignment uint64) uint64 {
+	return pg.ma.alloc(nil, size, alignment)
 }
 
 func (pg *Builder) AllocateVMA(npages uint64) uint64 {
-	psize := pg.target.PageSize
-	addr := pg.ma.alloc(nil, (npages+1)*psize)
-	return (addr + psize - 1) & ^(psize - 1)
+	return pg.ma.alloc(nil, npages*pg.target.PageSize, pg.target.PageSize)
 }
 
 func (pg *Builder) Finalize() (*Prog, error) {

--- a/prog/types.go
+++ b/prog/types.go
@@ -88,6 +88,7 @@ type Type interface {
 	Varlen() bool
 	Size() uint64
 	TypeBitSize() uint64
+	Alignment() uint64
 	Format() BinaryFormat
 	BitfieldOffset() uint64
 	BitfieldLength() uint64
@@ -118,6 +119,7 @@ func (ti Ref) Optional() bool                                        { panic("pr
 func (ti Ref) Varlen() bool                                          { panic("prog.Ref method called") }
 func (ti Ref) Size() uint64                                          { panic("prog.Ref method called") }
 func (ti Ref) TypeBitSize() uint64                                   { panic("prog.Ref method called") }
+func (ti Ref) Alignment() uint64                                     { panic("prog.Ref method called") }
 func (ti Ref) Format() BinaryFormat                                  { panic("prog.Ref method called") }
 func (ti Ref) BitfieldOffset() uint64                                { panic("prog.Ref method called") }
 func (ti Ref) BitfieldLength() uint64                                { panic("prog.Ref method called") }
@@ -151,6 +153,7 @@ type TypeCommon struct {
 	TypeName string
 	// Static size of the type, or 0 for variable size types and all but last bitfields in the group.
 	TypeSize   uint64
+	TypeAlign  uint64
 	IsOptional bool
 	IsVarlen   bool
 
@@ -221,6 +224,10 @@ func (t *TypeCommon) ref() Ref {
 
 func (t *TypeCommon) setRef(ref Ref) {
 	t.self = ref
+}
+
+func (t *TypeCommon) Alignment() uint64 {
+	return t.TypeAlign
 }
 
 type ResourceDesc struct {

--- a/tools/syz-trace2syz/proggen/proggen.go
+++ b/tools/syz-trace2syz/proggen/proggen.go
@@ -470,7 +470,7 @@ func (ctx *context) parseProc(syzType *prog.ProcType, dir prog.Dir, traceType pa
 }
 
 func (ctx *context) addr(syzType prog.Type, dir prog.Dir, size uint64, data prog.Arg) prog.Arg {
-	return prog.MakePointerArg(syzType, dir, ctx.builder.Allocate(size), data)
+	return prog.MakePointerArg(syzType, dir, ctx.builder.Allocate(size, data.Type().Alignment()), data)
 }
 
 func shouldSkip(c *parser.Syscall) bool {


### PR DESCRIPTION
AlignAttr was only used to set padding and not to align to the
given argument. Existing descriptions with [align[X]] don't have
an issue as they align to small blocks and default align is to 64.
This commits adds support for [align[X]] for an X larger than 64.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
