### PR TITLE
syz-manager: re-trigger smashing to trigger copy_from_user faults

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -105,7 +105,7 @@ const (
 	phaseTriagedHub
 )
 
-const currentDBVersion = 4
+const currentDBVersion = 5
 
 type Crash struct {
 	vmIndex int
@@ -490,6 +490,10 @@ func (mgr *Manager) loadCorpus() {
 	case 3:
 		// Version 3->4: to shake things up.
 		minimized = false
+		fallthrough
+	case 4:
+		// To re-trigger fault injection for copy_to/from_user.
+		smashed = false
 		fallthrough
 	case currentDBVersion:
 	}


### PR DESCRIPTION
Merge when the following commits reach upstream:
43371e0211d5a x86: add failure injection to get/put/clear_user
85423118e6c34 lib, uaccess: add failure injection to usercopy functions
9c99b8955eeb5 lib, include/linux: add usercopy failure capability
