### PR TITLE
sys/linux/test: add s390x GUP fast path test

### DIFF
--- a/sys/linux/test/gup_fast
+++ b/sys/linux/test/gup_fast
@@ -1,0 +1,13 @@
+# Test for GUP fast.
+# requires: arch=s390x
+
+mmap(&(0x7f0000000000/0x2000)=nil, 0x2000, 0x3, 0x32, 0xffffffffffffffff, 0x0)
+
+r0 = openat$urandom(0xffffffffffffff9c, &AUTO='/dev/urandom\x00', 0x0, 0x0)
+read(r0, &(0x7f0000000000), 0x2000)
+close(r0)
+
+r1 = openat(0xffffffffffffff9c, &AUTO='/proc/self/exe\x00', 0x105000, 0x0)
+read(r1, &(0x7f0000000000), 0x2000)
+close(r1)
+munmap(&(0x7f0000000000/0x2000), 0x2000)


### PR DESCRIPTION
https://lore.kernel.org/linuxppc-dev/20190418100218.0a4afd51@mschwideX1/

The test triggers this bug:
[  224.294341] ==================================================================
[  224.294389] BUG: KASAN: stack-out-of-bounds in gup_pgd_range+0x124a/0x1398
[  224.294405] Read of size 8 at addr 000003e002e8f3d8 by task gup_fast_regr-s/633
[  224.294417]
[  224.294431] CPU: 0 PID: 633 Comm: gup_fast_regr-s Not tainted 5.9.0-rc6 #1
[  224.294443] Hardware name: IBM 8561 T01 701 (KVM/Linux)
[  224.294454] Call Trace:
[  224.294470]  [<0000000047708384>] show_stack+0x174/0x220
[  224.294488]  [<000000004bbcfb9c>] dump_stack+0x274/0x2f8
[  224.294506]  [<0000000047f4e8e6>] print_address_description.constprop.0+0x5e/0x550
[  224.294523]  [<0000000047f4e4ea>] kasan_report+0x11a/0x168
[  224.294538]  [<0000000047e4a77a>] gup_pgd_range+0x124a/0x1398
[  224.294554]  [<0000000047e4cbea>] internal_get_user_pages_fast+0x212/0x460
[  224.294571]  [<0000000047e4cf10>] get_user_pages_fast+0x70/0xb0
[  224.294588]  [<0000000049886cee>] iov_iter_get_pages+0x2d6/0xdf0
[  224.294605]  [<000000004974aaca>] bio_iov_iter_get_pages+0x2ca/0x1088
[  224.294623]  [<0000000048210282>] iomap_dio_bio_actor+0x8e2/0x1118
[  224.294638]  [<0000000048210b64>] iomap_dio_actor+0xac/0x550
[  224.294655]  [<000000004820212a>] iomap_apply+0x21a/0x9d0
[  224.294670]  [<00000000482118ae>] iomap_dio_rw+0x7c6/0x11e8
[  224.294689]  [<0000000048374ca8>] ext4_file_read_iter+0x4b0/0x638
[  224.294707]  [<0000000047fd85ec>] new_sync_read+0x444/0x6d0
[  224.294722]  [<0000000047fde212>] vfs_read+0x2c2/0x4e0
[  224.294737]  [<0000000047fdf3ba>] ksys_read+0x16a/0x298
[  224.294754]  [<000000004bc37ee8>] system_call+0xdc/0x298
[  224.294794]
[  224.294800]
[  224.294809] addr 000003e002e8f3d8 is located in stack of task gup_fast_regr-s/633 at offset 72 in frame:
[  224.294827]  gup_pgd_range+0x0/0x1398
[  224.294837]
[  224.294844] this frame has 3 objects:
[  224.294854]  [32, 40) 'pgd'
[  224.294858]  [64, 72) 'p4d'
[  224.294867]  [96, 104) 'pud'
[  224.294874]
[  224.294885] Memory state around the buggy address:
[  224.294900]  000003e002e8f280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[  224.294915]  000003e002e8f300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[  224.294930] >000003e002e8f380: 00 00 f1 f1 f1 f1 00 f2 f2 f2 00 f2 f2 f2 00 f3
[  224.294943]                                                     ^
[  224.294957]  000003e002e8f400: f3 f3 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[  224.294972]  000003e002e8f480: 00 f1 f1 f1 f1 f1 f1 04 f2 00 f3 f3 f3 00 00 00
[  224.294984] ==================================================================

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
