### PR TITLE
dvyukov cover report refactor

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -4,6 +4,8 @@
 package backend
 
 import (
+	"fmt"
+
 	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -11,8 +13,8 @@ import (
 type Impl struct {
 	Units     []*CompileUnit
 	Symbols   []*Symbol
-	Frames    []symbolizer.Frame
-	Symbolize func(pcs []uint64) ([]symbolizer.Frame, error)
+	Frames    []Frame
+	Symbolize func(pcs []uint64) ([]Frame, error)
 	RestorePC func(pc uint32) uint64
 }
 
@@ -31,6 +33,14 @@ type Symbol struct {
 	Symbolized bool
 }
 
-func Make(target *targets.Target, vm, objDir string) (*Impl, error) {
-	return makeELF(target, objDir)
+type Frame struct {
+	symbolizer.Frame
+	Path string
+}
+
+func Make(target *targets.Target, vm, objDir, srcDir, buildDir string) (*Impl, error) {
+	if objDir == "" {
+		return nil, fmt.Errorf("kernel obj directory is not specified")
+	}
+	return makeELF(target, objDir, srcDir, buildDir)
 }

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -1,0 +1,35 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type Impl struct {
+	Units     []*CompileUnit
+	Symbols   []*Symbol
+	Frames    []symbolizer.Frame
+	Symbolize func(pcs []uint64) ([]symbolizer.Frame, error)
+}
+
+type CompileUnit struct {
+	Name string
+	Path string
+	PCs  []uint64
+}
+
+type Symbol struct {
+	Unit       *CompileUnit
+	Name       string
+	Start      uint64
+	End        uint64
+	PCs        []uint64
+	Symbolized bool
+}
+
+func Make(target *targets.Target, kernelObject, srcDir, buildDir string) (*Impl, error) {
+	return makeELF(target, kernelObject, srcDir, buildDir)
+}

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -30,6 +30,6 @@ type Symbol struct {
 	Symbolized bool
 }
 
-func Make(target *targets.Target, kernelObject, srcDir, buildDir string) (*Impl, error) {
+func Make(target *targets.Target, vm, kernelObject, srcDir, buildDir string) (*Impl, error) {
 	return makeELF(target, kernelObject, srcDir, buildDir)
 }

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -30,6 +30,6 @@ type Symbol struct {
 	Symbolized bool
 }
 
-func Make(target *targets.Target, vm, kernelObject, srcDir, buildDir string) (*Impl, error) {
-	return makeELF(target, kernelObject, srcDir, buildDir)
+func Make(target *targets.Target, vm, objDir string) (*Impl, error) {
+	return makeELF(target, objDir)
 }

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -52,5 +52,8 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string) (*Impl, e
 	if objDir == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
+	if vm == "gvisor" {
+		return makeGvisor(target, objDir, srcDir, buildDir)
+	}
 	return makeELF(target, objDir, srcDir, buildDir)
 }

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -6,7 +6,6 @@ package backend
 import (
 	"fmt"
 
-	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -34,9 +33,20 @@ type Symbol struct {
 }
 
 type Frame struct {
-	symbolizer.Frame
+	PC   uint64
+	Name string
 	Path string
+	Range
 }
+
+type Range struct {
+	StartLine int
+	StartCol  int
+	EndLine   int
+	EndCol    int
+}
+
+const LineEnd = 1 << 30
 
 func Make(target *targets.Target, vm, objDir, srcDir, buildDir string) (*Impl, error) {
 	if objDir == "" {

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Impl struct {
-	Units     []*CompileUnit
-	Symbols   []*Symbol
-	Frames    []symbolizer.Frame
-	Symbolize func(pcs []uint64) ([]symbolizer.Frame, error)
+	Units      []*CompileUnit
+	Symbols    []*Symbol
+	Frames     []symbolizer.Frame
+	TextOffset uint32 // high 32 bits of PCs
+	Symbolize  func(pcs []uint64) ([]symbolizer.Frame, error)
 }
 
 type CompileUnit struct {

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Impl struct {
-	Units      []*CompileUnit
-	Symbols    []*Symbol
-	Frames     []symbolizer.Frame
-	TextOffset uint32 // high 32 bits of PCs
-	Symbolize  func(pcs []uint64) ([]symbolizer.Frame, error)
+	Units     []*CompileUnit
+	Symbols   []*Symbol
+	Frames    []symbolizer.Frame
+	Symbolize func(pcs []uint64) ([]symbolizer.Frame, error)
+	RestorePC func(pc uint32) uint64
 }
 
 type CompileUnit struct {

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -74,11 +74,13 @@ func makeELF(target *targets.Target, objDir string) (*Impl, error) {
 		return nil, fmt.Errorf("failed to parse DWARF (set CONFIG_DEBUG_INFO=y?)")
 	}
 	impl := &Impl{
-		Units:      units,
-		Symbols:    symbols,
-		TextOffset: uint32(textAddr >> 32),
+		Units:   units,
+		Symbols: symbols,
 		Symbolize: func(pcs []uint64) ([]symbolizer.Frame, error) {
 			return symbolize(target, kernelObject, pcs)
+		},
+		RestorePC: func(pc uint32) uint64 {
+			return PreviousInstructionPC(target, RestorePC(pc, uint32(textAddr>>32)))
 		},
 	}
 	return impl, nil

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -293,9 +293,18 @@ func symbolize(target *targets.Target, objDir, srcDir, buildDir, obj string, pcs
 			err0 = res.err
 		}
 		for _, frame := range res.frames {
-			wrap := Frame{frame, ""}
-			wrap.File, wrap.Path = cleanPath(frame.File, objDir, srcDir, buildDir)
-			frames = append(frames, wrap)
+			name, path := cleanPath(frame.File, objDir, srcDir, buildDir)
+			frames = append(frames, Frame{
+				PC:   frame.PC,
+				Name: name,
+				Path: path,
+				Range: Range{
+					StartLine: frame.Line,
+					StartCol:  0,
+					EndLine:   frame.Line,
+					EndCol:    LineEnd,
+				},
+			})
 		}
 	}
 	if err0 != nil {

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -1,0 +1,434 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"bufio"
+	"bytes"
+	"debug/dwarf"
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"sort"
+	"strconv"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func makeELF(target *targets.Target, kernelObject, srcDir, buildDir string) (*Impl, error) {
+	file, err := elf.Open(kernelObject)
+	if err != nil {
+		return nil, err
+	}
+	var coverPoints []uint64
+	var symbols []*Symbol
+	errc := make(chan error, 1)
+	go func() {
+		var err error
+		var tracePC uint64
+		symbols, tracePC, err = readSymbols(file)
+		if err != nil {
+			errc <- err
+			return
+		}
+		if target.Arch == targets.AMD64 {
+			coverPoints, err = readCoverPoints(file, tracePC)
+		} else {
+			coverPoints, err = objdump(target, kernelObject)
+		}
+		errc <- err
+	}()
+	ranges, units, err := readTextRanges(file)
+	if err != nil {
+		return nil, err
+	}
+	if err := <-errc; err != nil {
+		return nil, err
+	}
+	if len(coverPoints) == 0 {
+		return nil, fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y)", kernelObject)
+	}
+	symbols = buildSymbols(symbols, ranges, coverPoints)
+	nunit := 0
+	for _, unit := range units {
+		if len(unit.PCs) == 0 {
+			continue // drop the unit
+		}
+		units[nunit] = unit
+		nunit++
+	}
+	units = units[:nunit]
+	if len(symbols) == 0 || len(units) == 0 {
+		return nil, fmt.Errorf("failed to parse DWARF (set CONFIG_DEBUG_INFO=y?)")
+	}
+	impl := &Impl{
+		Units:   units,
+		Symbols: symbols,
+		Symbolize: func(pcs []uint64) ([]symbolizer.Frame, error) {
+			return symbolize(target, kernelObject, pcs)
+		},
+	}
+	return impl, nil
+}
+
+type pcRange struct {
+	start uint64
+	end   uint64
+	unit  *CompileUnit
+}
+
+func buildSymbols(symbols []*Symbol, ranges []pcRange, coverPoints []uint64) []*Symbol {
+	// Assign coverage point PCs to symbols.
+	// Both symbols and coverage points are sorted, so we do it one pass over both.
+	var curSymbol *Symbol
+	firstSymbolPC, symbolIdx := -1, 0
+	for i := 0; i < len(coverPoints); i++ {
+		pc := coverPoints[i]
+		for ; symbolIdx < len(symbols) && pc >= symbols[symbolIdx].End; symbolIdx++ {
+		}
+		var symb *Symbol
+		if symbolIdx < len(symbols) && pc >= symbols[symbolIdx].Start && pc < symbols[symbolIdx].End {
+			symb = symbols[symbolIdx]
+		}
+		if curSymbol != nil && curSymbol != symb {
+			curSymbol.PCs = coverPoints[firstSymbolPC:i]
+			firstSymbolPC = -1
+		}
+		curSymbol = symb
+		if symb != nil && firstSymbolPC == -1 {
+			firstSymbolPC = i
+		}
+	}
+	if curSymbol != nil {
+		curSymbol.PCs = coverPoints[firstSymbolPC:]
+	}
+	// Assign compile units to symbols based on unit pc ranges.
+	// Do it one pass as both are sorted.
+	nsymbol := 0
+	rangeIndex := 0
+	for _, s := range symbols {
+		for ; rangeIndex < len(ranges) && ranges[rangeIndex].end <= s.Start; rangeIndex++ {
+		}
+		if rangeIndex == len(ranges) || s.Start < ranges[rangeIndex].start || len(s.PCs) == 0 {
+			continue // drop the symbol
+		}
+		unit := ranges[rangeIndex].unit
+		s.Unit = unit
+		symbols[nsymbol] = s
+		nsymbol++
+	}
+	symbols = symbols[:nsymbol]
+
+	for _, s := range symbols {
+		pos := len(s.Unit.PCs)
+		s.Unit.PCs = append(s.Unit.PCs, s.PCs...)
+		s.PCs = s.Unit.PCs[pos:]
+	}
+	return symbols
+}
+
+func readSymbols(file *elf.File) ([]*Symbol, uint64, error) {
+	text := file.Section(".text")
+	if text == nil {
+		return nil, 0, fmt.Errorf("no .text section in the object file")
+	}
+	allSymbols, err := file.Symbols()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read ELF symbols: %v", err)
+	}
+	var tracePC uint64
+	var symbols []*Symbol
+	for _, symb := range allSymbols {
+		if symb.Value < text.Addr || symb.Value+symb.Size > text.Addr+text.Size {
+			continue
+		}
+		symbols = append(symbols, &Symbol{
+			Name:  symb.Name,
+			Start: symb.Value,
+			End:   symb.Value + symb.Size,
+		})
+		if tracePC == 0 && symb.Name == "__sanitizer_cov_trace_pc" {
+			tracePC = symb.Value
+		}
+	}
+	if tracePC == 0 {
+		return nil, 0, fmt.Errorf("no __sanitizer_cov_trace_pc symbol in the object file")
+	}
+	sort.Slice(symbols, func(i, j int) bool {
+		return symbols[i].Start < symbols[j].Start
+	})
+	return symbols, tracePC, nil
+}
+
+func readTextRanges(file *elf.File) ([]pcRange, []*CompileUnit, error) {
+	text := file.Section(".text")
+	if text == nil {
+		return nil, nil, fmt.Errorf("no .text section in the object file")
+	}
+	kaslr := file.Section(".rela.text") != nil
+	debugInfo, err := file.DWARF()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse DWARF: %v (set CONFIG_DEBUG_INFO=y?)", err)
+	}
+	var ranges []pcRange
+	var units []*CompileUnit
+	for r := debugInfo.Reader(); ; {
+		ent, err := r.Next()
+		if err != nil {
+			return nil, nil, err
+		}
+		if ent == nil {
+			break
+		}
+		if ent.Tag != dwarf.TagCompileUnit {
+			return nil, nil, fmt.Errorf("found unexpected tag %v on top level", ent.Tag)
+		}
+		attrName := ent.Val(dwarf.AttrName)
+		if attrName == nil {
+			continue
+		}
+		unit := &CompileUnit{
+			Name: attrName.(string),
+		}
+		units = append(units, unit)
+		ranges1, err := debugInfo.Ranges(ent)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, r := range ranges1 {
+			if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
+				if kaslr {
+					// Linux kernel binaries with CONFIG_RANDOMIZE_BASE=y are strange.
+					// .text starts at 0xffffffff81000000 and symbols point there as well,
+					// but PC ranges point to addresses around 0.
+					// So try to add text offset and retry the check.
+					// It's unclear if we also need some offset on top of text.Addr,
+					// it gives approximately correct addresses, but not necessary precisely
+					// correct addresses.
+					r[0] += text.Addr
+					r[1] += text.Addr
+					if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
+						continue
+					}
+				}
+			}
+			ranges = append(ranges, pcRange{r[0], r[1], unit})
+		}
+		r.SkipChildren()
+	}
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].start < ranges[j].start
+	})
+	return ranges, units, nil
+}
+
+func symbolize(target *targets.Target, obj string, pcs []uint64) ([]symbolizer.Frame, error) {
+	procs := runtime.GOMAXPROCS(0) / 2
+	if need := len(pcs) / 1000; procs > need {
+		procs = need
+	}
+	const (
+		minProcs = 1
+		maxProcs = 4
+	)
+	// addr2line on a beefy vmlinux takes up to 1.6GB of RAM, so don't create too many of them.
+	if procs > maxProcs {
+		procs = maxProcs
+	}
+	if procs < minProcs {
+		procs = minProcs
+	}
+	type symbolizerResult struct {
+		frames []symbolizer.Frame
+		err    error
+	}
+	symbolizerC := make(chan symbolizerResult, procs)
+	pcchan := make(chan []uint64, procs)
+	for p := 0; p < procs; p++ {
+		go func() {
+			symb := symbolizer.NewSymbolizer(target)
+			defer symb.Close()
+			var res symbolizerResult
+			for pcs := range pcchan {
+				frames, err := symb.SymbolizeArray(obj, pcs)
+				if err != nil {
+					res.err = fmt.Errorf("failed to symbolize: %v", err)
+				}
+				res.frames = append(res.frames, frames...)
+			}
+			symbolizerC <- res
+		}()
+	}
+	for i := 0; i < len(pcs); {
+		end := i + 100
+		if end > len(pcs) {
+			end = len(pcs)
+		}
+		pcchan <- pcs[i:end]
+		i = end
+	}
+	close(pcchan)
+	var err0 error
+	var frames []symbolizer.Frame
+	for p := 0; p < procs; p++ {
+		res := <-symbolizerC
+		if res.err != nil {
+			err0 = res.err
+		}
+		frames = append(frames, res.frames...)
+	}
+	if err0 != nil {
+		return nil, err0
+	}
+	return frames, nil
+}
+
+// readCoverPoints finds all coverage points (calls of __sanitizer_cov_trace_pc) in the object file.
+// Currently it is amd64-specific: looks for e8 opcode and correct offset.
+// Running objdump on the whole object file is too slow.
+func readCoverPoints(file *elf.File, tracePC uint64) ([]uint64, error) {
+	text := file.Section(".text")
+	if text == nil {
+		return nil, fmt.Errorf("no .text section in the object file")
+	}
+	data, err := text.Data()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .text: %v", err)
+	}
+	var pcs []uint64
+	const callLen = 5
+	end := len(data) - callLen + 1
+	for i := 0; i < end; i++ {
+		pos := bytes.IndexByte(data[i:end], 0xe8)
+		if pos == -1 {
+			break
+		}
+		pos += i
+		i = pos
+		off := uint64(int64(int32(binary.LittleEndian.Uint32(data[pos+1:]))))
+		pc := text.Addr + uint64(pos)
+		target := pc + off + callLen
+		if target == tracePC {
+			pcs = append(pcs, pc)
+		}
+	}
+	return pcs, nil
+}
+
+// objdump is an old, slow way of finding coverage points.
+// amd64 uses faster option of parsing binary directly (readCoverPoints).
+// TODO: use the faster approach for all other arches and drop this.
+func objdump(target *targets.Target, obj string) ([]uint64, error) {
+	cmd := osutil.Command(target.Objdump, "-d", "--no-show-raw-insn", obj)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	defer stdout.Close()
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	defer stderr.Close()
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to run objdump on %v: %v", obj, err)
+	}
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+	s := bufio.NewScanner(stdout)
+	callInsns, traceFuncs := archCallInsn(target)
+	var pcs []uint64
+	for s.Scan() {
+		if pc := parseLine(callInsns, traceFuncs, s.Bytes()); pc != 0 {
+			pcs = append(pcs, pc)
+		}
+	}
+	stderrOut, _ := ioutil.ReadAll(stderr)
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to run objdump on %v: %v\n%s", obj, err, stderrOut)
+	}
+	if err := s.Err(); err != nil {
+		return nil, fmt.Errorf("failed to run objdump on %v: %v\n%s", obj, err, stderrOut)
+	}
+	return pcs, nil
+}
+
+func parseLine(callInsns, traceFuncs [][]byte, ln []byte) uint64 {
+	pos := -1
+	for _, callInsn := range callInsns {
+		if pos = bytes.Index(ln, callInsn); pos != -1 {
+			break
+		}
+	}
+	if pos == -1 {
+		return 0
+	}
+	hasCall := false
+	for _, traceFunc := range traceFuncs {
+		if hasCall = bytes.Contains(ln[pos:], traceFunc); hasCall {
+			break
+		}
+	}
+	if !hasCall {
+		return 0
+	}
+	for len(ln) != 0 && ln[0] == ' ' {
+		ln = ln[1:]
+	}
+	colon := bytes.IndexByte(ln, ':')
+	if colon == -1 {
+		return 0
+	}
+	pc, err := strconv.ParseUint(string(ln[:colon]), 16, 64)
+	if err != nil {
+		return 0
+	}
+	return pc
+}
+
+func archCallInsn(target *targets.Target) ([][]byte, [][]byte) {
+	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>")}
+	switch target.Arch {
+	case targets.I386:
+		// c1000102:       call   c10001f0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tcall ")}, callName
+	case targets.ARM64:
+		// ffff0000080d9cc0:       bl      ffff00000820f478 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl\t")}, callName
+	case targets.ARM:
+		// 8010252c:       bl      801c3280 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl\t")}, callName
+	case targets.PPC64LE:
+		// c00000000006d904:       bl      c000000000350780 <.__sanitizer_cov_trace_pc>
+		// This is only known to occur in the test:
+		// 838:   bl      824 <__sanitizer_cov_trace_pc+0x8>
+		// This occurs on PPC64LE:
+		// c0000000001c21a8:       bl      c0000000002df4a0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl ")}, [][]byte{
+			[]byte("<__sanitizer_cov_trace_pc>"),
+			[]byte("<__sanitizer_cov_trace_pc+0x8>"),
+			[]byte(" <.__sanitizer_cov_trace_pc>"),
+		}
+	case targets.MIPS64LE:
+		// ffffffff80100420:       jal     ffffffff80205880 <__sanitizer_cov_trace_pc>
+		// This is only known to occur in the test:
+		// b58:   bal     b30 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tjal\t"), []byte("\tbal\t")}, callName
+	case targets.S390x:
+		// 1001de:       brasl   %r14,2bc090 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbrasl\t")}, callName
+	case targets.RiscV64:
+		// ffffffe000200018:       jal     ra,ffffffe0002935b0 <__sanitizer_cov_trace_pc>
+		// ffffffe0000010da:       jalr    1242(ra) # ffffffe0002935b0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tjal\t"), []byte("\tjalr\t")}, callName
+	default:
+		panic(fmt.Sprintf("unknown arch %q", target.Arch))
+	}
+}

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
@@ -20,7 +21,8 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func makeELF(target *targets.Target, kernelObject, srcDir, buildDir string) (*Impl, error) {
+func makeELF(target *targets.Target, objDir string) (*Impl, error) {
+	kernelObject := filepath.Join(objDir, target.KernelObject)
 	file, err := elf.Open(kernelObject)
 	if err != nil {
 		return nil, err

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -1,0 +1,124 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func makeGvisor(target *targets.Target, objDir, srcDir, buildDir string) (*Impl, error) {
+	// pkg/build stores runsc as 'image', but a local build will have it as 'runsc'.
+	bin := filepath.Join(objDir, "image")
+	if !osutil.IsExist(bin) {
+		bin = filepath.Join(objDir, "runsc")
+	}
+	frames, err := gvisorSymbolize(bin, srcDir)
+	if err != nil {
+		return nil, err
+	}
+	unitMap := make(map[string]*CompileUnit)
+	for _, frame := range frames {
+		unit := unitMap[frame.Name]
+		if unit == nil {
+			unit = &CompileUnit{
+				Name: frame.Name,
+				Path: frame.Path,
+			}
+			unitMap[frame.Name] = unit
+		}
+		unit.PCs = append(unit.PCs, frame.PC)
+	}
+	var units []*CompileUnit
+	for _, unit := range unitMap {
+		units = append(units, unit)
+	}
+	impl := &Impl{
+		Units:  units,
+		Frames: frames,
+		RestorePC: func(pc uint32) uint64 {
+			return uint64(pc)
+		},
+	}
+	return impl, nil
+}
+
+func gvisorSymbolize(bin, srcDir string) ([]Frame, error) {
+	cmd := osutil.Command(bin, "symbolize", "-all")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	defer stdout.Close()
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	defer cmd.Wait()
+	var frames []Frame
+	s := bufio.NewScanner(stdout)
+	for s.Scan() {
+		frame, err := gvisorParseLine(s)
+		if err != nil {
+			return nil, err
+		}
+		frame.Path = filepath.Join(srcDir, frame.Name)
+		if !osutil.IsExist(frame.Path) {
+			// Try to locate auto-generated files.
+			// Note: some files are only present under some hashed path,
+			// e.g. bazel-out/k8-fastbuild-ST-4c64f0b3d5c7/bin/pkg/usermem/addr_range.go,
+			// it's unclear how we can locate them. In a local run that may be under objDir,
+			// but this is not the case for syz-ci.
+			path := filepath.Join(srcDir, "bazel-out", "k8-fastbuild", "bin", frame.Name)
+			if osutil.IsExist(path) {
+				frame.Path = path
+			}
+		}
+		frames = append(frames, frame)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return frames, nil
+}
+
+func gvisorParseLine(s *bufio.Scanner) (Frame, error) {
+	pc, err := strconv.ParseUint(s.Text(), 0, 64)
+	if err != nil {
+		return Frame{}, fmt.Errorf("read pc %q, but no line info", pc)
+	}
+	if !s.Scan() {
+		return Frame{}, fmt.Errorf("read pc %q, but no line info", pc)
+	}
+	match := gvisorLineRe.FindStringSubmatch(s.Text())
+	if match == nil {
+		return Frame{}, fmt.Errorf("failed to parse line: %q", s.Text())
+	}
+	var ints [4]int
+	for i := range ints {
+		x, err := strconv.ParseUint(match[i+2], 0, 32)
+		if err != nil {
+			return Frame{}, fmt.Errorf("failed to parse number %q: %v", match[i+2], err)
+		}
+		ints[i] = int(x)
+	}
+	frame := Frame{
+		PC:   pc,
+		Name: match[1],
+		Range: Range{
+			StartLine: ints[0],
+			StartCol:  ints[1],
+			EndLine:   ints[2],
+			EndCol:    ints[3],
+		},
+	}
+	return frame, nil
+}
+
+var gvisorLineRe = regexp.MustCompile(`/gvisor/([^:]+):([0-9]+).([0-9]+),([0-9]+).([0-9]+)$`)

--- a/pkg/cover/backend/pc.go
+++ b/pkg/cover/backend/pc.go
@@ -1,13 +1,17 @@
 // Copyright 2020 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package cover
+package backend
 
 import (
 	"fmt"
 
 	"github.com/google/syzkaller/sys/targets"
 )
+
+func RestorePC(pc, base uint32) uint64 {
+	return uint64(base)<<32 + uint64(pc)
+}
 
 func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
 	offset := instructionLen(target.Arch)

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -43,7 +43,3 @@ func (cov Cover) Serialize() []uint32 {
 	}
 	return res
 }
-
-func RestorePC(pc, base uint32) uint64 {
-	return uint64(base)<<32 + uint64(pc)
-}

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -65,6 +65,7 @@ func (rg *ReportGenerator) DoHTML(w io.Writer, progs []Prog) error {
 				Total:   file.totalPCs,
 				Covered: file.coveredPCs,
 			},
+			HasFunctions: len(file.functions) != 0,
 		}
 		pos.Files = append(pos.Files, f)
 		if file.coveredPCs == 0 {
@@ -354,7 +355,8 @@ type templateDir struct {
 
 type templateFile struct {
 	templateBase
-	Index int
+	Index        int
+	HasFunctions bool
 }
 
 var coverTemplate = template.Must(template.New("").Parse(`
@@ -541,7 +543,8 @@ var coverTemplate = template.Must(template.New("").Parse(`
 					{{$file.Name}}
 				</a>
 				<span class="cover hover">
-					<a href="#{{$file.Path}}/func_cov" id="path/{{$file.Path}}/func_cov" onclick="onPercentClick({{$file.Index}})">
+					<a href="#{{$file.Path}}" id="path/{{$file.Path}}"
+						onclick="{{if .HasFunctions}}onPercentClick{{else}}onFileClick{{end}}({{$file.Index}})">
                                                 {{$file.Percent}}%
 					</a>
 					<span class="cover-right">of {{$file.Total}}</span>

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -1,0 +1,448 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package cover
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"html"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"math"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func (rg *ReportGenerator) DoHTML(w io.Writer, progs []Prog) error {
+	files, err := rg.prepareFileMap(progs)
+	if err != nil {
+		return err
+	}
+	d := &templateData{
+		Root: new(templateDir),
+	}
+	for fname, file := range files {
+		pos := d.Root
+		path := ""
+		for {
+			if path != "" {
+				path += "/"
+			}
+			sep := strings.IndexByte(fname, filepath.Separator)
+			if sep == -1 {
+				path += fname
+				break
+			}
+			dir := fname[:sep]
+			path += dir
+			if pos.Dirs == nil {
+				pos.Dirs = make(map[string]*templateDir)
+			}
+			if pos.Dirs[dir] == nil {
+				pos.Dirs[dir] = &templateDir{
+					templateBase: templateBase{
+						Path: path,
+						Name: dir,
+					},
+				}
+			}
+			pos = pos.Dirs[dir]
+			fname = fname[sep+1:]
+		}
+		f := &templateFile{
+			templateBase: templateBase{
+				Path:    path,
+				Name:    fname,
+				Total:   file.pcs,
+				Covered: file.covered,
+			},
+		}
+		pos.Files = append(pos.Files, f)
+		if file.covered == 0 {
+			continue
+		}
+		lines, err := parseFile(file.filename)
+		if err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		for i, ln := range lines {
+			cov, ok := file.lines[i+1]
+			prog, class, count := "", "", "     "
+			if ok {
+				if len(cov.count) != 0 {
+					if cov.prog != -1 {
+						prog = fmt.Sprintf("onclick='onProgClick(%v)'", cov.prog)
+					}
+					count = fmt.Sprintf("% 5v", len(cov.count))
+					class = "covered"
+					if cov.uncovered {
+						class = "both"
+					}
+				} else {
+					class = "uncovered"
+				}
+			}
+			buf.WriteString(fmt.Sprintf("<span class='count' %v>%v</span>", prog, count))
+			if class == "" {
+				buf.WriteByte(' ')
+				buf.Write(ln)
+				buf.WriteByte('\n')
+			} else {
+				buf.WriteString(fmt.Sprintf("<span class='%v'> ", class))
+				buf.Write(ln)
+				buf.WriteString("</span>\n")
+			}
+		}
+		d.Contents = append(d.Contents, template.HTML(buf.String()))
+		f.Index = len(d.Contents) - 1
+
+		addFunctionCoverage(file, d)
+	}
+	for _, prog := range progs {
+		d.Progs = append(d.Progs, template.HTML(html.EscapeString(prog.Data)))
+	}
+
+	processDir(d.Root)
+	return coverTemplate.Execute(w, d)
+}
+
+var csvHeader = []string{
+	"Filename",
+	"Function",
+	"Covered PCs",
+	"Total PCs",
+}
+
+func (rg *ReportGenerator) DoCSV(w io.Writer, progs []Prog) error {
+	files, err := rg.prepareFileMap(progs)
+	if err != nil {
+		return err
+	}
+	var data [][]string
+	for fname, file := range files {
+		for _, function := range file.functions {
+			data = append(data, []string{
+				fname,
+				function.name,
+				strconv.Itoa(function.covered),
+				strconv.Itoa(function.pcs),
+			})
+		}
+	}
+	sort.Slice(data, func(i, j int) bool {
+		if data[i][0] != data[j][0] {
+			return data[i][0] < data[j][0]
+		}
+		return data[i][1] < data[j][1]
+	})
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+	if err := writer.Write(csvHeader); err != nil {
+		return err
+	}
+	return writer.WriteAll(data)
+}
+
+func addFunctionCoverage(file *file, data *templateData) {
+	var buf bytes.Buffer
+	for _, function := range file.functions {
+		percentage := ""
+		if function.covered > 0 {
+			percentage = fmt.Sprintf("%v%%", percent(function.covered, function.pcs))
+		} else {
+			percentage = "---"
+		}
+		buf.WriteString(fmt.Sprintf("<span class='hover'>%v", function.name))
+		buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentage))
+		buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(function.pcs)))
+		buf.WriteString("</span></span></span><br>\n")
+	}
+	data.Functions = append(data.Functions, template.HTML(buf.String()))
+}
+
+func processDir(dir *templateDir) {
+	for len(dir.Dirs) == 1 && len(dir.Files) == 0 {
+		for _, child := range dir.Dirs {
+			dir.Name += "/" + child.Name
+			dir.Files = child.Files
+			dir.Dirs = child.Dirs
+		}
+	}
+	sort.Slice(dir.Files, func(i, j int) bool {
+		return dir.Files[i].Name < dir.Files[j].Name
+	})
+	for _, f := range dir.Files {
+		dir.Total += f.Total
+		dir.Covered += f.Covered
+		f.Percent = percent(f.Covered, f.Total)
+	}
+	for _, child := range dir.Dirs {
+		processDir(child)
+		dir.Total += child.Total
+		dir.Covered += child.Covered
+	}
+	dir.Percent = percent(dir.Covered, dir.Total)
+	if dir.Covered == 0 {
+		dir.Dirs = nil
+		dir.Files = nil
+	}
+}
+
+func percent(covered, total int) int {
+	f := math.Ceil(float64(covered) / float64(total) * 100)
+	if f == 100 && covered < total {
+		f = 99
+	}
+	return int(f)
+}
+
+func parseFile(fn string) ([][]byte, error) {
+	data, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return nil, err
+	}
+	htmlReplacer := strings.NewReplacer(">", "&gt;", "<", "&lt;", "&", "&amp;", "\t", "        ")
+	var lines [][]byte
+	for {
+		idx := bytes.IndexByte(data, '\n')
+		if idx == -1 {
+			break
+		}
+		lines = append(lines, []byte(htmlReplacer.Replace(string(data[:idx]))))
+		data = data[idx+1:]
+	}
+	if len(data) != 0 {
+		lines = append(lines, data)
+	}
+	return lines, nil
+}
+
+type templateData struct {
+	Root      *templateDir
+	Contents  []template.HTML
+	Progs     []template.HTML
+	Functions []template.HTML
+}
+
+type templateBase struct {
+	Name    string
+	Path    string
+	Total   int
+	Covered int
+	Percent int
+}
+
+type templateDir struct {
+	templateBase
+	Dirs  map[string]*templateDir
+	Files []*templateFile
+}
+
+type templateFile struct {
+	templateBase
+	Index int
+}
+
+var coverTemplate = template.Must(template.New("").Parse(`
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<style>
+			.file {
+				display: none;
+				margin: 0;
+				padding: 0;
+			}
+			.count {
+				font-weight: bold;
+				border-right: 1px solid #ddd;
+				padding-right: 4px;
+				cursor: zoom-in;
+			}
+			.split {
+				height: 100%;
+				position: fixed;
+				z-index: 1;
+				top: 0;
+				overflow-x: hidden;
+			}
+			.tree {
+				left: 0;
+				width: 24%;
+			}
+			.function {
+				height: 100%;
+				position: fixed;
+				z-index: 1;
+				top: 0;
+				overflow-x: hidden;
+				display: none;
+			}
+			.list {
+				left: 24%;
+				width: 30%;
+			}
+			.right {
+				border-left: 2px solid #444;
+				right: 0;
+				width: 76%;
+				font-family: 'Courier New', Courier, monospace;
+				color: rgb(80, 80, 80);
+			}
+			.cover {
+				float: right;
+				width: 120px;
+				padding-right: 4px;
+			}
+			.cover-right {
+				float: right;
+			}
+			.covered {
+				color: rgb(0, 0, 0);
+				font-weight: bold;
+			}
+			.uncovered {
+				color: rgb(255, 0, 0);
+				font-weight: bold;
+			}
+			.both {
+				color: rgb(200, 100, 0);
+				font-weight: bold;
+			}
+			ul, #dir_list {
+				list-style-type: none;
+				padding-left: 16px;
+			}
+			#dir_list {
+				margin: 0;
+				padding: 0;
+			}
+			.hover:hover {
+				background: #ffff99;
+			}
+			.caret {
+				cursor: pointer;
+				user-select: none;
+			}
+			.caret::before {
+				color: black;
+				content: "\25B6";
+				display: inline-block;
+				margin-right: 3px;
+			}
+			.caret-down::before {
+				transform: rotate(90deg);
+			}
+			.nested {
+				display: none;
+			}
+			.active {
+				display: block;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="split tree">
+			<ul id="dir_list">
+				{{template "dir" .Root}}
+			</ul>
+		</div>
+		<div id="right_pane" class="split right">
+			{{range $i, $f := .Contents}}
+				<pre class="file" id="contents_{{$i}}">{{$f}}</pre>
+			{{end}}
+			{{range $i, $p := .Progs}}
+				<pre class="file" id="prog_{{$i}}">{{$p}}</pre>
+			{{end}}
+			{{range $i, $p := .Functions}}
+				<div class="function list" id="function_{{$i}}">{{$p}}</div>
+			{{end}}
+		</div>
+	</body>
+	<script>
+	(function() {
+		var toggler = document.getElementsByClassName("caret");
+		for (var i = 0; i < toggler.length; i++) {
+			toggler[i].addEventListener("click", function() {
+				this.parentElement.querySelector(".nested").classList.toggle("active");
+				this.classList.toggle("caret-down");
+			});
+		}
+		if (window.location.hash) {
+			var hash = decodeURIComponent(window.location.hash.substring(1)).split("/");
+			var path = "path";
+			for (var i = 0; i < hash.length; i++) {
+				path += "/" + hash[i];
+				var elem = document.getElementById(path);
+				if (elem)
+					elem.click();
+			}
+		}
+	})();
+	var visible;
+        function onPercentClick(index) {
+		if (visible)
+			visible.style.display = 'none';
+		visible = document.getElementById("function_" + index);
+		visible.style.display = 'block';
+		document.getElementById("right_pane").scrollTo(0, 0);
+	}
+	function onFileClick(index) {
+		if (visible)
+			visible.style.display = 'none';
+		visible = document.getElementById("contents_" + index);
+		visible.style.display = 'block';
+		document.getElementById("right_pane").scrollTo(0, 0);
+	}
+	function onProgClick(index) {
+		if (visible)
+			visible.style.display = 'none';
+		visible = document.getElementById("prog_" + index);
+		visible.style.display = 'block';
+		document.getElementById("right_pane").scrollTo(0, 0);
+	}
+	</script>
+</html>
+
+{{define "dir"}}
+	{{range $dir := .Dirs}}
+		<li>
+			<span id="path/{{$dir.Path}}" class="caret hover">
+				{{$dir.Name}}
+				<span class="cover hover">
+					{{if $dir.Covered}}{{$dir.Percent}}%{{else}}---{{end}}
+					<span class="cover-right">of {{$dir.Total}}</span>
+				</span>
+			</span>
+			<ul class="nested">
+				{{template "dir" $dir}}
+			</ul>
+		</li>
+	{{end}}
+	{{range $file := .Files}}
+		<li><span class="hover">
+			{{if $file.Covered}}
+				<a href="#{{$file.Path}}" id="path/{{$file.Path}}" onclick="onFileClick({{$file.Index}})">
+					{{$file.Name}}
+				</a>
+				<span class="cover hover">
+					<a href="#{{$file.Path}}/func_cov" id="path/{{$file.Path}}/func_cov" onclick="onPercentClick({{$file.Index}})">
+                                                {{$file.Percent}}%
+					</a>
+					<span class="cover-right">of {{$file.Total}}</span>
+				</span>
+			{{else}}
+					{{$file.Name}}<span class="cover hover">---<span class="cover-right">
+						of {{$file.Total}}</span></span>
+			{{end}}
+		</span></li>
+	{{end}}
+{{end}}
+`))

--- a/pkg/cover/pc.go
+++ b/pkg/cover/pc.go
@@ -1,0 +1,55 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package cover
+
+import (
+	"fmt"
+
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
+	offset := instructionLen(target.Arch)
+	pc -= offset
+	// THUMB instructions are 2 or 4 bytes with low bit set.
+	// ARM instructions are always 4 bytes.
+	if target.Arch == targets.ARM {
+		return pc & ^uint64(1)
+	}
+	return pc
+}
+
+func NextInstructionPC(target *targets.Target, pc uint64) uint64 {
+	offset := instructionLen(target.Arch)
+	pc += offset
+	// THUMB instructions are 2 or 4 bytes with low bit set.
+	// ARM instructions are always 4 bytes.
+	if target.Arch == targets.ARM {
+		return pc & ^uint64(1)
+	}
+	return pc
+}
+
+func instructionLen(arch string) uint64 {
+	switch arch {
+	case targets.AMD64:
+		return 5
+	case targets.I386:
+		return 5
+	case targets.ARM64:
+		return 4
+	case targets.ARM:
+		return 3
+	case targets.PPC64LE:
+		return 4
+	case targets.MIPS64LE:
+		return 8
+	case targets.S390x:
+		return 6
+	case targets.RiscV64:
+		return 4
+	default:
+		panic(fmt.Sprintf("unknown arch %q", arch))
+	}
+}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -26,6 +26,11 @@ type Prog struct {
 	PCs  []uint64
 }
 
+var (
+	RestorePC             = backend.RestorePC
+	PreviousInstructionPC = backend.PreviousInstructionPC
+)
+
 func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string) (*ReportGenerator, error) {
 	impl, err := backend.Make(target, vm, objDir)
 	if err != nil {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -4,38 +4,21 @@
 package cover
 
 import (
-	"bufio"
-	"bytes"
-	"debug/dwarf"
-	"debug/elf"
-	"encoding/binary"
-	"encoding/csv"
 	"fmt"
-	"html"
-	"html/template"
-	"io"
-	"io/ioutil"
-	"math"
 	"path/filepath"
-	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 
-	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/sys/targets"
 )
 
 type ReportGenerator struct {
-	target       *targets.Target
-	kernelObject string
-	srcDir       string
-	objDir       string
-	buildDir     string
-	units        []*compileUnit
-	symbols      []*symbol
-	pcs          map[uint64][]pcFrame
+	target   *targets.Target
+	srcDir   string
+	objDir   string
+	buildDir string
+	*backend.Impl
 }
 
 type Prog struct {
@@ -43,135 +26,22 @@ type Prog struct {
 	PCs  []uint64
 }
 
-type symbol struct {
-	name       string
-	unit       *compileUnit
-	start      uint64
-	end        uint64
-	pcs        []uint64
-	symbolized bool
-}
-
-type compileUnit struct {
-	name     string
-	filename string
-	pcs      int
-}
-
-type pcFrame struct {
-	symbolizer.Frame
-	filename string
-}
-
-type pcRange struct {
-	start uint64
-	end   uint64
-	cu    *compileUnit
-}
-
 func MakeReportGenerator(target *targets.Target, kernelObject, srcDir, buildDir string) (*ReportGenerator, error) {
-	file, err := elf.Open(kernelObject)
+	impl, err := backend.Make(target, kernelObject, srcDir, buildDir)
 	if err != nil {
 		return nil, err
-	}
-	var coverPoints []uint64
-	var symbols []*symbol
-	errc := make(chan error, 1)
-	go func() {
-		var err error
-		var tracePC uint64
-		symbols, tracePC, err = readSymbols(file)
-		if err != nil {
-			errc <- err
-			return
-		}
-		if target.Arch == targets.AMD64 {
-			coverPoints, err = readCoverPoints(file, tracePC)
-		} else {
-			coverPoints, err = objdump(target, kernelObject)
-		}
-		errc <- err
-	}()
-	ranges, units, err := readTextRanges(file)
-	if err != nil {
-		return nil, err
-	}
-	if err := <-errc; err != nil {
-		return nil, err
-	}
-	if len(coverPoints) == 0 {
-		return nil, fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y)", kernelObject)
-	}
-	symbols = buildSymbols(symbols, ranges, coverPoints)
-	objDir := filepath.Dir(kernelObject)
-	nunit := 0
-	for _, unit := range units {
-		if unit.pcs == 0 {
-			continue // drop the unit
-		}
-		unit.name, unit.filename = cleanPath(unit.name, srcDir, objDir, buildDir)
-		units[nunit] = unit
-		nunit++
-	}
-	units = units[:nunit]
-	if len(symbols) == 0 || len(units) == 0 {
-		return nil, fmt.Errorf("failed to parse DWARF (set CONFIG_DEBUG_INFO=y?)")
 	}
 	rg := &ReportGenerator{
-		target:       target,
-		kernelObject: kernelObject,
-		srcDir:       srcDir,
-		objDir:       objDir,
-		buildDir:     buildDir,
-		units:        units,
-		symbols:      symbols,
-		pcs:          make(map[uint64][]pcFrame),
+		target:   target,
+		srcDir:   srcDir,
+		objDir:   filepath.Dir(kernelObject),
+		buildDir: buildDir,
+		Impl:     impl,
+	}
+	for _, unit := range rg.Units {
+		unit.Name, unit.Path = rg.cleanPath(unit.Name)
 	}
 	return rg, nil
-}
-
-func buildSymbols(symbols []*symbol, ranges []pcRange, coverPoints []uint64) []*symbol {
-	// Assign coverage point PCs to symbols.
-	// Both symbols and coverage points are sorted, so we do it one pass over both.
-	var curSymbol *symbol
-	firstSymbolPC, symbolIdx := -1, 0
-	for i := 0; i < len(coverPoints); i++ {
-		pc := coverPoints[i]
-		for ; symbolIdx < len(symbols) && pc >= symbols[symbolIdx].end; symbolIdx++ {
-		}
-		var symb *symbol
-		if symbolIdx < len(symbols) && pc >= symbols[symbolIdx].start && pc < symbols[symbolIdx].end {
-			symb = symbols[symbolIdx]
-		}
-		if curSymbol != nil && curSymbol != symb {
-			curSymbol.pcs = coverPoints[firstSymbolPC:i]
-			firstSymbolPC = -1
-		}
-		curSymbol = symb
-		if symb != nil && firstSymbolPC == -1 {
-			firstSymbolPC = i
-		}
-	}
-	if curSymbol != nil {
-		curSymbol.pcs = coverPoints[firstSymbolPC:]
-	}
-	// Assign compile units to symbols based on unit pc ranges.
-	// Do it one pass as both are sorted.
-	nsymbol := 0
-	rangeIndex := 0
-	for _, s := range symbols {
-		for ; rangeIndex < len(ranges) && ranges[rangeIndex].end <= s.start; rangeIndex++ {
-		}
-		if rangeIndex == len(ranges) || s.start < ranges[rangeIndex].start || len(s.pcs) == 0 {
-			continue // drop the symbol
-		}
-		unit := ranges[rangeIndex].cu
-		s.unit = unit
-		unit.pcs += len(s.pcs)
-		symbols[nsymbol] = s
-		nsymbol++
-	}
-	return symbols[:nsymbol]
 }
 
 type file struct {
@@ -194,88 +64,79 @@ type line struct {
 	uncovered bool
 }
 
-func (rg *ReportGenerator) DoHTML(buf io.Writer, progs []Prog) error {
-	files, err := rg.prepareFileMap(progs)
-	if err != nil {
-		return err
-	}
-	return rg.generateHTML(buf, progs, files)
-}
-
-func (rg *ReportGenerator) DoCSV(buf io.Writer, progs []Prog) error {
-	files, err := rg.prepareFileMap(progs)
-	if err != nil {
-		return err
-	}
-	return rg.generateCSV(buf, progs, files)
-}
-
 func (rg *ReportGenerator) prepareFileMap(progs []Prog) (map[string]*file, error) {
-	files := make(map[string]*file)
-	for _, unit := range rg.units {
-		f := &file{
-			filename: unit.filename,
-			lines:    make(map[int]line),
-			pcs:      unit.pcs,
-		}
-		files[unit.name] = f
-	}
-	if err := rg.lazySymbolize(files, progs); err != nil {
+	if err := rg.lazySymbolize(progs); err != nil {
 		return nil, err
 	}
-	coveredPCs := make(map[uint64]bool)
-	for progIdx, prog := range progs {
+	files := make(map[string]*file)
+	for _, unit := range rg.Units {
+		files[unit.Name] = &file{
+			filename: unit.Path,
+			lines:    make(map[int]line),
+			pcs:      len(unit.PCs),
+		}
+	}
+	progPCs := make(map[uint64]map[int]bool)
+	for i, prog := range progs {
 		for _, pc := range prog.PCs {
-			frames, ok := rg.pcs[pc]
-			if !ok {
-				continue
+			if progPCs[pc] == nil {
+				progPCs[pc] = make(map[int]bool)
 			}
-			coveredPCs[pc] = true
-			for _, frame := range frames {
-				f := getFile(files, frame.File, frame.filename)
-				ln := f.lines[frame.Line]
-				if ln.count == nil {
-					ln.count = make(map[int]bool)
-					ln.prog = -1
-				}
+			progPCs[pc][i] = true
+		}
+	}
+	matchedPC := false
+	for _, frame := range rg.Frames {
+		name, path := rg.cleanPath(frame.File)
+		f := getFile(files, name, path)
+		ln := f.lines[frame.Line]
+		coveredBy := progPCs[frame.PC]
+		if len(coveredBy) != 0 {
+			// Covered frame.
+			matchedPC = true
+			if ln.count == nil {
+				ln.count = make(map[int]bool)
+				ln.prog = -1
+			}
+			for progIdx := range coveredBy {
 				ln.count[progIdx] = true
-				if ln.prog == -1 || len(prog.Data) < len(progs[ln.prog].Data) {
+				if ln.prog == -1 || len(progs[progIdx].Data) < len(progs[ln.prog].Data) {
 					ln.prog = progIdx
 				}
-				f.lines[frame.Line] = ln
 			}
-		}
-	}
-	if len(coveredPCs) == 0 {
-		return nil, fmt.Errorf("coverage doesn't match any coverage callbacks")
-	}
-	for pc, frames := range rg.pcs {
-		if coveredPCs[pc] {
-			continue
-		}
-		for _, frame := range frames {
-			f := getFile(files, frame.File, frame.filename)
-			ln := f.lines[frame.Line]
+		} else {
+			// Uncovered frame.
 			if !frame.Inline || len(ln.count) == 0 {
 				ln.uncovered = true
-				f.lines[frame.Line] = ln
 			}
 		}
+		f.lines[frame.Line] = ln
 	}
-	for _, s := range rg.symbols {
-		f := files[s.unit.name]
-		covered := 0
-		for _, pc := range s.pcs {
-			if coveredPCs[pc] {
-				covered++
+	if !matchedPC {
+		return nil, fmt.Errorf("coverage doesn't match any coverage callbacks")
+	}
+	for _, unit := range rg.Units {
+		f := files[unit.Name]
+		for _, pc := range unit.PCs {
+			if progPCs[pc] != nil {
 				f.covered++
 			}
 		}
-		f.functions = append(f.functions, &function{
-			name:    s.name,
-			pcs:     len(s.pcs),
-			covered: covered,
-		})
+	}
+	for _, s := range rg.Symbols {
+		fun := &function{
+			name: s.Name,
+			pcs:  len(s.PCs),
+		}
+		for _, pc := range s.PCs {
+			if progPCs[pc] != nil {
+				fun.covered++
+			}
+		}
+		f := files[s.Unit.Name]
+		f.functions = append(f.functions, fun)
+	}
+	for _, f := range files {
 		sort.Slice(f.functions, func(i, j int) bool {
 			return f.functions[i].name < f.functions[j].name
 		})
@@ -283,72 +144,51 @@ func (rg *ReportGenerator) prepareFileMap(progs []Prog) (map[string]*file, error
 	return files, nil
 }
 
-func (rg *ReportGenerator) lazySymbolize(files map[string]*file, progs []Prog) error {
+func (rg *ReportGenerator) lazySymbolize(progs []Prog) error {
+	if len(rg.Symbols) == 0 {
+		return nil
+	}
+	symbolize := make(map[*backend.Symbol]bool)
 	uniquePCs := make(map[uint64]bool)
-	symbolizeSymbols := make(map[*symbol]bool)
-	var symbolizePCs []uint64
-	anyPCs := false
+	var pcs []uint64
 	for _, prog := range progs {
 		for _, pc := range prog.PCs {
-			anyPCs = true
 			if uniquePCs[pc] {
 				continue
 			}
 			uniquePCs[pc] = true
-			s := findSymbol(rg.symbols, pc)
-			if s == nil {
+			sym := rg.findSymbol(pc)
+			if sym == nil {
 				continue
 			}
-			if !s.symbolized && !symbolizeSymbols[s] {
-				symbolizeSymbols[s] = true
-				symbolizePCs = append(symbolizePCs, s.pcs...)
+			if !sym.Symbolized && !symbolize[sym] {
+				symbolize[sym] = true
+				pcs = append(pcs, sym.PCs...)
 			}
 		}
 	}
-	if !anyPCs {
+	if len(uniquePCs) == 0 {
 		return fmt.Errorf("no coverage collected so far")
 	}
-	if len(symbolizeSymbols) == 0 {
+	if len(pcs) == 0 {
 		return nil
 	}
-	frames, err := symbolize(rg.target, rg.kernelObject, symbolizePCs)
+	frames, err := rg.Symbolize(pcs)
 	if err != nil {
 		return err
 	}
-	for _, frame := range frames {
-		f := pcFrame{frame, ""}
-		f.File, f.filename = cleanPath(frame.File, rg.srcDir, rg.objDir, rg.buildDir)
-		rg.pcs[frame.PC] = append(rg.pcs[frame.PC], f)
-	}
-	for s := range symbolizeSymbols {
-		s.symbolized = true
+	rg.Frames = append(rg.Frames, frames...)
+	for sym := range symbolize {
+		sym.Symbolized = true
 	}
 	return nil
 }
 
-type Symbol struct {
-	Name string
-	File string
-	PCs  []uint64
-}
-
-func (rg *ReportGenerator) GetSymbols() []Symbol {
-	var ret []Symbol
-	for _, sym := range rg.symbols {
-		ret = append(ret, Symbol{
-			Name: sym.name,
-			File: sym.unit.name,
-			PCs:  sym.pcs,
-		})
-	}
-	return ret
-}
-
-func getFile(files map[string]*file, name, filename string) *file {
+func getFile(files map[string]*file, name, path string) *file {
 	f := files[name]
 	if f == nil {
 		f = &file{
-			filename: filename,
+			filename: path,
 			lines:    make(map[int]line),
 			// Special mark for header files, if a file does not have coverage at all it is not shown.
 			pcs:     1,
@@ -359,798 +199,34 @@ func getFile(files map[string]*file, name, filename string) *file {
 	return f
 }
 
-var csvHeader = []string{
-	"Filename",
-	"Function",
-	"Covered PCs",
-	"Total PCs",
-}
-
-func (rg *ReportGenerator) generateCSV(w io.Writer, progs []Prog, files map[string]*file) error {
-	var data [][]string
-	for fname, file := range files {
-		for _, function := range file.functions {
-			data = append(data, []string{
-				fname,
-				function.name,
-				strconv.Itoa(function.covered),
-				strconv.Itoa(function.pcs),
-			})
-		}
-	}
-	sort.Slice(data, func(i, j int) bool {
-		if data[i][0] != data[j][0] {
-			return data[i][0] < data[j][0]
-		}
-		return data[i][1] < data[j][1]
-	})
-	writer := csv.NewWriter(w)
-	defer writer.Flush()
-	if err := writer.Write(csvHeader); err != nil {
-		return err
-	}
-	return writer.WriteAll(data)
-}
-
-func (rg *ReportGenerator) generateHTML(w io.Writer, progs []Prog, files map[string]*file) error {
-	d := &templateData{
-		Root: new(templateDir),
-	}
-	for fname, file := range files {
-		pos := d.Root
-		path := ""
-		for {
-			if path != "" {
-				path += "/"
-			}
-			sep := strings.IndexByte(fname, filepath.Separator)
-			if sep == -1 {
-				path += fname
-				break
-			}
-			dir := fname[:sep]
-			path += dir
-			if pos.Dirs == nil {
-				pos.Dirs = make(map[string]*templateDir)
-			}
-			if pos.Dirs[dir] == nil {
-				pos.Dirs[dir] = &templateDir{
-					templateBase: templateBase{
-						Path: path,
-						Name: dir,
-					},
-				}
-			}
-			pos = pos.Dirs[dir]
-			fname = fname[sep+1:]
-		}
-		f := &templateFile{
-			templateBase: templateBase{
-				Path:    path,
-				Name:    fname,
-				Total:   file.pcs,
-				Covered: file.covered,
-			},
-		}
-		pos.Files = append(pos.Files, f)
-		if file.covered == 0 {
-			continue
-		}
-		lines, err := parseFile(file.filename)
-		if err != nil {
-			return err
-		}
-		var buf bytes.Buffer
-		for i, ln := range lines {
-			cov, ok := file.lines[i+1]
-			prog, class, count := "", "", "     "
-			if ok {
-				if len(cov.count) != 0 {
-					if cov.prog != -1 {
-						prog = fmt.Sprintf("onclick='onProgClick(%v)'", cov.prog)
-					}
-					count = fmt.Sprintf("% 5v", len(cov.count))
-					class = "covered"
-					if cov.uncovered {
-						class = "both"
-					}
-				} else {
-					class = "uncovered"
-				}
-			}
-			buf.WriteString(fmt.Sprintf("<span class='count' %v>%v</span>", prog, count))
-			if class == "" {
-				buf.WriteByte(' ')
-				buf.Write(ln)
-				buf.WriteByte('\n')
-			} else {
-				buf.WriteString(fmt.Sprintf("<span class='%v'> ", class))
-				buf.Write(ln)
-				buf.WriteString("</span>\n")
-			}
-		}
-		d.Contents = append(d.Contents, template.HTML(buf.String()))
-		f.Index = len(d.Contents) - 1
-
-		addFunctionCoverage(file, d)
-	}
-	for _, prog := range progs {
-		d.Progs = append(d.Progs, template.HTML(html.EscapeString(prog.Data)))
-	}
-
-	processDir(d.Root)
-	return coverTemplate.Execute(w, d)
-}
-
-func addFunctionCoverage(file *file, data *templateData) {
-	var buf bytes.Buffer
-	for _, function := range file.functions {
-		percentage := ""
-		if function.covered > 0 {
-			percentage = fmt.Sprintf("%v%%", percent(function.covered, function.pcs))
-		} else {
-			percentage = "---"
-		}
-		buf.WriteString(fmt.Sprintf("<span class='hover'>%v", function.name))
-		buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentage))
-		buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(function.pcs)))
-		buf.WriteString("</span></span></span><br>\n")
-	}
-	data.Functions = append(data.Functions, template.HTML(buf.String()))
-}
-
-func processDir(dir *templateDir) {
-	for len(dir.Dirs) == 1 && len(dir.Files) == 0 {
-		for _, child := range dir.Dirs {
-			dir.Name += "/" + child.Name
-			dir.Files = child.Files
-			dir.Dirs = child.Dirs
-		}
-	}
-	sort.Slice(dir.Files, func(i, j int) bool {
-		return dir.Files[i].Name < dir.Files[j].Name
-	})
-	for _, f := range dir.Files {
-		dir.Total += f.Total
-		dir.Covered += f.Covered
-		f.Percent = percent(f.Covered, f.Total)
-	}
-	for _, child := range dir.Dirs {
-		processDir(child)
-		dir.Total += child.Total
-		dir.Covered += child.Covered
-	}
-	dir.Percent = percent(dir.Covered, dir.Total)
-	if dir.Covered == 0 {
-		dir.Dirs = nil
-		dir.Files = nil
-	}
-}
-
-func cleanPath(path, srcDir, objDir, buildDir string) (string, string) {
+func (rg *ReportGenerator) cleanPath(path string) (string, string) {
 	filename := ""
 	switch {
-	case strings.HasPrefix(path, objDir):
+	case strings.HasPrefix(path, rg.objDir):
 		// Assume the file was built there.
-		path = strings.TrimPrefix(path, objDir)
-		filename = filepath.Join(objDir, path)
-	case strings.HasPrefix(path, buildDir):
+		path = strings.TrimPrefix(path, rg.objDir)
+		filename = filepath.Join(rg.objDir, path)
+	case strings.HasPrefix(path, rg.buildDir):
 		// Assume the file was moved from buildDir to srcDir.
-		path = strings.TrimPrefix(path, buildDir)
-		filename = filepath.Join(srcDir, path)
+		path = strings.TrimPrefix(path, rg.buildDir)
+		filename = filepath.Join(rg.srcDir, path)
 	default:
 		// Assume this is relative path.
-		filename = filepath.Join(srcDir, path)
+		filename = filepath.Join(rg.srcDir, path)
 	}
 	return strings.TrimLeft(filepath.Clean(path), "/\\"), filename
 }
 
-func percent(covered, total int) int {
-	f := math.Ceil(float64(covered) / float64(total) * 100)
-	if f == 100 && covered < total {
-		f = 99
-	}
-	return int(f)
-}
-
-func findSymbol(symbols []*symbol, pc uint64) *symbol {
-	idx := sort.Search(len(symbols), func(i int) bool {
-		return pc < symbols[i].end
+func (rg *ReportGenerator) findSymbol(pc uint64) *backend.Symbol {
+	idx := sort.Search(len(rg.Symbols), func(i int) bool {
+		return pc < rg.Symbols[i].End
 	})
-	if idx == len(symbols) {
+	if idx == len(rg.Symbols) {
 		return nil
 	}
-	s := symbols[idx]
-	if pc < s.start || pc > s.end {
+	s := rg.Symbols[idx]
+	if pc < s.Start || pc > s.End {
 		return nil
 	}
 	return s
 }
-
-func readSymbols(file *elf.File) ([]*symbol, uint64, error) {
-	text := file.Section(".text")
-	if text == nil {
-		return nil, 0, fmt.Errorf("no .text section in the object file")
-	}
-	allSymbols, err := file.Symbols()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read ELF symbols: %v", err)
-	}
-	var tracePC uint64
-	var symbols []*symbol
-	for _, symb := range allSymbols {
-		if symb.Value < text.Addr || symb.Value+symb.Size > text.Addr+text.Size {
-			continue
-		}
-		symbols = append(symbols, &symbol{
-			name:  symb.Name,
-			start: symb.Value,
-			end:   symb.Value + symb.Size,
-		})
-		if tracePC == 0 && symb.Name == "__sanitizer_cov_trace_pc" {
-			tracePC = symb.Value
-		}
-	}
-	if tracePC == 0 {
-		return nil, 0, fmt.Errorf("no __sanitizer_cov_trace_pc symbol in the object file")
-	}
-	sort.Slice(symbols, func(i, j int) bool {
-		return symbols[i].start < symbols[j].start
-	})
-	return symbols, tracePC, nil
-}
-
-func readTextRanges(file *elf.File) ([]pcRange, []*compileUnit, error) {
-	text := file.Section(".text")
-	if text == nil {
-		return nil, nil, fmt.Errorf("no .text section in the object file")
-	}
-	kaslr := file.Section(".rela.text") != nil
-	debugInfo, err := file.DWARF()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse DWARF: %v (set CONFIG_DEBUG_INFO=y?)", err)
-	}
-	var ranges []pcRange
-	var units []*compileUnit
-	for r := debugInfo.Reader(); ; {
-		ent, err := r.Next()
-		if err != nil {
-			return nil, nil, err
-		}
-		if ent == nil {
-			break
-		}
-		if ent.Tag != dwarf.TagCompileUnit {
-			return nil, nil, fmt.Errorf("found unexpected tag %v on top level", ent.Tag)
-		}
-		attrName := ent.Val(dwarf.AttrName)
-		if attrName == nil {
-			continue
-		}
-		unit := &compileUnit{
-			name: attrName.(string),
-		}
-		units = append(units, unit)
-		ranges1, err := debugInfo.Ranges(ent)
-		if err != nil {
-			return nil, nil, err
-		}
-		for _, r := range ranges1 {
-			if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
-				if kaslr {
-					// Linux kernel binaries with CONFIG_RANDOMIZE_BASE=y are strange.
-					// .text starts at 0xffffffff81000000 and symbols point there as well,
-					// but PC ranges point to addresses around 0.
-					// So try to add text offset and retry the check.
-					// It's unclear if we also need some offset on top of text.Addr,
-					// it gives approximately correct addresses, but not necessary precisely
-					// correct addresses.
-					r[0] += text.Addr
-					r[1] += text.Addr
-					if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
-						continue
-					}
-				}
-			}
-			ranges = append(ranges, pcRange{r[0], r[1], unit})
-		}
-		r.SkipChildren()
-	}
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].start < ranges[j].start
-	})
-	return ranges, units, nil
-}
-
-func symbolize(target *targets.Target, obj string, pcs []uint64) ([]symbolizer.Frame, error) {
-	procs := runtime.GOMAXPROCS(0) / 2
-	const (
-		minProcs = 1
-		maxProcs = 4
-	)
-	// addr2line on a beefy vmlinux takes up to 1.6GB of RAM, so don't create too many of them.
-	if procs > maxProcs {
-		procs = maxProcs
-	}
-	if procs < minProcs {
-		procs = minProcs
-	}
-	type symbolizerResult struct {
-		frames []symbolizer.Frame
-		err    error
-	}
-	symbolizerC := make(chan symbolizerResult, procs)
-	pcchan := make(chan []uint64, procs)
-	for p := 0; p < procs; p++ {
-		go func() {
-			symb := symbolizer.NewSymbolizer(target)
-			defer symb.Close()
-			var res symbolizerResult
-			for pcs := range pcchan {
-				frames, err := symb.SymbolizeArray(obj, pcs)
-				if err != nil {
-					res.err = fmt.Errorf("failed to symbolize: %v", err)
-				}
-				res.frames = append(res.frames, frames...)
-			}
-			symbolizerC <- res
-		}()
-	}
-	for i := 0; i < len(pcs); {
-		end := i + 100
-		if end > len(pcs) {
-			end = len(pcs)
-		}
-		pcchan <- pcs[i:end]
-		i = end
-	}
-	close(pcchan)
-	var err0 error
-	var frames []symbolizer.Frame
-	for p := 0; p < procs; p++ {
-		res := <-symbolizerC
-		if res.err != nil {
-			err0 = res.err
-		}
-		frames = append(frames, res.frames...)
-	}
-	if err0 != nil {
-		return nil, err0
-	}
-	return frames, nil
-}
-
-// readCoverPoints finds all coverage points (calls of __sanitizer_cov_trace_pc) in the object file.
-// Currently it is amd64-specific: looks for e8 opcode and correct offset.
-// Running objdump on the whole object file is too slow.
-func readCoverPoints(file *elf.File, tracePC uint64) ([]uint64, error) {
-	text := file.Section(".text")
-	if text == nil {
-		return nil, fmt.Errorf("no .text section in the object file")
-	}
-	data, err := text.Data()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read .text: %v", err)
-	}
-	var pcs []uint64
-	const callLen = 5
-	end := len(data) - callLen + 1
-	for i := 0; i < end; i++ {
-		pos := bytes.IndexByte(data[i:end], 0xe8)
-		if pos == -1 {
-			break
-		}
-		pos += i
-		i = pos
-		off := uint64(int64(int32(binary.LittleEndian.Uint32(data[pos+1:]))))
-		pc := text.Addr + uint64(pos)
-		target := pc + off + callLen
-		if target == tracePC {
-			pcs = append(pcs, pc)
-		}
-	}
-	return pcs, nil
-}
-
-// objdump is an old, slow way of finding coverage points.
-// amd64 uses faster option of parsing binary directly (readCoverPoints).
-// TODO: use the faster approach for all other arches and drop this.
-func objdump(target *targets.Target, obj string) ([]uint64, error) {
-	cmd := osutil.Command(target.Objdump, "-d", "--no-show-raw-insn", obj)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	defer stdout.Close()
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
-	defer stderr.Close()
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to run objdump on %v: %v", obj, err)
-	}
-	defer func() {
-		cmd.Process.Kill()
-		cmd.Wait()
-	}()
-	s := bufio.NewScanner(stdout)
-	callInsns, traceFuncs := archCallInsn(target)
-	var pcs []uint64
-	for s.Scan() {
-		if pc := parseLine(callInsns, traceFuncs, s.Bytes()); pc != 0 {
-			pcs = append(pcs, pc)
-		}
-	}
-	stderrOut, _ := ioutil.ReadAll(stderr)
-	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("failed to run objdump on %v: %v\n%s", obj, err, stderrOut)
-	}
-	if err := s.Err(); err != nil {
-		return nil, fmt.Errorf("failed to run objdump on %v: %v\n%s", obj, err, stderrOut)
-	}
-	return pcs, nil
-}
-
-func parseLine(callInsns, traceFuncs [][]byte, ln []byte) uint64 {
-	pos := -1
-	for _, callInsn := range callInsns {
-		if pos = bytes.Index(ln, callInsn); pos != -1 {
-			break
-		}
-	}
-	if pos == -1 {
-		return 0
-	}
-	hasCall := false
-	for _, traceFunc := range traceFuncs {
-		if hasCall = bytes.Contains(ln[pos:], traceFunc); hasCall {
-			break
-		}
-	}
-	if !hasCall {
-		return 0
-	}
-	for len(ln) != 0 && ln[0] == ' ' {
-		ln = ln[1:]
-	}
-	colon := bytes.IndexByte(ln, ':')
-	if colon == -1 {
-		return 0
-	}
-	pc, err := strconv.ParseUint(string(ln[:colon]), 16, 64)
-	if err != nil {
-		return 0
-	}
-	return pc
-}
-
-func parseFile(fn string) ([][]byte, error) {
-	data, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return nil, err
-	}
-	htmlReplacer := strings.NewReplacer(">", "&gt;", "<", "&lt;", "&", "&amp;", "\t", "        ")
-	var lines [][]byte
-	for {
-		idx := bytes.IndexByte(data, '\n')
-		if idx == -1 {
-			break
-		}
-		lines = append(lines, []byte(htmlReplacer.Replace(string(data[:idx]))))
-		data = data[idx+1:]
-	}
-	if len(data) != 0 {
-		lines = append(lines, data)
-	}
-	return lines, nil
-}
-
-func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
-	offset := instructionLen(target.Arch)
-	pc -= offset
-	// THUMB instructions are 2 or 4 bytes with low bit set.
-	// ARM instructions are always 4 bytes.
-	if target.Arch == targets.ARM {
-		return pc & ^uint64(1)
-	}
-	return pc
-}
-
-func NextInstructionPC(target *targets.Target, pc uint64) uint64 {
-	offset := instructionLen(target.Arch)
-	pc += offset
-	// THUMB instructions are 2 or 4 bytes with low bit set.
-	// ARM instructions are always 4 bytes.
-	if target.Arch == targets.ARM {
-		return pc & ^uint64(1)
-	}
-	return pc
-}
-
-func instructionLen(arch string) uint64 {
-	switch arch {
-	case targets.AMD64:
-		return 5
-	case targets.I386:
-		return 5
-	case targets.ARM64:
-		return 4
-	case targets.ARM:
-		return 3
-	case targets.PPC64LE:
-		return 4
-	case targets.MIPS64LE:
-		return 8
-	case targets.S390x:
-		return 6
-	case targets.RiscV64:
-		return 4
-	default:
-		panic(fmt.Sprintf("unknown arch %q", arch))
-	}
-}
-
-func archCallInsn(target *targets.Target) ([][]byte, [][]byte) {
-	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>")}
-	switch target.Arch {
-	case targets.I386:
-		// c1000102:       call   c10001f0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tcall ")}, callName
-	case targets.ARM64:
-		// ffff0000080d9cc0:       bl      ffff00000820f478 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl\t")}, callName
-	case targets.ARM:
-		// 8010252c:       bl      801c3280 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl\t")}, callName
-	case targets.PPC64LE:
-		// c00000000006d904:       bl      c000000000350780 <.__sanitizer_cov_trace_pc>
-		// This is only known to occur in the test:
-		// 838:   bl      824 <__sanitizer_cov_trace_pc+0x8>
-		// This occurs on PPC64LE:
-		// c0000000001c21a8:       bl      c0000000002df4a0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl ")}, [][]byte{
-			[]byte("<__sanitizer_cov_trace_pc>"),
-			[]byte("<__sanitizer_cov_trace_pc+0x8>"),
-			[]byte(" <.__sanitizer_cov_trace_pc>"),
-		}
-	case targets.MIPS64LE:
-		// ffffffff80100420:       jal     ffffffff80205880 <__sanitizer_cov_trace_pc>
-		// This is only known to occur in the test:
-		// b58:   bal     b30 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tjal\t"), []byte("\tbal\t")}, callName
-	case targets.S390x:
-		// 1001de:       brasl   %r14,2bc090 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbrasl\t")}, callName
-	case targets.RiscV64:
-		// ffffffe000200018:       jal     ra,ffffffe0002935b0 <__sanitizer_cov_trace_pc>
-		// ffffffe0000010da:       jalr    1242(ra) # ffffffe0002935b0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tjal\t"), []byte("\tjalr\t")}, callName
-	default:
-		panic(fmt.Sprintf("unknown arch %q", target.Arch))
-	}
-}
-
-type templateData struct {
-	Root      *templateDir
-	Contents  []template.HTML
-	Progs     []template.HTML
-	Functions []template.HTML
-}
-
-type templateBase struct {
-	Name    string
-	Path    string
-	Total   int
-	Covered int
-	Percent int
-}
-
-type templateDir struct {
-	templateBase
-	Dirs  map[string]*templateDir
-	Files []*templateFile
-}
-
-type templateFile struct {
-	templateBase
-	Index int
-}
-
-var coverTemplate = template.Must(template.New("").Parse(`
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<style>
-			.file {
-				display: none;
-				margin: 0;
-				padding: 0;
-			}
-			.count {
-				font-weight: bold;
-				border-right: 1px solid #ddd;
-				padding-right: 4px;
-				cursor: zoom-in;
-			}
-			.split {
-				height: 100%;
-				position: fixed;
-				z-index: 1;
-				top: 0;
-				overflow-x: hidden;
-			}
-			.tree {
-				left: 0;
-				width: 24%;
-			}
-			.function {
-				height: 100%;
-				position: fixed;
-				z-index: 1;
-				top: 0;
-				overflow-x: hidden;
-				display: none;
-			}
-			.list {
-				left: 24%;
-				width: 30%;
-			}
-			.right {
-				border-left: 2px solid #444;
-				right: 0;
-				width: 76%;
-				font-family: 'Courier New', Courier, monospace;
-				color: rgb(80, 80, 80);
-			}
-			.cover {
-				float: right;
-				width: 120px;
-				padding-right: 4px;
-			}
-			.cover-right {
-				float: right;
-			}
-			.covered {
-				color: rgb(0, 0, 0);
-				font-weight: bold;
-			}
-			.uncovered {
-				color: rgb(255, 0, 0);
-				font-weight: bold;
-			}
-			.both {
-				color: rgb(200, 100, 0);
-				font-weight: bold;
-			}
-			ul, #dir_list {
-				list-style-type: none;
-				padding-left: 16px;
-			}
-			#dir_list {
-				margin: 0;
-				padding: 0;
-			}
-			.hover:hover {
-				background: #ffff99;
-			}
-			.caret {
-				cursor: pointer;
-				user-select: none;
-			}
-			.caret::before {
-				color: black;
-				content: "\25B6";
-				display: inline-block;
-				margin-right: 3px;
-			}
-			.caret-down::before {
-				transform: rotate(90deg);
-			}
-			.nested {
-				display: none;
-			}
-			.active {
-				display: block;
-			}
-		</style>
-	</head>
-	<body>
-		<div class="split tree">
-			<ul id="dir_list">
-				{{template "dir" .Root}}
-			</ul>
-		</div>
-		<div id="right_pane" class="split right">
-			{{range $i, $f := .Contents}}
-				<pre class="file" id="contents_{{$i}}">{{$f}}</pre>
-			{{end}}
-			{{range $i, $p := .Progs}}
-				<pre class="file" id="prog_{{$i}}">{{$p}}</pre>
-			{{end}}
-			{{range $i, $p := .Functions}}
-				<div class="function list" id="function_{{$i}}">{{$p}}</div>
-			{{end}}
-		</div>
-	</body>
-	<script>
-	(function() {
-		var toggler = document.getElementsByClassName("caret");
-		for (var i = 0; i < toggler.length; i++) {
-			toggler[i].addEventListener("click", function() {
-				this.parentElement.querySelector(".nested").classList.toggle("active");
-				this.classList.toggle("caret-down");
-			});
-		}
-		if (window.location.hash) {
-			var hash = decodeURIComponent(window.location.hash.substring(1)).split("/");
-			var path = "path";
-			for (var i = 0; i < hash.length; i++) {
-				path += "/" + hash[i];
-				var elem = document.getElementById(path);
-				if (elem)
-					elem.click();
-			}
-		}
-	})();
-	var visible;
-        function onPercentClick(index) {
-		if (visible)
-			visible.style.display = 'none';
-		visible = document.getElementById("function_" + index);
-		visible.style.display = 'block';
-		document.getElementById("right_pane").scrollTo(0, 0);
-	}
-	function onFileClick(index) {
-		if (visible)
-			visible.style.display = 'none';
-		visible = document.getElementById("contents_" + index);
-		visible.style.display = 'block';
-		document.getElementById("right_pane").scrollTo(0, 0);
-	}
-	function onProgClick(index) {
-		if (visible)
-			visible.style.display = 'none';
-		visible = document.getElementById("prog_" + index);
-		visible.style.display = 'block';
-		document.getElementById("right_pane").scrollTo(0, 0);
-	}
-	</script>
-</html>
-
-{{define "dir"}}
-	{{range $dir := .Dirs}}
-		<li>
-			<span id="path/{{$dir.Path}}" class="caret hover">
-				{{$dir.Name}}
-				<span class="cover hover">
-					{{if $dir.Covered}}{{$dir.Percent}}%{{else}}---{{end}}
-					<span class="cover-right">of {{$dir.Total}}</span>
-				</span>
-			</span>
-			<ul class="nested">
-				{{template "dir" $dir}}
-			</ul>
-		</li>
-	{{end}}
-	{{range $file := .Files}}
-		<li><span class="hover">
-			{{if $file.Covered}}
-				<a href="#{{$file.Path}}" id="path/{{$file.Path}}" onclick="onFileClick({{$file.Index}})">
-					{{$file.Name}}
-				</a>
-				<span class="cover hover">
-					<a href="#{{$file.Path}}/func_cov" id="path/{{$file.Path}}/func_cov" onclick="onPercentClick({{$file.Index}})">
-                                                {{$file.Percent}}%
-					</a>
-					<span class="cover-right">of {{$file.Total}}</span>
-				</span>
-			{{else}}
-					{{$file.Name}}<span class="cover hover">---<span class="cover-right">
-						of {{$file.Total}}</span></span>
-			{{end}}
-		</span></li>
-	{{end}}
-{{end}}
-`))

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -26,15 +26,15 @@ type Prog struct {
 	PCs  []uint64
 }
 
-func MakeReportGenerator(target *targets.Target, vm, kernelObject, srcDir, buildDir string) (*ReportGenerator, error) {
-	impl, err := backend.Make(target, vm, kernelObject, srcDir, buildDir)
+func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string) (*ReportGenerator, error) {
+	impl, err := backend.Make(target, vm, objDir)
 	if err != nil {
 		return nil, err
 	}
 	rg := &ReportGenerator{
 		target:   target,
 		srcDir:   srcDir,
-		objDir:   filepath.Dir(kernelObject),
+		objDir:   objDir,
 		buildDir: buildDir,
 		Impl:     impl,
 	}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -26,10 +26,7 @@ type Prog struct {
 	PCs  []uint64
 }
 
-var (
-	RestorePC             = backend.RestorePC
-	PreviousInstructionPC = backend.PreviousInstructionPC
-)
+var RestorePC = backend.RestorePC
 
 func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string) (*ReportGenerator, error) {
 	if objDir == "" {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -32,6 +32,9 @@ var (
 )
 
 func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string) (*ReportGenerator, error) {
+	if objDir == "" {
+		return nil, fmt.Errorf("kernel obj directory is not specified")
+	}
 	impl, err := backend.Make(target, vm, objDir)
 	if err != nil {
 		return nil, err

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -26,8 +26,8 @@ type Prog struct {
 	PCs  []uint64
 }
 
-func MakeReportGenerator(target *targets.Target, kernelObject, srcDir, buildDir string) (*ReportGenerator, error) {
-	impl, err := backend.Make(target, kernelObject, srcDir, buildDir)
+func MakeReportGenerator(target *targets.Target, vm, kernelObject, srcDir, buildDir string) (*ReportGenerator, error) {
+	impl, err := backend.Make(target, vm, kernelObject, srcDir, buildDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/symbolizer"
 	_ "github.com/google/syzkaller/sys"
@@ -190,7 +191,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 			if err != nil {
 				t.Fatal(err)
 			}
-			pcs = append(pcs, PreviousInstructionPC(target, pc))
+			pcs = append(pcs, backend.PreviousInstructionPC(target, pc))
 			t.Logf("using exact coverage PC 0x%x", pcs[0])
 		} else if target.OS == runtime.GOOS && (target.Arch == runtime.GOARCH || target.VMArch == runtime.GOARCH) {
 			t.Fatal(err)

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -151,7 +151,7 @@ void __sanitizer_cov_trace_pc() { printf("%llu", (long long)__builtin_return_add
 	}
 	kcovFlags := append([]string{"-c", "-w", "-x", "c", "-o", kcovObj, kcovSrc}, target.CFlags...)
 	src := filepath.Join(dir, "main.c")
-	bin := filepath.Join(dir, "bin")
+	bin := filepath.Join(dir, target.KernelObject)
 	if err := osutil.WriteFile(src, []byte(`int main() {}`)); err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 	}
 	defer os.RemoveAll(dir)
 	bin := buildTestBinary(t, target, test, dir)
-	rg, err := MakeReportGenerator(target, "", bin, dir, dir)
+	rg, err := MakeReportGenerator(target, "", dir, dir, dir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -179,7 +179,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 	}
 	defer os.RemoveAll(dir)
 	bin := buildTestBinary(t, target, test, dir)
-	rg, err := MakeReportGenerator(target, bin, dir, dir)
+	rg, err := MakeReportGenerator(target, "", bin, dir, dir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -32,13 +32,13 @@ func initCover(cfg *mgrconfig.Config) error {
 			initCoverError = fmt.Errorf("kernel_obj is not specified")
 			return
 		}
-		vmlinux := filepath.Join(cfg.KernelObj, cfg.SysTarget.KernelObject)
 		reportGenerator, initCoverError = cover.MakeReportGenerator(
-			cfg.SysTarget, cfg.Type, vmlinux, cfg.KernelSrc, cfg.KernelBuildSrc)
+			cfg.SysTarget, cfg.Type, cfg.KernelObj, cfg.KernelSrc, cfg.KernelBuildSrc)
 		if initCoverError != nil {
 			return
 		}
-		initCoverVMOffset, initCoverError = getVMOffset(cfg.SysTarget, vmlinux)
+		kernelObj := filepath.Join(cfg.KernelObj, cfg.SysTarget.KernelObject)
+		initCoverVMOffset, initCoverError = getVMOffset(cfg.SysTarget, kernelObj)
 	})
 	return initCoverError
 }
@@ -53,7 +53,7 @@ func coverToPCs(target *targets.Target, cov []uint32) []uint64 {
 	return pcs
 }
 
-func getVMOffset(target *targets.Target, vmlinux string) (uint32, error) {
+func getVMOffset(target *targets.Target, kernelObj string) (uint32, error) {
 	if target.OS == targets.FreeBSD {
 		return 0xffffffff, nil
 	}
@@ -61,7 +61,7 @@ func getVMOffset(target *targets.Target, vmlinux string) (uint32, error) {
 	if target.Triple != "" {
 		readelf = target.Triple + "-" + readelf
 	}
-	out, err := osutil.RunCmd(time.Hour, "", readelf, "-SW", vmlinux)
+	out, err := osutil.RunCmd(time.Hour, "", readelf, "-SW", kernelObj)
 	if err != nil {
 		return 0, err
 	}

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -25,18 +26,19 @@ var (
 	reportGenerator   *cover.ReportGenerator
 )
 
-func initCover(target *targets.Target, kernelObj, kernelSrc, kernelBuildSrc string) error {
+func initCover(cfg *mgrconfig.Config) error {
 	initCoverOnce.Do(func() {
-		if kernelObj == "" {
+		if cfg.KernelObj == "" {
 			initCoverError = fmt.Errorf("kernel_obj is not specified")
 			return
 		}
-		vmlinux := filepath.Join(kernelObj, target.KernelObject)
-		reportGenerator, initCoverError = cover.MakeReportGenerator(target, vmlinux, kernelSrc, kernelBuildSrc)
+		vmlinux := filepath.Join(cfg.KernelObj, cfg.SysTarget.KernelObject)
+		reportGenerator, initCoverError = cover.MakeReportGenerator(
+			cfg.SysTarget, cfg.Type, vmlinux, cfg.KernelSrc, cfg.KernelBuildSrc)
 		if initCoverError != nil {
 			return
 		}
-		initCoverVMOffset, initCoverError = getVMOffset(target, vmlinux)
+		initCoverVMOffset, initCoverError = getVMOffset(cfg.SysTarget, vmlinux)
 	})
 	return initCoverError
 }

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -33,9 +33,7 @@ func initCover(cfg *mgrconfig.Config) error {
 func coverToPCs(target *targets.Target, cov []uint32) []uint64 {
 	pcs := make([]uint64, 0, len(cov))
 	for _, pc := range cov {
-		fullPC := cover.RestorePC(pc, reportGenerator.TextOffset)
-		prevPC := cover.PreviousInstructionPC(target, fullPC)
-		pcs = append(pcs, prevPC)
+		pcs = append(pcs, reportGenerator.RestorePC(pc))
 	}
 	return pcs
 }

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -24,7 +24,7 @@ func createCoverageFilter(cfg *mgrconfig.Config) (string, map[uint32]uint32, err
 	filter := &cfg.CovFilter
 	if len(filter.Files) != 0 || len(filter.Functions) != 0 {
 		log.Logf(0, "initializing coverage information...")
-		if err := initCover(cfg.SysTarget, cfg.KernelObj, cfg.KernelSrc, cfg.KernelBuildSrc); err != nil {
+		if err := initCover(cfg); err != nil {
 			return "", nil, err
 		}
 		if err := initFilesFuncs(pcs, filter.Files, filter.Functions); err != nil {

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -23,14 +23,13 @@ import (
 func createCoverageFilter(cfg *mgrconfig.Config) (string, map[uint32]uint32, error) {
 	pcs := make(map[uint32]uint32)
 	filter := &cfg.CovFilter
-	if len(filter.Files) != 0 || len(filter.Functions) != 0 {
-		rg, err := getReportGenerator(cfg)
-		if err != nil {
-			return "", nil, err
-		}
-		if err := initFilesFuncs(pcs, filter.Files, filter.Functions, rg); err != nil {
-			return "", nil, err
-		}
+	// Always initialize ReportGenerator because RPCServer.NewInput will need it to filter coverage.
+	rg, err := getReportGenerator(cfg)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := initFilesFuncs(pcs, filter.Files, filter.Functions, rg); err != nil {
+		return "", nil, err
 	}
 	if err := initWeightedPCs(pcs, filter.RawPCs); err != nil {
 		return "", nil, err

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -214,7 +214,7 @@ func (mgr *Manager) httpCover(w http.ResponseWriter, r *http.Request) {
 	}
 	// Note: initCover is executed without mgr.mu because it takes very long time
 	// (but it only reads config and it protected by initCoverOnce).
-	if err := initCover(mgr.sysTarget, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc); err != nil {
+	if err := initCover(mgr.cfg); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -286,7 +286,7 @@ func (mgr *Manager) httpFuncCover(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "coverage is not enabled", http.StatusInternalServerError)
 		return
 	}
-	if err := initCover(mgr.sysTarget, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc); err != nil {
+	if err := initCover(mgr.cfg); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -392,7 +392,7 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 func (mgr *Manager) httpRawCover(w http.ResponseWriter, r *http.Request) {
 	// Note: initCover is executed without mgr.mu because it takes very long time
 	// (but it only reads config and it protected by initCoverOnce).
-	if err := initCover(mgr.sysTarget, mgr.cfg.KernelObj, mgr.cfg.KernelSrc, mgr.cfg.KernelBuildSrc); err != nil {
+	if err := initCover(mgr.cfg); err != nil {
 		http.Error(w, initCoverError.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -250,11 +250,15 @@ func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 	}
 	diff := serv.corpusCover.MergeDiff(a.Cover)
 	serv.stats.corpusCover.set(len(serv.corpusCover))
-	if serv.coverFilter != nil {
+	if len(diff) != 0 && serv.coverFilter != nil {
+		// Note: ReportGenerator is already initialized if coverFilter is enabled.
+		rg, err := getReportGenerator(serv.cfg)
+		if err != nil {
+			return err
+		}
 		filtered := 0
 		for _, pc := range diff {
-			prevPC := uint32(cover.PreviousInstructionPC(serv.cfg.SysTarget, uint64(pc)))
-			if serv.coverFilter[prevPC] != 0 {
+			if serv.coverFilter[uint32(rg.RestorePC(pc))] != 0 {
 				filtered++
 			}
 		}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -38,6 +38,7 @@ func main() {
 	var (
 		flagOS             = flag.String("os", runtime.GOOS, "target os")
 		flagArch           = flag.String("arch", runtime.GOARCH, "target arch")
+		flagVM             = flag.String("vm", "", "VM type")
 		flagKernelSrc      = flag.String("kernel_src", "", "path to kernel sources")
 		flagKernelBuildSrc = flag.String("kernel_build_src", "", "path to kernel image's build dir (optional)")
 		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
@@ -69,7 +70,7 @@ func main() {
 		failf("%v", err)
 	}
 	kernelObj := filepath.Join(*flagKernelObj, target.KernelObject)
-	rg, err := cover.MakeReportGenerator(target, kernelObj, *flagKernelSrc, *flagKernelBuildSrc)
+	rg, err := cover.MakeReportGenerator(target, *flagVM, kernelObj, *flagKernelSrc, *flagKernelBuildSrc)
 	if err != nil {
 		failf("%v", err)
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -69,8 +68,7 @@ func main() {
 	if err != nil {
 		failf("%v", err)
 	}
-	kernelObj := filepath.Join(*flagKernelObj, target.KernelObject)
-	rg, err := cover.MakeReportGenerator(target, *flagVM, kernelObj, *flagKernelSrc, *flagKernelBuildSrc)
+	rg, err := cover.MakeReportGenerator(target, *flagVM, *flagKernelObj, *flagKernelSrc, *flagKernelBuildSrc)
 	if err != nil {
 		failf("%v", err)
 	}


### PR DESCRIPTION
- pkg/cover: split into ELF-dependent/independent parts
- pkg/cover: pass VM type for report generator
- pkg/cover: accept object dir instead of object file
- pkg/cover: provide .text offset
- pkg/cover: provide ReportGenerator.RestorePC
- syz-manager: store mgrconfig.Config in RPCServer
- syz-manager: better encapsulate report generator
- syz-manager: use ReportGenerator.RestorePC in RPCServer.NewInput
- syz-manager: use compile units for file coverage filter
- pkg/cover: don't fail when can't open single source file
- pkg/cover: move cleanPath into backend
- pkg/cover: support compiler frontend coverage
- pkg/cover: don't show programs when we don't have them
- pkg/cover: don't show func coverage if we don't have it
- pkg/cover: add gvisor support
