### PR TITLE
docs/usage.md: correct grammatical error

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,7 @@ In case syzkaller only generated a syzkaller program, there's [a way to execute 
 
 ## Hub
 
-In case you're running multiple `syz-manager` instances, there's a way connect them together and allow to exchange programs and reproducers, see the details [here](hub.md).
+In case you're running multiple `syz-manager` instances, there's a way to connect them together and allow to exchange programs and reproducers, see the details [here](hub.md).
 
 ## Reporting bugs
 


### PR DESCRIPTION
'...a way connect them' -> '...a way to connect them'

Signed-off-by: Tree Davies <tdavies@darkphysics.net>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
