### PR TITLE
codecov.yml: disable github annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,5 +27,8 @@ comment:
   layout: "files"
   after_n_builds: 2
 
+github_checks:
+  annotations: false
+
 fixes:
   - "gopath/src/github.com/google/syzkaller/::"


### PR DESCRIPTION
Disable codecov annotations on PR.
So far they seem to be more annoying than useful.
We have some files that are not covered by unit tests
and these are just filled with "this line is not covered".

See https://docs.codecov.io/docs/codecovyml-reference
