### PR TITLE
Support coverage filter

### DIFF
--- a/executor/cov_filter.h
+++ b/executor/cov_filter.h
@@ -1,0 +1,58 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+#include <fcntl.h>
+#include <stdio.h>
+
+#if GOOS_linux || GOOS_freebsd || GOOS_netbsd || GOOS_openbsd || GOOS_akaros
+#include <sys/mman.h>
+#include <sys/stat.h>
+#endif
+
+struct cov_filter_t {
+	uint32 pcstart;
+	uint32 pcsize;
+	uint8 bitmap[];
+};
+
+static cov_filter_t* cov_filter;
+
+static void init_coverage_filter()
+{
+#if SYZ_EXECUTOR_USES_SHMEM
+	int f = open("/syz-cover-bitmap", O_RDONLY);
+	if (f < 0) {
+		// We don't fail here because we don't know yet if we should use coverage filter or not.
+		// We will receive the flag only in execute flags and will fail in coverage_filter if necessary.
+		debug("bitmap is no found, coverage filter disabled\n");
+		return;
+	}
+	struct stat st;
+	if (fstat(f, &st))
+		fail("faied to stat coverage filter");
+	// A random address for bitmap. Don't corrupt output_data.
+	void* preferred = (void*)0x110f230000ull;
+	cov_filter = (cov_filter_t*)mmap(preferred, st.st_size, PROT_READ, MAP_PRIVATE, f, 0);
+	if (cov_filter != preferred)
+		fail("failed to initialize coverage filter bitmap at %p", preferred);
+	if ((uint32)st.st_size != sizeof(uint32) * 2 + ((cov_filter->pcsize >> 4) + 7) / 8)
+		fail("bad coverage filter bitmap size");
+	close(f);
+#endif
+}
+
+static bool coverage_filter(uint64 pc)
+{
+	if (cov_filter == NULL)
+		fail("coverage filter was enabled but bitmap initialization failed");
+	// Prevent out of bound while searching bitmap.
+	uint32 pc32 = (uint32)(pc & 0xffffffff);
+	if (pc32 < cov_filter->pcstart || pc32 > cov_filter->pcstart + cov_filter->pcsize)
+		return false;
+	// For minimizing the size of bitmap, the lowest 4-bit will be dropped.
+	pc32 -= cov_filter->pcstart;
+	pc32 = pc32 >> 4;
+	uint32 idx = pc32 / 8;
+	uint32 shift = pc32 % 8;
+	return (cov_filter->bitmap[idx] & (1 << shift)) > 0;
+}

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -141,6 +141,7 @@ static bool flag_collect_cover;
 static bool flag_dedup_cover;
 static bool flag_threaded;
 static bool flag_collide;
+static bool flag_coverage_filter;
 
 // If true, then executor should write the comparisons data to fuzzer.
 static bool flag_comparisons;
@@ -350,6 +351,8 @@ static void setup_features(char** enable, int n);
 #error "unknown OS"
 #endif
 
+#include "cov_filter.h"
+
 #include "test.h"
 
 int main(int argc, char** argv)
@@ -428,6 +431,7 @@ int main(int argc, char** argv)
 			// Don't enable comps because we don't use them in the fuzzer yet.
 			cover_enable(&extra_cov, false, true);
 		}
+		init_coverage_filter();
 	}
 
 	int status = 0;
@@ -547,14 +551,15 @@ void receive_execute()
 	flag_comparisons = req.exec_flags & (1 << 3);
 	flag_threaded = req.exec_flags & (1 << 4);
 	flag_collide = req.exec_flags & (1 << 5);
+	flag_coverage_filter = req.exec_flags & (1 << 6);
 	flag_fault_call = req.fault_call;
 	flag_fault_nth = req.fault_nth;
 	if (!flag_threaded)
 		flag_collide = false;
