### PR TITLE
docs/linux: fix up example qemu command for Ubuntu

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -128,7 +128,7 @@ qemu-system-x86_64 \
 	-m 2G \
 	-smp 2 \
 	-kernel $KERNEL/arch/x86/boot/bzImage \
-	-append "console=ttyS0 root=/dev/sda earlyprintk=serial" \
+	-append "console=ttyS0 root=/dev/sda earlyprintk=serial net.ifnames=0" \
 	-drive file=$IMAGE/stretch.img,format=raw \
 	-net user,host=10.0.2.10,hostfwd=tcp:127.0.0.1:10021-:22 \
 	-net nic,model=e1000 \


### PR DESCRIPTION
setup_ubuntu-host_qemu-vm_x86-64-kernel.md recommends using
create_image.sh to create a Debian Stretch VM image.  The script
configures the image assuming that the kernel will be booted with
predictable network device naming disabled, which syz-manager
currently does but the example qemu command in the setup document
does not.

To avoid confusing the user, add "net.ifnames=0" to the example qemu
command to disable predictable device naming.  If not the VM fails to
bring up network interfaces and is then inaccessible via. ssh.

#2329 

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
