### PR TITLE
sys/linux, sys/freebsd: apply more ignore_return attributes

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1112,12 +1112,9 @@ void execute_call(thread_t* th)
 	errno = EFAULT;
 	NONFAILING(th->res = execute_syscall(call, th->args));
 	th->reserrno = errno;
-	if (th->res == -1 && th->reserrno == 0)
-		th->reserrno = EINVAL; // our syz syscalls may misbehave
-	if (call->attrs.ignore_return) {
-		th->res = 0;
-		th->reserrno = 0;
-	}
+	// Our pseudo-syscalls may misbehave.
+	if ((th->res == -1 && th->reserrno == 0) || call->attrs.ignore_return)
+		th->reserrno = EINVAL;
 	// Reset the flag before the first possible fail().
 	th->soft_fail_state = false;
 

--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -22,15 +22,6 @@ static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	intptr_t res = c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
 	if (strncmp(c->name, "zx_", 3) == 0) {
-		// Convert zircon error convention to the libc convention that executor expects.
-		// The following calls return arbitrary integers instead of error codes.
-		if (res == ZX_OK ||
-		    !strcmp(c->name, "zx_debuglog_read") ||
-		    !strcmp(c->name, "zx_clock_get") ||
-		    !strcmp(c->name, "zx_clock_get_monotonic") ||
-		    !strcmp(c->name, "zx_deadline_after") ||
-		    !strcmp(c->name, "zx_ticks_get"))
-			return 0;
 		errno = (-res) & 0x7f;
 		return -1;
 	}

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -84,13 +84,7 @@ static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	if (c->call)
 		return c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
-	intptr_t res = syscall(c->sys_nr, a[0], a[1], a[2], a[3], a[4], a[5]);
-	// Some prctl commands don't respect the normal convention for return values
-	// (e.g. PR_GET_TIMERSLACK, but there are more) and may produce all possible
-	// errno values. This conflicts with fallback coverage.
-	if (!flag_coverage && res == -1 && !strcmp(c->name, "prctl"))
-		errno = EINVAL;
-	return res;
+	return syscall(c->sys_nr, a[0], a[1], a[2], a[3], a[4], a[5]);
 }
 
 static void cover_open(cover_t* cov, bool extra)

--- a/sys/freebsd/ipc.txt
+++ b/sys/freebsd/ipc.txt
@@ -31,19 +31,24 @@ resource ipc_sem[ipc]
 semget(key proc[2039359027, 4], nsems flags[sem_sem_id], flags flags[semget_flags]) ipc_sem
 semget$private(key const[IPC_PRIVATE], nsems flags[sem_sem_id], flags flags[semget_flags]) ipc_sem
 semop(semid ipc_sem, ops ptr[in, array[sembuf]], nops len[ops])
-__semctl$IPC_STAT(semid ipc_sem, semnum const[0], cmd const[IPC_STAT], arg buffer[out])
-__semctl$IPC_SET(semid ipc_sem, semnum const[0], cmd const[IPC_SET], arg ptr[in, semid_ds])
-__semctl$IPC_RMID(semid ipc_sem, semnum const[0], cmd const[IPC_RMID])
-__semctl$IPC_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[IPC_INFO], buf buffer[out])
-__semctl$SEM_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_INFO], arg buffer[out])
-__semctl$SEM_STAT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT], arg buffer[out])
-__semctl$GETALL(semid ipc_sem, semnum const[0], cmd const[GETALL], arg buffer[out])
-__semctl$GETNCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETNCNT], arg buffer[out])
-__semctl$GETPID(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETPID], arg buffer[out])
-__semctl$GETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETVAL], arg buffer[out])
-__semctl$GETZCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETZCNT], arg buffer[out])
-__semctl$SETALL(semid ipc_sem, semnum const[0], cmd const[SETALL], arg ptr[in, array[int16]])
-__semctl$SETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SETVAL], arg ptr[in, int32])
+
+# __semctl$GETVAL produces random errno values, so we use ignore_return attribute.
+# Since we don't have strict const enforcement, we need to apply it to all variants.
+# When/if we have stricter enforcement of arguments for syscall variants, we may remove some of the attributes.
+
+__semctl$IPC_STAT(semid ipc_sem, semnum const[0], cmd const[IPC_STAT], arg buffer[out]) (ignore_return)
+__semctl$IPC_SET(semid ipc_sem, semnum const[0], cmd const[IPC_SET], arg ptr[in, semid_ds]) (ignore_return)
+__semctl$IPC_RMID(semid ipc_sem, semnum const[0], cmd const[IPC_RMID]) (ignore_return)
+__semctl$IPC_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[IPC_INFO], buf buffer[out]) (ignore_return)
+__semctl$SEM_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_INFO], arg buffer[out]) (ignore_return)
+__semctl$SEM_STAT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT], arg buffer[out]) (ignore_return)
+__semctl$GETALL(semid ipc_sem, semnum const[0], cmd const[GETALL], arg buffer[out]) (ignore_return)
+__semctl$GETNCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETNCNT], arg buffer[out]) (ignore_return)
+__semctl$GETPID(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETPID], arg buffer[out]) (ignore_return)
+__semctl$GETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETVAL], arg buffer[out]) (ignore_return)
+__semctl$GETZCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETZCNT], arg buffer[out]) (ignore_return)
+__semctl$SETALL(semid ipc_sem, semnum const[0], cmd const[SETALL], arg ptr[in, array[int16]]) (ignore_return)
+__semctl$SETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SETVAL], arg ptr[in, int32]) (ignore_return)
 
 resource ipc_shm[ipc]
 resource shmaddr[intptr]: 0

