### PR TITLE
dashboard/app: store and retrieve Recipients data

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -787,15 +787,14 @@ func saveCrash(c context.Context, ns string, req *dashapi.Crash, bugKey *db.Key,
 	if build.Arch == "amd64" {
 		prio += 1e3
 	}
+	maintainers := append(NewRecipients(req.Maintainers, To), ToApp(req.Recipients)...)
 	crash := &Crash{
-		Manager: build.Manager,
-		BuildID: req.BuildID,
-		Time:    timeNow(c),
-		Maintainers: email.MergeEmailLists(req.Maintainers,
-			GetEmails(req.Recipients, dashapi.To),
-			GetEmails(req.Recipients, dashapi.Cc)),
-		ReproOpts: req.ReproOpts,
-		ReportLen: prio,
+		Manager:     build.Manager,
+		BuildID:     req.BuildID,
+		Time:        timeNow(c),
+		Maintainers: maintainers.StringSlice(),
+		ReproOpts:   req.ReproOpts,
+		ReportLen:   prio,
 	}
 	var err error
 	if crash.Log, err = putText(c, ns, textCrashLog, req.Log, false); err != nil {
@@ -1233,15 +1232,4 @@ func limitLength(s string, max int) string {
 		}
 		max--
 	}
-}
-
-func GetEmails(r dashapi.Recipients, filter dashapi.RecipientType) []string {
-	emails := []string{}
-	for _, user := range r {
-		if user.Type == filter {
-			emails = append(emails, user.Address.Address)
-		}
-	}
-	sort.Strings(emails)
-	return emails
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1125,7 +1125,7 @@ func makeUIJob(job *Job, jobKey *db.Key, bug *Bug, crash *Crash, build *Build) *
 			Hash:   com.Hash,
 			Title:  com.Title,
 			Author: fmt.Sprintf("%v <%v>", com.AuthorName, com.Author),
-			CC:     strings.Split(com.CC, "|"),
+			CC:     SplitEmails(strings.Split(com.CC, "|")),
 			Date:   com.Date,
 		})
 	}

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -302,7 +302,7 @@ func createNotification(c context.Context, typ dashapi.BugNotif, public bool, te
 		CC:        kernelRepo.CC,
 	}
 	if public {
-		notif.Maintainers = append(crash.Maintainers, kernelRepo.Maintainers...)
+		notif.Maintainers = append(SplitEmails(crash.Maintainers), kernelRepo.Maintainers...)
 	}
 	if (public || reporting.moderation) && bugReporting.CC != "" {
 		notif.CC = append(notif.CC, strings.Split(bugReporting.CC, "|")...)
@@ -421,7 +421,7 @@ func createBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key
 		Report:       report,
 		ReportLink:   externalLink(c, textCrashReport, crash.Report),
 		CC:           kernelRepo.CC,
-		Maintainers:  append(crash.Maintainers, kernelRepo.Maintainers...),
+		Maintainers:  append(SplitEmails(crash.Maintainers), kernelRepo.Maintainers...),
 		ReproC:       reproC,
 		ReproCLink:   externalLink(c, textReproC, crash.ReproC),
 		ReproSyz:     reproSyz,


### PR DESCRIPTION
This commit will handle the Recipients information on the database. It
creates functions to transform the Recipients information into the way
the old fields (Maintainers, Cc) are stored.
Update #1534

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
