### PR TITLE
tools/check-commits.sh: fix commit range detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           path: gopath/src/github.com/google/syzkaller
           # This is needed for tools/check-commits.sh
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 100
       # Caches everything in .cache dir, in partiuclar we want to cache go-build and golangci-lint stuff.
       # For reference see:
@@ -29,7 +28,9 @@ jobs:
       # Run make presubmit_smoke.
       - name: run
         env:
+          GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_smoke
       # Upload coverage report to codecov.io. For reference see:
       # https://github.com/codecov/codecov-action/blob/master/README.md

--- a/tools/syz-env
+++ b/tools/syz-env
@@ -64,7 +64,9 @@ docker run \
 	--env FUZZIT_API_KEY \
 	--env GITHUB_REF \
 	--env GITHUB_SHA \
+	--env GITHUB_PR_HEAD_SHA \
 	--env GITHUB_PR_BASE_SHA \
+	--env GITHUB_PR_COMMITS \
 	--env CI \
 	${DOCKERARGS[@]} \
 	gcr.io/syzkaller/${IMAGE} -c "$COMMAND"


### PR DESCRIPTION
We currently check from github.event.pull_request.base.sha
to github.event.pull_request.head.sha, but they may be in
different branches if the PR commits are branched not from
the latest master HEAD (at the time of PR creation).
Then GH will create a merge commit, and the range we try
to check is not valid.

Check github.event.pull_request.commits commits backwards
from github.event.pull_request.head.sha commit.
