### PR TITLE
syz-fuzzer: ignore encodingexec buffer overflow errors

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -253,7 +253,7 @@ func (env *Env) Exec(opts *ExecOpts, p *prog.Prog) (output []byte, info *ProgInf
 	// Copy-in serialized program.
 	progSize, err := p.SerializeForExec(env.in)
 	if err != nil {
-		err0 = fmt.Errorf("failed to serialize: %v", err)
+		err0 = err
 		return
 	}
 	var progData []byte

--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -20,6 +20,7 @@
 package prog
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
@@ -53,6 +54,8 @@ const (
 	ExecNoCopyout  = ^uint64(0)
 )
 
+var ErrExecBufferTooSmall = errors.New("encodingexec: provided buffer is too small")
+
 // SerializeForExec serializes program p for execution by process pid into the provided buffer.
 // Returns number of bytes written to the buffer.
 // If the provided buffer is too small for the program an error is returned.
@@ -70,7 +73,7 @@ func (p *Prog) SerializeForExec(buffer []byte) (int, error) {
 	}
 	w.write(execInstrEOF)
 	if w.eof {
-		return 0, fmt.Errorf("provided buffer is too small")
+		return 0, ErrExecBufferTooSmall
 	}
 	return len(buffer) - len(w.buf), nil
 }


### PR DESCRIPTION
We started to see lots of "provided buffer is too small" with seeded
syz_mount_image programs. Currently it fails whole VM, which is not good.
Ignoring them is not perfect, but there does not seem to be any better
simple solution.
