### PR TITLE
Fuchsia Fixes

### DIFF
--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -50,7 +50,14 @@ $ make TARGETOS=fuchsia TARGETARCH=amd64 \
 Running syz-manager requires you to have built fuchsia previously, and added the ssh keys to the fuchsia.zbi image:
 
 ```
-$ ${SOURCEDIR}/out/x64.zircon/tools/zbi -o ${SOURCEDIR}/out/x64/fuchsia-ssh.zbi ${SOURCEDIR}/out/x64/fuchsia.zbi --entry "data/ssh/authorized_keys=${SOURCEDIR}/.ssh/authorized_keys"
+$ ${SOURCEDIR}/out/x64/host_x64/zbi -o ${SOURCEDIR}/out/x64/fuchsia-ssh.zbi ${SOURCEDIR}/out/x64/fuchsia.zbi --entry "data/ssh/authorized_keys=${SOURCEDIR}/.ssh/authorized_keys"
+```
+
+You will also need to extend the `fvm` image:
+
+```
+$ cp "${SOURCEDIR}/out/x64/obj/build/images/fvm.blk" "${SOURCEDIR}/out/x64/obj/build/images/fvm-extended.blk"
+$ ${SOURCEDIR}/out/x64/host_x64/fvm "${SOURCEDIR}/out/x64/obj/build/images/fvm-extended.blk" extend --length 3G
 ```
 
 Note: This needs to be repeated after each `fx build`.
@@ -64,7 +71,7 @@ Run `syz-manager` with a config along the lines of:
         "workdir": "/workdir.fuchsia",
         "kernel_obj": "/fuchsia/out/x64.zircon/kernel-x64-gcc",
         "syzkaller": "/syzkaller",
-        "image": "/fuchsia/out/x64/obj/build/images/fvm.blk",
+        "image": "/fuchsia/out/x64/obj/build/images/fvm-extended.blk",
         "sshkey": "/fuchsia/.ssh/pkey",
         "reproduce": false,
         "cover": false,
@@ -74,7 +81,7 @@ Run `syz-manager` with a config along the lines of:
                 "count": 10,
                 "cpu": 4,
                 "mem": 2048,
-                "kernel": "/fuchsia/out/x64.zircon/multiboot.bin",
+                "kernel": "/fuchsia/out/x64/multiboot.bin",
                 "initrd": "/fuchsia/out/x64/fuchsia-ssh.zbi"
         }
 }

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -57,7 +57,7 @@ func (fu fuchsia) build(params *Params) error {
 	kernelZBI := filepath.Join(params.KernelDir, "out", arch, "fuchsia.zbi")
 	authorizedKeys := fmt.Sprintf("data/ssh/authorized_keys=%s",
 		filepath.Join(params.KernelDir, ".ssh", "authorized_keys"))
-	if _, err := runSandboxed(time.Minute, params.KernelDir, "out/"+arch+".zircon/tools/zbi",
+	if _, err := runSandboxed(time.Minute, params.KernelDir, "out/"+arch+"/host_x64/zbi",
 		"-o", sshZBI, kernelZBI, "--entry", authorizedKeys); err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (fu fuchsia) build(params *Params) error {
 		"out/" + arch + "/obj/build/images/fvm.blk": "image",
 		".ssh/pkey": "key",
 		"out/" + arch + ".zircon/kernel-" + arch + "-kasan/obj/kernel/zircon.elf": "obj/zircon.elf",
-		"out/" + arch + ".zircon/multiboot.bin":                                   "kernel",
+		"out/" + arch + "/multiboot.bin":                                          "kernel",
 		"out/" + arch + "/fuchsia-ssh.zbi":                                        "initrd",
 	} {
 		fullSrc := filepath.Join(params.KernelDir, filepath.FromSlash(src))

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -68,8 +68,18 @@ func (fu fuchsia) build(params *Params) error {
 		return err
 	}
 
+	// Copy and extend the fvm.
+	fvmTool := filepath.Join("out", arch, "host_x64", "fvm")
+	fvmDst := filepath.Join(params.OutputDir, "image")
+	fvmSrc := filepath.Join(params.KernelDir, "out", arch, "obj/build/images/fvm.blk")
+	if err := osutil.CopyFile(fvmSrc, fvmDst); err != nil {
+		return err
+	}
+	if _, err := osutil.RunCmd(time.Minute*5, params.KernelDir, fvmTool, fvmDst, "extend", "--length", "3G"); err != nil {
+		return err
+	}
+
 	for src, dst := range map[string]string{
-		"out/" + arch + "/obj/build/images/fvm.blk":                               "image",
 		"out/" + arch + ".zircon/kernel-" + arch + "-kasan/obj/kernel/zircon.elf": "obj/zircon.elf",
 		"out/" + arch + "/multiboot.bin":                                          "kernel",
 	} {


### PR DESCRIPTION
This PR fixes a bunch of small issues in syzkaller for fuchsia:

* zbi tool path changed
* multiboot.bin path changed.
* ssh key paths have changed, so now we create new ssh images.
* fvm image needs to be extended before booting.