### PR TITLE
syz-manager, executor: fix out-of-bound access

### DIFF
--- a/executor/cov_filter.h
+++ b/executor/cov_filter.h
@@ -31,7 +31,7 @@ static void init_coverage_filter(char* filename)
 	cov_filter = (cov_filter_t*)mmap(preferred, st.st_size, PROT_READ, MAP_PRIVATE, f, 0);
 	if (cov_filter != preferred)
 		failmsg("failed to mmap coverage filter bitmap", "want=%p, got=%p", preferred, cov_filter);
-	if ((uint32)st.st_size != sizeof(uint32) * 2 + ((cov_filter->pcsize >> 4) + 7) / 8)
+	if ((uint32)st.st_size != sizeof(uint32) * 2 + ((cov_filter->pcsize >> 4) / 8 + 1))
 		fail("bad coverage filter bitmap size");
 	close(f);
 }

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -134,9 +134,9 @@ func createCoverageBitmap(target *targets.Target, pcs map[uint32]uint32) []byte 
 	start, size := coverageFilterRegion(pcs)
 	log.Logf(0, "coverage filter from 0x%x to 0x%x, size 0x%x, pcs %v", start, start+size, size, len(pcs))
 	// The file starts with two uint32: covFilterStart and covFilterSize,
-	// and a bitmap with size ((covFilterSize>>4) + 7)/8 bytes follow them.
-	// 8-bit = 1-byte, additional 1-byte to prevent overflow
-	data := make([]byte, 8+((size>>4)+7)/8)
+	// and a bitmap with size ((covFilterSize>>4)/8+1 bytes follow them.
+	// 8-bit = 1-byte
+	data := make([]byte, 8+((size>>4)/8+1))
 	order := binary.ByteOrder(binary.BigEndian)
 	if target.LittleEndian {
 		order = binary.LittleEndian
@@ -163,9 +163,6 @@ func coverageFilterRegion(pcs map[uint32]uint32) (uint32, uint32) {
 			end = pc
 		}
 	}
-	// align
-	start &= ^uint32(0xf)
-	end = (end + 0xf) &^ uint32(0xf)
 	return start, end - start
 }
 

--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -19,7 +19,7 @@ func TestCreateBitmap(t *testing.T) {
 	bitmap := createCoverageBitmap(target, pcs)
 	start := order.Uint32(bitmap[0:])
 	size := order.Uint32(bitmap[4:])
-	if start != 0x81000000 || size != 0x200020 {
+	if start != 0x81000002 || size != 0x20001b {
 		t.Fatalf("bad region 0x%x/0x%x", start, size)
 	}
 	for i, byte := range bitmap[8:] {
@@ -34,4 +34,20 @@ func TestCreateBitmap(t *testing.T) {
 			t.Errorf("bad bitmap byte 0x%x: 0x%x, expect 0x%x", i, byte, expect)
 		}
 	}
+	pcs = map[uint32]uint32{
+		0:          1,
+		0xffffffff: 1,
+	}
+	createCoverageBitmap(target, pcs)
+	pcs = map[uint32]uint32{
+		0x81000000: 1,
+		0x81000100: 1,
+	}
+	createCoverageBitmap(target, pcs)
+	pcs = map[uint32]uint32{
+		0x81000002: 1,
+		0x81000010: 1,
+		0x81000102: 1,
+	}
+	createCoverageBitmap(target, pcs)
 }


### PR DESCRIPTION
There is an out-of-bound array access when cov filter enabled.
1 byte less is allocated

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
