### PR TITLE
syz-ci: make polling times configurable

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -96,6 +96,10 @@ type Config struct {
 	BisectBinDir    string           `json:"bisect_bin_dir"`
 	Ccache          string           `json:"ccache"`
 	Managers        []*ManagerConfig `json:"managers"`
+	// Poll period for jobs in seconds (optional, defaults to 10 seconds)
+	JobPollPeriod int `json:"job_poll_period"`
+	// Poll period for commits in seconds (optional, defaults to 3600 seconds)
+	CommitPollPeriod int `json:"commit_poll_period"`
 }
 
 type ManagerConfig struct {
@@ -237,10 +241,12 @@ func serveHTTP(cfg *Config) {
 
 func loadConfig(filename string) (*Config, error) {
 	cfg := &Config{
-		SyzkallerRepo:   "https://github.com/google/syzkaller.git",
-		SyzkallerBranch: "master",
-		ManagerPort:     10000,
-		Goroot:          os.Getenv("GOROOT"),
+		SyzkallerRepo:    "https://github.com/google/syzkaller.git",
+		SyzkallerBranch:  "master",
+		ManagerPort:      10000,
+		Goroot:           os.Getenv("GOROOT"),
+		JobPollPeriod:    10,
+		CommitPollPeriod: 3600,
 	}
 	if err := config.LoadFile(filename, cfg); err != nil {
 		return nil, err

--- a/syz-ci/testdata/example.cfg
+++ b/syz-ci/testdata/example.cfg
@@ -5,6 +5,8 @@
 	"hub_addr": "2.3.4.5:2345",
 	"hub_key": "222",
 	"goroot": "/syzkaller/goroot",
+	"job_poll_period": 20,
+	"commit_poll_period": 1800,
 	"managers": [
 		{
 			"name": "upstream-kasan",


### PR DESCRIPTION
Some users may wish to reduce the frequency at which syz-ci polls for jobs.

Add two new optional settings, job_poll_period and commit_poll_period, that
allow the administrator to set how often syz-ci polls for jobs and commits.
Keep the existing defaults of 10 seconds and 1 hour respectively.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>
