### PR TITLE
dashboard/app: store and retrieve Recipients data

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -787,15 +787,14 @@ func saveCrash(c context.Context, ns string, req *dashapi.Crash, bugKey *db.Key,
 	if build.Arch == "amd64" {
 		prio += 1e3
 	}
+	maintainers := append(NewRecipients(req.Maintainers, To), ToApp(req.Recipients)...)
 	crash := &Crash{
-		Manager: build.Manager,
-		BuildID: req.BuildID,
-		Time:    timeNow(c),
-		Maintainers: email.MergeEmailLists(req.Maintainers,
-			GetEmails(req.Recipients, dashapi.To),
-			GetEmails(req.Recipients, dashapi.Cc)),
-		ReproOpts: req.ReproOpts,
-		ReportLen: prio,
+		Manager:     build.Manager,
+		BuildID:     req.BuildID,
+		Time:        timeNow(c),
+		Maintainers: maintainers.StringSlice(),
+		ReproOpts:   req.ReproOpts,
+		ReportLen:   prio,
 	}
 	var err error
 	if crash.Log, err = putText(c, ns, textCrashLog, req.Log, false); err != nil {
@@ -1233,15 +1232,4 @@ func limitLength(s string, max int) string {
 		}
 		max--
 	}
-}
-
-func GetEmails(r dashapi.Recipients, filter dashapi.RecipientType) []string {
-	emails := []string{}
-	for _, user := range r {
-		if user.Type == filter {
-			emails = append(emails, user.Address.Address)
-		}
-	}
-	sort.Strings(emails)
-	return emails
 }

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -206,7 +206,7 @@ dashboard link: https://testapp.appspot.com/bug?extid=%[1]v
 compiler:       compiler1
 syz repro:      %[4]v
 C reproducer:   %[5]v
-CC:             [author@kernel.org reviewer1@kernel.org reviewer2@kernel.org]
+CC:             [author@kernel.org <reviewer1@kernel.org> <reviewer2@kernel.org>]
 
 The issue was bisected to:
 

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -56,8 +56,8 @@ func handleTestRequest(c context.Context, bugID, user, extID, link, patch, repo,
 		}
 		bug.LastActivity = now
 		bugReporting = bugReportingByName(bug, bugReporting.Name)
