### PR TITLE
docs: fix scp command in instructions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Heyuan Shi
 Christian Brauner
 Johannes Wellhöfer
 Microsoft Corporation
+Muhammad Usama Anjum

--- a/docs/executing_syzkaller_programs.md
+++ b/docs/executing_syzkaller_programs.md
@@ -25,7 +25,7 @@ $ make
 4. Copy binaries and the program to test machine (substitue target `linux_amd64`
 as necessary):
 ``` bash
-$ scp bin/linux_amd64/syz-execprog bin/linux_amd64/syz-executor program test@machine
+$ scp -P 10022 -i stretch.img.key bin/linux_amd64/syz-execprog bin/linux_amd64/syz-executor program root@localhost:
 ```
 
 5. Run the program on the test machine:


### PR DESCRIPTION
'scp' command needs 10022 port number specified to establish connection
over which vm is listening. If it isn't specified, scp tries to connect
over port 22 and connection fails.

The other docs write machine as 'root@localhost'. Replace it here to
avoid confusion.

Collon is necessary at the end for the command to work.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
