### PR TITLE
all: make timeouts configurable

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -53,6 +53,7 @@ var executorOpts = Options{
 	Collide:   true,
 	Repeat:    true,
 	Procs:     2,
+	Slowdown:  1,
 	Sandbox:   "none",
 	Repro:     true,
 	UseTmpDir: true,

--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	Repeat      bool   `json:"repeat,omitempty"`
 	RepeatTimes int    `json:"repeat_times,omitempty"` // if non-0, repeat that many times
 	Procs       int    `json:"procs"`
+	Slowdown    int    `json:"slowdown"`
 	Sandbox     string `json:"sandbox"`
 
 	Fault     bool `json:"fault,omitempty"` // inject fault into FaultCall/FaultNth
@@ -154,6 +155,7 @@ func DefaultOpts(cfg *mgrconfig.Config) Options {
 		Collide:    true,
 		Repeat:     true,
 		Procs:      cfg.Procs,
+		Slowdown:   cfg.Timeouts.Slowdown,
 		Sandbox:    cfg.Sandbox,
 		UseTmpDir:  true,
 		HandleSegv: true,
@@ -190,9 +192,11 @@ func (opts Options) Serialize() []byte {
 }
 
 func DeserializeOptions(data []byte) (Options, error) {
-	var opts Options
-	// Before CloseFDs was added, close_fds() was always called, so default to true.
-	opts.CloseFDs = true
+	opts := Options{
+		Slowdown: 1,
+		// Before CloseFDs was added, close_fds() was always called, so default to true.
+		CloseFDs: true,
+	}
 	if err := json.Unmarshal(data, &opts); err == nil {
 		return opts, nil
 	}

--- a/pkg/csource/options_test.go
+++ b/pkg/csource/options_test.go
@@ -37,6 +37,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			Collide:      true,
 			Repeat:       true,
 			Procs:        10,
+			Slowdown:     1,
 			Sandbox:      "namespace",
 			Fault:        true,
 			FaultCall:    1,
@@ -59,6 +60,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			Collide:      true,
 			Repeat:       true,
 			Procs:        10,
+			Slowdown:     1,
 			Sandbox:      "android",
 			Fault:        true,
 			FaultCall:    1,
@@ -78,6 +80,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			Collide:      true,
 			Repeat:       true,
 			Procs:        1,
+			Slowdown:     1,
 			Sandbox:      "none",
 			Fault:        false,
 			FaultCall:    -1,
@@ -95,6 +98,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			Collide:      true,
 			Repeat:       true,
 			Procs:        1,
+			Slowdown:     1,
 			Sandbox:      "",
 			Fault:        false,
 			FaultCall:    -1,
@@ -112,6 +116,7 @@ func TestParseOptionsCanned(t *testing.T) {
 			Collide:      true,
 			Repeat:       true,
 			Procs:        1,
+			Slowdown:     1,
 			Sandbox:      "namespace",
 			Fault:        false,
 			FaultCall:    -1,
@@ -147,6 +152,7 @@ func allOptionsSingle(OS string) []Options {
 			Repeat:    true,
 			Sandbox:   "none",
 			UseTmpDir: true,
+			Slowdown:  1,
 		}
 		opts = append(opts, enumerateField(OS, opt, i)...)
 	}
@@ -198,6 +204,11 @@ func enumerateField(OS string, opt Options, field int) []Options {
 	} else if fldName == "RepeatTimes" {
 		for _, times := range []int64{0, 10} {
 			fld.SetInt(times)
+			opts = append(opts, opt)
+		}
+	} else if fldName == "Slowdown" {
+		for _, val := range []int64{1, 10} {
+			fld.SetInt(val)
 			opts = append(opts, opt)
 		}
 	} else if fldName == "FaultCall" {

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -32,7 +33,7 @@ func TestFuzzerCmd(t *testing.T) {
 	flagDebug := flags.Bool("debug", false, "debug output from executor")
 	flagV := flags.Int("v", 0, "verbosity")
 	cmdLine := OldFuzzerCmd(os.Args[0], "/myexecutor", "myname", targets.Linux, targets.I386, "localhost:1234",
-		"namespace", 3, true, true)
+		"namespace", 3, true, true, false, 0)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatal(err)
@@ -93,10 +94,11 @@ func TestExecprogCmd(t *testing.T) {
 	flagCollide := flags.Bool("collide", true, "collide syscalls to provoke data races")
 	flagSignal := flags.Bool("cover", false, "collect feedback signals (coverage)")
 	flagSandbox := flags.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace)")
+	flagSlowdown := flags.Int("slowdown", 1, "")
 	cmdLine := ExecprogCmd(os.Args[0], "/myexecutor", targets.FreeBSD, targets.I386,
-		"namespace", true, false, false, 7, 2, 3, "myprog")
+		"namespace", true, false, false, 7, 2, 3, true, 10, "myprog")
 	args := strings.Split(cmdLine, " ")[1:]
-	if err := flags.Parse(args); err != nil {
+	if err := tool.ParseFlags(flags, args); err != nil {
 		t.Fatal(err)
 	}
 	if len(flags.Args()) != 1 || flags.Arg(0) != "myprog" {
@@ -134,5 +136,8 @@ func TestExecprogCmd(t *testing.T) {
 	}
 	if *flagCollide {
 		t.Errorf("bad collide: %v, want: %v", *flagCollide, false)
+	}
+	if *flagSlowdown != 10 {
+		t.Errorf("bad slowdown: %v, want: %v", *flagSlowdown, 10)
 	}
 }

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -30,7 +30,7 @@ func buildExecutor(t *testing.T, target *prog.Target) string {
 	return bin
 }
 
-func initTest(t *testing.T) (*prog.Target, rand.Source, int, bool, bool) {
+func initTest(t *testing.T) (*prog.Target, rand.Source, int, bool, bool, targets.Timeouts) {
 	t.Parallel()
 	iters := 100
 	if testing.Short() {
@@ -50,7 +50,7 @@ func initTest(t *testing.T) (*prog.Target, rand.Source, int, bool, bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return target, rs, iters, cfg.UseShmem, cfg.UseForkServer
+	return target, rs, iters, cfg.UseShmem, cfg.UseForkServer, cfg.Timeouts
 }
 
 // TestExecutor runs all internal executor unit tests.
@@ -82,7 +82,7 @@ func TestExecutor(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	target, _, _, useShmem, useForkServer := initTest(t)
+	target, _, _, useShmem, useForkServer, timeouts := initTest(t)
 
 	bin := buildExecutor(t, target)
 	defer os.Remove(bin)
@@ -94,6 +94,7 @@ func TestExecute(t *testing.T) {
 			Executor:      bin,
 			UseShmem:      useShmem,
 			UseForkServer: useForkServer,
+			Timeouts:      timeouts,
 		}
 		env, err := MakeEnv(cfg, 0)
 		if err != nil {
@@ -127,13 +128,14 @@ func TestExecute(t *testing.T) {
 }
 
 func TestParallel(t *testing.T) {
-	target, _, _, useShmem, useForkServer := initTest(t)
+	target, _, _, useShmem, useForkServer, timeouts := initTest(t)
 	bin := buildExecutor(t, target)
 	defer os.Remove(bin)
 	cfg := &Config{
 		Executor:      bin,
 		UseShmem:      useShmem,
 		UseForkServer: useForkServer,
+		Timeouts:      timeouts,
 	}
 	const P = 10
 	errs := make(chan error, P)

--- a/pkg/ipc/ipcconfig/ipcconfig.go
+++ b/pkg/ipc/ipcconfig/ipcconfig.go
@@ -18,11 +18,14 @@ var (
 	flagSignal   = flag.Bool("cover", false, "collect feedback signals (coverage)")
 	flagSandbox  = flag.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace/android)")
 	flagDebug    = flag.Bool("debug", false, "debug output from executor")
+	flagSlowdown = flag.Int("slowdown", 1, "execution slowdown caused by emulation/instrumentation")
 )
 
 func Default(target *prog.Target) (*ipc.Config, *ipc.ExecOpts, error) {
+	sysTarget := targets.Get(target.OS, target.Arch)
 	c := &ipc.Config{
 		Executor: *flagExecutor,
+		Timeouts: sysTarget.Timeouts(*flagSlowdown),
 	}
 	if *flagSignal {
 		c.Flags |= ipc.FlagSignal
@@ -35,7 +38,6 @@ func Default(target *prog.Target) (*ipc.Config, *ipc.ExecOpts, error) {
 		return nil, nil, err
 	}
 	c.Flags |= sandboxFlags
-	sysTarget := targets.Get(target.OS, target.Arch)
 	c.UseShmem = sysTarget.ExecutorUsesShmem
 	c.UseForkServer = sysTarget.ExecutorUsesForkServer
 	opts := &ipc.ExecOpts{

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -376,6 +376,7 @@ func (ctx *Context) createSyzTest(p *prog.Prog, sandbox string, threaded, cov bo
 	opts := new(ipc.ExecOpts)
 	cfg.UseShmem = sysTarget.ExecutorUsesShmem
 	cfg.UseForkServer = sysTarget.ExecutorUsesForkServer
+	cfg.Timeouts = sysTarget.Timeouts(1)
 	sandboxFlags, err := ipc.SandboxToFlags(sandbox)
 	if err != nil {
 		return nil, err
@@ -427,6 +428,7 @@ func (ctx *Context) createCTest(p *prog.Prog, sandbox string, threaded bool, tim
 		Repeat:      times > 1,
 		RepeatTimes: times,
 		Procs:       1,
+		Slowdown:    1,
 		Sandbox:     sandbox,
 		UseTmpDir:   true,
 		HandleSegv:  true,

--- a/sys/linux/init.go
+++ b/sys/linux/init.go
@@ -280,6 +280,7 @@ func (arch *arch) generateTimespec(g *prog.Gen, typ0 prog.Type, dir prog.Dir, ol
 	// Note: timespec/timeval can be absolute or relative to now.
 	// Note: executor has blocking syscall timeout of 45 ms,
 	// so we generate both 10ms and 60ms.
+	// TODO(dvyukov): this is now all outdated with tunable timeouts.
 	const (
 		timeout1 = uint64(10)
 		timeout2 = uint64(60)

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -33,7 +33,7 @@ type checkArgs struct {
 
 func testImage(hostAddr string, args *checkArgs) {
 	log.Logf(0, "connecting to host at %v", hostAddr)
-	conn, err := rpctype.Dial(hostAddr)
+	conn, err := rpctype.Dial(hostAddr, args.ipcConfig.Timeouts.Scale)
 	if err != nil {
 		log.Fatalf("BUG: failed to connect to host: %v", err)
 	}

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -101,10 +101,10 @@ func (hc *HubConnector) connect(corpus [][]byte) (*rpctype.RPCClient, error) {
 	}
 	// Hub.Connect request can be very large, so do it on a transient connection
 	// (rpc connection buffers never shrink).
-	if err := rpctype.RPCCall(hc.cfg.HubAddr, "Hub.Connect", a, nil); err != nil {
+	if err := rpctype.RPCCall(hc.cfg.HubAddr, 1, "Hub.Connect", a, nil); err != nil {
 		return nil, err
 	}
-	hub, err := rpctype.NewRPCClient(hc.cfg.HubAddr)
+	hub, err := rpctype.NewRPCClient(hc.cfg.HubAddr, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -293,7 +293,7 @@ func (mgr *Manager) vmLoop() {
 	go func() {
 		for i := 0; i < vmCount; i++ {
 			bootInstance <- i
-			time.Sleep(10 * time.Second)
+			time.Sleep(10 * time.Second * mgr.cfg.Timeouts.Scale)
 		}
 	}()
 	var instances []int
@@ -629,8 +629,8 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 
 	cmd := instance.FuzzerCmd(fuzzerBin, executorBin, instanceName,
 		mgr.cfg.TargetOS, mgr.cfg.TargetArch, fwdAddr, mgr.cfg.Sandbox, procs, fuzzerV,
-		mgr.cfg.Cover, *flagDebug, false, false)
-	outc, errc, err := inst.Run(time.Hour, mgr.vmStop, cmd)
+		mgr.cfg.Cover, *flagDebug, false, false, true, mgr.cfg.Timeouts.Slowdown)
+	outc, errc, err := inst.Run(mgr.cfg.Timeouts.VMRunningTime, mgr.vmStop, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run fuzzer: %v", err)
 	}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -283,8 +283,7 @@ func loadPrograms(target *prog.Target, files []string) []*prog.LogEntry {
 	return entries
 }
 
-func createConfig(target *prog.Target,
-	features *host.Features, featuresFlags csource.Features) (
+func createConfig(target *prog.Target, features *host.Features, featuresFlags csource.Features) (
 	*ipc.Config, *ipc.ExecOpts) {
 	config, execOpts, err := ipcconfig.Default(target)
 	if err != nil {

--- a/tools/syz-hubtool/hubtool.go
+++ b/tools/syz-hubtool/hubtool.go
@@ -51,7 +51,7 @@ func main() {
 		return
 	}
 	log.Printf("connecting to hub at %v...", *flagHubAddress)
-	conn, err := rpctype.NewRPCClient(*flagHubAddress)
+	conn, err := rpctype.NewRPCClient(*flagHubAddress, 1)
 	if err != nil {
 		log.Fatalf("failed to connect to hub: %v", err)
 	}

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -175,7 +175,7 @@ func (mgr *Manager) boot(name string, index int) (*report.Report, error) {
 	}
 	cmd := instance.FuzzerCmd(fuzzerBin, executorBin, name,
 		mgr.cfg.TargetOS, mgr.cfg.TargetArch, fwdAddr, mgr.cfg.Sandbox, mgr.cfg.Procs, 0,
-		mgr.cfg.Cover, mgr.debug, false, true)
+		mgr.cfg.Cover, mgr.debug, false, true, true, mgr.cfg.Timeouts.Slowdown)
 	outc, errc, err := inst.Run(time.Hour, mgr.vmStop, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run fuzzer: %v", err)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -73,7 +73,6 @@ func (inst *testInstance) Close() {
 func init() {
 	beforeContext = maxErrorLength + 100
 	tickerPeriod = 1 * time.Second
-	NoOutputTimeout = 5 * time.Second
 	waitForOutputTimeout = 3 * time.Second
 
 	ctor := func(env *vmimpl.Env) (vmimpl.Pool, error) {
@@ -344,6 +343,11 @@ func testMonitorExecution(t *testing.T, test *Test) {
 			TargetOS:     targets.Linux,
 			TargetArch:   targets.AMD64,
 			TargetVMArch: targets.AMD64,
+			Timeouts: targets.Timeouts{
+				Scale:    1,
+				Slowdown: 1,
+				NoOutput: 5 * time.Second,
+			},
 		},
 		Workdir: dir,
 		Type:    "test",


### PR DESCRIPTION
Add sys/targets.Timeouts struct that parametrizes timeouts throughout the system.
The struct allows to control syscall/program/no output timeouts for OS/arch/VM/etc.
See comment on the struct for more details.