### PR TITLE
executor: don't include kvm on arm

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2892,7 +2892,7 @@ error_clear_loop:
 
 #if SYZ_EXECUTOR || __NR_syz_kvm_setup_cpu
 // KVM is not yet supported on RISC-V
-#if !GOARCH_riscv64
+#if !GOARCH_riscv64 && !GOARCH_arm
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/kvm.h>

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6243,7 +6243,7 @@ error_clear_loop:
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_kvm_setup_cpu
-#if !GOARCH_riscv64
+#if !GOARCH_riscv64 && !GOARCH_arm
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/kvm.h>


### PR DESCRIPTION
KVM was removed for arm architecture.
Latest Linux headers don't contain <asm/kvm.h> for arm.
So don't even include them.
