### PR TITLE
tools/docker: mirror images on github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ check_commits:
 	./tools/check-commits.sh
 
 check_links:
-	python ./tools/check_links.py $$(pwd) $$(ls ./*.md; find ./docs/ -name '*.md')
+	python ./tools/check_links.py $$(pwd) $$(find -name '*.md' | grep -v "./vendor/")
 
 # Check that the diff is empty. This is meant to be executed after generating
 # and formatting the code to make sure that everything is committed.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -127,3 +127,16 @@ To update `syz-env` container to the latest version do:
 ``` bash
 docker pull gcr.io/syzkaller/env
 ```
+
+If you do not have access to the `gcr.io` registry, there is also a mirror in `docker.pkg.github.com` registry.
+In order to use it, you need to
+[authenticate Docker](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages)
+with your Github account with:
+```
+docker login https://docker.pkg.github.com
+```
+and then pull the image and retag it to the name expacted by `syz-env`:
+```
+docker pull docker.pkg.github.com/google/syzkaller/env
+docker tag docker.pkg.github.com/google/syzkaller/env gcr.io/syzkaller/env
+```

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,30 @@
+# Docker images
+
+We provide a set of Docker images that provide dev environment suitable for syzkaller development/testing.
+These images are used by CI, but can also be used for [local development](/docs/contributing.md#using-syz-env).
+
+- [env](/tools/docker/env/Dockerfile) includes Go toolchain, C/C++ cross-compilers, make, git and other essential tools.
+- [big-env](/tools/docker/big-env/Dockerfile) includes akaros/fuchsia/netbsd toolchains and gcloud sdk on top of `env` image.
+- [old-env](/tools/docker/old-env/Dockerfile) provides essential tools but based on an older disto (ubuntu:16.04).
+
+These images are available as `gcr.io/syzkaller/{env,big-env,old-env}`, respectively.
+
+To download and run locally:
+```
+docker pull gcr.io/syzkaller/env
+docker run -it gcr.io/syzkaller/env
+```
+
+To build and push a new version:
+```
+docker build -t gcr.io/syzkaller/env tools/docker/env
+gcloud auth login && gcloud auth configure-docker
+docker push gcr.io/syzkaller/env
+```
+
+Also upload a copy to Github packages (some users don't have access to `gcr.io`):
+```
+docker tag gcr.io/syzkaller/env docker.pkg.github.com/google/syzkaller/env
+docker login https://docker.pkg.github.com
+docker push docker.pkg.github.com/google/syzkaller/env
+```

--- a/tools/docker/big-env/Dockerfile
+++ b/tools/docker/big-env/Dockerfile
@@ -1,13 +1,7 @@
 # Copyright 2020 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-# The image provides dev environment suitable for syzkaller development/testing.
-# On top of syz-env it provides akaros/fuchsia/netbsd toolchains and gcloud sdk.
-
-# The image is available as gcr.io/syzkaller/big-env.
-
-# Build as:
-# docker build -t gcr.io/syzkaller/big-env tools/docker/big-env
+# See /tools/docker/README.md for details.
 
 FROM gcr.io/syzkaller/env
 

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -1,19 +1,7 @@
 # Copyright 2020 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-# The image provides dev environment suitable for syzkaller development/testing.
-# It includes Go toolchain and C/C++ cross-compilers.
-
-# The image is available as gcr.io/syzkaller/env.
-
-# To download and run locally:
-#	docker pull gcr.io/syzkaller/env
-#	docker run -it gcr.io/syzkaller/env
-
-# To build and push new version:
-#	docker build -t gcr.io/syzkaller/env tools/docker/env
-#	gcloud auth login && gcloud auth configure-docker
-#	docker push gcr.io/syzkaller/env
+# See /tools/docker/README.md for details.
 
 FROM debian:buster
 

--- a/tools/docker/old-env/Dockerfile
+++ b/tools/docker/old-env/Dockerfile
@@ -1,19 +1,7 @@
 # Copyright 2020 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-# The image provides dev environment suitable for syzkaller development/testing.
-# It includes Go toolchain and C/C++ cross-compilers.
-
-# The image is available as gcr.io/syzkaller/old-env.
-
-# To download and run locally:
-#	docker pull gcr.io/syzkaller/old-env
-#	docker run -it gcr.io/syzkaller/old-env
-
-# To build and push new version:
-#	docker build -t gcr.io/syzkaller/old-env tools/docker/old-env
-#	gcloud auth login && gcloud auth configure-docker
-#	docker push gcr.io/syzkaller/old-env
+# See /tools/docker/README.md for details.
 
 FROM ubuntu:16.04
 


### PR DESCRIPTION
Some users don't have access to the gcr.io registry.
Mirror images on github as well.
