### PR TITLE
syz-fuzzer, executor: add shared file descriptor

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -9,7 +9,7 @@ arg = argname type
 argname = identifier
 type = typename [ "[" type-options "]" ]
 typename = "const" | "intN" | "intptr" | "flags" | "array" | "ptr" |
-	   "string" | "strconst" | "filename" | "len" |
+	   "string" | "strconst" | "filename" | "dirname" | "len" |
 	   "bytesize" | "bytesizeN" | "bitsize" | "vma" | "proc"
 type-options = [type-opt ["," type-opt]]
 ```
@@ -38,6 +38,7 @@ rest of the type-options are type-specific:
 "string": a zero-terminated memory buffer (no pointer indirection implied), type-options:
 	either a string value in quotes for constant strings (e.g. "foo" or `deadbeef` for hex literal),
 	or a reference to string flags (special value `filename` produces file names),
+        or a dirname prefix to pick random file from vm,
 	optionally followed by a buffer size (string values will be padded with \x00 to that size)
 "stringnoz": a non-zero-terminated memory buffer (no pointer indirection implied), type-options:
 	either a string value in quotes for constant strings (e.g. "foo" or `deadbeef` for hex literal),

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -601,7 +601,7 @@ const (
 )
 
 var typeString = &typeDesc{
-	Names:        []string{"string", stringnoz},
+	Names:        []string{"string", "dirname", stringnoz},
 	CanBeTypedef: true,
 	OptArgs:      2,
 	Args: []namedArg{
@@ -643,6 +643,16 @@ var typeString = &typeDesc{
 				TypeCommon: base.TypeCommon,
 				Kind:       prog.BufferFilename,
 				NoZ:        t.Ident == stringnoz,
+			}
+		}
+		if len(args) > 0 && t.Ident == "dirname" {
+			base.TypeSize = comp.stringSize(t, args)
+			vals := []string{args[0].String}
+			return &prog.BufferType{
+				TypeCommon: base.TypeCommon,
+				Kind:       prog.BufferDirname,
+				Values:     vals,
+				NoZ:        false,
 			}
 		}
 		subkind := ""

--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -38,8 +38,16 @@ func CollectModulesInfo() ([]KernelModule, error) {
 	return machineModulesInfo()
 }
 
+func CollectDirsInfo() ([]string, error) {
+	if machineModulesInfo == nil {
+		return nil, nil
+	}
+	return machineDirsInfo()
+}
+
 var machineInfoFuncs []machineInfoFunc
 var machineModulesInfo func() ([]KernelModule, error)
+var machineDirsInfo func() ([]string, error)
 
 type machineInfoFunc struct {
 	name string

--- a/prog/analysis.go
+++ b/prog/analysis.go
@@ -21,6 +21,7 @@ type state struct {
 	strings   map[string]bool
 	ma        *memAlloc
 	va        *vmaAlloc
+	listFiles []string
 }
 
 // analyze analyzes the program p up to but not including call c.
@@ -82,7 +83,7 @@ func (s *state) analyzeImpl(c *Call, resources bool) {
 					val = val[:len(val)-1]
 				}
 				switch typ.Kind {
-				case BufferString:
+				case BufferString, BufferDirname:
 					s.strings[val] = true
 				case BufferFilename:
 					if len(val) < 3 || escapingFilename(val) {

--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -853,7 +853,7 @@ func encodeData(buf *bytes.Buffer, data []byte, readable, cstr bool) {
 }
 
 func isReadableDataType(typ *BufferType) bool {
-	return typ.Kind == BufferString || typ.Kind == BufferFilename
+	return typ.Kind == BufferString || typ.Kind == BufferFilename || typ.Kind == BufferDirname
 }
 
 func isReadableData(data []byte) bool {

--- a/prog/generation.go
+++ b/prog/generation.go
@@ -12,9 +12,11 @@ import (
 func (target *Target) Generate(rs rand.Source, ncalls int, ct *ChoiceTable) *Prog {
 	p := &Prog{
 		Target: target,
+		Files:  target.Files,
 	}
 	r := newRand(target, rs)
 	s := newState(target, ct, nil)
+	s.listFiles = p.Files
 	for len(p.Calls) < ncalls {
 		calls := r.generateCall(s, p, len(p.Calls))
 		for _, c := range calls {

--- a/prog/hints.go
+++ b/prog/hints.go
@@ -102,7 +102,7 @@ func generateHints(compMap CompMap, arg Arg, exec func()) {
 		case BufferFilename:
 			// This can generate escaping paths and is probably not too useful anyway.
 			return
-		case BufferString:
+		case BufferString, BufferDirname:
 			if len(t.Values) != 0 {
 				// These are frequently file names or complete enumerations.
 				// Mutating these may be useful iff we intercept strcmp

--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -178,6 +178,7 @@ func (ctx *mutator) mutateArg() bool {
 			return false
 		}
 		s := analyze(ctx.ct, ctx.corpus, p, c)
+		s.listFiles = p.Files
 		arg, argCtx := ma.chooseArg(r.Rand)
 		calls, ok1 := p.Target.mutateArg(r, s, arg, argCtx, &updateSizes)
 		if !ok1 {
@@ -349,6 +350,8 @@ func (t *BufferType) mutate(r *randGen, s *state, arg Arg, ctx ArgCtx) (calls []
 		}
 	case BufferFilename:
 		a.data = []byte(r.filename(s, t))
+	case BufferDirname:
+		a.data = []byte(r.filenameInDir(s, t))
 	case BufferText:
 		data := append([]byte{}, a.Data()...)
 		a.data = r.mutateText(t.Text, data)

--- a/prog/prio.go
+++ b/prog/prio.go
@@ -103,6 +103,8 @@ func (target *Target) calcResourceUsage() map[string]map[int]weights {
 				}
 			case BufferFilename:
 				noteUsage(uses, c, 10, DirIn, "filename")
+			case BufferDirname:
+				noteUsage(uses, c, 10, ctx.Dir, "dirname")
 			default:
 				panic("unknown buffer kind")
 			}

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -11,6 +11,7 @@ type Prog struct {
 	Target   *Target
 	Calls    []*Call
 	Comments []string
+	Files    []string
 }
 
 type Call struct {

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -268,6 +268,25 @@ func (r *randGen) filename(s *state, typ *BufferType) string {
 	return fn
 }
 
+func (r *randGen) filenameInDir(s *state, typ *BufferType) string {
+	if len(typ.Values) == 0 {
+		return ""
+	}
+	prefix := typ.Values[0]
+	var files []string
+	for _, f := range s.listFiles {
+		if strings.HasPrefix(f, prefix) {
+			files = append(files, f)
+		}
+	}
+	size := len(files)
+	if size != 0 {
+		i := r.Intn(size)
+		return files[i]
+	}
+	return prefix
+}
+
 func escapingFilename(file string) bool {
 	file = filepath.Clean(file)
 	return len(file) >= 1 && file[0] == '/' ||
@@ -382,6 +401,7 @@ func (r *randGen) createResource(s *state, res *ResourceType, dir Dir) (arg Arg,
 		meta := metas[r.Intn(len(metas))]
 		calls := r.generateParticularCall(s, meta)
 		s1 := newState(r.target, s.ct, nil)
+		s1.listFiles = s.listFiles
 		s1.analyze(calls[len(calls)-1])
 		// Now see if we have what we want.
 		var allres []*ResultArg
@@ -734,6 +754,8 @@ func (a *BufferType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*
 			return MakeOutDataArg(a, dir, sz), nil
 		}
 		return MakeDataArg(a, dir, []byte(r.filename(s, a))), nil
+	case BufferDirname:
+		return MakeDataArg(a, dir, []byte(r.filenameInDir(s, a))), nil
 	case BufferText:
 		if dir == DirOut {
 			return MakeOutDataArg(a, dir, uint64(r.Intn(100))), nil
@@ -805,6 +827,15 @@ func (a *UnionType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*C
 }
 
 func (a *PtrType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*Call) {
+	switch t := a.Elem.(type) {
+	case *BufferType:
+		switch t.Kind {
+		case BufferDirname:
+			inner, calls := r.generateArg(s, a.Elem, a.ElemDir)
+			arg = r.allocAddr(s, a, dir, inner.Size(), inner)
+			return arg, calls
+		}
+	}
 	if r.oneOf(1000) {
 		index := r.rand(len(r.target.SpecialPointers))
 		return MakeSpecialPointerArg(a, dir, index), nil

--- a/prog/target.go
+++ b/prog/target.go
@@ -68,6 +68,8 @@ type Target struct {
 	// The default ChoiceTable is used only by tests and utilities, so we initialize it lazily.
 	defaultOnce        sync.Once
 	defaultChoiceTable *ChoiceTable
+
+	Files []string
 }
 
 const maxSpecialPointers = 16

--- a/prog/types.go
+++ b/prog/types.go
@@ -481,6 +481,7 @@ const (
 	BufferString
 	BufferFilename
 	BufferText
+	BufferDirname
 )
 
 type TextKind int

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -58,6 +58,7 @@ include <uapi/linux/close_range.h>
 
 resource fd[int32]: -1
 resource fd_dir[fd]: AT_FDCWD
+resource fd_sys[fd]
 
 # alignptr/align32/align64 can be used when ABI uses int64/intptr to hold a smaller tqype.
 # E.g. pid/uid stored as intptr/int64.
@@ -77,6 +78,10 @@ type signalno int32[0:65]
 type signalnoptr intptr[0:65]
 
 syz_execute_func(text ptr[in, text[target]])
+
+openat$sysfs(fd const[AT_FDCWD], dir ptr[in, dirname["/sys/"]], flags flags[open_flags], mode flags[open_mode]) fd_sys
+write$sysfs(fd fd_sys, buf buffer[in], count len[buf])
+read$sysfs(fd fd_sys, buf buffer[out], count len[buf])
 
 open(file ptr[in, filename], flags flags[open_flags], mode flags[open_mode]) fd
 # Just so that we have something that creates fd_dir resources.

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -179,14 +179,7 @@ func main() {
 		return
 	}
 
-	machineInfo, err := host.CollectMachineInfo()
-	if err != nil {
-		log.Fatalf("failed to collect machine information: %v", err)
-	}
-	modules, err := host.CollectModulesInfo()
-	if err != nil {
-		log.Fatalf("failed to collect modules info: %v", err)
-	}
+	machineInfo, modules, files := collectMachineInfo()
 
 	log.Logf(0, "dialing manager at %v", *flagManager)
 	manager, err := rpctype.NewRPCClient(*flagManager, timeouts.Scale)
@@ -291,11 +284,29 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to create proc: %v", err)
 		}
+		proc.files = files
 		fuzzer.procs = append(fuzzer.procs, proc)
 		go proc.loop()
 	}
 
 	fuzzer.pollLoop()
+}
+
+func collectMachineInfo() ([]byte, []host.KernelModule, []string) {
+	machineInfo, err := host.CollectMachineInfo()
+	if err != nil {
+		log.Fatalf("failed to collect machine information: %v", err)
+	}
+	modules, err := host.CollectModulesInfo()
+	if err != nil {
+		log.Fatalf("failed to collect modules info: %v", err)
+	}
+	files, err := host.CollectDirsInfo()
+	if err != nil {
+		log.Fatalf("faield to collect files info: %v", err)
+	}
+
+	return machineInfo, modules, files
 }
 
 // Returns gateCallback for leak checking if enabled.

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -32,6 +32,7 @@ type Proc struct {
 	execOptsCover     *ipc.ExecOpts
 	execOptsComps     *ipc.ExecOpts
 	execOptsNoCollide *ipc.ExecOpts
+	files             []string
 }
 
 func newProc(fuzzer *Fuzzer, pid int) (*Proc, error) {
@@ -86,12 +87,14 @@ func (proc *Proc) loop() {
 		fuzzerSnapshot := proc.fuzzer.snapshot()
 		if len(fuzzerSnapshot.corpus) == 0 || i%generatePeriod == 0 {
 			// Generate a new prog.
+			proc.fuzzer.target.Files = proc.files
 			p := proc.fuzzer.target.Generate(proc.rnd, prog.RecommendedCalls, ct)
 			log.Logf(1, "#%v: generated", proc.pid)
 			proc.execute(proc.execOpts, p, ProgNormal, StatGenerate)
 		} else {
 			// Mutate an existing prog.
 			p := fuzzerSnapshot.chooseProgram(proc.rnd).Clone()
+			p.Files = proc.files
 			p.Mutate(proc.rnd, prog.RecommendedCalls, ct, fuzzerSnapshot.corpus)
 			log.Logf(1, "#%v: mutated", proc.pid)
 			proc.execute(proc.execOpts, p, ProgNormal, StatFuzz)
@@ -210,6 +213,7 @@ func (proc *Proc) smashInput(item *WorkSmash) {
 	fuzzerSnapshot := proc.fuzzer.snapshot()
 	for i := 0; i < 100; i++ {
 		p := item.p.Clone()
+		p.Files = proc.files
 		p.Mutate(proc.rnd, prog.RecommendedCalls, proc.fuzzer.choiceTable, fuzzerSnapshot.corpus)
 		log.Logf(1, "#%v: smash mutated", proc.pid)
 		proc.execute(proc.execOpts, p, ProgNormal, StatSmash)


### PR DESCRIPTION
Some driver was only opened once, all other opens will fail.
So developed a feature to reuse the fd for other syscalls.

syz-fuzzer launches a background service that will open
and share reusable file descriptors to clients.

Add a new syzkaller method syz_reopen_dev which will query
the fd server for an existing fd and retrieve the fd through
socket control messages.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
