### PR TITLE
Fix fuchsia build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ host: manager runtest repro mutate prog2c db upgrade
 target: fuzzer execprog stress executor
 
 executor: descriptions
+ifeq ($(TARGETOS),fuchsia)
+	# Dont build syz-executor for fuchsia.
+else
 ifneq ("$(BUILDOS)", "$(NATIVEBUILDOS)")
 	$(info ************************************************************************************)
 	$(info Executor will not be built)
@@ -128,6 +131,7 @@ else
 	$(CC) -o ./bin/$(TARGETOS)_$(TARGETARCH)/syz-executor$(EXE) executor/executor.cc \
 		$(ADDCFLAGS) $(CFLAGS) -DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1 \
 		-DHOSTGOOS_$(HOSTOS)=1 -DGIT_REVISION=\"$(REV)\"
+endif
 endif
 endif
 

--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -23,7 +23,7 @@
 #include <zircon/syscalls.h>
 
 #if SYZ_EXECUTOR || __NR_get_root_resource
-#include <ddk/driver.h>
+#include <lib/ddk/driver.h>
 #endif
 
 #if SYZ_EXECUTOR || SYZ_HANDLE_SEGV

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -46,6 +46,7 @@ func (fu fuchsia) build(params *Params) error {
 		"--with-base", "//bundles:tools",
 		"--with-base", "//src/testing/fuzzing/syzkaller",
 		"--variant", "kasan",
+		"--no-goma",
 	); err != nil {
 		return err
 	}

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -80,8 +80,8 @@ func (fu fuchsia) build(params *Params) error {
 	}
 
 	for src, dst := range map[string]string{
-		"out/" + arch + ".zircon/kernel-" + arch + "-kasan/obj/kernel/zircon.elf": "obj/zircon.elf",
-		"out/" + arch + "/multiboot.bin":                                          "kernel",
+		"out/" + arch + "/kernel_" + arch + "-kasan/zircon.elf": "obj/zircon.elf",
+		"out/" + arch + "/multiboot.bin":                        "kernel",
 	} {
 		fullSrc := filepath.Join(params.KernelDir, filepath.FromSlash(src))
 		fullDst := filepath.Join(params.OutputDir, filepath.FromSlash(dst))

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1999,7 +1999,7 @@ static int do_sandbox_setuid(void)
 #include <zircon/syscalls.h>
 
 #if SYZ_EXECUTOR || __NR_get_root_resource
-#include <ddk/driver.h>
+#include <lib/ddk/driver.h>
 #endif
 
 #if SYZ_EXECUTOR || SYZ_HANDLE_SEGV

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -240,13 +240,17 @@ func (cfg *Config) completeBinaries() error {
 	cfg.FuzzerBin = targetBin("syz-fuzzer", cfg.TargetVMArch)
 	cfg.ExecprogBin = targetBin("syz-execprog", cfg.TargetVMArch)
 	cfg.ExecutorBin = targetBin("syz-executor", cfg.TargetArch)
+	// If the target already provides an executor binary, we don't need to copy it.
+	if cfg.SysTarget.ExecutorBin != "" {
+		cfg.ExecutorBin = ""
+	}
 	if !osutil.IsExist(cfg.FuzzerBin) {
 		return fmt.Errorf("bad config syzkaller param: can't find %v", cfg.FuzzerBin)
 	}
 	if !osutil.IsExist(cfg.ExecprogBin) {
 		return fmt.Errorf("bad config syzkaller param: can't find %v", cfg.ExecprogBin)
 	}
-	if !osutil.IsExist(cfg.ExecutorBin) {
+	if cfg.ExecutorBin != "" && !osutil.IsExist(cfg.ExecutorBin) {
 		return fmt.Errorf("bad config syzkaller param: can't find %v", cfg.ExecutorBin)
 	}
 	return nil

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -82,7 +82,9 @@ func NewSyzUpdater(cfg *Config) *SyzUpdater {
 		targets[os+"/"+vmarch+"/"+arch] = true
 		files[fmt.Sprintf("bin/%v_%v/syz-fuzzer", os, vmarch)] = true
 		files[fmt.Sprintf("bin/%v_%v/syz-execprog", os, vmarch)] = true
-		files[fmt.Sprintf("bin/%v_%v/syz-executor", os, arch)] = true
+		if mgrcfg.SysTarget.ExecutorBin == "" {
+			files[fmt.Sprintf("bin/%v_%v/syz-executor", os, arch)] = true
+		}
 	}
 	syzFiles := make(map[string]bool)
 	for f := range files {


### PR DESCRIPTION
Multiple small commits to fix various issues in building syzkaller for fuchsia.

* `driver.h` file moved. This breaks syz-executor build.
* There's no need to build syz-executor if we are building targetting fuchsia: that binary gets built as part of the fuchsia build.
* `zircon.elf` file moved. This breaks syz-ci.
* `goma` is deprecated. Disable for now.