### PR TITLE
pkg/cover: fix calculation of prev PC for i386

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -475,7 +475,7 @@ func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
 	case "amd64":
 		return pc - 5
 	case "386":
-		return pc - 1
+		return pc - 5
 	case "arm64":
 		return pc - 4
 	case "arm":


### PR DESCRIPTION
For the ReportGenerator it is impossible to determine the covered PCs:
"failed to generate coverage profile: coverage (1668) doesn't match coverage callbacks"
This is due to the fact that the calculation of the previous PC is wrong.
For i386, PreviousInstructionPC() substracts 1 from the PC which is to little.
Using a GCC 8.3.0, the call to __sanitizer_cov_trace_pc uses 5 bytes:
c136212f:       e8 3c f6 e8 ff          call   c11f1770 <__sanitizer_cov_trace_pc>
c1362134:       31 c0                   xor    %eax,%eax
