### PR TITLE
vm/qemu : update scp timeout for qemu

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -77,3 +77,4 @@ Jouni Högander
 VMware
  Radoslav Gerganov
 Suraj K Suresh
+Palash Oswal

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -522,7 +522,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	if inst.debug {
 		log.Logf(0, "running command: scp %#v", args)
 	}
-	_, err := osutil.RunCmd(3*time.Minute, "", "scp", args...)
+	_, err := osutil.RunCmd(10*time.Minute, "", "scp", args...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Changes - vm/qemu/qemu.go: update SCP Timeout for Slower devices/Nested Virtualisation

Problem - Repeated SCP Timeouts in nested virtualized environments

Solution - Increased the timeout for SCP of the initial binaries after boot to 10 minutes to allow more time in a slow environment. This was causing timeouts often in a nested virtualised environment on a slower hardware. This should be a harmless change as it's only related to timeout faults.