### PR TITLE
executor: remove stray recv in netlink_query_family_id

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -235,8 +235,6 @@ static int netlink_query_family_id(struct nlmsg* nlmsg, int sock, const char* fa
 		debug("netlink: failed to parse family id for %.*s\n", GENL_NAMSIZ, family_name);
 		return -1;
 	}
-	recv(sock, nlmsg->buf, sizeof(nlmsg->buf), 0); // recv ack
-
 	return id;
 }
 

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2466,8 +2466,6 @@ static int netlink_query_family_id(struct nlmsg* nlmsg, int sock, const char* fa
 		debug("netlink: failed to parse family id for %.*s\n", GENL_NAMSIZ, family_name);
 		return -1;
 	}
-	recv(sock, nlmsg->buf, sizeof(nlmsg->buf), 0);
-
 	return id;
 }
 


### PR DESCRIPTION
It has a long story. It was added in devlink code,
then copy-pasted into wireguard code, then migrated into the common code.
But the original code in syz_genetlink_get_family_id never had
that additional recv and netlink_send_ext does recv of the reply.
Remove the second recv.
