### PR TITLE
executor/common: repair clang complaint about bad indentation

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -676,8 +676,9 @@ static void loop(void)
 			if (current_time_ms() - start < program_timeout_ms)
 				continue;
 #else
-		if (current_time_ms() - start < /*{{{PROGRAM_TIMEOUT_MS}}}*/)
+		if (current_time_ms() - start < /*{{{PROGRAM_TIMEOUT_MS}}}*/) {
 			continue;
+		}
 #endif
 			debug("killing hanging pid %d\n", pid);
 			kill_and_wait(pid, &status);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -10223,8 +10223,9 @@ static void loop(void)
 			if (current_time_ms() - start < program_timeout_ms)
 				continue;
 #else
-		if (current_time_ms() - start < /*{{{PROGRAM_TIMEOUT_MS}}}*/)
+		if (current_time_ms() - start < /*{{{PROGRAM_TIMEOUT_MS}}}*/) {
 			continue;
+		}
 #endif
 			debug("killing hanging pid %d\n", pid);
 			kill_and_wait(pid, &status);


### PR DESCRIPTION
```
                <stdin>:353:4: error: misleading indentation; statement is not part of the previous 'if' [-Werror,-Wmisleading-indentation]
                                        kill_and_wait(pid, &status);
                                        ^
                <stdin>:351:3: note: previous statement is here
                                if (current_time_ms() - start < 5000)
                                ^
                1 error generated.
```
dashboard link: https://syzkaller.appspot.com/bug?extid=38fe37bc451a42e6c9a4
Reported-by: syzbot+38fe37bc451a42e6c9a4@syzkaller.appspotmail.com

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
