### PR TITLE
all: check and fix comments style

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -60,7 +60,7 @@ func accessLevel(c context.Context, r *http.Request) AccessLevel {
 	}
 	u := user.Current(c)
 	if u == nil ||
-		// devappserver is broken
+		// Devappserver does not pass AuthDomain.
 		u.AuthDomain != "gmail.com" && !isBrokenAuthDomainInTest ||
 		!strings.HasSuffix(u.Email, config.AuthDomain) {
 		return AccessPublic

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -940,14 +940,14 @@ func TestBugBisectionResults(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
 	c.client2.ReportCrash(crash)
 	c.client2.pollEmailBug()
 
-	// Receive the JobBisectCause and send cause information
+	// Receive the JobBisectCause and send cause information.
 	resp := c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectCause)
@@ -978,7 +978,7 @@ func TestBugBisectionResults(t *testing.T) {
 	}
 	c.expectOK(c.client2.JobDone(done))
 
-	// Advance time by 30 days and read out any notification emails
+	// Advance time by 30 days and read out any notification emails.
 	{
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
@@ -1022,7 +1022,7 @@ func TestBugBisectionResults(t *testing.T) {
 	msg := c.client2.pollEmailBug()
 	c.expectTrue(strings.Contains(msg.Body, "syzbot suspects this bug was fixed by commit:"))
 
-	// Fetch bug details
+	// Fetch bug details.
 	var bugs []*Bug
 	keys, err := db.NewQuery("Bug").GetAll(c.ctx, &bugs)
 	c.expectEQ(err, nil)
@@ -1043,14 +1043,14 @@ func TestBugBisectionStatus(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
 	c.client2.ReportCrash(crash)
 	c.client2.pollEmailBug()
 
-	// Receive the JobBisectCause and send cause information
+	// Receive the JobBisectCause and send cause information.
 	resp := c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectCause)
@@ -1081,7 +1081,7 @@ func TestBugBisectionStatus(t *testing.T) {
 	}
 	c.expectOK(c.client2.JobDone(done))
 
-	// Fetch bug, namespace details
+	// Fetch bug, namespace details.
 	var bugs []*Bug
 	_, err := db.NewQuery("Bug").GetAll(c.ctx, &bugs)
 	c.expectEQ(err, nil)
@@ -1091,7 +1091,7 @@ func TestBugBisectionStatus(t *testing.T) {
 	c.expectEQ(err, nil)
 	c.expectTrue(bytes.Contains(content, []byte("cause")))
 
-	// Advance time by 30 days and read out any notification emails
+	// Advance time by 30 days and read out any notification emails.
 	{
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -413,7 +413,7 @@ func TestEmailDup(t *testing.T) {
 	c.incomingEmail(msg2.Sender, "#syz dup: BUG: slightly more elaborate title")
 	c.expectNoEmail()
 
-	// Second crash happens again
+	// Second crash happens again.
 	crash2.ReproC = []byte("int main() {}")
 	c.client2.ReportCrash(crash2)
 	c.expectNoEmail()
@@ -421,7 +421,7 @@ func TestEmailDup(t *testing.T) {
 	// Now close the original bug, and check that new bugs for dup are now created.
 	c.incomingEmail(msg1.Sender, "#syz invalid")
 
-	// uncc command must not trugger error reply even for closed bug.
+	// "uncc" command must not trugger error reply even for closed bug.
 	c.incomingEmail(msg1.Sender, "#syz uncc", EmailOptCC(nil))
 	c.expectNoEmail()
 

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -208,7 +208,7 @@ func getNextJob(c context.Context, managers map[string]dashapi.ManagerJobs) (*Jo
 		return job, jobKey, err
 	}
 	// We need both C and syz repros, but the crazy datastore query restrictions
-	// do not allow to use ReproLevel>ReproLevelNone in the query.  So we do 2 separate queries.
+	// do not allow to use ReproLevel>ReproLevelNone in the query. So we do 2 separate queries.
 	// C repros tend to be of higher reliability so maybe it's not bad.
 	job, jobKey, err = createBisectJob(c, managers, ReproLevelC)
 	if job != nil || err != nil {

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -366,14 +366,14 @@ func TestBisectFixJob(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
 	c.client2.ReportCrash(crash)
 	c.client2.pollEmailBug()
 
-	// Receive the JobBisectCause
+	// Receive the JobBisectCause.
 	resp := c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectCause)
@@ -383,11 +383,11 @@ func TestBisectFixJob(t *testing.T) {
 	}
 	c.client2.expectOK(c.client2.JobDone(done))
 
-	// Ensure no more jobs
+	// Ensure no more jobs.
 	resp = c.client2.pollJobs(build.Manager)
 	c.client2.expectEQ(resp.ID, "")
 
-	// Advance time by 30 days and read out any notification emails
+	// Advance time by 30 days and read out any notification emails.
 	{
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
@@ -399,7 +399,7 @@ func TestBisectFixJob(t *testing.T) {
 		c.expectTrue(strings.Contains(msg.Body, "syzbot found the following crash"))
 	}
 
-	// Ensure that we get a JobBisectFix
+	// Ensure that we get a JobBisectFix.
 	resp = c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectFix)
@@ -415,14 +415,14 @@ func TestBisectFixRetry(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
 	c.client2.ReportCrash(crash)
 	c.client2.pollEmailBug()
 
-	// Receive the JobBisectCause
+	// Receive the JobBisectCause.
 	resp := c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectCause)
@@ -432,7 +432,7 @@ func TestBisectFixRetry(t *testing.T) {
 	}
 	c.client2.expectOK(c.client2.JobDone(done))
 
-	// Advance time by 30 days and read out any notification emails
+	// Advance time by 30 days and read out any notification emails.
 	{
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
@@ -444,7 +444,7 @@ func TestBisectFixRetry(t *testing.T) {
 		c.expectTrue(strings.Contains(msg.Body, "syzbot found the following crash"))
 	}
 
-	// Ensure that we get a JobBisectFix. We send back a crashlog, no error, no commits
+	// Ensure that we get a JobBisectFix. We send back a crashlog, no error, no commits.
 	resp = c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectFix)
@@ -458,12 +458,12 @@ func TestBisectFixRetry(t *testing.T) {
 	}
 	c.client2.expectOK(c.client2.JobDone(done))
 
-	// Advance time by 30 days. No notification emails
+	// Advance time by 30 days. No notification emails.
 	{
 		c.advanceTime(30 * 24 * time.Hour)
 	}
 
-	// Ensure that we get a JobBisectFix retry
+	// Ensure that we get a JobBisectFix retry.
 	resp = c.client2.pollJobs(build.Manager)
 	c.client2.expectNE(resp.ID, "")
 	c.client2.expectEQ(resp.Type, dashapi.JobBisectFix)
@@ -561,7 +561,7 @@ func TestFixBisectionsListed(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
@@ -648,7 +648,7 @@ func TestFixBisectionsDisabled(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	// Upload a crash report
+	// Upload a crash report.
 	build := testBuild(1)
 	build.Manager = "no-fix-bisection-manager"
 	c.client2.UploadBuild(build)

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -30,25 +30,25 @@ func (ctx netbsd) build(params *Params) error {
 		return err
 	}
 
-	// Clear the tools
+	// Clear the tools.
 	if _, err := osutil.RunCmd(5*time.Minute, params.KernelDir, "rm", "-rf", "obj/"); err != nil {
 		return err
 	}
 
-	// Clear the build files
+	// Clear the build files.
 	if _, err := osutil.RunCmd(5*time.Minute, params.KernelDir, "rm", "-rf", compileDir); err != nil {
 		return err
 	}
 
 	if strings.HasSuffix(params.Compiler, "clang++") {
-		// Build tools before building kernel
+		// Build tools before building kernel.
 		if _, err := osutil.RunCmd(60*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
 			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "tools"); err != nil {
 			return err
 		}
 
-		// Build kernel
+		// Build kernel.
 		if _, err := osutil.RunCmd(20*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
 			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "kernel="+kernelName); err != nil {
@@ -126,7 +126,7 @@ func (ctx netbsd) copyKernelToDisk(targetArch, vmType, outputDir, kernel string)
 		return fmt.Errorf("failed to create the VM Instance: %v", err)
 	}
 	defer inst.Close()
-	// Copy the kernel into the disk image and replace it
+	// Copy the kernel into the disk image and replace it.
 	kernel, err = inst.Copy(kernel)
 	if err != nil {
 		return fmt.Errorf("error copying the kernel: %v", err)

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -107,9 +107,9 @@ var typeInt = &typeDesc{
 				comp.error(args[0].Pos, "bad int range [%v:%v]", begin, end)
 				return
 			}
-			// range is in [0:MAX_UINT]
+			// The range fits into the size if treated as unsigned [0:MAX_UINT].
 			inUnsignedBase := begin <= maxUInt && end <= maxUInt
-			// range is in [-MIN_SINT:MAX_SINT]
+			// The range fits into the size if treated as signed [-MIN_SINT:MAX_SINT].
 			inSignedBase := begin+maxSInt <= maxUInt && end+maxSInt <= maxUInt
 			if size < 64 && !inUnsignedBase && !inSignedBase {
 				comp.error(args[0].Colon[0].Pos, "int range [%v:%v] is too large for base type of size %v",

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -407,18 +407,18 @@ func (ctx *context) constArgToStr(arg prog.ExecArgConst, handleBigEndian, native
 	}
 	if native && arg.Size == 8 {
 		// syscall() is variadic, so constant arguments must be explicitly
-		// promoted.  Otherwise the compiler is free to leave garbage in the
-		// upper 32 bits of the argument value.  In practice this can happen
+		// promoted. Otherwise the compiler is free to leave garbage in the
+		// upper 32 bits of the argument value. In practice this can happen
 		// on amd64 with arguments that are passed on the stack, i.e.,
-		// arguments beyond the first six.  For example, on freebsd/amd64,
+		// arguments beyond the first six. For example, on freebsd/amd64,
 		// syscall(SYS_mmap, ..., 0) causes clang to emit a 32-bit store of
 		// 0 to the stack, but the kernel expects a 64-bit value.
 		//
 		// syzkaller's argument type representations do not always match
-		// the OS ABI.  For instance, "flags" is always 64 bits wide on 64-bit
+		// the OS ABI. For instance, "flags" is always 64 bits wide on 64-bit
 		// platforms, but is a 32-bit value ("unsigned int" or so) in many
-		// cases.  Thus, we assume here that passing a 64-bit argument where
-		// a 32-bit argument is expected won't break anything.  On amd64
+		// cases. Thus, we assume here that passing a 64-bit argument where
+		// a 32-bit argument is expected won't break anything. On amd64
 		// this should be fine: arguments are passed in 64-bit registers or
 		// at 64 bit-aligned addresses on the stack.
 		if ctx.target.PtrSize == 4 {

--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -358,7 +358,7 @@ func isSupportedOpenAt(c *prog.Syscall) (bool, string) {
 
 	modes := []int{syscall.O_RDONLY, syscall.O_WRONLY, syscall.O_RDWR}
 
-	// Attempt to extract flags from the syscall description
+	// Attempt to extract flags from the syscall description.
 	if mode, ok := c.Args[2].Type.(*prog.ConstType); ok {
 		modes = []int{int(mode.Val)}
 	}

--- a/pkg/host/syscalls_linux_test.go
+++ b/pkg/host/syscalls_linux_test.go
@@ -116,7 +116,7 @@ c037c7f8 T sys_getppid
 			[]string{"setfsgid", "getpid", "gettid", "getppid"},
 			[]string{"setfsgid", "getpid", "gettid", "getppid"},
 		},
-		// Test kallsymsRenameMap
+		// Test kallsymsRenameMap.
 		{
 			"ppc64le",
 			[]byte(`

--- a/pkg/ifuzz/gen/gen.go
+++ b/pkg/ifuzz/gen/gen.go
@@ -343,7 +343,7 @@ func parsePattern(insn *ifuzz.Insn, vals []string) error {
 		case v == "SE_IMM8()":
 			addImm(insn, 1)
 
-		// Modes
+		// Modes.
 		case v == "mode64":
 			insn.Mode &= 1 << ifuzz.ModeLong64
 		case v == "not64":

--- a/pkg/ifuzz/ifuzz.go
+++ b/pkg/ifuzz/ifuzz.go
@@ -140,37 +140,37 @@ func Mutate(cfg *Config, r *rand.Rand, text []byte) []byte {
 		retry = false
 		switch x := r.Intn(100); {
 		case x < 10 && len(insns) != 0:
-			// delete instruction
+			// Delete instruction.
 			i := r.Intn(len(insns))
 			copy(insns[i:], insns[i+1:])
 			insns = insns[:len(insns)-1]
 		case x < 40 && len(insns) != 0:
-			// replace instruction with another
+			// Replace instruction with another.
 			insn := randInsn(cfg, r)
 			text1 := insn.Encode(cfg, r)
 			i := r.Intn(len(insns))
 			insns[i] = text1
 		case x < 70 && len(insns) != 0:
-			// mutate instruction
+			// Mutate instruction.
 			i := r.Intn(len(insns))
 			text1 := insns[i]
 			for stop := false; !stop || len(text1) == 0; stop = r.Intn(2) == 0 {
 				switch x := r.Intn(100); {
 				case x < 5 && len(text1) != 0:
-					// delete byte
+					// Delete byte.
 					pos := r.Intn(len(text1))
 					copy(text1[pos:], text1[pos+1:])
 					text1 = text1[:len(text1)-1]
 				case x < 40 && len(text1) != 0:
-					// replace a byte
+					// Replace a byte.
 					pos := r.Intn(len(text1))
 					text1[pos] = byte(r.Intn(256))
 				case x < 70 && len(text1) != 0:
-					// flip a bit
+					// Flip a bit.
 					pos := r.Intn(len(text1))
 					text1[pos] ^= 1 << byte(r.Intn(8))
 				default:
-					// insert a byte
+					// Insert a byte.
 					pos := r.Intn(len(text1) + 1)
 					text1 = append(text1, 0)
 					copy(text1[pos+1:], text1[pos:])
@@ -179,7 +179,7 @@ func Mutate(cfg *Config, r *rand.Rand, text []byte) []byte {
 			}
 			insns[i] = text1
 		case len(insns) < cfg.Len:
-			// insert a new instruction
+			// Insert a new instruction.
 			insn := randInsn(cfg, r)
 			text1 := insn.Encode(cfg, r)
 			i := r.Intn(len(insns) + 1)

--- a/pkg/ifuzz/pseudo.go
+++ b/pkg/ifuzz/pseudo.go
@@ -162,7 +162,7 @@ func initPseudo() {
 			}
 			reg := uint8(r.Intn(6))
 			gen.mov16(regAX, sel)
-			gen.byte(0x8e, 0xc0|(reg<<3)) // mov %ax, %seg
+			gen.byte(0x8e, 0xc0|(reg<<3)) // MOV %ax, %seg
 			return gen.text
 		},
 	})
@@ -421,10 +421,10 @@ func (gen *generator) xor32(reg int, v uint32) {
 
 func (gen *generator) readCR(cr uint8) {
 	if cr < 8 {
-		// mov %crN, %eax/%rax
+		// MOV %crN, %eax/%rax
 		gen.byte(0x0f, 0x20, 0xc0|cr<<3)
 	} else if cr < 16 {
-		// mov %crN, %eax/%rax
+		// MOV %crN, %eax/%rax
 		gen.byte(0x44, 0x0f, 0x20, 0xc0|(cr-8)<<3)
 	} else {
 		panic("bad cr")
@@ -433,10 +433,10 @@ func (gen *generator) readCR(cr uint8) {
 
 func (gen *generator) writeCR(cr uint8) {
 	if cr < 8 {
-		// mov %eax/%rax, %crN
+		// MOV %eax/%rax, %crN
 		gen.byte(0x0f, 0x22, 0xc0|cr<<3)
 	} else if cr < 16 {
-		// mov %eax/%rax, %crN
+		// MOV %eax/%rax, %crN
 		gen.byte(0x44, 0x0f, 0x22, 0xc0|(cr-8)<<3)
 	} else {
 		panic("bad cr")
@@ -447,7 +447,7 @@ func (gen *generator) readDR(dr uint8) {
 	if dr >= 8 {
 		panic("bad dr")
 	}
-	// mov %drN, %eax/%rax
+	// MOV %drN, %eax/%rax
 	gen.byte(0x0f, 0x21, 0xc0|dr<<3)
 }
 
@@ -455,7 +455,7 @@ func (gen *generator) writeDR(dr uint8) {
 	if dr >= 8 {
 		panic("bad dr")
 	}
-	// mov %eax/%rax, %drN
+	// MOV %eax/%rax, %drN
 	gen.byte(0x0f, 0x23, 0xc0|dr<<3)
 }
 

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -507,7 +507,8 @@ type executeReq struct {
 	faultCall uint64
 	faultNth  uint64
 	progSize  uint64
-	// prog follows on pipe or in shmem
+	// This structure is followed by a serialized test program in encodingexec format.
+	// Both when sent over a pipe or in shared memory.
 }
 
 type executeReply struct {

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -139,7 +139,7 @@ func (ctx *fuchsia) processPC(out *bytes.Buffer, symb *symbolizer.Symbolizer,
 		file := ctx.trimFile(frame.File)
 		name := demangle.Filter(frame.Func, demangle.NoParams, demangle.NoTemplateParams)
 		if strings.Contains(name, "<lambda(") {
-			// demangle produces super long (full) names for lambdas.
+			// Demangling produces super long (full) names for lambdas.
 			name = "lambda"
 		}
 		id := "[ inline ]"

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -318,7 +318,7 @@ func (ctx *linux) stripLinePrefix(line []byte, context string, useQuestionable b
 			pos := bytes.Index(line, []byte(" ? "))
 			return line[pos+2:], !useQuestionable
 		}
-		// powerpc suffix.
+		// PowerPC suffix.
 		if bytes.HasSuffix(line, []byte(" (unreliable)")) {
 			return line[:len(line)-13], !useQuestionable
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -263,7 +263,7 @@ var dynamicTitleReplacement = []replacement{
 		"syz-executor",
 	},
 	{
-		// syzkaller binaries are coming from repro.
+		// Executor process IDs are dynamic and are not interesting.
 		regexp.MustCompile(`syzkaller[0-9]+((/|:)[0-9]+)?`),
 		"syzkaller",
 	},

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -27,7 +27,7 @@ func newFuchsia(vm, dir string) *fuchsia {
 
 func (ctx *fuchsia) Poll(repo, branch string) (*Commit, error) {
 	if repo != "https://fuchsia.googlesource.com" || branch != "master" {
-		// fuchsia ecosystem is hard-tailored to the main repo.
+		// Fuchsia ecosystem is hard-wired to the main repo.
 		return nil, fmt.Errorf("fuchsia: can only check out https://fuchsia.googlesource.com/master")
 	}
 	if _, err := runSandboxed(ctx.dir, "./.jiri_root/bin/jiri", "update"); err != nil {

--- a/pkg/vcs/linux_test.go
+++ b/pkg/vcs/linux_test.go
@@ -18,9 +18,9 @@ import (
 type MinimizationTest struct {
 	config         string
 	baselineConfig string
-	// Output contains expected config option
+	// Output contains expected config option.
 	expectedConfig string
-	// Minimization is expected to pass or fail
+	// Minimization is expected to pass or fail.
 	passing bool
 }
 
@@ -104,7 +104,7 @@ func createTestLinuxRepo(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	// Copy stubbed scripts used by config bisect
+	// Copy stubbed scripts used by config bisect.
 	err = osutil.CopyFile("testdata/linux/config-bisect.pl",
 		baseDir+"/tools/testing/ktest/config-bisect.pl")
 	if err != nil {

--- a/prog/analysis.go
+++ b/prog/analysis.go
@@ -100,11 +100,11 @@ func (s *state) analyzeImpl(c *Call, resources bool) {
 }
 
 type ArgCtx struct {
-	Parent *[]Arg      // GroupArg.Inner (for structs) or Call.Args containing this arg
-	Fields []Field     // Fields of the parent struct/syscall
-	Base   *PointerArg // pointer to the base of the heap object containing this arg
-	Offset uint64      // offset of this arg from the base
-	Stop   bool        // if set by the callback, subargs of this arg are not visited
+	Parent *[]Arg      // GroupArg.Inner (for structs) or Call.Args containing this arg.
+	Fields []Field     // Fields of the parent struct/syscall.
+	Base   *PointerArg // Pointer to the base of the heap object containing this arg.
+	Offset uint64      // Offset of this arg from the base.
+	Stop   bool        // If set by the callback, subargs of this arg are not visited.
 }
 
 func ForeachSubArg(arg Arg, f func(Arg, *ArgCtx)) {

--- a/prog/hints.go
+++ b/prog/hints.go
@@ -218,7 +218,7 @@ func shrinkExpand(v uint64, compMap CompMap, bitsize uint64) []uint64 {
 				mutant = swapInt(mutant, width)
 			}
 			for newV := range compMap[mutant] {
-				// Check the limit for negative numbers
+				// Check the limit for negative numbers.
 				if newV > limit && ((^(limit >> 1) & newV) != ^(limit >> 1)) {
 					continue
 				}

--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Minimize minimizes program p into an equivalent program using the equivalence
-// predicate pred.  It iteratively generates simpler programs and asks pred
+// predicate pred. It iteratively generates simpler programs and asks pred
 // whether it is equal to the original program or not. If it is equivalent then
 // the simplification attempt is committed and the process continues.
 func Minimize(p0 *Prog, callIndex0 int, crash bool, pred0 func(*Prog, int) bool) (*Prog, int) {

--- a/prog/mutation_test.go
+++ b/prog/mutation_test.go
@@ -102,17 +102,17 @@ func TestMutateArgument(t *testing.T) {
 			`mutate_integer2(0x00, 0x00, 0x20, 0x00, 0x01)`,
 			`mutate_integer2(0x00, 0x00, 0x20, 0x00, 0x07)`,
 		},
-		// Mutate an array of structs
+		// Mutate an array of structs.
 		{
 			`mutate_array2(&(0x7f0000000000)=[{0x0}, {0x0}, {0x0}, {0x0}, {0x0}])`,
 			`mutate_array2(&(0x7f0000000000)=[{0x0}, {0x0}, {0x3}, {0x0}, {0x0}])`,
 		},
-		// Mutate a non-special union that have more than 1 option
+		// Mutate a non-special union that have more than 1 option.
 		{
 			`mutate_union(&(0x7f0000000000)=@f1=[0x0, 0x1, 0x2, 0x3, 0x0, 0x1, 0x2, 0x3, 0x0, 0x0])`,
 			`mutate_union(&(0x7f0000000000)=@f0=0x2)`,
 		},
-		// Mutate the value of the current option in union
+		// Mutate the value of the current option in union.
 		{
 			`mutate_union(&(0x7f0000000000)=@f1=[0x0, 0x1, 0x2, 0x3, 0x0, 0x1, 0x2, 0x3, 0x0, 0x0])`,
 			`mutate_union(&(0x7f0000000000)=@f1=[0x0, 0x1, 0xff, 0x3, 0x0, 0x1, 0x2, 0x3, 0x0, 0x0])`,
@@ -318,19 +318,19 @@ mutate8(0x2)
 `, `
 mutate8(0xffffffffffffffff)
 `},
-		// Increase buffer length
+		// Increase buffer length.
 		{`
 mutate_buffer(&(0x7f0000000000)=""/100)
 `, `
 mutate_buffer(&(0x7f0000000000)=""/200)
 `},
-		// Decrease buffer length
+		// Decrease buffer length.
 		{`
 mutate_buffer(&(0x7f0000000000)=""/800)
 `, `
 mutate_buffer(&(0x7f0000000000)=""/4)
 `},
-		// Mutate a ranged buffer
+		// Mutate a ranged buffer.
 		{`
 mutate_rangedbuffer(&(0x7f00000000c0)=""/10)
 `, `
@@ -343,7 +343,7 @@ mutate_rangedbuffer(&(0x7f00000000c0)=""/7)
 
 func TestNegativeMutations(t *testing.T) {
 	tests := [][2]string{
-		// Mutate buffer size outside the range limits
+		// Mutate buffer size outside the range limits.
 		{`
 mutate_rangedbuffer(&(0x7f00000000c0)=""/7)
 `, `

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -260,7 +260,7 @@ type ResultArg struct {
 	OpDiv uint64              // divide result (executed before OpAdd)
 	OpAdd uint64              // add to result
 	Val   uint64              // value used if Res is nil
-	uses  map[*ResultArg]bool // ArgResult args that use this arg
+	uses  map[*ResultArg]bool // args that use this arg
 }
 
 func MakeResultArg(t Type, dir Dir, r *ResultArg, v uint64) *ResultArg {

--- a/prog/resources.go
+++ b/prog/resources.go
@@ -104,14 +104,14 @@ func (target *Target) isCompatibleResource(dst, src string) bool {
 // as a more specialized resource (e.g. socket). Otherwise it does.
 func isCompatibleResourceImpl(dst, src []string, precise bool) bool {
 	if len(dst) > len(src) {
-		// dst is more specialized, e.g dst=socket, src=fd.
+		// Destination resource is more specialized, e.g dst=socket, src=fd.
 		if precise {
 			return false
 		}
 		dst = dst[:len(src)]
 	}
 	if len(src) > len(dst) {
-		// src is more specialized, e.g dst=fd, src=socket.
+		// Source resource is more specialized, e.g dst=fd, src=socket.
 		src = src[:len(dst)]
 	}
 	for i, k := range dst {

--- a/prog/types.go
+++ b/prog/types.go
@@ -231,7 +231,7 @@ type ResourceDesc struct {
 }
 
 type ResourceCtor struct {
-	Call    int // Index in Target.Syscalls
+	Call    int // index in Target.Syscalls
 	Precise bool
 }
 

--- a/sys/akaros/init.go
+++ b/sys/akaros/init.go
@@ -26,7 +26,7 @@ func (arch *arch) Neutralize(c *prog.Call) {
 		c.Args[3].(*prog.ConstArg).Val |= arch.MAP_FIXED
 	case "provision":
 		if pid, ok := c.Args[0].(*prog.ConstArg); ok && uint32(pid.Val) == ^uint32(0) {
-			// pid -1 causes some debugging splat on console.
+			// PID -1 causes some debugging splat on console.
 			pid.Val = 0
 		}
 	}

--- a/sys/linux/init.go
+++ b/sys/linux/init.go
@@ -288,7 +288,7 @@ func (arch *arch) generateTimespec(g *prog.Gen, typ0 prog.Type, dir prog.Dir, ol
 			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, 0),
 		})
 	case g.NOutOf(1, 3):
-		// Few ms ahead for relative, past for absolute
+		// Few ms ahead for relative, past for absolute.
 		nsec := timeout1 * 1e6
 		if g.NOutOf(1, 2) {
 			nsec = timeout2 * 1e6
@@ -301,7 +301,7 @@ func (arch *arch) generateTimespec(g *prog.Gen, typ0 prog.Type, dir prog.Dir, ol
 			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, nsec),
 		})
 	case g.NOutOf(1, 2):
-		// Unreachable fututre for both relative and absolute
+		// Unreachable fututre for both relative and absolute.
 		arg = prog.MakeGroupArg(typ, dir, []prog.Arg{
 			prog.MakeResultArg(typ.Fields[0].Type, dir, nil, 2e9),
 			prog.MakeResultArg(typ.Fields[1].Type, dir, nil, 0),

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -89,7 +89,7 @@ var List = map[string]map[string]*Target{
 		"64": {
 			PtrSize:  8,
 			PageSize: 4 << 10,
-			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le
+			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le.
 			CFlags: []string{"-m64", "-fsanitize=address", "-no-pie"},
 			osCommon: osCommon{
 				SyscallNumbers:         true,
@@ -102,7 +102,7 @@ var List = map[string]map[string]*Target{
 		"64_fork": {
 			PtrSize:  8,
 			PageSize: 8 << 10,
-			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le
+			// Compile with -no-pie due to issues with ASan + ASLR on ppc64le.
 			CFlags: []string{"-m64", "-fsanitize=address", "-no-pie"},
 			osCommon: osCommon{
 				SyscallNumbers:         true,

--- a/syz-ci/managercmd.go
+++ b/syz-ci/managercmd.go
@@ -70,8 +70,8 @@ func (mc *ManagerCmd) loop() {
 	}()
 	for closing != nil || cmd != nil {
 		if cmd == nil {
-			// cmd is not running
-			// don't restart too frequently (in case it instantly exits with an error)
+			// The command is not running.
+			// Don't restart too frequently (in case it instantly exits with an error).
 			if time.Since(started) > restartPeriod {
 				started = time.Now()
 				osutil.Rename(mc.log, mc.log+".old")
@@ -96,7 +96,7 @@ func (mc *ManagerCmd) loop() {
 				}
 			}
 		} else {
-			// cmd is running
+			// The command is running. Check if we need to kill it.
 			if closing == nil && time.Since(interrupted) > interruptTimeout {
 				log.Logf(1, "%v: killing manager", mc.name)
 				cmd.Process.Kill()

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -108,7 +108,7 @@ type ManagerConfig struct {
 	Compiler     string `json:"compiler"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
-	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig
+	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig.
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
 	// File with kernel cmdline values (optional).
 	KernelCmdline string `json:"kernel_cmdline"`

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -32,7 +32,10 @@ func returnString() string { return "foo" }
 //	  Tab and spaces.	// want "Use either //<one-or-more-spaces>comment or //<one-or-more-tabs>comment format for comments"
 // 	Space and tab.		// want "Use either //<one-or-more-spaces>comment or //<one-or-more-tabs>comment format for comments"
 func checkCommentSpace() {
-	// Comment without a dot at the end
+	checkCommentSpace() // lower-case comment is OK
+	// Capital letter comment.
+	checkCommentSpace()
+	// Don't use 2 spaces after dot.  Like this.	// want "Use one space after a period"
 	checkCommentSpace()
 }
 
@@ -46,7 +49,7 @@ func funcArgsBad0(a int, b int) { // want "Use 'a, b int'"
 }
 
 func funcArgsBad1() (a int, b int) { // want "Use 'a, b int'"
-	return 0, 0
+	return 0, 0	// lower-case comment is OK
 }
 
 func funcArgsBad2(a int16, b, c uint32, d uint32, e int16) { // want "Use 'b, c, d uint32'"
@@ -66,7 +69,7 @@ func logErrorMessages() {
 	log.Fatalf("Bad message %v", 1) // want "Don't start log/error messages with a Capital letter"
 	log.Printf("Bad message %v", 1) // want "Don't start log/error messages with a Capital letter"
 	log.Print("Bad message") // want "Don't start log/error messages with a Capital letter"
-	log.Print("also ad message.") // want "Don't use dot at the end of log/error messages"
+	log.Print("also ad message.") // want "Don't use period at the end of log/error messages"
 	log.Print("no new lines\n") // want "Don't use \\\\n at the end of log/error messages"
 	log.Print("") // want "Don't use empty log/error messages"
 }

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -322,10 +322,10 @@ func (inst *instance) checkBatteryLevel() error {
 func (inst *instance) getBatteryLevel(numRetry int) (int, error) {
 	out, err := inst.adb("shell", "dumpsys battery | grep level:")
 
-	// allow for retrying for devices that does not boot up so fast
+	// Allow for retrying for devices that does not boot up so fast.
 	for ; numRetry >= 0 && err != nil; numRetry-- {
 		if numRetry > 0 {
-			// sleep for 5 seconds before retrying
+			// Sleep for 5 seconds before retrying.
 			time.Sleep(5 * time.Second)
 			out, err = inst.adb("shell", "dumpsys battery | grep level:")
 		}

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -112,9 +112,9 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	// Destroy a lingering snapshot and clone.
 	osutil.RunCmd(time.Minute, "", "zfs", "destroy", "-R", snapshot)
 
-	// Create a snapshot of the data set containing the VM image.  bhyve will
-	// use a clone of the snapshot, which gets recreated every time the VM
-	// is restarted.  This is all to work around bhyve's current lack of an
+	// Create a snapshot of the data set containing the VM image.
+	// bhyve will use a clone of the snapshot, which gets recreated every time the VM
+	// is restarted. This is all to work around bhyve's current lack of an
 	// image snapshot facility.
 	if _, err := osutil.RunCmd(time.Minute, "", "zfs", "snapshot", snapshot); err != nil {
 		inst.Close()

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -307,7 +307,7 @@ func (inst *instance) waitForReboot(timeout int) error {
 		if !vmimpl.SleepInterruptible(time.Second) {
 			return fmt.Errorf("shutdown in progress")
 		}
-		// If it fails, then the reboot started
+		// If it fails, then the reboot started.
 		if err = inst.ssh("pwd"); err != nil {
 			return nil
 		}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -84,8 +84,8 @@ func init() {
 type Test struct {
 	Name           string
 	Exit           ExitCondition
-	DiagnoseBug    bool // Diagnose produces output that is detected as kernel crash
-	DiagnoseNoWait bool // Diagnose returns output directly rather than to console
+	DiagnoseBug    bool // Diagnose produces output that is detected as kernel crash.
+	DiagnoseNoWait bool // Diagnose returns output directly rather than to console.
 	Body           func(outc chan []byte, errc chan error)
 	Report         *report.Report
 }

--- a/vm/vmimpl/console.go
+++ b/vm/vmimpl/console.go
@@ -31,11 +31,11 @@ func OpenConsole(con string) (rc io.ReadCloser, err error) {
 	if errno != 0 {
 		return nil, fmt.Errorf("failed to get console termios: %v", errno)
 	}
-	// no parity bit, only need 1 stop bit, no hardware flowcontrol
+	// No parity bit, only need 1 stop bit, no hardware flowcontrol,
 	term.Cflag &^= unixCBAUD | unix.CSIZE | unix.PARENB | unix.CSTOPB | unixCRTSCTS
-	// ignore modem controls
+	// Ignore modem controls.
 	term.Cflag |= unix.B115200 | unix.CS8 | unix.CLOCAL | unix.CREAD
-	// setup for non-canonical mode
+	// Setup for non-canonical mode.
 	term.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR |
 		unix.IGNCR | unix.ICRNL | unix.IXON
 	term.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN

--- a/vm/vmimpl/freebsd.go
+++ b/vm/vmimpl/freebsd.go
@@ -9,9 +9,9 @@ import (
 )
 
 // DiagnoseFreeBSD sends the debug commands to the given writer which
-// is expected to be connected to a panicked FreeBSD kernel.  If kernel
-// just hanged, we've lost connection or detected some non-panic
-// error, console still shows normal login prompt.
+// is expected to be connected to a panicked FreeBSD kernel. If kernel
+// just hanged, we've lost connection or detected some non-panic error,
+// console still shows normal login prompt.
 func DiagnoseFreeBSD(w io.Writer) ([]byte, bool) {
 	commands := []string{
 		"",

--- a/vm/vmimpl/openbsd.go
+++ b/vm/vmimpl/openbsd.go
@@ -9,9 +9,9 @@ import (
 )
 
 // DiagnoseOpenBSD sends the debug commands to the given writer which
-// is expected to be connected to a paniced openbsd kernel.  If kernel
-// just hanged, we've lost connection or detected some non-panic
-// error, console still shows normal login prompt.
+// is expected to be connected to a paniced openbsd kernel. If kernel
+// just hanged, we've lost connection or detected some non-panic error,
+// console still shows normal login prompt.
 func DiagnoseOpenBSD(w io.Writer) ([]byte, bool) {
 	commands := []string{
 		"",


### PR DESCRIPTION
This includes 2 commits that check for some comment style violations and fix these violations.

tools/syz-linter: check comments format

Check for capitalization, dots at the end
and two spaces after a period.

all: fix comments format

Fix capitalization, dots at the end
and two spaces after a period.

Update #1876