### PR TITLE
docs/linux: updated setup_ubuntu-host_qemu-vm_x86-64-kernel.md

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -30,6 +30,9 @@ Generate default configs:
 cd $KERNEL
 make CC="$GCC/bin/gcc" defconfig
 make CC="$GCC/bin/gcc" kvmconfig
+# After Linux kernel v5.10
+make CC="$GCC/bin/gcc" defconfig
+make CC="$GCC/bin/gcc" kvm_guest.config
 ```
 
 Enable kernel config options required for syzkaller as described [here](kernel_configs.md).


### PR DESCRIPTION
'make kvmconfig' will be removed after Linux 5.10,
Please use 'make kvm_guest.config' instead.
