### PR TITLE
all: add KernelModule cfg to show DLKM coverage

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -17,9 +17,8 @@ type Impl struct {
 	Units     []*CompileUnit
 	Symbols   []*Symbol
 	Frames    []Frame
-	Symbolize func(pcs []uint64, obj string) ([]Frame, error)
+	Symbolize func(pcs []uint64) ([]Frame, error)
 	RestorePC func(pc uint32) uint64
-	Modules   []*KernelModule
 }
 
 type CompileUnit struct {
@@ -65,10 +64,4 @@ func Make(target *targets.Target, vm, srcDir, buildDir string,
 		return makeGvisor(target, srcDir, buildDir, modules)
 	}
 	return makeELF(target, srcDir, buildDir, moduleObj, modules)
-}
-
-var GroupPCsByModule = func(pcs []uint64, modules []*KernelModule) map[*KernelModule][]uint64 {
-	groupPCs := make(map[*KernelModule][]uint64)
-	groupPCs[modules[0]] = pcs
-	return groupPCs
 }

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -7,18 +7,18 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 )
 
-type KernelModule struct {
-	Name string
-	Path string
-	Addr uint64
-}
-
 type Impl struct {
 	Units     []*CompileUnit
 	Symbols   []*Symbol
 	Frames    []Frame
 	Symbolize func(pcs []uint64) ([]Frame, error)
 	RestorePC func(pc uint32) uint64
+}
+
+type Module struct {
+	Name string
+	Path string
+	Addr uint64
 }
 
 type CompileUnit struct {
@@ -42,7 +42,7 @@ type ObjectUnit struct {
 }
 
 type Frame struct {
-	Module *KernelModule
+	Module *Module
 	PC     uint64
 	Name   string
 	Path   string
@@ -59,7 +59,7 @@ type Range struct {
 const LineEnd = 1 << 30
 
 func Make(target *targets.Target, vm, srcDir, buildDir string,
-	moduleObj []string, modules []*KernelModule) (*Impl, error) {
+	moduleObj []string, modules []*Module) (*Impl, error) {
 	if vm == "gvisor" {
 		return makeGvisor(target, srcDir, buildDir, modules)
 	}

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -11,7 +11,7 @@ type Impl struct {
 	Units     []*CompileUnit
 	Symbols   []*Symbol
 	Frames    []Frame
-	Symbolize func(pcs []uint64) ([]Frame, error)
+	Symbolize func(pcs map[*Module][]uint64) ([]Frame, error)
 	RestorePC func(pc uint32) uint64
 }
 
@@ -28,6 +28,7 @@ type CompileUnit struct {
 
 type Symbol struct {
 	ObjectUnit
+	Module     *Module
 	Unit       *CompileUnit
 	Start      uint64
 	End        uint64

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -4,6 +4,9 @@
 package backend
 
 import (
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -59,10 +62,13 @@ type Range struct {
 
 const LineEnd = 1 << 30
 
-func Make(target *targets.Target, vm, srcDir, buildDir string,
-	moduleObj []string, modules []*Module) (*Impl, error) {
-	if vm == "gvisor" {
-		return makeGvisor(target, srcDir, buildDir, modules)
+func Make(target *targets.Target, vm, objDir, srcDir, buildDir string,
+	moduleObj []string, modules []host.KernelModule) (*Impl, error) {
+	if objDir == "" {
+		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
-	return makeELF(target, srcDir, buildDir, moduleObj, modules)
+	if vm == "gvisor" {
+		return makeGvisor(target, objDir, srcDir, buildDir, modules)
+	}
+	return makeELF(target, objDir, srcDir, buildDir, moduleObj, modules)
 }

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -99,7 +99,7 @@ func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
 			continue // drop the unit
 		}
 		// TODO: objDir won't work for out-of-tree modules.
-		unit.Name, unit.Path = cleanPath(unit.Name, objDir, srcDir, buildDir)
+		unit.Name, unit.Path = cleanPath(unit.Name, srcDir, buildDir)
 		allUnits[nunit] = unit
 		nunit++
 	}
@@ -370,7 +370,6 @@ func symbolizeModule(target *targets.Target, srcDir, buildDir string, mod *Modul
 		i = end
 	}
 	close(pcchan)
-	objDir := filepath.Dir(mod.Path)
 	var err0 error
 	var frames []Frame
 	for p := 0; p < procs; p++ {
@@ -379,7 +378,7 @@ func symbolizeModule(target *targets.Target, srcDir, buildDir string, mod *Modul
 			err0 = res.err
 		}
 		for _, frame := range res.frames {
-			name, path := cleanPath(frame.File, objDir, srcDir, buildDir)
+			name, path := cleanPath(frame.File, srcDir, buildDir)
 			frames = append(frames, Frame{
 				Module: mod,
 				PC:     frame.PC + mod.Addr,
@@ -536,13 +535,9 @@ func parseLine(callInsns, traceFuncs [][]byte, ln []byte) uint64 {
 	return pc
 }
 
-func cleanPath(path, objDir, srcDir, buildDir string) (string, string) {
+func cleanPath(path, srcDir, buildDir string) (string, string) {
 	filename := ""
 	switch {
-	case strings.HasPrefix(path, objDir):
-		// Assume the file was built there.
-		path = strings.TrimPrefix(path, objDir)
-		filename = filepath.Join(objDir, path)
 	case strings.HasPrefix(path, buildDir):
 		// Assume the file was moved from buildDir to srcDir.
 		path = strings.TrimPrefix(path, buildDir)

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -303,9 +303,6 @@ func readTextRanges(file *elf.File, module *Module) ([]pcRange, []*CompileUnit, 
 		}
 		r.SkipChildren()
 	}
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].start < ranges[j].start
-	})
 	return ranges, units, nil
 }
 

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -435,19 +435,17 @@ func symbolize(target *targets.Target, srcDir, buildDir string, modules []*Kerne
 	})
 	for _, pc := range pcs {
 		if pc > smodules[0].Addr {
-			if smodules[0].Name == "" {
-				groupPCs[smodules[0]] = append(groupPCs[smodules[0]], pc)
-			} else {
-				groupPCs[smodules[0]] = append(groupPCs[smodules[0]], pc-smodules[0].Addr)
+			if smodules[0].Name != "" {
+				pc -= smodules[0].Addr
 			}
+			groupPCs[smodules[0]] = append(groupPCs[smodules[0]], pc)
 		} else {
 			for i := 0; i < len(modules)-1; i++ {
 				if pc < smodules[i].Addr && pc >= smodules[i+1].Addr {
-					if smodules[i+1].Name == "" {
-						groupPCs[smodules[i+1]] = append(groupPCs[smodules[i+1]], pc)
-					} else {
-						groupPCs[smodules[i+1]] = append(groupPCs[smodules[i+1]], pc-smodules[i+1].Addr)
+					if smodules[i+1].Name != "" {
+						pc -= smodules[i+1].Addr
 					}
+					groupPCs[smodules[i+1]] = append(groupPCs[smodules[i+1]], pc)
 					break
 				}
 			}

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -133,110 +132,6 @@ func makeELF(target *targets.Target, srcDir, buildDir string,
 		},
 	}
 	return impl, nil
-}
-
-func getModules(dirs []string, modules []*Module) {
-	byName := make(map[string]*Module)
-	for _, mod := range modules {
-		byName[mod.Name] = mod
-	}
-	files := findModulePaths(dirs)
-	for _, path := range files {
-		name := strings.TrimSuffix(filepath.Base(path), ".ko")
-		if module := byName[name]; module != nil {
-			if module.Path != "" {
-				continue
-			}
-			module.Path = path
-			continue
-		}
-		name, err := getModuleName(path)
-		if err != nil {
-			log.Logf(0, "failed to get module name for %v: %v", path, err)
-			continue
-		}
-		if name == "" {
-			continue
-		}
-		if module := byName[name]; module != nil {
-			if module.Path != "" {
-				continue
-			}
-			module.Path = path
-		}
-	}
-	log.Logf(0, "kernel modules: %v", modules)
-}
-
-func findModulePaths(dirs []string) []string {
-	var files []string
-	for _, path := range dirs {
-		mfiles, err := walkModulePath(path)
-		if err != nil {
-			log.Logf(0, "failed to find modules in %v: %v", path, err)
-			continue
-		}
-		files = append(files, mfiles...)
-	}
-	return files
-}
-
-func walkModulePath(dir string) ([]string, error) {
-	files := []string{}
-	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-		if filepath.Ext(path) == ".ko" {
-			files = append(files, path)
-		}
-		return nil
-	})
-	return files, err
-}
-
-func getModuleName(path string) (string, error) {
-	file, err := elf.Open(path)
-	if err != nil {
-		return "", fmt.Errorf("failed to open %v: %v", path, err)
-	}
-	defer file.Close()
-	section := file.Section(".modinfo")
-	if section == nil {
-		return "", fmt.Errorf("no .modinfo section")
-	}
-	data, err := section.Data()
-	if err != nil {
-		return "", fmt.Errorf("failed to read .modinfo")
-	}
-	name := searchModuleName(data)
-	if name == "" {
-		section = file.Section(".gnu.linkonce.this_module")
-		if section == nil {
-			return "", fmt.Errorf("no .gnu.linkonce.this_module section")
-		}
-		data, err = section.Data()
-		if err != nil {
-			return "", fmt.Errorf("failed to read .gnu.linkonce.this_module: %v", err)
-		}
-		name = string(data)
-	}
-	return name, nil
-}
-
-func searchModuleName(data []byte) string {
-	data = append([]byte{0}, data...)
-	key := []byte("\x00name=")
-	pos := bytes.Index(data, key)
-	if pos == -1 {
-		return ""
-	}
-	end := bytes.IndexByte(data[pos+len(key):], 0)
-	if end == -1 {
-		return ""
-	}
-	end = pos + len(key) + end
-	if end > len(data) {
-		return ""
-	}
-	return string(data[pos+len(key) : end])
 }
 
 type pcRange struct {

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -351,11 +351,12 @@ func readTextRanges(file *elf.File, module *Module) ([]pcRange, []*CompileUnit, 
 	}
 	kaslr := file.Section(".rela.text") != nil
 	debugInfo, err := file.DWARF()
-	if err != nil && module.Name == "" {
+	if err != nil {
+		if module.Name != "" {
+			log.Logf(0, "ignoring module %v without DEBUG_INFO", module.Name)
+			return nil, nil, nil
+		}
 		return nil, nil, fmt.Errorf("failed to parse DWARF: %v (set CONFIG_DEBUG_INFO=y?)", err)
-	} else if err != nil {
-		log.Logf(0, "ignore module %v which doesn't have DEBUG_INFO", module.Name)
-		return nil, nil, nil
 	}
 	var ranges []pcRange
 	var units []*CompileUnit

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -10,15 +10,16 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func makeGvisor(target *targets.Target, srcDir, buildDir string, modules []*Module) (*Impl, error) {
-	if len(modules) != 1 {
+func makeGvisor(target *targets.Target, objDir, srcDir, buildDir string, modules []host.KernelModule) (*Impl, error) {
+	if len(modules) != 0 {
 		return nil, fmt.Errorf("gvisor coverage does not support modules")
 	}
-	bin := modules[0].Path
+	bin := filepath.Join(objDir, target.KernelObject)
 	// pkg/build stores runsc as 'vmlinux' (we pretent to be linux), but a local build will have it as 'runsc'.
 	if !osutil.IsExist(bin) {
 		bin = filepath.Join(filepath.Dir(bin), "runsc")

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func makeGvisor(target *targets.Target, srcDir, buildDir string, modules []*KernelModule) (*Impl, error) {
+func makeGvisor(target *targets.Target, srcDir, buildDir string, modules []*Module) (*Impl, error) {
 	if len(modules) != 1 {
 		return nil, fmt.Errorf("gvisor coverage does not support modules")
 	}

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -1,0 +1,119 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/log"
+)
+
+func getModules(dirs []string, modules []*Module) {
+	byName := make(map[string]*Module)
+	for _, mod := range modules {
+		byName[mod.Name] = mod
+	}
+	files := findModulePaths(dirs)
+	for _, path := range files {
+		name := strings.TrimSuffix(filepath.Base(path), ".ko")
+		if module := byName[name]; module != nil {
+			if module.Path != "" {
+				continue
+			}
+			module.Path = path
+			continue
+		}
+		name, err := getModuleName(path)
+		if err != nil {
+			log.Logf(0, "failed to get module name for %v: %v", path, err)
+			continue
+		}
+		if name == "" {
+			continue
+		}
+		if module := byName[name]; module != nil {
+			if module.Path != "" {
+				continue
+			}
+			module.Path = path
+		}
+	}
+	log.Logf(0, "kernel modules: %v", modules)
+}
+
+func findModulePaths(dirs []string) []string {
+	var files []string
+	for _, path := range dirs {
+		mfiles, err := walkModulePath(path)
+		if err != nil {
+			log.Logf(0, "failed to find modules in %v: %v", path, err)
+			continue
+		}
+		files = append(files, mfiles...)
+	}
+	return files
+}
+
+func walkModulePath(dir string) ([]string, error) {
+	files := []string{}
+	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".ko" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+func getModuleName(path string) (string, error) {
+	file, err := elf.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %v: %v", path, err)
+	}
+	defer file.Close()
+	section := file.Section(".modinfo")
+	if section == nil {
+		return "", fmt.Errorf("no .modinfo section")
+	}
+	data, err := section.Data()
+	if err != nil {
+		return "", fmt.Errorf("failed to read .modinfo")
+	}
+	name := searchModuleName(data)
+	if name == "" {
+		section = file.Section(".gnu.linkonce.this_module")
+		if section == nil {
+			return "", fmt.Errorf("no .gnu.linkonce.this_module section")
+		}
+		data, err = section.Data()
+		if err != nil {
+			return "", fmt.Errorf("failed to read .gnu.linkonce.this_module: %v", err)
+		}
+		name = string(data)
+	}
+	return name, nil
+}
+
+func searchModuleName(data []byte) string {
+	data = append([]byte{0}, data...)
+	key := []byte("\x00name=")
+	pos := bytes.Index(data, key)
+	if pos == -1 {
+		return ""
+	}
+	end := bytes.IndexByte(data[pos+len(key):], 0)
+	if end == -1 {
+		return ""
+	}
+	end = pos + len(key) + end
+	if end > len(data) {
+		return ""
+	}
+	return string(data[pos+len(key) : end])
+}

--- a/pkg/cover/backend/modules_test.go
+++ b/pkg/cover/backend/modules_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"flag"
+	"testing"
+)
+
+var flagModuleDir = flag.String("module_dir", "", "directory to discover modules")
+
+func TestLocateModules(t *testing.T) {
+	// Dump modules discovered in a dir, not really an automated test, use as:
+	// go test -run TestLocateModules -v ./pkg/cover/backend -module_dir=/linux/build/dir
+	if *flagModuleDir == "" {
+		t.Skip("no module dir specified")
+	}
+	paths, err := locateModules([]string{*flagModuleDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, path := range paths {
+		t.Logf("%32v -> %v", name, path)
+	}
+}

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -6,11 +6,6 @@ package cover
 
 type Cover map[uint32]struct{}
 
-type Subsystem struct {
-	Name  string   `json:"name"`
-	Paths []string `json:"path"`
-}
-
 func (cov *Cover) Merge(raw []uint32) {
 	c := *cov
 	if c == nil {

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/cover/backend"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
 func (rg *ReportGenerator) DoHTML(w io.Writer, progs []Prog) error {
@@ -199,7 +200,7 @@ func (rg *ReportGenerator) DoCSVFiles(w io.Writer, progs []Prog) error {
 	return writer.WriteAll(d)
 }
 
-func groupCoverByFilePrefixes(datas []fileStats, subsystems []Subsystem) map[string]map[string]string {
+func groupCoverByFilePrefixes(datas []fileStats, subsystems []mgrconfig.Subsystem) map[string]map[string]string {
 	d := make(map[string]map[string]string)
 
 	for _, subsystem := range subsystems {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/google/syzkaller/pkg/cover/backend"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -16,7 +17,7 @@ type ReportGenerator struct {
 	srcDir    string
 	objDir    string
 	buildDir  string
-	subsystem []Subsystem
+	subsystem []mgrconfig.Subsystem
 	*backend.Impl
 }
 
@@ -27,13 +28,13 @@ type Prog struct {
 
 var RestorePC = backend.RestorePC
 
-func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string,
-	subsystem []Subsystem, moduleObj []string, modules map[string]backend.KernelModule) (*ReportGenerator, error) {
+func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string, subsystem []mgrconfig.Subsystem,
+	moduleObj []string, modules map[string]backend.KernelModule) (*ReportGenerator, error) {
 	impl, err := backend.Make(target, vm, objDir, srcDir, buildDir, moduleObj, modules)
 	if err != nil {
 		return nil, err
 	}
-	subsystem = append(subsystem, Subsystem{
+	subsystem = append(subsystem, mgrconfig.Subsystem{
 		Name:  "all",
 		Paths: []string{""},
 	})

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -35,13 +35,13 @@ func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir st
 		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
 	moduleObj = append([]string{objDir}, moduleObj...)
-	modules := []*backend.KernelModule{
+	modules := []*backend.Module{
 		{
 			Path: filepath.Join(objDir, target.KernelObject),
 		},
 	}
 	for _, mod := range hostModules {
-		modules = append(modules, &backend.KernelModule{
+		modules = append(modules, &backend.Module{
 			Name: mod.Name,
 			Addr: mod.Addr,
 		})

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -5,7 +5,6 @@ package cover
 
 import (
 	"fmt"
-	"path/filepath"
 	"sort"
 
 	"github.com/google/syzkaller/pkg/cover/backend"
@@ -30,23 +29,8 @@ type Prog struct {
 var RestorePC = backend.RestorePC
 
 func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string, subsystem []mgrconfig.Subsystem,
-	moduleObj []string, hostModules []host.KernelModule) (*ReportGenerator, error) {
-	if objDir == "" {
-		return nil, fmt.Errorf("kernel obj directory is not specified")
-	}
-	moduleObj = append([]string{objDir}, moduleObj...)
-	modules := []*backend.Module{
-		{
-			Path: filepath.Join(objDir, target.KernelObject),
-		},
-	}
-	for _, mod := range hostModules {
-		modules = append(modules, &backend.Module{
-			Name: mod.Name,
-			Addr: mod.Addr,
-		})
-	}
-	impl, err := backend.Make(target, vm, srcDir, buildDir, moduleObj, modules)
+	moduleObj []string, modules []host.KernelModule) (*ReportGenerator, error) {
+	impl, err := backend.Make(target, vm, objDir, srcDir, buildDir, moduleObj, modules)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -195,19 +195,11 @@ func (rg *ReportGenerator) lazySymbolize(progs []Prog) error {
 	if len(pcs) == 0 {
 		return nil
 	}
-	for mod, pcs := range backend.GroupPCsByModule(pcs, rg.Modules) {
-		if len(pcs) == 0 {
-			continue
-		}
-		frames, err := rg.Symbolize(pcs, mod.Path)
-		if err != nil {
-			return err
-		}
-		for i := range frames {
-			frames[i].Module = mod
-		}
-		rg.Frames = append(rg.Frames, frames...)
+	frames, err := rg.Symbolize(pcs)
+	if err != nil {
+		return err
 	}
+	rg.Frames = append(rg.Frames, frames...)
 	for sym := range symbolize {
 		sym.Symbolized = true
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -190,7 +190,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 		},
 	}
 
-	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem)
+	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, make(map[string]backend.KernelModule))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/cover/backend"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/symbolizer"
 	_ "github.com/google/syzkaller/sys"
@@ -180,7 +181,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 	}
 	defer os.RemoveAll(dir)
 	bin := buildTestBinary(t, target, test, dir)
-	subsystem := []Subsystem{
+	subsystem := []mgrconfig.Subsystem{
 		{
 			Name: "sound",
 			Paths: []string{

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -191,7 +191,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 		},
 	}
 
-	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, make(map[string]backend.KernelModule))
+	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -26,9 +26,19 @@ func CollectMachineInfo() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func CollectModulesInfo() ([]KernelModule, error) {
+	return machineModulesInfo()
+}
+
 var machineInfoFuncs []machineInfoFunc
+var machineModulesInfo func() ([]KernelModule, error)
 
 type machineInfoFunc struct {
 	name string
 	fn   func(*bytes.Buffer) error
+}
+
+type KernelModule struct {
+	Name string
+	Addr uint64
 }

--- a/pkg/host/machine_info_linux.go
+++ b/pkg/host/machine_info_linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -124,14 +125,13 @@ func readKVMInfo(buffer *bytes.Buffer) error {
 }
 
 func getModulesInfo() ([]KernelModule, error) {
-	var addr uint64
 	var modules []KernelModule
 	modulesText, _ := ioutil.ReadFile("/proc/modules")
 	re := regexp.MustCompile(`(\w+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
-	matches := re.FindAllSubmatch(modulesText, -1)
-	for _, m := range matches {
-		if _, err := fmt.Sscanf(strings.TrimPrefix(strings.ToLower(string(m[2])), "0x"), "%x", &addr); err != nil {
-			return nil, fmt.Errorf("address parsing error in /proc/modules")
+	for _, m := range re.FindAllSubmatch(modulesText, -1) {
+		addr, err := strconv.ParseUint(string(m[2]), 0, 64)
+		if err != nil {
+			return nil, fmt.Errorf("address parsing error in /proc/modules: %v", err)
 		}
 		modules = append(modules, KernelModule{
 			Name: string(m[1]),

--- a/pkg/host/machine_info_linux_test.go
+++ b/pkg/host/machine_info_linux_test.go
@@ -143,6 +143,14 @@ D:	d
 	}
 }
 
+func TestGetModulesInfo(t *testing.T) {
+	modules, err := getModulesInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("modules:\n%v", modules)
+}
+
 type cannedTest struct {
 	arch string
 	data string

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -5,6 +5,7 @@ package mgrconfig
 
 import (
 	"encoding/json"
+
 	"github.com/google/syzkaller/pkg/cover"
 )
 
@@ -38,8 +39,11 @@ type Config struct {
 	//	"qemu_args": "-fda {{TEMPLATE}}/fd"
 	WorkdirTemplate string `json:"workdir_template"`
 	// Directory with kernel object files (e.g. `vmlinux` for linux)
-	// (used for report symbolization and coverage reports, optional).
+	// (used for report symbolization, coverage reports and in tree modules finding, optional).
 	KernelObj string `json:"kernel_obj"`
+	// Directories for unstripped kernel module object files (optional)
+	// It's needed for out-of-tree module build in order to find ko files automatically
+	ModuleObj []string `json:"module_obj"`
 	// Kernel source directory (if not set defaults to KernelObj).
 	KernelSrc string `json:"kernel_src,omitempty"`
 	// Location of the driectory where the kernel was built (if not set defaults to KernelSrc)

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -5,8 +5,6 @@ package mgrconfig
 
 import (
 	"encoding/json"
-
-	"github.com/google/syzkaller/pkg/cover"
 )
 
 type Config struct {
@@ -55,7 +53,7 @@ type Config struct {
 	//		{ "name": "sound", "path": ["sound", "techpack/audio"]},
 	//		{ "name": "mydriver": "path": ["mydriver_path"]}
 	//	]
-	KernelSubsystem []cover.Subsystem `json:"kernel_subsystem,omitempty"`
+	KernelSubsystem []Subsystem `json:"kernel_subsystem,omitempty"`
 	// Arbitrary optional tag that is saved along with crash reports (e.g. branch/commit).
 	Tag string `json:"tag,omitempty"`
 	// Location of the disk image file.
@@ -158,6 +156,11 @@ type Config struct {
 
 	// Implementation details beyond this point. Filled after parsing.
 	Derived `json:"-"`
+}
+
+type Subsystem struct {
+	Name  string   `json:"name"`
+	Paths []string `json:"path"`
 }
 
 type covFilterCfg struct {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -41,8 +41,10 @@ type Config struct {
 	// Directory with kernel object files (e.g. `vmlinux` for linux)
 	// (used for report symbolization, coverage reports and in tree modules finding, optional).
 	KernelObj string `json:"kernel_obj"`
-	// Directories for unstripped kernel module object files (optional)
-	// It's needed for out-of-tree module build in order to find ko files automatically
+	// Directories with out-of-free kernel module object files (optional).
+	// KernelObj is also scanned for in-tree kernel modules and does not need to be duplicated here.
+	// Note: KASLR needs to be disabled and modules need to be pre-loaded at fixed addressses by init process.
+	// Note: the modules need to be unstripped and contain debug info.
 	ModuleObj []string `json:"module_obj"`
 	// Kernel source directory (if not set defaults to KernelObj).
 	KernelSrc string `json:"kernel_src,omitempty"`

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -27,17 +27,18 @@ type RPCCandidate struct {
 type ConnectArgs struct {
 	Name        string
 	MachineInfo []byte
+	Modules     []host.KernelModule
 }
 
 type ConnectRes struct {
-	EnabledCalls       []int
-	GitRevision        string
-	TargetRevision     string
-	AllSandboxes       bool
-	CheckResult        *CheckArgs
-	MemoryLeakFrames   []string
-	DataRaceFrames     []string
-	EnabledCoverFilter bool
+	EnabledCalls      []int
+	GitRevision       string
+	TargetRevision    string
+	AllSandboxes      bool
+	CheckResult       *CheckArgs
+	MemoryLeakFrames  []string
+	DataRaceFrames    []string
+	CoverFilterBitmap []byte
 }
 
 type CheckArgs struct {

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -7,19 +7,21 @@ import (
 	"sync"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
-var getReportGenerator = func() func(cfg *mgrconfig.Config) (*cover.ReportGenerator, error) {
+var getReportGenerator = func() func(cfg *mgrconfig.Config,
+	modules map[string]backend.KernelModule) (*cover.ReportGenerator, error) {
 	var once sync.Once
 	var rg *cover.ReportGenerator
 	var err error
-	return func(cfg *mgrconfig.Config) (*cover.ReportGenerator, error) {
+	return func(cfg *mgrconfig.Config, modules map[string]backend.KernelModule) (*cover.ReportGenerator, error) {
 		once.Do(func() {
 			log.Logf(0, "initializing coverage information...")
 			rg, err = cover.MakeReportGenerator(cfg.SysTarget, cfg.Type, cfg.KernelObj, cfg.KernelSrc,
-				cfg.KernelBuildSrc, cfg.KernelSubsystem)
+				cfg.KernelBuildSrc, cfg.KernelSubsystem, cfg.ModuleObj, modules)
 		})
 		return rg, err
 	}

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -7,17 +7,17 @@ import (
 	"sync"
 
 	"github.com/google/syzkaller/pkg/cover"
-	"github.com/google/syzkaller/pkg/cover/backend"
+	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
 var getReportGenerator = func() func(cfg *mgrconfig.Config,
-	modules map[string]backend.KernelModule) (*cover.ReportGenerator, error) {
+	modules []host.KernelModule) (*cover.ReportGenerator, error) {
 	var once sync.Once
 	var rg *cover.ReportGenerator
 	var err error
-	return func(cfg *mgrconfig.Config, modules map[string]backend.KernelModule) (*cover.ReportGenerator, error) {
+	return func(cfg *mgrconfig.Config, modules []host.KernelModule) (*cover.ReportGenerator, error) {
 		once.Do(func() {
 			log.Logf(0, "initializing coverage information...")
 			rg, err = cover.MakeReportGenerator(cfg.SysTarget, cfg.Type, cfg.KernelObj, cfg.KernelSrc,

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
@@ -67,7 +68,8 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	rg, err := cover.MakeReportGenerator(target, *flagVM, *flagKernelObj, *flagKernelSrc, *flagKernelBuildSrc, nil)
+	rg, err := cover.MakeReportGenerator(target, *flagVM, *flagKernelObj,
+		*flagKernelSrc, *flagKernelBuildSrc, nil, nil, make(map[string]backend.KernelModule))
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/cover"
-	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
@@ -69,7 +68,7 @@ func main() {
 		tool.Fail(err)
 	}
 	rg, err := cover.MakeReportGenerator(target, *flagVM, *flagKernelObj,
-		*flagKernelSrc, *flagKernelBuildSrc, nil, nil, make(map[string]backend.KernelModule))
+		*flagKernelSrc, *flagKernelBuildSrc, nil, nil, nil)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
PC returned for dynamic loaded module (DLKM) is not
parsed in coverage page.
So the commit is to use DLKM modules' load address
to restore the PC and show coverage data of DLKM.

As the load address is written in cfg file, so kaslr
needs to be disabled.
And for linux target, load address is getting from
/proc/modules during instance setup.

For either manual or auto address setting case,
name and path are needed in config kernel_modules, where

name is module name on target.
path is module unstripped object path on host.
addr is decimal value of module load address on target.

Example of config:
 "kernel_modules": [
  {
    "name": "nf_nat",
    "path": "/usr/src/linux-source/net/netfilter/nf_nat.ko",
    "addr": 18446744072637911040
  }
 ]

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
