### PR TITLE
tools/create-image.sh: map qemu -> Debian architecture names

### DIFF
--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -75,6 +75,22 @@ while true; do
     esac
 done
 
+# Handle cases where qemu and Debian use different arch names
+case "$ARCH" in
+	ppc64le)
+		DEBARCH=ppc64el
+		;;
+	aarch64)
+		DEBARCH=arm64
+		;;
+	arm)
+		DEBARCH=armel
+		;;
+	*)
+		DEBARCH=$ARCH
+		;;
+esac
+
 # Foreign architecture
 if [ $ARCH != $(uname -m) ]; then
     # Check for according qemu static binary
@@ -108,7 +124,7 @@ sudo chmod 0755 $DIR
 
 DEBOOTSTRAP_PARAMS="--include=$PREINSTALL_PKGS --components=main,contrib,non-free $RELEASE $DIR"
 if [ $ARCH != $(uname -m) ]; then
-    DEBOOTSTRAP_PARAMS="--arch=$ARCH --foreign $DEBOOTSTRAP_PARAMS"
+    DEBOOTSTRAP_PARAMS="--arch=$DEBARCH --foreign $DEBOOTSTRAP_PARAMS"
 fi
 sudo debootstrap $DEBOOTSTRAP_PARAMS
 


### PR DESCRIPTION
create-image.sh assumes that the qemu name and the Debian name for the
target architecture are the same. This is not always true.

For comedy and/or historical reasons, Debian refers to 64-bit little
endian PowerPC as ppc64el, whereas qemu and most other things use ppc64le.
Debian refers to aarch64 as arm64, and 32-bit little endian arm as armel.
Add special cases to handle this.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
