### PR TITLE
sys/targets: use a better DataOffset for linux/s390x

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -203,6 +203,7 @@ var List = map[string]map[string]*Target{
 		"s390x": {
 			PtrSize:          8,
 			PageSize:         4 << 10,
+			DataOffset:       0xfffff000,
 			LittleEndian:     false,
 			Triple:           "s390x-linux-gnu",
 			KernelArch:       "s390",


### PR DESCRIPTION
Use as data offset the address 0xfffff000 for s390x arch.
It is better for testing because it crosses the 4GB address space.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
