### PR TITLE
executor: fix definition of __NR_io_uring_setup

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1467,13 +1467,11 @@ struct io_uring_params {
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifndef __NR_io_uring_setup
-#ifdef __alpha__
-#define __NR_io_uring_setup 535
-#else // !__alpha__
-#define __NR_io_uring_setup 425
+#if GOARCH_mips64le
+#define sys_io_uring_setup 5425
+#else
+#define sys_io_uring_setup 425
 #endif
-#endif // __NR_io_uring_setup
 
 // Wrapper for io_uring_setup and the subsequent mmap calls that map the ring and the sqes
 static long syz_io_uring_setup(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5)
@@ -1489,7 +1487,7 @@ static long syz_io_uring_setup(volatile long a0, volatile long a1, volatile long
 	void** ring_ptr_out = (void**)a4;
 	void** sqes_ptr_out = (void**)a5;
 
-	uint32 fd_io_uring = syscall(__NR_io_uring_setup, entries, setup_params);
+	uint32 fd_io_uring = syscall(sys_io_uring_setup, entries, setup_params);
 
 	// Compute the ring sizes
 	uint32 sq_ring_sz = setup_params->sq_off.array + setup_params->sq_entries * sizeof(uint32);

--- a/executor/style_test.go
+++ b/executor/style_test.go
@@ -44,6 +44,24 @@ if (foo)
 			},
 		},
 		{
+			pattern: `#define __NR_`,
+			message: "Don't define syscall __NR_foo constants.\n" +
+				"These should be guarded by #ifndef __NR_foo, but this is dependent on the host " +
+				"and may break on other machines (after pkg/csource processing).\n" +
+				"Define sys_foo constants instead.",
+			tests: []string{
+				`
+#ifndef __NR_io_uring_setup
+#ifdef __alpha__
+#define __NR_io_uring_setup 535
+#else // !__alpha__
+#define __NR_io_uring_setup 425
+#endif
+#endif // __NR_io_uring_setup
+`,
+			},
+		},
+		{
 			pattern:     `//[^\s]`,
 			suppression: `https?://`,
 			message:     "Add a space after //",

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -3589,12 +3589,10 @@ struct io_uring_params {
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifndef __NR_io_uring_setup
-#ifdef __alpha__
-#define __NR_io_uring_setup 535
+#if GOARCH_mips64le
+#define sys_io_uring_setup 5425
 #else
-#define __NR_io_uring_setup 425
-#endif
+#define sys_io_uring_setup 425
 #endif
 static long syz_io_uring_setup(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5)
 {
@@ -3605,7 +3603,7 @@ static long syz_io_uring_setup(volatile long a0, volatile long a1, volatile long
 	void** ring_ptr_out = (void**)a4;
 	void** sqes_ptr_out = (void**)a5;
 
-	uint32 fd_io_uring = syscall(__NR_io_uring_setup, entries, setup_params);
+	uint32 fd_io_uring = syscall(sys_io_uring_setup, entries, setup_params);
 	uint32 sq_ring_sz = setup_params->sq_off.array + setup_params->sq_entries * sizeof(uint32);
 	uint32 cq_ring_sz = setup_params->cq_off.cqes + setup_params->cq_entries * SIZEOF_IO_URING_CQE;
 	uint32 ring_sz = sq_ring_sz > cq_ring_sz ? sq_ring_sz : cq_ring_sz;


### PR DESCRIPTION
Sone syzbot instances broke with:

<stdin>: In function ‘syz_io_uring_setup’:
<stdin>:476:33: error: ‘__NR_io_uring_setup’ undeclared (first use in this function)
<stdin>:476:33: note: each undeclared identifier is reported only once for each function it appears in

pkg/csource resolves #ifdef's at generation time.