-	debug("[%llums] exec opts: procid=%llu threaded=%d collide=%d cover=%d comps=%d dedup=%d fault=%d/%d/%d prog=%llu\n",
+	debug("[%llums] exec opts: procid=%llu threaded=%d collide=%d cover=%d comps=%d dedup=%d fault=%d/%d/%d prog=%llu filter=%d\n",
 	      current_time_ms() - start_time_ms, procid, flag_threaded, flag_collide,
 	      flag_collect_cover, flag_comparisons, flag_dedup_cover, flag_fault,
-	      flag_fault_call, flag_fault_nth, req.prog_size);
+	      flag_fault_call, flag_fault_nth, req.prog_size, flag_coverage_filter);
 	if (SYZ_EXECUTOR_USES_SHMEM) {
 		if (req.prog_size)
 			fail("need_prog: no program");
@@ -873,6 +878,8 @@ void write_coverage_signal(cover_t* cov, uint32* signal_count_pos, uint32* cover
 		}
 		cover_data_t sig = pc ^ prev;
 		prev = hash(pc);
+		if (flag_coverage_filter && !coverage_filter((uint64)pc))
+			continue;
 		if (dedup(sig))
 			continue;
 		write_output(sig);

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -48,12 +48,13 @@ const (
 type ExecFlags uint64
 
 const (
-	FlagCollectCover ExecFlags = 1 << iota // collect coverage
-	FlagDedupCover                         // deduplicate coverage in executor
-	FlagInjectFault                        // inject a fault in this execution (see ExecOpts)
-	FlagCollectComps                       // collect KCOV comparisons
-	FlagThreaded                           // use multiple threads to mitigate blocked syscalls
-	FlagCollide                            // collide syscalls to provoke data races
+	FlagCollectCover         ExecFlags = 1 << iota // collect coverage
+	FlagDedupCover                                 // deduplicate coverage in executor
+	FlagInjectFault                                // inject a fault in this execution (see ExecOpts)
+	FlagCollectComps                               // collect KCOV comparisons
+	FlagThreaded                                   // use multiple threads to mitigate blocked syscalls
+	FlagCollide                                    // collide syscalls to provoke data races
+	FlagEnableCoverageFilter                       // setup and use bitmap to do coverage filter
 )
 
 type ExecOpts struct {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -106,6 +106,16 @@ type Config struct {
 
 	// Use KCOV coverage (default: true).
 	Cover bool `json:"cover"`
+	// Use coverage filter. Supported types of filter:
+	// "files": support specifying kernel source files, support regular expression.
+	// eg. "files": ["^net/core/tcp.c$", "^net/sctp/", "tcp"].
+	// "functions": support specifying kernel functions, support regular expression.
+	// eg. "functions": ["^foo$", "^bar", "baz"].
+	// "pcs": specify raw PC table files name.
+	// Each line of the file should be: "64-bit-pc:32-bit-weight\n".
+	// eg. "0xffffffff81000000:0x10\n"
+	CovFilter covFilterCfg `json:"cover_filter"`
+
 	// Reproduce, localize and minimize crashers (default: true).
 	Reproduce bool `json:"reproduce"`
 
@@ -130,4 +140,10 @@ type Config struct {
 
 	// Implementation details beyond this point. Filled after parsing.
 	Derived `json:"-"`
+}
+
+type covFilterCfg struct {
+	Files     []string `json:"files"`
+	Functions []string `json:"functions"`
+	RawPCs    []string `json:"pcs"`
 }

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -30,13 +30,14 @@ type ConnectArgs struct {
 }
 
 type ConnectRes struct {
-	EnabledCalls     []int
-	GitRevision      string
-	TargetRevision   string
-	AllSandboxes     bool
-	CheckResult      *CheckArgs
-	MemoryLeakFrames []string
-	DataRaceFrames   []string
+	EnabledCalls       []int
+	GitRevision        string
+	TargetRevision     string
+	AllSandboxes       bool
+	CheckResult        *CheckArgs
+	MemoryLeakFrames   []string
+	DataRaceFrames     []string
+	EnabledCoverFilter bool
 }
 
 type CheckArgs struct {

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -269,6 +269,10 @@ func main() {
 	}
 	fuzzer.choiceTable = target.BuildChoiceTable(fuzzer.corpus, calls)
 
+	if r.EnabledCoverFilter {
+		fuzzer.execOpts.Flags |= ipc.FlagEnableCoverageFilter
+	}
+
 	for pid := 0; pid < *flagProcs; pid++ {
 		proc, err := newProc(fuzzer, pid)
 		if err != nil {

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -1,0 +1,213 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type CoverFilter struct {
+	pcStart     uint32
+	pcSize      uint32
+	pcEnd       uint32
+	weightedPCs map[uint32]uint32
+
+	bitmapFilename string
+	target         *targets.Target
+}
+
+func createCoverageFilter(cfg *mgrconfig.Config) (covFilterFilename string, err error) {
+	files := cfg.CovFilter.Files
+	funcs := cfg.CovFilter.Functions
+	rawPCs := cfg.CovFilter.RawPCs
+	if len(files) == 0 && len(funcs) == 0 && len(rawPCs) == 0 {
+		return "", nil
+	}
+	filesRegexp, err := getRegexps(files)
+	if err != nil {
+		return "", err
+	}
+	funcsRegexp, err := getRegexps(funcs)
+	if err != nil {
+		return "", err
+	}
+
+	covFilter := CoverFilter{
+		weightedPCs:    make(map[uint32]uint32),
+		target:         cfg.SysTarget,
+		bitmapFilename: cfg.Workdir + "/" + "syz-cover-bitmap",
+	}
+
+	if len(filesRegexp) > 0 || len(funcsRegexp) > 0 {
+		log.Logf(0, "initialize coverage information...")
+		if err = initCover(cfg.SysTarget, cfg.KernelObj, cfg.KernelSrc, cfg.KernelBuildSrc); err != nil {
+			return "", err
+		}
+		symbols := reportGenerator.GetSymbolsInfo()
+		if err = covFilter.initFilesFuncs(filesRegexp, funcsRegexp, symbols); err != nil {
+			return "", err
+		}
+	}
+
+	if err = covFilter.initWeightedPCs(rawPCs); err != nil {
+		return "", err
+	}
+
+	covFilter.detectRegion()
+	if covFilter.pcSize > 0 {
+		log.Logf(0, "coverage filter from 0x%x to 0x%x, size 0x%x",
+			covFilter.pcStart, covFilter.pcEnd, covFilter.pcSize)
+	} else {
+		return "", fmt.Errorf("coverage filter is enabled but nothing will be filtered")
+	}
+
+	if err = osutil.WriteFile(covFilter.bitmapFilename, covFilter.bitmapBytes()); err != nil {
+		return "", err
+	}
+	return covFilter.bitmapFilename, nil
+}
+
+func getRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
+	var regexps []*regexp.Regexp
+	for _, rs := range regexpStrings {
+		r, err := regexp.Compile(rs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile regexp: %v", err)
+		}
+		regexps = append(regexps, r)
+	}
+	return regexps, nil
+}
+
+func (covFilter *CoverFilter) initFilesFuncs(filesRegexp, funcsRegexp []*regexp.Regexp, symbols []cover.Symbol) error {
+	fileDedup := make(map[string]bool)
+	used := make(map[*regexp.Regexp][]string)
+	for _, sym := range symbols {
+		matched := false
+		for _, re := range funcsRegexp {
+			if re.MatchString(sym.Name) {
+				matched = true
+				used[re] = append(used[re], sym.Name)
+				break
+			}
+		}
+		for _, re := range filesRegexp {
+			if re.MatchString(sym.File) {
+				matched = true
+				if !fileDedup[sym.File] {
+					fileDedup[sym.File] = true
+					used[re] = append(used[re], sym.File)
+				}
+				break
+			}
+		}
+		if matched {
+			for _, pc := range sym.PCs {
+				covFilter.weightedPCs[uint32(pc)] = 1
+			}
+		}
+	}
+
+	for _, re := range filesRegexp {
+		if _, ok := used[re]; !ok {
+			log.Logf(0, "coverage file filter doesn't match anything: %v", re.String())
+		} else {
+			log.Logf(1, "coverage file filter: %v: %v", re.String(), used[re])
+		}
+	}
+	for _, re := range funcsRegexp {
+		if _, ok := used[re]; !ok {
+			log.Logf(0, "coverage func filter doesn't match anything: %v", re.String())
+		} else {
+			log.Logf(1, "coverage func filter: %v: %v", re.String(), used[re])
+		}
+	}
+	// TODO: do we want to error on this? or logging it enough?
+	if len(filesRegexp)+len(funcsRegexp) != len(used) {
+		return fmt.Errorf("some coverage filters don't match anything")
+	}
+	return nil
+}
+
+func (covFilter *CoverFilter) initWeightedPCs(rawPCsFiles []string) error {
+	for _, f := range rawPCsFiles {
+		rawFile, err := os.Open(f)
+		if err != nil {
+			return fmt.Errorf("failed to open raw PCs file: %v", err)
+		}
+		defer rawFile.Close()
+
+		s := bufio.NewScanner(rawFile)
+		re := regexp.MustCompile(`(0x[0-9a-f]+)(?:: (0x[0-9a-f]+))?`)
+		for s.Scan() {
+			match := re.FindStringSubmatch(s.Text())
+			if match == nil {
+				return fmt.Errorf("bad line: %q", s.Text())
+			}
+			pc, err := strconv.ParseUint(match[1], 0, 64)
+			if err != nil {
+				return err
+			}
+			weight, err := strconv.ParseUint(match[2], 0, 32)
+			if match[2] != "" && err != nil {
+				return err
+			}
+			// If no weight is detected, set the weight to 0x1 by default.
+			if match[2] == "" || weight < 1 {
+				weight = 1
+			}
+			covFilter.weightedPCs[uint32(pc)] = uint32(weight)
+		}
+	}
+	return nil
+}
+
+func (covFilter *CoverFilter) detectRegion() {
+	covFilter.pcStart = ^uint32(0)
+	covFilter.pcEnd = 0x0
+	for pc := range covFilter.weightedPCs {
+		if pc < covFilter.pcStart {
+			covFilter.pcStart = pc
+		}
+		if pc > covFilter.pcEnd {
+			covFilter.pcEnd = pc
+		}
+	}
+	// align
+	covFilter.pcStart &= ^uint32(0xf)
+	covFilter.pcEnd = (covFilter.pcEnd + 0xf) &^ uint32(0xf)
+	covFilter.pcSize = covFilter.pcEnd - covFilter.pcStart
+}
+
+func (covFilter *CoverFilter) bitmapBytes() []byte {
+	// The file starts with two uint32: covFilterStart and covFilterSize,
+	// and a bitmap with size ((covFilterSize>>4) + 7)/8 bytes follow them.
+	// 8-bit = 1-byte, additional 1-byte to prevent overflow
+	data := make([]byte, 8+((covFilter.pcSize>>4)+7)/8)
+	order := binary.ByteOrder(binary.BigEndian)
+	if covFilter.target.LittleEndian {
+		order = binary.LittleEndian
+	}
+	order.PutUint32(data, covFilter.pcStart)
+	order.PutUint32(data[4:], covFilter.pcSize)
+
+	bitmap := data[8:]
+	for pc := range covFilter.weightedPCs {
+		// The lowest 4-bit is dropped.
+		pc = (pc - covFilter.pcStart) >> 4
+		bitmap[pc/8] |= (1 << (pc % 8))
+	}
+	return data
+}

--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func TestCreateBitmap(t *testing.T) {
+	target := targets.Get("test", "64")
+	filter := &CoverFilter{
+		weightedPCs: make(map[uint32]uint32),
+		target:      target,
+	}
+	enablePCStart := uint32(0x81000002)
+	enablePCEnd := uint32(0x8120001d)
+	filter.weightedPCs[enablePCStart] = 1
+	filter.weightedPCs[enablePCEnd] = 1
+
+	filter.detectRegion()
+	if filter.pcStart != 0x81000000 ||
+		filter.pcEnd != 0x81200020 ||
+		filter.pcSize != 0x200020 {
+		t.Fatalf("filte.detectReigion test failed %x %x %x",
+			filter.pcStart, filter.pcEnd, filter.pcSize)
+	}
+	bitmap := filter.bitmapBytes()
+	bitmap = bitmap[8:]
+	for i, byte := range bitmap {
+		if i == 0 {
+			if byte != 0x1 {
+				t.Fatalf("filter.bitmapByte enable PC failed")
+			}
+		} else if i == (0x20001 / 0x8) {
+			if byte != byte&(1<<(0x20001%0x8)) {
+				t.Fatalf("filter.bitmapByte enable PC failed")
+			}
+		} else {
+			if byte != 0x0 {
+				t.Fatalf("filter.bitmapByte disable PC failed")
+			}
+		}
+	}
+}


### PR DESCRIPTION
syz-manager/manager.go: read coverage filter from the configuration, generate regular expressions from files or functions. Pick out PCs if files or functions match to those regular expressions, and create a bitmap for executor filtering.

executor/executor.cc, executor/bitmap.h: read bitmap and do coverage filter.

pkg/cover/report.go: add method "PCs" to visit the member "pcs" of ReportGenerator. Define arch name as constant because the message from "make presubmit" recommended.