-		bugCC := strings.Split(bugReporting.CC, "|")
-		merged := email.MergeEmailLists(bugCC, jobCC)
+		bugTo, bugCC := SplitEmails(strings.Split(bugReporting.CC, "|"))
+		merged := email.MergeEmailLists(jobCC, RecipientStrSlice(bugCC), RecipientStrSlice(bugTo))
 		bugReporting.CC = strings.Join(merged, "|")
 		if _, err := db.Put(c, bugKey, bug); err != nil {
 			return fmt.Errorf("failed to put bug: %v", err)
@@ -489,15 +489,13 @@ func doneJob(c context.Context, req *dashapi.JobDoneReq) error {
 			return err
 		}
 		for _, com := range req.Commits {
-			cc := email.MergeEmailLists(com.CC,
-				GetEmails(com.Recipients, dashapi.To),
-				GetEmails(com.Recipients, dashapi.Cc))
+			cc := append(NewRecipients(sanitizeCC(c, com.CC), To), ToApp(com.Recipients)...)
 			job.Commits = append(job.Commits, Commit{
 				Hash:       com.Hash,
 				Title:      com.Title,
 				Author:     com.Author,
 				AuthorName: com.AuthorName,
-				CC:         strings.Join(sanitizeCC(c, cc), "|"),
+				CC:         cc.String(),
 				Date:       com.Date,
 			})
 		}
@@ -685,7 +683,7 @@ func createBugReportForJob(c context.Context, job *Job, jobKey *db.Key, config i
 		PatchLink:    externalLink(c, textPatch, job.Patch),
 	}
 	if job.Type == JobBisectCause || job.Type == JobBisectFix {
-		rep.Maintainers = append(crash.Maintainers, kernelRepo.Maintainers...)
+		rep.Maintainers = append(RecipientStrSlice(crash.Maintainers), kernelRepo.Maintainers...)
 		rep.ExtID = bugReporting.ExtID
 		if bugReporting.CC != "" {
 			rep.CC = strings.Split(bugReporting.CC, "|")
@@ -729,7 +727,10 @@ func bisectFromJob(c context.Context, rep *dashapi.BugReport, job *Job) *dashapi
 		bisect.Commits = nil
 		com := job.Commits[0]
 		rep.Maintainers = append(rep.Maintainers, com.Author)
-		rep.Maintainers = append(rep.Maintainers, strings.Split(com.CC, "|")...)
+		to, cc := SplitEmails(strings.Split(string(com.CC), "|"))
+		toStr := RecipientStrSlice(to)
+		ccStr := RecipientStrSlice(cc)
+		rep.Maintainers = append(rep.Maintainers, append(toStr, ccStr...)...)
 	}
 	return bisect
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -919,7 +919,7 @@ func makeUICrash(crash *Crash, build *Build) *uiCrash {
 	ui := &uiCrash{
 		Manager:      crash.Manager,
 		Time:         crash.Time,
-		Maintainers:  strings.Join(crash.Maintainers, ", "),
+		Maintainers:  strings.Join(RecipientStrSlice(crash.Maintainers), ", "),
 		LogLink:      textLink(textCrashLog, crash.Log),
 		ReportLink:   textLink(textCrashReport, crash.Report),
 		ReproSyzLink: textLink(textReproSyz, crash.ReproSyz),
@@ -1121,11 +1121,12 @@ func makeUIJob(job *Job, jobKey *db.Key, bug *Bug, crash *Crash, build *Build) *
 		}
 	}
 	for _, com := range job.Commits {
+		to, cc := SplitEmails(strings.Split(string(com.CC), "|"))
 		ui.Commits = append(ui.Commits, &uiCommit{
 			Hash:   com.Hash,
 			Title:  com.Title,
 			Author: fmt.Sprintf("%v <%v>", com.AuthorName, com.Author),
-			CC:     strings.Split(com.CC, "|"),
+			CC:     append(RecipientStrSlice(to), RecipientStrSlice(cc)...),
 			Date:   com.Date,
 		})
 	}

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -302,7 +302,8 @@ func createNotification(c context.Context, typ dashapi.BugNotif, public bool, te
 		CC:        kernelRepo.CC,
 	}
 	if public {
-		notif.Maintainers = append(crash.Maintainers, kernelRepo.Maintainers...)
+		to, cc := GetEmails(crash.Maintainers)
+		notif.Maintainers = append(append(to, cc...), kernelRepo.Maintainers...)
 	}
 	if (public || reporting.moderation) && bugReporting.CC != "" {
 		notif.CC = append(notif.CC, strings.Split(bugReporting.CC, "|")...)
@@ -410,6 +411,7 @@ func createBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key
 	}
 
 	kernelRepo := kernelRepoInfo(build)
+	to, cc := GetEmails(crash.Maintainers)
 	rep := &dashapi.BugReport{
 		Type:         typ,
 		Config:       reportingConfig,
@@ -421,7 +423,7 @@ func createBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key
 		Report:       report,
 		ReportLink:   externalLink(c, textCrashReport, crash.Report),
 		CC:           kernelRepo.CC,
-		Maintainers:  append(crash.Maintainers, kernelRepo.Maintainers...),
+		Maintainers:  append(append(to, cc...), kernelRepo.Maintainers...),
 		ReproC:       reproC,
 		ReproCLink:   externalLink(c, textReproC, crash.ReproC),
 		ReproSyz:     reproSyz,

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -50,7 +50,7 @@ func TestReportBug(t *testing.T) {
 		Title:             "title1",
 		Link:              fmt.Sprintf("https://testapp.appspot.com/bug?extid=%v", rep.ID),
 		CreditEmail:       fmt.Sprintf("syzbot+%v@testapp.appspotmail.com", rep.ID),
-		Maintainers:       []string{"bar@foo.com", "foo@bar.com"},
+		Maintainers:       []string{"<bar@foo.com>", "<foo@bar.com>"},
 		CompilerID:        "compiler1",
 		KernelRepo:        "repo1",
 		KernelRepoAlias:   "repo1 branch1",


### PR DESCRIPTION
This commit will handle the Recipients information on the database. It
creates functions to transform the Recipients information into the way
the old fields (Maintainers, Cc) are stored.
Update #1534

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
