### PR TITLE
executor: msvc support syz-executor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -76,3 +76,4 @@ Marijo Simunovic
 Jouni Högander
 VMware
  Radoslav Gerganov
+Suraj K Suresh

--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -126,13 +126,16 @@ static void install_segv_handler(void)
 }
 
 #define NONFAILING(...)                                              \
-	{                                                            \
+	({                                                           \
+		int ok = 1;                                          \
 		__atomic_fetch_add(&skip_segv, 1, __ATOMIC_SEQ_CST); \
 		if (sigsetjmp(segv_env, 0) == 0) {                   \
 			__VA_ARGS__;                                 \
-		}                                                    \
+		} else                                               \
+			ok = 0;                                      \
 		__atomic_fetch_sub(&skip_segv, 1, __ATOMIC_SEQ_CST); \
-	}
+		ok;                                                  \
+	})
 #endif
 
 #if SYZ_EXECUTOR || SYZ_THREADED

--- a/executor/executor_windows.h
+++ b/executor/executor_windows.h
@@ -6,6 +6,9 @@
 
 #include "nocover.h"
 
+#define read read_win
+#define write write_win
+
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
 	if (VirtualAlloc(data, data_size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE) != data)
@@ -19,4 +22,19 @@ static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 	} __except (EXCEPTION_EXECUTE_HANDLER) {
 		return -1;
 	}
+}
+
+static __inline int read_win(int pipe_id, void* input_data, int data_size)
+{
+	DWORD dwBytesRead = 0;
+	ReadFile((HANDLE)_get_osfhandle(pipe_id), input_data, data_size, &dwBytesRead, NULL);
+
+	return (int)dwBytesRead;
+}
+
+static __inline int write_win(int pipe_id, void* input_data, int data_size)
+{
+	DWORD dwBytesWritten = 0;
+	WriteFile((HANDLE)_get_osfhandle(pipe_id), input_data, data_size, &dwBytesWritten, NULL);
+	return (int)dwBytesWritten;
 }


### PR DESCRIPTION
This PR lets you build the executor using MSVC. The commands to build the executor using MSVC is as follows.
```
cl executor.cc /EHsc /DGOOS_windows /DGOARCH_amd64 /DEBUG:FULL -o syz-executor.exe kernel32.lib user32.lib 
gdi32.lib\winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib winmm.lib 
rpcrt4.lib Crypt32.lib imm32.lib Urlmon.lib Oleaut32.lib Winscard.lib Opengl32.lib Mpr.lib Ws2_32.lib Bcrypt.lib Ncrypt.lib 
Synchronization.lib Shell32.lib Rpcns4.lib Mswsock.lib  Mincore.lib Msimg32.lib RpcRT4.lib Rpcrt4.lib lz32.lib
```
NOTE: This PR is a continuation of the previous PR I'd sent and the changes you asked me to make have been applied in this PR.