--- a/sys/linux/ipc.txt
+++ b/sys/linux/ipc.txt
@@ -32,20 +32,25 @@ semget(key ipc_key_t, nsems flags[sem_sem_id], flags flags[semget_flags]) ipc_se
 semget$private(key const[IPC_PRIVATE], nsems flags[sem_sem_id], flags flags[semget_flags]) ipc_sem
 semop(semid ipc_sem, ops ptr[in, array[sembuf]], nops len[ops])
 semtimedop(semid ipc_sem, ops ptr[in, array[sembuf]], nops len[ops], timeout ptr[in, timespec])
-semctl$IPC_STAT(semid ipc_sem, semnum const[0], cmd const[IPC_STAT], arg buffer[out])
-semctl$IPC_SET(semid ipc_sem, semnum const[0], cmd const[IPC_SET], arg ptr[in, semid_ds])
-semctl$IPC_RMID(semid ipc_sem, semnum const[0], cmd const[IPC_RMID])
-semctl$IPC_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[IPC_INFO], buf buffer[out])
-semctl$SEM_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_INFO], arg buffer[out])
-semctl$SEM_STAT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT], arg buffer[out])
-semctl$SEM_STAT_ANY(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT_ANY], arg buffer[out])
-semctl$GETALL(semid ipc_sem, semnum const[0], cmd const[GETALL], arg buffer[out])
-semctl$GETNCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETNCNT], arg buffer[out])
-semctl$GETPID(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETPID], arg buffer[out])
-semctl$GETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETVAL], arg buffer[out])
-semctl$GETZCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETZCNT], arg buffer[out])
-semctl$SETALL(semid ipc_sem, semnum const[0], cmd const[SETALL], arg ptr[in, array[int16]])
-semctl$SETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SETVAL], arg ptr[in, int32])
+
+# semctl$GETVAL produces random errno values, so we use ignore_return attribute.
+# Since we don't have strict const enforcement, we need to apply it to all variants.
+# When/if we have stricter enforcement of arguments for syscall variants, we may remove some of the attributes.
+
+semctl$IPC_STAT(semid ipc_sem, semnum const[0], cmd const[IPC_STAT], arg buffer[out]) (ignore_return)
+semctl$IPC_SET(semid ipc_sem, semnum const[0], cmd const[IPC_SET], arg ptr[in, semid_ds]) (ignore_return)
+semctl$IPC_RMID(semid ipc_sem, semnum const[0], cmd const[IPC_RMID]) (ignore_return)
+semctl$IPC_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[IPC_INFO], buf buffer[out]) (ignore_return)
+semctl$SEM_INFO(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_INFO], arg buffer[out]) (ignore_return)
+semctl$SEM_STAT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT], arg buffer[out]) (ignore_return)
+semctl$SEM_STAT_ANY(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SEM_STAT_ANY], arg buffer[out]) (ignore_return)
+semctl$GETALL(semid ipc_sem, semnum const[0], cmd const[GETALL], arg buffer[out]) (ignore_return)
+semctl$GETNCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETNCNT], arg buffer[out]) (ignore_return)
+semctl$GETPID(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETPID], arg buffer[out]) (ignore_return)
+semctl$GETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETVAL], arg buffer[out]) (ignore_return)
+semctl$GETZCNT(semid ipc_sem, semnum flags[sem_sem_id], cmd const[GETZCNT], arg buffer[out]) (ignore_return)
+semctl$SETALL(semid ipc_sem, semnum const[0], cmd const[SETALL], arg ptr[in, array[int16]]) (ignore_return)
+semctl$SETVAL(semid ipc_sem, semnum flags[sem_sem_id], cmd const[SETVAL], arg ptr[in, int32]) (ignore_return)
 
 resource ipc_shm[ipc]
 resource shmaddr[intptr]: 0

