### PR TITLE
Makefile: try to install python-is-python3 package as needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ install_prerequisites:
 	sudo apt-get install -y -q g++-s390x-linux-gnu || true
 	sudo apt-get install -y -q g++-riscv64-linux-gnu || true
 	sudo apt-get install -y -q g++ || true
+	[ -z "$(shell which python)" -a -n "$(shell which python3)" ] && sudo apt-get install -y -q python-is-python3 || true
 	sudo apt-get install -y -q clang-tidy || true
 	sudo apt-get install -y -q clang clang-format ragel
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/goyacc


### PR DESCRIPTION
Since some scripts are executed using "python", create a symlink when "python3" exists
and "python" does not exist, by installing python-is-python3 package.

  /bin/sh: 1: python: not found
  make[2]: *** [Makefile:364: check_links] Error 127
