### PR TITLE
pkg/report: make panic oops on openbsd more stringent

### DIFF
--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -37,7 +37,7 @@ var openbsdOopses = append([]*oops{
 		[]*regexp.Regexp{},
 	},
 	{
-		[]byte("panic"),
+		[]byte("panic:"),
 		[]oopsFormat{
 			{
 				title: compile("panic: kernel diagnostic assertion (.+) failed: file \".*/([^\"]+)"),

--- a/pkg/report/testdata/openbsd/report/34
+++ b/pkg/report/testdata/openbsd/report/34
@@ -1,0 +1,24 @@
+
+OpenBSD/amd64 (ci-openbsd-setuid-9.c.syzkaller.internal) (tty00)
+
+login: set $lines = 0
+Password:
+Login incorrect
+login: show panic
+Password:
+Login incorrect
+login: show registers
+Password:
+Login incorrect
+login: ps
+Password:
+Login incorrect
+show malloc
+login: Password:
+Login incorrect
+machine ddbcpu 0
+login: Password:
+Login incorrect
+machine ddbcpu 1
+login: Password:
+Login incorrect


### PR DESCRIPTION
It looks we got a couple of odd crashes where the syz-executor is
probably hanging but the VM is still responsive[1].

Does the hypervisor try to diagnose the VM under such circumstances?
Since the VM is still responsive, the input written to the console is
echoed back which in turns causes a panic to be detected.
If this theory is true, we can avoid detecting such false positives by
making the oops indicator disjoint from the input written to the
console.

[1] https://syzkaller.appspot.com/bug?id=af604b59c590384e9faa00dfc958ef87a922ae71