### PR TITLE
prog: make priority calculation faster

### DIFF
--- a/prog/prio_test.go
+++ b/prog/prio_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 func TestNormalizePrio(t *testing.T) {
-	prios := [][]float32{
+	prios := [][]int32{
 		{2, 2, 2},
 		{1, 2, 4},
 		{1, 2, 0},
 	}
-	want := [][]float32{
-		{1, 1, 1},
-		{0.1, 0.4, 1},
-		{0.4, 1, 0.1},
+	want := [][]int32{
+		{1000, 1000, 1000},
+		{257, 505, 1000},
+		{505, 1000, 10},
 	}
 	t.Logf("had:  %+v", prios)
 	normalizePrio(prios)

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -823,7 +823,7 @@ type UIPrioData struct {
 
 type UIPrio struct {
 	Call string
-	Prio float32
+	Prio int32
 }
 
 var prioTemplate = html.CreatePage(`
@@ -842,7 +842,7 @@ var prioTemplate = html.CreatePage(`
 	</tr>
 	{{range $p := $.Prios}}
 	<tr>
-		<td>{{printf "%.4f" $p.Prio}}</td>
+		<td>{{printf "%5v" $p.Prio}}</td>
 		<td><a href='/prio?call={{$p.Call}}'>{{$p.Call}}</a></td>
 	</tr>
 	{{end}}

--- a/tools/syz-showprio/showprio.go
+++ b/tools/syz-showprio/showprio.go
@@ -48,13 +48,13 @@ func main() {
 	showPriorities(enabled, target.CalculatePriorities(corpus), target)
 }
 
-func showPriorities(calls []string, prios [][]float32, target *prog.Target) {
+func showPriorities(calls []string, prios [][]int32, target *prog.Target) {
 	printLine(append([]string{"CALLS"}, calls...))
 	for _, callRow := range calls {
 		line := []string{callRow}
 		for _, callCol := range calls {
 			val := prios[target.SyscallMap[callRow].ID][target.SyscallMap[callCol].ID]
-			line = append(line, fmt.Sprintf("%.2f", val))
+			line = append(line, fmt.Sprintf("%v", val))
 		}
 		printLine(line)
 	}


### PR DESCRIPTION
Switch from float32 to int32.
Float32 is super slow in arm emulation.
Plus flats are generally non-deterministic due to order of operations,
so we needed to do additional sorts to deal with that. Now we don't.
