### PR TITLE
Missing space at end of line of command

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -128,7 +128,7 @@ qemu-system-x86_64 \
 	-m 2G \
 	-smp 2 \
 	-kernel $KERNEL/arch/x86/boot/bzImage \
-	-append "console=ttyS0 root=/dev/sda earlyprintk=serial"\
+	-append "console=ttyS0 root=/dev/sda earlyprintk=serial" \
 	-drive file=$IMAGE/stretch.img,format=raw \
 	-net user,host=10.0.2.10,hostfwd=tcp:127.0.0.1:10021-:22 \
 	-net nic,model=e1000 \


### PR DESCRIPTION
There is a missing space on the command at line 131, which when copied causes it not to execute properly.
