### PR TITLE
dvyukov ifuzz refactoring

### DIFF
--- a/pkg/ifuzz/ifuzz.go
+++ b/pkg/ifuzz/ifuzz.go
@@ -5,56 +5,134 @@ package ifuzz
 
 import (
 	"math/rand"
+
+	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	_ "github.com/google/syzkaller/pkg/ifuzz/powerpc/generated" // pull in generated instruction descriptions
+	_ "github.com/google/syzkaller/pkg/ifuzz/x86/generated"     // pull in generated instruction descriptions
+)
+
+type (
+	Config    = ifuzzimpl.Config
+	MemRegion = ifuzzimpl.MemRegion
+	Mode      = ifuzzimpl.Mode
 )
 
 const (
-	ModeLong64 = iota
-	ModeProt32
-	ModeProt16
-	ModeReal16
-	ModeLast
+	ArchX86     = ifuzzimpl.ArchX86
+	ArchPowerPC = ifuzzimpl.ArchPowerPC
+	ModeLong64  = ifuzzimpl.ModeLong64
+	ModeProt32  = ifuzzimpl.ModeProt32
+	ModeProt16  = ifuzzimpl.ModeProt16
+	ModeReal16  = ifuzzimpl.ModeReal16
 )
 
-type Config struct {
-	Arch       string
-	Len        int         // number of instructions to generate
-	Mode       int         // one of ModeXXX
-	Priv       bool        // generate CPL=0 instructions (x86), HV/!PR mode (PPC)
-	Exec       bool        // generate instructions sequences interesting for execution
-	MemRegions []MemRegion // generated instructions will reference these regions
+func Generate(cfg *Config, r *rand.Rand) []byte {
+	var text []byte
+	for i := 0; i < cfg.Len; i++ {
+		insn := randInsn(cfg, r)
+		text = append(text, insn.Encode(cfg, r)...)
+	}
+	return text
 }
 
-type MemRegion struct {
-	Start uint64
-	Size  uint64
+func Mutate(cfg *Config, r *rand.Rand, text []byte) []byte {
+	insns := split(cfg, text)
+	retry := false
+	for stop := false; !stop || retry || len(insns) == 0; stop = r.Intn(2) == 0 {
+		retry = false
+		switch x := r.Intn(100); {
+		case x < 10 && len(insns) != 0:
+			// Delete instruction.
+			i := r.Intn(len(insns))
+			copy(insns[i:], insns[i+1:])
+			insns = insns[:len(insns)-1]
+		case x < 40 && len(insns) != 0:
+			// Replace instruction with another.
+			insn := randInsn(cfg, r)
+			text1 := insn.Encode(cfg, r)
+			i := r.Intn(len(insns))
+			insns[i] = text1
+		case x < 70 && len(insns) != 0:
+			// Mutate instruction.
+			i := r.Intn(len(insns))
+			text1 := insns[i]
+			for stop := false; !stop || len(text1) == 0; stop = r.Intn(2) == 0 {
+				switch x := r.Intn(100); {
+				case x < 5 && len(text1) != 0:
+					// Delete byte.
+					pos := r.Intn(len(text1))
+					copy(text1[pos:], text1[pos+1:])
+					text1 = text1[:len(text1)-1]
+				case x < 40 && len(text1) != 0:
+					// Replace a byte.
+					pos := r.Intn(len(text1))
+					text1[pos] = byte(r.Intn(256))
+				case x < 70 && len(text1) != 0:
+					// Flip a bit.
+					pos := r.Intn(len(text1))
+					text1[pos] ^= 1 << byte(r.Intn(8))
+				default:
+					// Insert a byte.
+					pos := r.Intn(len(text1) + 1)
+					text1 = append(text1, 0)
+					copy(text1[pos+1:], text1[pos:])
+					text1[pos] = byte(r.Intn(256))
+				}
+			}
+			insns[i] = text1
+		case len(insns) < cfg.Len:
+			// Insert a new instruction.
+			insn := randInsn(cfg, r)
+			text1 := insn.Encode(cfg, r)
+			i := r.Intn(len(insns) + 1)
+			insns = append(insns, nil)
+			copy(insns[i+1:], insns[i:])
+			insns[i] = text1
+		default:
+			retry = true
+		}
+	}
+	text = nil
+	for _, insn := range insns {
+		text = append(text, insn...)
+	}
+	return text
 }
 
-const (
-	TypeExec = iota
-	TypePriv
-	TypeUser
-	TypeAll
-	TypeLast
-)
-
-type Insn interface {
-	GetName() string
-	GetMode() int
-	GetPseudo() bool
-	GetPriv() bool
-	IsCompatible(cfg *Config) bool
-	Encode(cfg *Config, r *rand.Rand) []byte
+func randInsn(cfg *Config, r *rand.Rand) ifuzzimpl.Insn {
+	insnset := ifuzzimpl.Arches[cfg.Arch]
+	var insns []ifuzzimpl.Insn
+	if cfg.Priv && cfg.Exec {
+		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.Type(r.Intn(3)))
+	} else if cfg.Priv {
+		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.Type(r.Intn(2)))
+	} else {
+		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.TypeUser)
+	}
+	return insns[r.Intn(len(insns))]
 }
 
