### PR TITLE
dashboard/app: add new config parameters for own email(s) and app URL 

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -44,6 +44,14 @@ type GlobalConfig struct {
 	// Each namespace has own reporting config, own API clients
 	// and bugs are not merged across namespaces.
 	Namespaces map[string]*Config
+	// app's own email address which will appear in FROM field of mails sent by the app.
+	OwnEmailAddress string
+	// List of email addresses which are considered app's own email addresses.
+	// All emails sent from one of these email addresses shall be ignored by the app on reception.
+	ExtraOwnEmailAddresses []string
+	// Main part of the URL at which the app is reachable.
+	// This URL is used e.g. to construct HTML links contained in the emails sent by the app.
+	AppURL string
 }
 
 // Per-namespace config.

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -514,6 +514,9 @@ var sendEmail = func(c context.Context, msg *aemail.Message) error {
 }
 
 func ownEmail(c context.Context) string {
+	if config.OwnEmailAddress != "" {
+		return config.OwnEmailAddress
+	}
 	return fmt.Sprintf("syzbot@%v.appspotmail.com", appengine.AppID(c))
 }
 
@@ -522,11 +525,14 @@ func fromAddr(c context.Context) string {
 }
 
 func ownEmails(c context.Context) []string {
-	// Now we use syzbot@ but we used to use bot@, so we add them both.
-	return []string{
-		ownEmail(c),
-		fmt.Sprintf("bot@%v.appspotmail.com", appengine.AppID(c)),
+	emails := []string{ownEmail(c)}
+	if config.ExtraOwnEmailAddresses != nil {
+		emails = append(emails, config.ExtraOwnEmailAddresses...)
+	} else if config.OwnEmailAddress == "" {
+		// Now we use syzbot@ but we used to use bot@, so we add them both.
+		emails = append(emails, fmt.Sprintf("bot@%v.appspotmail.com", appengine.AppID(c)))
 	}
+	return emails
 }
 
 func sanitizeCC(c context.Context, cc []string) []string {
@@ -552,6 +558,9 @@ func externalLink(c context.Context, tag string, id int64) string {
 }
 
 func appURL(c context.Context) string {
+	if config.AppURL != "" {
+		return config.AppURL
+	}
 	return fmt.Sprintf("https://%v.appspot.com", appengine.AppID(c))
 }
 


### PR DESCRIPTION
* Allows using a mail account provider other than Google App Engine
* Allows changing the app URL that appears in emails sent by syzbot

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
