### PR TITLE
docs/linux: fix config syntax

### DIFF
--- a/docs/linux/setup_linux-host_android-device_arm-kernel.md
+++ b/docs/linux/setup_linux-host_android-device_arm-kernel.md
@@ -53,10 +53,8 @@ Create a manager config `android.cfg`:
 	"workdir": "$GOPATH/src/github.com/google/syzkaller/workdir",
 	"kernel_obj": "$KERNEL",
 	"syzkaller": "$GOPATH/src/github.com/google/syzkaller",
-	"sandbox": none,
-	"procs": 1,
-	"type": "adb",
 	"cover": true,
+	"type": "adb",
 	"vm": {
 		"devices": [$DEVICES],
 		"battery_check": true


### PR DESCRIPTION
Sandbox value needs quotes,
but we can simply drop sandbox as "none" is the default value.

Fixes #2526
