### PR TITLE
Fix kernel signature calculation

### DIFF
--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -24,6 +24,30 @@ type linux struct{}
 
 var _ signer = linux{}
 
+// Key for module signing.
+const moduleSigningKey = `-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAxu5GRXw7d13xTLlZ
+GT1y63U4Firk3WjXapTgf9radlfzpqheFr5HWO8f11U/euZQWXDzi+Bsq+6s/2lJ
+AU9XWQIDAQABAkB24ZxTGBv9iMGURUvOvp83wRRkgvvEqUva4N+M6MAXagav3GRi
+K/gl3htzQVe+PLGDfbIkstPJUvI2izL8ZWmBAiEA/P72IitEYE4NQj4dPcYglEYT
+Hbh2ydGYFbYxvG19DTECIQDJSvg7NdAaZNd9faE5UIAcLF35k988m9hSqBjtz0tC
+qQIgGOJC901mJkrHBxLw8ViBb9QMoUm5dVRGLyyCa9QhDqECIQCQGLX4lP5DVrsY
+X43BnMoI4Q3o8x1Uou/JxAIMg1+J+QIgamNCPBLeP8Ce38HtPcm8BXmhPKkpCXdn
+uUf4bYtfSSw=
+-----END PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIBvzCCAWmgAwIBAgIUKoM7Idv4nw571nWDgYFpw6I29u0wDQYJKoZIhvcNAQEF
+BQAwLjEsMCoGA1UEAwwjQnVpbGQgdGltZSBhdXRvZ2VuZXJhdGVkIGtlcm5lbCBr
+ZXkwIBcNMjAxMDA4MTAzMzIwWhgPMjEyMDA5MTQxMDMzMjBaMC4xLDAqBgNVBAMM
+I0J1aWxkIHRpbWUgYXV0b2dlbmVyYXRlZCBrZXJuZWwga2V5MFwwDQYJKoZIhvcN
+AQEBBQADSwAwSAJBAMbuRkV8O3dd8Uy5WRk9cut1OBYq5N1o12qU4H/a2nZX86ao
+Xha+R1jvH9dVP3rmUFlw84vgbKvurP9pSQFPV1kCAwEAAaNdMFswDAYDVR0TAQH/
+BAIwADALBgNVHQ8EBAMCB4AwHQYDVR0OBBYEFPhQx4etmYw5auCJwIO5QP8Kmrt3
+MB8GA1UdIwQYMBaAFPhQx4etmYw5auCJwIO5QP8Kmrt3MA0GCSqGSIb3DQEBBQUA
+A0EAK5moCH39eLLn98pBzSm3MXrHpLtOWuu2p696fg/ZjiUmRSdHK3yoRONxMHLJ
+1nL9cAjWPantqCm5eoyhj7V7gg==
+-----END CERTIFICATE-----`
+
 func (linux linux) build(params *Params) error {
 	if err := linux.buildKernel(params); err != nil {
 		return err
@@ -80,6 +104,17 @@ func (linux) buildKernel(params *Params) error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	// Different key is generated for each build if key is not provided.
+	// see Documentation/reproducible-builds.rst. This is causing problems to our signature
+	// calculation.
+	certsDir := filepath.Join(params.KernelDir, "certs")
+	if osutil.IsExist(certsDir) {
+		err := osutil.WriteFile(filepath.Join(certsDir, "signing_key.pem"), []byte(moduleSigningKey))
+		if err != nil {
+			return err
 		}
 	}
 	if err := runMake(params.KernelDir, target, "CC="+ccParam); err != nil {

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -185,6 +185,10 @@ func linuxAlterConfigs(config []byte, tags map[string]bool) []byte {
 		// and kernel is boot-broken for prolonged ranges of commits with deadlock
 		// which makes bisections take weeks.
 		"CONFIG_DEBUG_KOBJECT": "disable-always",
+		// This config is causing problems to kernel signature calculation as new initramfs is generated
+		// as a part of every build. Due to this init.data section containing this generated initramfs
+		// is differing between builds causing signture being random number.
+		"CONFIG_BLK_DEV_INITRD": "disable-always",
 	}
 	for cfg, tag := range disable {
 		if !tags[tag] {


### PR DESCRIPTION
This pull request is fixing kernel signature calculation in pkg/build/linux.go:elfBinarySignature. This issue is discussed here: https://github.com/google/syzkaller/issues/1271. The root cause for signature being a random number is Linux kernel build not being reproducible. Addition to handling MODULE_SIG_ALL case listed in Documentation/kbuild/reproducible-builds.rst BLK_DEV_INITRD was found to cause init.data section to change between builds. These are both fixed in this pull request.
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
