### PR TITLE
executor/linux: change mount propagation type to private

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3318,6 +3318,9 @@ static void sandbox_common()
 	if (unshare(CLONE_NEWNS)) {
 		debug("unshare(CLONE_NEWNS): %d\n", errno);
 	}
+	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL)) {
+		debug("mount(\"/\", MS_REC | MS_PRIVATE): %d\n", errno);
+	}
 	if (unshare(CLONE_NEWIPC)) {
 		debug("unshare(CLONE_NEWIPC): %d\n", errno);
 	}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7576,6 +7576,9 @@ static void sandbox_common()
 	if (unshare(CLONE_NEWNS)) {
 		debug("unshare(CLONE_NEWNS): %d\n", errno);
 	}
+	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL)) {
+		debug("mount(\"/\", MS_REC | MS_PRIVATE): %d\n", errno);
+	}
 	if (unshare(CLONE_NEWIPC)) {
 		debug("unshare(CLONE_NEWIPC): %d\n", errno);
 	}


### PR DESCRIPTION
unshare(CLONE_NEWNS) might not be sufficient for making all test processes run in separate mount namespace, for "mount --make-rshared /" request issued by systemd causes mount operations issued by test processes visible from outside of test
processes. Issue "mount --make-rprivate /" request after unshare(CLONE_NEWNS). Also, always print error message in order to help finding possible culprit for unexpected mount namespace modification.