### PR TITLE
pkg/cover: fix location of gvisor object file

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type gvisor struct{}
@@ -70,13 +71,13 @@ func (gvisor gvisor) build(params *Params) error {
 	if match == nil {
 		return fmt.Errorf("failed to find the runsc binary")
 	}
-	outBinary := string(match[1])
-	outBinary = filepath.Join(params.KernelDir, filepath.FromSlash(outBinary))
+	outBinary := filepath.Join(params.KernelDir, filepath.FromSlash(string(match[1])))
 
 	if err := osutil.CopyFile(outBinary, filepath.Join(params.OutputDir, "image")); err != nil {
 		return err
 	}
-	return nil
+	sysTarget := targets.Get(params.TargetOS, params.TargetArch)
+	return osutil.CopyFile(outBinary, filepath.Join(params.OutputDir, "obj", sysTarget.KernelObject))
 }
 
 func (gvisor) clean(kernelDir, targetArch string) error {

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -15,8 +15,8 @@ import (
 )
 
 func makeGvisor(target *targets.Target, objDir, srcDir, buildDir string) (*Impl, error) {
-	// pkg/build stores runsc as 'image', but a local build will have it as 'runsc'.
-	bin := filepath.Join(objDir, "image")
+	// pkg/build stores runsc as 'vmlinux' (we pretent to be linux), but a local build will have it as 'runsc'.
+	bin := filepath.Join(objDir, target.KernelObject)
 	if !osutil.IsExist(bin) {
 		bin = filepath.Join(objDir, "runsc")
 	}

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -20,6 +20,9 @@ import (
 )
 
 func createCoverageFilter(cfg *mgrconfig.Config) (string, map[uint32]uint32, error) {
+	if len(cfg.CovFilter.Functions)+len(cfg.CovFilter.Files)+len(cfg.CovFilter.RawPCs) == 0 {
+		return "", nil, nil
+	}
 	// Always initialize ReportGenerator because RPCServer.NewInput will need it to filter coverage.
 	rg, err := getReportGenerator(cfg)
 	if err != nil {


### PR DESCRIPTION
When running under syz-ci gvisor image is called 'image',
but it's not in objDir. pkg/build/gvisor.go doesn't copy
anything into obj/.
Copy runsc into obj/vmlinux (as expected for linux target)
and open it in pkg/cover.
