### PR TITLE
tools/syz-reporter: add summary and reproducer information

### DIFF
--- a/dashboard/app/static/common.js
+++ b/dashboard/app/static/common.js
@@ -43,6 +43,7 @@ function numSort(v) { return -parseInt(v); }
 function floatSort(v) { return -parseFloat(v); }
 function reproSort(v) { return v == "C" ? 0 : v == "syz" ? 1 : 2; }
 function patchedSort(v) { return v == "" ? -1 : parseInt(v); }
+function lineSort(v) { return -v.split(/\r\n|\r|\n/g).length }
 
 function timeSort(v) {
 	if (v == "now")

--- a/pkg/html/generated.go
+++ b/pkg/html/generated.go
@@ -260,6 +260,7 @@ function numSort(v) { return -parseInt(v); }
 function floatSort(v) { return -parseFloat(v); }
 function reproSort(v) { return v == "C" ? 0 : v == "syz" ? 1 : 2; }
 function patchedSort(v) { return v == "" ? -1 : parseInt(v); }
+function lineSort(v) { return -v.split(/\r\n|\r|\n/g).length }
 
 function timeSort(v) {
 	if (v == "now")


### PR DESCRIPTION
This pull request is adding reproducer information into generated report. "Tags" column is changed as Reproducer column. For syz-crush workdir listed reproducers are read from a tag file and syz-manager workdir repro.(c)prog filename is added into column. Now you get view how many of found crashes do have reproducer when generating report from syz-manager workdir

Also summary is added. I.e. "Crash Count" and "Crash With Reproducers Count"

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
