### PR TITLE
syz-manager : add signal handling for reload config

### DIFF
--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// "android": (Android) Emulate permissions of an untrusted app.
 	Sandbox string `json:"sandbox"`
 
+	// Reload MgrConfig (default: false).
+	ReloadConfig bool `json:"reloadconfig"`
+
 	// Use KCOV coverage (default: true).
 	Cover bool `json:"cover"`
 	// Use coverage filter. Supported types of filter:

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -82,6 +82,7 @@ func defaultValues() *Config {
 		Sandbox:   "none",
 		RPC:       ":0",
 		Procs:     6,
+		ReloadConfig: false,
 	}
 }
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -254,6 +254,11 @@ func RunManager(cfg *mgrconfig.Config) {
 	}
 
 	osutil.HandleInterrupts(vm.Shutdown)
+	ReloadConfig := mgr.cfg.ReloadConfig
+	if ReloadConfig {
+		log.Logf(0, "Config Reloaded...\n")
+		mgr.cfg.ReloadConfig = false
+	}
 	if mgr.vmPool == nil {
 		log.Logf(0, "no VMs started (type=none)")
 		log.Logf(0, "you are supposed to start syz-fuzzer manually as:")


### PR DESCRIPTION
[WIP PR]
Adding support for SIGUSR1 signal to add the ability to reload config. 
There is a dependency loop where `pkg/config` imports `pkg/osutil` but `osutil` needs the ability to update config.