--- a/sys/linux/prctl.txt
+++ b/sys/linux/prctl.txt
@@ -10,79 +10,80 @@ include <uapi/linux/securebits.h>
 include <asm/prctl.h>
 
 # Only some commands break return values.
-# When/if we have stricter enforcement of arguments, we may remove some of breaks_returns attributes.
-prctl$PR_SET_PDEATHSIG(option const[PR_SET_PDEATHSIG], arg signalnoptr) (breaks_returns)
-prctl$PR_GET_PDEATHSIG(option const[PR_GET_PDEATHSIG], arg ptr[out, int32]) (breaks_returns)
+# PR_GET_TIMERSLACK and maybe more produce random errno's.
+# When/if we have stricter enforcement of arguments for syscall variants, we may remove some of breaks_returns attributes.
+prctl$PR_SET_PDEATHSIG(option const[PR_SET_PDEATHSIG], arg signalnoptr) (breaks_returns, ignore_return)
+prctl$PR_GET_PDEATHSIG(option const[PR_GET_PDEATHSIG], arg ptr[out, int32]) (breaks_returns, ignore_return)
 
-prctl$PR_GET_DUMPABLE(option const[PR_GET_DUMPABLE]) (breaks_returns)
-prctl$PR_SET_DUMPABLE(option const[PR_SET_DUMPABLE], arg flags[prctl_dump_mode]) (breaks_returns)
+prctl$PR_GET_DUMPABLE(option const[PR_GET_DUMPABLE]) (breaks_returns, ignore_return)
+prctl$PR_SET_DUMPABLE(option const[PR_SET_DUMPABLE], arg flags[prctl_dump_mode]) (breaks_returns, ignore_return)
 
 prctl_dump_mode = SUID_DUMP_USER, SUID_DUMP_ROOT
 
-prctl$PR_GET_UNALIGN(option const[PR_GET_UNALIGN], arg ptr[out, int32]) (breaks_returns)
-prctl$PR_SET_UNALIGN(option const[PR_SET_UNALIGN], arg flags[prctl_align_mode]) (breaks_returns)
+prctl$PR_GET_UNALIGN(option const[PR_GET_UNALIGN], arg ptr[out, int32]) (breaks_returns, ignore_return)
+prctl$PR_SET_UNALIGN(option const[PR_SET_UNALIGN], arg flags[prctl_align_mode]) (breaks_returns, ignore_return)
 
 prctl_align_mode = PR_UNALIGN_NOPRINT, PR_UNALIGN_SIGBUS
 
-prctl$PR_GET_KEEPCAPS(option const[PR_GET_KEEPCAPS]) (breaks_returns)
-prctl$PR_SET_KEEPCAPS(option const[PR_SET_KEEPCAPS], arg boolptr) (breaks_returns)
+prctl$PR_GET_KEEPCAPS(option const[PR_GET_KEEPCAPS]) (breaks_returns, ignore_return)
+prctl$PR_SET_KEEPCAPS(option const[PR_SET_KEEPCAPS], arg boolptr) (breaks_returns, ignore_return)
 
