### PR TITLE
executor/linux: unshare mount namespace

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -67,26 +67,26 @@ static void os_init(int argc, char** argv, char* data, size_t data_size)
 {
 	struct statfs sbuf;
 	// Unshare mount namespace.
-	if (unshare(CLONE_NEWNS))
+	if (unshare(CLONE_NEWNS) && errno != EPERM)
 		fail("unshare mount namespace failed");
 	// Undo mount("/", MS_REC|MS_SHARED) made by systemd.
-	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL))
+	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) && errno != EPERM)
 		fail("mount --make-rprivate / failed");
 	// Mount proc as needed.
 	if (statfs("/proc/", &sbuf) || sbuf.f_type != PROC_SUPER_MAGIC) {
 		mkdir("/proc/", 0755);
-		if (mount("/proc/", "/proc/", "proc", 0, NULL))
+		if (mount("/proc/", "/proc/", "proc", 0, NULL) && errno != EPERM)
 			fail("mount -t proc /proc/ /proc/ failed");
 	}
 	// Mount sysfs as needed.
 	if (statfs("/sys/", &sbuf) || sbuf.f_type != SYSFS_MAGIC) {
 		mkdir("/sys/", 0755);
-		if (mount("/sys/", "/sys/", "sysfs", 0, NULL))
+		if (mount("/sys/", "/sys/", "sysfs", 0, NULL) && errno != EPERM)
 			fail("mount -t sysfs /sys/ /sys/ failed");
 	}
 	// Mount debugfs as needed.
 	if (statfs("/sys/kernel/debug/", &sbuf) || sbuf.f_type != DEBUGFS_MAGIC) {
-		if (mount("/sys/kernel/debug/", "/sys/kernel/debug/", "debugfs", 0, NULL))
+		if (mount("/sys/kernel/debug/", "/sys/kernel/debug/", "debugfs", 0, NULL) && errno != EPERM)
 			fail("mount -t debugfs /sys/kernel/debug/ /sys/kernel/debug/ failed");
 	}
 


### PR DESCRIPTION
With commit 598f4936eb24a383 ("executor/linux: dump more information when failed to open kcov file"), we got an unexpected result.

  (1) sysfs was already detached from /sys/ .
  (2) procfs was still mounted on /proc/ even when /proc/mounts could not be opened.
  (3) Mounting another procfs on /proc/ failed on some reports and did not fail on other reports.
  (4) Only / and several /proc/ are shown by /proc/mounts .

Since "umount -l /" cannot explain (2) and (3), I don't know what is happening.
But we might be able to mitigate this problem by always unsharing mount namespace and changing mount propagation type to 'private'.