### PR TITLE
Makefile: set GO111MODULE=off for go get in install_prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ install_prerequisites:
 	sudo apt-get install -y -q g++-s390x-linux-gnu || true
 	sudo apt-get install -y -q g++-riscv64-linux-gnu || true
 	sudo apt-get install -y -q clang clang-format ragel
-	go get -u golang.org/x/tools/cmd/goyacc
+	GO111MODULE=off go get -u golang.org/x/tools/cmd/goyacc
 
 check_copyright:
 	./tools/check-copyright.sh


### PR DESCRIPTION
Otherwise the versions in go.mod are updated on running `make
install_prerequisites` leading to inconsistent vendoring errors:

```
go: inconsistent vendoring in /go/src/github.com/google/syzkaller:
	golang.org/x/net@v0.0.0-20200625001655-4c5254603344: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/tools@v0.0.0-20200717024301-6ddee64345a6: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/net@v0.0.0-20200520182314-0ba52f642ac2: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
	golang.org/x/tools@v0.0.0-20200626171337-aa94e735be7f: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
```