### PR TITLE
tools/syz-crush: make the results saving more flexible

### DIFF
--- a/tools/syz-crush/crush.go
+++ b/tools/syz-crush/crush.go
@@ -138,7 +138,7 @@ func main() {
 
 func storeCrash(cfg *mgrconfig.Config, rep *report.Report) {
 	id := hash.String([]byte(rep.Title))
-	dir := filepath.Join(cfg.Workdir, "crashes", id)
+	dir := filepath.Join(filepath.Dir(flag.Args()[0]), "crashes", id)
 	osutil.MkdirAll(dir)
 
 	index := 0


### PR DESCRIPTION
Currently syz-crush saves the results in the syzkaller workdir.
That brings a side effect: if you test two different reproducers giving
crashes with the same title, syz-crush saves all your results in
a single crash directory.

Let's make it more flexible. Save syz-crush results in the directory
containing the tested reproducer:
 - we have the original workflow, if all tested reproducers reside
   in the syzkaller workdir;
 - we can get the results separately, if all tested reproducers reside
   in separate directories.

Signed-off-by: Alexander Popov <alex.popov@linux.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
