### PR TITLE
tools/create-gce-image.sh: drop rodata=n

### DIFF
--- a/dashboard/config/bits-syzbot.config
+++ b/dashboard/config/bits-syzbot.config
@@ -103,6 +103,9 @@ CONFIG_PRINTK_TIME=y
 ### This config does not add any debug checks (only debug output).
 # CONFIG_DEBUG_KOBJECT is not set
 
+### Very slow with KASAN and is not useful for fuzzing.
+# CONFIG_DEBUG_WX is not set
+
 ### Fault injection
 CONFIG_FAULT_INJECTION=y
 CONFIG_FAULT_INJECTION_USERCOPY=y

--- a/docs/syzbot.md
+++ b/docs/syzbot.md
@@ -255,7 +255,7 @@ qemu-system-x86_64 -smp 2 -m 4G -enable-kvm -cpu host \
     -device virtio-scsi-pci,id=scsi \
     -device scsi-hd,bus=scsi.0,drive=d0 \
     -drive file=stretch.img,format=raw,if=none,id=d0 \
-    -append "root=/dev/sda console=ttyS0 earlyprintk=serial rodata=n \
+    -append "root=/dev/sda console=ttyS0 earlyprintk=serial \
       oops=panic panic_on_warn=1 panic=86400 kvm-intel.nested=1 \
       security=apparmor ima_policy=tcb workqueue.watchdog_thresh=140 \
       nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 \

--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -140,7 +140,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_msdos
 	insmod ext2
 	set root='(hd0,1)'
-	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 $CMDLINE
+	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 $CMDLINE
 }
 EOF
 	sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
@@ -155,14 +155,14 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_gpt
 	insmod ext2
 	set root='(ieee1275/disk,gpt2)'
-	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
+	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF
 	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"
 	;;
 s390x)
 	sudo zipl -V -t disk.mnt/boot -i disk.mnt/vmlinuz \
-	     -P "root=/dev/vda1 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 net.ifnames=0 biosdevname=0 $CMDLINE" \
+	     -P "root=/dev/vda1 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 net.ifnames=0 biosdevname=0 $CMDLINE" \
 	     --targetbase=$DISKDEV --targettype=SCSI --targetblocksize=512 --targetoffset=2048
 	;;
 esac

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -186,7 +186,6 @@ terminal_output console
 set timeout=0
 # vsyscall=native: required to run x86_64 executables on android kernels
 #   (for some reason they disable VDSO by default)
-# rodata=n: mark_rodata_ro becomes very slow with KASAN (lots of PGDs)
 # panic=86400: prevents kernel from rebooting so that we don't get reboot output in all crash reports
 # debug is not set as it produces too much output
 menuentry 'linux' --class gnu-linux --class gnu --class os {
@@ -198,7 +197,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_msdos
 	insmod ext2
 	set root='(hd0,1)'
-	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 $CMDLINE
+	linux /vmlinuz root=/dev/sda1 console=ttyS0 earlyprintk=serial vsyscall=native oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 $CMDLINE
 }
 EOF
 	sudo grub-install --target=i386-pc --boot-directory=disk.mnt/boot --no-floppy $DISKDEV
@@ -208,7 +207,6 @@ ppc64le)
 terminal_input console
 terminal_output console
 set timeout=0
-# rodata=n: mark_rodata_ro becomes very slow with KASAN (lots of PGDs)
 # panic=86400: prevents kernel from rebooting so that we don't get reboot output in all crash reports
 # debug is not set as it produces too much output
 menuentry 'linux' --class gnu-linux --class gnu --class os {
@@ -216,14 +214,14 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_gpt
 	insmod ext2
 	set root='(ieee1275/disk,gpt2)'
-	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
+	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF
 	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"
 	;;
 s390x)
 	sudo zipl -V -t disk.mnt/boot -i disk.mnt/vmlinuz \
-	     -P "root=/dev/vda1 console=ttyS0 earlyprintk=serial rodata=n oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 net.ifnames=0 biosdevname=0 $CMDLINE" \
+	     -P "root=/dev/vda1 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 net.ifnames=0 biosdevname=0 $CMDLINE" \
 	     --targetbase=$DISKDEV --targettype=SCSI --targetblocksize=512 --targetoffset=2048
 	;;
 esac

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -218,7 +218,6 @@ var linuxCmdline = []string{
 	"panic_on_warn=1",
 	"panic=1",
 	"ftrace_dump_on_oops=orig_cpu",
-	"rodata=n",
 	"vsyscall=native",
 	"net.ifnames=0",
 	"biosdevname=0",


### PR DESCRIPTION
There is suspicion that the random programs corrupt .text segment:
https://groups.google.com/g/syzkaller-bugs/c/d5GC1V8S34k/m/6LTarP8mBAAJ
which leads to a number of assorted confusing crashes:
https://syzkaller.appspot.com/bug?extid=ce179bc99e64377c24bc

Turns out we disable text ro protection with rodata=n.
The comment says that's because it's slow with KASAN,
but most likely what was slow is actually additional
debug checking due to CONFIG_DEBUG_WX.
If we don't enable CONFIG_DEBUG_WX (which we don't),
rodata itself should be fine and desirable.

My experiment with the latest kernel does not show
any noticable slowdown without rodata=n:

[   11.985152][    T1] Freeing unused kernel image (initmem) memory: 3432K
[   11.986129][    T1] Write protecting the kernel read-only data: 147456k
[   11.990863][    T1] Freeing unused kernel image (text/rodata gap) memory: 2012K
[   11.992797][    T1] Freeing unused kernel image (rodata/data gap) memory: 1324K
[   11.993895][    T1] Run /sbin/init as init process

[   11.910396][    T1] Freeing unused kernel image (initmem) memory: 3432K
[   11.911277][    T1] Kernel memory protection disabled.
[   11.911984][    T1] Run /sbin/init as init process
