### PR TITLE
pkg/build: exclude gvisor pkg/coverage from coverage instrumentation

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -33,7 +33,8 @@ func (gvisor gvisor) build(params *Params) error {
 	if coverageEnabled(config) {
 		coverageFiles := "//pkg/..."
 		exclusions := []string{
-			"//pkg/sentry/platform", // Breaks kvm.
+			"//pkg/sentry/platform",   // Breaks kvm.
+			"//pkg/coverage:coverage", // Too slow.
 		}
 		if race {
 			// These targets use go:norace, which is not


### PR DESCRIPTION
Instrumenting this package is too slow--every time the Sentry switches
to the application, task work will iterate through all of the coverage
counters. Instrumenting this code path will add many atomic operations
on race builds, drastically degrading performance.