### PR TITLE
executor/common_linux.h: fix build breakage for Linux 4.14

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4269,11 +4269,94 @@ static void setup_usb()
 
 #if SYZ_EXECUTOR || __NR_syz_fuse_handle_req
 #include <fcntl.h>
-#include <linux/fuse.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+// From linux/fuse.h
+#define FUSE_MIN_READ_BUFFER 8192
+
+// From linux/fuse.h
+enum fuse_opcode {
+	FUSE_LOOKUP = 1,
+	FUSE_FORGET = 2, // no reply
+	FUSE_GETATTR = 3,
+	FUSE_SETATTR = 4,
+	FUSE_READLINK = 5,
+	FUSE_SYMLINK = 6,
+	FUSE_MKNOD = 8,
+	FUSE_MKDIR = 9,
+	FUSE_UNLINK = 10,
+	FUSE_RMDIR = 11,
+	FUSE_RENAME = 12,
+	FUSE_LINK = 13,
+	FUSE_OPEN = 14,
+	FUSE_READ = 15,
+	FUSE_WRITE = 16,
+	FUSE_STATFS = 17,
+	FUSE_RELEASE = 18,
+	FUSE_FSYNC = 20,
+	FUSE_SETXATTR = 21,
+	FUSE_GETXATTR = 22,
+	FUSE_LISTXATTR = 23,
+	FUSE_REMOVEXATTR = 24,
+	FUSE_FLUSH = 25,
+	FUSE_INIT = 26,
+	FUSE_OPENDIR = 27,
+	FUSE_READDIR = 28,
+	FUSE_RELEASEDIR = 29,
+	FUSE_FSYNCDIR = 30,
+	FUSE_GETLK = 31,
+	FUSE_SETLK = 32,
+	FUSE_SETLKW = 33,
+	FUSE_ACCESS = 34,
+	FUSE_CREATE = 35,
+	FUSE_INTERRUPT = 36,
+	FUSE_BMAP = 37,
+	FUSE_DESTROY = 38,
+	FUSE_IOCTL = 39,
+	FUSE_POLL = 40,
+	FUSE_NOTIFY_REPLY = 41,
+	FUSE_BATCH_FORGET = 42,
+	FUSE_FALLOCATE = 43,
+	FUSE_READDIRPLUS = 44,
+	FUSE_RENAME2 = 45,
+	FUSE_LSEEK = 46,
+	FUSE_COPY_FILE_RANGE = 47,
+	FUSE_SETUPMAPPING = 48,
+	FUSE_REMOVEMAPPING = 49,
+
+	// CUSE specific operations
+	CUSE_INIT = 4096,
+
+	// Reserved opcodes: helpful to detect structure endian-ness
+	CUSE_INIT_BSWAP_RESERVED = 1048576, // CUSE_INIT << 8
+	FUSE_INIT_BSWAP_RESERVED = 436207616, // FUSE_INIT << 24
+};
+
+// From linux/fuse.h
+struct fuse_in_header {
+	uint32 len;
+	uint32 opcode;
+	uint64 unique;
+	uint64 nodeid;
+	uint32 uid;
+	uint32 gid;
+	uint32 pid;
+	uint32 padding;
+};
+
+// From linux/fuse.h
+struct fuse_out_header {
+	uint32 len;
+	// This is actually a int32_t but *_t variants fail to compile inside
+	// the executor (it appends an additional _t for some reason) and int32
+	// does not exist. Since we don't touch this field, defining it as
+	// unsigned should not cause any problems.
+	uint32 error;
+	uint64 unique;
+};
 
 // Struct shared between syz_fuse_handle_req() and the fuzzer. Used to provide
 // a fuzzed response for each request type.
@@ -4297,10 +4380,9 @@ struct syz_fuse_req_out {
 };
 
 // Link the reponse to the request and send it to /dev/fuse.
-static int
-fuse_send_response(int fd,
-		   const struct fuse_in_header* in_hdr,
-		   struct fuse_out_header* out_hdr)
+static int fuse_send_response(int fd,
+			      const struct fuse_in_header* in_hdr,
+			      struct fuse_out_header* out_hdr)
 {
 	if (!out_hdr) {
 		debug("fuse_send_response: received a NULL out_hdr\n");


### PR DESCRIPTION
I have removed the `#include <linux/fs_fuse.h>` dependency and defined the required structures and constants locally. This should fix the problem reported by syzbot [here](https://groups.google.com/g/syzkaller-lts-bugs/c/Ya6US4zCyzs/m/TwRitPIdBgAJ).

For some reason, using standard fixed size C types (e.g. `uint32_t`) breaks the executor compilation, so I am using the non-standard variant. Is this intended behavior?

---
CC: @balsini 