### PR TITLE
docs: update test for syntax

### DIFF
--- a/docs/syscall_descriptions.md
+++ b/docs/syscall_descriptions.md
@@ -300,5 +300,5 @@ if you add some temporal `debug` calls to the pseudo-syscall, `syz-execprog -deb
 
 The test syntax can be checked by running:
 ```
-go test -run=TestSysTests ./pkg/csource
+go test -run=TestParsing ./pkg/runtest
 ```


### PR DESCRIPTION
Synchronize with commit 2bd9619f7621 ("pkg/runtest: check arch
requirement early"), which removes TestSysTests.