### PR TITLE
tools/create-gce-image.sh: mount the root filesystem read-write

### DIFF
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -87,6 +87,7 @@ sudo cp $2 disk.mnt/vmlinuz
 sudo sed -i "/^root/ { s/:x:/::/ }" disk.mnt/etc/passwd
 echo "T0:23:respawn:/sbin/getty -L ttyS0 115200 vt100" | sudo tee -a disk.mnt/etc/inittab
 echo -en "auto lo\niface lo inet loopback\nauto eth0\niface eth0 inet dhcp\n" | sudo tee disk.mnt/etc/network/interfaces
+echo '/dev/root / ext4 defaults 0 0' | sudo tee -a disk.mnt/etc/fstab
 echo "debugfs /sys/kernel/debug debugfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab
 echo "securityfs /sys/kernel/security securityfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab
 echo "configfs /sys/kernel/config/ configfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -136,6 +136,7 @@ sudo cp $2 disk.mnt/vmlinuz
 sudo sed -i "/^root/ { s/:x:/::/ }" disk.mnt/etc/passwd
 echo "T0:23:respawn:/sbin/getty -L ttyS0 115200 vt100" | sudo tee -a disk.mnt/etc/inittab
 echo -en "auto lo\niface lo inet loopback\nauto eth0\niface eth0 inet dhcp\n" | sudo tee disk.mnt/etc/network/interfaces
+echo '/dev/root / ext4 defaults 0 0' | sudo tee -a disk.mnt/etc/fstab
 echo "debugfs /sys/kernel/debug debugfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab
 echo "securityfs /sys/kernel/security securityfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab
 echo "configfs /sys/kernel/config/ configfs defaults 0 0" | sudo tee -a disk.mnt/etc/fstab


### PR DESCRIPTION
Add fstab entry to mount the root filesystem read-write after boot. This
has been done with commit 873745 for create-image.sh. Maybe this hint is
not necessary for GCE but it is required when running on other platforms
(e.g. VMware).

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
