### PR TITLE
dashboard/app: show crash titles

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -166,6 +166,7 @@ type uiBug struct {
 }
 
 type uiCrash struct {
+	Title           string
 	Manager         string
 	Time            time.Time
 	Maintainers     string
@@ -178,9 +179,8 @@ type uiCrash struct {
 }
 
 type uiCrashTable struct {
-	Crashes        []*uiCrash
-	Caption        string
-	HasMaintainers bool
+	Crashes []*uiCrash
+	Caption string
 }
 
 type uiJob struct {
@@ -369,12 +369,6 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 	crashesTable := &uiCrashTable{
 		Crashes: crashes,
 		Caption: fmt.Sprintf("Crashes (%d)", bug.NumCrashes),
-	}
-	for _, crash := range crashesTable.Crashes {
-		if crash.Maintainers != "" {
-			crashesTable.HasMaintainers = true
-			break
-		}
 	}
 	dups, err := loadDupsForBug(c, r, bug, state, managers)
 	if err != nil {
@@ -932,6 +926,7 @@ func loadFixBisectionsForBug(c context.Context, bug *Bug) ([]*uiCrash, error) {
 
 func makeUICrash(crash *Crash, build *Build) *uiCrash {
 	ui := &uiCrash{
+		Title:           crash.Title,
 		Manager:         crash.Manager,
 		Time:            crash.Time,
 		Maintainers:     strings.Join(crash.Maintainers, ", "),

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -317,10 +317,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<th><a onclick="return sortTable(this, 'Report', reproSort)" href="#">Report</a></th>
 			<th><a onclick="return sortTable(this, 'Syz repro', reproSort)" href="#">Syz repro</a></th>
 			<th><a onclick="return sortTable(this, 'C repro', textSort)" href="#">C repro</a></th>
-			<th><a onclick="return sortTable(this, 'machine info', textSort)" href="#">VM info</a></th>
-			{{if .HasMaintainers}}
-			<th><a onclick="return sortTable(this, 'Maintainers', textSort)" href="#">Maintainers</a></th>
-			{{end}}
+			<th><a onclick="return sortTable(this, 'VM info', textSort)" href="#">VM info</a></th>
+			<th><a onclick="return sortTable(this, 'Title', textSort)" href="#">Title</a></th>
 		</tr>
 		</thead>
 		<tbody>
@@ -338,9 +336,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="repro">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}</td>
 			<td class="repro">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
 			<td class="repro">{{if $b.MachineInfoLink}}<a href="{{$b.MachineInfoLink}}">info</a>{{end}}</td>
-			{{if $.HasMaintainers}}
-			<td class="maintainers" title="{{$b.Maintainers}}">{{$b.Maintainers}}</td>
-			{{end}}
+			<td class="manager">{{$b.Title}}</td>
 		</tr>
 		{{end}}
 		</tbody>


### PR DESCRIPTION
Show crash title for each crash, since they can be different now.
More fancy solutions are possible, but let's start with just
exposing it.
Remove Maintainers instead, I am not sure who/how uses them.
Nobody uses them now to the best of my knowledge, but they
take lots of page space.

Update #1575