-prctl$PR_GET_FPEMU(option const[PR_GET_FPEMU], arg ptr[out, int32]) (breaks_returns)
-prctl$PR_SET_FPEMU(option const[PR_SET_FPEMU], arg flags[prctl_fpemu_mode]) (breaks_returns)
+prctl$PR_GET_FPEMU(option const[PR_GET_FPEMU], arg ptr[out, int32]) (breaks_returns, ignore_return)
+prctl$PR_SET_FPEMU(option const[PR_SET_FPEMU], arg flags[prctl_fpemu_mode]) (breaks_returns, ignore_return)
 
 prctl_fpemu_mode = PR_FPEMU_NOPRINT, PR_FPEMU_SIGFPE
 
-prctl$PR_GET_FPEXC(option const[PR_GET_FPEXC], arg ptr[out, int32]) (breaks_returns)
-prctl$PR_SET_FPEXC(option const[PR_SET_FPEXC], arg flags[prctl_fpexc_mode]) (breaks_returns)
+prctl$PR_GET_FPEXC(option const[PR_GET_FPEXC], arg ptr[out, int32]) (breaks_returns, ignore_return)
+prctl$PR_SET_FPEXC(option const[PR_SET_FPEXC], arg flags[prctl_fpexc_mode]) (breaks_returns, ignore_return)
 
 prctl_fpexc_mode = PR_FP_EXC_SW_ENABLE, PR_FP_EXC_DIV, PR_FP_EXC_OVF, PR_FP_EXC_UND, PR_FP_EXC_RES, PR_FP_EXC_INV, PR_FP_EXC_DISABLED, PR_FP_EXC_NONRECOV, PR_FP_EXC_ASYNC, PR_FP_EXC_PRECISE
 
 # These are not implemented.
 _ = PR_GET_TIMING, PR_SET_TIMING
 
-prctl$PR_SET_NAME(option const[PR_SET_NAME], name ptr[in, string]) (breaks_returns)
-prctl$PR_GET_NAME(option const[PR_GET_NAME], name ptr[out, array[int8]]) (breaks_returns)
+prctl$PR_SET_NAME(option const[PR_SET_NAME], name ptr[in, string]) (breaks_returns, ignore_return)
+prctl$PR_GET_NAME(option const[PR_GET_NAME], name ptr[out, array[int8]]) (breaks_returns, ignore_return)
 
-prctl$PR_GET_ENDIAN(option const[PR_GET_ENDIAN], arg ptr[out, int32]) (breaks_returns)
-prctl$PR_SET_ENDIAN(option const[PR_SET_ENDIAN], arg flags[prctl_endian_mode]) (breaks_returns)
+prctl$PR_GET_ENDIAN(option const[PR_GET_ENDIAN], arg ptr[out, int32]) (breaks_returns, ignore_return)
+prctl$PR_SET_ENDIAN(option const[PR_SET_ENDIAN], arg flags[prctl_endian_mode]) (breaks_returns, ignore_return)
 
 prctl_endian_mode = PR_ENDIAN_BIG, PR_ENDIAN_LITTLE, PR_ENDIAN_PPC_LITTLE
 
-prctl$PR_GET_SECCOMP(option const[PR_GET_SECCOMP]) (breaks_returns)
-prctl$PR_SET_SECCOMP(option const[PR_SET_SECCOMP], mode flags[prctl_seccomp_mode], prog ptr[in, sock_fprog]) (breaks_returns)
+prctl$PR_GET_SECCOMP(option const[PR_GET_SECCOMP]) (breaks_returns, ignore_return)
+prctl$PR_SET_SECCOMP(option const[PR_SET_SECCOMP], mode flags[prctl_seccomp_mode], prog ptr[in, sock_fprog]) (breaks_returns, ignore_return)
 
 prctl_seccomp_mode = SECCOMP_MODE_DISABLED, SECCOMP_MODE_STRICT, SECCOMP_MODE_FILTER
 
-prctl$PR_CAPBSET_READ(option const[PR_CAPBSET_READ], arg intptr[0:CAP_LAST_CAP]) (breaks_returns)
-prctl$PR_CAPBSET_DROP(option const[PR_CAPBSET_DROP], arg intptr[0:CAP_LAST_CAP]) (breaks_returns)
+prctl$PR_CAPBSET_READ(option const[PR_CAPBSET_READ], arg intptr[0:CAP_LAST_CAP]) (breaks_returns, ignore_return)
+prctl$PR_CAPBSET_DROP(option const[PR_CAPBSET_DROP], arg intptr[0:CAP_LAST_CAP]) (breaks_returns, ignore_return)
 
