### PR TITLE
Makefile: try to install clang-tidy package explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,7 @@ install_prerequisites:
 	sudo apt-get install -y -q g++-mips64el-linux-gnuabi64 || true
 	sudo apt-get install -y -q g++-s390x-linux-gnu || true
 	sudo apt-get install -y -q g++-riscv64-linux-gnu || true
+	sudo apt-get install -y -q clang-tidy || true
 	sudo apt-get install -y -q clang clang-format ragel
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/goyacc
 


### PR DESCRIPTION
Commit 43f1389 ("Makefile: enable clang-tidy in presubmit tests") added clang-tidy to only tools/docker/env/Dockerfile file.
We should try to explicitly install clang-tidy in Makefile for those who don't use docker.