### PR TITLE
pkg/build: exclude gvisor pkg/ring0 from coverage instrumentation

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -39,7 +39,7 @@ func (gvisor gvisor) build(params *Params) error {
 	if coverageEnabled(config) {
 		coverageFiles := "//pkg/..."
 		exclusions := []string{
-			"//pkg/sentry/platform",   // Breaks kvm.
+			"//pkg/sentry/platform", "//pkg/ring0", // Breaks kvm.
 			"//pkg/coverage:coverage", // Too slow.
 		}
 		if race {


### PR DESCRIPTION
It was a part of the pkg/sentry/platform, but recently it was moved out.


