### PR TITLE
Revert "executor: enable extra coverage on OpenBSD"

### DIFF
--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -66,13 +66,6 @@ static void cover_open(cover_t* cov, bool extra)
 	unsigned long cover_size = kCoverSize;
 	if (ioctl(cov->fd, KIOSETBUFSIZE, &cover_size))
 		fail("ioctl init trace write failed");
-	if (extra) {
-		struct kio_remote_attach args;
-		args.subsystem = KCOV_REMOTE_COMMON;
-		args.id = 0;
-		if (ioctl(cov->fd, KIOREMOTEATTACH, &args))
-			fail("ioctl remote attach failed");
-	}
 	size_t mmap_alloc_size = kCoverSize * (is_kernel_64_bit ? 8 : 4);
 #elif GOOS_netbsd
 	uint64_t cover_size;
@@ -142,8 +135,6 @@ static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
 		exitf("cover enable write trace failed, mode=%d", kcov_mode);
 #elif GOOS_openbsd
 	// OpenBSD uses an pointer to an int as the third argument.
-	// Whether it is a regular coverage or an extra coverage, the enable
-	// ioctl is the same.
 	if (ioctl(cov->fd, KIOENABLE, &kcov_mode))
 		exitf("cover enable write trace failed, mode=%d", kcov_mode);
 #elif GOOS_netbsd

--- a/pkg/host/host_openbsd.go
+++ b/pkg/host/host_openbsd.go
@@ -31,7 +31,6 @@ func isSupportedVMM() (bool, string) {
 func init() {
 	checkFeature[FeatureCoverage] = unconditionallyEnabled
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
-	checkFeature[FeatureExtraCoverage] = unconditionallyEnabled
 	checkFeature[FeatureNetInjection] = unconditionallyEnabled
 	checkFeature[FeatureSandboxSetuid] = unconditionallyEnabled
 }


### PR DESCRIPTION
Forgot that the build machine must be updated to a newer OpenBSD
snapshot first in order to make the new kcov stuff available.

This reverts commit 96dd36234d97bbf6b403f3a7f03cfc0296422879.