### PR TITLE
Expand linux coverage docs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -71,3 +71,4 @@ Jukka Kaartinen
 Alexander Egorenkov
 Matthew Halchyshak
 Heyuan Shi
+Marijo Simunovic

--- a/docs/linux/coverage.md
+++ b/docs/linux/coverage.md
@@ -19,7 +19,7 @@ The target-triple prefix is determined based on the `target` config option.
 
 ### readelf
 
-`readelf` is used to detect virtual memory offset. 
+`readelf` is used to detect virtual memory offset.
 
 ```
 readelf -SW kernel_image
@@ -55,7 +55,7 @@ Executor truncates PC values into `uint32` before sending them to `syz-manager` 
 
 ## Reporting coverage data
 
-`MakeReportGenerator` factory creates an object database for the report. It requires target data, as well as information on the location of the source files and build directory. The first step in building this database is 
+`MakeReportGenerator` factory creates an object database for the report. It requires target data, as well as information on the location of the source files and build directory. The first step in building this database is
 extracting the function data from the target binary.
 ### nm
 

--- a/docs/linux/coverage.md
+++ b/docs/linux/coverage.md
@@ -15,18 +15,112 @@ ln -s `which mips64el-linux-gnuabi64-readelf` ~/bin/mips64le/readelf
 export PATH=~/bin/mips64le:$PATH
 ```
 
-### objdump
-
-`objdump` is used to parse PC value of each call to `__sanitizer_cov_trace_pc` in the kernel image. These PC values are representing all code that is built into kernel image. PC values exported by kcov are compared against these to determine coverage.
-
-### nm
-
-`nm` is used to parse address and size of each function in the kernel image. This information is used to map coverage data to functions. This is needed to find out whether certain functions are called at all.
-
-### addr2line
-
-`addr2line` is used for mapping PC values exported by kcov and parsed by `objdump` to source code files and lines.
+The target-triple prefix is determined based on the _target_ config option.
 
 ### readelf
 
 `readelf` is used to detect virtual memory offset. Executor truncates PC values into `uint32` before sending them to `syz-manager` and `syz-manager` has to detect the offset.
+
+
+## Reporting coverage data
+
+_MakeReportGenerator_ factory creates an object database for the report. It requires target data, as well as information on the location of the source files and build directory. The first step in building this database is 
+extracting the function data from the target binary.
+
+### nm
+`nm` is used to parse address and size of each function in the kernel image
+```
+nm -Ptx kernel_image
+```
+The meaning of the flags is as follows:
+* -P - use the portable output format (Standard Output)
+* -tx - write the numeric values in the hex format
+
+Output is of the following form:
+```
+tracepoint_module_nb d ffffffff84509580 0000000000000018
+...
+udp_lib_hash t ffffffff831a4660 0000000000000007
+```
+
+The first column is a symbol name and the second column its type (e.g. text section, data section, debugging symbol, undefined, zero-init section, etc.). The third column is the symbol value in hex format while the forth column contains the its size. The size is always rounded to up to 16 in syzkaller. For the report, we are only interested in the code sections so the _nm_ output is filtered for the symbols with type _t_ or _T_.
+The final result is a  map with symbol names as keys, values being starting and ending address of a symbol. This information is used to map coverage data to symbols (functions). This step is needed to find out whether certain functions are called at all.
+
+## Object Dump and Symbolize
+
+In order to provide the necessary information for tracking the coverage information with syzkaller, the compiler is instrumented to insert the __trace_pc__ instruction into every basic block generated during the build process. These instructions are then used as anchor points to backtrack the covered code lines.
+
+### objdump
+
+`objdump` is used to parse PC value of each call to `__sanitizer_cov_trace_pc` in the kernel image. These PC values are representing all code that is built into kernel image. PC values exported by kcov are compared against these to determine coverage
+The kernel image is dissasembled using the following command:
+```
+objdump -d --no-show-raw-insn kernel_image
+```
+The meaning of the flags is as follows:
+* -d - disassemble executable code blocks
+* -no-show-raw-insn - prevent printing hex alongside symbolic disassembly
+
+Excerpt output looks like this:
+```
+...
+ffffffff81000f41:	callq  ffffffff81382a00 <__sanitizer_cov_trace_pc>
+ffffffff81000f46:	lea    -0x80(%r13),%rdx
+ffffffff81000f4a:	lea    -0x40(%r13),%rsi
+ffffffff81000f4e:	mov    $0x1c,%edi
+ffffffff81000f53:	callq  ffffffff813ed680 <perf_trace_buf_alloc>
+ffffffff81000f58:	test   %rax,%rax
+ffffffff81000f5b:	je     ffffffff8100110e <perf_trace_initcall_finish+0x2ae>
+ffffffff81000f61:	mov    %rax,-0xd8(%rbp)
+ffffffff81000f68:	callq  ffffffff81382a00 <__sanitizer_cov_trace_pc>
+ffffffff81000f6d:	mov    -0x40(%r13),%rdx
+ffffffff81000f71:	mov    0x8(%rbp),%rsi
+...
+)
+```
+From this output coverage trace calls are identified to determine the start of the executable block addresses:
+```
+ffffffff81000f41:	callq  ffffffff81382a00 <__sanitizer_cov_trace_pc>
+ffffffff81000f68:	callq  ffffffff81382a00 <__sanitizer_cov_trace_pc>
+```
+
+### addr2line
+
+`addr2line` is used for mapping PC values exported by kcov and parsed by `objdump` to source code files and lines.
+```
+addr2line -afi -e kernel_image
+```
+
+The meaning of the flags is as follows:
+* -afi - means show addresses, function names and unwind inlined functions
+* -e - is switch for specifying executable instead of using default
+
+addr2line reads hexadecimal addresses from standard input and prints the filename
+function and line number for each address on standard output. Example usage:
+```
+>> ffffffff8148ba08
+<< 0xffffffff8148ba08
+<< generic_file_read_iter
+<< /home/user/linux/mm/filemap.c:2363
+```
+where `>>` represents query and `<<` is the response from the addr2line.
+
+The final goal is to have a hash table of frames where key is a program counter
+and value is a frame array consisting of a following information:
+- PC - 64bit program counter value (same as key)
+- Func - function name to which the frame belongs
+- File - file where function/frame code is located
+- Line - Line in a file to which program counter maps
+- Inline - boolean inlining information
+
+Multiple frames can be linked to a single program counter value due to inlining.
+
+
+## Creating report
+
+Once the database of the frames and function address ranges is created the next step is to determine the program coverage. Each program is represented here as a series of program counter values. As the function address ranges are know at this point it is easy to determine which functions were called simply by comparing the program counters against this address intervals. In addition, the coverage information is aggregated over the source files based on the program counters that are keys in the frame hash map. These are marked as _coveredPCs_. The resulting coverage is not line based but the frame block based. The end result is stored in the _file_ struct containing the following information:
+* lines - lines covered in the file
+* totalPCs - total program counters identified for this file
+* coveredPcs - the program counters that were executed in the program run
+* totalInline - total number of program counters mapped to inlined frames
+* coveredInline - the program counters mapped to inlined frames that were executed in the program run


### PR DESCRIPTION
Expand Linux coverage document. This document explains how binutil tools are utilized to symbolize the kernel image and link the exported program counters to source information for coverage reporting on Linux.
