### PR TITLE
pkg/cover: fix comparison filtering

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -18,18 +18,23 @@ type Impl struct {
 }
 
 type CompileUnit struct {
-	Name string
+	ObjectUnit
 	Path string
-	PCs  []uint64
 }
 
 type Symbol struct {
+	ObjectUnit
 	Unit       *CompileUnit
-	Name       string
 	Start      uint64
 	End        uint64
-	PCs        []uint64
 	Symbolized bool
+}
+
+// ObjectUnit represents either CompileUnit or Symbol.
+type ObjectUnit struct {
+	Name string
+	PCs  []uint64 // PCs we can get in coverage callbacks for this unit.
+	CMPs []uint64 // PCs we can get in comparison interception callbacks for this unit.
 }
 
 type Frame struct {

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -29,7 +29,9 @@ func makeGvisor(target *targets.Target, objDir, srcDir, buildDir string) (*Impl,
 		unit := unitMap[frame.Name]
 		if unit == nil {
 			unit = &CompileUnit{
-				Name: frame.Name,
+				ObjectUnit: ObjectUnit{
+					Name: frame.Name,
+				},
 				Path: frame.Path,
 			}
 			unitMap[frame.Name] = unit


### PR DESCRIPTION
If coverage filter is enabled, executor filters comparisons based on PCs.
But we don't include comparison callback PCs in the filter,
so most of them will be falsely filtered away.
Add comparison callback PCs to symbols and compile units and use
both when creating coverage filter. But still use only coverage
PCs while generating coverage reports.

Reported-by: Kaipeng Zeng
Link: https://groups.google.com/g/syzkaller/c/mD0wv-A2wno/m/v1ntQbTUAwAJ
