### PR TITLE
vm/qemu: use virtio-rng-ccw on s390x arch

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -379,9 +379,13 @@ func (inst *instance) boot() error {
 		"-mon", "chardev=SOCKSYZ,mode=control",
 		"-display", "none",
 		"-serial", "stdio",
-		"-device", "virtio-rng-pci",
 		"-no-reboot",
 		"-name", fmt.Sprintf("VM-%v", inst.index),
+	}
+	if inst.target.Arch == targets.S390x {
+		args = append(args, "-device", "virtio-rng-ccw")
+	} else {
+		args = append(args, "-device", "virtio-rng-pci")
 	}
 	templateDir := filepath.Join(inst.workdir, "template")
 	args = append(args, splitArgs(inst.cfg.QemuArgs, templateDir, inst.index)...)


### PR DESCRIPTION
MSI-X support is mandatory for any PCI device on s390x but
virtio-rng-pci doesn't support it.

Fixes the following error on s390x:
  qemu-system-s390x: -device virtio-rng-pci: MSI-X support is mandatory in the S390 architecture

The problem was introduced in commit 36e8b020 ("vm/qemu: enable virtio-rng-pci").

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
