### PR TITLE
pkg/report: merge KASAN/GPF/etc crashes together

### DIFF
--- a/pkg/report/testdata/linux/report/0
+++ b/pkg/report/testdata/linux/report/0
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [  772.918915] BUG: unable to handle kernel paging request at ffff88002bde1e40

--- a/pkg/report/testdata/linux/report/10
+++ b/pkg/report/testdata/linux/report/10
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in __call_rcu
+ALT: bad-access in __call_rcu
 CORRUPTED: Y
 
 [ 1019.110825] BUG: unable to handle kernel paging request at 00000000ffffff8a

--- a/pkg/report/testdata/linux/report/100
+++ b/pkg/report/testdata/linux/report/100
@@ -1,4 +1,5 @@
 TITLE: general protection fault in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [ 1722.511384] kasan: CONFIG_KASAN_INLINE enabled

--- a/pkg/report/testdata/linux/report/105
+++ b/pkg/report/testdata/linux/report/105
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in ip6_fragment
+ALT: bad-access in ip6_fragment
 
 [   42.361487] ==================================================================
 [   42.364412] BUG: KASAN: slab-out-of-bounds in ip6_fragment+0x11c8/0x3730

--- a/pkg/report/testdata/linux/report/106
+++ b/pkg/report/testdata/linux/report/106
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in consume_skb
+ALT: bad-access in consume_skb
 CORRUPTED: Y
 
 [   55.468844] ==================================================================

--- a/pkg/report/testdata/linux/report/109
+++ b/pkg/report/testdata/linux/report/109
@@ -1,4 +1,5 @@
 TITLE: KASAN: stack-out-of-bounds Read in xfrm_state_find
+ALT: bad-access in xfrm_state_find
 
 [  189.525626] ==================================================================
 [  189.533112] BUG: KASAN: stack-out-of-bounds in xfrm_state_find+0x30fc/0x3230

--- a/pkg/report/testdata/linux/report/11
+++ b/pkg/report/testdata/linux/report/11
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [ 1581.999813] BUG: unable to handle kernel paging request at ffffea0000f0e440

--- a/pkg/report/testdata/linux/report/110
+++ b/pkg/report/testdata/linux/report/110
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in sg_remove_request
+ALT: bad-access in sg_remove_request
 
 [  190.154802] ==================================================================
 [  190.154802] BUG: KASAN: slab-out-of-bounds in __lock_acquire+0x2eff/0x3640 at addr ffff8801a751e6f8

--- a/pkg/report/testdata/linux/report/111
+++ b/pkg/report/testdata/linux/report/111
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in sg_remove_request
+ALT: bad-access in sg_remove_request
 
 [  190.154802] ==================================================================
 [  190.154802] BUG: KASAN: slab-out-of-bounds in sg_remove_request+0x103/0x120 at addr ffff8801a85de8c0

--- a/pkg/report/testdata/linux/report/112
+++ b/pkg/report/testdata/linux/report/112
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in process_one_work
+ALT: bad-access in process_one_work
 
 [  190.154802] BUG: unable to handle kernel NULL pointer dereference at 0000000000000286
 [  190.154802] IP: 0x286

--- a/pkg/report/testdata/linux/report/12
+++ b/pkg/report/testdata/linux/report/12
@@ -1,4 +1,5 @@
 TITLE: general protection fault in drm_legacy_newctx
