### PR TITLE
syz-manager: fix createCoverageBitmap

### DIFF
--- a/pkg/cover/backend/pc.go
+++ b/pkg/cover/backend/pc.go
@@ -53,6 +53,8 @@ func instructionLen(arch string) uint64 {
 		return 6
 	case targets.RiscV64:
 		return 4
+	case targets.TestArch64:
+		return 0
 	default:
 		panic(fmt.Sprintf("unknown arch %q", arch))
 	}

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -147,6 +147,7 @@ func createCoverageBitmap(target *targets.Target, pcs map[uint32]uint32) []byte 
 	bitmap := data[8:]
 	for pc := range pcs {
 		// The lowest 4-bit is dropped.
+		pc = uint32(backend.NextInstructionPC(target, uint64(pc)))
 		pc = (pc - start) >> 4
 		bitmap[pc/8] |= (1 << (pc % 8))
 	}


### PR DESCRIPTION
Hi @dvyukov ,
It seems we made a mistake in the cover filter.
The PCs of compileunits or symbols is the address of "call __sanitizer_*".
But, what the cover filter of the executor needs is the return address of it.
Although we drop the lowest 4-bit of address, it would cause a little PC were filtered.