### PR TITLE
Introduce new overrides feature with "override" keyword

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Ethercflow
 Collabora
 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 Heyuan Shi
+Microsoft

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -82,3 +82,5 @@ Palash Oswal
 Tiger Gao
 Congyu Liu
 Kyle Evans
+Microsoft
+ Kevin Colley

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -85,6 +85,27 @@ func (n *Resource) Info() (Pos, string, string) {
 	return n.Pos, tok2str[tokResource], n.Name.Name
 }
 
+type Override struct {
+	Pos     Pos
+	NewType Node
+}
+
+func (n *Override) Info() (Pos, string, string) {
+	_, _, name := n.NewType.Info()
+	return n.Pos, "override", name
+}
+
+type VarOverride struct {
+	Pos           Pos
+	ContainerName *Ident
+	VarName       *Ident
+	NewVarType    *Type
+}
+
+func (n *VarOverride) Info() (Pos, string, string) {
+	return n.Pos, "var_override", n.ContainerName.Name + "." + n.VarName.Name
+}
+
 type Call struct {
 	Pos      Pos
 	Name     *Ident

--- a/pkg/ast/clone.go
+++ b/pkg/ast/clone.go
@@ -55,6 +55,22 @@ func (n *Resource) Clone() Node {
 	}
 }
 
