### PR TITLE
Disallow SSH Authentication Agent

### DIFF
--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -69,6 +69,7 @@ func sshArgs(debug bool, sshKey, portArg string, port int) []string {
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "BatchMode=yes",
 		"-o", "IdentitiesOnly=yes",
+		"-o", "IdentityAgent=none",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "ConnectTimeout=10",
 	}


### PR DESCRIPTION
    This commit adds a new option to SSH options, disallowing the
    authentication agent. This is specially useful when you are testing
    in a machine that sets the `SSH_AUTH_SOCK` environment variable, as
    ssh will try to use that authentication agent on each ssh connection.