### PR TITLE
pkg/repro: match report crash to desired crash. Fixes #2323

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -680,6 +680,10 @@ func (ctx *context) testImpl(inst *vm.Instance, command string, duration time.Du
 	}
 	ctx.report = rep
 	ctx.reproLogf(2, "program crashed: %v", rep.Title)
+	if ctx.crashTitle != rep.Title {
+		ctx.reproLogf(2, "program crashed for different reason")
+		return false, nil
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
Post commit : 
```
2020/12/07 19:46:44 reproducing crash 'no output/lost connection': program crashed: WARNING: kernel stack regs has bad 'bp' value
2020/12/07 19:46:44 reproducing crash 'no output/lost connection': program crashed for different reason
```