### PR TITLE
tools/syz-headerparser/headerparser.py: Update scripts to use python3

### DIFF
--- a/tools/syz-headerparser/headerlib/container.py
+++ b/tools/syz-headerparser/headerlib/container.py
@@ -210,7 +210,7 @@ class GlobalHierarchy(dict):
             sr.set_global_hierarchy(self)
             self["struct %s" % (struct_name)] = sr
 
-        for struct_name in self.keys():
+        for struct_name in list(self.keys()):
             sr = self[struct_name]
             for field in sr.get_fields():
                 # If the item is a struct object, we link it against an

--- a/tools/syz-headerparser/headerlib/struct_walker.py
+++ b/tools/syz-headerparser/headerlib/struct_walker.py
@@ -10,7 +10,7 @@ import collections
 import logging
 
 from pycparser import c_ast
-from header_preprocessor import HeaderFilePreprocessor
+from .header_preprocessor import HeaderFilePreprocessor
 
 
 class StructWalkerException(Exception):

--- a/tools/syz-headerparser/headerparser.py
+++ b/tools/syz-headerparser/headerparser.py
@@ -55,7 +55,7 @@ def main():
         sys.exit(-1)
 
 
-    print gh.get_metadata_structs()
+    print(gh.get_metadata_structs())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The scripts were written to use python2/pip by default but as of now,
python2 is EOL. Therefore, upgrading the script and package with 2to3

