### PR TITLE
tools/create-image.sh: misc architecture fixes

### DIFF
--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -77,18 +77,21 @@ done
 
 # Handle cases where qemu and Debian use different arch names
 case "$ARCH" in
-	ppc64le)
-		DEBARCH=ppc64el
-		;;
-	aarch64)
-		DEBARCH=arm64
-		;;
-	arm)
-		DEBARCH=armel
-		;;
-	*)
-		DEBARCH=$ARCH
-		;;
+    ppc64le)
+        DEBARCH=ppc64el
+        ;;
+    aarch64)
+        DEBARCH=arm64
+        ;;
+    arm)
+        DEBARCH=armel
+        ;;
+    x86_64)
+        DEBARCH=amd64
+        ;;
+    *)
+        DEBARCH=$ARCH
+        ;;
 esac
 
 # Foreign architecture

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -8,7 +8,7 @@ set -eux
 
 # Create a minimal Debian distribution in a directory.
 DIR=chroot
-PREINSTALL_PKGS=openssh-server,curl,tar,gcc,libc6-dev,time,strace,sudo,less,psmisc,selinux-utils,policycoreutils,checkpolicy,selinux-policy-default,firmware-atheros
+PREINSTALL_PKGS=openssh-server,curl,tar,gcc,libc6-dev,time,strace,sudo,less,psmisc,selinux-utils,policycoreutils,checkpolicy,selinux-policy-default,firmware-atheros,debian-ports-archive-keyring
 
 # If ADD_PACKAGE is not defined as an external environment variable, use our default packages
 if [ -z ${ADD_PACKAGE+x} ]; then
@@ -139,6 +139,11 @@ if [ $FOREIGN = "true" ]; then
     DEBOOTSTRAP_PARAMS="--foreign $DEBOOTSTRAP_PARAMS"
 fi
 
+# riscv64 is hosted in the debian-ports repository
+# debian-ports doesn't include non-free, so we exclude firmware-atheros
+if [ $DEBARCH == "riscv64" ]; then
+    DEBOOTSTRAP_PARAMS="--keyring /usr/share/keyrings/debian-ports-archive-keyring.gpg --exclude firmware-atheros $DEBOOTSTRAP_PARAMS http://deb.debian.org/debian-ports"
+fi
 sudo debootstrap $DEBOOTSTRAP_PARAMS
 
 # 2. debootstrap stage: only necessary if target != host architecture


### PR DESCRIPTION
Fix building of riscv64 and x86_64 images, and i386 images on an x86_64 build host.