### PR TITLE
pkg/compiler: check for unused resources

### DIFF
--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -547,16 +547,17 @@ type structDir struct {
 }
 
 func (comp *compiler) checkConstructors() {
-	ctors := make(map[string]bool) // resources for which we have ctors
+	ctors := make(map[string]bool)  // resources for which we have ctors
+	inputs := make(map[string]bool) // resources which are used as inputs
 	checked := make(map[structDir]bool)
 	for _, decl := range comp.desc.Nodes {
 		switch n := decl.(type) {
 		case *ast.Call:
 			for _, arg := range n.Args {
-				comp.checkTypeCtors(arg.Type, prog.DirIn, true, ctors, checked)
+				comp.checkTypeCtors(arg.Type, prog.DirIn, true, ctors, inputs, checked)
 			}
 			if n.Ret != nil {
-				comp.checkTypeCtors(n.Ret, prog.DirOut, true, ctors, checked)
+				comp.checkTypeCtors(n.Ret, prog.DirOut, true, ctors, inputs, checked)
 			}
 		}
 	}
@@ -564,17 +565,23 @@ func (comp *compiler) checkConstructors() {
 		switch n := decl.(type) {
 		case *ast.Resource:
 			name := n.Name.Name
-			if !ctors[name] && comp.used[name] {
+			if !comp.used[name] {
+				continue
+			}
+			if !ctors[name] {
 				comp.error(n.Pos, "resource %v can't be created"+
-					" (never mentioned as a syscall return value or output argument/field)",
-					name)
+					" (never mentioned as a syscall return value or output argument/field)", name)
+			}
+			if !inputs[name] {
+				comp.error(n.Pos, "resource %v is never used as an input"+
+					"(such resources are not useful)", name)
 			}
 		}
 	}
 }
 
 func (comp *compiler) checkTypeCtors(t *ast.Type, dir prog.Dir, isArg bool,
-	ctors map[string]bool, checked map[structDir]bool) {
+	ctors, inputs map[string]bool, checked map[structDir]bool) {
 	desc := comp.getTypeDesc(t)
 	if desc == typeResource {
 		// TODO(dvyukov): consider changing this to "dir == prog.DirOut".
@@ -589,6 +596,13 @@ func (comp *compiler) checkTypeCtors(t *ast.Type, dir prog.Dir, isArg bool,
 				r = comp.resources[r.Base.Ident]
 			}
 		}
+		if dir != prog.DirOut {
+			r := comp.resources[t.Ident]
+			for r != nil && !inputs[r.Name.Name] {
+				inputs[r.Name.Name] = true
+				r = comp.resources[r.Base.Ident]
+			}
+		}
 		return
 	}
 	if desc == typeStruct {
@@ -600,7 +614,7 @@ func (comp *compiler) checkTypeCtors(t *ast.Type, dir prog.Dir, isArg bool,
 		}
 		checked[key] = true
 		for _, fld := range s.Fields {
-			comp.checkTypeCtors(fld.Type, dir, false, ctors, checked)
+			comp.checkTypeCtors(fld.Type, dir, false, ctors, inputs, checked)
 		}
 		return
 	}
@@ -610,7 +624,7 @@ func (comp *compiler) checkTypeCtors(t *ast.Type, dir prog.Dir, isArg bool,
 	_, args, _ := comp.getArgsBase(t, isArg)
 	for i, arg := range args {
 		if desc.Args[i].Type == typeArgType {
-			comp.checkTypeCtors(arg, dir, desc.Args[i].IsArg, ctors, checked)
+			comp.checkTypeCtors(arg, dir, desc.Args[i].IsArg, ctors, inputs, checked)
 		}
 	}
 }

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -11,6 +11,7 @@ resource r2[r1]			### recursive resource r2->r1->r2
 resource r3[int32]		### unused resource r3
 
 foo$0(a0 ptr[out, r0], a1 ptr[out, r1], a2 ptr[out, r2])
+foo$1(a0 r0, a1 r1, a2 r2)
 
 # Recursive structs/unions.
 
@@ -175,9 +176,11 @@ resource r104[int8]
 resource r105[int8]
 resource r106[int8]		### resource r106 can't be created (never mentioned as a syscall return value or output argument/field)
 resource r107[int8]		### resource r107 can't be created (never mentioned as a syscall return value or output argument/field)
