### PR TITLE
executor: fix style checking test

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3482,7 +3482,7 @@ static int do_sandbox_setuid(void)
 	if (syscall(SYS_setresuid, nobody, nobody, nobody))
 		fail("failed to setresuid");
 
-	// This is required to open /proc/self/* files.
+	// This is required to open /proc/self/ files.
 	// Otherwise they are owned by root and we can't open them after setuid.
 	// See task_dump_owner function in kernel.
 	prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -192,6 +192,5 @@ static feature_t features[] = {
 
 static void setup_machine(void)
 {
-	/* nothing */
 }
 #endif

--- a/executor/style_test.go
+++ b/executor/style_test.go
@@ -73,13 +73,13 @@ if (foo)
 			supp := regexp.MustCompile(check.suppression)
 			for _, match := range re.FindAllIndex(data, -1) {
 				start, end := match[0], match[1]
-				for start != 0 && data[start-1] != '\n' {
+				for check.pattern[0] != '\n' && start != 0 && data[start-1] != '\n' {
 					start--
 				}
-				for end != len(data) && data[end] != '\n' {
+				for check.pattern[len(check.pattern)-1] != '\n' && end != len(data) && data[end] != '\n' {
 					end++
 				}
-				if supp.Match(data[start:end]) {
+				if check.suppression != "" && supp.Match(data[start:end]) {
 					continue
 				}
 				line := bytes.Count(data[:start], []byte{'\n'}) + 1


### PR DESCRIPTION
The regexp for empty suppressions matches _everything_...
Don't match suppression if it's empty.
