### PR TITLE
syz-manager: fix endianess for covfilter test

### DIFF
--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/google/syzkaller/sys/targets"
@@ -15,9 +14,11 @@ func TestCreateBitmap(t *testing.T) {
 		0x81000002: 1,
 		0x8120001d: 1,
 	}
-	bitmap := createCoverageBitmap(targets.Get("test", "64"), pcs)
-	start := binary.LittleEndian.Uint32(bitmap[0:])
-	size := binary.LittleEndian.Uint32(bitmap[4:])
+	target := targets.Get("test", "64")
+	order := target.HostEndian
+	bitmap := createCoverageBitmap(target, pcs)
+	start := order.Uint32(bitmap[0:])
+	size := order.Uint32(bitmap[4:])
 	if start != 0x81000000 || size != 0x200020 {
 		t.Fatalf("bad region 0x%x/0x%x", start, size)
 	}


### PR DESCRIPTION
Support little as well as big endian architectures.

Fixes this on s390x arch:

=== RUN   TestCreateBitmap
2021/01/12 16:42:44 coverage filter from 0x81000000 to 0x81200020, size 0x200020, pcs 2
    covfilter_test.go:22: bad region 0x81/0x20002000
--- FAIL: TestCreateBitmap (0.18s)

Signed-off-by: Alexander Egorenkov <Alexander.Egorenkov@ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