-prctl$PR_GET_TSC(option const[PR_GET_TSC], arg ptr[out, int32]) (breaks_returns)
-prctl$PR_SET_TSC(option const[PR_SET_TSC], arg flags[prctl_tsc_mode]) (breaks_returns)
+prctl$PR_GET_TSC(option const[PR_GET_TSC], arg ptr[out, int32]) (breaks_returns, ignore_return)
+prctl$PR_SET_TSC(option const[PR_SET_TSC], arg flags[prctl_tsc_mode]) (breaks_returns, ignore_return)
 
 prctl_tsc_mode = PR_TSC_ENABLE, PR_TSC_SIGSEGV
 
-prctl$PR_GET_SECUREBITS(option const[PR_GET_SECUREBITS]) (breaks_returns)
-prctl$PR_SET_SECUREBITS(option const[PR_SET_SECUREBITS], arg flags[prctl_securebits]) (breaks_returns)
+prctl$PR_GET_SECUREBITS(option const[PR_GET_SECUREBITS]) (breaks_returns, ignore_return)
+prctl$PR_SET_SECUREBITS(option const[PR_SET_SECUREBITS], arg flags[prctl_securebits]) (breaks_returns, ignore_return)
 
 prctl_securebits = SECBIT_NOROOT, SECBIT_NOROOT_LOCKED, SECBIT_NO_SETUID_FIXUP, SECBIT_NO_SETUID_FIXUP_LOCKED, SECBIT_KEEP_CAPS, SECBIT_KEEP_CAPS_LOCKED
 
-prctl$PR_SET_TIMERSLACK(option const[PR_SET_TIMERSLACK], arg intptr) (breaks_returns)
-prctl$PR_GET_TIMERSLACK(option const[PR_GET_TIMERSLACK]) (breaks_returns)
+prctl$PR_SET_TIMERSLACK(option const[PR_SET_TIMERSLACK], arg intptr) (breaks_returns, ignore_return)
+prctl$PR_GET_TIMERSLACK(option const[PR_GET_TIMERSLACK]) (breaks_returns, ignore_return)
 
-prctl$PR_TASK_PERF_EVENTS_DISABLE(option const[PR_TASK_PERF_EVENTS_DISABLE]) (breaks_returns)
-prctl$PR_TASK_PERF_EVENTS_ENABLE(option const[PR_TASK_PERF_EVENTS_ENABLE]) (breaks_returns)
+prctl$PR_TASK_PERF_EVENTS_DISABLE(option const[PR_TASK_PERF_EVENTS_DISABLE]) (breaks_returns, ignore_return)
+prctl$PR_TASK_PERF_EVENTS_ENABLE(option const[PR_TASK_PERF_EVENTS_ENABLE]) (breaks_returns, ignore_return)
 
-prctl$PR_MCE_KILL(option const[PR_MCE_KILL], arg2 flags[prctl_mce_kill_mode], arg3 flags[prctl_mce_kill_submode]) (breaks_returns)
-prctl$PR_MCE_KILL_GET(option const[PR_MCE_KILL_GET]) (breaks_returns)
+prctl$PR_MCE_KILL(option const[PR_MCE_KILL], arg2 flags[prctl_mce_kill_mode], arg3 flags[prctl_mce_kill_submode]) (breaks_returns, ignore_return)
+prctl$PR_MCE_KILL_GET(option const[PR_MCE_KILL_GET]) (breaks_returns, ignore_return)
 
 prctl_mce_kill_mode = PR_MCE_KILL_CLEAR, PR_MCE_KILL_SET
 prctl_mce_kill_submode = PR_MCE_KILL_LATE, PR_MCE_KILL_EARLY, PR_MCE_KILL_DEFAULT
 
