### PR TITLE
docs/contributing.md: Fix syz-env invocation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,7 +114,7 @@ Then it can be used to wrap almost any make invocation as:
 ```
 syz-env make format
 syz-env make presubmit
-syz-env make extract SOURCEDIR=~/linux
+syz-env make extract SOURCEDIR=$(readlink -f ~/linux)
 ```
 Or other commands/scripts, e.g.:
 ```


### PR DESCRIPTION
Paths like SOURCEDIR must be absolute as they're being used as volume
paths given to Docker and will be interpreted as Docker volume names if
not absolute paths.