### PR TITLE
pkg/compiler: fix handling of defines with a 0 value

### DIFF
--- a/pkg/compiler/const_file.go
+++ b/pkg/compiler/const_file.go
@@ -123,7 +123,7 @@ func (cf *ConstFile) Serialize() []byte {
 		handled := make([]bool, len(arches))
 		for i, arch := range arches {
 			val, ok := cv.vals[arch]
-			if ok && val == dflt || handled[i] {
+			if ok && (max != 0 && val == dflt) || handled[i] {
 				// Default value or serialized on a previous iteration.
 				continue
 			}


### PR DESCRIPTION
While adding new syscall descriptions to OpenBSD I ran into the following problem:

	$ gmake extract SOURCEDIR=/home/src && ./bin/syz-sysgen
	fs.txt.const:15: failed to parse int: strconv.ParseUint: parsing "": invalid syntax
	$ tail -n +15 sys/openbsd/fs.txt.const | head -1
	O_RDONLY =

Note that `O_RDONLY` lacks a value and the same directive is defined as
0 on OpenBSD.

In `ConstFile.Serialize()`, if val is equal to the default value is has
only already been serialized if `max != 0`.