### PR TITLE
executor, pkg/csource: remove setpgrp() in sandbox_common()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -80,3 +80,4 @@ VMware
 Suraj K Suresh
 Palash Oswal
 Tiger Gao
+Congyu Liu

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3559,7 +3559,6 @@ static void loop();
 static void sandbox_common()
 {
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
-	setpgrp();
 	setsid();
 
 #if SYZ_EXECUTOR || __NR_syz_init_net_socket || SYZ_DEVLINK_PCI

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7807,7 +7807,6 @@ static void loop();
 static void sandbox_common()
 {
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
-	setpgrp();
 	setsid();
 
 #if SYZ_EXECUTOR || __NR_syz_init_net_socket || SYZ_DEVLINK_PCI


### PR DESCRIPTION
Process group leader is not allowed to call setsid, thus remove setpgrp.
