### PR TITLE
Mknod variants

### DIFF
--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -264,6 +264,7 @@ mq_unlink(name ptr[in, string])
 
 mknod(file ptr[in, filename], mode flags[mknod_mode], dev int32)
 mknod$loop(file ptr[in, filename], mode flags[mknod_mode], dev proc[1792, 2])
+mknodat$null(dirfd fd_dir, file ptr[in, filename], mode flags[mknod_mode], dev const[0x103])
 mknodat(dirfd fd_dir, file ptr[in, filename], mode flags[mknod_mode], dev int32)
 chmod(file ptr[in, filename], mode flags[open_mode])
 fchmod(fd fd, mode flags[open_mode])

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -264,6 +264,7 @@ mq_unlink(name ptr[in, string])
 
 mknod(file ptr[in, filename], mode flags[mknod_mode], dev int32)
 mknod$loop(file ptr[in, filename], mode flags[mknod_mode], dev proc[1792, 2])
+mknodat$loop(dirfd fd_dir, file ptr[in, filename], mode flags[mknod_mode], dev proc[1792, 2])
 mknodat$null(dirfd fd_dir, file ptr[in, filename], mode flags[mknod_mode], dev const[0x103])
 mknodat(dirfd fd_dir, file ptr[in, filename], mode flags[mknod_mode], dev int32)
 chmod(file ptr[in, filename], mode flags[open_mode])

--- a/sys/targets/common.go
+++ b/sys/targets/common.go
@@ -123,6 +123,9 @@ func (arch *UnixNeutralizer) Neutralize(c *prog.Call) {
 			mode.Val &^= arch.S_IFBLK
 			mode.Val |= arch.S_IFREG
 		case arch.S_IFCHR:
+			if dev.Val == 0x103 {
+				break // /dev/null
+			}
 			mode.Val &^= arch.S_IFCHR
 			mode.Val |= arch.S_IFREG
 		}


### PR DESCRIPTION
Enable creation of a safe character device: /dev/null .

Also add mknodat$null and mknodat$loop .