### PR TITLE
executor: fix build errors in setup_32bit_idt()

### DIFF
--- a/executor/common_kvm_amd64.h
+++ b/executor/common_kvm_amd64.h
@@ -208,7 +208,7 @@ static void setup_32bit_idt(struct kvm_sregs* sregs, char* host_mem, uintptr_t g
 			gate.type = 15;
 			gate.base = SEL_CS32;
 			break;
-		case 6:
+		case 5:
 			// 32-bit task gate
 			gate.type = 11;
 			gate.base = SEL_TGATE32;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -5651,7 +5651,7 @@ static void setup_32bit_idt(struct kvm_sregs* sregs, char* host_mem, uintptr_t g
 			gate.type = 15;
 			gate.base = SEL_CS32;
 			break;
-		case 6:
+		case 5:
 			gate.type = 11;
 			gate.base = SEL_TGATE32;
 			break;


### PR DESCRIPTION
Fix build errors:
```
gcc -o ./bin/linux_amd64/syz-executor executor/executor.cc \
-m64 -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384  -DGOOS_linux=1 -DGOARCH_amd64=1 \
-DHOSTGOOS_linux=1 -DGIT_REVISION=\"d88894e6773ab63ac8b3f4b2edbae88290aaf0d6\"
In file included from executor/common_linux.h:1867,
from executor/common.h:394,
from executor/executor.cc:146:
executor/common_kvm_amd64.h: In function ‘void setup_32bit_idt(kvm_sregs*, char*, uintptr_t)’:
executor/common_kvm_amd64.h:143:64: error: ‘gate.kvm_segment::type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
143 |  uint64 sd = (limit & 0xffff) | (seg->base & 0xffffff) << 16 | (uint64)seg->type<< 40 | (uint64)seg->s << 44 | (uint64)seg->dpl << 45 | (uint64)seg->present << 47 | (limit & 0xf0000ULL) << 48 | (uint64)seg->avl << 52 | (uint64)seg->l << 53 | (uint64)seg->db << 54 | (uint64)seg->g << 55 | (seg->base & 0xff000000ULL) << 56;
|                                                                ^~~~~~~~~~~~~~~~~
In file included from executor/common_linux.h:1867,
from executor/common.h:394,
from executor/executor.cc:146:
executor/common_kvm_amd64.h:183:22: note: ‘gate.kvm_segment::type’ was declared here
183 |   struct kvm_segment gate;
|                      ^~~~
In file included from executor/common_linux.h:1867,
from executor/common.h:394,
from executor/executor.cc:146:
executor/common_kvm_amd64.h:143:56: error: ‘gate.kvm_segment::base’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
143 |  uint64 sd = (limit & 0xffff) | (seg->base & 0xffffff) << 16 | (uint64)seg->type<< 40 | (uint64)seg->s << 44 | (uint64)seg->dpl << 45 | (uint64)seg->present << 47 | (limit & 0xf0000ULL) << 48 | (uint64)seg->avl << 52 | (uint64)seg->l << 53 | (uint64)seg->db << 54 | (uint64)seg->g << 55 | (seg->base & 0xff000000ULL) << 56;
|                                 ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
In file included from executor/common_linux.h:1867,
from executor/common.h:394,
from executor/executor.cc:146:
executor/common_kvm_amd64.h:183:22: note: ‘gate.kvm_segment::base’ was declared here
183 |   struct kvm_segment gate;
|                      ^~~~
cc1plus: all warnings being treated as errors
```