### PR TITLE
pkg/vcs: use gcc 10 for linux v5.9+

### DIFF
--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -149,6 +149,8 @@ func (ctx *linux) EnvForCommit(binDir, commit string, kernelConfig []byte) (*Bis
 
 func linuxCompilerVersion(tags map[string]bool) string {
 	switch {
+	case tags["v5.9"]:
+		return "10.1.0"
 	case tags["v4.12"]:
 		return "8.1.0"
 	case tags["v4.11"]:


### PR DESCRIPTION
All bisections started failing with:
Compiler lacks asm-goto support.
Use gcc 10 for v5.9+.
