### PR TITLE
pkg/vcs/git: optimize CheckoutBranch

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -99,7 +99,10 @@ func (git *git) CheckoutBranch(repo, branch string) (*Commit, error) {
 	if err := git.repair(); err != nil {
 		return nil, err
 	}
-	_, err := git.git("fetch", repo, branch)
+	repoHash := hash.String([]byte(repo))
+	// Ignore error as we can double add the same remote and that will fail.
+	git.git("remote", "add", repoHash, repo)
+	_, err := git.git("fetch", repoHash, branch)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fetching a remote branch w/o the corresponding remote with git
disables delta optimization on the server's side and the git
client is forced to download the complete branch even if it
already has got an older version. This leads to several problems as:
* Long fetch time
* Limitless growth of local git repo due to git fetch creating
  a new pack file every time

Create a remote before fetching to fix the above issues.
With a remote, only the first fetch will take some time and all the following
ones shall be very fast. Furthermore, git fetch will avoid creating many
pack files in .git/objects/pack.

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
