### PR TITLE
pkg/report: skip drivers/usb/core/urb.c as guilty file

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -84,7 +84,8 @@ func ctorLinux(cfg *config) (Reporter, []string, error) {
 		regexp.MustCompile(`^net/core/sock.c`),
 		regexp.MustCompile(`^net/core/skbuff.c`),
 		regexp.MustCompile(`^fs/proc/generic.c`),
-		regexp.MustCompile(`^trusty/`), // Trusty sources are not in linux kernel tree.
+		regexp.MustCompile(`^trusty/`),                // Trusty sources are not in linux kernel tree.
+		regexp.MustCompile(`^drivers/usb/core/urb.c`), // WARNING in urb.c usually means a bug in a driver
 	}
 	// These pattern do _not_ start a new report, i.e. can be in a middle of another report.
 	ctx.reportStartIgnores = []*regexp.Regexp{

--- a/pkg/report/testdata/linux/guilty/45
+++ b/pkg/report/testdata/linux/guilty/45
@@ -1,0 +1,49 @@
+FILE: drivers/input/misc/cm109.c
+
+------------[ cut here ]------------
+URB 0000000056bd5df7 submitted while active
+WARNING: CPU: 0 PID: 8490 at drivers/usb/core/urb.c:378 usb_submit_urb+0x1228/0x14e0 drivers/usb/core/urb.c:378
+Modules linked in:
+CPU: 0 PID: 8490 Comm: syz-executor949 Not tainted 5.10.0-rc5-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+RIP: 0010:usb_submit_urb+0x1228/0x14e0 drivers/usb/core/urb.c:378
+Code: 89 de e8 6b d6 3b fc 84 db 0f 85 da f4 ff ff e8 4e de 3b fc 4c 89 fe 48 c7 c7 00 57 e1 89 c6 05 01 64 a4 07 01 e8 d4 0c 78 03 <0f> 0b e9 b8 f4 ff ff c7 44 24 14 01 00 00 00 e9 6f f5 ff ff 41 bd
+RSP: 0018:ffffc900012ef710 EFLAGS: 00010086
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: 0000000000000000
+RDX: ffff88802068b480 RSI: ffffffff8158d875 RDI: fffff5200025ded4
+RBP: 0000000000000020 R08: 0000000000000001 R09: ffff8880b9e2011b
+R10: 0000000000000000 R11: 0000000000000000 R12: ffff8880117c3078
+R13: 00000000fffffff0 R14: ffffffff85a190a0 R15: ffff88801d38cd00
+FS: 0000000001949880(0000) GS:ffff8880b9e00000(0000) knlGS:0000000000000000
+CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00005637666ec160 CR3: 0000000029267000 CR4: 00000000001506f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+Call Trace:
+cm109_submit_buzz_toggle+0xd0/0x130 drivers/input/misc/cm109.c:351
+cm109_toggle_buzzer_async drivers/input/misc/cm109.c:487 [inline]
+cm109_input_ev+0x1ea/0x230 drivers/input/misc/cm109.c:621
+input_handle_event+0x66e/0x1400 drivers/input/input.c:376
+input_inject_event+0x2f5/0x310 drivers/input/input.c:471
+kd_sound_helper+0x122/0x260 drivers/tty/vt/keyboard.c:242
+input_handler_for_each_handle+0xf4/0x210 drivers/input/input.c:2356
+kd_mksound+0x85/0x120 drivers/tty/vt/keyboard.c:266
+do_con_trol+0x813/0x54c0 drivers/tty/vt/vt.c:2152
+do_con_write+0xb89/0x1dd0 drivers/tty/vt/vt.c:2911
+con_write+0x22/0xb0 drivers/tty/vt/vt.c:3255
+process_output_block drivers/tty/n_tty.c:595 [inline]
+n_tty_write+0x3ce/0xf80 drivers/tty/n_tty.c:2333
+do_tty_write drivers/tty/tty_io.c:962 [inline]
+tty_write+0x4d9/0x870 drivers/tty/tty_io.c:1046
+vfs_write+0x28e/0xa30 fs/read_write.c:603
+ksys_write+0x12d/0x250 fs/read_write.c:658
+do_syscall_64+0x2d/0x70 arch/x86/entry/common.c:46
+entry_SYSCALL_64_after_hwframe+0x44/0xa9
+RIP: 0033:0x444859
+Code: e8 bc af 02 00 48 83 c4 18 c3 0f 1f 80 00 00 00 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 0f 83 9b d7 fb ff c3 66 2e 0f 1f 84 00 00 00 00
+RSP: 002b:00007ffd082c1508 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
+RAX: ffffffffffffffda RBX: 00000000004002e0 RCX: 0000000000444859
+RDX: 0000000000001006 RSI: 0000000020001440 RDI: 0000000000000005
+RBP: 00000000006d0018 R08: 00000000004002e0 R09: 00000000004002e0
+R10: 000000000000000d R11: 0000000000000246 R12: 0000000000402480
+R13: 0000000000402510 R14: 0000000000000000 R15: 0000000000000000

--- a/pkg/report/testdata/linux/guilty/46
+++ b/pkg/report/testdata/linux/guilty/46
@@ -1,0 +1,49 @@
+FILE: drivers/input/misc/cm109.c
+
+------------[ cut here ]------------
+URB 000000001dc45296 submitted while active
+WARNING: CPU: 0 PID: 17232 at drivers/usb/core/urb.c:378 usb_submit_urb+0xf57/0x1510 drivers/usb/core/urb.c:378
+Modules linked in:
+CPU: 0 PID: 17232 Comm: syz-executor.2 Not tainted 5.10.0-rc4-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+RIP: 0010:usb_submit_urb+0xf57/0x1510 drivers/usb/core/urb.c:378
+Code: 5c 41 5d 41 5e 41 5f 5d e9 76 5b ff ff e8 01 2f 05 fc c6 05 07 61 6b 07 01 48 c7 c7 c0 cd 3b 8a 4c 89 e6 31 c0 e8 e9 3b d5 fb <0f> 0b e9 20 f1 ff ff e8 dd 2e 05 fc eb 05 e8 d6 2e 05 fc bb a6 ff
+RSP: 0018:ffffc90007fef6d8 EFLAGS: 00010046
+RAX: 43026b24801f6b00 RBX: ffff88802d664908 RCX: 0000000000040000
+RDX: ffffc9000cd3d000 RSI: 000000000003ffff RDI: 0000000000040000
+RBP: 0000000000000a20 R08: ffffffff815d2bc2 R09: ffffed1017383ffc
+R10: ffffed1017383ffc R11: 0000000000000000 R12: ffff88802d664900
+R13: dffffc0000000000 R14: dffffc0000000000 R15: ffff88801c943050
+FS:  00007f61c5444700(0000) GS:ffff8880b9c00000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000001b2de23000 CR3: 000000001caa5000 CR4: 00000000001506f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+Call Trace:
+ cm109_submit_buzz_toggle drivers/input/misc/cm109.c:351 [inline]
+ cm109_toggle_buzzer_async drivers/input/misc/cm109.c:487 [inline]
+ cm109_input_ev+0x1dc/0x3a0 drivers/input/misc/cm109.c:621
+ input_handle_event+0x895/0x1510 drivers/input/input.c:376
+ input_inject_event+0x1e8/0x280 drivers/input/input.c:471
+ kd_sound_helper+0xfc/0x200 drivers/tty/vt/keyboard.c:242
+ input_handler_for_each_handle+0xc8/0x160 drivers/input/input.c:2356
+ kd_mksound+0x6c/0x140 drivers/tty/vt/keyboard.c:266
+ do_con_trol drivers/tty/vt/vt.c:2152 [inline]
+ do_con_write+0x3325/0xdee0 drivers/tty/vt/vt.c:2911
+ con_write+0x20/0x40 drivers/tty/vt/vt.c:3255
+ process_output_block drivers/tty/n_tty.c:595 [inline]
+ n_tty_write+0xcc2/0x1160 drivers/tty/n_tty.c:2333
+ do_tty_write drivers/tty/tty_io.c:962 [inline]
+ tty_write+0x585/0x8f0 drivers/tty/tty_io.c:1046
+ vfs_write+0x220/0xab0 fs/read_write.c:603
+ ksys_write+0x11b/0x220 fs/read_write.c:658
+ do_syscall_64+0x2d/0x70 arch/x86/entry/common.c:46
+ entry_SYSCALL_64_after_hwframe+0x44/0xa9
+RIP: 0033:0x45deb9
+Code: 0d b4 fb ff c3 66 2e 0f 1f 84 00 00 00 00 00 66 90 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 0f 83 db b3 fb ff c3 66 2e 0f 1f 84 00 00 00 00
+RSP: 002b:00007f61c5443c78 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
+RAX: ffffffffffffffda RBX: 000000000003a680 RCX: 000000000045deb9
+RDX: 0000000000001006 RSI: 00000000200002c0 RDI: 0000000000000007
+RBP: 000000000118bf60 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 000000000118bf2c
+R13: 00007ffd5f57ac1f R14: 00007f61c54449c0 R15: 000000000118bf2c

--- a/pkg/report/testdata/linux/guilty/47
+++ b/pkg/report/testdata/linux/guilty/47
@@ -1,0 +1,53 @@
+FILE: drivers/net/ieee802154/atusb.c
+
+BUG: memory leak
+unreferenced object 0xffff888109e0af00 (size 192):
+  comm "kworker/1:2", pid 3205, jiffies 4294942324 (age 8.180s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 18 af e0 09 81 88 ff ff  ................
+  backtrace:
+    [<0000000070ad19b0>] kmalloc include/linux/slab.h:557 [inline]
+    [<0000000070ad19b0>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000008781be0e>] atusb_alloc_urbs drivers/net/ieee802154/atusb.c:362 [inline]
+    [<000000008781be0e>] atusb_probe+0x158/0x820 drivers/net/ieee802154/atusb.c:1038
+    [<00000000cce0cf01>] usb_probe_interface+0x177/0x370 drivers/usb/core/driver.c:396
+    [<0000000020e0d57d>] really_probe+0x159/0x480 drivers/base/dd.c:554
+    [<00000000e105c1d7>] driver_probe_device+0x84/0x100 drivers/base/dd.c:738
+    [<0000000027607927>] __device_attach_driver+0xee/0x110 drivers/base/dd.c:844
+    [<000000003813d62a>] bus_for_each_drv+0xb7/0x100 drivers/base/bus.c:431
+    [<00000000e9e76ec4>] __device_attach+0x122/0x250 drivers/base/dd.c:912
+    [<00000000db4b9c2e>] bus_probe_device+0xc6/0xe0 drivers/base/bus.c:491
+    [<0000000004dae719>] device_add+0x5ac/0xc30 drivers/base/core.c:2936
+    [<000000002e126243>] usb_set_configuration+0x9de/0xb90 drivers/usb/core/message.c:2159
+    [<0000000076889926>] usb_generic_driver_probe+0x8c/0xc0 drivers/usb/core/generic.c:238
+    [<000000004ff8d735>] usb_probe_device+0x5c/0x140 drivers/usb/core/driver.c:293
+    [<0000000020e0d57d>] really_probe+0x159/0x480 drivers/base/dd.c:554
+    [<00000000e105c1d7>] driver_probe_device+0x84/0x100 drivers/base/dd.c:738
+    [<0000000027607927>] __device_attach_driver+0xee/0x110 drivers/base/dd.c:844
+
+BUG: memory leak
+unreferenced object 0xffff888109e0a300 (size 192):
+  comm "kworker/1:2", pid 3205, jiffies 4294942324 (age 8.180s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 18 a3 e0 09 81 88 ff ff  ................
+  backtrace:
+    [<0000000070ad19b0>] kmalloc include/linux/slab.h:557 [inline]
+    [<0000000070ad19b0>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000008781be0e>] atusb_alloc_urbs drivers/net/ieee802154/atusb.c:362 [inline]
+    [<000000008781be0e>] atusb_probe+0x158/0x820 drivers/net/ieee802154/atusb.c:1038
+    [<00000000cce0cf01>] usb_probe_interface+0x177/0x370 drivers/usb/core/driver.c:396
+    [<0000000020e0d57d>] really_probe+0x159/0x480 drivers/base/dd.c:554
+    [<00000000e105c1d7>] driver_probe_device+0x84/0x100 drivers/base/dd.c:738
+    [<0000000027607927>] __device_attach_driver+0xee/0x110 drivers/base/dd.c:844
+    [<000000003813d62a>] bus_for_each_drv+0xb7/0x100 drivers/base/bus.c:431
+    [<00000000e9e76ec4>] __device_attach+0x122/0x250 drivers/base/dd.c:912
+    [<00000000db4b9c2e>] bus_probe_device+0xc6/0xe0 drivers/base/bus.c:491
+    [<0000000004dae719>] device_add+0x5ac/0xc30 drivers/base/core.c:2936
+    [<000000002e126243>] usb_set_configuration+0x9de/0xb90 drivers/usb/core/message.c:2159
+    [<0000000076889926>] usb_generic_driver_probe+0x8c/0xc0 drivers/usb/core/generic.c:238
+    [<000000004ff8d735>] usb_probe_device+0x5c/0x140 drivers/usb/core/driver.c:293
+    [<0000000020e0d57d>] really_probe+0x159/0x480 drivers/base/dd.c:554
+    [<00000000e105c1d7>] driver_probe_device+0x84/0x100 drivers/base/dd.c:738
+    [<0000000027607927>] __device_attach_driver+0xee/0x110 drivers/base/dd.c:844

--- a/pkg/report/testdata/linux/guilty/48
+++ b/pkg/report/testdata/linux/guilty/48
@@ -1,0 +1,96 @@
+FILE: drivers/net/wireless/ath/ath9k/hif_usb.c
+
+BUG: memory leak
+unreferenced object 0xffff888109b4dc00 (size 192):
+  comm "kworker/1:2", pid 3705, jiffies 4294941906 (age 14.110s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 18 dc b4 09 81 88 ff ff  ................
+  backtrace:
+    [<000000006422299c>] kmalloc include/linux/slab.h:557 [inline]
+    [<000000006422299c>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000007744b258>] ath9k_hif_usb_alloc_tx_urbs drivers/net/wireless/ath/ath9k/hif_usb.c:829 [inline]
+    [<000000007744b258>] ath9k_hif_usb_alloc_urbs+0x148/0x640 drivers/net/wireless/ath/ath9k/hif_usb.c:1008
+    [<000000006c8e4116>] ath9k_hif_usb_dev_init drivers/net/wireless/ath/ath9k/hif_usb.c:1102 [inline]
+    [<000000006c8e4116>] ath9k_hif_usb_firmware_cb+0x88/0x1f0 drivers/net/wireless/ath/ath9k/hif_usb.c:1235
+    [<00000000e5c70763>] request_firmware_work_func+0x47/0x90 drivers/base/firmware_loader/main.c:1079
+    [<0000000089bbfbae>] process_one_work+0x27d/0x590 kernel/workqueue.c:2272
+    [<00000000d58def96>] worker_thread+0x59/0x5d0 kernel/workqueue.c:2418
+    [<000000001b9033f3>] kthread+0x178/0x1b0 kernel/kthread.c:292
+    [<000000001b3150ee>] ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:296
+
+BUG: memory leak
+unreferenced object 0xffff88810efed240 (size 192):
+  comm "kworker/1:2", pid 3705, jiffies 4294941906 (age 14.110s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 58 d2 fe 0e 81 88 ff ff  ........X.......
+  backtrace:
+    [<000000006422299c>] kmalloc include/linux/slab.h:557 [inline]
+    [<000000006422299c>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000007744b258>] ath9k_hif_usb_alloc_tx_urbs drivers/net/wireless/ath/ath9k/hif_usb.c:829 [inline]
+    [<000000007744b258>] ath9k_hif_usb_alloc_urbs+0x148/0x640 drivers/net/wireless/ath/ath9k/hif_usb.c:1008
+    [<000000006c8e4116>] ath9k_hif_usb_dev_init drivers/net/wireless/ath/ath9k/hif_usb.c:1102 [inline]
+    [<000000006c8e4116>] ath9k_hif_usb_firmware_cb+0x88/0x1f0 drivers/net/wireless/ath/ath9k/hif_usb.c:1235
+    [<00000000e5c70763>] request_firmware_work_func+0x47/0x90 drivers/base/firmware_loader/main.c:1079
+    [<0000000089bbfbae>] process_one_work+0x27d/0x590 kernel/workqueue.c:2272
+    [<00000000d58def96>] worker_thread+0x59/0x5d0 kernel/workqueue.c:2418
+    [<000000001b9033f3>] kthread+0x178/0x1b0 kernel/kthread.c:292
+    [<000000001b3150ee>] ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:296
+
+BUG: memory leak
+unreferenced object 0xffff88810efedb40 (size 192):
+  comm "kworker/1:2", pid 3705, jiffies 4294941906 (age 14.110s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 58 db fe 0e 81 88 ff ff  ........X.......
+  backtrace:
+    [<000000006422299c>] kmalloc include/linux/slab.h:557 [inline]
+    [<000000006422299c>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000007744b258>] ath9k_hif_usb_alloc_tx_urbs drivers/net/wireless/ath/ath9k/hif_usb.c:829 [inline]
+    [<000000007744b258>] ath9k_hif_usb_alloc_urbs+0x148/0x640 drivers/net/wireless/ath/ath9k/hif_usb.c:1008
+    [<000000006c8e4116>] ath9k_hif_usb_dev_init drivers/net/wireless/ath/ath9k/hif_usb.c:1102 [inline]
+    [<000000006c8e4116>] ath9k_hif_usb_firmware_cb+0x88/0x1f0 drivers/net/wireless/ath/ath9k/hif_usb.c:1235
+    [<00000000e5c70763>] request_firmware_work_func+0x47/0x90 drivers/base/firmware_loader/main.c:1079
+    [<0000000089bbfbae>] process_one_work+0x27d/0x590 kernel/workqueue.c:2272
+    [<00000000d58def96>] worker_thread+0x59/0x5d0 kernel/workqueue.c:2418
+    [<000000001b9033f3>] kthread+0x178/0x1b0 kernel/kthread.c:292
+    [<000000001b3150ee>] ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:296
+
+BUG: memory leak
+unreferenced object 0xffff88810efedf00 (size 192):
+  comm "kworker/1:2", pid 3705, jiffies 4294941906 (age 14.110s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 18 df fe 0e 81 88 ff ff  ................
+  backtrace:
+    [<000000006422299c>] kmalloc include/linux/slab.h:557 [inline]
+    [<000000006422299c>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000007744b258>] ath9k_hif_usb_alloc_tx_urbs drivers/net/wireless/ath/ath9k/hif_usb.c:829 [inline]
+    [<000000007744b258>] ath9k_hif_usb_alloc_urbs+0x148/0x640 drivers/net/wireless/ath/ath9k/hif_usb.c:1008
+    [<000000006c8e4116>] ath9k_hif_usb_dev_init drivers/net/wireless/ath/ath9k/hif_usb.c:1102 [inline]
+    [<000000006c8e4116>] ath9k_hif_usb_firmware_cb+0x88/0x1f0 drivers/net/wireless/ath/ath9k/hif_usb.c:1235
+    [<00000000e5c70763>] request_firmware_work_func+0x47/0x90 drivers/base/firmware_loader/main.c:1079
+    [<0000000089bbfbae>] process_one_work+0x27d/0x590 kernel/workqueue.c:2272
+    [<00000000d58def96>] worker_thread+0x59/0x5d0 kernel/workqueue.c:2418
+    [<000000001b9033f3>] kthread+0x178/0x1b0 kernel/kthread.c:292
+    [<000000001b3150ee>] ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:296
+
+BUG: memory leak
+unreferenced object 0xffff88810efedc00 (size 192):
+  comm "kworker/1:2", pid 3705, jiffies 4294941906 (age 14.110s)
+  hex dump (first 32 bytes):
+    01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+    00 00 00 00 00 00 00 00 18 dc fe 0e 81 88 ff ff  ................
+  backtrace:
+    [<000000006422299c>] kmalloc include/linux/slab.h:557 [inline]
+    [<000000006422299c>] usb_alloc_urb+0x66/0xe0 drivers/usb/core/urb.c:74
+    [<000000007744b258>] ath9k_hif_usb_alloc_tx_urbs drivers/net/wireless/ath/ath9k/hif_usb.c:829 [inline]
+    [<000000007744b258>] ath9k_hif_usb_alloc_urbs+0x148/0x640 drivers/net/wireless/ath/ath9k/hif_usb.c:1008
+    [<000000006c8e4116>] ath9k_hif_usb_dev_init drivers/net/wireless/ath/ath9k/hif_usb.c:1102 [inline]
+    [<000000006c8e4116>] ath9k_hif_usb_firmware_cb+0x88/0x1f0 drivers/net/wireless/ath/ath9k/hif_usb.c:1235
+    [<00000000e5c70763>] request_firmware_work_func+0x47/0x90 drivers/base/firmware_loader/main.c:1079
+    [<0000000089bbfbae>] process_one_work+0x27d/0x590 kernel/workqueue.c:2272
+    [<00000000d58def96>] worker_thread+0x59/0x5d0 kernel/workqueue.c:2418
+    [<000000001b9033f3>] kthread+0x178/0x1b0 kernel/kthread.c:292
+    [<000000001b3150ee>] ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:296


### PR DESCRIPTION
We are getting lots of WARNINGs in urb.c and all of them seem
to mean a bug in a particular driver. And fixes for these bugs
go into a particular driver code. But we send all of them to
urb.c maintainers. Skip urb.c as a guilty file.
If a bug happens to be in urb.c for real, a driver maintainers
should CC USB core maintainers on it.

Update #2284
