### PR TITLE
executor, syz-fuzzer: fix readonly root

### DIFF
--- a/executor/cov_filter.h
+++ b/executor/cov_filter.h
@@ -14,13 +14,13 @@ struct cov_filter_t {
 
 static cov_filter_t* cov_filter;
 
-static void init_coverage_filter()
+static void init_coverage_filter(char* filename)
 {
-	int f = open("/syz-cover-bitmap", O_RDONLY);
+	int f = open(filename, O_RDONLY);
 	if (f < 0) {
 		// We don't fail here because we don't know yet if we should use coverage filter or not.
 		// We will receive the flag only in execute flags and will fail in coverage_filter if necessary.
-		debug("bitmap is no found, coverage filter disabled\n");
+		debug("bitmap is not found, coverage filter disabled\n");
 		return;
 	}
 	struct stat st;
@@ -55,7 +55,7 @@ static bool coverage_filter(uint64 pc)
 }
 
 #else
-static void init_coverage_filter()
+static void init_coverage_filter(char* filename)
 {
 }
 #endif

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -444,7 +444,17 @@ int main(int argc, char** argv)
 			// Don't enable comps because we don't use them in the fuzzer yet.
 			cover_enable(&extra_cov, false, true);
 		}
-		init_coverage_filter();
+		char sep = '/';
+#if GOOS_windows
+		sep = '\\';
+#endif
+		char filename[1024] = {0};
+		char* end = strrchr(argv[0], sep);
+		size_t len = end - argv[0];
+		strncpy(filename, argv[0], len + 1);
+		strncat(filename, "syz-cover-bitmap", 17);
+		filename[sizeof(filename) - 1] = '\0';
+		init_coverage_filter(filename);
 	}
 
 	int status = 0;

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -206,8 +206,8 @@ func main() {
 		log.Fatal(err)
 	}
 	if r.CoverFilterBitmap != nil {
-		if err := osutil.WriteFile("/syz-cover-bitmap", r.CoverFilterBitmap); err != nil {
-			log.Fatalf("failed to write /syz-cover-bitmap: %v", err)
+		if err := osutil.WriteFile("syz-cover-bitmap", r.CoverFilterBitmap); err != nil {
+			log.Fatalf("failed to write syz-cover-bitmap: %v", err)
 		}
 	}
 	if r.CheckResult == nil {


### PR DESCRIPTION
Some target device has ro rootfs, when cover filter enabled,
syz-fuzzer will crash.
So use TMPDIR to store syz-cover-bitmap file.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