-type InsnSet interface {
-	GetInsns(mode, insntype int) []Insn
-	Decode(mode int, text []byte) (int, error)
-	DecodeExt(mode int, text []byte) (int, error) // XED, to keep ifuzz_test happy
+func split(cfg *Config, text []byte) [][]byte {
+	insnset := ifuzzimpl.Arches[cfg.Arch]
+	text = append([]byte{}, text...)
+	var insns [][]byte
+	var bad []byte
+	for len(text) != 0 {
+		n, err := insnset.Decode(cfg.Mode, text)
+		if err != nil || n == 0 {
+			bad = append(bad, text[0])
+			text = text[1:]
+			continue
+		}
+		if bad != nil {
+			insns = append(insns, bad)
+			bad = nil
+		}
+		insns = append(insns, text[:n])
+		text = text[n:]
+	}
+	if bad != nil {
+		insns = append(insns, bad)
+	}
+	return insns
 }
-
-const (
-	ArchX86     = "x86"
-	ArchPowerPC = "powerpc"
-)
-
-var SpecialNumbers = [...]uint64{0, 1 << 15, 1 << 16, 1 << 31, 1 << 32, 1 << 47, 1 << 47, 1 << 63}

--- a/pkg/ifuzz/ifuzz.go
+++ b/pkg/ifuzz/ifuzz.go
@@ -6,24 +6,24 @@ package ifuzz
 import (
 	"math/rand"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 	_ "github.com/google/syzkaller/pkg/ifuzz/powerpc/generated" // pull in generated instruction descriptions
 	_ "github.com/google/syzkaller/pkg/ifuzz/x86/generated"     // pull in generated instruction descriptions
 )
 
 type (
-	Config    = ifuzzimpl.Config
-	MemRegion = ifuzzimpl.MemRegion
-	Mode      = ifuzzimpl.Mode
+	Config    = iset.Config
+	MemRegion = iset.MemRegion
+	Mode      = iset.Mode
 )
 
 const (
-	ArchX86     = ifuzzimpl.ArchX86
-	ArchPowerPC = ifuzzimpl.ArchPowerPC
-	ModeLong64  = ifuzzimpl.ModeLong64
-	ModeProt32  = ifuzzimpl.ModeProt32
-	ModeProt16  = ifuzzimpl.ModeProt16
-	ModeReal16  = ifuzzimpl.ModeReal16
+	ArchX86     = iset.ArchX86
+	ArchPowerPC = iset.ArchPowerPC
+	ModeLong64  = iset.ModeLong64
+	ModeProt32  = iset.ModeProt32
+	ModeProt16  = iset.ModeProt16
+	ModeReal16  = iset.ModeReal16
 )
 
 func Generate(cfg *Config, r *rand.Rand) []byte {
@@ -99,21 +99,21 @@ func Mutate(cfg *Config, r *rand.Rand, text []byte) []byte {
 	return text
 }
 
-func randInsn(cfg *Config, r *rand.Rand) ifuzzimpl.Insn {
-	insnset := ifuzzimpl.Arches[cfg.Arch]
-	var insns []ifuzzimpl.Insn
+func randInsn(cfg *Config, r *rand.Rand) iset.Insn {
+	insnset := iset.Arches[cfg.Arch]
+	var insns []iset.Insn
 	if cfg.Priv && cfg.Exec {
-		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.Type(r.Intn(3)))
+		insns = insnset.GetInsns(cfg.Mode, iset.Type(r.Intn(3)))
 	} else if cfg.Priv {
-		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.Type(r.Intn(2)))
+		insns = insnset.GetInsns(cfg.Mode, iset.Type(r.Intn(2)))
 	} else {
-		insns = insnset.GetInsns(cfg.Mode, ifuzzimpl.TypeUser)
+		insns = insnset.GetInsns(cfg.Mode, iset.TypeUser)
 	}
 	return insns[r.Intn(len(insns))]
 }
 
 func split(cfg *Config, text []byte) [][]byte {
-	insnset := ifuzzimpl.Arches[cfg.Arch]
+	insnset := iset.Arches[cfg.Arch]
 	text = append([]byte{}, text...)
 	var insns [][]byte
 	var bad []byte

--- a/pkg/ifuzz/ifuzz_test.go
+++ b/pkg/ifuzz/ifuzz_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package ifuzz_test
+package ifuzz
 
 import (
 	"encoding/hex"
@@ -10,13 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/syzkaller/pkg/ifuzz"
 	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
-	_ "github.com/google/syzkaller/pkg/ifuzz/powerpc/generated"
-	_ "github.com/google/syzkaller/pkg/ifuzz/x86/generated"
 )
 
-var allArches = []string{ifuzz.ArchX86, ifuzz.ArchPowerPC}
+var allArches = []string{ArchX86, ArchPowerPC}
 
 func TestMode(t *testing.T) {
 	for _, arch := range allArches {
@@ -27,11 +24,11 @@ func TestMode(t *testing.T) {
 }
 
 func testMode(t *testing.T, arch string) {
-	all := make(map[ifuzz.Insn]bool)
-	for mode := 0; mode < ifuzz.ModeLast; mode++ {
+	all := make(map[ifuzzimpl.Insn]bool)
+	for mode := ifuzzimpl.Mode(0); mode < ifuzzimpl.ModeLast; mode++ {
 		for priv := 0; priv < 2; priv++ {
 			for exec := 0; exec < 2; exec++ {
-				cfg := &ifuzz.Config{
+				cfg := &Config{
 					Arch: arch,
 					Mode: mode,
 					Priv: priv != 0,
@@ -57,7 +54,7 @@ func TestDecode(t *testing.T) {
 }
 
 func testDecode(t *testing.T, arch string) {
-	insnset := ifuzzimpl.Types[arch]
+	insnset := ifuzzimpl.Arches[arch]
 	xedEnabled := false
 	if _, err := insnset.DecodeExt(0, nil); err == nil {
 		xedEnabled = true
@@ -70,8 +67,8 @@ func testDecode(t *testing.T, arch string) {
 	r := rand.New(rand.NewSource(seed))
 
 	for repeat := 0; repeat < 10; repeat++ {
-		for mode := 0; mode < ifuzz.ModeLast; mode++ {
-			cfg := &ifuzz.Config{
+		for mode := ifuzzimpl.Mode(0); mode < ifuzzimpl.ModeLast; mode++ {
+			cfg := &Config{
 				Arch: arch,
 				Mode: mode,
 				Priv: true,

--- a/pkg/ifuzz/ifuzz_test.go
+++ b/pkg/ifuzz/ifuzz_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 )
 
 var allArches = []string{ArchX86, ArchPowerPC}
@@ -24,8 +24,8 @@ func TestMode(t *testing.T) {
 }
 
 func testMode(t *testing.T, arch string) {
-	all := make(map[ifuzzimpl.Insn]bool)
-	for mode := ifuzzimpl.Mode(0); mode < ifuzzimpl.ModeLast; mode++ {
+	all := make(map[iset.Insn]bool)
+	for mode := iset.Mode(0); mode < iset.ModeLast; mode++ {
 		for priv := 0; priv < 2; priv++ {
 			for exec := 0; exec < 2; exec++ {
 				insns := allInsns(arch, mode, priv != 0, exec != 0)
@@ -48,7 +48,7 @@ func TestDecode(t *testing.T) {
 }
 
 func testDecode(t *testing.T, arch string) {
-	insnset := ifuzzimpl.Arches[arch]
+	insnset := iset.Arches[arch]
 	xedEnabled := false
 	if _, err := insnset.DecodeExt(0, nil); err == nil {
 		xedEnabled = true
@@ -61,8 +61,8 @@ func testDecode(t *testing.T, arch string) {
 	r := rand.New(rand.NewSource(seed))
 
 	for repeat := 0; repeat < 10; repeat++ {
-		for mode := ifuzzimpl.Mode(0); mode < ifuzzimpl.ModeLast; mode++ {
-			cfg := &ifuzzimpl.Config{
+		for mode := iset.Mode(0); mode < iset.ModeLast; mode++ {
+			cfg := &iset.Config{
 				Mode: mode,
 				Priv: true,
 				Exec: true,
@@ -122,13 +122,13 @@ func testDecode(t *testing.T, arch string) {
 	}
 }
 
-func allInsns(arch string, mode ifuzzimpl.Mode, priv, exec bool) []ifuzzimpl.Insn {
-	insnset := ifuzzimpl.Arches[arch]
-	insns := insnset.GetInsns(mode, ifuzzimpl.TypeUser)
+func allInsns(arch string, mode iset.Mode, priv, exec bool) []iset.Insn {
+	insnset := iset.Arches[arch]
+	insns := insnset.GetInsns(mode, iset.TypeUser)
 	if priv {
-		insns = append(insns, insnset.GetInsns(mode, ifuzzimpl.TypePriv)...)
+		insns = append(insns, insnset.GetInsns(mode, iset.TypePriv)...)
 		if exec {
-			insns = append(insns, insnset.GetInsns(mode, ifuzzimpl.TypeExec)...)
+			insns = append(insns, insnset.GetInsns(mode, iset.TypeExec)...)
 		}
 	}
 	return insns

--- a/pkg/ifuzz/ifuzz_test.go
+++ b/pkg/ifuzz/ifuzz_test.go
@@ -69,12 +69,13 @@ func testDecode(t *testing.T, arch string) {
 			}
 			failed := false
 			for _, insn := range allInsns(arch, mode, true, true) {
+				name, pseudo := insn.Info()
 				text0 := insn.Encode(cfg, r)
 				text := text0
 			repeat:
 				size, err := insnset.Decode(mode, text)
 				if err != nil {
-					t.Errorf("decoding %v %v failed (mode=%v): %v", insn.GetName(), hex.EncodeToString(text), mode, err)
+					t.Errorf("decoding %v %v failed (mode=%v): %v", name, hex.EncodeToString(text), mode, err)
 					if len(text) != len(text0) {
 						t.Errorf("whole: %v", hex.EncodeToString(text0))
 					}
@@ -84,7 +85,7 @@ func testDecode(t *testing.T, arch string) {
 				if xedEnabled {
 					xedSize, xedErr := insnset.DecodeExt(mode, text)
 					if xedErr != nil {
-						t.Errorf("xed decoding %v %v failed (mode=%v): %v", insn.GetName(), hex.EncodeToString(text), mode, xedErr)
+						t.Errorf("xed decoding %v %v failed (mode=%v): %v", name, hex.EncodeToString(text), mode, xedErr)
 						if len(text) != len(text0) {
 							t.Errorf("whole: %v", hex.EncodeToString(text0))
 						}
@@ -93,7 +94,7 @@ func testDecode(t *testing.T, arch string) {
 					}
 					if size != xedSize {
 						t.Errorf("decoding %v %v failed (mode=%v): decoded %v/%v, xed decoded %v/%v",
-							insn.GetName(), hex.EncodeToString(text), mode, size, xedSize, size, len(text))
+							name, hex.EncodeToString(text), mode, size, xedSize, size, len(text))
 						if len(text) != len(text0) {
 							t.Errorf("whole: %v", hex.EncodeToString(text0))
 						}
@@ -101,13 +102,13 @@ func testDecode(t *testing.T, arch string) {
 						continue
 					}
 				}
-				if insn.GetPseudo() && size >= 0 && size < len(text) {
+				if pseudo && size >= 0 && size < len(text) {
 					text = text[size:]
 					goto repeat
 				}
 				if size != len(text) {
 					t.Errorf("decoding %v %v failed (mode=%v): decoded %v/%v",
-						insn.GetName(), hex.EncodeToString(text), mode, size, len(text))
+						name, hex.EncodeToString(text), mode, size, len(text))
 					if len(text) != len(text0) {
 						t.Errorf("whole: %v", hex.EncodeToString(text0))
 					}

--- a/pkg/ifuzz/ifuzz_test.go
+++ b/pkg/ifuzz/ifuzz_test.go
@@ -16,7 +16,17 @@ import (
 	_ "github.com/google/syzkaller/pkg/ifuzz/x86/generated"
 )
 
-func testmodearch(t *testing.T, arch string) {
+var allArches = []string{ifuzz.ArchX86, ifuzz.ArchPowerPC}
+
+func TestMode(t *testing.T) {
+	for _, arch := range allArches {
+		t.Run(arch, func(t *testing.T) {
+			testMode(t, arch)
+		})
+	}
+}
+
+func testMode(t *testing.T, arch string) {
 	all := make(map[ifuzz.Insn]bool)
 	for mode := 0; mode < ifuzz.ModeLast; mode++ {
 		for priv := 0; priv < 2; priv++ {
@@ -38,12 +48,15 @@ func testmodearch(t *testing.T, arch string) {
 	t.Logf("total: %v instructions", len(all))
 }
 
-func TestMode(t *testing.T) {
-	testmodearch(t, ifuzz.ArchX86)
-	testmodearch(t, ifuzz.ArchPowerPC)
+func TestDecode(t *testing.T) {
+	for _, arch := range allArches {
+		t.Run(arch, func(t *testing.T) {
+			testDecode(t, arch)
+		})
+	}
 }
 
-func testdecodearch(t *testing.T, arch string) {
+func testDecode(t *testing.T, arch string) {
 	insnset := ifuzzimpl.Types[arch]
 	xedEnabled := false
 	if _, err := insnset.DecodeExt(0, nil); err == nil {
@@ -116,9 +129,4 @@ func testdecodearch(t *testing.T, arch string) {
 			}
 		}
 	}
-}
-
-func TestDecode(t *testing.T) {
-	testdecodearch(t, ifuzz.ArchX86)
-	testdecodearch(t, ifuzz.ArchPowerPC)
 }

--- a/pkg/ifuzz/ifuzz_test.go
+++ b/pkg/ifuzz/ifuzz_test.go
@@ -69,7 +69,7 @@ func testDecode(t *testing.T, arch string) {
 			}
 			failed := false
 			for _, insn := range allInsns(arch, mode, true, true) {
-				name, pseudo := insn.Info()
+				name, _, pseudo, _ := insn.Info()
 				text0 := insn.Encode(cfg, r)
 				text := text0
 			repeat:

--- a/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
+++ b/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
@@ -20,11 +20,7 @@ type (
 )
 
 type Insn interface {
-	GetName() string
-	GetMode() int
-	GetPseudo() bool
-	GetPriv() bool
-	IsCompatible(cfg *Config) bool
+	Info() (string, bool)
 	Encode(cfg *Config, r *rand.Rand) []byte
 }
 

--- a/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
+++ b/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
@@ -82,3 +82,20 @@ func (modeInsns *ModeInsns) Add(insn Insn) {
 		}
 	}
 }
+
+func (cfg *Config) IsCompatible(insn Insn) bool {
+	_, mode, pseudo, priv := insn.Info()
+	if cfg.Mode < 0 || cfg.Mode >= ModeLast {
+		panic("bad mode")
+	}
+	if priv && !cfg.Priv {
+		return false
+	}
+	if pseudo && !cfg.Exec {
+		return false
+	}
+	if mode&(1<<uint(cfg.Mode)) == 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
+++ b/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
@@ -64,20 +64,4 @@ const (
 	TypeLast
 )
 
-// ModeInsns returns list of all instructions for the given mode.
-func ModeInsns(cfg *Config) []Insn {
-	insnset := Arches[cfg.Arch]
-	if cfg.Mode < 0 || cfg.Mode >= ModeLast {
-		panic("bad mode")
-	}
-	insns := insnset.GetInsns(cfg.Mode, TypeUser)
-	if cfg.Priv {
-		insns = append(insns, insnset.GetInsns(cfg.Mode, TypePriv)...)
-		if cfg.Exec {
-			insns = append(insns, insnset.GetInsns(cfg.Mode, TypeExec)...)
-		}
-	}
-	return insns
-}
-
 var SpecialNumbers = [...]uint64{0, 1 << 15, 1 << 16, 1 << 31, 1 << 32, 1 << 47, 1 << 47, 1 << 63}

--- a/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
+++ b/pkg/ifuzz/ifuzzimpl/ifuzzimpl.go
@@ -4,142 +4,80 @@
 package ifuzzimpl
 
 import (
-	"github.com/google/syzkaller/pkg/ifuzz"
 	"math/rand"
 )
 
-var (
-	Types = make(map[string]ifuzz.InsnSet)
+const (
+	ArchX86     = "x86"
+	ArchPowerPC = "powerpc"
 )
 
-func Register(arch string, insns ifuzz.InsnSet) {
-	Types[arch] = insns
+var Arches = make(map[string]InsnSet)
+
+type (
+	Mode int
+	Type int
+)
+
+type Insn interface {
+	GetName() string
+	GetMode() int
+	GetPseudo() bool
+	GetPriv() bool
+	IsCompatible(cfg *Config) bool
+	Encode(cfg *Config, r *rand.Rand) []byte
 }
+
+type InsnSet interface {
+	GetInsns(mode Mode, typ Type) []Insn
+	Decode(mode Mode, text []byte) (int, error)
+	DecodeExt(mode Mode, text []byte) (int, error) // XED, to keep ifuzz_test happy
+}
+
+type Config struct {
+	Arch       string
+	Len        int         // number of instructions to generate
+	Mode       Mode        // one of ModeXXX
+	Priv       bool        // generate CPL=0 instructions (x86), HV/!PR mode (PPC)
+	Exec       bool        // generate instructions sequences interesting for execution
+	MemRegions []MemRegion // generated instructions will reference these regions
+}
+
+type MemRegion struct {
+	Start uint64
+	Size  uint64
+}
+
+const (
+	ModeLong64 Mode = iota
+	ModeProt32
+	ModeProt16
+	ModeReal16
+	ModeLast
+)
+
+const (
+	TypeExec Type = iota
+	TypePriv
+	TypeUser
+	TypeAll
+	TypeLast
+)
 
 // ModeInsns returns list of all instructions for the given mode.
-func ModeInsns(cfg *ifuzz.Config) []ifuzz.Insn {
-	insnset := Types[cfg.Arch]
-	if cfg.Mode < 0 || cfg.Mode >= ifuzz.ModeLast {
+func ModeInsns(cfg *Config) []Insn {
+	insnset := Arches[cfg.Arch]
+	if cfg.Mode < 0 || cfg.Mode >= ModeLast {
 		panic("bad mode")
 	}
-	var insns []ifuzz.Insn
-	insns = append(insns, insnset.GetInsns(cfg.Mode, ifuzz.TypeUser)...)
+	insns := insnset.GetInsns(cfg.Mode, TypeUser)
 	if cfg.Priv {
-		insns = append(insns, insnset.GetInsns(cfg.Mode, ifuzz.TypePriv)...)
+		insns = append(insns, insnset.GetInsns(cfg.Mode, TypePriv)...)
 		if cfg.Exec {
-			insns = append(insns, insnset.GetInsns(cfg.Mode, ifuzz.TypeExec)...)
+			insns = append(insns, insnset.GetInsns(cfg.Mode, TypeExec)...)
 		}
 	}
 	return insns
 }
 
-func Generate(cfg *ifuzz.Config, r *rand.Rand) []byte {
-	var text []byte
-	for i := 0; i < cfg.Len; i++ {
-		insn := randInsn(cfg, r)
-		text = append(text, insn.Encode(cfg, r)...)
-	}
-	return text
-}
-
-func Mutate(cfg *ifuzz.Config, r *rand.Rand, text []byte) []byte {
-	insns := split(cfg, text)
-	retry := false
-	for stop := false; !stop || retry || len(insns) == 0; stop = r.Intn(2) == 0 {
-		retry = false
-		switch x := r.Intn(100); {
-		case x < 10 && len(insns) != 0:
-			// Delete instruction.
-			i := r.Intn(len(insns))
-			copy(insns[i:], insns[i+1:])
-			insns = insns[:len(insns)-1]
-		case x < 40 && len(insns) != 0:
-			// Replace instruction with another.
-			insn := randInsn(cfg, r)
-			text1 := insn.Encode(cfg, r)
-			i := r.Intn(len(insns))
-			insns[i] = text1
-		case x < 70 && len(insns) != 0:
-			// Mutate instruction.
-			i := r.Intn(len(insns))
-			text1 := insns[i]
-			for stop := false; !stop || len(text1) == 0; stop = r.Intn(2) == 0 {
-				switch x := r.Intn(100); {
-				case x < 5 && len(text1) != 0:
-					// Delete byte.
-					pos := r.Intn(len(text1))
-					copy(text1[pos:], text1[pos+1:])
-					text1 = text1[:len(text1)-1]
-				case x < 40 && len(text1) != 0:
-					// Replace a byte.
-					pos := r.Intn(len(text1))
-					text1[pos] = byte(r.Intn(256))
-				case x < 70 && len(text1) != 0:
-					// Flip a bit.
-					pos := r.Intn(len(text1))
-					text1[pos] ^= 1 << byte(r.Intn(8))
-				default:
-					// Insert a byte.
-					pos := r.Intn(len(text1) + 1)
-					text1 = append(text1, 0)
-					copy(text1[pos+1:], text1[pos:])
-					text1[pos] = byte(r.Intn(256))
-				}
-			}
-			insns[i] = text1
-		case len(insns) < cfg.Len:
-			// Insert a new instruction.
-			insn := randInsn(cfg, r)
-			text1 := insn.Encode(cfg, r)
-			i := r.Intn(len(insns) + 1)
-			insns = append(insns, nil)
-			copy(insns[i+1:], insns[i:])
-			insns[i] = text1
-		default:
-			retry = true
-		}
-	}
-	text = nil
-	for _, insn := range insns {
-		text = append(text, insn...)
-	}
-	return text
-}
-
-func randInsn(cfg *ifuzz.Config, r *rand.Rand) ifuzz.Insn {
-	insnset := Types[cfg.Arch]
-	var insns []ifuzz.Insn
-	if cfg.Priv && cfg.Exec {
-		insns = insnset.GetInsns(cfg.Mode, r.Intn(3))
-	} else if cfg.Priv {
-		insns = insnset.GetInsns(cfg.Mode, r.Intn(2))
-	} else {
-		insns = insnset.GetInsns(cfg.Mode, ifuzz.TypeUser)
-	}
-	return insns[r.Intn(len(insns))]
-}
-
-func split(cfg *ifuzz.Config, text []byte) [][]byte {
-	insnset := Types[cfg.Arch]
-	text = append([]byte{}, text...)
-	var insns [][]byte
-	var bad []byte
-	for len(text) != 0 {
-		n, err := insnset.Decode(cfg.Mode, text)
-		if err != nil || n == 0 {
-			bad = append(bad, text[0])
-			text = text[1:]
-			continue
-		}
-		if bad != nil {
-			insns = append(insns, bad)
-			bad = nil
-		}
-		insns = append(insns, text[:n])
-		text = text[n:]
-	}
-	if bad != nil {
-		insns = append(insns, bad)
-	}
-	return insns
-}
+var SpecialNumbers = [...]uint64{0, 1 << 15, 1 << 16, 1 << 31, 1 << 32, 1 << 47, 1 << 47, 1 << 63}

--- a/pkg/ifuzz/iset/iset.go
+++ b/pkg/ifuzz/iset/iset.go
@@ -1,7 +1,8 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package ifuzzimpl
+// Package iset ("instruction set") provides base and helper types for ifuzz arch implementations.
+package iset
 
 import (
 	"math/rand"

--- a/pkg/ifuzz/iset/iset.go
+++ b/pkg/ifuzz/iset/iset.go
@@ -16,8 +16,8 @@ const (
 var Arches = make(map[string]InsnSet)
 
 type (
-	Mode int
-	Type int
+	Mode uint
+	Type uint
 )
 
 type Insn interface {
@@ -86,7 +86,7 @@ func (modeInsns *ModeInsns) Add(insn Insn) {
 
 func (cfg *Config) IsCompatible(insn Insn) bool {
 	_, mode, pseudo, priv := insn.Info()
-	if cfg.Mode < 0 || cfg.Mode >= ModeLast {
+	if cfg.Mode >= ModeLast {
 		panic("bad mode")
 	}
 	if priv && !cfg.Priv {

--- a/pkg/ifuzz/powerpc/powerpc.go
+++ b/pkg/ifuzz/powerpc/powerpc.go
@@ -38,17 +38,17 @@ type Insn struct {
 	generator func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte
 }
 
-type InsnSetPowerPC struct {
+type InsnSet struct {
 	Insns     []*Insn
 	modeInsns [ifuzzimpl.ModeLast][ifuzzimpl.TypeLast][]ifuzzimpl.Insn
 	insnMap   map[string]*Insn
 }
 
-func (insnset *InsnSetPowerPC) GetInsns(mode ifuzzimpl.Mode, typ ifuzzimpl.Type) []ifuzzimpl.Insn {
+func (insnset *InsnSet) GetInsns(mode ifuzzimpl.Mode, typ ifuzzimpl.Type) []ifuzzimpl.Insn {
 	return insnset.modeInsns[mode][typ]
 }
 
-func (insnset *InsnSetPowerPC) Decode(mode ifuzzimpl.Mode, text []byte) (int, error) {
+func (insnset *InsnSet) Decode(mode ifuzzimpl.Mode, text []byte) (int, error) {
 	if len(text) < 4 {
 		return 0, errors.New("must be at least 4 bytes")
 	}
@@ -61,7 +61,7 @@ func (insnset *InsnSetPowerPC) Decode(mode ifuzzimpl.Mode, text []byte) (int, er
 	return 0, fmt.Errorf("unrecognised instruction %08x", insn32)
 }
 
-func (insnset *InsnSetPowerPC) DecodeExt(mode ifuzzimpl.Mode, text []byte) (int, error) {
+func (insnset *InsnSet) DecodeExt(mode ifuzzimpl.Mode, text []byte) (int, error) {
 	return 0, fmt.Errorf("no external decoder")
 }
 
@@ -97,7 +97,7 @@ func Register(insns []*Insn) {
 	if len(insns) == 0 {
 		panic("no instructions")
 	}
-	insnset := &InsnSetPowerPC{
+	insnset := &InsnSet{
 		Insns:   insns,
 		insnMap: make(map[string]*Insn),
 	}

--- a/pkg/ifuzz/powerpc/pseudo.go
+++ b/pkg/ifuzz/powerpc/pseudo.go
@@ -10,7 +10,7 @@ import (
 )
 
 // nolint:dupl
-func (insnset *InsnSetPowerPC) initPseudo() {
+func (insnset *InsnSet) initPseudo() {
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_hypercall",
 		Priv:   true,
@@ -50,7 +50,7 @@ type generator struct {
 	text []byte
 }
 
-func makeGen(insnset *InsnSetPowerPC, cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
+func makeGen(insnset *InsnSet, cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
 	return &generator{
 		imap: insnset.insnMap,
 		mode: cfg.Mode,

--- a/pkg/ifuzz/powerpc/pseudo.go
+++ b/pkg/ifuzz/powerpc/pseudo.go
@@ -4,8 +4,9 @@
 package powerpc
 
 import (
-	"github.com/google/syzkaller/pkg/ifuzz"
 	"math/rand"
+
+	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
 )
 
 // nolint:dupl
@@ -14,7 +15,7 @@ func (insnset *InsnSetPowerPC) initPseudo() {
 		Name:   "PSEUDO_hypercall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(1)
 			return gen.text
@@ -24,7 +25,7 @@ func (insnset *InsnSetPowerPC) initPseudo() {
 		Name:   "PSEUDO_syscall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(0)
 			return gen.text
@@ -34,7 +35,7 @@ func (insnset *InsnSetPowerPC) initPseudo() {
 		Name:   "PSEUDO_ultracall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(2)
 			return gen.text
@@ -44,12 +45,12 @@ func (insnset *InsnSetPowerPC) initPseudo() {
 
 type generator struct {
 	imap map[string]*Insn
-	mode int
+	mode ifuzzimpl.Mode
 	r    *rand.Rand
 	text []byte
 }
 
-func makeGen(insnset *InsnSetPowerPC, cfg *ifuzz.Config, r *rand.Rand) *generator {
+func makeGen(insnset *InsnSetPowerPC, cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
 	return &generator{
 		imap: insnset.insnMap,
 		mode: cfg.Mode,

--- a/pkg/ifuzz/powerpc/pseudo.go
+++ b/pkg/ifuzz/powerpc/pseudo.go
@@ -6,7 +6,7 @@ package powerpc
 import (
 	"math/rand"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 )
 
 // nolint:dupl
@@ -15,7 +15,7 @@ func (insnset *InsnSet) initPseudo() {
 		Name:   "PSEUDO_hypercall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(1)
 			return gen.text
@@ -25,7 +25,7 @@ func (insnset *InsnSet) initPseudo() {
 		Name:   "PSEUDO_syscall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(0)
 			return gen.text
@@ -35,7 +35,7 @@ func (insnset *InsnSet) initPseudo() {
 		Name:   "PSEUDO_ultracall",
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(insnset, cfg, r)
 			gen.sc(2)
 			return gen.text
@@ -45,12 +45,12 @@ func (insnset *InsnSet) initPseudo() {
 
 type generator struct {
 	imap map[string]*Insn
-	mode ifuzzimpl.Mode
+	mode iset.Mode
 	r    *rand.Rand
 	text []byte
 }
 
-func makeGen(insnset *InsnSet, cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
+func makeGen(insnset *InsnSet, cfg *iset.Config, r *rand.Rand) *generator {
 	return &generator{
 		imap: insnset.insnMap,
 		mode: cfg.Mode,

--- a/pkg/ifuzz/x86/decode.go
+++ b/pkg/ifuzz/x86/decode.go
@@ -13,7 +13,7 @@ import (
 // It can have falsely decode incorrect instructions,
 // but should not fail to decode correct instructions.
 // nolint: gocyclo, nestif, gocognit, funlen
-func (insnset *InsnSetX86) Decode(mode ifuzzimpl.Mode, text []byte) (int, error) {
+func (insnset *InsnSet) Decode(mode ifuzzimpl.Mode, text []byte) (int, error) {
 	if len(text) == 0 {
 		return 0, fmt.Errorf("zero-length instruction")
 	}
@@ -226,7 +226,7 @@ var (
 	}
 )
 
-func (insnset *InsnSetX86) DecodeExt(mode ifuzzimpl.Mode, text []byte) (int, error) {
+func (insnset *InsnSet) DecodeExt(mode ifuzzimpl.Mode, text []byte) (int, error) {
 	if XedDecode != nil && text != nil && len(text) > 0 {
 		return XedDecode(mode, text)
 	}

--- a/pkg/ifuzz/x86/encode.go
+++ b/pkg/ifuzz/x86/encode.go
@@ -15,7 +15,7 @@ import (
 
 // nolint: gocyclo, nestif, gocognit, funlen
 func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
-	if !insn.isCompatible(cfg) {
+	if !cfg.IsCompatible(insn) {
 		panic("instruction is not suitable for this mode")
 	}
 	if insn.Pseudo {

--- a/pkg/ifuzz/x86/encode.go
+++ b/pkg/ifuzz/x86/encode.go
@@ -15,7 +15,7 @@ import (
 
 // nolint: gocyclo, nestif, gocognit, funlen
 func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
-	if !insn.IsCompatible(cfg) {
+	if !insn.isCompatible(cfg) {
 		panic("instruction is not suitable for this mode")
 	}
 	if insn.Pseudo {

--- a/pkg/ifuzz/x86/encode.go
+++ b/pkg/ifuzz/x86/encode.go
@@ -10,11 +10,11 @@ package x86
 import (
 	"math/rand"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 )
 
 // nolint: gocyclo, nestif, gocognit, funlen
-func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+func (insn *Insn) Encode(cfg *iset.Config, r *rand.Rand) []byte {
 	if !cfg.IsCompatible(insn) {
 		panic("instruction is not suitable for this mode")
 	}
@@ -24,11 +24,11 @@ func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 
 	var operSize, immSize, dispSize, addrSize int
 	switch cfg.Mode {
-	case ifuzzimpl.ModeLong64:
+	case iset.ModeLong64:
 		operSize, immSize, dispSize, addrSize = 4, 4, 4, 8
-	case ifuzzimpl.ModeProt32:
+	case iset.ModeProt32:
 		operSize, immSize, dispSize, addrSize = 4, 4, 4, 4
-	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
+	case iset.ModeProt16, iset.ModeReal16:
 		operSize, immSize, dispSize, addrSize = 2, 2, 2, 2
 	default:
 		panic("bad mode")
@@ -54,7 +54,7 @@ func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			if !insn.No66Prefix {
 				prefixes = append(prefixes, 0x66) // operand size
 			}
-			if cfg.Mode == ifuzzimpl.ModeLong64 || !insn.Mem32 {
+			if cfg.Mode == iset.ModeLong64 || !insn.Mem32 {
 				prefixes = append(prefixes, 0x67) // address size
 			}
 			if !insn.NoRepPrefix {
@@ -71,7 +71,7 @@ func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 
 		// REX
 		var rex byte
-		if cfg.Mode == ifuzzimpl.ModeLong64 && r.Intn(2) == 0 {
+		if cfg.Mode == iset.ModeLong64 && r.Intn(2) == 0 {
 			// bit 0 - B
 			// bit 1 - X
 			// bit 2 - R
@@ -119,7 +119,7 @@ func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 		code = append(code, insn.Vex)
 		vexR = byte(1)
 		vexX = byte(1)
-		if cfg.Mode == ifuzzimpl.ModeLong64 {
+		if cfg.Mode == iset.ModeLong64 {
 			vexR = byte(r.Intn(2))
 			vexX = byte(r.Intn(2))
 		}
@@ -147,7 +147,7 @@ func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 		code = append(code, vexR<<7|vexX<<6|vexB<<5|insn.VexMap)
 		code = append(code, W<<7|vvvv<<3|L<<2|pp)
 		// TODO: short encoding
-		if cfg.Mode != ifuzzimpl.ModeLong64 {
+		if cfg.Mode != iset.ModeLong64 {
 			vvvv |= 8
 		}
 	}

--- a/pkg/ifuzz/x86/encode.go
+++ b/pkg/ifuzz/x86/encode.go
@@ -8,12 +8,13 @@
 package x86
 
 import (
-	"github.com/google/syzkaller/pkg/ifuzz"
 	"math/rand"
+
+	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
 )
 
 // nolint: gocyclo, nestif, gocognit, funlen
-func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
+func (insn *Insn) Encode(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 	if !insn.IsCompatible(cfg) {
 		panic("instruction is not suitable for this mode")
 	}
@@ -23,11 +24,11 @@ func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
 
 	var operSize, immSize, dispSize, addrSize int
 	switch cfg.Mode {
-	case ifuzz.ModeLong64:
+	case ifuzzimpl.ModeLong64:
 		operSize, immSize, dispSize, addrSize = 4, 4, 4, 8
-	case ifuzz.ModeProt32:
+	case ifuzzimpl.ModeProt32:
 		operSize, immSize, dispSize, addrSize = 4, 4, 4, 4
-	case ifuzz.ModeProt16, ifuzz.ModeReal16:
+	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
 		operSize, immSize, dispSize, addrSize = 2, 2, 2, 2
 	default:
 		panic("bad mode")
@@ -53,7 +54,7 @@ func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
 			if !insn.No66Prefix {
 				prefixes = append(prefixes, 0x66) // operand size
 			}
-			if cfg.Mode == ifuzz.ModeLong64 || !insn.Mem32 {
+			if cfg.Mode == ifuzzimpl.ModeLong64 || !insn.Mem32 {
 				prefixes = append(prefixes, 0x67) // address size
 			}
 			if !insn.NoRepPrefix {
@@ -70,7 +71,7 @@ func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
 
 		// REX
 		var rex byte
-		if cfg.Mode == ifuzz.ModeLong64 && r.Intn(2) == 0 {
+		if cfg.Mode == ifuzzimpl.ModeLong64 && r.Intn(2) == 0 {
 			// bit 0 - B
 			// bit 1 - X
 			// bit 2 - R
@@ -118,7 +119,7 @@ func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
 		code = append(code, insn.Vex)
 		vexR = byte(1)
 		vexX = byte(1)
-		if cfg.Mode == ifuzz.ModeLong64 {
+		if cfg.Mode == ifuzzimpl.ModeLong64 {
 			vexR = byte(r.Intn(2))
 			vexX = byte(r.Intn(2))
 		}
@@ -146,7 +147,7 @@ func (insn *Insn) Encode(cfg *ifuzz.Config, r *rand.Rand) []byte {
 		code = append(code, vexR<<7|vexX<<6|vexB<<5|insn.VexMap)
 		code = append(code, W<<7|vvvv<<3|L<<2|pp)
 		// TODO: short encoding
-		if cfg.Mode != ifuzz.ModeLong64 {
+		if cfg.Mode != ifuzzimpl.ModeLong64 {
 			vvvv |= 8
 		}
 	}

--- a/pkg/ifuzz/x86/gen/gen.go
+++ b/pkg/ifuzz/x86/gen/gen.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 	"github.com/google/syzkaller/pkg/ifuzz/x86"
 	"github.com/google/syzkaller/pkg/serializer"
 )
@@ -102,7 +102,7 @@ func main() {
 			insn.Extension = vals[0]
 			switch insn.Extension {
 			case "FMA", "AVX2", "AVX", "F16C", "BMI2", "BMI", "XOP", "FMA4", "AVXAES", "BMI1", "AVX2GATHER":
-				insn.Mode = 1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32
+				insn.Mode = 1<<iset.ModeLong64 | 1<<iset.ModeProt32
 			}
 			insn.Avx2Gather = insn.Extension == "AVX2GATHER"
 		case "PATTERN":
@@ -201,7 +201,7 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 		return errSkip("")
 	}
 	if insn.Mode == 0 {
-		insn.Mode = 1<<ifuzzimpl.ModeLast - 1
+		insn.Mode = 1<<iset.ModeLast - 1
 	}
 	insn.Mod = -100
 	insn.Reg = -100
@@ -314,7 +314,7 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 		// VOP/VEX
 		case v == "XOPV":
 			insn.Vex = 0x8f
-			insn.Mode &^= 1 << ifuzzimpl.ModeReal16
+			insn.Mode &^= 1 << iset.ModeReal16
 		case v == "EVV":
 			insn.Vex = 0xc4
 		case v == "VV1":
@@ -355,13 +355,13 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 
 		// Modes.
 		case v == "mode64":
-			insn.Mode &= 1 << ifuzzimpl.ModeLong64
+			insn.Mode &= 1 << iset.ModeLong64
 		case v == "not64":
-			insn.Mode &^= 1 << ifuzzimpl.ModeLong64
+			insn.Mode &^= 1 << iset.ModeLong64
 		case v == "mode32":
-			insn.Mode &= 1 << ifuzzimpl.ModeProt32
+			insn.Mode &= 1 << iset.ModeProt32
 		case v == "mode16":
-			insn.Mode &= 1<<ifuzzimpl.ModeProt16 | 1<<ifuzzimpl.ModeReal16
+			insn.Mode &= 1<<iset.ModeProt16 | 1<<iset.ModeReal16
 		case v == "eamode64",
 			v == "eamode32",
 			v == "eamode16",

--- a/pkg/ifuzz/x86/gen/gen.go
+++ b/pkg/ifuzz/x86/gen/gen.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/syzkaller/pkg/ifuzz"
+	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
 	"github.com/google/syzkaller/pkg/ifuzz/x86"
 	"github.com/google/syzkaller/pkg/serializer"
 )
@@ -102,7 +102,7 @@ func main() {
 			insn.Extension = vals[0]
 			switch insn.Extension {
 			case "FMA", "AVX2", "AVX", "F16C", "BMI2", "BMI", "XOP", "FMA4", "AVXAES", "BMI1", "AVX2GATHER":
-				insn.Mode = 1<<ifuzz.ModeLong64 | 1<<ifuzz.ModeProt32
+				insn.Mode = 1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32
 			}
 			insn.Avx2Gather = insn.Extension == "AVX2GATHER"
 		case "PATTERN":
@@ -201,7 +201,7 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 		return errSkip("")
 	}
 	if insn.Mode == 0 {
-		insn.Mode = 1<<ifuzz.ModeLast - 1
+		insn.Mode = 1<<ifuzzimpl.ModeLast - 1
 	}
 	insn.Mod = -100
 	insn.Reg = -100
@@ -314,7 +314,7 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 		// VOP/VEX
 		case v == "XOPV":
 			insn.Vex = 0x8f
-			insn.Mode &^= 1 << ifuzz.ModeReal16
+			insn.Mode &^= 1 << ifuzzimpl.ModeReal16
 		case v == "EVV":
 			insn.Vex = 0xc4
 		case v == "VV1":
@@ -355,13 +355,13 @@ func parsePattern(insn *x86.Insn, vals []string) error {
 
 		// Modes.
 		case v == "mode64":
-			insn.Mode &= 1 << ifuzz.ModeLong64
+			insn.Mode &= 1 << ifuzzimpl.ModeLong64
 		case v == "not64":
-			insn.Mode &^= 1 << ifuzz.ModeLong64
+			insn.Mode &^= 1 << ifuzzimpl.ModeLong64
 		case v == "mode32":
-			insn.Mode &= 1 << ifuzz.ModeProt32
+			insn.Mode &= 1 << ifuzzimpl.ModeProt32
 		case v == "mode16":
-			insn.Mode &= 1<<ifuzz.ModeProt16 | 1<<ifuzz.ModeReal16
+			insn.Mode &= 1<<ifuzzimpl.ModeProt16 | 1<<ifuzzimpl.ModeReal16
 		case v == "eamode64",
 			v == "eamode32",
 			v == "eamode16",

--- a/pkg/ifuzz/x86/pseudo.go
+++ b/pkg/ifuzz/x86/pseudo.go
@@ -10,7 +10,7 @@ import (
 )
 
 // nolint: funlen
-func (insnset *InsnSetX86) initPseudo() {
+func (insnset *InsnSet) initPseudo() {
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_RDMSR",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,

--- a/pkg/ifuzz/x86/pseudo.go
+++ b/pkg/ifuzz/x86/pseudo.go
@@ -6,16 +6,16 @@ package x86
 import (
 	"math/rand"
 
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
+	"github.com/google/syzkaller/pkg/ifuzz/iset"
 )
 
 var pseudo = []*Insn{
 	{
 		Name:   "PSEUDO_RDMSR",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			msr := msrs[r.Intn(len(msrs))]
 			gen.mov32(regECX, msr)
@@ -25,10 +25,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_WRMSR",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			msr := msrs[r.Intn(len(msrs))]
 			v := generateInt(cfg, r, 8)
@@ -41,10 +41,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_PCI_READ",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			addr, port, size := pciAddrPort(r)
 			gen.out32(0xcf8, addr)
@@ -54,10 +54,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_PCI_WRITE",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			addr, port, size := pciAddrPort(r)
 			val := generateInt(cfg, r, 4)
@@ -68,10 +68,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_PORT_READ",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			port := ports[r.Intn(len(ports))]
 			gen.in(port, r.Intn(3))
@@ -80,10 +80,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_PORT_WRITE",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			port := ports[r.Intn(len(ports))]
 			val := generateInt(cfg, r, 4)
@@ -93,10 +93,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_XOR_CR",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			cr := controlRegisters[r.Intn(len(controlRegisters))]
 			var v uint32
@@ -114,10 +114,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_XOR_EFER",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			gen.mov32(regECX, eferMSR)
 			gen.byte(0x0f, 0x32) // rdmsr
@@ -129,16 +129,16 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_SET_BREAK",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			br := uint8(r.Intn(4))
 			loc := uint32(r.Intn(4))
 			typ := uint32(r.Intn(16))
 			addr := generateInt(cfg, r, 8)
-			if cfg.Mode == ifuzzimpl.ModeLong64 {
+			if cfg.Mode == iset.ModeLong64 {
 				gen.mov64(regRAX, addr)
 			} else {
 				gen.mov32(regEAX, uint32(addr))
@@ -152,13 +152,13 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_LOAD_SEG",
-		Mode:   1<<ifuzzimpl.ModeLast - 1,
+		Mode:   1<<iset.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
-			if cfg.Mode == ifuzzimpl.ModeReal16 {
+			if cfg.Mode == iset.ModeReal16 {
 				sel = uint16(generateInt(cfg, r, 8)) >> 4
 			}
 			reg := uint8(r.Intn(6))
@@ -169,14 +169,14 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_FAR_JMP",
-		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
+		Mode:   1<<iset.ModeLong64 | 1<<iset.ModeProt32 | 1<<iset.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
 			off := generateInt(cfg, r, 4)
-			if cfg.Mode == ifuzzimpl.ModeLong64 {
+			if cfg.Mode == iset.ModeLong64 {
 				gen.mov32toSPaddr(uint32(sel), 0)
 				gen.mov32toSPaddr(uint32(off), 2)
 				if r.Intn(2) == 0 {
@@ -190,7 +190,7 @@ var pseudo = []*Insn{
 				} else {
 					gen.byte(0x9a) // lcall $imm16, $imm16/32
 				}
-				if cfg.Mode == ifuzzimpl.ModeProt16 {
+				if cfg.Mode == iset.ModeProt16 {
 					gen.imm16(uint16(off))
 				} else {
 					gen.imm32(uint32(off))
@@ -202,10 +202,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_LTR_LLDT",
-		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
+		Mode:   1<<iset.ModeLong64 | 1<<iset.ModeProt32 | 1<<iset.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
 			gen.mov16(regAX, sel)
@@ -219,10 +219,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_LGIDT",
-		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
+		Mode:   1<<iset.ModeLong64 | 1<<iset.ModeProt32 | 1<<iset.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			limit := uint32(generateInt(cfg, r, 2))
 			base := uint32(generateInt(cfg, r, 4))
@@ -240,10 +240,10 @@ var pseudo = []*Insn{
 	},
 	{
 		Name:   "PSEUDO_HYPERCALL",
-		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
+		Mode:   1<<iset.ModeLong64 | 1<<iset.ModeProt32 | 1<<iset.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
+		generator: func(cfg *iset.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			switch r.Intn(2) {
 			case 0:
@@ -280,12 +280,12 @@ const (
 )
 
 type generator struct {
-	mode ifuzzimpl.Mode
+	mode iset.Mode
 	r    *rand.Rand
 	text []byte
 }
 
-func makeGen(cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
+func makeGen(cfg *iset.Config, r *rand.Rand) *generator {
 	return &generator{
 		mode: cfg.Mode,
 		r:    r,
@@ -311,9 +311,9 @@ func (gen *generator) imm64(v uint64) {
 
 func (gen *generator) operand16() {
 	switch gen.mode {
-	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
+	case iset.ModeLong64, iset.ModeProt32:
 		gen.byte(0x66)
-	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
+	case iset.ModeProt16, iset.ModeReal16:
 	default:
 		panic("bad mode")
 	}
@@ -321,8 +321,8 @@ func (gen *generator) operand16() {
 
 func (gen *generator) operand32() {
 	switch gen.mode {
-	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
-	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
+	case iset.ModeLong64, iset.ModeProt32:
+	case iset.ModeProt16, iset.ModeReal16:
 		gen.byte(0x66)
 	default:
 		panic("bad mode")
@@ -331,8 +331,8 @@ func (gen *generator) operand32() {
 
 func (gen *generator) addr32() {
 	switch gen.mode {
-	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
-	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
+	case iset.ModeLong64, iset.ModeProt32:
+	case iset.ModeProt16, iset.ModeReal16:
 		gen.byte(0x67)
 	default:
 		panic("bad mode")
@@ -384,7 +384,7 @@ func (gen *generator) mov32(reg int, v uint32) {
 }
 
 func (gen *generator) mov64(reg int, v uint64) {
-	if gen.mode != ifuzzimpl.ModeLong64 {
+	if gen.mode != iset.ModeLong64 {
 		panic("bad mode")
 	}
 	gen.byte(0x48)

--- a/pkg/ifuzz/x86/pseudo.go
+++ b/pkg/ifuzz/x86/pseudo.go
@@ -4,18 +4,19 @@
 package x86
 
 import (
-	"github.com/google/syzkaller/pkg/ifuzz"
 	"math/rand"
+
+	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
 )
 
 // nolint: funlen
 func (insnset *InsnSetX86) initPseudo() {
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_RDMSR",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			msr := msrs[r.Intn(len(msrs))]
 			gen.mov32(regECX, msr)
@@ -25,10 +26,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_WRMSR",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			msr := msrs[r.Intn(len(msrs))]
 			v := generateInt(cfg, r, 8)
@@ -41,10 +42,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_PCI_READ",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			addr, port, size := pciAddrPort(r)
 			gen.out32(0xcf8, addr)
@@ -54,10 +55,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_PCI_WRITE",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			addr, port, size := pciAddrPort(r)
 			val := generateInt(cfg, r, 4)
@@ -68,10 +69,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_PORT_READ",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			port := ports[r.Intn(len(ports))]
 			gen.in(port, r.Intn(3))
@@ -80,10 +81,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_PORT_WRITE",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			port := ports[r.Intn(len(ports))]
 			val := generateInt(cfg, r, 4)
@@ -93,10 +94,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_XOR_CR",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			cr := controlRegisters[r.Intn(len(controlRegisters))]
 			var v uint32
@@ -114,10 +115,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_XOR_EFER",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			gen.mov32(regECX, eferMSR)
 			gen.byte(0x0f, 0x32) // rdmsr
@@ -129,16 +130,16 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_SET_BREAK",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			br := uint8(r.Intn(4))
 			loc := uint32(r.Intn(4))
 			typ := uint32(r.Intn(16))
 			addr := generateInt(cfg, r, 8)
-			if cfg.Mode == ifuzz.ModeLong64 {
+			if cfg.Mode == ifuzzimpl.ModeLong64 {
 				gen.mov64(regRAX, addr)
 			} else {
 				gen.mov32(regEAX, uint32(addr))
@@ -152,13 +153,13 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_LOAD_SEG",
-		Mode:   1<<ifuzz.ModeLast - 1,
+		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
-			if cfg.Mode == ifuzz.ModeReal16 {
+			if cfg.Mode == ifuzzimpl.ModeReal16 {
 				sel = uint16(generateInt(cfg, r, 8)) >> 4
 			}
 			reg := uint8(r.Intn(6))
@@ -169,14 +170,14 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_FAR_JMP",
-		Mode:   1<<ifuzz.ModeLong64 | 1<<ifuzz.ModeProt32 | 1<<ifuzz.ModeProt16,
+		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
 			off := generateInt(cfg, r, 4)
-			if cfg.Mode == ifuzz.ModeLong64 {
+			if cfg.Mode == ifuzzimpl.ModeLong64 {
 				gen.mov32toSPaddr(uint32(sel), 0)
 				gen.mov32toSPaddr(uint32(off), 2)
 				if r.Intn(2) == 0 {
@@ -190,7 +191,7 @@ func (insnset *InsnSetX86) initPseudo() {
 				} else {
 					gen.byte(0x9a) // lcall $imm16, $imm16/32
 				}
-				if cfg.Mode == ifuzz.ModeProt16 {
+				if cfg.Mode == ifuzzimpl.ModeProt16 {
 					gen.imm16(uint16(off))
 				} else {
 					gen.imm32(uint32(off))
@@ -202,10 +203,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_LTR_LLDT",
-		Mode:   1<<ifuzz.ModeLong64 | 1<<ifuzz.ModeProt32 | 1<<ifuzz.ModeProt16,
+		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			sel := randSelector(r)
 			gen.mov16(regAX, sel)
@@ -219,10 +220,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_LGIDT",
-		Mode:   1<<ifuzz.ModeLong64 | 1<<ifuzz.ModeProt32 | 1<<ifuzz.ModeProt16,
+		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			limit := uint32(generateInt(cfg, r, 2))
 			base := uint32(generateInt(cfg, r, 4))
@@ -240,10 +241,10 @@ func (insnset *InsnSetX86) initPseudo() {
 	})
 	insnset.Insns = append(insnset.Insns, &Insn{
 		Name:   "PSEUDO_HYPERCALL",
-		Mode:   1<<ifuzz.ModeLong64 | 1<<ifuzz.ModeProt32 | 1<<ifuzz.ModeProt16,
+		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
 		Pseudo: true,
-		generator: func(cfg *ifuzz.Config, r *rand.Rand) []byte {
+		generator: func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte {
 			gen := makeGen(cfg, r)
 			switch r.Intn(2) {
 			case 0:
@@ -280,12 +281,12 @@ const (
 )
 
 type generator struct {
-	mode int
+	mode ifuzzimpl.Mode
 	r    *rand.Rand
 	text []byte
 }
 
-func makeGen(cfg *ifuzz.Config, r *rand.Rand) *generator {
+func makeGen(cfg *ifuzzimpl.Config, r *rand.Rand) *generator {
 	return &generator{
 		mode: cfg.Mode,
 		r:    r,
@@ -311,9 +312,9 @@ func (gen *generator) imm64(v uint64) {
 
 func (gen *generator) operand16() {
 	switch gen.mode {
-	case ifuzz.ModeLong64, ifuzz.ModeProt32:
+	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
 		gen.byte(0x66)
-	case ifuzz.ModeProt16, ifuzz.ModeReal16:
+	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
 	default:
 		panic("bad mode")
 	}
@@ -321,8 +322,8 @@ func (gen *generator) operand16() {
 
 func (gen *generator) operand32() {
 	switch gen.mode {
-	case ifuzz.ModeLong64, ifuzz.ModeProt32:
-	case ifuzz.ModeProt16, ifuzz.ModeReal16:
+	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
+	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
 		gen.byte(0x66)
 	default:
 		panic("bad mode")
@@ -331,8 +332,8 @@ func (gen *generator) operand32() {
 
 func (gen *generator) addr32() {
 	switch gen.mode {
-	case ifuzz.ModeLong64, ifuzz.ModeProt32:
-	case ifuzz.ModeProt16, ifuzz.ModeReal16:
+	case ifuzzimpl.ModeLong64, ifuzzimpl.ModeProt32:
+	case ifuzzimpl.ModeProt16, ifuzzimpl.ModeReal16:
 		gen.byte(0x67)
 	default:
 		panic("bad mode")
@@ -384,7 +385,7 @@ func (gen *generator) mov32(reg int, v uint32) {
 }
 
 func (gen *generator) mov64(reg int, v uint64) {
-	if gen.mode != ifuzz.ModeLong64 {
+	if gen.mode != ifuzzimpl.ModeLong64 {
 		panic("bad mode")
 	}
 	gen.byte(0x48)

--- a/pkg/ifuzz/x86/pseudo.go
+++ b/pkg/ifuzz/x86/pseudo.go
@@ -9,9 +9,8 @@ import (
 	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
 )
 
-// nolint: funlen
-func (insnset *InsnSet) initPseudo() {
-	insnset.Insns = append(insnset.Insns, &Insn{
+var pseudo = []*Insn{
+	{
 		Name:   "PSEUDO_RDMSR",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -23,8 +22,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.byte(0x0f, 0x32) // rdmsr
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_WRMSR",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -39,8 +38,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.byte(0x0f, 0x30) // wrmsr
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_PCI_READ",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -52,8 +51,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.in(port, size)
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_PCI_WRITE",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -66,8 +65,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.out(port, uint32(val), size)
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_PORT_READ",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -78,8 +77,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.in(port, r.Intn(3))
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_PORT_WRITE",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -91,8 +90,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.out(port, uint32(val), r.Intn(3))
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_XOR_CR",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -112,8 +111,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.writeCR(cr)
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_XOR_EFER",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -127,8 +126,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.byte(0x0f, 0x30) // wrmsr
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_SET_BREAK",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -150,8 +149,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.writeDR(7)
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_LOAD_SEG",
 		Mode:   1<<ifuzzimpl.ModeLast - 1,
 		Priv:   true,
@@ -167,8 +166,8 @@ func (insnset *InsnSet) initPseudo() {
 			gen.byte(0x8e, 0xc0|(reg<<3)) // MOV %ax, %seg
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_FAR_JMP",
 		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
@@ -200,8 +199,8 @@ func (insnset *InsnSet) initPseudo() {
 			}
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_LTR_LLDT",
 		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
@@ -217,8 +216,8 @@ func (insnset *InsnSet) initPseudo() {
 			}
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_LGIDT",
 		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
@@ -238,8 +237,8 @@ func (insnset *InsnSet) initPseudo() {
 			}
 			return gen.text
 		},
-	})
-	insnset.Insns = append(insnset.Insns, &Insn{
+	},
+	{
 		Name:   "PSEUDO_HYPERCALL",
 		Mode:   1<<ifuzzimpl.ModeLong64 | 1<<ifuzzimpl.ModeProt32 | 1<<ifuzzimpl.ModeProt16,
 		Priv:   true,
@@ -262,7 +261,7 @@ func (insnset *InsnSet) initPseudo() {
 			}
 			return gen.text
 		},
-	})
+	},
 }
 
 const (

--- a/pkg/ifuzz/x86/x86.go
+++ b/pkg/ifuzz/x86/x86.go
@@ -47,7 +47,7 @@ type Insn struct {
 	generator func(cfg *ifuzzimpl.Config, r *rand.Rand) []byte // for pseudo instructions
 }
 
-type InsnSetX86 struct {
+type InsnSet struct {
 	modeInsns [ifuzzimpl.ModeLast][ifuzzimpl.TypeLast][]ifuzzimpl.Insn
 	Insns     []*Insn
 }
@@ -56,7 +56,7 @@ func Register(insns []*Insn) {
 	if len(insns) == 0 {
 		panic("no instructions")
 	}
-	insnset := &InsnSetX86{
+	insnset := &InsnSet{
 		Insns: insns,
 	}
 	insnset.initPseudo()
@@ -84,7 +84,7 @@ func Register(insns []*Insn) {
 	ifuzzimpl.Arches[ifuzzimpl.ArchX86] = insnset
 }
 
-func (insnset *InsnSetX86) GetInsns(mode ifuzzimpl.Mode, typ ifuzzimpl.Type) []ifuzzimpl.Insn {
+func (insnset *InsnSet) GetInsns(mode ifuzzimpl.Mode, typ ifuzzimpl.Type) []ifuzzimpl.Insn {
 	return insnset.modeInsns[mode][typ]
 }
 

--- a/pkg/ifuzz/x86/x86.go
+++ b/pkg/ifuzz/x86/x86.go
@@ -57,9 +57,8 @@ func Register(insns []*Insn) {
 		panic("no instructions")
 	}
 	insnset := &InsnSet{
-		Insns: insns,
+		Insns: append(insns, pseudo...),
 	}
-	insnset.initPseudo()
 	for mode := ifuzzimpl.Mode(0); mode < ifuzzimpl.ModeLast; mode++ {
 		for _, insn := range insnset.Insns {
 			if insn.Mode&(1<<uint(mode)) == 0 {

--- a/pkg/ifuzz/x86/x86.go
+++ b/pkg/ifuzz/x86/x86.go
@@ -83,22 +83,6 @@ func generateArg(cfg *ifuzzimpl.Config, r *rand.Rand, size int) []byte {
 	return arg
 }
 
-func (insn *Insn) isCompatible(cfg *ifuzzimpl.Config) bool {
-	if cfg.Mode < 0 || cfg.Mode >= ifuzzimpl.ModeLast {
-		panic("bad mode")
-	}
-	if insn.Priv && !cfg.Priv {
-		return false
-	}
-	if insn.Pseudo && !cfg.Exec {
-		return false
-	}
-	if insn.Mode&(1<<uint(cfg.Mode)) == 0 {
-		return false
-	}
-	return true
-}
-
 func generateInt(cfg *ifuzzimpl.Config, r *rand.Rand, size int) uint64 {
 	if size != 1 && size != 2 && size != 4 && size != 8 {
 		panic("bad arg size")

--- a/pkg/ifuzz/x86/x86.go
+++ b/pkg/ifuzz/x86/x86.go
@@ -88,20 +88,8 @@ func (insnset *InsnSetX86) GetInsns(mode ifuzzimpl.Mode, typ ifuzzimpl.Type) []i
 	return insnset.modeInsns[mode][typ]
 }
 
-func (insn Insn) GetName() string {
-	return insn.Name
-}
-
-func (insn Insn) GetMode() int {
-	return insn.Mode
-}
-
-func (insn Insn) GetPriv() bool {
-	return insn.Priv
-}
-
-func (insn Insn) GetPseudo() bool {
-	return insn.Pseudo
+func (insn *Insn) Info() (string, bool) {
+	return insn.Name, insn.Pseudo
 }
 
 func generateArg(cfg *ifuzzimpl.Config, r *rand.Rand, size int) []byte {
@@ -114,7 +102,7 @@ func generateArg(cfg *ifuzzimpl.Config, r *rand.Rand, size int) []byte {
 	return arg
 }
 
-func (insn Insn) IsCompatible(cfg *ifuzzimpl.Config) bool {
+func (insn *Insn) isCompatible(cfg *ifuzzimpl.Config) bool {
 	if cfg.Mode < 0 || cfg.Mode >= ifuzzimpl.ModeLast {
 		panic("bad mode")
 	}

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -13,9 +13,6 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/ifuzz"
-	"github.com/google/syzkaller/pkg/ifuzz/ifuzzimpl"
-	_ "github.com/google/syzkaller/pkg/ifuzz/powerpc/generated" // pull in generated instruction descriptions
-	_ "github.com/google/syzkaller/pkg/ifuzz/x86/generated"     // pull in generated instruction descriptions
 )
 
 const (
@@ -428,7 +425,7 @@ func (r *randGen) generateText(kind TextKind) []byte {
 	switch kind {
 	case TextTarget:
 		if cfg := createTargetIfuzzConfig(r.target); cfg != nil {
-			return ifuzzimpl.Generate(cfg, r.Rand)
+			return ifuzz.Generate(cfg, r.Rand)
 		}
 		fallthrough
 	case TextArm64:
@@ -440,7 +437,7 @@ func (r *randGen) generateText(kind TextKind) []byte {
 		return text
 	default:
 		cfg := createIfuzzConfig(kind)
-		return ifuzzimpl.Generate(cfg, r.Rand)
+		return ifuzz.Generate(cfg, r.Rand)
 	}
 }
 
@@ -448,14 +445,14 @@ func (r *randGen) mutateText(kind TextKind, text []byte) []byte {
 	switch kind {
 	case TextTarget:
 		if cfg := createTargetIfuzzConfig(r.target); cfg != nil {
-			return ifuzzimpl.Mutate(cfg, r.Rand, text)
+			return ifuzz.Mutate(cfg, r.Rand, text)
 		}
 		fallthrough
 	case TextArm64:
 		return mutateData(r, text, 40, 60)
 	default:
 		cfg := createIfuzzConfig(kind)
-		return ifuzzimpl.Mutate(cfg, r.Rand, text)
+		return ifuzz.Mutate(cfg, r.Rand, text)
 	}
 }
 


### PR DESCRIPTION
- pkg/ifuzz: use sub-tests for arches
- pkg/ifuzz: invert ifuzz and ifuzzimpl
- pkg/ifuzz/ifuzzimpl: move ModeInsns into tests
- pkg/ifuzz/ifuzzimpl: simplify Insn interface
- pkg/ifuzz/x86: don't use X86 suffix for types
- pkg/ifuzz/x86: simplify pseudo-instruction intialization
- pkg/ifuzz/x86: deduplicate modeInsns population logic
- pkg/ifuzz/ifuzzimpl: move IsCompatible from x86
