### PR TITLE
.github/workflows: switch fuzzit to syz-old-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,12 @@ jobs:
           key: cache
       - name: regression
         if: ${{ github.event_name == 'pull_request' }}
-        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env tools/fuzzit.sh local-regression
+        # We use syz-old-env because it contains Go 1.14.
+        # syz-env contains Go 1.15 and go-fuzz is broken with Go 1.15:
+        # https://github.com/dvyukov/go-fuzz/issues/294
+        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-old-env tools/fuzzit.sh local-regression
       - name: fuzzing
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:
           FUZZIT_API_KEY: ${{ secrets.FUZZIT_API_KEY }}
-        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env tools/fuzzit.sh fuzzing
+        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-old-env tools/fuzzit.sh fuzzing

--- a/tools/docker/old-env/Dockerfile
+++ b/tools/docker/old-env/Dockerfile
@@ -7,10 +7,10 @@ FROM ubuntu:16.04
 
 LABEL homepage="https://github.com/google/syzkaller"
 
-RUN dpkg --add-architecture i386 && \
-	apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
-	sudo make nano git curl ca-certificates g++ \
+RUN dpkg --add-architecture i386 && apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+	sudo make nano git curl ca-certificates gnupg \
+	apt-transport-https software-properties-common g++ \
 	g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu \
 	linux-libc-dev:i386 lib32gcc-5-dev lib32stdc++-5-dev \
@@ -22,6 +22,14 @@ RUN dpkg --add-architecture i386 && \
 RUN curl https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath
+
+# Install clang-10 from llvm.org.
+# The distro-provided clang is too old for Go fuzzing.
+RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+RUN apt-get update
+RUN apt-get install -y -q --no-install-recommends clang-10
+RUN ln -s /usr/bin/clang-10 /usr/bin/clang
 
 # Pre-create dirs for syz-env.
 # This is necessary to make docker work with the current user,


### PR DESCRIPTION
Use syz-old-env because it contains Go 1.14.
syz-env contains Go 1.15 and go-fuzz is broken with Go 1.15:
https://github.com/dvyukov/go-fuzz/issues/294
