### PR TITLE
prog: enable timespec translation more broadly

### DIFF
--- a/prog/resources.go
+++ b/prog/resources.go
@@ -134,7 +134,7 @@ func (target *Target) getInputResources(c *Syscall) []*ResourceDesc {
 				resources = append(resources, typ1.Desc)
 			}
 		case *StructType:
-			if target.OS == "linux" && (typ1.Name() == "timespec" || typ1.Name() == "timeval") {
+			if target.SyscallMap["clock_gettime"] != nil && (typ1.Name() == "timespec" || typ1.Name() == "timeval") {
 				resources = append(resources, timespecRes)
 			}
 		}


### PR DESCRIPTION
Admittedly, my understanding of how this works right now (in a FreeBSD context) is incredibly limited, but I suspect the consequence of this previously being gated on `target.OS == "linux"` is that timespec/timeval arguments in descriptions on other OS with clock_gettime weren't necessarily initialized to the current time, perhaps triggering some other heuristic for syscalls timing out instead (where it specifies a timeout value, of course).