### PR TITLE
syz-ci: support HTTP PUT method to upload coverage reports

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -91,7 +91,8 @@ type Config struct {
 	SyzkallerBranch string `json:"syzkaller_branch"` // Defaults to "master".
 	// Dir with additional syscall descriptions (.txt and .const files).
 	SyzkallerDescriptions string `json:"syzkaller_descriptions"`
-	// GCS path to upload coverage reports from managers (optional).
+	// Protocol-specific path to upload coverage reports from managers (optional).
+	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).
 	CoverUploadPath string           `json:"cover_upload_path"`
 	BisectBinDir    string           `json:"bisect_bin_dir"`
 	Ccache          string           `json:"ccache"`


### PR DESCRIPTION
The syz-ci's configuration parameter *cover_upload_path*
contains a protocol-specific path now. Currently, only two
protocols for uploading of manager's coverage reports are supported:
* Google Cloud Storage (GCS)
* HTTP PUT

- A path which starts with "gs://" shall be interpreted as a GCS path
with gcs:// prefix stripped.
- For a path which starts with http:// or https:// the HTTP PUT method
shall be used for uploading.
- If the given path contains no supported protocol prefix, then syz-ci
shall assume that it is a GCS path.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
