### PR TITLE
Make the maximum number of crash logs to store configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Collabora
 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 Heyuan Shi
 Christian Brauner
+Johannes Wellhöfer

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,3 +85,4 @@ Congyu Liu
 Kyle Evans
 Darby Sauter
 Christian Brauner
+Johannes Wellhöfer

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// but to not oversubscribe CPU and memory too severe to not cause OOMs and false hangs/stalls.
 	Procs int `json:"procs"`
 
+	// Maximum number of logs to store per crash (default: 100).
+	MaxCrashLogs int `json:"max_crash_logs"`
+
 	// Type of sandbox to use during fuzzing:
 	// "none": don't do anything special beyond resource sandboxing, default
 	// "setuid": impersonate into user nobody (65534). Supported only for some OSes.

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -78,12 +78,13 @@ func LoadPartialFile(filename string) (*Config, error) {
 
 func defaultValues() *Config {
 	return &Config{
-		SSHUser:   "root",
-		Cover:     true,
-		Reproduce: true,
-		Sandbox:   "none",
-		RPC:       ":0",
-		Procs:     6,
+		SSHUser:      "root",
+		Cover:        true,
+		Reproduce:    true,
+		Sandbox:      "none",
+		RPC:          ":0",
+		MaxCrashLogs: 100,
+		Procs:        6,
 	}
 }
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -728,12 +728,13 @@ func (mgr *Manager) saveCrash(crash *Crash) bool {
 	if err := osutil.WriteFile(filepath.Join(dir, "description"), []byte(crash.Title+"\n")); err != nil {
 		log.Logf(0, "failed to write crash: %v", err)
 	}
-	// Save up to 100 reports. If we already have 100, overwrite the oldest one.
+
+	// Save up to mgr.cfg.MaxCrashLogs reports, overwrite the oldest once we've reached that number.
 	// Newer reports are generally more useful. Overwriting is also needed
 	// to be able to understand if a particular bug still happens or already fixed.
 	oldestI := 0
 	var oldestTime time.Time
-	for i := 0; i < 100; i++ {
+	for i := 0; i < mgr.cfg.MaxCrashLogs; i++ {
 		info, err := os.Stat(filepath.Join(dir, fmt.Sprintf("log%v", i)))
 		if err != nil {
 			oldestI = i


### PR DESCRIPTION
This doesn't change any current behaviour, but makes it possible to keep arbitrarily many crash logs.
