### PR TITLE
executor: forbid inlining of 'remove_dir'

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -205,7 +205,14 @@ static void use_temporary_dir(void)
 #include <sys/stat.h>
 #include <sys/types.h>
 
-static void remove_dir(const char* dir)
+// We need to prevent the compiler from unrolling the while loop by using the gcc's noinline attribute
+// because otherwise it could trigger the compiler warning about a potential format truncation
+// when a filename is constructed with help of snprintf. This warning occurs because by unrolling
+// the while loop, the snprintf call will try to concatenate 2 buffers of length FILENAME_MAX and put
+// the result into a buffer of length FILENAME_MAX which is apparently not possible. But this is no
+// problem in our case because file and directory names should be short enough and fit into a buffer
+// of length FILENAME_MAX.
+static void __attribute__((noinline)) remove_dir(const char* dir)
 {
 	DIR* dp = opendir(dir);
 	if (dp == NULL) {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -184,8 +184,7 @@ static void use_temporary_dir(void)
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-static void remove_dir(const char* dir)
+static void __attribute__((noinline)) remove_dir(const char* dir)
 {
 	DIR* dp = opendir(dir);
 	if (dp == NULL) {


### PR DESCRIPTION
Fixes the issue with gcc 10 on Fedora 32 s390x:

In file included from ../../executor/executor.cc:147:
../../executor/common.h: In function ‘void remove_dir(const char*)’:
../../executor/common.h:229:44: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ^~
../../executor/common.h:229:11: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../executor/common.h:229:44: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ^~
../../executor/common.h:229:11: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../executor/common.h:229:44: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ^~
../../executor/common.h:229:11: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../executor/common.h:229:44: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ^~
../../executor/common.h:229:11: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
229 | snprintf(filename, sizeof(filename), "%s/%s", dir, ep->d_name);
| ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../executor/common.h:243:1: error: the frame size of 21200 bytes is larger than 16384 bytes [-Werror=frame-larger-than=]
243 | }
| ^
cc1plus: all warnings being treated as errors

compiler invocation: gcc [-o /tmp/syz-executor383272105 -DGOOS_test=1 -DGOARCH_64_fork=1 -DHOSTGOOS_linux=1 ../../executor/executor.cc -m64 -no-pie -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384]
FAIL
FAIL github.com/google/syzkaller/pkg/runtest 0.998s
FAIL

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
