### PR TITLE
syz-manager: fix machine check sequence

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1061,23 +1061,6 @@ func (mgr *Manager) fuzzerConnect() ([]rpctype.RPCInput, BugFrames, bool) {
 func (mgr *Manager) machineChecked(a *rpctype.CheckArgs, enabledSyscalls map[*prog.Syscall]bool) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	if len(mgr.cfg.EnabledSyscalls) != 0 && len(a.DisabledCalls[mgr.cfg.Sandbox]) != 0 {
-		disabled := make(map[string]string)
-		for _, dc := range a.DisabledCalls[mgr.cfg.Sandbox] {
-			disabled[mgr.target.Syscalls[dc.ID].Name] = dc.Reason
-		}
-		for _, id := range mgr.cfg.Syscalls {
-			name := mgr.target.Syscalls[id].Name
-			if reason := disabled[name]; reason != "" {
-				log.Logf(0, "disabling %v: %v", name, reason)
-			}
-		}
-	}
-	log.Logf(0, "machine check:")
-	log.Logf(0, "%-24v: %v/%v", "syscalls", len(enabledSyscalls), len(mgr.target.Syscalls))
-	for _, feat := range a.Features.Supported() {
-		log.Logf(0, "%-24v: %v", feat.Name, feat.Reason)
-	}
 	mgr.checkResult = a
 	mgr.targetEnabledSyscalls = enabledSyscalls
 	mgr.loadCorpus()


### PR DESCRIPTION
We used to print disabled syscalls before failing due to an error.
This helped to debug "all system calls are disabled" error.
After a recent change we fail before printing disabled syscalls,
as the result manager just prints "all system calls are disabled"
and fails. Restore the check sequence.