+resource r108[int8]		### resource r108 is never used as an input(such resources are not useful)
 
-foo$300(a r100)
+foo$300(a0 r100, a1 r101, a2 r102, a3 r103, a4 r104)
 foo$301(a ptr[out, array[r103]], b ptr[in, s300], c r107) r104
+foo$302() r108
 
 s300 {
 	f1	ptr[inout, s301]

--- a/sys/freebsd/socket_inet_icmp.txt
+++ b/sys/freebsd/socket_inet_icmp.txt
@@ -7,12 +7,8 @@ include <sys/types.h>
 include <sys/socket.h>
 include <netinet/in.h>
 
-resource sock_icmp[sock_in]
+socket$inet_icmp(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_ICMP]) sock_in
+socket$inet_icmp_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_ICMP]) sock_in
 
-socket$inet_icmp(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_ICMP]) sock_icmp
-socket$inet_icmp_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_ICMP]) sock_icmp
-
-resource sock_icmp6[sock_in6]
-
-socket$inet6_icmp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_ICMPV6]) sock_icmp6
-socket$inet6_icmp_raw(domain const[AF_INET6], type const[SOCK_RAW], proto const[IPPROTO_ICMPV6]) sock_icmp6
+socket$inet6_icmp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_ICMPV6]) sock_in6
+socket$inet6_icmp_raw(domain const[AF_INET6], type const[SOCK_RAW], proto const[IPPROTO_ICMPV6]) sock_in6

--- a/sys/fuchsia/events.txt
+++ b/sys/fuchsia/events.txt
@@ -3,8 +3,5 @@
 
 include <zircon/syscalls.h>
 
-resource zx_event[zx_handle]
-resource zx_eventpair[zx_handle]
-
-zx_event_create(options const[0], out ptr[out, zx_event])
-zx_eventpair_create(options const[0], out0 ptr[out, zx_event], out1 ptr[out, zx_event])
+zx_event_create(options const[0], out ptr[out, zx_handle])
+zx_eventpair_create(options const[0], out0 ptr[out, zx_handle], out1 ptr[out, zx_handle])