+func (n *Override) Clone() Node {
+	return &Override{
+		Pos:     n.Pos,
+		NewType: n.NewType.Clone(),
+	}
+}
+
+func (n *VarOverride) Clone() Node {
+	return &VarOverride{
+		Pos:           n.Pos,
+		ContainerName: n.ContainerName,
+		VarName:       n.VarName.Clone().(*Ident),
+		NewVarType:    n.NewVarType.Clone().(*Type),
+	}
+}
+
 func (n *TypeDef) Clone() Node {
 	var args []*Ident
 	for _, v := range n.Args {

--- a/pkg/ast/format.go
+++ b/pkg/ast/format.go
@@ -93,6 +93,19 @@ func (n *Resource) serialize(w io.Writer) {
 	fmt.Fprintf(w, "\n")
 }
 
+func (ovr *Override) serialize(w io.Writer) {
+	fmt.Fprintf(w, "override ")
+	t, ok := ovr.NewType.(serializer)
+	if !ok {
+		panic(fmt.Sprintf("unknown node: %#v", t))
+	}
+	t.serialize(w)
+}
+
+func (ovr *VarOverride) serialize(w io.Writer) {
+	fmt.Fprintf(w, "override %v.%v %v\n", ovr.ContainerName, ovr.VarName, fmtType(ovr.NewVarType))
+}
+
 func (n *TypeDef) serialize(w io.Writer) {
 	fmt.Fprintf(w, "type %v%v", n.Name.Name, fmtIdentList(n.Args))
 	if n.Type != nil {

--- a/pkg/ast/format.go
+++ b/pkg/ast/format.go
@@ -103,7 +103,7 @@ func (ovr *Override) serialize(w io.Writer) {
 }
 
 func (ovr *VarOverride) serialize(w io.Writer) {
-	fmt.Fprintf(w, "override %v.%v %v\n", ovr.ContainerName, ovr.VarName, fmtType(ovr.NewVarType))
+	fmt.Fprintf(w, "override %v.%v %v\n", ovr.ContainerName.Name, ovr.VarName.Name, fmtType(ovr.NewVarType))
 }
 
 func (n *TypeDef) serialize(w io.Writer) {

--- a/pkg/ast/scanner.go
+++ b/pkg/ast/scanner.go
@@ -20,6 +20,7 @@ const (
 	tokIncdir
 	tokDefine
 	tokResource
+	tokOverride
 	tokString
 	tokStringHex
 	tokCExpr
@@ -35,6 +36,7 @@ const (
 	tokEq
 	tokComma
 	tokColon
+	tokDot
 
 	tokEOF
 )
@@ -50,6 +52,7 @@ var punctuation = [256]token{
 	'=':  tokEq,
 	',':  tokComma,
 	':':  tokColon,
+	'.':  tokDot,
 }
 
 var tok2str = [...]string{
@@ -60,6 +63,7 @@ var tok2str = [...]string{
 	tokIncdir:    "incdir",
 	tokDefine:    "define",
 	tokResource:  "resource",
+	tokOverride:  "override",
 	tokString:    "string",
 	tokStringHex: "hex string",
 	tokCExpr:     "CEXPR",
@@ -82,6 +86,7 @@ var keywords = map[string]token{
 	"incdir":   tokIncdir,
 	"define":   tokDefine,
 	"resource": tokResource,
+	"override": tokOverride,
 }
 
 func (tok token) String() string {

--- a/pkg/ast/walk.go
+++ b/pkg/ast/walk.go
@@ -56,6 +56,16 @@ func (n *Resource) walk(cb func(Node)) {
 	}
 }
 
+func (n *Override) walk(cb func(Node)) {
+	cb(n.NewType)
+}
+
+func (n *VarOverride) walk(cb func(Node)) {
+	cb(n.ContainerName)
+	cb(n.VarName)
+	cb(n.NewVarType)
+}
+
 func (n *TypeDef) walk(cb func(Node)) {
 	cb(n.Name)
 	for _, a := range n.Args {

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -694,6 +694,10 @@ func (comp *compiler) collectUsedType(structs, flags, strflags map[string]bool, 
 	}
 	_, args, _ := comp.getArgsBase(t, isArg)
 	for i, arg := range args {
+		if i >= len(desc.Args) {
+			break
+		}
+
 		if desc.Args[i].Type == typeArgType {
 			comp.collectUsedType(structs, flags, strflags, arg, desc.Args[i].IsArg)
 		}

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -137,29 +137,80 @@ func (comp *compiler) checkNames() {
 					name, prev.Pos)
 			}
 			calls[name] = n
+		case *ast.Override:
+			switch n.NewType.(type) {
+			case *ast.Resource, *ast.Struct, *ast.TypeDef, *ast.Call:
+				pos, typ, name := n.NewType.Info()
+
+				if prev := comp.overrides[name]; prev != nil {
+					comp.error(pos, "override for %v %v redeclared, previously declared at %v",
+						typ, name, prev.Pos)
+				}
+				if prev := comp.varOverrides[name]; prev != nil {
+					comp.error(pos, "override for %v %v conflicts with previous var override",
+						typ, name)
+				}
+				comp.overrides[name] = n
+
+			default:
+				pos, typ, _ := n.NewType.Info()
+				comp.error(pos, "cannot override a %v", typ)
+			}
+		case *ast.VarOverride:
+			containerName := n.ContainerName.Name
+			varName := n.VarName.Name
+
+			if prev := comp.overrides[containerName]; prev != nil {
+				comp.error(n.Pos, "override for %v.%v conflicts with override previously declared at %v",
+					containerName, varName, prev.Pos)
+			}
+
+			container := comp.varOverrides[containerName]
+			if container == nil {
+				container = make(map[string]*ast.VarOverride)
+				comp.varOverrides[containerName] = container
+			}
+
+			if varName == "parent" {
+				comp.error(n.Pos, "cannot override reserved field name \"parent\" in %v",
+					containerName)
+			}
+
+			if prev := container[varName]; prev != nil {
+				comp.error(n.Pos, "override for %v.%v redeclared, previously declared at %v",
+					containerName, varName, prev.Pos)
+			}
+
+			container[varName] = n
 		}
 	}
 }
 
 func (comp *compiler) checkFields() {
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Struct:
-			_, typ, name := n.Info()
-			comp.checkStructFields(n, typ, name)
-		case *ast.TypeDef:
-			if n.Struct != nil {
-				_, typ, _ := n.Struct.Info()
-				comp.checkStructFields(n.Struct, "template "+typ, n.Name.Name)
-			}
-		case *ast.Call:
-			name := n.Name.Name
-			comp.checkFieldGroup(n.Args, "argument", "syscall "+name)
-			if len(n.Args) > prog.MaxArgs {
-				comp.error(n.Pos, "syscall %v has %v arguments, allowed maximum is %v",
-					name, len(n.Args), prog.MaxArgs)
-			}
+		comp.checkFieldsInNode(decl)
+	}
+}
+
+func (comp *compiler) checkFieldsInNode(decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.Struct:
+		_, typ, name := n.Info()
+		comp.checkStructFields(n, typ, name)
+	case *ast.TypeDef:
+		if n.Struct != nil {
+			_, typ, _ := n.Struct.Info()
+			comp.checkStructFields(n.Struct, "template "+typ, n.Name.Name)
 		}
+	case *ast.Call:
+		name := n.Name.Name
+		comp.checkFieldGroup(n.Args, "argument", "syscall "+name)
+		if len(n.Args) > prog.MaxArgs {
+			comp.error(n.Pos, "syscall %v has %v arguments, allowed maximum is %v",
+				name, len(n.Args), prog.MaxArgs)
+		}
+	case *ast.Override:
+		comp.checkFieldsInNode(n.NewType)
 	}
 }
 
@@ -196,103 +247,123 @@ const argBase = "BASE"
 
 func (comp *compiler) checkTypedefs() {
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.TypeDef:
-			if len(n.Args) == 0 {
-				// Non-template types are fully typed, so we check them ahead of time.
-				err0 := comp.errors
-				comp.checkType(checkCtx{}, n.Type, checkIsTypedef)
-				if err0 != comp.errors {
-					// To not produce confusing errors on broken type usage.
-					delete(comp.typedefs, n.Name.Name)
+		comp.checkTypedefsInNode(decl)
+	}
+}
+
+func (comp *compiler) checkTypedefsInNode(decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.TypeDef:
+		if len(n.Args) == 0 {
+			// Non-template types are fully typed, so we check them ahead of time.
+			err0 := comp.errors
+			comp.checkType(checkCtx{}, n.Type, checkIsTypedef)
+			if err0 != comp.errors {
+				// To not produce confusing errors on broken type usage.
+				delete(comp.typedefs, n.Name.Name)
+			}
+		} else {
+			// For templates we only do basic checks of arguments.
+			names := make(map[string]bool)
+			for i, arg := range n.Args {
+				if arg.Name == argBase && i != len(n.Args)-1 {
+					comp.error(arg.Pos, "type argument BASE must be the last argument")
 				}
-			} else {
-				// For templates we only do basic checks of arguments.
-				names := make(map[string]bool)
-				for i, arg := range n.Args {
-					if arg.Name == argBase && i != len(n.Args)-1 {
-						comp.error(arg.Pos, "type argument BASE must be the last argument")
+				if names[arg.Name] {
+					comp.error(arg.Pos, "duplicate type argument %v", arg.Name)
+				}
+				names[arg.Name] = true
+				for _, c := range arg.Name {
+					if c >= 'A' && c <= 'Z' ||
+						c >= '0' && c <= '9' ||
+						c == '_' {
+						continue
 					}
-					if names[arg.Name] {
-						comp.error(arg.Pos, "duplicate type argument %v", arg.Name)
-					}
-					names[arg.Name] = true
-					for _, c := range arg.Name {
-						if c >= 'A' && c <= 'Z' ||
-							c >= '0' && c <= '9' ||
-							c == '_' {
-							continue
-						}
-						comp.error(arg.Pos, "type argument %v must be ALL_CAPS",
-							arg.Name)
-						break
-					}
+					comp.error(arg.Pos, "type argument %v must be ALL_CAPS",
+						arg.Name)
+					break
 				}
 			}
 		}
+	case *ast.Override:
+		comp.checkTypedefsInNode(n.NewType)
 	}
 }
 
 func (comp *compiler) checkTypes() {
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Resource:
-			comp.checkType(checkCtx{}, n.Base, checkIsResourceBase)
-		case *ast.Struct:
-			comp.checkStruct(checkCtx{}, n)
-		case *ast.Call:
-			comp.checkCall(n)
-		}
+		comp.checkTypesInNode(decl)
+	}
+}
+
+func (comp *compiler) checkTypesInNode(decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.Resource:
+		comp.checkType(checkCtx{}, n.Base, checkIsResourceBase)
+	case *ast.Struct:
+		comp.checkStruct(checkCtx{}, n)
+	case *ast.Call:
+		comp.checkCall(n)
+	case *ast.Override:
+		comp.checkTypesInNode(n.NewType)
 	}
 }
 
 func (comp *compiler) checkTypeValues() {
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Call, *ast.Struct, *ast.Resource, *ast.TypeDef:
-			comp.foreachType(decl, func(t *ast.Type, desc *typeDesc,
-				args []*ast.Type, base prog.IntTypeCommon) {
-				if desc.CheckConsts != nil {
-					desc.CheckConsts(comp, t, args, base)
-				}
-				for i, arg := range args {
-					if check := desc.Args[i].Type.CheckConsts; check != nil {
-						check(comp, arg)
-					}
-				}
-			})
-		case *ast.IntFlags:
-			allEqual := len(n.Values) >= 2
-			for _, val := range n.Values {
-				if val.Value != n.Values[0].Value {
-					allEqual = false
+		comp.checkTypeValuesInNode(decl)
+	}
+}
+
+func (comp *compiler) checkTypeValuesInNode(decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.Call, *ast.Struct, *ast.Resource, *ast.TypeDef:
+		comp.foreachType(decl, func(t *ast.Type, desc *typeDesc,
+			args []*ast.Type, base prog.IntTypeCommon) {
+			if desc.CheckConsts != nil {
+				desc.CheckConsts(comp, t, args, base)
+			}
+			for i, arg := range args {
+				if check := desc.Args[i].Type.CheckConsts; check != nil {
+					check(comp, arg)
 				}
 			}
-			if allEqual {
-				comp.error(n.Pos, "all %v values are equal %v", n.Name.Name, n.Values[0].Value)
+		})
+	case *ast.IntFlags:
+		allEqual := len(n.Values) >= 2
+		for _, val := range n.Values {
+			if val.Value != n.Values[0].Value {
+				allEqual = false
 			}
+		}
+		if allEqual {
+			comp.error(n.Pos, "all %v values are equal %v", n.Name.Name, n.Values[0].Value)
 		}
 	}
 }
 
 func (comp *compiler) checkAttributeValues() {
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Struct:
-			for _, attr := range n.Attrs {
-				desc := structOrUnionAttrs(n)[attr.Ident]
-				if desc.CheckConsts != nil {
-					desc.CheckConsts(comp, n, attr)
-				}
+		comp.checkAttributeValuesInNode(decl)
+	}
+}
+
+func (comp *compiler) checkAttributeValuesInNode(decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.Struct:
+		for _, attr := range n.Attrs {
+			desc := structOrUnionAttrs(n)[attr.Ident]
+			if desc.CheckConsts != nil {
+				desc.CheckConsts(comp, n, attr)
 			}
-			// Check each field's attributes.
-			st := decl.(*ast.Struct)
-			for _, f := range st.Fields {
-				for _, attr := range f.Attrs {
-					desc := fieldAttrs[attr.Ident]
-					if desc.CheckConsts != nil {
-						desc.CheckConsts(comp, f, attr)
-					}
+		}
+		// Check each field's attributes.
+		st := decl.(*ast.Struct)
+		for _, f := range st.Fields {
+			for _, attr := range f.Attrs {
+				desc := fieldAttrs[attr.Ident]
+				if desc.CheckConsts != nil {
+					desc.CheckConsts(comp, f, attr)
 				}
 			}
 		}
@@ -302,13 +373,17 @@ func (comp *compiler) checkAttributeValues() {
 func (comp *compiler) checkLenTargets() {
 	warned := make(map[string]bool)
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Call:
-			for _, arg := range n.Args {
-				checked := make(map[string]bool)
-				parents := []parentDesc{{fields: n.Args}}
-				comp.checkLenType(arg.Type, arg.Type, parents, checked, warned, true)
-			}
+		comp.checkLenTargetsInNode(decl, warned)
+	}
+}
+
+func (comp *compiler) checkLenTargetsInNode(decl ast.Node, warned map[string]bool) {
+	switch n := decl.(type) {
+	case *ast.Call:
+		for _, arg := range n.Args {
+			checked := make(map[string]bool)
+			parents := []parentDesc{{fields: n.Args}}
+			comp.checkLenType(arg.Type, arg.Type, parents, checked, warned, true)
 		}
 	}
 }
@@ -463,8 +538,20 @@ func CollectUnused(desc *ast.Description, target *targets.Target, eh ast.ErrorHa
 func (comp *compiler) collectUnused() []ast.Node {
 	var unused []ast.Node
 
-	comp.used, _, _ = comp.collectUsed(false)
+	used, _, _ := comp.collectUsed(false)
+
+	// Add used types to the (possibly empty) set of already used types
+	for k, v := range used {
+		comp.used[k] = v
+	}
+
 	structs, flags, strflags := comp.collectUsed(true)
+
+	// Add used structs to the (possibly empty) set of already used structs
+	for k, v := range structs {
+		comp.usedStructs[k] = v
+	}
+	structs = comp.usedStructs
 
 	note := func(n ast.Node) {
 		if pos, _, _ := n.Info(); pos.Builtin() {
@@ -473,6 +560,19 @@ func (comp *compiler) collectUnused() []ast.Node {
 		unused = append(unused, n)
 	}
 
+	for name, n := range comp.overrides {
+		if !comp.ovrUsed[name] {
+			note(n)
+		}
+	}
+	for containerName, container := range comp.varOverrides {
+		for varName, varType := range container {
+			name := containerName + "." + varName
+			if !comp.ovrUsed[name] {
+				note(varType)
+			}
+		}
+	}
 	for name, n := range comp.intFlags {
 		if !flags[name] {
 			note(n)
@@ -507,20 +607,58 @@ func (comp *compiler) collectUsed(all bool) (structs, flags, strflags map[string
 	flags = make(map[string]bool)
 	strflags = make(map[string]bool)
 	for _, decl := range comp.desc.Nodes {
-		switch n := decl.(type) {
-		case *ast.Call:
-			if !all && n.NR == ^uint64(0) {
-				break
-			}
-			for _, arg := range n.Args {
-				comp.collectUsedType(structs, flags, strflags, arg.Type, true)
-			}
-			if n.Ret != nil {
-				comp.collectUsedType(structs, flags, strflags, n.Ret, true)
-			}
-		}
+		comp.collectUsedNode(all, structs, flags, strflags, decl)
 	}
 	return
+}
+
+func (comp *compiler) collectUsedNode(all bool, structs, flags, strflags map[string]bool, decl ast.Node) {
+	switch n := decl.(type) {
+	case *ast.Call:
+		if !all && n.NR == ^uint64(0) {
+			break
+		}
+		for _, arg := range n.Args {
+			comp.collectUsedType(structs, flags, strflags, arg.Type, true)
+		}
+		if n.Ret != nil {
+			comp.collectUsedType(structs, flags, strflags, n.Ret, true)
+		}
+	}
+}
+
+func (comp *compiler) collectOverriddenNode(decl ast.Node) {
+	if decl == nil {
+		return
+	}
+
+	switch n := decl.(type) {
+	case *ast.Call:
+		comp.collectUsedNode(true, comp.ovrStructs, comp.ovrFlags, comp.ovrStrFlags, decl)
+
+	case *ast.Resource:
+		comp.collectOverriddenType(n.Base, false)
+
+	case *ast.TypeDef:
+		if n.Type != nil {
+			comp.collectOverriddenType(n.Type, false)
+		} else {
+			comp.collectOverriddenNode(n.Struct)
+		}
+
+	case *ast.Struct:
+		for _, field := range n.Fields {
+			comp.collectOverriddenType(field.Type, false)
+		}
+	}
+}
+
+func (comp *compiler) collectOverriddenType(t *ast.Type, isArg bool) {
+	if t == nil {
+		return
+	}
+
+	comp.collectUsedType(comp.ovrStructs, comp.ovrFlags, comp.ovrStrFlags, t, isArg)
 }
 
 func (comp *compiler) collectUsedType(structs, flags, strflags map[string]bool, t *ast.Type, isArg bool) {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -55,12 +55,19 @@ func createCompiler(desc *ast.Description, target *targets.Target, eh ast.ErrorH
 		ptrSize:      target.PtrSize,
 		unsupported:  make(map[string]bool),
 		resources:    make(map[string]*ast.Resource),
+		overrides:    make(map[string]*ast.Override),
+		varOverrides: make(map[string]map[string]*ast.VarOverride),
 		typedefs:     make(map[string]*ast.TypeDef),
 		structs:      make(map[string]*ast.Struct),
 		intFlags:     make(map[string]*ast.IntFlags),
 		strFlags:     make(map[string]*ast.StrFlags),
 		used:         make(map[string]bool),
 		usedTypedefs: make(map[string]bool),
+		usedStructs:  make(map[string]bool),
+		ovrUsed:      make(map[string]bool),
+		ovrStructs:   make(map[string]bool),
+		ovrFlags:     make(map[string]bool),
+		ovrStrFlags:  make(map[string]bool),
 		structVarlen: make(map[string]bool),
 		structTypes:  make(map[string]prog.Type),
 		builtinConsts: map[string]uint64{
@@ -72,7 +79,9 @@ func createCompiler(desc *ast.Description, target *targets.Target, eh ast.ErrorH
 
 // Compile compiles sys description.
 func Compile(desc *ast.Description, consts map[string]uint64, target *targets.Target, eh ast.ErrorHandler) *Prog {
-	comp := createCompiler(desc.Clone(), target, eh)
+	// Applying overrides returns a new compiler
+	comp := createCompiler(desc.Clone(), target, eh).applyOverrides()
+
 	comp.typecheck()
 	// The subsequent, more complex, checks expect basic validity of the tree,
 	// in particular corrent number of type arguments. If there were errors,
@@ -123,12 +132,19 @@ type compiler struct {
 
 	unsupported  map[string]bool
 	resources    map[string]*ast.Resource
+	overrides    map[string]*ast.Override
+	varOverrides map[string]map[string]*ast.VarOverride
 	typedefs     map[string]*ast.TypeDef
 	structs      map[string]*ast.Struct
 	intFlags     map[string]*ast.IntFlags
 	strFlags     map[string]*ast.StrFlags
 	used         map[string]bool // contains used structs/resources
 	usedTypedefs map[string]bool
+	usedStructs  map[string]bool
+	ovrUsed      map[string]bool
+	ovrStructs   map[string]bool
+	ovrFlags     map[string]bool
+	ovrStrFlags  map[string]bool
 
 	structVarlen  map[string]bool
 	structTypes   map[string]prog.Type
@@ -221,6 +237,172 @@ func (comp *compiler) parseAttrArg(attr *ast.Type) uint64 {
 		return 0
 	}
 	return sz.Value
+}
+
+func (comp *compiler) applyOverrides() *compiler {
+	newComp := createCompiler(&ast.Description{}, comp.target, comp.eh)
+	origDesc := comp.desc.Clone()
+
+	comp.typecheck()
+	// comp.warnings = []warn{}
+	// comp.errors = 0
+
+	newDesc := &ast.Description{}
+
+	for _, decl := range origDesc.Nodes {
+		switch n := decl.(type) {
+		case *ast.Call:
+			name := n.Name.Name
+			if ovrCall := comp.overrides[name]; ovrCall != nil {
+				// Make sure that if the only use of a type is overridden there
+				// aren't compiler errors generated for the type being unused.
+				comp.collectOverriddenNode(n)
+
+				// Mark this override as used
+				comp.ovrUsed[name] = true
+
+				// It doesn't make sense to override a call with some other type
+				newCall, ok := ovrCall.NewType.(*ast.Call)
+				if !ok {
+					_, typ, _ := ovrCall.NewType.Info()
+					comp.error(ovrCall.Pos, "Cannot override call %v with a %v", name, typ)
+					newDesc.Nodes = append(newDesc.Nodes, n)
+					continue
+				}
+
+				// Replace old call declaration with new overridden declaration in newDesc
+				newDesc.Nodes = append(newDesc.Nodes, newCall)
+			} else if container := comp.varOverrides[name]; container != nil {
+				newCall := n.Clone().(*ast.Call)
+
+				// Iterate through arguments, checking whether there's an override for each
+				for _, arg := range newCall.Args {
+					argName := arg.Name.Name
+					if ovrParam := container[argName]; ovrParam != nil {
+						// Override function argument's type
+						comp.collectOverriddenType(arg.Type, true)
+						comp.ovrUsed[name+"."+argName] = true
+						arg.Type = ovrParam.NewVarType
+					}
+				}
+
+				// Check for `override Function.return NewReturnType`
+				if ovrRet := container["return"]; ovrRet != nil {
+					comp.collectOverriddenType(newCall.Ret, false)
+					comp.ovrUsed[name+".return"] = true
+					newCall.Ret = ovrRet.NewVarType
+				}
+
+				newDesc.Nodes = append(newDesc.Nodes, newCall)
+			} else {
+				// Add the unmodified call to newDesc, as there were no overrides for it
+				newDesc.Nodes = append(newDesc.Nodes, n)
+			}
+
+		case *ast.Struct:
+			name := n.Name.Name
+			if ovrStruct := comp.overrides[name]; ovrStruct != nil {
+				comp.collectOverriddenNode(n)
+				comp.ovrUsed[name] = true
+
+				// It doesn't make sense to override a struct with a call
+				if _, ok := ovrStruct.NewType.(*ast.Call); ok {
+					comp.error(ovrStruct.Pos, "Cannot override struct %v with a call", name)
+					newDesc.Nodes = append(newDesc.Nodes, n)
+					continue
+				}
+
+				newDesc.Nodes = append(newDesc.Nodes, ovrStruct.NewType)
+			} else if container := comp.varOverrides[name]; container != nil {
+				newStruct := n.Clone().(*ast.Struct)
+
+				// Iterate through fields, checking whether there's an override for each
+				for _, field := range newStruct.Fields {
+					fieldName := field.Name.Name
+					if ovrField := container[fieldName]; ovrField != nil {
+						// Override struct field's type
+						comp.collectOverriddenType(field.Type, false)
+						comp.ovrUsed[name+"."+fieldName] = true
+						field.Type = ovrField.NewVarType
+					}
+				}
+
+				newDesc.Nodes = append(newDesc.Nodes, newStruct)
+			} else {
+				// Add the unmodified struct to newDesc, as there were no overrides for it
+				newDesc.Nodes = append(newDesc.Nodes, n)
+			}
+
+		case *ast.TypeDef:
+			name := n.Name.Name
+			if ovrTypeDef := comp.overrides[name]; ovrTypeDef != nil {
+				comp.collectOverriddenNode(n)
+				comp.ovrUsed[name] = true
+
+				// It doesn't make sense to override a typedef with a call
+				if _, ok := ovrTypeDef.NewType.(*ast.Call); ok {
+					comp.error(ovrTypeDef.Pos, "Cannot override typedef %v with a call", name)
+					newDesc.Nodes = append(newDesc.Nodes, n)
+					continue
+				}
+
+				newDesc.Nodes = append(newDesc.Nodes, ovrTypeDef.NewType)
+			} else {
+				// Add the unmodified typedef to newDesc, as there were no overrides for it
+				newDesc.Nodes = append(newDesc.Nodes, n)
+			}
+
+		case *ast.Resource:
+			name := n.Name.Name
+			if ovrResource := comp.overrides[name]; ovrResource != nil {
+				comp.collectOverriddenNode(n)
+				comp.ovrUsed[name] = true
+
+				// It doesn't make sense to override a resource with a call
+				if _, ok := ovrResource.NewType.(*ast.Call); ok {
+					comp.error(ovrResource.Pos, "Cannot override resource %v with a call", name)
+					newDesc.Nodes = append(newDesc.Nodes, n)
+					continue
+				}
+
+				newDesc.Nodes = append(newDesc.Nodes, ovrResource.NewType)
+			} else {
+				// Add the unmodified resource to newDesc, as there were no overrides for it
+				newDesc.Nodes = append(newDesc.Nodes, n)
+			}
+
+		// These are being handled so they are not added to newDesc
+		case *ast.Override, *ast.VarOverride:
+			continue
+
+		default:
+			newDesc.Nodes = append(newDesc.Nodes, decl)
+		}
+	}
+
+	// Replace AST with the overridden ones
+	newComp.desc = newDesc
+
+	// Copy used sets to the new compiler
+	newComp.used, _, _ = comp.collectUsed(false)
+	newComp.usedTypedefs = comp.usedTypedefs
+	newComp.usedStructs, _, _ = comp.collectUsed(true)
+	newComp.ovrUsed = comp.ovrUsed
+	newComp.ovrStructs = comp.ovrStructs
+	newComp.ovrFlags = comp.ovrFlags
+	newComp.ovrStrFlags = comp.ovrStrFlags
+
+	// Even though they have already been processed, these will still be
+	// used during checkUnused(), so pass them on
+	newComp.overrides = comp.overrides
+	newComp.varOverrides = comp.varOverrides
+
+	// In case there were any errors during the override resolution phase,
+	// pass them on to the new compiler
+	newComp.errors = comp.errors
+	newComp.warnings = comp.warnings
+
+	return newComp
 }
 
 func (comp *compiler) getTypeDesc(t *ast.Type) *typeDesc {

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -862,3 +862,66 @@ syz_r103_r104_s {
 	opt0	r103	(out)
 	opt1	r104	(in)
 }
+
+
+# Testing overrides support
+
+syz_ovr_proc(a int32)
+
+override syz_ovr_proc(a const[0x12345678])
+
+syz_ovr_param(a int32, b int32)
+
+override syz_ovr_param.b const[0xaabbccdd]
+
+ovr_struct {
+	f0	int32
+	f1	const[0x12344321, int32]
+}
+
+override ovr_struct.f1 const[0x56788765, int32]
+syz_ovr_struct(a ptr[in, ovr_struct])
+
+ovr_union [
+	f0	int32
+	f1	const[0xbabababa, int32]
+]
+
+override ovr_union.f1 const[0xfefefefe, int32]
+syz_ovr_union(a ptr[in, ovr_union])
+
+type ovr_unused_after_override int32
+syz_ovr_unused_after(a ovr_unused_after_override)
+
+override syz_ovr_unused_after.a const[0xdadadada]
+
+resource ovr_unused_before_override[intptr]
+syz_ovr_unused_before(a ptr[out, intptr])
+
+override syz_ovr_unused_before.a ptr[out, ovr_unused_before_override]
+
+type ovr_type const[0x10101010, int32]
+override type ovr_type const[0x12121212, int32]
+syz_ovr_type(a ovr_type)
+
+resource ovr_resource[int32]
+override resource ovr_resource[int64]
+ovr_resource_struct {
+	f0	ovr_resource
+}
+syz_ovr_resource(a ptr[out, ovr_resource_struct])
+
+type ovr_change_to_resource int32
+override resource ovr_change_to_resource[int32]
+syz_ovr_change_to_resource(a ptr[out, ovr_change_to_resource])
+
+syz_ovr_disable_call(a int32)
+override syz_ovr_disable_call(a int32) (disabled)
+
+syz_ovr_return(a int32)
+override syz_ovr_return.return ovr_resource
+
+syz_ovr_use_resources(a ovr_unused_before_override, b ovr_resource, c int32)
+override syz_ovr_use_resources.c ovr_change_to_resource
+
+# bin/syz-mutate -os test -arch 64 -enable syz_ovr_proc,syz_ovr_param,syz_ovr_struct,syz_ovr_union,syz_ovr_unused_after,syz_ovr_unused_before,syz_ovr_type,syz_ovr_resource,syz_ovr_change_to_resource,syz_ovr_disable_call,syz_ovr_return,syz_ovr_use_resources

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -865,13 +865,13 @@ syz_r103_r104_s {
 
 # Testing overrides support
 
-syz_ovr_proc(a int32)
+test_ovr_proc(a int32)
 
-override syz_ovr_proc(a const[0x12345678])
+override test_ovr_proc(a const[0x12345678])
 
-syz_ovr_param(a int32, b int32)
+test_ovr_param(a int32, b int32)
 
-override syz_ovr_param.b const[0xaabbccdd]
+override test_ovr_param.b const[0xaabbccdd]
 
 ovr_struct {
 	f0	int32
@@ -879,7 +879,7 @@ ovr_struct {
 }
 
 override ovr_struct.f1 const[0x56788765, int32]
-syz_ovr_struct(a ptr[in, ovr_struct])
+test_ovr_struct(a ptr[in, ovr_struct])
 
 ovr_union [
 	f0	int32
@@ -887,42 +887,43 @@ ovr_union [
 ]
 
 override ovr_union.f1 const[0xfefefefe, int32]
-syz_ovr_union(a ptr[in, ovr_union])
+test_ovr_union(a ptr[in, ovr_union])
 
 type ovr_unused_after_override int32
-syz_ovr_unused_after(a ovr_unused_after_override)
+test_ovr_unused_after(a ovr_unused_after_override)
 
-override syz_ovr_unused_after.a const[0xdadadada]
+override test_ovr_unused_after.a const[0xdadadada]
 
 resource ovr_unused_before_override[intptr]
-syz_ovr_unused_before(a ptr[out, intptr])
+test_ovr_unused_before(a ptr[out, intptr])
 
-override syz_ovr_unused_before.a ptr[out, ovr_unused_before_override]
+override test_ovr_unused_before.a ptr[out, ovr_unused_before_override]
 
 type ovr_type const[0x10101010, int32]
 override type ovr_type const[0x12121212, int32]
-syz_ovr_type(a ovr_type)
+test_ovr_type(a ovr_type)
 
-resource ovr_resource[int32]
-override resource ovr_resource[int64]
+resource ovr_resource_in_struct[int32]
+override resource ovr_resource_in_struct[int64]: 0x1122334455667788
 
 ovr_resource_struct {
-	f0	ovr_resource
+	f0	ovr_resource_in_struct
 }
 
-syz_ovr_resource(a ptr[out, ovr_resource_struct])
+test_ovr_struct_with_resource(a ptr[out, ovr_resource_struct])
 
 type ovr_change_to_resource int32
 override resource ovr_change_to_resource[int32]
-syz_ovr_change_to_resource(a ptr[out, ovr_change_to_resource])
+test_ovr_create_changed(a ptr[out, ovr_change_to_resource])
 
-syz_ovr_disable_call(a int32)
-override syz_ovr_disable_call(a int32) (disabled)
+test_ovr_disable_call(a int32)
+override test_ovr_disable_call(a int32) (disabled)
 
-syz_ovr_return(a int32)
-override syz_ovr_return.return ovr_resource
+test_ovr_return(a int32)
+resource ovr_return_resource[int32]
+override test_ovr_return.return ovr_return_resource
 
-syz_ovr_use_resources(a ovr_unused_before_override, b ovr_resource, c int32)
-override syz_ovr_use_resources.c ovr_change_to_resource
+test_ovr_use_resources(a ovr_unused_before_override, b ovr_resource_in_struct, c int32, d ovr_return_resource)
+override test_ovr_use_resources.c ovr_change_to_resource
 
-# bin/syz-mutate -os test -arch 64 -enable syz_ovr_proc,syz_ovr_param,syz_ovr_struct,syz_ovr_union,syz_ovr_unused_after,syz_ovr_unused_before,syz_ovr_type,syz_ovr_resource,syz_ovr_change_to_resource,syz_ovr_disable_call,syz_ovr_return,syz_ovr_use_resources
+# bin/syz-mutate -os test -arch 64 -enable test_ovr_proc,test_ovr_param,test_ovr_struct,test_ovr_union,test_ovr_unused_after,test_ovr_unused_before,test_ovr_type,test_ovr_struct_with_resource,test_ovr_create_changed,test_ovr_disable_call,test_ovr_return,test_ovr_use_resources

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -863,7 +863,6 @@ syz_r103_r104_s {
 	opt1	r104	(in)
 }
 
-
 # Testing overrides support
 
 syz_ovr_proc(a int32)
@@ -906,9 +905,11 @@ syz_ovr_type(a ovr_type)
 
 resource ovr_resource[int32]
 override resource ovr_resource[int64]
+
 ovr_resource_struct {
 	f0	ovr_resource
 }
+
 syz_ovr_resource(a ptr[out, ovr_resource_struct])
 
 type ovr_change_to_resource int32


### PR DESCRIPTION
This pull request adds an overrides feature to syzlang. Excerpt from the documentation:

## Overrides

In case you're auto-generating syzkaller definitions, it is often useful to apply
manual overrides to the definitions without needing to directly edit the generated
file. To support this usecase, you can create another syzlang file such as `overrides.txt`
which contains additional syzlang definitions and overrides. There are two syntaxes
for the `override` keyword:

1. Re-definition of a complete type: `override type-decl`
  This form completely replaces the type definition of a named type with the new one.
2. Re-definition of a parameter/field's type: `override container.param/fieldName newType`
  This form replaces the type of a struct/union field or call parameter with the new type.

As an example, assume this is in `generated.txt`:

```
customOpen(path ptr[in, filename])
customRead(handle int32, buf buffer[out], size len[buffer])
```

Then, you could override these calls to use resources by creating `overrides.txt` (any name
ending in `.txt` will work):

```
# Define fileHandle as a resource w/ underlying type int32
resource fileHandle[int32]

# Override the customOpen() call to return an `fileHandle` resource
override customOpen.return fileHandle

# Override customRead()'s `fileHandle` parameter to be an `fileHandle` resource
override customRead.handle fileHandle
```