### PR TITLE
[RFC] Use ccache in bisection

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -72,3 +72,5 @@ Alexander Egorenkov
 Matthew Halchyshak
 Heyuan Shi
 Marijo Simunovic
+Jouni Högander
+

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,9 @@ usbgen:
 symbolize:
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-symbolize github.com/google/syzkaller/tools/syz-symbolize
 
+bisect: descriptions
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-bisect github.com/google/syzkaller/tools/syz-bisect
+
 # `extract` extracts const files from various kernel sources, and may only
 # re-generate parts of files.
 extract: bin/syz-extract

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -22,6 +22,7 @@ type Config struct {
 	Trace     io.Writer
 	Fix       bool
 	BinDir    string
+	Ccache    string
 	DebugDir  string
 	Timeout   time.Duration
 	Kernel    KernelConfig
@@ -448,7 +449,7 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		return nil, "", fmt.Errorf("kernel clean failed: %v", err)
 	}
 	kern := &env.cfg.Kernel
-	_, kernelSign, err := env.inst.BuildKernel(bisectEnv.Compiler, kern.Userspace,
+	_, kernelSign, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Ccache, kern.Userspace,
 		kern.Cmdline, kern.Sysctl, bisectEnv.KernelConfig)
 	if kernelSign != "" {
 		env.log("kernel signature: %v", kernelSign)

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -32,7 +32,7 @@ func (env *testEnv) BuildSyzkaller(repo, commit string) error {
 	return nil
 }
 
-func (env *testEnv) BuildKernel(compilerBin, userspaceDir, cmdlineFile, sysctlFile string,
+func (env *testEnv) BuildKernel(compilerBin, cCache, userspaceDir, cmdlineFile, sysctlFile string,
 	kernelConfig []byte) (string, string, error) {
 	commit := env.headCommit()
 	configHash := hash.String(kernelConfig)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -26,6 +26,7 @@ type Params struct {
 	KernelDir    string
 	OutputDir    string
 	Compiler     string
+	Ccache       string
 	UserspaceDir string
 	CmdlineFile  string
 	SysctlFile   string

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -29,7 +29,7 @@ import (
 
 type Env interface {
 	BuildSyzkaller(string, string) error
-	BuildKernel(string, string, string, string, []byte) (string, string, error)
+	BuildKernel(string, string, string, string, string, []byte) (string, string, error)
 	Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]error, error)
 }
 
@@ -94,7 +94,7 @@ func (env *env) BuildSyzkaller(repo, commit string) error {
 	return nil
 }
 
-func (env *env) BuildKernel(compilerBin, userspaceDir, cmdlineFile, sysctlFile string, kernelConfig []byte) (
+func (env *env) BuildKernel(compilerBin, ccacheBin, userspaceDir, cmdlineFile, sysctlFile string, kernelConfig []byte) (
 	string, string, error) {
 	imageDir := filepath.Join(env.cfg.Workdir, "image")
 	params := &build.Params{
@@ -104,6 +104,7 @@ func (env *env) BuildKernel(compilerBin, userspaceDir, cmdlineFile, sysctlFile s
 		KernelDir:    env.cfg.KernelSrc,
 		OutputDir:    imageDir,
 		Compiler:     compilerBin,
+		Ccache:       ccacheBin,
 		UserspaceDir: userspaceDir,
 		CmdlineFile:  cmdlineFile,
 		SysctlFile:   sysctlFile,

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -124,6 +124,7 @@ func (ctx *linux) EnvForCommit(binDir, commit string, kernelConfig []byte) (*Bis
 			return nil, err
 		}
 	}
+
 	return env, nil
 }
 

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -405,6 +405,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		Timeout: 8 * time.Hour,
 		Fix:     req.Type == dashapi.JobBisectFix,
 		BinDir:  jp.cfg.BisectBinDir,
+		Ccache:  jp.cfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:           mgr.mgrcfg.Repo,
 			Branch:         mgr.mgrcfg.Branch,
@@ -527,8 +528,8 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	}
 
 	log.Logf(0, "job: building kernel...")
-	kernelConfig, _, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Userspace, mgr.mgrcfg.KernelCmdline,
-		mgr.mgrcfg.KernelSysctl, req.KernelConfig)
+	kernelConfig, _, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Ccache, mgr.mgrcfg.Userspace,
+		mgr.mgrcfg.KernelCmdline, mgr.mgrcfg.KernelSysctl, req.KernelConfig)
 	if err != nil {
 		return err
 	}

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -301,6 +301,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 		KernelDir:    mgr.kernelDir,
 		OutputDir:    tmpDir,
 		Compiler:     mgr.mgrcfg.Compiler,
+		Ccache:       mgr.mgrcfg.Ccache,
 		UserspaceDir: mgr.mgrcfg.Userspace,
 		CmdlineFile:  mgr.mgrcfg.KernelCmdline,
 		SysctlFile:   mgr.mgrcfg.KernelSysctl,

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -93,6 +93,7 @@ type Config struct {
 	// GCS path to upload coverage reports from managers (optional).
 	CoverUploadPath string           `json:"cover_upload_path"`
 	BisectBinDir    string           `json:"bisect_bin_dir"`
+	Ccache          string           `json:"ccache"`
 	Managers        []*ManagerConfig `json:"managers"`
 }
 
@@ -106,6 +107,7 @@ type ManagerConfig struct {
 	RepoAlias    string `json:"repo_alias"`
 	Branch       string `json:"branch"` // Defaults to "master".
 	Compiler     string `json:"compiler"`
+	Ccache       string `json:"ccache"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
 	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig.

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -46,6 +46,7 @@ type Config struct {
 	// gcc versions. A working archive can be downloaded from:
 	// https://storage.googleapis.com/syzkaller/bisect_bin.tar.gz
 	BinDir        string `json:"bin_dir"`
+	Ccache        string `json:"ccache"`
 	KernelRepo    string `json:"kernel_repo"`
 	KernelBranch  string `json:"kernel_branch"`
 	SyzkallerRepo string `json:"syzkaller_repo"`
@@ -86,6 +87,7 @@ func main() {
 		Trace:    os.Stdout,
 		Fix:      *flagFix,
 		BinDir:   mycfg.BinDir,
+		Ccache:   mycfg.Ccache,
 		DebugDir: *flagCrash,
 		Kernel: bisect.KernelConfig{
 			Repo:      mycfg.KernelRepo,

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -128,7 +128,7 @@ func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instanc
 	if err := build.Clean(*flagOS, *flagArch, vmType, *flagKernelSrc); err != nil {
 		fail(err)
 	}
-	_, _, err = env.BuildKernel(bisectEnv.Compiler, *flagUserspace,
+	_, _, err = env.BuildKernel(bisectEnv.Compiler, "", *flagUserspace,
 		*flagKernelCmdline, *flagKernelSysctl, bisectEnv.KernelConfig)
 	if err != nil {
 		if verr, ok := err.(*osutil.VerboseError); ok {


### PR DESCRIPTION
Most of the time during bisection is used in building kernels. This patch set is enabling ccache usage for kernel building during bisection.

I did evaluation how using ccache impacts bisection/build times. In this evaluation I used 30 GB cache size. Linux kernel version used in evaluation was v4.19.59 and configuration was upstream-leak.config. HW used in evaluation was Intel core i7 3.2Hz, 32 GB memory and 250GB SSD.

55fc56e39caaf4f597fdbf388108892196d55f3f
with ccache:
revisions tested: 10, total time: 1h2m28.486458285s (build: 52m12.726715465s, test: 7m55.631365309s)
without ccache:
revisions tested: 10, total time: 1h49m56.85679912s (build: 1h39m39.424251006s, test: 7m57.998117335s)

4b61862ab93380cf84d66e09596ff3cbc3bc5341
with ccache:
revisions tested: 79, total time: 13h8m24.916824421s (build: 11h8m47.562970391s, test: 1h45m26.068855043s)est.
without ccache:
revisions tested: 79, total time: 15h5m7.760620606s (build: 13h6m22.505936225s, test: 1h44m27.350875575s)

Average time spent in building kernel is 9m57s per revision without ccache and 8m5s with ccache. Average build time per revision drops ~18 %.

Here are also same numbers together with config bisection:

55fc56e39caaf4f597fdbf388108892196d55f3f
with ccache
revisions tested: 22, total time: 1h21m24.433970146s (build: 1h1m11.361405361s, test: 14m58.913992815s)
without ccache
revisions tested: 22, total time: 1h48m34.092609326s (build: 1h29m1.636968553s, test: 14m20.4402857s))

4b61862ab93380cf84d66e09596ff3cbc3bc5341
with ccache:
revisions tested: 80, total time: 5h12m8.53764234s (build: 3h14m58.178713649s, test: 1h43m24.594562308s)
without ccache:
revisions tested: 80, total time: 6h18m11.041697988s (build: 4h15m54.746695641s, test: 1h48m27.179096144s)

Average time spent in building kernel is 3m9s per revision without ccache and 2m20s with ccache. Average build time per revision drops ~26 %.

This evaluation can be replicated by running tools/bisect_evaluation/run.sh in my ccache_evaluation branch here:

https://github.com/hogander-unikie/syzkaller/tree/ccache_evaluation

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
