### PR TITLE
dashboard/app: remove restriction on max log size

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -629,9 +629,6 @@ func createBugReportForJob(c context.Context, job *Job, jobKey *db.Key, config i
 	if err != nil {
 		return nil, err
 	}
-	if len(crashLog) > maxMailLogLen {
-		crashLog = crashLog[len(crashLog)-maxMailLogLen:]
-	}
 	report, _, err := getText(c, textCrashReport, job.CrashReport)
 	if err != nil {
 		return nil, err

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -27,7 +27,6 @@ import (
 //  - incomingCommand is called by backends to update bug statuses.
 
 const (
-	maxMailLogLen              = 1 << 20
 	maxMailReportLen           = 64 << 10
 	maxInlineError             = 16 << 10
 	notifyResendPeriod         = 14 * 24 * time.Hour
@@ -390,9 +389,6 @@ func createBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key
 	crashLog, _, err := getText(c, textCrashLog, crash.Log)
 	if err != nil {
 		return nil, err
-	}
-	if len(crashLog) > maxMailLogLen {
-		crashLog = crashLog[len(crashLog)-maxMailLogLen:]
 	}
 	report, _, err := getText(c, textCrashReport, crash.Report)
 	if err != nil {


### PR DESCRIPTION
This restriction was meant or emails.
But now we don't embed log in emails, they are provided as dashboard links.
Now this only affects external reporting, which can handle large logs itself.
On the other hand, external reporting does not have a way to "restore" full log.
Remove the restriction.
