### PR TITLE
Add Linux syscall variants

### DIFF
--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -11,6 +11,7 @@ umount2(path ptr[in, filename], flags flags[umount_flags])
 mount$bpf(src const[0], dst ptr[in, filename], type ptr[in, string["bpf"]], flags flags[mount_flags], opts ptr[in, fs_options[bpf_options]])
 mount$overlay(src const[0], dst ptr[in, filename], type ptr[in, string["overlay"]], flags flags[mount_flags], opts ptr[in, fs_options[overlay_options]])
 mount$binder(src const[0], dst ptr[in, filename], type ptr[in, string["binder"]], flags flags[mount_flags], opts ptr[in, fs_options[binder_options]])
+mount$tmpfs(src ptr[in, string["tmp"]], dst ptr[in, filename], type ptr[in, string["tmpfs"]], flags flags[mount_flags], opts ptr[in, fs_options[tmpfs_options]])
 
 # A bind mount ignores the filesystem type argument, but
 # pkg/host/syscalls_linux.go:isSupportedFilesystem() requires one in

--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -12,6 +12,12 @@ mount$bpf(src const[0], dst ptr[in, filename], type ptr[in, string["bpf"]], flag
 mount$overlay(src const[0], dst ptr[in, filename], type ptr[in, string["overlay"]], flags flags[mount_flags], opts ptr[in, fs_options[overlay_options]])
 mount$binder(src const[0], dst ptr[in, filename], type ptr[in, string["binder"]], flags flags[mount_flags], opts ptr[in, fs_options[binder_options]])
 
+# A bind mount ignores the filesystem type argument, but
+# pkg/host/syscalls_linux.go:isSupportedFilesystem() requires one in
+# /proc/filesystems.  Use a common and valid filesystem string ("pipefs") to
+# pass the check.
+mount$bind(src ptr[in, filename], dst ptr[in, filename], type ptr[in, string["pipefs"]], flags flags[mount_flags], data const[0])
+
 # esdfs is ChromeOS-specific:
 # https://chromium.googlesource.com/chromiumos/third_party/kernel/+/d2c1fb9fcdb53%5E%21/
 mount$esdfs(src ptr[in, filename], dst ptr[in, filename], type ptr[in, string["esdfs"]], flags flags[mount_flags], opts ptr[in, fs_options[esdfs_options]])

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -280,6 +280,7 @@ utimes(filename ptr[in, filename], times ptr[in, itimerval])
 futimesat(dir fd_dir, pathname ptr[in, filename], times ptr[in, itimerval])
 utimensat(dir fd_dir, pathname ptr[in, filename], times ptr[in, itimerval], flags flags[utimensat_flags])
 
+fork() pid (breaks_returns)
 clone(flags flags[clone_flags], sp buffer[in], parentid ptr[out, int32], childtid ptr[out, int32], tls buffer[in]) (breaks_returns)
 clone3(args ptr[in, clone_args], size bytesize[args]) pid (breaks_returns)
 

--- a/sys/linux/sys.txt.const
+++ b/sys/linux/sys.txt.const
@@ -608,6 +608,7 @@ __NR_fcntl = 55, amd64:72, arm64:riscv64:25, mips64le:5070
 __NR_fdatasync = 148, amd64:75, arm64:riscv64:83, mips64le:5073
 __NR_finit_module = 273, 386:350, amd64:313, arm:379, mips64le:5307, ppc64le:353, s390x:344
 __NR_flock = 143, amd64:73, arm64:riscv64:32, mips64le:5071
+__NR_fork = 2, amd64:57, arm64:riscv64:???, mips64le:5056
 __NR_fstat = 108, amd64:5, arm64:riscv64:80, mips64le:5005
 __NR_fstat64 = 197, amd64:arm64:mips64le:ppc64le:riscv64:s390x:???
 __NR_fstatat64 = 386:300, amd64:arm64:mips64le:ppc64le:riscv64:s390x:???, arm:327


### PR DESCRIPTION
Hi,

This commits add a new syscall and new variants for Linux. It may be useful to fuzz features like Landlock #2380 .

I'm not sure how to handle the `fork()` syscall because of its return value (cf. `breaks_return` for `clone3()`).

I'm also not sure how to write tests with `fork()` or `clone()` because they create two flows of execution. Is there a way to have conditions in such tests?