### PR TITLE
Bisect improvement

### DIFF
--- a/docs/bisect.md
+++ b/docs/bisect.md
@@ -1,0 +1,88 @@
+# Syz-bisect
+
+`syz-bisect` program can be used to bisect culprit and fix commits for
+crashes found by syzkaller. It can also identify configuration options
+that are triggers for the crash.
+
+## Usage
+
+Build `syz-bisect` with `make bisect`.
+
+During bisection different compilers depending on kernel revision are
+used. These compilers are available
+[here](https://storage.googleapis.com/syzkaller/bisect_bin.tar.gz).
+
+Install ccache to speed up kernel compilations during bisecton.
+
+Create user-space (chroot) using [create-image.sh](../tools/create-image.sh)
+
+Create a config file with following lines adjusted for your environment:
+
+```
+{
+	"bin_dir": "/home/syzkaller/bisect_bin",
+	"ccache": "/usr/bin/ccache",
+	"kernel_repo": "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git",
+	"kernel_branch": "master",
+	"syzkaller_repo": "https://github.com/google/syzkaller",
+	"userspace": "/home/syzkaller/image/chroot",
+	"kernel_config": "/home/syzkaller/go/src/github.com/google/syzkaller/dashboard/config/linux/upstream-apparmor-kasan.config",
+	"kernel_baseline_config": "/home/syzkaller/go/src/github.com/google/syzkaller/dashboard/config/linux/upstream-apparmor-kasan-base.config",
+	"syzctl": /home/syzkaller/go/src/github.com/google/syzkaller/dashboard/config/linux/upstream.sysctl,
+	"cmdline": /home/syzkaller/go/src/github.com/google/syzkaller/dashboard/config/linux/upstream.cmdline,
+	"manager":
+	{
+		"name" : "bisect",
+		"target": "linux/amd64",
+		"http": "127.0.0.1:56741",
+		"workdir": "/home/syzkaller/workdir",
+		"kernel_obj": "/home/syzkaller/linux",
+		"image": "/home/syzkaller/workdir/image/image",
+		"sshkey": "/home/syzkaller/workdir/image/key",
+		"syzkaller": "/home/syzkaller/go/src/github.com/google/syzkaller_bisect",
+		"procs": 8,
+		"type": "qemu",
+		"kernel_src": "/syzkaller/linux",
+		"vm": {
+		      "count": 4,
+		      "kernel": "/home/syzkaller/linux/arch/x86/boot/bzImage",
+		      "cpu": 2,
+		      "mem": 2048,
+		      "cmdline": "root=/dev/sda1 rw console=ttyS0 kaslr crashkernel=512M minnowboard_1:eth0::: security=none"
+		}
+	}
+}
+```
+
+And run bisection with `bin/syz-bisect -config vm_bisect.cfg -crash
+/syzkaller/workdir/crashes/03ee30ae11dfd0ddd062af26566c34a8c853698d`.
+
+`Syz-bisect` is expecting finding repro.cprog or repro.prog in given
+crash directory. It will also utilize repro.opts, but it's not
+mandatory.
+
+## Additional Arguments
+
+`-syzkaller_commit` use this if you want to use specific version of syzkaller
+
+`-kernel_commit` kernel commit where crash is known to reproduce. You
+want to use this when bisecting fixing commit
+
+`-fix` use this if you want to bisect a fixing commit.
+
+## Output
+
+It takes some time, but after `syz-bisect` completes it dumps out it's
+results into console It also stores results into files in given crash
+directory:
+
+`cause.commit` commit identified causing the crash or text "the crash
+already happened on the oldest tested release"
+
+`fix.commit` commit identified fixing the crash or text "the crash
+still happens on HEAD"
+
+`cause.config` config options identified working as one trigger for the crash
+
+`original.config, baseline.config, minimized.config` config files used
+in config bisection

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -4,13 +4,13 @@
 package bisect
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -122,10 +122,9 @@ func runBisection(t *testing.T, baseDir string, test BisectionTest) (*Result, er
 	if err != nil {
 		t.Fatal(err)
 	}
-	trace := new(bytes.Buffer)
 	cfg := &Config{
 		Fix:   test.fix,
-		Trace: trace,
+		Trace: &debugtracer.TestTracer{T: t},
 		Manager: &mgrconfig.Config{
 			Derived: mgrconfig.Derived{
 				TargetOS:     targets.TestOS,
@@ -147,7 +146,6 @@ func runBisection(t *testing.T, baseDir string, test BisectionTest) (*Result, er
 		test: test,
 	}
 	res, err := runImpl(cfg, r, inst)
-	t.Log(trace.String())
 	return res, err
 }
 

--- a/pkg/debugtracer/debug.go
+++ b/pkg/debugtracer/debug.go
@@ -1,0 +1,58 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package debugtracer
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+type DebugTracer interface {
+	Log(msg string, args ...interface{})
+	SaveFile(filename string, data []byte)
+}
+
+type GenericTracer struct {
+	TraceWriter io.Writer
+	OutDir      string
+}
+
+type TestTracer struct {
+	T *testing.T
+}
+
+type NullTracer struct {
+}
+
+func (gt *GenericTracer) Log(msg string, args ...interface{}) {
+	fmt.Fprintf(gt.TraceWriter, msg+"\n", args...)
+}
+
+func (gt *GenericTracer) SaveFile(filename string, data []byte) {
+	if gt.OutDir == "" {
+		return
+	}
+	osutil.MkdirAll(gt.OutDir)
+	osutil.WriteFile(filepath.Join(gt.OutDir, filename), data)
+}
+
+func (tt *TestTracer) Log(msg string, args ...interface{}) {
+	tt.T.Log(msg, args)
+}
+
+func (tt *TestTracer) SaveFile(filename string, data []byte) {
+	// Not implemented.
+}
+
+func (nt *NullTracer) Log(msg string, args ...interface{}) {
+	// Not implemented.
+}
+
+func (nt *NullTracer) SaveFile(filename string, data []byte) {
+	// Not implemented.
+}

--- a/pkg/kconfig/minimize_test.go
+++ b/pkg/kconfig/minimize_test.go
@@ -4,10 +4,10 @@
 package kconfig
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -106,9 +106,7 @@ CONFIG_ROSE=y
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			trace := new(bytes.Buffer)
-			res, err := kconf.Minimize(base, full, test.pred, trace)
-			t.Log(trace.String())
+			res, err := kconf.Minimize(base, full, test.pred, &debugtracer.TestTracer{T: t})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/vcs/git_repo_test.go
+++ b/pkg/vcs/git_repo_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/syzkaller/pkg/debugtracer"
 )
 
 func init() {
@@ -378,7 +379,7 @@ func TestBisect(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Logf("TEST %v", i)
-		result, err := repo.repo.Bisect(commits[4], commits[0], (*testWriter)(t), test.pred)
+		result, err := repo.repo.Bisect(commits[4], commits[0], &debugtracer.TestTracer{T: t}, test.pred)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -393,11 +394,4 @@ func TestBisect(t *testing.T) {
 			t.Fatal(diff)
 		}
 	}
-}
-
-type testWriter testing.T
-
-func (t *testWriter) Write(data []byte) (int, error) {
-	(*testing.T)(t).Log(string(data))
-	return len(data), nil
 }

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -5,8 +5,8 @@ package vcs
 
 import (
 	"fmt"
-	"io"
 
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -30,8 +30,8 @@ func (ctx *testos) EnvForCommit(binDir, commit string, kernelConfig []byte) (*Bi
 	return &BisectEnv{KernelConfig: kernelConfig}, nil
 }
 
-func (ctx *testos) Minimize(target *targets.Target, original, baseline []byte, trace io.Writer,
-	pred func(test []byte) (BisectResult, error)) ([]byte, error) {
+func (ctx *testos) Minimize(target *targets.Target, original, baseline []byte,
+	dt debugtracer.DebugTracer, pred func(test []byte) (BisectResult, error)) ([]byte, error) {
 	if res, err := pred(baseline); err != nil {
 		return nil, err
 	} else if res == BisectBad {

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -300,6 +300,8 @@ var commitPrefixes = []string{
 
 const SyzkallerRepo = "https://github.com/google/syzkaller"
 
+const HEAD = "HEAD"
+
 func CommitLink(url, hash string) string {
 	return link(url, hash, 0)
 }

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -7,7 +7,6 @@ package vcs
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/mail"
 	"regexp"
 	"sort"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -116,7 +116,7 @@ type Bisecter interface {
 	// Progress of the process is streamed to the provided trace.
 	// Returns the first commit on which the predicate returns BisectBad,
 	// or multiple commits if bisection is inconclusive due to BisectSkip.
-	Bisect(bad, good string, trace io.Writer, pred func() (BisectResult, error)) ([]*Commit, error)
+	Bisect(bad, good string, dt debugtracer.DebugTracer, pred func() (BisectResult, error)) ([]*Commit, error)
 
 	// PreviousReleaseTags returns list of preceding release tags that are reachable from the given commit.
 	// If the commit itself has a release tag, this tag is not included.
@@ -128,7 +128,7 @@ type Bisecter interface {
 }
 
 type ConfigMinimizer interface {
-	Minimize(target *targets.Target, original, baseline []byte, trace io.Writer,
+	Minimize(target *targets.Target, original, baseline []byte, dt debugtracer.DebugTracer,
 		pred func(test []byte) (BisectResult, error)) ([]byte, error)
 }
 

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/bisect"
 	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -377,8 +378,10 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 	}
 	trace := new(bytes.Buffer)
 	cfg := &bisect.Config{
-		Trace:    io.MultiWriter(trace, log.VerboseWriter(3)),
-		DebugDir: osutil.Abs(filepath.Join("jobs", "debug", strings.Replace(req.ID, "|", "_", -1))),
+		Trace: &debugtracer.GenericTracer{
+			TraceWriter: io.MultiWriter(trace, log.VerboseWriter(3)),
+			OutDir:      osutil.Abs(filepath.Join("jobs", "debug", strings.Replace(req.ID, "|", "_", -1))),
+		},
 		// Out of 1049 cause bisections that we have now:
 		// -  891 finished under  6h (84.9%)
 		// -  957 finished under  8h (91.2%)

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/syzkaller/pkg/config"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 var (
@@ -114,6 +115,13 @@ func main() {
 	if len(cfg.Repro.Syz) == 0 && len(cfg.Repro.C) == 0 {
 		fmt.Fprintf(os.Stderr, "no repro.cprog or repro.prog found\n")
 		os.Exit(1)
+	}
+
+	if cfg.Syzkaller.Commit == "" {
+		cfg.Syzkaller.Commit = vcs.HEAD
+	}
+	if cfg.Kernel.Commit == "" {
+		cfg.Kernel.Commit = vcs.HEAD
 	}
 
 	if _, err := bisect.Run(cfg); err != nil {

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/bisect"
 	"github.com/google/syzkaller/pkg/config"
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/vcs"
@@ -87,11 +88,13 @@ func main() {
 		defer os.RemoveAll(mgrcfg.Workdir)
 	}
 	cfg := &bisect.Config{
-		Trace:    os.Stdout,
-		Fix:      *flagFix,
-		BinDir:   mycfg.BinDir,
-		Ccache:   mycfg.Ccache,
-		DebugDir: *flagCrash,
+		Trace: &debugtracer.GenericTracer{
+			TraceWriter: os.Stdout,
+			OutDir:      *flagCrash,
+		},
+		Fix:    *flagFix,
+		BinDir: mycfg.BinDir,
+		Ccache: mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:      mycfg.KernelRepo,
 			Branch:    mycfg.KernelBranch,

--- a/tools/syz-minconfig/minconfig.go
+++ b/tools/syz-minconfig/minconfig.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/kconfig"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -49,7 +50,10 @@ func main() {
 		}
 		return true, nil
 	}
-	res, err := kconf.Minimize(base, full, pred, os.Stderr)
+	gt := &debugtracer.GenericTracer{
+		TraceWriter: os.Stdout,
+	}
+	res, err := kconf.Minimize(base, full, pred, gt)
 	if err != nil {
 		failf("%v", err)
 	}


### PR DESCRIPTION
This patchset is trying to ease up usage of syz-bisect tool and also implements storing results of bisection into files located in crash directory. This make syz-bisect more usable as standalone tool. Also syz-bisect results are now added into syz-report output. Example report is attached in this pull request.

[syz-reporter.html.gz](https://github.com/google/syzkaller/files/5546178/syz-reporter.html.gz)

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
