### PR TITLE
tools/syz-linter: enable some standard linters

### DIFF
--- a/syz-ci/jobs_test.go
+++ b/syz-ci/jobs_test.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"errors"
-	"reflect"
+	"fmt"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/instance"
@@ -105,7 +105,7 @@ func TestAggregateTestResults(t *testing.T) {
 	}
 	for i, test := range tests {
 		rep, err := aggregateTestResults(test.results)
-		if !reflect.DeepEqual(err, test.err) {
+		if fmt.Sprint(err) != fmt.Sprint(test.err) {
 			t.Errorf("test #%v: got err: %q, want: %q", i, err, test.err)
 		}
 		got := ""

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -25,6 +25,11 @@ import (
 	"unicode"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/atomicalign"
+	"golang.org/x/tools/go/analysis/passes/copylock"
+	"golang.org/x/tools/go/analysis/passes/deepequalerrors"
+	"golang.org/x/tools/go/analysis/passes/nilness"
+	"golang.org/x/tools/go/analysis/passes/structtag"
 )
 
 var AnalyzerPlugin analyzerPlugin
@@ -38,6 +43,12 @@ func main() {
 func (*analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
 	return []*analysis.Analyzer{
 		SyzAnalyzer,
+		// Some standard analyzers that are not enabled in vet.
+		atomicalign.Analyzer,
+		copylock.Analyzer,
+		deepequalerrors.Analyzer,
+		nilness.Analyzer,
+		structtag.Analyzer,
 	}
 }
 

--- a/tools/syz-reporter/reporter.go
+++ b/tools/syz-reporter/reporter.go
@@ -131,10 +131,6 @@ func readCrash(workdir, dir string) *UICrashType {
 		return nil
 	}
 	desc := string(trimNewLines(descBytes))
-	if err != nil {
-		return nil
-	}
-
 	descFile.Close()
 
 	files, err := osutil.ListDir(filepath.Join(crashdir, dir))


### PR DESCRIPTION
Enable some x/tools linters that are not enabled in vet.

Update #1876

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
