### PR TITLE
pkg/vcs: use committer date than author date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifeq ("$(shell git diff --shortstat)", "")
 else
 	REV=$(GITREV)+
 endif
-GITREVDATE=$(shell git log -n 1 --format="%ad")
+GITREVDATE=$(shell git log -n 1 --format="%cd")
 
 # Don't generate symbol table and DWARF debug info.
 # Reduces build time and binary sizes considerably.

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -18,6 +18,8 @@ rbtree: include rcu.h
 foobar@foobar.de
 Foo Bar
 Fri May 11 16:02:14 2018 -0700
+78eb0c6356cda285c6ee6e29bea0c0188368103e
+Fri May 11 17:28:45 2018 -0700
 Since commit c1adf20052d8 ("Introduce rb_replace_node_rcu()")
 rbtree_augmented.h uses RCU related data structures but does not include
 the header file.  It works as long as it gets somehow included before
@@ -47,7 +49,8 @@ Signed-off-by: Linux Master <linux@linux-foundation.org>
 				"subsystem@reviewer.com",
 				"yetanother@email.org",
 			}, To),
-			Date: time.Date(2018, 5, 11, 16, 02, 14, 0, time.FixedZone("", -7*60*60)),
+			Date:       time.Date(2018, 5, 11, 16, 02, 14, 0, time.FixedZone("", -7*60*60)),
+			CommitDate: time.Date(2018, 5, 11, 17, 28, 45, 0, time.FixedZone("", -7*60*60)),
 		},
 	}
 	for input, com := range tests {
@@ -75,6 +78,9 @@ Signed-off-by: Linux Master <linux@linux-foundation.org>
 		}
 		if !com.Date.Equal(res.Date) {
 			t.Fatalf("want date %v, got %v", com.Date, res.Date)
+		}
+		if !com.CommitDate.Equal(res.CommitDate) {
+			t.Fatalf("want date %v, got %v", com.CommitDate, res.CommitDate)
 		}
 	}
 }

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -135,6 +135,7 @@ type Commit struct {
 	Tags       []string
 	Parents    []string
 	Date       time.Time
+	CommitDate time.Time
 }
 
 type BisectResult int

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -475,7 +475,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 			// If there is a report and there is no commit, it means a crash
 			// occurred on HEAD(for BisectFix) and oldest tested release(for BisectCause).
 			resp.Build.KernelCommit = res.Commit.Hash
-			resp.Build.KernelCommitDate = res.Commit.Date
+			resp.Build.KernelCommitDate = res.Commit.CommitDate
 			resp.Build.KernelCommitTitle = res.Commit.Title
 		}
 	}
@@ -516,7 +516,7 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	}
 	resp.Build.KernelCommit = kernelCommit.Hash
 	resp.Build.KernelCommitTitle = kernelCommit.Title
-	resp.Build.KernelCommitDate = kernelCommit.Date
+	resp.Build.KernelCommitDate = kernelCommit.CommitDate
 
 	if err := build.Clean(mgrcfg.TargetOS, mgrcfg.TargetVMArch, mgrcfg.Type, mgrcfg.KernelSrc); err != nil {
 		return fmt.Errorf("kernel clean failed: %v", err)

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -281,7 +281,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 		KernelBranch:      mgr.mgrcfg.Branch,
 		KernelCommit:      kernelCommit.Hash,
 		KernelCommitTitle: kernelCommit.Title,
-		KernelCommitDate:  kernelCommit.Date,
+		KernelCommitDate:  kernelCommit.CommitDate,
 		KernelConfigTag:   mgr.configTag,
 	}
 

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -310,7 +310,7 @@ func (upd *SyzUpdater) uploadBuildError(commit *vcs.Commit, buildErr error) {
 				Arch:                managercfg.TargetArch,
 				VMArch:              managercfg.TargetVMArch,
 				SyzkallerCommit:     commit.Hash,
-				SyzkallerCommitDate: commit.Date,
+				SyzkallerCommitDate: commit.CommitDate,
 				CompilerID:          upd.compilerID,
 				KernelRepo:          upd.repoAddress,
 				KernelBranch:        upd.branch,


### PR DESCRIPTION
The Freshness columns in Instances: table on the dashboard page look outdated, for
these fields are showing when that patch was authored. Showing when that patch was
committed into the tree in question would be more meaningful.
