### PR TITLE
executor: warn about C89-style var declarations

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -206,11 +206,10 @@ static void use_temporary_dir(void)
 
 static void remove_dir(const char* dir)
 {
-	DIR* dp;
-	struct dirent* ep;
-	dp = opendir(dir);
+	DIR* dp = opendir(dir);
 	if (dp == NULL)
 		exitf("opendir(%s) failed", dir);
+	struct dirent* ep = 0;
 	while ((ep = readdir(dp))) {
 		if (strcmp(ep->d_name, ".") == 0 || strcmp(ep->d_name, "..") == 0)
 			continue;
@@ -260,11 +259,11 @@ static void thread_start(void* (*fn)(void*), void* arg)
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
 	pthread_attr_setstacksize(&attr, 128 << 10);
-	int i;
 	// Clone can fail spuriously with EAGAIN if there is a concurrent execve in progress.
 	// (see linux kernel commit 498052bba55ec). But it can also be a true limit imposed by cgroups.
 	// In one case we want to retry infinitely, in another -- fail immidiately...
-	for (i = 0; i < 100; i++) {
+	int i = 0;
+	for (; i < 100; i++) {
 		if (pthread_create(&th, &attr, fn, arg) == 0) {
 			pthread_attr_destroy(&attr);
 			return;
@@ -379,8 +378,8 @@ static void csum_inet_update(struct csum_inet* csum, const uint8* data, size_t l
 	if (length == 0)
 		return;
 
-	size_t i;
-	for (i = 0; i < length - 1; i += 2)
+	size_t i = 0;
+	for (; i < length - 1; i += 2)
 		csum->acc += *(uint16*)&data[i];
 
 	if (length & 1)
@@ -545,11 +544,11 @@ static void loop(void)
 	if (pipe(child_pipe))
 		fail("pipe failed");
 #endif
-	int iter;
+	int iter = 0;
 #if SYZ_REPEAT_TIMES
-	for (iter = 0; iter < /*{{{REPEAT_TIMES}}}*/; iter++) {
+	for (; iter < /*{{{REPEAT_TIMES}}}*/; iter++) {
 #else
-	for (iter = 0;; iter++) {
+	for (;; iter++) {
 #endif
 #if SYZ_EXECUTOR || SYZ_USE_TMP_DIR
 		// Create a new private work dir for this test (removed at the end of the loop).

--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -20,19 +20,17 @@
 #include <dirent.h>
 static void setup_usb(void)
 {
-	struct dirent* ent;
-	char path[1024];
-	DIR* dir;
-
-	dir = opendir("/dev");
+	DIR* dir = opendir("/dev");
 	if (dir == NULL)
 		fail("failed to open /dev");
 
+	struct dirent* ent = NULL;
 	while ((ent = readdir(dir)) != NULL) {
 		if (ent->d_type != DT_CHR)
 			continue;
 		if (strncmp(ent->d_name, "vhci", 4))
 			continue;
+		char path[1024];
 		snprintf(path, sizeof(path), "/dev/%s", ent->d_name);
 		if (chmod(path, 0666))
 			fail("failed to chmod %s", path);
@@ -147,9 +145,7 @@ static int tunfd = -1;
 
 static void vsnprintf_check(char* str, size_t size, const char* format, va_list args)
 {
-	int rv;
-
-	rv = vsnprintf(str, size, format, args);
+	int rv = vsnprintf(str, size, format, args);
 	if (rv < 0)
 		fail("vsnprintf failed");
 	if ((size_t)rv >= size)
@@ -172,17 +168,15 @@ static void snprintf_check(char* str, size_t size, const char* format, ...)
 static void execute_command(bool panic, const char* format, ...)
 {
 	va_list args;
-	char command[PATH_PREFIX_LEN + COMMAND_MAX_LEN];
-	int rv;
-
 	va_start(args, format);
 	// Executor process does not have any env, including PATH.
 	// On some distributions, system/shell adds a minimal PATH, on some it does not.
 	// Set own standard PATH to make it work across distributions.
+	char command[PATH_PREFIX_LEN + COMMAND_MAX_LEN];
 	memcpy(command, PATH_PREFIX, PATH_PREFIX_LEN);
 	vsnprintf_check(command + PATH_PREFIX_LEN, COMMAND_MAX_LEN, format, args);
 	va_end(args);
-	rv = system(command);
+	int rv = system(command);
 	if (rv) {
 		if (panic)
 			fail("command '%s' failed: %d", &command[0], rv);
@@ -351,12 +345,11 @@ static long syz_extract_tcp_res(volatile long a0, volatile long a1, volatile lon
 	size_t length = rv;
 	debug_dump_data(data, length);
 
-	struct tcphdr* tcphdr;
-
 	if (length < sizeof(struct ether_header))
 		return (uintptr_t)-1;
 	struct ether_header* ethhdr = (struct ether_header*)&data[0];
 
+	struct tcphdr* tcphdr = 0;
 	if (ethhdr->ether_type == htons(ETHERTYPE_IP)) {
 		if (length < sizeof(struct ether_header) + sizeof(struct ip))
 			return (uintptr_t)-1;

--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -245,8 +245,7 @@ static long syz_job_default(void)
 #if SYZ_EXECUTOR || __NR_syz_future_time
 static long syz_future_time(volatile long when)
 {
-	zx_time_t delta_ms;
-	zx_time_t now;
+	zx_time_t delta_ms = 10000;
 	switch (when) {
 	case 0:
 		delta_ms = 5;
@@ -254,10 +253,8 @@ static long syz_future_time(volatile long when)
 	case 1:
 		delta_ms = 30;
 		break;
-	default:
-		delta_ms = 10000;
-		break;
 	}
+	zx_time_t now = 0;
 	zx_clock_get(ZX_CLOCK_MONOTONIC, &now);
 	return now + delta_ms * 1000 * 1000;
 }

--- a/executor/common_kvm_amd64.h
+++ b/executor/common_kvm_amd64.h
@@ -178,8 +178,7 @@ static void setup_32bit_idt(struct kvm_sregs* sregs, char* host_mem, uintptr_t g
 	sregs->idt.base = guest_mem + ADDR_VAR_IDT;
 	sregs->idt.limit = 0x1ff;
 	uint64* idt = (uint64*)(host_mem + sregs->idt.base);
-	int i;
-	for (i = 0; i < 32; i++) {
+	for (int i = 0; i < 32; i++) {
 		struct kvm_segment gate;
 		gate.selector = i << 3;
 		switch (i % 6) {
@@ -231,8 +230,7 @@ static void setup_64bit_idt(struct kvm_sregs* sregs, char* host_mem, uintptr_t g
 	sregs->idt.base = guest_mem + ADDR_VAR_IDT;
 	sregs->idt.limit = 0x1ff;
 	uint64* idt = (uint64*)(host_mem + sregs->idt.base);
-	int i;
-	for (i = 0; i < 32; i++) {
+	for (int i = 0; i < 32; i++) {
 		struct kvm_segment gate;
 		gate.selector = (i * 2) << 3;
 		gate.type = (i & 1) ? 14 : 15; // interrupt or trap gate
@@ -290,8 +288,7 @@ static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long 
 	const void* text = text_array_ptr[0].text;
 	uintptr_t text_size = text_array_ptr[0].size;
 
-	uintptr_t i;
-	for (i = 0; i < guest_mem_size / page_size; i++) {
+	for (uintptr_t i = 0; i < guest_mem_size / page_size; i++) {
 		struct kvm_userspace_memory_region memreg;
 		memreg.slot = i;
 		memreg.flags = 0; // can be KVM_MEM_LOG_DIRTY_PAGES | KVM_MEM_READONLY
@@ -715,7 +712,7 @@ static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long 
 
 	if (opt_count > 2)
 		opt_count = 2;
-	for (i = 0; i < opt_count; i++) {
+	for (uintptr_t i = 0; i < opt_count; i++) {
 		uint64 typ = opt_array_ptr[i].typ;
 		uint64 val = opt_array_ptr[i].val;
 		switch (typ % 9) {

--- a/executor/common_kvm_arm64.h
+++ b/executor/common_kvm_arm64.h
@@ -45,8 +45,7 @@ static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long 
 	uint32 features = 0;
 	if (opt_count > 1)
 		opt_count = 1;
-	uintptr_t i;
-	for (i = 0; i < opt_count; i++) {
+	for (uintptr_t i = 0; i < opt_count; i++) {
 		uint64 typ = opt_array_ptr[i].typ;
 		uint64 val = opt_array_ptr[i].val;
 		switch (typ) {
@@ -56,7 +55,7 @@ static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long 
 		}
 	}
 
-	for (i = 0; i < guest_mem_size / page_size; i++) {
+	for (uintptr_t i = 0; i < guest_mem_size / page_size; i++) {
 		struct kvm_userspace_memory_region memreg;
 		memreg.slot = i;
 		memreg.flags = 0; // can be KVM_MEM_LOG_DIRTY_PAGES | KVM_MEM_READONLY

--- a/executor/common_usb.h
+++ b/executor/common_usb.h
@@ -116,8 +116,7 @@ static struct usb_device_index* add_usb_index(int fd, const char* dev, size_t de
 
 static struct usb_device_index* lookup_usb_index(int fd)
 {
-	int i;
-	for (i = 0; i < USB_MAX_FDS; i++) {
+	for (int i = 0; i < USB_MAX_FDS; i++) {
 		if (__atomic_load_n(&usb_devices[i].fd, __ATOMIC_ACQUIRE) == fd) {
 			return &usb_devices[i].index;
 		}

--- a/executor/common_usb_linux.h
+++ b/executor/common_usb_linux.h
@@ -158,12 +158,10 @@ static int usb_raw_ep0_stall(int fd)
 static int lookup_interface(int fd, uint8 bInterfaceNumber, uint8 bAlternateSetting)
 {
 	struct usb_device_index* index = lookup_usb_index(fd);
-	int i;
-
 	if (!index)
 		return -1;
 
-	for (i = 0; i < index->ifaces_num; i++) {
+	for (int i = 0; i < index->ifaces_num; i++) {
 		if (index->ifaces[i].bInterfaceNumber == bInterfaceNumber &&
 		    index->ifaces[i].bAlternateSetting == bAlternateSetting)
 			return i;
@@ -176,14 +174,12 @@ static int lookup_interface(int fd, uint8 bInterfaceNumber, uint8 bAlternateSett
 static int lookup_endpoint(int fd, uint8 bEndpointAddress)
 {
 	struct usb_device_index* index = lookup_usb_index(fd);
-	int ep;
-
 	if (!index)
 		return -1;
 	if (index->iface_cur < 0)
 		return -1;
 
-	for (ep = 0; index->ifaces[index->iface_cur].eps_num; ep++)
+	for (int ep = 0; index->ifaces[index->iface_cur].eps_num; ep++)
 		if (index->ifaces[index->iface_cur].eps[ep].desc.bEndpointAddress == bEndpointAddress)
 			return index->ifaces[index->iface_cur].eps[ep].handle;
 	return -1;
@@ -193,13 +189,11 @@ static int lookup_endpoint(int fd, uint8 bEndpointAddress)
 static void set_interface(int fd, int n)
 {
 	struct usb_device_index* index = lookup_usb_index(fd);
-	int ep;
-
 	if (!index)
 		return;
 
 	if (index->iface_cur >= 0 && index->iface_cur < index->ifaces_num) {
-		for (ep = 0; ep < index->ifaces[index->iface_cur].eps_num; ep++) {
+		for (int ep = 0; ep < index->ifaces[index->iface_cur].eps_num; ep++) {
 			int rv = usb_raw_ep_disable(fd, index->ifaces[index->iface_cur].eps[ep].handle);
 			if (rv < 0) {
 				debug("set_interface: failed to disable endpoint 0x%02x\n",
@@ -211,7 +205,7 @@ static void set_interface(int fd, int n)
 		}
 	}
 	if (n >= 0 && n < index->ifaces_num) {
-		for (ep = 0; ep < index->ifaces[n].eps_num; ep++) {
+		for (int ep = 0; ep < index->ifaces[n].eps_num; ep++) {
 			int rv = usb_raw_ep_enable(fd, &index->ifaces[n].eps[ep].desc);
 			if (rv < 0) {
 				debug("set_interface: failed to enable endpoint 0x%02x\n",

--- a/executor/common_usb_netbsd.h
+++ b/executor/common_usb_netbsd.h
@@ -176,10 +176,9 @@ static int vhci_usb_attach(int fd)
 static int vhci_usb_recv(int fd, void* buf, size_t size)
 {
 	uint8* ptr = (uint8*)buf;
-	ssize_t done;
 
 	while (1) {
-		done = read(fd, ptr, size);
+		ssize_t done = read(fd, ptr, size);
 		if (done < 0)
 			return -1;
 		if ((size_t)done == size)
@@ -192,10 +191,9 @@ static int vhci_usb_recv(int fd, void* buf, size_t size)
 static int vhci_usb_send(int fd, void* buf, size_t size)
 {
 	uint8* ptr = (uint8*)buf;
-	ssize_t done;
 
 	while (1) {
-		done = write(fd, ptr, size);
+		ssize_t done = write(fd, ptr, size);
 		if (done <= 0)
 			return -1;
 		if ((size_t)done == size)
@@ -205,32 +203,14 @@ static int vhci_usb_send(int fd, void* buf, size_t size)
 	}
 }
 
-static volatile long syz_usb_connect_impl(uint64 speed, uint64 dev_len,
+static volatile long syz_usb_connect_impl(int fd, uint64 speed, uint64 dev_len,
 					  const char* dev, const struct vusb_connect_descriptors* descs,
 					  lookup_connect_out_response_t lookup_connect_response_out)
 {
-	struct usb_device_index* index;
-	int fd, rv;
-	bool done;
-
-	debug("syz_usb_connect: dev: %p\n", dev);
-	if (!dev) {
-		debug("syz_usb_connect: dev is null\n");
-		return -1;
-	}
-
-	debug("syz_usb_connect: device data:\n");
-	debug_dump_data(dev, dev_len);
-
-	fd = vhci_open();
-	if (fd < 0) {
-		fail("syz_usb_connect: vhci_open failed with %d", errno);
-	}
-
-	index = add_usb_index(fd, dev, dev_len);
+	struct usb_device_index* index = add_usb_index(fd, dev, dev_len);
 	if (!index) {
 		debug("syz_usb_connect: add_usb_index failed\n");
-		goto err;
+		return -1;
 	}
 	debug("syz_usb_connect: add_usb_index success\n");
 
@@ -238,7 +218,7 @@ static volatile long syz_usb_connect_impl(uint64 speed, uint64 dev_len,
 	analyze_usb_device(index);
 #endif
 
-	rv = vhci_setport(fd, 1);
+	int rv = vhci_setport(fd, 1);
 	if (rv != 0) {
 		fail("syz_usb_connect: vhci_setport failed with %d", errno);
 	}
@@ -246,22 +226,22 @@ static volatile long syz_usb_connect_impl(uint64 speed, uint64 dev_len,
 	rv = vhci_usb_attach(fd);
 	if (rv != 0) {
 		debug("syz_usb_connect: vhci_usb_attach failed with %d\n", rv);
-		goto err;
+		return -1;
 	}
 	debug("syz_usb_connect: vhci_usb_attach success\n");
 
-	done = false;
+	bool done = false;
 	while (!done) {
 		vhci_request_t req;
 
 		rv = vhci_usb_recv(fd, &req, sizeof(req));
 		if (rv != 0) {
 			debug("syz_usb_connect: vhci_usb_recv failed with %d\n", errno);
-			goto err;
+			return -1;
 		}
 		if (req.type != VHCI_REQ_CTRL) {
 			debug("syz_usb_connect: received non-control transfer\n");
-			goto err;
+			return -1;
 		}
 
 		debug("syz_usb_connect: bReqType: 0x%x (%s), bReq: 0x%x, wVal: 0x%x, wIdx: 0x%x, wLen: %d\n",
@@ -279,12 +259,12 @@ static volatile long syz_usb_connect_impl(uint64 speed, uint64 dev_len,
 		if (req.u.ctrl.bmRequestType & UE_DIR_IN) {
 			if (!lookup_connect_response_in(fd, descs, (const struct usb_ctrlrequest*)&req.u.ctrl, &response_data, &response_length)) {
 				debug("syz_usb_connect: unknown control IN request\n");
-				goto err;
+				return -1;
 			}
 		} else {
 			if (!lookup_connect_response_out(fd, descs, (const struct usb_ctrlrequest*)&req.u.ctrl, &done)) {
 				debug("syz_usb_connect: unknown control OUT request\n");
-				goto err;
+				return -1;
 			}
 			response_data = NULL;
 			response_length = UGETW(req.u.ctrl.wLength);
@@ -321,17 +301,13 @@ static volatile long syz_usb_connect_impl(uint64 speed, uint64 dev_len,
 		}
 		if (rv < 0) {
 			debug("syz_usb_connect: usb_raw_ep0_read/write failed with %d\n", rv);
-			goto err;
+			return -1;
 		}
 	}
 
 	sleep_ms(200);
 	debug("syz_usb_connect: configured\n");
 	return fd;
-
-err:
-	close(fd);
-	return -1;
 }
 
 #if SYZ_EXECUTOR || __NR_syz_usb_connect
@@ -343,8 +319,22 @@ static volatile long syz_usb_connect(volatile long a0, volatile long a1,
 	const char* dev = (const char*)a2;
 	const struct vusb_connect_descriptors* descs = (const struct vusb_connect_descriptors*)a3;
 
-	return syz_usb_connect_impl(speed, dev_len, dev, descs,
-				    &lookup_connect_response_out_generic);
+	debug("syz_usb_connect: dev: %p\n", dev);
+	if (!dev) {
+		debug("syz_usb_connect: dev is null\n");
+		return -1;
+	}
+
+	debug("syz_usb_connect: device data:\n");
+	debug_dump_data(dev, dev_len);
+
+	int fd = vhci_open();
+	if (fd < 0) {
+		fail("syz_usb_connect: vhci_open failed with %d", errno);
+	}
+	long res = syz_usb_connect_impl(fd, speed, dev_len, dev, descs, &lookup_connect_response_out_generic);
+	close(fd);
+	return res;
 }
 #endif // SYZ_EXECUTOR || __NR_syz_usb_connect
 

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -809,8 +809,8 @@ retry:
 thread_t* schedule_call(int call_index, int call_num, bool colliding, uint64 copyout_index, uint64 num_args, uint64* args, uint64* pos)
 {
 	// Find a spare thread to execute the call.
-	int i;
-	for (i = 0; i < kMaxThreads; i++) {
+	int i = 0;
+	for (; i < kMaxThreads; i++) {
 		thread_t* th = &threads[i];
 		if (!th->created)
 			thread_create(th, i);
@@ -1504,8 +1504,8 @@ void debug_dump_data(const char* data, int length)
 {
 	if (!flag_debug)
 		return;
-	int i;
-	for (i = 0; i < length; i++) {
+	int i = 0;
+	for (; i < length; i++) {
 		debug("%02x ", data[i] & 0xff);
 		if (i % 16 == 15)
 			debug("\n");

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -117,14 +117,12 @@ static void cover_protect(cover_t* cov)
 			 PROT_READ);
 #elif GOOS_openbsd
 	int mib[2], page_size;
-	size_t len;
 	size_t mmap_alloc_size = kCoverSize * sizeof(uintptr_t);
 	mib[0] = CTL_HW;
 	mib[1] = HW_PAGESIZE;
-	len = sizeof(page_size);
+	size_t len = sizeof(page_size);
 	if (sysctl(mib, ARRAY_SIZE(mib), &page_size, &len, NULL, 0) != -1)
-		mprotect(cov->data + page_size, mmap_alloc_size - page_size,
-			 PROT_READ);
+		mprotect(cov->data + page_size, mmap_alloc_size - page_size, PROT_READ);
 #endif
 }
 

--- a/executor/test.h
+++ b/executor/test.h
@@ -176,19 +176,17 @@ static int test_csum_inet_acc()
 {
 	uint8 buffer[128];
 
-	int test;
-	for (test = 0; test < 256; test++) {
+	for (int test = 0; test < 256; test++) {
 		int size = rand_int_range(1, 128);
 		int step = rand_int_range(1, 8) * 2;
 
-		int i;
-		for (i = 0; i < size; i++)
+		for (int i = 0; i < size; i++)
 			buffer[i] = rand_int_range(0, 255);
 
 		struct csum_inet csum_acc;
 		csum_inet_init(&csum_acc);
 
-		for (i = 0; i < size / step; i++)
+		for (int i = 0; i < size / step; i++)
 			csum_inet_update(&csum_acc, &buffer[i * step], step);
 		if (size % step != 0)
 			csum_inet_update(&csum_acc, &buffer[size - size % step], size % step);


### PR DESCRIPTION
We generally use the newer C99 var declarations combined with initialization because:
 - declarations are more local, reduced scope
 - fewer lines of code
 - less potential for using uninit vars and other bugs
However, we have some relic code from times when we did not understand
if we need to stick with C89 or not. Also some external contributions
that don't follow style around.

Add a static check for C89-style declarations and fix existing precedents.

There was something about for loops IIRC. But I can't find any details now.
Let's see if there is still something that prevents us from declaring
variables inside of for loops.