### PR TITLE
build/gvisor: don't instrument the platform code

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -33,7 +33,7 @@ func (gvisor gvisor) build(params *Params) error {
 	if coverageEnabled(config) {
 		coverageFiles := "//pkg/..."
 		exclusions := []string{
-			"//pkg/sentry/platform:platform", // Breaks kvm.
+			"//pkg/sentry/platform", // Breaks kvm.
 		}
 		if race {
 			// These targets use go:norace, which is not


### PR DESCRIPTION
The instrumentation filter has to match all sub-packges of
//pkg/sentry/platform.

Signed-off-by: Andrei Vagin <avagin@google.com>

