### PR TITLE
executor: don't use coverage edges for gvisor

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -873,11 +873,9 @@ void write_coverage_signal(cover_t* cov, uint32* signal_count_pos, uint32* cover
 	bool prev_filter = true;
 	for (uint32 i = 0; i < cov->size; i++) {
 		cover_data_t pc = cover_data[i];
-		if (!cover_check(pc)) {
-			debug("got bad pc: 0x%llx\n", (uint64)pc);
-			doexit(0);
-		}
-		cover_data_t sig = pc ^ hash(prev_pc);
+		uint32 sig = pc;
+		if (use_cover_edges(pc))
+			sig ^= hash(prev_pc);
 		bool filter = coverage_filter(pc);
 		// Ignore the edge only if both current and previous PCs are filtered out
 		// to capture all incoming and outcoming edges into the interesting code.

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -168,12 +168,7 @@ static void cover_collect(cover_t* cov)
 	cov->size = *(uint64*)cov->data;
 }
 
-static bool cover_check(uint32 pc)
-{
-	return true;
-}
-
-static bool cover_check(uint64 pc)
+static bool use_cover_edges(uint64 pc)
 {
 	return true;
 }

--- a/executor/nocover.h
+++ b/executor/nocover.h
@@ -26,12 +26,7 @@ static void cover_unprotect(cover_t* cov)
 {
 }
 
-static bool cover_check(uint32 pc)
-{
-	return true;
-}
-
-static bool cover_check(uint64 pc)
+static bool use_cover_edges(uint64 pc)
 {
 	return true;
 }


### PR DESCRIPTION
gvisor coverage is not a trace, so producing edges won't work.
