### PR TITLE
executor: skip setsid() for threaded reproducers

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -389,8 +389,13 @@ static long syz_extract_tcp_res(volatile long a0, volatile long a1, volatile lon
 
 static void sandbox_common()
 {
-	if (setsid() == -1)
-		fail("setsid failed");
+#if !SYZ_THREADED
+#if SYZ_EXECUTOR
+	if (!flag_threaded)
+#endif
+		if (setsid() == -1)
+			fail("setsid failed");
+#endif
 
 	// Some minimal sandboxing.
 	struct rlimit rlim;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1894,8 +1894,13 @@ static long syz_extract_tcp_res(volatile long a0, volatile long a1, volatile lon
 
 static void sandbox_common()
 {
-	if (setsid() == -1)
-		fail("setsid failed");
+#if !SYZ_THREADED
+#if SYZ_EXECUTOR
+	if (!flag_threaded)
+#endif
+		if (setsid() == -1)
+			fail("setsid failed");
+#endif
 	struct rlimit rlim;
 #ifdef GOOS_freebsd
 	rlim.rlim_cur = rlim.rlim_max = 128 << 20;


### PR DESCRIPTION
Lately, I've been looking into why such low amount of syz reproducers on
OpenBSD are turned into C reproducers. One thing I did notice is that
such syz reproducers have one thing in common: they use the
threaded=true and sandbox=none parameters. Such C reproducer always
exits non-zero early on since the call to setsid() fails with EPERM.
Meaning, the calling process is already a process group leader.

Not sure if the preprocessor conditional should be tweaked in order to
avoid unwanted side effects on other BSDs or configurations.