### PR TITLE
docs/linux: fix KMEMLEAK variable in suggested kernel configs

### DIFF
--- a/docs/linux/kernel_configs.md
+++ b/docs/linux/kernel_configs.md
@@ -21,7 +21,7 @@ To detect memory leaks using the [Kernel Memory Leak Detector
 (kmemleak)](https://www.kernel.org/doc/html/latest/dev-tools/kmemleak.html):
 
 ```
-CONFIG_KMEMLEAK=y
+CONFIG_DEBUG_KMEMLEAK=y
 ```
 
 To show code coverage in web interface:


### PR DESCRIPTION
Replace `CONFIG_KMEMLEAK` with `CONFIG_DEBUG_KMEMLEAK` in list of recommended kernel configs for `syzkaller`:
https://www.kernel.org/doc/html/latest/dev-tools/kmemleak.html#usage