### PR TITLE
[RFC] Add new flag "flaky" for marking bisection result as ignore.

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -362,7 +362,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 
 	// Hack: if the manager has only, say, 5 VMs, but bisect wants 10, try to override number of VMs to 10.
 	// OverrideVMCount is opportunistic and should do it only if it's safe.
-	if err := instance.OverrideVMCount(mgrcfg, bisect.NumTests); err != nil {
+	if err := instance.OverrideVMCount(mgrcfg, bisect.MaxNumTests); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If during bisection we detect more "good" results than "bad" bisection is marked as flaky and number of tests is doubled.
Number of tests is also doubled if crash is not reproduced on original commit. 