### PR TITLE
pkg/host: make machine info tests linux-specific

### DIFF
--- a/pkg/host/machine_info_linux_test.go
+++ b/pkg/host/machine_info_linux_test.go
@@ -6,15 +6,11 @@ package host
 import (
 	"bufio"
 	"bytes"
-	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestMachineInfoLinux(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip()
-	}
 	result, err := CollectMachineInfo()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TestScanCPUInfo does not build on !linux.
TestMachineInfoLinux builds, but does not do anything useful.
