### PR TITLE
Makefile: try to install g++ package explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,7 @@ install_prerequisites:
 	sudo apt-get install -y -q g++-mips64el-linux-gnuabi64 || true
 	sudo apt-get install -y -q g++-s390x-linux-gnu || true
 	sudo apt-get install -y -q g++-riscv64-linux-gnu || true
+	sudo apt-get install -y -q g++ || true
 	sudo apt-get install -y -q clang-tidy || true
 	sudo apt-get install -y -q clang clang-format ragel
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/goyacc


### PR DESCRIPTION
Since executor/gen.go invokes "gcc kvm_gen.cc kvm.S -o kvm_gen", g++ is needed.

  go generate ./pkg/csource ./executor ./pkg/ifuzz ./pkg/build ./pkg/html
  gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
  compilation terminated.
  executor/gen.go:6: running "bash": exit status 1
