### PR TITLE
pkg/runtest: check arch requirement early

### DIFF
--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -310,3 +310,15 @@ func PrintAvailableFeaturesFlags() {
 		fmt.Printf("  %s - %s\n", name, features[name].Description)
 	}
 }
+
+// This is the main configuration used by executor, only for testing.
+var ExecutorOpts = Options{
+	Threaded:  true,
+	Collide:   true,
+	Repeat:    true,
+	Procs:     2,
+	Slowdown:  1,
+	Sandbox:   "none",
+	Repro:     true,
+	UseTmpDir: true,
+}


### PR DESCRIPTION
Need to check arch requirement early as some programs
may fail to deserialize on some arches due to missing syscalls.
See discussion on #2380.
Also support negative arch requirements (-arch=amd64).
