### PR TITLE
syz-ci/jobs: improve log message for non-found git commits

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -187,7 +187,7 @@ func (jp *JobProcessor) getCommitInfo(mgr *Manager, URL, branch string, commits 
 		return nil, err
 	}
 	for _, title := range missing {
-		log.Logf(0, "did not find commit %q", title)
+		log.Logf(0, "did not find commit %q in kernel repo %v/%v", title, URL, branch)
 	}
 	return results, nil
 }


### PR DESCRIPTION
Display kernel repo's URL and branch if a commit cannot be found
by getCommitInfo().

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
