### PR TITLE
executor: fix use of SYZ_SANDBOX_ANDROID define

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3773,12 +3773,13 @@ static void remove_dir(const char* dir)
 	int iter = 0;
 	DIR* dp = 0;
 retry:
-#if not SYZ_SANDBOX_ANDROID
-	if (!flag_sandbox_android) {
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
+	if (!flag_sandbox_android)
+#endif
 		while (umount2(dir, MNT_DETACH) == 0) {
 			debug("umount(%s)\n", dir);
 		}
-	}
 #endif
 	dp = opendir(dir);
 	if (dp == NULL) {
@@ -3798,12 +3799,13 @@ retry:
 		snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
 		// If it's 9p mount with broken transport, lstat will fail.
 		// So try to umount first.
-#if not SYZ_SANDBOX_ANDROID
-		if (!flag_sandbox_android) {
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
+		if (!flag_sandbox_android)
+#endif
 			while (umount2(filename, MNT_DETACH) == 0) {
 				debug("umount(%s)\n", filename);
 			}
-		}
 #endif
 		struct stat st;
 		if (lstat(filename, &st))
@@ -3834,12 +3836,16 @@ retry:
 			}
 			if (errno != EBUSY || i > 100)
 				exitf("unlink(%s) failed", filename);
-#if not SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
 			if (!flag_sandbox_android) {
+#endif
 				debug("umount(%s)\n", filename);
 				if (umount2(filename, MNT_DETACH))
 					exitf("umount(%s) failed", filename);
+#if SYZ_EXECUTOR
 			}
+#endif
 #endif
 		}
 	}
@@ -3865,12 +3871,16 @@ retry:
 				break;
 			}
 			if (errno == EBUSY) {
-#if not SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
 				if (!flag_sandbox_android) {
+#endif
 					debug("umount(%s)\n", dir);
 					if (umount2(dir, MNT_DETACH))
 						exitf("umount(%s) failed", dir);
+#if SYZ_EXECUTOR
 				}
+#endif
 #endif
 				continue;
 			}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -8479,12 +8479,13 @@ static void remove_dir(const char* dir)
 	int iter = 0;
 	DIR* dp = 0;
 retry:
-#if not SYZ_SANDBOX_ANDROID
-	if (!flag_sandbox_android) {
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
+	if (!flag_sandbox_android)
+#endif
 		while (umount2(dir, MNT_DETACH) == 0) {
 			debug("umount(%s)\n", dir);
 		}
-	}
 #endif
 	dp = opendir(dir);
 	if (dp == NULL) {
@@ -8499,12 +8500,13 @@ retry:
 			continue;
 		char filename[FILENAME_MAX];
 		snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
-#if not SYZ_SANDBOX_ANDROID
-		if (!flag_sandbox_android) {
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
+		if (!flag_sandbox_android)
+#endif
 			while (umount2(filename, MNT_DETACH) == 0) {
 				debug("umount(%s)\n", filename);
 			}
-		}
 #endif
 		struct stat st;
 		if (lstat(filename, &st))
@@ -8534,12 +8536,16 @@ retry:
 			}
 			if (errno != EBUSY || i > 100)
 				exitf("unlink(%s) failed", filename);
-#if not SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
 			if (!flag_sandbox_android) {
+#endif
 				debug("umount(%s)\n", filename);
 				if (umount2(filename, MNT_DETACH))
 					exitf("umount(%s) failed", filename);
+#if SYZ_EXECUTOR
 			}
+#endif
 #endif
 		}
 	}
@@ -8564,12 +8570,16 @@ retry:
 				break;
 			}
 			if (errno == EBUSY) {
-#if not SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
+#if SYZ_EXECUTOR
 				if (!flag_sandbox_android) {
+#endif
 					debug("umount(%s)\n", dir);
 					if (umount2(dir, MNT_DETACH))
 						exitf("umount(%s) failed", dir);
+#if SYZ_EXECUTOR
 				}
+#endif
 #endif
 				continue;
 			}


### PR DESCRIPTION
"#if not" does not seem to be a thing in C:

$ cpp -undef -fdirectives-only -dDI -E -P -DSYZ_REPEAT -DSYZ_USE_TMP_DIR executor/common_linux.h 1>/dev/null
executor/common_linux.h:3776:9: error: missing binary operator before token "SYZ_SANDBOX_ANDROID"
 3776 | #if not SYZ_SANDBOX_ANDROID
      |         ^~~~~~~~~~~~~~~~~~~
executor/common_linux.h:3801:9: error: missing binary operator before token "SYZ_SANDBOX_ANDROID"
 3801 | #if not SYZ_SANDBOX_ANDROID
      |         ^~~~~~~~~~~~~~~~~~~
executor/common_linux.h:3837:9: error: missing binary operator before token "SYZ_SANDBOX_ANDROID"
 3837 | #if not SYZ_SANDBOX_ANDROID
      |         ^~~~~~~~~~~~~~~~~~~
executor/common_linux.h:3868:9: error: missing binary operator before token "SYZ_SANDBOX_ANDROID"
 3868 | #if not SYZ_SANDBOX_ANDROID
      |         ^~~~~~~~~~~~~~~~~~~

Currently parts under "#if not SYZ_SANDBOX_ANDROID" are always stripped from
reproducers under all sandboxes. Use the standard !SYZ_SANDBOX_ANDROID.

We also need SYZ_EXECUTOR part because sandbox is not statically known
when we are building syz-executor.

And we also need to remove the use of flag_sandbox_android for C reproducers
because for these sandbox is statically known and we don't have flag_sandbox_*.
