### PR TITLE
pkg/host: use 'machine' field as cpu model on IBM/Z

### DIFF
--- a/pkg/host/machine_info_linux_test.go
+++ b/pkg/host/machine_info_linux_test.go
@@ -48,7 +48,7 @@ func checkCPUInfo(t *testing.T, scanner *bufio.Scanner) {
 
 	importantKeys := [][]string{
 		{"vendor", "vendor_id", "CPU implementer"},
-		{"model", "CPU part", "cpu model"},
+		{"model", "CPU part", "cpu model", "machine"},
 		{"flags", "features", "Features", "ASEs implemented", "type"},
 	}
 	for _, possibleNames := range importantKeys {


### PR DESCRIPTION
Use the field 'machine' in /proc/cpuinfo on IBM/Z
to find out the "CPU model".

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
