### PR TITLE
sys/linux: add process_madvise

### DIFF
--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -153,6 +153,7 @@ remap_file_pages(addr vma, size len[addr], prot flags[mmap_prot], pgoff intptr, 
 mprotect(addr vma, len len[addr], prot flags[mmap_prot])
 msync(addr vma, len len[addr], f flags[msync_flags])
 madvise(addr vma, len len[addr], advice flags[madvise_flags])
+process_madvise(pidfd fd_pidfd, vec ptr[in, array[iovec_in]], vlen len[vec], advice flags[madvise_flags], flags const[0])
 fadvise64(fd fd, offset fileoff, len intptr, advice flags[fadvise_flags])
 readahead(fd fd, off intptr, count intptr)
 mbind(addr vma, len len[addr], mode flags[mbind_mode], nodemask ptr[in, int64], maxnode intptr, flags flags[mbind_flags])

--- a/sys/linux/sys_386.const
+++ b/sys/linux/sys_386.const
@@ -716,6 +716,7 @@ __NR_ppoll = 309
 __NR_pread64 = 180
 __NR_preadv = 333
 __NR_prlimit64 = 340
+__NR_process_madvise = 443
 __NR_process_vm_readv = 347
 __NR_process_vm_writev = 348
 __NR_pselect6 = 308

--- a/sys/linux/sys_amd64.const
+++ b/sys/linux/sys_amd64.const
@@ -716,6 +716,7 @@ __NR_ppoll = 271
 __NR_pread64 = 17
 __NR_preadv = 295
 __NR_prlimit64 = 302
+__NR_process_madvise = 443
 __NR_process_vm_readv = 310
 __NR_process_vm_writev = 311
 __NR_pselect6 = 270

--- a/sys/linux/sys_arm.const
+++ b/sys/linux/sys_arm.const
@@ -716,6 +716,7 @@ __NR_ppoll = 336
 __NR_pread64 = 180
 __NR_preadv = 361
 __NR_prlimit64 = 369
+__NR_process_madvise = 443
 __NR_process_vm_readv = 376
 __NR_process_vm_writev = 377
 __NR_pselect6 = 335

--- a/sys/linux/sys_arm64.const
+++ b/sys/linux/sys_arm64.const
@@ -716,6 +716,7 @@ __NR_ppoll = 73
 __NR_pread64 = 67
 __NR_preadv = 69
 __NR_prlimit64 = 261
+__NR_process_madvise = 443
 __NR_process_vm_readv = 270
 __NR_process_vm_writev = 271
 __NR_pselect6 = 72

--- a/sys/linux/sys_mips64le.const
+++ b/sys/linux/sys_mips64le.const
@@ -716,6 +716,7 @@ __NR_ppoll = 5261
 __NR_pread64 = 5016
 __NR_preadv = 5289
 __NR_prlimit64 = 5297
+__NR_process_madvise = 5443
 __NR_process_vm_readv = 5304
 __NR_process_vm_writev = 5305
 __NR_pselect6 = 5260

--- a/sys/linux/sys_ppc64le.const
+++ b/sys/linux/sys_ppc64le.const
@@ -716,6 +716,7 @@ __NR_ppoll = 281
 __NR_pread64 = 179
 __NR_preadv = 320
 __NR_prlimit64 = 325
+__NR_process_madvise = 443
 __NR_process_vm_readv = 351
 __NR_process_vm_writev = 352
 __NR_pselect6 = 280

--- a/sys/linux/sys_riscv64.const
+++ b/sys/linux/sys_riscv64.const
@@ -716,6 +716,7 @@ __NR_ppoll = 73
 __NR_pread64 = 67
 __NR_preadv = 69
 __NR_prlimit64 = 261
+__NR_process_madvise = 443
 __NR_process_vm_readv = 270
 __NR_process_vm_writev = 271
 __NR_pselect6 = 72

--- a/sys/linux/sys_s390x.const
+++ b/sys/linux/sys_s390x.const
@@ -716,6 +716,7 @@ __NR_ppoll = 302
 __NR_pread64 = 180
 __NR_preadv = 328
 __NR_prlimit64 = 334
+__NR_process_madvise = 443
 __NR_process_vm_readv = 340
 __NR_process_vm_writev = 341
 __NR_pselect6 = 301


### PR DESCRIPTION
Added the description for the newly added process_madvise syscall
(https://lkml.org/lkml/2020/5/15/1321).

