### PR TITLE
Use OpenSBI included with QEMU for linux/riscv64

### DIFF
--- a/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
@@ -55,7 +55,6 @@ Choose the following options:
 ```
     Target packages
 	    Networking applications
-	        [*] dhcpcd
 	        [*] iproute2
 	        [*] openssh
     Filesystem images

--- a/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
@@ -88,6 +88,10 @@ PermitEmptyPasswords yes
 
 Run `make` again.
 
+# QEMU
+
+The following instructions were tested with QEMU 5.0. At least QEMU 4.1 is needed.
+
 # Test kernel and image
 
 Run:

--- a/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_riscv64-kernel.md
@@ -147,6 +147,35 @@ Create the manager config `riscv64.cfg` similar to the following one (adjusting 
 }
 ```
 
+Alternatively, you may try to use the default OpenSBI firmware provided with QEMU 4.1 and newer by
+specifying `-machine virt -bios default` in `qemu_args` and pass the kernel image in the `kernel`
+config option:
+
+```
+{
+	"name": "riscv64",
+	"target": "linux/riscv64",
+	"http": ":56700",
+	"workdir": "/workdir",
+	"kernel_obj": "/linux",
+	"syzkaller": "/gopath/src/github.com/google/syzkaller",
+	"image": "/buildroot/output/images/rootfs.ext2",
+	"procs": 8,
+	"type": "qemu",
+	"vm": {
+		"count": 1,
+		"qemu_args": "-machine virt -bios default",
+		"kernel": "/linux/arch/riscv/boot/Image",
+		"cpu": 2,
+		"mem": 2048
+	}
+}
+```
+
+This would allow to boot a different kernel without having to re-compile OpenSBI. However, on some
+distributions the default OpenSBI firmware required by the `-bios default` option might not be
+available yet.
+
 Finally, run `bin/syz-manager -config riscv64.cfg`. After it successfully starts, you should be able
 to visit `localhost:56700` to view the fuzzing results.
 


### PR DESCRIPTION
Use the `-bios default` QEMU option (available since QEMU 4.1 [1]). This allows to directly boot the built kernel with QEMU and drops the requirement for wrapping the kernel into an OpenSBI image.

[1] https://www.qemu.org/docs/master/qemu-doc.html#RISC_002dV-_002dbios-_0028since-4_002e1_0029