-prctl$PR_SET_MM(option const[PR_SET_MM], opt flags[prctl_mm_option], arg vma) (breaks_returns)
-prctl$PR_SET_MM_EXE_FILE(option const[PR_SET_MM], opt const[PR_SET_MM_EXE_FILE], arg fd) (breaks_returns)
-prctl$PR_SET_MM_AUXV(option const[PR_SET_MM], opt const[PR_SET_MM_AUXV], arg ptr[in, array[int8]], len bytesize[arg]) (breaks_returns)
-prctl$PR_SET_MM_MAP(option const[PR_SET_MM], opt const[PR_SET_MM_MAP], arg ptr[in, prctl_mm_map], len bytesize[arg]) (breaks_returns)
-prctl$PR_SET_MM_MAP_SIZE(option const[PR_SET_MM], opt const[PR_SET_MM_MAP_SIZE], arg ptr[out, int32]) (breaks_returns)
+prctl$PR_SET_MM(option const[PR_SET_MM], opt flags[prctl_mm_option], arg vma) (breaks_returns, ignore_return)
+prctl$PR_SET_MM_EXE_FILE(option const[PR_SET_MM], opt const[PR_SET_MM_EXE_FILE], arg fd) (breaks_returns, ignore_return)
+prctl$PR_SET_MM_AUXV(option const[PR_SET_MM], opt const[PR_SET_MM_AUXV], arg ptr[in, array[int8]], len bytesize[arg]) (breaks_returns, ignore_return)
+prctl$PR_SET_MM_MAP(option const[PR_SET_MM], opt const[PR_SET_MM_MAP], arg ptr[in, prctl_mm_map], len bytesize[arg]) (breaks_returns, ignore_return)
+prctl$PR_SET_MM_MAP_SIZE(option const[PR_SET_MM], opt const[PR_SET_MM_MAP_SIZE], arg ptr[out, int32]) (breaks_returns, ignore_return)
 
 prctl_mm_option = PR_SET_MM_START_CODE, PR_SET_MM_END_CODE, PR_SET_MM_START_DATA, PR_SET_MM_END_DATA, PR_SET_MM_START_STACK, PR_SET_MM_START_BRK, PR_SET_MM_BRK, PR_SET_MM_ARG_START, PR_SET_MM_ARG_END, PR_SET_MM_ENV_START, PR_SET_MM_ENV_END
 
@@ -103,36 +104,36 @@ prctl_mm_map {
 	exe_fd		fd
 }
 
-prctl$PR_SET_PTRACER(option const[PR_SET_PTRACER], pid pid) (breaks_returns)
+prctl$PR_SET_PTRACER(option const[PR_SET_PTRACER], pid pid) (breaks_returns, ignore_return)
 
-prctl$PR_SET_CHILD_SUBREAPER(option const[PR_SET_CHILD_SUBREAPER], arg boolptr) (breaks_returns)
-prctl$PR_GET_CHILD_SUBREAPER(option const[PR_GET_CHILD_SUBREAPER]) (breaks_returns)
+prctl$PR_SET_CHILD_SUBREAPER(option const[PR_SET_CHILD_SUBREAPER], arg boolptr) (breaks_returns, ignore_return)
+prctl$PR_GET_CHILD_SUBREAPER(option const[PR_GET_CHILD_SUBREAPER]) (breaks_returns, ignore_return)
 
-prctl$PR_SET_NO_NEW_PRIVS(option const[PR_SET_NO_NEW_PRIVS], arg const[1]) (breaks_returns)
-prctl$PR_GET_NO_NEW_PRIVS(option const[PR_GET_NO_NEW_PRIVS]) (breaks_returns)
+prctl$PR_SET_NO_NEW_PRIVS(option const[PR_SET_NO_NEW_PRIVS], arg const[1]) (breaks_returns, ignore_return)
+prctl$PR_GET_NO_NEW_PRIVS(option const[PR_GET_NO_NEW_PRIVS]) (breaks_returns, ignore_return)
 
-prctl$PR_GET_TID_ADDRESS(option const[PR_GET_TID_ADDRESS], arg ptr[out, intptr]) (breaks_returns)
+prctl$PR_GET_TID_ADDRESS(option const[PR_GET_TID_ADDRESS], arg ptr[out, intptr]) (breaks_returns, ignore_return)
 
-prctl$PR_SET_THP_DISABLE(option const[PR_SET_THP_DISABLE], arg boolptr) (breaks_returns)
-prctl$PR_GET_THP_DISABLE(option const[PR_GET_THP_DISABLE]) (breaks_returns)
+prctl$PR_SET_THP_DISABLE(option const[PR_SET_THP_DISABLE], arg boolptr) (breaks_returns, ignore_return)
+prctl$PR_GET_THP_DISABLE(option const[PR_GET_THP_DISABLE]) (breaks_returns, ignore_return)
 
