### PR TITLE
executor/common_linux.h: add missing FUSE opcodes

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4497,6 +4497,8 @@ static volatile long syz_fuse_handle_req(volatile long a0, // /dev/fuse fd.
 	case FUSE_FLUSH:
 	case FUSE_RELEASE:
 	case FUSE_RELEASEDIR:
+	case FUSE_UNLINK:
+	case FUSE_DESTROY:
 		// These opcodes do not have any reply data. Hence, we pick
 		// another response and only use the shared header.
 		out_hdr = req_out->init;
@@ -4535,10 +4537,12 @@ static volatile long syz_fuse_handle_req(volatile long a0, // /dev/fuse fd.
 		out_hdr = req_out->getxattr;
 		break;
 	case FUSE_WRITE:
+	case FUSE_COPY_FILE_RANGE:
 		out_hdr = req_out->write;
 		break;
 	case FUSE_FORGET:
-		// FUSE_FORGET expects no reply.
+	case FUSE_BATCH_FORGET:
+		// FUSE_FORGET and FUSE_BATCH_FORGET expect no reply.
 		return 0;
 	case FUSE_CREATE:
 		out_hdr = req_out->create_open;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9134,6 +9134,8 @@ static volatile long syz_fuse_handle_req(volatile long a0,
 	case FUSE_FLUSH:
 	case FUSE_RELEASE:
 	case FUSE_RELEASEDIR:
+	case FUSE_UNLINK:
+	case FUSE_DESTROY:
 		out_hdr = req_out->init;
 		if (!out_hdr) {
 			debug("syz_fuse_handle_req: received a NULL out_hdr\n");
@@ -9170,9 +9172,11 @@ static volatile long syz_fuse_handle_req(volatile long a0,
 		out_hdr = req_out->getxattr;
 		break;
 	case FUSE_WRITE:
+	case FUSE_COPY_FILE_RANGE:
 		out_hdr = req_out->write;
 		break;
 	case FUSE_FORGET:
+	case FUSE_BATCH_FORGET:
 		return 0;
 	case FUSE_CREATE:
 		out_hdr = req_out->create_open;


### PR DESCRIPTION
Add the following missing FUSE opcodes to the syz_fuse_handle_req
pseudo-syscall: FUSE_COPY_FILE_RANGE, FUSE_UNLINK, FUSE_DESTROY and
FUSE_BATCH_FORGET.

---
CC: @balsini