### PR TITLE
build/gvisor: fix compile time warning

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -31,7 +31,7 @@ func (gvisor gvisor) build(params *Params) error {
 	target := "//runsc:runsc"
 	race := raceEnabled(config)
 	if race {
-		args = append(args, "--features=race")
+		args = append(args, "--@io_bazel_rules_go//go/config:race")
 		target = "//runsc:runsc-race"
 	}
 	if coverageEnabled(config) {


### PR DESCRIPTION
$ bazel build --features=race  //runsc:runsc-race
...
WARNING: --features=race is no longer supported. Use
         --@io_bazel_rules_go//go/config:race instead.