### PR TITLE
dvyukov syz ci abs paths

### DIFF
--- a/pkg/build/linux_linux.go
+++ b/pkg/build/linux_linux.go
@@ -48,7 +48,7 @@ func embedLinuxKernel(params *Params, kernelPath string) error {
 		return err
 	}
 	if err := unix.Mount(loopFile+"p1", mountDir, "ext4", 0, ""); err != nil {
-		return err
+		return fmt.Errorf("mount(%vp1, %v) failed: %v", loopFile, mountDir, err)
 	}
 	defer unix.Unmount(mountDir, 0)
 	if err := osutil.CopyFile(kernelPath, filepath.Join(mountDir, "vmlinuz")); err != nil {

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -297,8 +297,8 @@ func loadConfig(filename string) (*Config, error) {
 			managercfg.HTTP = fmt.Sprintf(":%v", cfg.ManagerPort)
 			cfg.ManagerPort++
 		}
-		mgr.Compiler = osutil.Abs(mgr.Compiler)
-		mgr.Ccache = osutil.Abs(mgr.Ccache)
+		// Note: we don't change Compiler/Ccache because it may be just "gcc" referring
+		// to the system binary, or pkg/build/netbsd.go uses "g++" and "clang++" as special marks.
 		mgr.Userspace = osutil.Abs(mgr.Userspace)
 		mgr.KernelConfig = osutil.Abs(mgr.KernelConfig)
 		mgr.KernelBaselineConfig = osutil.Abs(mgr.KernelBaselineConfig)


### PR DESCRIPTION
- pkg/build: extend error message
- syz-ci: don't make compiler/ccache paths absolute
