### PR TITLE
dashboard/app: allow CCing people for bug on specific manager

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -60,16 +60,20 @@ var testConfig = &GlobalConfig{
 			},
 			Repos: []KernelRepo{
 				{
-					URL:         "git://syzkaller.org",
-					Branch:      "branch10",
-					Alias:       "repo10alias",
-					Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
+					URL:    "git://syzkaller.org",
+					Branch: "branch10",
+					Alias:  "repo10alias",
+					CC: CCConfig{
+						Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
+					},
 				},
 				{
-					URL:         "git://github.com/google/syzkaller",
-					Branch:      "master",
-					Alias:       "repo10alias",
-					Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
+					URL:    "git://github.com/google/syzkaller",
+					Branch: "master",
+					Alias:  "repo10alias",
+					CC: CCConfig{
+						Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
+					},
 				},
 			},
 			Managers: map[string]ConfigManager{
@@ -105,27 +109,38 @@ var testConfig = &GlobalConfig{
 			},
 			Repos: []KernelRepo{
 				{
-					URL:              "git://syzkaller.org",
-					Branch:           "branch10",
-					Alias:            "repo10alias",
-					CC:               []string{"always@cc.me"},
-					Maintainers:      []string{"maintainers@repo10.org", "bugs@repo10.org"},
-					BuildMaintainers: []string{"build-maintainers@repo10.org"},
+					URL:    "git://syzkaller.org",
+					Branch: "branch10",
+					Alias:  "repo10alias",
+					CC: CCConfig{
+						Always:           []string{"always@cc.me"},
+						Maintainers:      []string{"maintainers@repo10.org", "bugs@repo10.org"},
+						BuildMaintainers: []string{"build-maintainers@repo10.org"},
+					},
 				},
 				{
-					URL:         "git://syzkaller.org",
-					Branch:      "branch20",
-					Alias:       "repo20",
-					Maintainers: []string{"maintainers@repo20.org", "bugs@repo20.org"},
+					URL:    "git://syzkaller.org",
+					Branch: "branch20",
+					Alias:  "repo20",
+					CC: CCConfig{
+						Maintainers: []string{"maintainers@repo20.org", "bugs@repo20.org"},
+					},
 				},
 			},
 			Managers: map[string]ConfigManager{
-				"restricted-manager": {
+				restrictedManager: {
 					RestrictedTestingRepo:   "git://restricted.git/restricted.git",
 					RestrictedTestingReason: "you should test only on restricted.git",
 				},
-				"no-fix-bisection-manager": {
+				noFixBisectionManager: {
 					FixBisectionDisabled: true,
+				},
+				specialCCManager: {
+					CC: CCConfig{
+						Always:           []string{"always@manager.org"},
+						Maintainers:      []string{"maintainers@manager.org"},
+						BuildMaintainers: []string{"build-maintainers@manager.org"},
+					},
 				},
 			},
 			Reporting: []Reporting{
@@ -254,6 +269,10 @@ const (
 	keyUser      = "clientuserkeyclientuserkey"
 	clientPublic = "client-public"
 	keyPublic    = "clientpublickeyclientpublickey"
+
+	restrictedManager     = "restricted-manager"
+	noFixBisectionManager = "no-fix-bisection-manager"
+	specialCCManager      = "special-cc-manager"
 )
 
 func skipWithRepro(bug *Bug) FilterResult {

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -74,7 +74,10 @@ func TestBisectCause(t *testing.T) {
 	c.expectEQ(pollResp.KernelConfig, build.KernelConfig)
 	c.expectEQ(pollResp.SyzkallerCommit, build.SyzkallerCommit)
 	c.expectEQ(pollResp.ReproOpts, []byte("repro opts 3"))
-	c.expectEQ(pollResp.ReproSyz, []byte("syncfs(3)"))
+	c.expectEQ(pollResp.ReproSyz, []byte(
+		"# See https://goo.gl/kgGztJ for information about syzkaller reproducers.\n"+
+			"#repro opts 3\n"+
+			"syncfs(3)"))
 	c.expectEQ(pollResp.ReproC, []byte("int main() { return 3; }"))
 
 	// Since we did not reply, we should get the same response.

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -204,6 +204,19 @@ const (
 	JobBisectFix
 )
 
+func (typ JobType) toDashapiReportType() dashapi.ReportType {
+	switch typ {
+	case JobTestPatch:
+		return dashapi.ReportTestPatch
+	case JobBisectCause:
+		return dashapi.ReportBisectCause
+	case JobBisectFix:
+		return dashapi.ReportBisectFix
+	default:
+		panic(fmt.Sprintf("unknown job type %v", typ))
+	}
+}
+
 type JobFlags int64
 
 const (

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -103,7 +103,10 @@ func TestJob(t *testing.T) {
 	c.expectEQ(pollResp.SyzkallerCommit, build.SyzkallerCommit)
 	c.expectEQ(pollResp.Patch, []byte(patch))
 	c.expectEQ(pollResp.ReproOpts, []byte("repro opts"))
-	c.expectEQ(pollResp.ReproSyz, []byte("repro syz"))
+	c.expectEQ(pollResp.ReproSyz, []byte(
+		"# See https://goo.gl/kgGztJ for information about syzkaller reproducers.\n"+
+			"#repro opts\n"+
+			"repro syz"))
 	c.expectEQ(pollResp.ReproC, []byte("repro C"))
 
 	pollResp2 := c.client2.pollJobs(build.Manager)
@@ -337,7 +340,7 @@ func TestJobRestrictedManager(t *testing.T) {
 	defer c.Close()
 
 	build := testBuild(1)
-	build.Manager = "restricted-manager"
+	build.Manager = restrictedManager
 	c.client2.UploadBuild(build)
 
 	crash := testCrash(build, 1)
@@ -650,7 +653,7 @@ func TestFixBisectionsDisabled(t *testing.T) {
 
 	// Upload a crash report.
 	build := testBuild(1)
-	build.Manager = "no-fix-bisection-manager"
+	build.Manager = noFixBisectionManager
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 20)
 	c.client2.ReportCrash(crash)

--- a/dashboard/app/notifications_test.go
+++ b/dashboard/app/notifications_test.go
@@ -290,7 +290,7 @@ func TestEmailNotifObsoletedManager(t *testing.T) {
 	defer c.Close()
 
 	build := testBuild(1)
-	build.Manager = "no-fix-bisection-manager"
+	build.Manager = noFixBisectionManager
 	c.client2.UploadBuild(build)
 	crash := testCrashWithRepro(build, 1)
 	c.client2.ReportCrash(crash)


### PR DESCRIPTION
Currently we can CC specific people for bugs on a particular kernel repo
(always, upstream, for build bugs). Add similar functionality for bugs
on a particular manager. This will be needed to CC people on clang instances.
