### PR TITLE
sys/freebsd: fix struct sockaddr_storage usage

### DIFF
--- a/sys/freebsd/socket_inet.txt
+++ b/sys/freebsd/socket_inet.txt
@@ -21,7 +21,7 @@ sockaddr_in {
 
 sockaddr_storage_in {
 	addr	sockaddr_in
-	pad	array[const[0, int64], 15]
+	pad	array[const[0, int64], 14]
 }
 
 socket$inet(domain const[AF_INET], type flags[socket_type], proto int8) sock_in

--- a/sys/freebsd/socket_inet_sctp.txt
+++ b/sys/freebsd/socket_inet_sctp.txt
@@ -351,7 +351,7 @@ sctp_initmsg {
 sctp_prim {
 	ssp_addr	sockaddr_storage_sctp
 	ssp_assoc_id	assoc_id
-} [packed, align[4]]
+}
 
 sockaddr_sctp [
 	in	sockaddr_in
@@ -361,7 +361,7 @@ sockaddr_sctp [
 sockaddr_storage_sctp [
 	in	sockaddr_storage_in
 	in6	sockaddr_storage_in6
-] [varlen]
+]
 
 sctp_setadaptation {
 	ssb_adaptation_ind	int32
@@ -376,7 +376,7 @@ sctp_paddrparams {
 	spp_ipv6_flowlabel	int32
 	spp_pathmaxrxt		int16
 	spp_dscp		int8
-} [packed, align[4]]
+}
 
 sctp_spp_flags = SPP_HB_ENABLE, SPP_HB_DISABLE, SPP_HB_DEMAND, SPP_PMTUD_ENABLE, SPP_PMTUD_DISABLE, SPP_HB_TIME_IS_ZERO, SPP_IPV6_FLOWLABEL, SPP_DSCP
 
@@ -440,7 +440,7 @@ sctp_paddrinfo {
 	spinfo_srtt	int32
 	spinfo_rto	int32
 	spinfo_mtu	int32
-} [packed, align[4]]
+}
 
 sctp_sack_info {
 	sack_assoc_id	assoc_id
@@ -494,7 +494,7 @@ sctp_paddrthlds {
 	spt_pathmaxrxt	int16
 	spt_pathpfthld	int16
 	spt_pathcpthld	int16
-} [packed, align[4]]
+}
 
 sctp_sndinfo {
 	snd_sid		int16


### PR DESCRIPTION
The size of struct sockaddr_storage is always 128 bytes.
So the padding after struct sockaddr_in, which is of size 16,
needs to be an array of 14 uint64s.
This allows to describe the structures used in the SCTP socket
options as unpacked

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
