### PR TITLE
pkg/kconfig: add minimization test with dependent configs

### DIFF
--- a/pkg/kconfig/kconfig.go
+++ b/pkg/kconfig/kconfig.go
@@ -166,6 +166,7 @@ func (kp *kconfigParser) parseFile() {
 			_ = kp.ConsumeLine()
 		}
 	}
+	kp.endCurrent()
 }
 
 func (kp *kconfigParser) parseLine() {
@@ -347,7 +348,7 @@ func (kp *kconfigParser) pushCurrent(m *Menu) {
 func (kp *kconfigParser) popCurrent() {
 	kp.endCurrent()
 	if len(kp.stack) < 2 {
-		kp.failf("unbalanced menuend")
+		kp.failf("unbalanced endmenu")
 		return
 	}
 	last := kp.stack[len(kp.stack)-1]
@@ -375,7 +376,7 @@ func (kp *kconfigParser) endCurrent() {
 		return
 	}
 	if len(kp.stack) == 0 {
-		kp.failf("unbalanced menuend")
+		kp.failf("unbalanced endmenu")
 		return
 	}
 	top := kp.stack[len(kp.stack)-1]

--- a/pkg/kconfig/minimize_test.go
+++ b/pkg/kconfig/minimize_test.go
@@ -21,6 +21,18 @@ config C
 config D
 config I
 config S
+
+menuconfig HAMRADIO
+	depends on NET && !S390
+	bool "Amateur Radio support"
+
+config AX25
+	tristate "Amateur Radio AX.25 Level 2 protocol"
+	depends on HAMRADIO
+
+config ROSE
+	tristate "Amateur Radio X.25 PLP (Rose)"
+	depends on AX25
 `
 		baseConfig = `
 CONFIG_A=y
@@ -33,6 +45,9 @@ CONFIG_C=y
 CONFIG_D=y
 CONFIG_I=42
 CONFIG_S="foo"
+CONFIG_HAMRADIO=y
+CONFIG_AX25=y
+CONFIG_ROSE=y
 `
 	)
 	type Test struct {
@@ -61,6 +76,19 @@ CONFIG_A=y
 CONFIG_I=42
 CONFIG_S="foo"
 CONFIG_C=y
+`,
+		},
+		{
+			pred: func(cf *ConfigFile) (bool, error) {
+				return cf.Value("HAMRADIO") == Yes && cf.Value("AX25") == Yes && cf.Value("ROSE") == Yes, nil
+			},
+			result: `
+CONFIG_A=y
+CONFIG_I=42
+CONFIG_S="foo"
+CONFIG_AX25=y
+CONFIG_HAMRADIO=y
+CONFIG_ROSE=y
 `,
 		},
 	}


### PR DESCRIPTION
Test for case described in:
https://groups.google.com/g/syzkaller/c/c1J1kzzW7Ew/m/CeyEJm04AQAJ

It seems to work as is (mostly).
Fix parsing of the very last kconfig config (currently it's dropped).
s/menuend/endmenu/ in error message.
Sort dependencies so that we can express the test.
But none of this should have affected actual config minimization.
