### PR TITLE
pkg/build: use RATELIMIT kernel option on FreeBSD

### DIFF
--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -31,6 +31,7 @@ options 	KCOV
 
 options 	KERN_TLS
 options 	TCPHPTS
+options 	RATELIMIT
 
 options 	DEBUG_VFS_LOCKS
 options 	DIAGNOSTIC


### PR DESCRIPTION
This option is required for the TCP RACK and TCP BBR stack.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
