### PR TITLE
executor: execute syscalls on all threads

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -527,7 +527,6 @@ again:
 				break;
 #endif
 			event_timedwait(&th->done, /*{{{CALL_TIMEOUT}}}*/);
-			break;
 		}
 	}
 	for (i = 0; i < 100 && __atomic_load_n(&running, __ATOMIC_RELAXED); i++)


### PR DESCRIPTION
I've been investigating why such low amount of reproducers on OpenBSD
are turned into C reproducers lately. One thing that I don't grasp is
the unconditional break in loop() causing syscalls only to be executed
by the first thread, leaving the remaining 15 threads not being created.
I might be missing something obvious...