-prctl$PR_MPX_ENABLE_MANAGEMENT(option const[PR_MPX_ENABLE_MANAGEMENT]) (breaks_returns)
-prctl$PR_MPX_DISABLE_MANAGEMENT(option const[PR_MPX_DISABLE_MANAGEMENT]) (breaks_returns)
+prctl$PR_MPX_ENABLE_MANAGEMENT(option const[PR_MPX_ENABLE_MANAGEMENT]) (breaks_returns, ignore_return)
+prctl$PR_MPX_DISABLE_MANAGEMENT(option const[PR_MPX_DISABLE_MANAGEMENT]) (breaks_returns, ignore_return)
 
-prctl$PR_SET_FP_MODE(option const[PR_SET_FP_MODE], arg flags[prctl_fp_mode]) (breaks_returns)
-prctl$PR_GET_FP_MODE(option const[PR_GET_FP_MODE]) (breaks_returns)
+prctl$PR_SET_FP_MODE(option const[PR_SET_FP_MODE], arg flags[prctl_fp_mode]) (breaks_returns, ignore_return)
+prctl$PR_GET_FP_MODE(option const[PR_GET_FP_MODE]) (breaks_returns, ignore_return)
 
 prctl_fp_mode = PR_FP_MODE_FR, PR_FP_MODE_FRE
 
-prctl$PR_CAP_AMBIENT(option const[PR_CAP_AMBIENT], arg2 flags[prctl_cap_ambient], arg3 int32[0:CAP_LAST_CAP]) (breaks_returns)
+prctl$PR_CAP_AMBIENT(option const[PR_CAP_AMBIENT], arg2 flags[prctl_cap_ambient], arg3 int32[0:CAP_LAST_CAP]) (breaks_returns, ignore_return)
 
 prctl_cap_ambient = PR_CAP_AMBIENT_IS_SET, PR_CAP_AMBIENT_RAISE, PR_CAP_AMBIENT_LOWER, PR_CAP_AMBIENT_CLEAR_ALL
 
-prctl$PR_SVE_SET_VL(option const[PR_SVE_SET_VL], arg intptr[0:PR_SVE_SET_VL_ONEXEC]) (breaks_returns)
-prctl$PR_SVE_GET_VL(option const[PR_SVE_GET_VL], arg intptr[0:PR_SVE_VL_INHERIT]) (breaks_returns)
+prctl$PR_SVE_SET_VL(option const[PR_SVE_SET_VL], arg intptr[0:PR_SVE_SET_VL_ONEXEC]) (breaks_returns, ignore_return)
+prctl$PR_SVE_GET_VL(option const[PR_SVE_GET_VL], arg intptr[0:PR_SVE_VL_INHERIT]) (breaks_returns, ignore_return)
 
-prctl$PR_GET_SPECULATION_CTRL(option const[PR_GET_SPECULATION_CTRL], arg2 const[PR_SPEC_STORE_BYPASS], arg3 flags[pr_spec_mode]) (breaks_returns)
-prctl$PR_SET_SPECULATION_CTRL(option const[PR_SET_SPECULATION_CTRL], arg2 const[PR_SPEC_STORE_BYPASS]) (breaks_returns)
+prctl$PR_GET_SPECULATION_CTRL(option const[PR_GET_SPECULATION_CTRL], arg2 const[PR_SPEC_STORE_BYPASS], arg3 flags[pr_spec_mode]) (breaks_returns, ignore_return)
+prctl$PR_SET_SPECULATION_CTRL(option const[PR_SET_SPECULATION_CTRL], arg2 const[PR_SPEC_STORE_BYPASS]) (breaks_returns, ignore_return)
 
 pr_spec_mode = PR_SPEC_ENABLE, PR_SPEC_DISABLE, PR_SPEC_FORCE_DISABLE
 


### PR DESCRIPTION
1. Apply ignore_return to semctl$GETVAL which produces random errno
values on linux and freebsd.

2. Apply ignore_return to prctl and remove the custom code in executor.

3. Remove the custom errno ignoring code in fuchsia executor.
The calls are already marked as ignore_return, so this is just a leftover.

4. Only reset errno for ignore_return.
The syscall can still return a resource (maybe).
We only need to reset errno for fallback coverage.