+ALT: bad-access in drm_legacy_newctx
 START: [ 1021.364461] general protection fault: 0000 [#1] SMP DEBUG_PAGEALLOC KASAN
 CORRUPTED: Y
 

--- a/pkg/report/testdata/linux/report/120
+++ b/pkg/report/testdata/linux/report/120
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Write in __unwind_start
+ALT: bad-access in __unwind_start
 CORRUPTED: Y
 
 [   80.262156] ==================================================================

--- a/pkg/report/testdata/linux/report/121
+++ b/pkg/report/testdata/linux/report/121
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in __unwind_start
+ALT: bad-access in __unwind_start
 CORRUPTED: Y
 
 [  244.844737] ==================================================================

--- a/pkg/report/testdata/linux/report/13
+++ b/pkg/report/testdata/linux/report/13
@@ -1,4 +1,5 @@
 TITLE: general protection fault in logfs_init_inode
+ALT: bad-access in logfs_init_inode
 CORRUPTED: Y
 
 [ 1722.509639] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/130
+++ b/pkg/report/testdata/linux/report/130
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in aead_recvmsg
+ALT: bad-access in aead_recvmsg
 START: [   53.730124] BUG: KASAN: use-after-free in aead_recvmsg+0x1758/0x1bc0
 
 2017/11/27 07:13:57 executing program 2:

--- a/pkg/report/testdata/linux/report/139
+++ b/pkg/report/testdata/linux/report/139
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in hash_sendmsg
+ALT: bad-access in hash_sendmsg
 
 [   70.687256] sctp: [Deprecated]: syz-executor5 (pid 16777) Use of int in maxseg socket option.
 [   70.687256] Use struct sctp_assoc_value instead

--- a/pkg/report/testdata/linux/report/14
+++ b/pkg/report/testdata/linux/report/14
@@ -1,4 +1,5 @@
 TITLE: general protection fault in __ip_options_echo
+ALT: bad-access in __ip_options_echo
 CORRUPTED: Y
 
 [ 1722.511384] general protection fault: 0000 [#1] SMP KASAN

--- a/pkg/report/testdata/linux/report/146
+++ b/pkg/report/testdata/linux/report/146
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in remove_wait_queue
+ALT: bad-access in remove_wait_queue
 
 [   19.572672] BUG: unable to handle kernel paging request at 0000000100000137
 [   19.572683] IP: __lock_acquire+0xd8/0x1430

--- a/pkg/report/testdata/linux/report/147
+++ b/pkg/report/testdata/linux/report/147
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in remove_wait_queue
+ALT: bad-access in remove_wait_queue
 
 [   19.121820] ==================================================================
 [   19.121834] BUG: KASAN: use-after-free in __lock_acquire+0x3c41/0x3cf0

--- a/pkg/report/testdata/linux/report/148
+++ b/pkg/report/testdata/linux/report/148
@@ -1,4 +1,5 @@
 TITLE: general protection fault in tipc_subscrb_subscrp_delete
+ALT: bad-access in tipc_subscrb_subscrp_delete
 
 [   41.864973] kasan: CONFIG_KASAN_INLINE enabled
 [   41.869549] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/149
+++ b/pkg/report/testdata/linux/report/149
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in __queue_work
+ALT: bad-access in __queue_work
 
 [ 1140.689311] ==================================================================
 [ 1140.696784] BUG: KASAN: use-after-free in work_is_static_object+0x39/0x40

--- a/pkg/report/testdata/linux/report/15
+++ b/pkg/report/testdata/linux/report/15
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [ 1722.511384] ==================================================================

--- a/pkg/report/testdata/linux/report/154
+++ b/pkg/report/testdata/linux/report/154
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [   85.149573] BUG: unable to handle kernel paging request at ffffffff0001eea6

--- a/pkg/report/testdata/linux/report/16
+++ b/pkg/report/testdata/linux/report/16
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in remove_wait_queue
+ALT: bad-access in remove_wait_queue
 CORRUPTED: Y
 
 [   50.583499] BUG: KASAN: use-after-free in remove_wait_queue+0xfb/0x120 at addr ffff88002db3cf50

--- a/pkg/report/testdata/linux/report/160
+++ b/pkg/report/testdata/linux/report/160
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in __run_timers
+ALT: bad-access in __run_timers
 
 [  190.751093] BUG: unable to handle kernel paging request at ffffffffffffffff
 [  190.757101] IP: 0xffffffffffffffff

--- a/pkg/report/testdata/linux/report/162
+++ b/pkg/report/testdata/linux/report/162
@@ -1,4 +1,5 @@
 TITLE: general protection fault in sg_remove_request
+ALT: bad-access in sg_remove_request
 
 [   27.258999] ==================================================================
 [   27.260623] kasan: CONFIG_KASAN_INLINE enabled

--- a/pkg/report/testdata/linux/report/165
+++ b/pkg/report/testdata/linux/report/165
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in shmem_disband_hugehead
+ALT: bad-access in shmem_disband_hugehead
 
 [  176.379525] ==================================================================
 [  176.386974] BUG: KASAN: use-after-free in __lock_acquire+0x462f/0x49f0 at addr ffff8800b5a9f8c0

--- a/pkg/report/testdata/linux/report/167
+++ b/pkg/report/testdata/linux/report/167
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in snd_pcm_oss_write
+ALT: bad-access in snd_pcm_oss_write
 
 [  522.218303] BUG: unable to handle kernel paging request at ffffc90001691000
 [  522.225453] IP: memset_erms+0x9/0x10

--- a/pkg/report/testdata/linux/report/17
+++ b/pkg/report/testdata/linux/report/17
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in copy_from_iter
+ALT: bad-access in copy_from_iter
 CORRUPTED: Y
 
 [  380.688570] BUG: KASAN: use-after-free in copy_from_iter+0xf30/0x15e0 at addr ffff880033f4b02a

--- a/pkg/report/testdata/linux/report/172
+++ b/pkg/report/testdata/linux/report/172
@@ -1,4 +1,5 @@
 TITLE: KASAN: stack-out-of-bounds Read in xfrm_selector_match
+ALT: bad-access in xfrm_selector_match
 
 [  396.956335] ==================================================================
 [  396.963769] BUG: KASAN: stack-out-of-bounds in memcmp+0xe3/0x160

--- a/pkg/report/testdata/linux/report/174
+++ b/pkg/report/testdata/linux/report/174
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in rtnl_dump_ifinfo
+ALT: bad-access in rtnl_dump_ifinfo
 
 [  218.951194] BUG: unable to handle kernel NULL pointer dereference at 0000000000000010
 [  218.959174] IP: strlen+0x0/0x30

--- a/pkg/report/testdata/linux/report/175
+++ b/pkg/report/testdata/linux/report/175
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in ipcget
+ALT: bad-access in ipcget
 
 [   83.458005] BUG: unable to handle kernel paging request at ffffffffffffffd8
 [   83.465166] IP: memcmp+0x9/0x40

--- a/pkg/report/testdata/linux/report/177
+++ b/pkg/report/testdata/linux/report/177
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in selinux_inode_free_security
+ALT: bad-access in selinux_inode_free_security
 
 [   70.363639] ==================================================================
 [   70.371158] BUG: KASAN: use-after-free in do_raw_spin_lock+0x1aa/0x1e0

--- a/pkg/report/testdata/linux/report/180
+++ b/pkg/report/testdata/linux/report/180
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [   85.149573] BUG: unable to handle kernel paging request at ffffffff0001eea6

--- a/pkg/report/testdata/linux/report/183
+++ b/pkg/report/testdata/linux/report/183
@@ -1,4 +1,5 @@
 TITLE: BUG: corrupted list in tipc_nametbl_unsubscribe
+ALT: bad-access in tipc_nametbl_unsubscribe
 
 [  440.811510] list_del corruption. prev->next should be 00000000bc6553ca, but was 0000000038fa8131
 [  440.811620] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/184
+++ b/pkg/report/testdata/linux/report/184
@@ -1,4 +1,5 @@
 TITLE: BUG: corrupted list in __dev_remove_pack
+ALT: bad-access in __dev_remove_pack
 
 [   50.710530] list_del corruption. next->prev should be ffff8801d8caa528, but was ffffffff868a8010
 [   50.719785] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/195
+++ b/pkg/report/testdata/linux/report/195
@@ -1,4 +1,5 @@
 TITLE: KASAN: wild-memory-access Read in sg_read
+ALT: bad-access in sg_read
 
 [   67.633749] ==================================================================
 [   67.633767] BUG: KASAN: wild-memory-access in sg_read+0xe5c/0x1440

--- a/pkg/report/testdata/linux/report/196
+++ b/pkg/report/testdata/linux/report/196
@@ -1,4 +1,5 @@
 TITLE: KASAN: wild-memory-access Read in sg_read
+ALT: bad-access in sg_read
 
 [   67.633749] ==================================================================
 [   67.633767] BUG: KASAN: wild-memory-access in sg_read+0xe5c/0x1440

--- a/pkg/report/testdata/linux/report/197
+++ b/pkg/report/testdata/linux/report/197
@@ -1,4 +1,5 @@
 TITLE: KASAN: global-out-of-bounds Read in show_timer
+ALT: bad-access in show_timer
 
 [   66.768767] ==================================================================
 [   66.776196] BUG: KASAN: global-out-of-bounds in show_timer+0x27a/0x2b0 at addr ffffffff82cda558

--- a/pkg/report/testdata/linux/report/198
+++ b/pkg/report/testdata/linux/report/198
@@ -1,4 +1,5 @@
 TITLE: general protection fault in ip6t_do_table
+ALT: bad-access in ip6t_do_table
 
 [  159.247590] syz-executor6: vmalloc: allocation failure: 8589934588 bytes, mode:0x14080c0(GFP_KERNEL|__GFP_ZERO), nodemask=(null)
 [  159.259380] syz-executor6 cpuset=/ mems_allowed=0

--- a/pkg/report/testdata/linux/report/199
+++ b/pkg/report/testdata/linux/report/199
@@ -1,4 +1,5 @@
 TITLE: KASAN: stack-out-of-bounds Read in iov_iter_advance
+ALT: bad-access in iov_iter_advance
 
 [   81.174109] ==================================================================
 [   81.174125] BUG: KASAN: stack-out-of-bounds in iov_iter_advance+0x4c0/0x4f0 at addr ffff8801ca657d38

--- a/pkg/report/testdata/linux/report/20
+++ b/pkg/report/testdata/linux/report/20
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [  149.188010] BUG: unable to handle kernel NULL pointer dereference at 000000000000058c

--- a/pkg/report/testdata/linux/report/200
+++ b/pkg/report/testdata/linux/report/200
@@ -1,4 +1,5 @@
 TITLE: general protection fault in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [   73.452724] FAULT_INJECTION: forcing a failure.

--- a/pkg/report/testdata/linux/report/201
+++ b/pkg/report/testdata/linux/report/201
@@ -1,4 +1,5 @@
 TITLE: general protection fault in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [   32.536478] binder: BINDER_SET_CONTEXT_MGR already set

--- a/pkg/report/testdata/linux/report/21
+++ b/pkg/report/testdata/linux/report/21
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in skb_release_data
+ALT: bad-access in skb_release_data
 CORRUPTED: Y
 
 [   55.112844] BUG: unable to handle kernel NULL pointer dereference at 000000000000001a

--- a/pkg/report/testdata/linux/report/215
+++ b/pkg/report/testdata/linux/report/215
@@ -1,4 +1,5 @@
 TITLE: general protection fault in ucma_close
+ALT: bad-access in ucma_close
 
 [   52.099632] kasan: GPF could be caused by NULL-ptr deref or user memory access
 [   52.106982] general protection fault: 0000 [#1] SMP KASAN

--- a/pkg/report/testdata/linux/report/217
+++ b/pkg/report/testdata/linux/report/217
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in foo_ioctl
+ALT: bad-access in foo_ioctl
 CORRUPTED: Y
 
 foo

--- a/pkg/report/testdata/linux/report/222
+++ b/pkg/report/testdata/linux/report/222
@@ -1,4 +1,5 @@
 TITLE: general protection fault in tipc_nametbl_unsubscribe
+ALT: bad-access in tipc_nametbl_unsubscribe
 
 [   24.236490] kasan: CONFIG_KASAN_INLINE enabled
 [   24.241061] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/223
+++ b/pkg/report/testdata/linux/report/223
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in binder_release_work
+ALT: bad-access in binder_release_work
 
 [   46.527263] ==================================================================
 [   46.534609] BUG: KASAN: use-after-free in __list_del_entry+0x196/0x1d0

--- a/pkg/report/testdata/linux/report/224
+++ b/pkg/report/testdata/linux/report/224
@@ -1,4 +1,5 @@
 TITLE: general protection fault in xfrm_state_walk_done
+ALT: bad-access in xfrm_state_walk_done
 
 [   44.866009] kasan: CONFIG_KASAN_INLINE enabled
 [   44.870467] kasan: GPF could be caused by NULL-ptr deref or user memory accessgeneral protection fault: 0000 [#1] PREEMPT SMP KASAN

--- a/pkg/report/testdata/linux/report/225
+++ b/pkg/report/testdata/linux/report/225
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in binder_release_work
+ALT: bad-access in binder_release_work
 
 [   32.347901] ==================================================================
 [   32.355262] BUG: KASAN: use-after-free in __list_del_entry+0x196/0x1d0

--- a/pkg/report/testdata/linux/report/226
+++ b/pkg/report/testdata/linux/report/226
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in rdma_listen
+ALT: bad-access in rdma_listen
 
 [  353.728146] ==================================================================
 [  353.735888] BUG: KASAN: use-after-free in __list_add_valid+0xc6/0xd0

--- a/pkg/report/testdata/linux/report/227
+++ b/pkg/report/testdata/linux/report/227
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in cma_cancel_operation
+ALT: bad-access in cma_cancel_operation
 
 syzkaller login: [   23.820987] ==================================================================
 [   23.828498] BUG: KASAN: use-after-free in __list_del_entry_valid+0x144/0x150

--- a/pkg/report/testdata/linux/report/238
+++ b/pkg/report/testdata/linux/report/238
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 Unable to handle kernel paging request at virtual address 80b0f484

--- a/pkg/report/testdata/linux/report/241
+++ b/pkg/report/testdata/linux/report/241
@@ -1,4 +1,5 @@
 TITLE: Unhandled fault in n_tty_set_termios
+ALT: bad-access in n_tty_set_termios
 
 Unhandled fault: page domain fault (0x81b) at 0x00001044
 pgd = 74561366

--- a/pkg/report/testdata/linux/report/243
+++ b/pkg/report/testdata/linux/report/243
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in migrate_task_rq_fair
+ALT: bad-access in migrate_task_rq_fair
 
 syzkaller login: Unable to handle kernel paging request at virtual address fc14ef08
 pgd = c60b8887

--- a/pkg/report/testdata/linux/report/247
+++ b/pkg/report/testdata/linux/report/247
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in inet_sendmsg
+ALT: bad-access in inet_sendmsg
 
 [   61.889077] BUG: unable to handle kernel NULL pointer dereference at           (null)
 [   61.890070] IP: [<          (null)>]           (null)

--- a/pkg/report/testdata/linux/report/256
+++ b/pkg/report/testdata/linux/report/256
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in sock_poll
+ALT: bad-access in sock_poll
 
 [   27.294614] random: sshd: uninitialized urandom read (32 bytes read)
 [   27.396136] BUG: unable to handle kernel NULL pointer dereference at 0000000000000000

--- a/pkg/report/testdata/linux/report/260
+++ b/pkg/report/testdata/linux/report/260
@@ -1,4 +1,5 @@
 TITLE: general protection fault in p9_conn_cancel
+ALT: bad-access in p9_conn_cancel
 
 [  242.871006] kasan: CONFIG_KASAN_INLINE enabled
 [  242.875630] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/261
+++ b/pkg/report/testdata/linux/report/261
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in snd_timer_user_interrupt
+ALT: bad-access in snd_timer_user_interrupt
 
 [  168.248365] ==================================================================
 [  168.255760] BUG: KASAN: use-after-free in register_lock_class+0xf9c/0x1470

--- a/pkg/report/testdata/linux/report/306
+++ b/pkg/report/testdata/linux/report/306
@@ -1,4 +1,5 @@
 TITLE: KASAN: global-out-of-bounds Read in __aa_lookupn_ns
+ALT: bad-access in __aa_lookupn_ns
 
 [  218.522865] ==================================================================
 [  218.530431] BUG: KASAN: global-out-of-bounds in memcmp+0xe3/0x160

--- a/pkg/report/testdata/linux/report/307
+++ b/pkg/report/testdata/linux/report/307
@@ -1,4 +1,5 @@
 TITLE: KASAN: stack-out-of-bounds Read in do_ip_vs_set_ctl
+ALT: bad-access in do_ip_vs_set_ctl
 
 [   29.725847] ==================================================================
 [   29.733228] BUG: KASAN: stack-out-of-bounds in strnlen+0xc1/0xd0

--- a/pkg/report/testdata/linux/report/308
+++ b/pkg/report/testdata/linux/report/308
@@ -1,4 +1,5 @@
 TITLE: general protection fault in __aa_lookupn_ns
+ALT: bad-access in __aa_lookupn_ns
 
 [  234.220213] kasan: GPF could be caused by NULL-ptr deref or user memory access
 [  234.245620] general protection fault: 0000 [#1] PREEMPT SMP KASAN

--- a/pkg/report/testdata/linux/report/323
+++ b/pkg/report/testdata/linux/report/323
@@ -1,4 +1,5 @@
 TITLE: general protection fault in vmalloc_fault
+ALT: bad-access in vmalloc_fault
 CORRUPTED: Y
 
 [  888.868901] IPv6: ADDRCONF(NETDEV_UP): team_slave_0: link is not ready

--- a/pkg/report/testdata/linux/report/324
+++ b/pkg/report/testdata/linux/report/324
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in lookup_object
+ALT: bad-access in lookup_object
 CORRUPTED: Y
 
 [  946.951230] BUG: unable to handle kernel paging request at 000000fe840fc4b9

--- a/pkg/report/testdata/linux/report/329
+++ b/pkg/report/testdata/linux/report/329
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in bpf_prog_kallsyms_find
+ALT: bad-access in bpf_prog_kallsyms_find
 CORRUPTED: Y
 
 [  235.855782] BUG: unable to handle kernel paging request at ffffc90001935030

--- a/pkg/report/testdata/linux/report/338
+++ b/pkg/report/testdata/linux/report/338
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Write in do_one_initcall
+ALT: bad-access in do_one_initcall
 
 [   35.046212][ T5851] ==================================================================
 [   35.047479][ T5851] BUG: KASAN: slab-out-of-bounds in kmalloc_oob_right+0xac/0xc3 [test_kasan]

--- a/pkg/report/testdata/linux/report/339
+++ b/pkg/report/testdata/linux/report/339
@@ -1,4 +1,5 @@
 TITLE: general protection fault in sysrq_handle_crash
+ALT: bad-access in sysrq_handle_crash
 
 [   39.546482][ T5855] sysrq: SysRq : Trigger a crash
 [   39.547393][ T5855] kasan: CONFIG_KASAN_INLINE enabled

--- a/pkg/report/testdata/linux/report/340
+++ b/pkg/report/testdata/linux/report/340
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Write in do_one_initcall
+ALT: bad-access in do_one_initcall
 
 [   35.046212][ T5851] ==================================================================
 [   35.047479][ T5851] BUG: KASAN: slab-out-of-bounds in memcpy+0xac/0xc3 [test_kasan]

--- a/pkg/report/testdata/linux/report/343
+++ b/pkg/report/testdata/linux/report/343
@@ -1,5 +1,5 @@
-# TODO: this is not corrupted (maybe)
 TITLE: KASAN: stack-out-of-bounds Read in __udp6_lib_err
+ALT: bad-access in __udp6_lib_err
 CORRUPTED: Y
 
 [  183.310893] ==================================================================

--- a/pkg/report/testdata/linux/report/357
+++ b/pkg/report/testdata/linux/report/357
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in icmp_send
+ALT: bad-access in icmp_send
 
 [  237.893047] ==================================================================
 [  237.900729] BUG: KASAN: use-after-free in do_raw_spin_trylock+0x82/0x270

--- a/pkg/report/testdata/linux/report/358
+++ b/pkg/report/testdata/linux/report/358
@@ -1,4 +1,5 @@
 TITLE: general protection fault in run_timer_softirq
+ALT: bad-access in run_timer_softirq
 
 [  155.297335] kasan: CONFIG_KASAN_INLINE enabled
 [  155.302006] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/359
+++ b/pkg/report/testdata/linux/report/359
@@ -1,4 +1,5 @@
 TITLE: general protection fault in run_timer_softirq
+ALT: bad-access in run_timer_softirq
 
 [  159.840224] kasan: CONFIG_KASAN_INLINE enabled
 [  159.844860] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/360
+++ b/pkg/report/testdata/linux/report/360
@@ -1,4 +1,5 @@
 TITLE: general protection fault in locks_remove_file
+ALT: bad-access in locks_remove_file
 
 [   51.907753] kasan: CONFIG_KASAN_INLINE enabled
 [   51.913122] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/361
+++ b/pkg/report/testdata/linux/report/361
@@ -1,4 +1,5 @@
 TITLE: general protection fault in ipv6_rcv
+ALT: bad-access in ipv6_rcv
 
 [  639.214515] kasan: CONFIG_KASAN_INLINE enabled
 [  639.219296] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/362
+++ b/pkg/report/testdata/linux/report/362
@@ -1,4 +1,5 @@
 TITLE: general protection fault in shrink_slab
+ALT: bad-access in shrink_slab
 
 [  415.516184] kasan: CONFIG_KASAN_INLINE enabled
 [  415.520916] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/364
+++ b/pkg/report/testdata/linux/report/364
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in qlist_free_all
+ALT: bad-access in qlist_free_all
 
 [ 2766.561238][T26603] BUG: unable to handle kernel paging request at ffffe8ffffe00000
 [ 2766.569067][T26603] #PF error: [normal kernel read fault]

--- a/pkg/report/testdata/linux/report/371
+++ b/pkg/report/testdata/linux/report/371
@@ -1,4 +1,5 @@
 TITLE: KASAN: null-ptr-deref Read in zr364xx_vidioc_querycap
+ALT: bad-access in zr364xx_vidioc_querycap
 
 [   62.911361] ==================================================================
 [   62.919256] BUG: KASAN: null-ptr-deref in read_word_at_a_time+0xe/0x20

--- a/pkg/report/testdata/linux/report/372
+++ b/pkg/report/testdata/linux/report/372
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in au0828_usb_disconnect
+ALT: bad-access in au0828_usb_disconnect
 
 [ 1087.420767] BUG: unable to handle kernel paging request at fffffffc45040758
 [ 1087.427881] #PF error: [normal kernel read fault]

--- a/pkg/report/testdata/linux/report/376
+++ b/pkg/report/testdata/linux/report/376
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in hdpvr_probe
+ALT: bad-access in hdpvr_probe
 
 [  105.345542][ T5735] ==================================================================
 [  105.345545][ T5735] BUG: KASAN: slab-out-of-bounds in string+0x1f6/0x220

--- a/pkg/report/testdata/linux/report/377
+++ b/pkg/report/testdata/linux/report/377
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in dlfb_usb_probe
+ALT: bad-access in dlfb_usb_probe
 
 [   59.694766][   T12] ==================================================================
 [   59.694770][   T12] BUG: KASAN: slab-out-of-bounds in hex_string+0x418/0x4b0

--- a/pkg/report/testdata/linux/report/382
+++ b/pkg/report/testdata/linux/report/382
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in iptunnel_xmit
+ALT: bad-access in iptunnel_xmit
 
 [ 2494.421785][T17591] BUG: unable to handle page fault for address: ffffde202758ca0b
 [ 2494.429575][T17591] #PF: supervisor read access in kernel mode

--- a/pkg/report/testdata/linux/report/391
+++ b/pkg/report/testdata/linux/report/391
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in nr_release
+ALT: bad-access in nr_release
 
 [  334.230640][T12837] ==================================================================
 [  334.239022][T12837] BUG: KASAN: use-after-free in refcount_inc_not_zero_checked+0x81/0x200

--- a/pkg/report/testdata/linux/report/392
+++ b/pkg/report/testdata/linux/report/392
@@ -1,4 +1,5 @@
 TITLE: general protection fault in x25_connect
+ALT: bad-access in x25_connect
 
 [ 2348.757430][ T1533] ==================================================================
 [ 2348.763145][ T1560] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/395
+++ b/pkg/report/testdata/linux/report/395
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in usb_anchor_resume_wakeups
+ALT: bad-access in usb_anchor_resume_wakeups
 
 [  136.593735][    C1] ==================================================================
 [  136.593749][    C1] BUG: KASAN: use-after-free in register_lock_class+0xeb7/0x1240

--- a/pkg/report/testdata/linux/report/410
+++ b/pkg/report/testdata/linux/report/410
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in hiddev_read
+ALT: bad-access in hiddev_read
 
 [  501.875843][ T9186] ==================================================================
 [  501.883925][ T9186] BUG: KASAN: use-after-free in __lock_acquire+0x302a/0x3b50

--- a/pkg/report/testdata/linux/report/413
+++ b/pkg/report/testdata/linux/report/413
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in iowarrior_disconnect
+ALT: bad-access in iowarrior_disconnect
 
 [  272.327487][   T12] ==================================================================
 [  272.335789][   T12] BUG: KASAN: use-after-free in __list_del_entry_valid+0x15e/0x170

--- a/pkg/report/testdata/linux/report/414
+++ b/pkg/report/testdata/linux/report/414
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in iowarrior_disconnect
+ALT: bad-access in iowarrior_disconnect
 
 [   72.512165][   T17] ==================================================================
 [   72.520532][   T17] BUG: KASAN: use-after-free in usb_kill_urb+0x18f/0x2c0

--- a/pkg/report/testdata/linux/report/416
+++ b/pkg/report/testdata/linux/report/416
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in video_unregister_device
+ALT: bad-access in video_unregister_device
 
 [ 1527.943923][T23697] ==================================================================
 [ 1527.952472][T23697] BUG: KASAN: use-after-free in kobject_del+0x12e/0x170

--- a/pkg/report/testdata/linux/report/417
+++ b/pkg/report/testdata/linux/report/417
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in usbvision_release
+ALT: bad-access in usbvision_release
 
 [  472.680102][ T9268] ==================================================================
 [  472.689737][ T9268] BUG: KASAN: use-after-free in sysfs_remove_file_ns+0x5f/0x70

--- a/pkg/report/testdata/linux/report/418
+++ b/pkg/report/testdata/linux/report/418
@@ -1,4 +1,5 @@
 TITLE: general protection fault in hdm_disconnect
+ALT: bad-access in hdm_disconnect
 
 [   43.976394][   T12] kasan: CONFIG_KASAN_INLINE enabled
 [   43.981766][   T12] kasan: GPF could be caused by NULL-ptr deref or user memory access

--- a/pkg/report/testdata/linux/report/422
+++ b/pkg/report/testdata/linux/report/422
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in hso_probe
+ALT: bad-access in hso_probe
 
 [   54.689586][ T1737] ==================================================================
 [   54.697746][ T1737] BUG: KASAN: use-after-free in __mutex_lock+0xf23/0x1360

--- a/pkg/report/testdata/linux/report/423
+++ b/pkg/report/testdata/linux/report/423
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in mcba_usb_disconnect
+ALT: bad-access in mcba_usb_disconnect
 
 [  723.789406][  T102] ==================================================================
 [  723.790974][  T102] BUG: KASAN: use-after-free in __lock_acquire+0x3377/0x3eb0

--- a/pkg/report/testdata/linux/report/424
+++ b/pkg/report/testdata/linux/report/424
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in chaoskey_disconnect
+ALT: bad-access in chaoskey_disconnect
 
 [  744.592276][ T3173] ==================================================================
 [  744.593789][ T3173] BUG: KASAN: use-after-free in refcount_inc_not_zero_checked+0x72/0x1e0

--- a/pkg/report/testdata/linux/report/431
+++ b/pkg/report/testdata/linux/report/431
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in partition_sched_domains_locked
+ALT: bad-access in partition_sched_domains_locked
 
 IPVS: ftp: loaded support on port[0] = 21
 IPVS: ftp: loaded support on port[0] = 21

--- a/pkg/report/testdata/linux/report/45
+++ b/pkg/report/testdata/linux/report/45
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in _snd_timer_stop
+ALT: bad-access in _snd_timer_stop
 CORRUPTED: Y
 
 [  167.347989] Disabling lock debugging due to kernel taint

--- a/pkg/report/testdata/linux/report/450
+++ b/pkg/report/testdata/linux/report/450
@@ -1,4 +1,5 @@
 TITLE: general protection fault in dma_direct_max_mapping_size
+ALT: bad-access in dma_direct_max_mapping_size
 
 [    3.598126][  T259] kworker/u4:1 (259) used greatest stack depth: 27248 bytes left
 [    3.853329][  T895] kworker/u4:0 (895) used greatest stack depth: 27168 bytes left

--- a/pkg/report/testdata/linux/report/451
+++ b/pkg/report/testdata/linux/report/451
@@ -1,4 +1,5 @@
 TITLE: general protection fault in deliberately_dereference_bad_address
+ALT: bad-access in deliberately_dereference_bad_address
 
 [   32.082291] general protection fault for non-canonical address 0xe017577ddf75b7dd: 0000 [#1] PREEMPT SMP KASAN PTI
 [   32.084238] KASAN: maybe wild-memory-access in range [0x00badbeefbadbee8-0x00badbeefbadbeef]

--- a/pkg/report/testdata/linux/report/452
+++ b/pkg/report/testdata/linux/report/452
@@ -1,4 +1,5 @@
 TITLE: general protection fault in deliberately_dereference_bad_address
+ALT: bad-access in deliberately_dereference_bad_address
 
 [   37.352047] segment-related general protection fault: beec [#2] PREEMPT SMP KASAN PTI
 [   37.354009] CPU: 0 PID: 1858 Comm: ioctl Tainted: G      D           5.4.0-rc7+ #567

--- a/pkg/report/testdata/linux/report/458
+++ b/pkg/report/testdata/linux/report/458
@@ -1,4 +1,5 @@
 TITLE: general protection fault in input_close_device
+ALT: bad-access in input_close_device
 
 [   28.272365][ T1713] general protection fault: 0000 [#1] SMP KASAN
 [   28.278580][ T1713] CPU: 0 PID: 1713 Comm: syz-executor493 Not tainted 5.4.0-rc6-syzkaller #0

--- a/pkg/report/testdata/linux/report/459
+++ b/pkg/report/testdata/linux/report/459
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in input_unregister_device
+ALT: bad-access in input_unregister_device
 
 [  346.619398][  T102] BUG: unable to handle page fault for address: ffff8801d386d964
 [  346.627264][  T102] #PF: supervisor read access in kernel mode

--- a/pkg/report/testdata/linux/report/46
+++ b/pkg/report/testdata/linux/report/46
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in blk_rq_map_sg
+ALT: bad-access in blk_rq_map_sg
 CORRUPTED: Y
 
 [ 1722.511384] Unable to handle kernel paging request at virtual address 0c0c9ca0

--- a/pkg/report/testdata/linux/report/469
+++ b/pkg/report/testdata/linux/report/469
@@ -1,4 +1,5 @@
 TITLE: KASAN: slab-out-of-bounds Read in dlfb_usb_probe
+ALT: bad-access in dlfb_usb_probe
 
 0.337143][   T95] ==================================================================
 [   40.337147][   T95] BUG: KASAN: slab-out-of-bounds in hex_string+0x439/0x4c0

--- a/pkg/report/testdata/linux/report/470
+++ b/pkg/report/testdata/linux/report/470
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in bcsp_close
+ALT: bad-access in bcsp_close
 
 [ 1018.906812][ T7994] ==================================================================
 [ 1018.915133][ T7994] BUG: KASAN: use-after-free in kfree_skb+0x2a/0xb0

--- a/pkg/report/testdata/linux/report/472
+++ b/pkg/report/testdata/linux/report/472
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in pn533_send_complete
+ALT: bad-access in pn533_send_complete
 
 [   50.500958][    C1] ==================================================================
 [   50.509230][    C1] BUG: KASAN: use-after-free in pn533_send_complete.cold+0x47/0x6c

--- a/pkg/report/testdata/linux/report/475
+++ b/pkg/report/testdata/linux/report/475
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in ip6_fragment
+ALT: bad-access in ip6_fragment
 
 [   78.614475][ T8947] ==================================================================
 [   78.622699][ T8947] BUG: KASAN: use-after-free in kfree_skb_list+0x5d/0x60

--- a/pkg/report/testdata/linux/report/476
+++ b/pkg/report/testdata/linux/report/476
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in audit_data_to_entry
+ALT: bad-access in audit_data_to_entry
 
 [   17.577241][ T1878] BUG: unable to handle page fault for address: ffffebde00002008
 [   17.586014][ T1878] #PF: supervisor read access in kernel mode

--- a/pkg/report/testdata/linux/report/477
+++ b/pkg/report/testdata/linux/report/477
@@ -1,4 +1,5 @@
 TITLE: BUG: corrupted list in ath9k_htc_wait_for_target
+ALT: bad-access in ath9k_htc_wait_for_target
 
 [  348.947111][ T4333] ------------[ cut here ]------------
 [  348.947754][ T4333] kernel BUG at lib/list_debug.c:51!

--- a/pkg/report/testdata/linux/report/478
+++ b/pkg/report/testdata/linux/report/478
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in ucma_destroy_id
+ALT: bad-access in ucma_destroy_id
 
 [  308.398169] ==================================================================
 [  308.405617] BUG: KASAN: use-after-free in __lock_acquire+0x37c2/0x4ec0

--- a/pkg/report/testdata/linux/report/479
+++ b/pkg/report/testdata/linux/report/479
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [  490.564553][T16898] BUG: unable to handle page fault for address: 0000000000ffff88

--- a/pkg/report/testdata/linux/report/480
+++ b/pkg/report/testdata/linux/report/480
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [  202.652969][ T9969] BUG: kernel NULL pointer dereference, address: 0000000000000086

--- a/pkg/report/testdata/linux/report/481
+++ b/pkg/report/testdata/linux/report/481
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [  418.945118][T17277] BUG: kernel NULL pointer dereference, address: 0000000000000086

--- a/pkg/report/testdata/linux/report/510
+++ b/pkg/report/testdata/linux/report/510
@@ -1,4 +1,5 @@
 TITLE: general protection fault in __kernfs_remove
+ALT: bad-access in __kernfs_remove
 
 [ 1703.516227][ T2809] general protection fault, probably for non-canonical address 0xdffffc0000000002: 0000 [#1] PREEMPT SMP KASAN
 [ 1703.528051][ T2809] KASAN: null-ptr-deref in range [0x0000000000000010-0x0000000000000017]

--- a/pkg/report/testdata/linux/report/511
+++ b/pkg/report/testdata/linux/report/511
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Write in bpf_prog_kallsyms_del
+ALT: bad-access in bpf_prog_kallsyms_del
 
 [  284.023898] ==================================================================
 [  284.031579] BUG: KASAN: use-after-free in rb_erase+0x26d0/0x3710

--- a/pkg/report/testdata/linux/report/512
+++ b/pkg/report/testdata/linux/report/512
@@ -1,4 +1,5 @@
 TITLE: general protection fault in dup_mm
+ALT: bad-access in dup_mm
 
 [ 1959.698473][ T6611] general protection fault, probably for non-canonical address 0xdffffc0002c3fefa: 0000 [#1] PREEMPT SMP KASAN
 [ 1959.710215][ T6611] KASAN: probably user-memory-access in range [0x00000000161ff7d0-0x00000000161ff7d7]

--- a/pkg/report/testdata/linux/report/513
+++ b/pkg/report/testdata/linux/report/513
@@ -1,4 +1,5 @@
 TITLE: general protection fault in integrity_inode_free
+ALT: bad-access in integrity_inode_free
 
 [   36.583433] kasan: GPF could be caused by NULL-ptr deref or user memory access
 [   36.590897] general protection fault: 0000 [#1] PREEMPT SMP KASAN

--- a/pkg/report/testdata/linux/report/514
+++ b/pkg/report/testdata/linux/report/514
@@ -1,4 +1,5 @@
 TITLE: general protection fault in fq_reset
+ALT: bad-access in fq_reset
 
 [ 1503.551672][T10069] general protection fault, probably for non-canonical address 0xdffffc000eeeeef0: 0000 [#1] PREEMPT SMP KASAN
 [ 1503.563429][T10069] KASAN: probably user-memory-access in range [0x0000000077777780-0x0000000077777787]

--- a/pkg/report/testdata/linux/report/515
+++ b/pkg/report/testdata/linux/report/515
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in nfsd_reply_cache_free_locked
+ALT: bad-access in nfsd_reply_cache_free_locked
 
 [ 1261.886878][ T8682] BUG: unable to handle page fault for address: ffff887ffffffff0
 [ 1261.894638][ T8682] #PF: supervisor read access in kernel mode

--- a/pkg/report/testdata/linux/report/517
+++ b/pkg/report/testdata/linux/report/517
@@ -1,4 +1,5 @@
 TITLE: general protection fault in timerqueue_del
+ALT: bad-access in timerqueue_del
 
 [  110.420358][    C0] general protection fault: 0000 [#1] PREEMPT SMP KASAN
 [  110.427307][    C0] CPU: 0 PID: 12754 Comm: syz-executor.2 Not tainted 5.3.0-rc2 #81

--- a/pkg/report/testdata/linux/report/518
+++ b/pkg/report/testdata/linux/report/518
@@ -1,4 +1,5 @@
 TITLE: general protection fault in timerqueue_del
+ALT: bad-access in timerqueue_del
 
 [   71.480406][    C0] general protection fault: 0000 [#1] PREEMPT SMP KASAN
 [   71.480415][    C0] CPU: 0 PID: 8856 Comm: syz-executor.2 Not tainted 5.2.0-rc4+ #32

--- a/pkg/report/testdata/linux/report/519
+++ b/pkg/report/testdata/linux/report/519
@@ -1,4 +1,5 @@
 TITLE: general protection fault in set_next_entity
+ALT: bad-access in set_next_entity
 
 [   61.686373] kasan: GPF could be caused by NULL-ptr deref or user memory access
 [   61.693805] general protection fault: 0000 [#1] PREEMPT SMP KASAN

--- a/pkg/report/testdata/linux/report/520
+++ b/pkg/report/testdata/linux/report/520
@@ -1,4 +1,5 @@
 TITLE: UBSAN: array-index-out-of-bounds in arch_uprobe_analyze_insn
+ALT: bad-access in arch_uprobe_analyze_insn
 
 [  175.967267][T13309] ================================================================================
 [  175.968362][T13309] UBSAN: array-index-out-of-bounds in /usr/local/google/home/dvyukov/src/linux2/arch/x86/kernel/uprobes.c:263:56

--- a/pkg/report/testdata/linux/report/524
+++ b/pkg/report/testdata/linux/report/524
@@ -1,4 +1,5 @@
 TITLE: Internal error in ns558_init
+ALT: bad-access in ns558_init
 
 [  211.592905][    T1] Internal error: synchronous external abort: 96000010 [#1] PREEMPT SMP
 [  211.594621][    T1] Dumping ftrace buffer:

--- a/pkg/report/testdata/linux/report/536
+++ b/pkg/report/testdata/linux/report/536
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in selinux_socket_sendmsg
+ALT: bad-access in selinux_socket_sendmsg
 
 [ 1418.056449][ T6604] Unable to handle kernel paging request at virtual address dfffa00000000003
 [ 1418.057778][ T6604] Mem abort info:

--- a/pkg/report/testdata/linux/report/541
+++ b/pkg/report/testdata/linux/report/541
@@ -1,4 +1,5 @@
 TITLE: Internal error in clear_page
+ALT: bad-access in clear_page
 
 [    4.227552][    T1] DMI not present or invalid.
 [    4.282443][    T1] NET: Registered protocol family 16

--- a/pkg/report/testdata/linux/report/548
+++ b/pkg/report/testdata/linux/report/548
@@ -1,4 +1,5 @@
 TITLE: Unhandled fault in trace_hardirqs_off
+ALT: bad-access in trace_hardirqs_off
 
 [ 9080.453689][T11783] 8<--- cut here ---
 [ 9080.454760][T11783] Unhandled fault: page domain fault (0x01b) at 0x00000e30

--- a/pkg/report/testdata/linux/report/551
+++ b/pkg/report/testdata/linux/report/551
@@ -1,4 +1,5 @@
 TITLE: Unhandled fault in jffs2_parse_param
+ALT: bad-access in jffs2_parse_param
 
 8<--- cut here ---
 Unhandled fault: page domain fault (0x01b) at 0x00000008

--- a/pkg/report/testdata/linux/report/552
+++ b/pkg/report/testdata/linux/report/552
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in io_serial_out
+ALT: bad-access in io_serial_out
 
 8<--- cut here ---
 Unable to handle kernel paging request at virtual address fee00001

--- a/pkg/report/testdata/linux/report/554
+++ b/pkg/report/testdata/linux/report/554
@@ -1,4 +1,5 @@
 TITLE: Unhandled fault in write_comp_data
+ALT: bad-access in write_comp_data
 
 [ 1328.320581][    C1] 8<--- cut here ---
 [ 1328.320974][    C1] Unhandled fault: page domain fault (0x01b) at 0x00000ea3

--- a/pkg/report/testdata/linux/report/555
+++ b/pkg/report/testdata/linux/report/555
@@ -1,4 +1,5 @@
 TITLE: Unhandled fault in trace_hardirqs_off
+ALT: bad-access in trace_hardirqs_off
 
 [ 9080.453689][T11783] 8<--- cut here ---
 [ 9080.454760][T11783] Unhandled fault: page domain fault (0x01b) at 0x00000e30

--- a/pkg/report/testdata/linux/report/567
+++ b/pkg/report/testdata/linux/report/567
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in vhci_shutdown_connection
+ALT: bad-access in vhci_shutdown_connection
 
 [  775.896747][ T5109] 8<--- cut here ---
 [  775.897679][ T5109] Unable to handle kernel NULL pointer dereference at virtual address 00000004

--- a/pkg/report/testdata/linux/report/568
+++ b/pkg/report/testdata/linux/report/568
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in io_submit_sqes
+ALT: bad-access in io_submit_sqes
 
 [ 1344.478322][ T6700] ==================================================================
 [ 1344.479538][ T6700] BUG: KASAN: invalid-access in __memset+0x16c/0x188

--- a/pkg/report/testdata/linux/report/569
+++ b/pkg/report/testdata/linux/report/569
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in enqueue_timer
+ALT: bad-access in enqueue_timer
 
 [ 1039.654796][    C0] ==================================================================
 [ 1039.655950][    C0] BUG: KASAN: invalid-access in enqueue_timer+0x18/0xc0

--- a/pkg/report/testdata/linux/report/570
+++ b/pkg/report/testdata/linux/report/570
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in bond_ipsec_del_sa
+ALT: bad-access in bond_ipsec_del_sa
 
 [  678.660041][ T2885] ==================================================================
 [  678.660727][ T2885] BUG: KASAN: invalid-access in bond_ipsec_del_sa+0x4/0x70

--- a/pkg/report/testdata/linux/report/571
+++ b/pkg/report/testdata/linux/report/571
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in __run_timers
+ALT: bad-access in __run_timers
 
 [  931.917437][    C0] ==================================================================
 [  931.918594][    C0] BUG: KASAN: invalid-access in __run_timers.part.0+0xc0/0x224

--- a/pkg/report/testdata/linux/report/572
+++ b/pkg/report/testdata/linux/report/572
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in l2cap_sock_teardown_cb
+ALT: bad-access in l2cap_sock_teardown_cb
 
 [ 5825.407853][ T9802] ==================================================================
 [ 5825.409134][ T9802] BUG: KASAN: invalid-access in _raw_spin_lock_bh+0x2c/0x70

--- a/pkg/report/testdata/linux/report/573
+++ b/pkg/report/testdata/linux/report/573
@@ -1,4 +1,5 @@
 TITLE: KASAN: invalid-access Read in firmware_fallback_sysfs
+ALT: bad-access in firmware_fallback_sysfs
 
 [ 4452.860624][T17139] ==================================================================
 [ 4452.861782][T17139] BUG: KASAN: invalid-access in __list_add_valid+0x14/0x90

--- a/pkg/report/testdata/linux/report/8
+++ b/pkg/report/testdata/linux/report/8
@@ -1,4 +1,5 @@
 TITLE: KASAN: use-after-free Read in snd_seq_queue_alloc
+ALT: bad-access in snd_seq_queue_alloc
 CORRUPTED: Y
 
 [   94.864848] line 0

--- a/pkg/report/testdata/linux/report/84
+++ b/pkg/report/testdata/linux/report/84
@@ -1,4 +1,5 @@
 TITLE: general protection fault in corrupted
+ALT: bad-access in corrupted
 CORRUPTED: Y
 
 [   92.396607] general protection fault: 0000 [#1] [ 387.811073] audit: type=1326 audit(1486238739.637:135): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=10020 comm="syz-executor1" exe="/root/syz-executor1" sig=31 arch=c000003e syscall=202 compat=0 ip=0x44fad9 code=0x0

--- a/pkg/report/testdata/linux/report/9
+++ b/pkg/report/testdata/linux/report/9
@@ -1,4 +1,5 @@
 TITLE: BUG: unable to handle kernel paging request in skb_release_data
+ALT: bad-access in skb_release_data
 CORRUPTED: Y
 
 [ 1019.110825] BUG: unable to handle kernel paging request at 000000010000001a


### PR DESCRIPTION
These cause lots of duplicates.
See existing syzbot bugs and the issue.

Update #1575
