### PR TITLE
pkg/host: use 'processor 0' as cpu model on s390x inside container

### DIFF
--- a/pkg/host/machine_info_linux_test.go
+++ b/pkg/host/machine_info_linux_test.go
@@ -48,7 +48,7 @@ func checkCPUInfo(t *testing.T, scanner *bufio.Scanner) {
 
 	importantKeys := [][]string{
 		{"vendor", "vendor_id", "CPU implementer"},
-		{"model", "CPU part", "cpu model", "machine"},
+		{"model", "CPU part", "cpu model", "machine", "processor 0"},
 		{"flags", "features", "Features", "ASEs implemented", "type"},
 	}
 	for _, possibleNames := range importantKeys {


### PR DESCRIPTION
There is no field 'machine' in /proc/cpuinfo when we run inside
a Docker container but there is a 'processor 0' field which
provides the same information.

Example:

processor 0: version = 00,  identification = 310C57,  machine = 3906

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
