### PR TITLE
dashboard: Add missing index for job_poll API call

### DIFF
--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -51,6 +51,14 @@ indexes:
 
 - kind: Bug
   properties:
+  - name: BisectCause
+  - name: ReproLevel
+  - name: Status
+  - name: FirstTime
+    direction: desc
+
+- kind: Bug
+  properties:
   - name: BisectFix
   - name: ReproLevel
   - name: Status


### PR DESCRIPTION
At least on my dashboard setup, the API call 'job_poll' results in a
NEED_INDEX datastore error.

Add the index definition that the development server generates if you make
the job_poll API call.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
