### PR TITLE
vm/vmimpl/merger: remove all CRs from output

### DIFF
--- a/pkg/report/akaros.go
+++ b/pkg/report/akaros.go
@@ -54,7 +54,7 @@ func (ctx *akaros) Symbolize(rep *Report) error {
 	var symbolized []byte
 	s := bufio.NewScanner(bytes.NewReader(rep.Report))
 	for s.Scan() {
-		line := bytes.Trim(s.Bytes(), "\r")
+		line := s.Bytes()
 		line = ctx.symbolizeLine(symb.Symbolize, ctx.objfile, line)
 		symbolized = append(symbolized, line...)
 		symbolized = append(symbolized, '\n')
@@ -100,7 +100,7 @@ func (ctx *akaros) symbolizeLine(symbFunc func(bin string, pc uint64) ([]symboli
 func (ctx *akaros) minimizeReport(report []byte) []byte {
 	out := new(bytes.Buffer)
 	for s := bufio.NewScanner(bytes.NewReader(report)); s.Scan(); {
-		line := bytes.Trim(s.Bytes(), "\r")
+		line := s.Bytes()
 		if len(line) == 0 ||
 			bytes.Contains(line, []byte("Entering Nanwan's Dungeon")) ||
 			bytes.Contains(line, []byte("Type 'help' for a list of commands")) {

--- a/pkg/report/bsd.go
+++ b/pkg/report/bsd.go
@@ -50,17 +50,7 @@ func (ctx *bsd) ContainsCrash(output []byte) bool {
 }
 
 func (ctx *bsd) Parse(output []byte) *Report {
-	stripped := bytes.Replace(output, []byte{'\r', '\n'}, []byte{'\n'}, -1)
-	stripped = bytes.Replace(stripped, []byte{'\n', '\r'}, []byte{'\n'}, -1)
-	for len(stripped) != 0 && stripped[0] == '\r' {
-		stripped = stripped[1:]
-	}
-	rep := simpleLineParser(stripped, ctx.oopses, nil, ctx.ignores)
-	if rep == nil {
-		return nil
-	}
-	rep.Output = output
-	return rep
+	return simpleLineParser(output, ctx.oopses, nil, ctx.ignores)
 }
 
 func (ctx *bsd) Symbolize(rep *Report) error {

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -48,11 +48,7 @@ func (ctx *freebsd) Parse(output []byte) *Report {
 		// Console output is indistinguishable from fuzzer output,
 		// so we just collect everything after the oops.
 		if oops != nil {
-			lineEnd := next
-			if lineEnd != 0 && output[lineEnd-1] == '\r' {
-				lineEnd--
-			}
-			rep.Report = append(rep.Report, output[pos:lineEnd]...)
+			rep.Report = append(rep.Report, output[pos:next]...)
 			rep.Report = append(rep.Report, '\n')
 		}
 		pos = next + 1
@@ -78,19 +74,19 @@ var freebsdOopses = append([]*oops{
 		[]byte("Fatal trap"),
 		[]oopsFormat{
 			{
-				title: compile("Fatal trap (.+?)\\r?\\n(?:.*\\n)+?" +
-					"KDB: stack backtrace:\\r?\\n" +
+				title: compile("Fatal trap (.+?)\\n(?:.*\\n)+?" +
+					"KDB: stack backtrace:\\n" +
 					"(?:#[0-9]+ {{ADDR}} at (?:kdb_backtrace|vpanic|panic|trap_fatal|" +
 					"trap_pfault|trap|calltrap|m_copydata|__rw_wlock_hard)" +
-					"\\+{{ADDR}}\\r?\\n)*#[0-9]+ {{ADDR}} at {{FUNC}}{{ADDR}}"),
+					"\\+{{ADDR}}\\n)*#[0-9]+ {{ADDR}} at {{FUNC}}{{ADDR}}"),
 				fmt: "Fatal trap %[1]v in %[2]v",
 			},
 			{
-				title: compile("(Fatal trap [0-9]+:.*) while in (?:user|kernel) mode\\r?\\n(?:.*\\n)+?" +
-					"KDB: stack backtrace:\\r?\\n" +
-					"(?:[a-zA-Z0-9_]+\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\r?\\n)*" +
-					"--- trap 0x[0-9a-fA-F]+.* ---\\r?\\n" +
-					"([a-zA-Z0-9_]+)\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\r?\\n"),
+				title: compile("(Fatal trap [0-9]+:.*) while in (?:user|kernel) mode\\n(?:.*\\n)+?" +
+					"KDB: stack backtrace:\\n" +
+					"(?:[a-zA-Z0-9_]+\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\n)*" +
+					"--- trap 0x[0-9a-fA-F]+.* ---\\n" +
+					"([a-zA-Z0-9_]+)\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\n"),
 				fmt: "%[1]v in %[2]v",
 			},
 		},
@@ -109,27 +105,27 @@ var freebsdOopses = append([]*oops{
 				fmt: "panic: %[1]v of destroyed %[2]v at %[3]v",
 			},
 			{
-				title: compile("panic: No chunks on the queues for sid [0-9]+\\.\\r?\\n"),
+				title: compile("panic: No chunks on the queues for sid [0-9]+\\.\\n"),
 				fmt:   "panic: sctp: no chunks on the queues",
 			},
 			{
-				title: compile("panic: size_on_all_streams = [0-9]+ smaller than control length [0-9]+\\r?\\n"),
+				title: compile("panic: size_on_all_streams = [0-9]+ smaller than control length [0-9]+\\n"),
 				fmt:   "panic: size_on_all_streams smaller than control length",
 			},
 			{
-				title: compile("panic: sbflush_internal: ccc [0-9]+ mb [0-9]+ mbcnt [0-9]+\\r?\\n"),
+				title: compile("panic: sbflush_internal: ccc [0-9]+ mb [0-9]+ mbcnt [0-9]+\\n"),
 				fmt:   "panic: sbflush_internal: residual data",
 			},
 			{
-				title: compile("(panic: sx lock still held)\\r?\\n(?:.*\\n)+?" +
-					"KDB: stack backtrace:\\r?\\n" +
-					"(?:[a-zA-Z0-9_]+\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\r?\\n)*" +
-					"sx_destroy\\(\\) at [a-zA-Z0-9_+/ ]+\\r?\\n" +
-					"([a-zA-Z0-9_]+)\\(\\) at [a-zA-Z0-9_+/ ]+\\+0x.*\\r?\\n"),
+				title: compile("(panic: sx lock still held)\\n(?:.*\\n)+?" +
+					"KDB: stack backtrace:\\n" +
+					"(?:[a-zA-Z0-9_]+\\(\\) at [a-zA-Z0-9_]+\\+0x.*\\n)*" +
+					"sx_destroy\\(\\) at [a-zA-Z0-9_+/ ]+\\n" +
+					"([a-zA-Z0-9_]+)\\(\\) at [a-zA-Z0-9_+/ ]+\\+0x.*\\n"),
 				fmt: "%[1]v in %[2]v",
 			},
 			{
-				title: compile("panic: pfi_dynaddr_setup: dyn is 0x[0-9a-f]+\\r?\\n"),
+				title: compile("panic: pfi_dynaddr_setup: dyn is 0x[0-9a-f]+\\n"),
 				fmt:   "panic: pfi_dynaddr_setup: non-NULL dyn",
 			},
 		},

--- a/pkg/report/fuzz.go
+++ b/pkg/report/fuzz.go
@@ -32,10 +32,8 @@ func Fuzz(data []byte) int {
 		if len(rep.Output) == 0 {
 			panic(fmt.Sprintf("%v: len(Output) == 0", typ))
 		}
-		switch os {
-		case "openbsd", "netbsd", "fuchsia":
-			// openbsd/netbsd has Start/End/SkipPos set incorrectly due to messing with /r/n.
-			// fuchsia because it symbolizes before parsing.
+		if os == "fuchsia" {
+			// Fuchsia has Start/End/SkipPos set incorrectly because it symbolizes before parsing.
 			continue
 		}
 		if rep.StartPos != 0 && rep.EndPos != 0 && rep.StartPos >= rep.EndPos {

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -304,9 +304,6 @@ func (ctx *linux) findReport(output []byte, oops *oops, startPos int, context st
 }
 
 func (ctx *linux) stripLinePrefix(line []byte, context string, useQuestionable bool) ([]byte, bool) {
-	if last := len(line) - 1; last >= 0 && line[last] == '\r' {
-		line = line[:last]
-	}
 	if context == "" {
 		return line, false
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -509,7 +509,7 @@ nextPart:
 	for _, part := range parts {
 		if part == parseStackTrace {
 			for s.Scan() {
-				ln := bytes.Trim(s.Bytes(), "\r")
+				ln := s.Bytes()
 				if matchesAny(ln, params.corruptedLines) {
 					break nextPart
 				}
@@ -527,7 +527,7 @@ nextPart:
 			}
 		} else {
 			for s.Scan() {
-				ln := bytes.Trim(s.Bytes(), "\r")
+				ln := s.Bytes()
 				if matchesAny(ln, params.corruptedLines) {
 					break nextPart
 				}

--- a/vm/vmimpl/merger.go
+++ b/vm/vmimpl/merger.go
@@ -63,7 +63,12 @@ func (merger *OutputMerger) AddDecoder(name string, r io.ReadCloser,
 						merger.Output <- decoded // note: this can block
 					}
 				}
-				pending = append(pending, buf[:n]...)
+				// Remove all carriage returns.
+				buf := buf[:n]
+				if bytes.IndexByte(buf, '\r') != -1 {
+					buf = bytes.ReplaceAll(buf, []byte("\r"), nil)
+				}
+				pending = append(pending, buf...)
 				if pos := bytes.LastIndexByte(pending, '\n'); pos != -1 {
 					out := pending[:pos+1]
 					if merger.tee != nil {

--- a/vm/vmimpl/merger_test.go
+++ b/vm/vmimpl/merger_test.go
@@ -44,13 +44,13 @@ func TestMerger(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 	}
 
-	wp1.Write([]byte("333\n444"))
+	wp1.Write([]byte("333\n444\r"))
 	got := string(<-merger.Output)
 	if want := "111333\n"; got != want {
 		t.Fatalf("bad line: '%s', want '%s'", got, want)
 	}
 
-	wp2.Write([]byte("555\n666\n777"))
+	wp2.Write([]byte("555\r\n666\n\r\r777"))
 	got = string(<-merger.Output)
 	if want := "222555\n666\n"; got != want {
 		t.Fatalf("bad line: '%s', want '%s'", got, want)


### PR DESCRIPTION
I have a problem on s390x arch. 
All kernel messages contain a CR at the beginning and this is an attempt to fix it.
I'm open to better solutions :) 
Do we need CRs at all in kernel output ? LFs are not enough ?

Regards
Alex
