### PR TITLE
tools/docker: add libc6-dev-i386-amd64-cross to syzbot image

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -28,7 +28,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	# Cross-compilation:
 	g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu \
-	libc6-dev-i386 lib32gcc-10-dev lib32stdc++-10-dev
+	libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-10-dev lib32stdc++-10-dev
 
+# pkg/osutil uses syzkaller user for sandboxing.
+RUN useradd syzkaller
 RUN echo "export PS1='\n\W🤖 '" >> /root/.bashrc
-RUN echo "export EDITOR=nano" >> /root/.bashrc


### PR DESCRIPTION
A new image required to build i386 executables in bullseye.