--- a/sys/fuchsia/fuchsia_io.syz.txt
+++ b/sys/fuchsia/fuchsia_io.syz.txt
@@ -11,8 +11,8 @@ fuchsia_io_ServiceHandles {
 } [packed]
 
 fuchsia_io_FileObjectHandles {
-	event	zx_event
-	stream	zx_stream
+	event	zx_handle
+	stream	zx_handle
 } [packed]
 
 fuchsia_io_DirectoryObjectHandles {
@@ -28,15 +28,15 @@ fuchsia_io_VmofileHandles {
 } [packed]
 
 fuchsia_io_DeviceHandles {
-	event	zx_eventpair
+	event	zx_handle
 } [packed]
 
 fuchsia_io_TtyHandles {
-	event	zx_eventpair
+	event	zx_handle
 } [packed]
 
 fuchsia_io_DatagramSocketHandles {
-	event	zx_eventpair
+	event	zx_handle
 } [packed]
 
 fuchsia_io_StreamSocketHandles {

--- a/sys/fuchsia/objects.txt
+++ b/sys/fuchsia/objects.txt
@@ -8,8 +8,7 @@ include <zircon/syscalls/port.h>
 
 resource koid[int64]: 0
 
-# TODO: temporary disabled as it crashes kernel left and right.
-# zx_object_get_child(handle zx_handle, koid koid, rights flags[zx_rights], out ptr[out, zx_handle])
+zx_object_get_child(handle zx_handle, koid koid, rights flags[zx_rights], out ptr[out, zx_handle])
 zx_object_get_info$ZX_INFO_HANDLE_VALID(handle zx_handle, topic const[ZX_INFO_HANDLE_VALID], buffer const[0], buffer_size const[0], actual ptr[out, intptr], avail ptr[out, intptr])
 zx_object_get_info$ZX_INFO_HANDLE_BASIC(handle zx_handle, topic const[ZX_INFO_HANDLE_BASIC], buffer ptr[out, zx_info_handle_basic], buffer_size bytesize[buffer], actual ptr[out, intptr], avail ptr[out, intptr])
 zx_object_get_info$ZX_INFO_HANDLE_COUNT(handle zx_handle, topic const[ZX_INFO_HANDLE_COUNT], buffer ptr[out, zx_info_handle_count], buffer_size bytesize[buffer], actual ptr[out, intptr], avail ptr[out, intptr])

--- a/sys/fuchsia/posix.txt
+++ b/sys/fuchsia/posix.txt
@@ -15,7 +15,6 @@ include <unistd.h>
 include <utime.h>
 
 resource fd[int32]: 0xffffffffffffffff, AT_FDCWD
-resource pid[int32]: 0, 0xffffffffffffffff
 resource uid[int32]: 0, 0xffffffffffffffff
 resource gid[int32]: 0, 0xffffffffffffffff
 
@@ -78,7 +77,7 @@ chdir(dir ptr[in, filename])
 
 getgid() gid
 getuid() uid
-getpid() pid
+getpid()
 
 pipe(pipefd ptr[out, pipefd])
 

--- a/sys/fuchsia/streams.txt
+++ b/sys/fuchsia/streams.txt
@@ -3,6 +3,4 @@
 
 include <zircon/syscalls.h>
 
-resource zx_stream[zx_handle]
-
 # TODO: Add stream-related system calls.

--- a/sys/linux/bpf.txt
+++ b/sys/linux/bpf.txt
@@ -10,14 +10,12 @@ include <uapi/linux/btf.h>
 
 resource fd_bpf_map[fd]: BPF_PSEUDO_MAP_FD
 resource fd_bpf_prog[fd]
-resource fd_rawtp[fd_perf_base]
 resource fd_btf[fd]
 resource bpf_prog_id[int32]: 0, -1
 resource bpf_map_id[int32]: 0, -1
 resource bpf_btf_id[int32]: 0, -1
 resource bpf_link_id[int32]: 0, -1
 resource fd_bpf_link[fd]
-resource fd_bpf_iter[fd]
 
 # NEED: this is a random index in btf_header:types. We can't express this, so we just use a small index.
 type btf_type_id int32[1:5]
@@ -50,7 +48,7 @@ bpf$BPF_GET_PROG_INFO(cmd const[BPF_OBJ_GET_INFO_BY_FD], arg ptr[in, bpf_get_pro
 bpf$BPF_GET_MAP_INFO(cmd const[BPF_OBJ_GET_INFO_BY_FD], arg ptr[in, bpf_get_map_info_arg], size len[arg])
 bpf$BPF_GET_BTF_INFO(cmd const[BPF_OBJ_GET_INFO_BY_FD], arg ptr[in, bpf_get_btf_info_arg], size len[arg])
 bpf$BPF_PROG_QUERY(cmd const[BPF_PROG_QUERY], arg ptr[in, bpf_prog_query], size len[arg])
-bpf$BPF_RAW_TRACEPOINT_OPEN(cmd const[BPF_RAW_TRACEPOINT_OPEN], arg ptr[in, bpf_raw_tracepoint], size len[arg]) fd_rawtp
+bpf$BPF_RAW_TRACEPOINT_OPEN(cmd const[BPF_RAW_TRACEPOINT_OPEN], arg ptr[in, bpf_raw_tracepoint], size len[arg]) fd_perf_base
 bpf$BPF_BTF_LOAD(cmd const[BPF_BTF_LOAD], arg ptr[in, bpf_btf_load], size len[arg]) fd_btf
 bpf$BPF_BTF_GET_FD_BY_ID(cmd const[BPF_BTF_GET_FD_BY_ID], arg ptr[in, bpf_btf_id], size len[arg]) fd_btf
 bpf$BPF_TASK_FD_QUERY(cmd const[BPF_TASK_FD_QUERY], arg ptr[inout, bpf_task_fd_query], size len[arg])
@@ -63,7 +61,7 @@ bpf$BPF_MAP_LOOKUP_AND_DELETE_BATCH(cmd const[BPF_MAP_LOOKUP_AND_DELETE_BATCH], 
 bpf$BPF_LINK_CREATE(cmd const[BPF_LINK_CREATE], arg ptr[in, bpf_link_create_arg], size len[arg]) fd_bpf_link
 bpf$BPF_LINK_UPDATE(cmd const[BPF_LINK_UPDATE], arg ptr[in, bpf_link_update_arg], size len[arg])
 bpf$ENABLE_STATS(cmd const[BPF_ENABLE_STATS], arg ptr[in, bpf_enable_stats_arg], size len[arg])
-bpf$ITER_CREATE(cmd const[BPF_ITER_CREATE], arg ptr[in, bpf_iter_create_arg], size len[arg]) fd_bpf_iter
+bpf$ITER_CREATE(cmd const[BPF_ITER_CREATE], arg ptr[in, bpf_iter_create_arg], size len[arg]) fd
 bpf$LINK_GET_FD_BY_ID(cmd const[BPF_LINK_GET_FD_BY_ID], arg ptr[in, bpf_link_id], size len[arg]) fd_bpf_link
 bpf$LINK_GET_NEXT_ID(cmd const[BPF_LINK_GET_NEXT_ID], arg ptr[inout, bpf_link_get_next_id_arg], size len[arg])
 

--- a/sys/linux/dev_infiniband_rdma.txt
+++ b/sys/linux/dev_infiniband_rdma.txt
@@ -16,19 +16,20 @@ include <uapi/rdma/mlx5_user_ioctl_cmds.h>
 # resources
 resource fd_rdma[fd]
 resource pd_handle[int32]
-resource ah_handle[int32]
 resource mr_handle[int32]
 resource mr_rkey[int32]
-resource mr_lkey[int32]
 resource cq_handle[int32]
 resource qp_handle[int32]
-resource qp_number[int32]
 resource mw_handle[int32]
 resource srq_handle[int32]
 resource xrcd_handle[int32]
 resource wq_handle[int32]
 resource ind_tbl_handle[int32]
 resource flow_handle[int32]
+
+type ah_handle int32
+type mr_lkey int32
+type qp_number int32
 
 # defines
 define IB_USER_VERBS_EX_CMD_QUERY_DEVICE	0x80000001

--- a/sys/linux/dev_sr.txt
+++ b/sys/linux/dev_sr.txt
@@ -3,6 +3,4 @@
 
 include <uapi/linux/fcntl.h>
 
-resource fd_sr[fd_block]
-
-openat$sr(fd const[AT_FDCWD], file ptr[in, string["/dev/sr0"]], flags flags[open_flags], mode const[0]) fd_sr
+openat$sr(fd const[AT_FDCWD], file ptr[in, string["/dev/sr0"]], flags flags[open_flags], mode const[0]) fd

--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -13,7 +13,6 @@ mount$overlay(src const[0], dst ptr[in, filename], type ptr[in, string["overlay"
 mount$binder(src const[0], dst ptr[in, filename], type ptr[in, string["binder"]], flags flags[mount_flags], opts ptr[in, fs_options[binder_options]])
 
 resource fd_fscontext[fd]
-resource fd_open_tree[fd]
 
 fsopen(type ptr[in, string[filesystem]], flags flags[fsopen_flags]) fd_fscontext
 fspick(dfd fd_dir[opt], path ptr[in, filename], flags flags[fspick_flags]) fd_fscontext
@@ -25,9 +24,9 @@ fsconfig$FSCONFIG_SET_PATH_EMPTY(fd fd_fscontext, cmd const[FSCONFIG_SET_PATH_EM
 fsconfig$FSCONFIG_SET_FD(fd fd_fscontext, cmd const[FSCONFIG_SET_FD], key ptr[in, string], value const[0], aux fd)
 fsconfig$FSCONFIG_CMD_CREATE(fd fd_fscontext, cmd const[FSCONFIG_CMD_CREATE], key const[0], value const[0], aux const[0])
 fsconfig$FSCONFIG_CMD_RECONFIGURE(fd fd_fscontext, cmd const[FSCONFIG_CMD_RECONFIGURE], key const[0], value const[0], aux const[0])
-fsmount(fs_fd fd_fscontext, flags flags[fsmount_flags], attr_flags flags[fsmount_attr_flags]) fd_open_tree
+fsmount(fs_fd fd_fscontext, flags flags[fsmount_flags], attr_flags flags[fsmount_attr_flags]) fd
 move_mount(from_dfd fd_dir[opt], from_pathname ptr[in, filename], to_dfd fd_dir[opt], to_pathname ptr[in, filename], flags flags[move_mount_flags])
-open_tree(dfd fd_dir[opt], filename ptr[in, filename], flags flags[open_tree_flags]) fd_open_tree
+open_tree(dfd fd_dir[opt], filename ptr[in, filename], flags flags[open_tree_flags]) fd
 
 open_tree_flags = AT_EMPTY_PATH, AT_NO_AUTOMOUNT, AT_RECURSIVE, AT_SYMLINK_NOFOLLOW, OPEN_TREE_CLONE, OPEN_TREE_CLOEXEC
 fsmount_flags = FSMOUNT_CLOEXEC

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -138,10 +138,9 @@ epoll_ctl$EPOLL_CTL_DEL(epfd fd_epoll, op const[EPOLL_CTL_DEL], fd fd)
 epoll_wait(epfd fd_epoll, events ptr[out, array[epoll_event]], maxevents len[events], timeout int32)
 epoll_pwait(epfd fd_epoll, events ptr[out, array[epoll_event]], maxevents len[events], timeout int32, sigmask ptr[in, sigset_t], size len[sigmask])
 
-resource fd_signal[fd]
 resource fd_timer[fd]
-signalfd(fd fd, mask ptr[in, sigset_t], size len[mask]) fd_signal
-signalfd4(fd fd, mask ptr[in, sigset_t], size len[mask], flags flags[signalfd_flags]) fd_signal
+signalfd(fd fd, mask ptr[in, sigset_t], size len[mask]) fd
+signalfd4(fd fd, mask ptr[in, sigset_t], size len[mask], flags flags[signalfd_flags]) fd
 timerfd_create(clockid flags[clock_type], flags flags[timerfd_create_flags]) fd_timer
 timerfd_settime(fd fd_timer, flags flags[timerfd_settime_flags], new ptr[in, itimerspec], old ptr[out, itimerspec])
 timerfd_gettime(fd fd_timer, cur ptr[out, itimerspec])

--- a/sys/netbsd/fs.txt
+++ b/sys/netbsd/fs.txt
@@ -18,9 +18,10 @@ resource uid[int32]: 0, 0xffffffffffffffff
 resource gid[int32]: 0, 0xffffffffffffffff
 
 resource dev[int64]: 0, 0xffffffffffffffff
-resource mode[int32]: 0, 0xffffffffffffffff
-resource ino[int64]: 0, 0xffffffffffffffff
-resource nlink[int32]: 0, 0xffffffffffffffff
+
+type mode int32
+type ino int64
+type nlink int32
 
 compat_43_ocreat(path ptr[in, filename], mode flags[open_mode])
 open(file ptr[in, filename], flags flags[open_flags], mode flags[open_mode]) fd

--- a/sys/netbsd/vnet.txt
+++ b/sys/netbsd/vnet.txt
@@ -3,11 +3,9 @@
 
 syz_emit_ethernet(len len[packet], packet ptr[in, array[int8]])
 
-resource tcp_seq_num[int32]: 0x41424344
-
 tcp_resources {
-	seq	tcp_seq_num
-	ack	tcp_seq_num
+	seq	int32
+	ack	int32
 }
 
 # These pseudo syscalls read a packet from tap device and extract tcp sequence and acknowledgement numbers from it.

--- a/sys/netbsd/vusb.txt
+++ b/sys/netbsd/vusb.txt
@@ -524,9 +524,7 @@ usb_descriptor_types = USB_DT_DEVICE, USB_DT_CONFIG, USB_DT_STRING, USB_DT_INTER
 # Connected HID devices are known to create the following /dev/ files:
 # /dev/hidraw#, /dev/usb/hiddev# and /dev/input/event#.
 
-resource fd_usb_hid[fd_usb]
-
-syz_usb_connect$hid(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_hid], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb_hid (timeout[3000], prog_timeout[3000])
+syz_usb_connect$hid(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_hid], conn_descs ptr[in, vusb_connect_descriptors]) fd (timeout[3000], prog_timeout[3000])
 
 # idVendor and idProduct are patched by Go code, see sys/linux/init_vusb.go.
 usb_device_descriptor_hid {
@@ -601,9 +599,7 @@ define USBLP_REQ_HP_CHANNEL_CHANGE_REQUEST	0x00
 define USBLP_FIRST_PROTOCOL	1
 define USBLP_LAST_PROTOCOL	3
 
-resource fd_usb_printer[fd_usb]
-
-syz_usb_connect$printer(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_printer], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb_printer (timeout[3000], prog_timeout[3000])
+syz_usb_connect$printer(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_printer], conn_descs ptr[in, vusb_connect_descriptors]) fd (timeout[3000], prog_timeout[3000])
 
 usb_device_descriptor_printer {
 	inner	usb_device_descriptor_t[0, 0, 0, 0x525, 0xa4a8, 64, array[usb_config_descriptor_printer, 1]]
@@ -649,9 +645,7 @@ define USB_ENDPOINT_PRINTER_IN_ADDRESS	(2 | USB_DIR_IN)
 # Connected CDC ECM devices are known to create usbN network interfaces.
 # TODO: write descriptions for those.
 
-resource fd_usb_cdc_ecm[fd_usb]
-
-syz_usb_connect$cdc_ecm(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_cdc_ecm], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb_cdc_ecm (timeout[3000], prog_timeout[3000])
+syz_usb_connect$cdc_ecm(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_cdc_ecm], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb (timeout[3000], prog_timeout[3000])
 
 usb_device_descriptor_cdc_ecm {
 	inner	usb_device_descriptor_t[USB_CLASS_COMM, 0, 0, 0x525, 0xa4a1, 64, array[usb_config_descriptor_cdc_ecm, 1]]
@@ -896,9 +890,7 @@ usb_cdc_mbim_extended_desc {
 # https://elixir.bootlin.com/linux/latest/source/drivers/usb/gadget/legacy/ncm.c
 # https://elixir.bootlin.com/linux/latest/source/drivers/usb/gadget/function/f_ncm.c
 
-resource fd_usb_cdc_ncm[fd_usb]
-
-syz_usb_connect$cdc_ncm(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_cdc_ncm], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb_cdc_ncm (timeout[3000], prog_timeout[3000])
+syz_usb_connect$cdc_ncm(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_cdc_ncm], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb (timeout[3000], prog_timeout[3000])
 
 usb_device_descriptor_cdc_ncm {
 	inner	usb_device_descriptor_t[USB_CLASS_COMM, 0, 0, 0x525, 0xa4a1, 64, array[usb_config_descriptor_cdc_ncm, 1]]
@@ -983,9 +975,7 @@ define USB_CDC_SET_CRC_MODE	0x8a
 
 # TODO: find out which /dev/ files are created by connected UAC1 devices and add descriptions for those.
 
-resource fd_usb_uac1[fd_usb]
-
-syz_usb_connect$uac1(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_uac1], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb_uac1 (timeout[3000], prog_timeout[3000])
+syz_usb_connect$uac1(speed flags[usb_device_speed], dev_len len[dev], dev ptr[in, usb_device_descriptor_uac1], conn_descs ptr[in, vusb_connect_descriptors]) fd_usb (timeout[3000], prog_timeout[3000])
 
 usb_device_descriptor_uac1 {
 	inner	usb_device_descriptor_t[0, 0, 0, 0x1d6b, 0x101, 64, array[usb_config_descriptor_uac1, 1]]

--- a/sys/openbsd/dev_pf.txt
+++ b/sys/openbsd/dev_pf.txt
@@ -10,9 +10,6 @@ include <net/if.h>
 include <net/pfvar.h>
 
 # The following ioctl commands are restricted in neutralize(), see init.go.
-_ = DIOCCLRSTATES
-_ = DIOCKILLSTATES
+_ = DIOCCLRSTATES, DIOCKILLSTATES
 
-resource fd_pf[fd]
-
-openat$pf(fd const[AT_FDCWD], file ptr[in, string["/dev/pf"]], flags flags[open_flags], mode const[0]) fd_pf
+openat$pf(fd const[AT_FDCWD], file ptr[in, string["/dev/pf"]], flags flags[open_flags], mode const[0]) fd

--- a/sys/openbsd/dev_speaker.txt
+++ b/sys/openbsd/dev_speaker.txt
@@ -11,8 +11,8 @@ resource fd_speaker[fd]
 
 openat$speaker(fd const[AT_FDCWD], file ptr[in, string["/dev/speaker"]], flags flags[open_flags], mode const[0]) fd_speaker
 
-ioctl$SPKRTONE(fd fd_diskmap, cmd const[SPKRTONE], arg ptr[in, tone])
-ioctl$SPKRTUNE(fd fd_diskmap, cmd const[SPKRTUNE], arg ptr[in, tone])
+ioctl$SPKRTONE(fd fd_speaker, cmd const[SPKRTONE], arg ptr[in, tone])
+ioctl$SPKRTUNE(fd fd_speaker, cmd const[SPKRTUNE], arg ptr[in, tone])
 
 tone {
 	frequency	int32

--- a/sys/openbsd/wscons.txt
+++ b/sys/openbsd/wscons.txt
@@ -87,10 +87,8 @@ ioctl$WSMOUSEIO_SETMODE(fd fd_wsmouse, cmd const[WSMOUSEIO_SETMODE], arg ptr[in,
 ioctl$WSMOUSEIO_SETPARAMS(fd fd_wsmouse, cmd const[WSMOUSEIO_SETPARAMS], arg ptr[in, wsmouse_parameters])
 ioctl$WSMOUSEIO_SRES(fd fd_wsmouse, cmd const[WSMOUSEIO_SRES], arg ptr[in, int32])
 
-resource fd_wsmux[fd]
-
-openat$wsmuxkbd(fd const[AT_FDCWD], file ptr[in, string["/dev/wskbd"]], flags flags[open_flags], mode const[0]) fd_wsmux
-openat$wsmuxmouse(fd const[AT_FDCWD], file ptr[in, string["/dev/wsmouse"]], flags flags[open_flags], mode const[0]) fd_wsmux
+openat$wsmuxkbd(fd const[AT_FDCWD], file ptr[in, string["/dev/wskbd"]], flags flags[open_flags], mode const[0]) fd
+openat$wsmuxmouse(fd const[AT_FDCWD], file ptr[in, string["/dev/wsmouse"]], flags flags[open_flags], mode const[0]) fd
 
 wsmux_device {
 	type	flags[wsmux_device_flags, int32]

--- a/sys/windows/sys.txt
+++ b/sys/windows/sys.txt
@@ -4,12 +4,11 @@
 include <windows.h>
 
 resource HANDLE[intptr]: INVALID_HANDLE_VALUE
-resource hFile[HANDLE]
 
 syz_execute_func(text ptr[in, text[target]])
 
 CloseHandle(hObject HANDLE)
-CreateFileA(lpFileName ptr[in, filename], dwDesiredAccess flags[file_access_rights], dwShareMode flags[file_share_mode], lpSecurityAttributes ptr[in, SECURITY_ATTRIBUTES, opt], dwCreationDisposition flags[file_create_disposition], dwFlagsAndAttributes flags[file_attributes], hTemplateFile HANDLE[opt]) hFile
+CreateFileA(lpFileName ptr[in, filename], dwDesiredAccess flags[file_access_rights], dwShareMode flags[file_share_mode], lpSecurityAttributes ptr[in, SECURITY_ATTRIBUTES, opt], dwCreationDisposition flags[file_create_disposition], dwFlagsAndAttributes flags[file_attributes], hTemplateFile HANDLE[opt]) HANDLE
 VirtualAlloc(lpAddress vma, dwSize len[lpAddress], flAllocationType flags[allocation_type], flProtect flags[protect_flags])
 
 SECURITY_ATTRIBUTES {


### PR DESCRIPTION
If a resource is never used as an input, it is not useful.
It's effectively the same as using an integer.
Detect such cases, they are quite confusing.
Fix all existing errors in descriptions.
This uncovered some interesting bugs as well,
e.g. use of a completely unrelated fd subtype after copy-paste
(while the resource that was supposed to be used there is completely unused).
