### PR TITLE
tools/check-commits.sh: use PR head instead of base

### DIFF
--- a/tools/check-commits.sh
+++ b/tools/check-commits.sh
@@ -4,13 +4,13 @@
 
 set -e
 
-# .github/workflows/ci.yml passes GITHUB_PR_BASE_SHA and GITHUB_PR_COMMITS for pull requests.
+# .github/workflows/ci.yml passes GITHUB_PR_HEAD_SHA and GITHUB_PR_COMMITS for pull requests.
 # That's the range we want to check for PRs. If these are not set, we check from the current HEAD
 # to the master branch (presumably a local run). If master does not exist (presumably CI run on
 # a commit into a fork tree), check HEAD commit only.
-GITHUB_PR_BASE_SHA="${GITHUB_PR_BASE_SHA:-HEAD}"
+GITHUB_PR_HEAD_SHA="${GITHUB_PR_HEAD_SHA:-HEAD}"
 if [ "${GITHUB_PR_COMMITS}" == "" ]; then
-	GITHUB_PR_COMMITS=`git log --oneline master..${GITHUB_PR_BASE_SHA} | wc -l`
+	GITHUB_PR_COMMITS=`git log --oneline master..${GITHUB_PR_HEAD_SHA} | wc -l`
 	if [ "${GITHUB_PR_COMMITS}" == "" ] || [ "${GITHUB_PR_COMMITS}" == "0" ]; then
 		GITHUB_PR_COMMITS=1
 	fi
@@ -18,7 +18,7 @@ fi
 
 COMMITS=0
 FAILED=""
-HASHES=$(git log --format="%h" -n ${GITHUB_PR_COMMITS} ${GITHUB_PR_BASE_SHA})
+HASHES=$(git log --format="%h" -n ${GITHUB_PR_COMMITS} ${GITHUB_PR_HEAD_SHA})
 for HASH in ${HASHES}; do
 	((COMMITS+=1))
 	SUBJECT=$(git show --format="%s" --no-patch ${HASH})
@@ -37,5 +37,5 @@ for HASH in ${HASHES}; do
 		FAILED="1"
 	fi
 done
+echo "$COMMITS commits checked for format style (git log -n ${GITHUB_PR_COMMITS} ${GITHUB_PR_HEAD_SHA})"
 if [ "$FAILED" != "" ]; then exit 1; fi
-echo "$COMMITS commits checked for format style"


### PR DESCRIPTION
Base points to already commetted changes,
we really want to cheack head of the PR.
