### PR TITLE
pkg/cover/backend: add mach-o object support in coverage machinery

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Google Inc.
  Dean Deng
  Pi-Hsun Shih
  Stephen Boyd
+ Patrick Meyer
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,7 +64,7 @@ Commit message line length is limited to 120 characters.
 
 Also:
 
-- If you commit fixes an issue, please include `Fixes #NNN` line into commit message
+- If your commit fixes an issue, please include `Fixes #NNN` line into commit message
 (where `NNN` is the issue number). This will auto-close the issue. If you need to mention
 an issue without closing it, add `Update #NNN`.
 - For syscall descriptions `*.const` files are checked-in with the `*.txt` changes

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -67,6 +67,9 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string,
 	if objDir == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
+	if target.OS == "darwin" {
+		return makeMachO(target, objDir, srcDir, buildDir, moduleObj, modules)
+	}
 	if vm == "gvisor" {
 		return makeGvisor(target, objDir, srcDir, buildDir, modules)
 	}

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -1,0 +1,542 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"bufio"
+	"bytes"
+	"debug/dwarf"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type containerFns struct {
+	readSymbols           func(*Module, *symbolInfo) ([]*Symbol, error)
+	readTextData          func(*Module) ([]byte, error)
+	readModuleCoverPoints func(*Module, *symbolInfo) ([2][]uint64, error)
+	readTextRanges        func(*Module) ([]pcRange, []*CompileUnit, error)
+}
+
+func makeDWARF(target *targets.Target, objDir, srcDir, buildDir string,
+	moduleObj []string, hostModules []host.KernelModule, fn *containerFns) (
+	*Impl, error) {
+	modules, err := discoverModules(target, objDir, moduleObj, hostModules)
+	if err != nil {
+		return nil, err
+	}
+
+	// Here and below index 0 refers to coverage callbacks (__sanitizer_cov_trace_pc(_guard))
+	// and index 1 refers to comparison callbacks (__sanitizer_cov_trace_cmp*).
+	var allCoverPoints [2][]uint64
+	var allSymbols []*Symbol
+	var allRanges []pcRange
+	var allUnits []*CompileUnit
+	var pcBase uint64
+	for _, module := range modules {
+		errc := make(chan error, 1)
+		go func() {
+			info := &symbolInfo{
+				traceCmp:    make(map[uint64]bool),
+				tracePCIdx:  make(map[int]bool),
+				traceCmpIdx: make(map[int]bool),
+			}
+			symbols, err := fn.readSymbols(module, info)
+			if err != nil {
+				errc <- err
+				return
+			}
+			allSymbols = append(allSymbols, symbols...)
+			if module.Name == "" {
+				pcBase = info.textAddr
+			}
+			var data []byte
+			var coverPoints [2][]uint64
+			if target.Arch != targets.AMD64 && target.Arch != targets.ARM64 {
+				coverPoints, err = objdump(target, module)
+			} else if module.Name == "" {
+				data, err = fn.readTextData(module)
+				if err != nil {
+					errc <- err
+					return
+				}
+				coverPoints, err = readCoverPoints(target, info, data)
+			} else {
+				coverPoints, err = fn.readModuleCoverPoints(module, info)
+			}
+			allCoverPoints[0] = append(allCoverPoints[0], coverPoints[0]...)
+			allCoverPoints[1] = append(allCoverPoints[1], coverPoints[1]...)
+			if err == nil && module.Name == "" && len(coverPoints[0]) == 0 {
+				err = fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y on linux)", module.Path)
+			}
+			errc <- err
+		}()
+		ranges, units, err := fn.readTextRanges(module)
+		if err != nil {
+			return nil, err
+		}
+		if err := <-errc; err != nil {
+			return nil, err
+		}
+		allRanges = append(allRanges, ranges...)
+		allUnits = append(allUnits, units...)
+	}
+
+	sort.Slice(allSymbols, func(i, j int) bool {
+		return allSymbols[i].Start < allSymbols[j].Start
+	})
+	sort.Slice(allRanges, func(i, j int) bool {
+		return allRanges[i].start < allRanges[j].start
+	})
+	for k := range allCoverPoints {
+		sort.Slice(allCoverPoints[k], func(i, j int) bool {
+			return allCoverPoints[k][i] < allCoverPoints[k][j]
+		})
+	}
+
+	allSymbols = buildSymbols(allSymbols, allRanges, allCoverPoints)
+	nunit := 0
+	for _, unit := range allUnits {
+		if len(unit.PCs) == 0 {
+			continue // drop the unit
+		}
+		// TODO: objDir won't work for out-of-tree modules.
+		unit.Name, unit.Path = cleanPath(unit.Name, objDir, srcDir, buildDir)
+		allUnits[nunit] = unit
+		nunit++
+	}
+	allUnits = allUnits[:nunit]
+	if len(allSymbols) == 0 || len(allUnits) == 0 {
+		return nil, fmt.Errorf("failed to parse DWARF (set CONFIG_DEBUG_INFO=y on linux)")
+	}
+	if target.OS == targets.FreeBSD {
+		// On FreeBSD .text address in ELF is 0, but .text is actually mapped at 0xffffffff.
+		pcBase = ^uint64(0)
+	}
+	impl := &Impl{
+		Units:   allUnits,
+		Symbols: allSymbols,
+		Symbolize: func(pcs map[*Module][]uint64) ([]Frame, error) {
+			return symbolize(target, objDir, srcDir, buildDir, pcs)
+		},
+		RestorePC: func(pc uint32) uint64 {
+			return PreviousInstructionPC(target, RestorePC(pc, uint32(pcBase>>32)))
+		},
+	}
+	return impl, nil
+}
+
+func buildSymbols(symbols []*Symbol, ranges []pcRange, coverPoints [2][]uint64) []*Symbol {
+	// Assign coverage point PCs to symbols.
+	// Both symbols and coverage points are sorted, so we do it one pass over both.
+	selectPCs := func(u *ObjectUnit, typ int) *[]uint64 {
+		return [2]*[]uint64{&u.PCs, &u.CMPs}[typ]
+	}
+	for pcType := range coverPoints {
+		pcs := coverPoints[pcType]
+		var curSymbol *Symbol
+		firstSymbolPC, symbolIdx := -1, 0
+		for i := 0; i < len(pcs); i++ {
+			pc := pcs[i]
+			for ; symbolIdx < len(symbols) && pc >= symbols[symbolIdx].End; symbolIdx++ {
+			}
+			var symb *Symbol
+			if symbolIdx < len(symbols) && pc >= symbols[symbolIdx].Start && pc < symbols[symbolIdx].End {
+				symb = symbols[symbolIdx]
+			}
+			if curSymbol != nil && curSymbol != symb {
+				*selectPCs(&curSymbol.ObjectUnit, pcType) = pcs[firstSymbolPC:i]
+				firstSymbolPC = -1
+			}
+			curSymbol = symb
+			if symb != nil && firstSymbolPC == -1 {
+				firstSymbolPC = i
+			}
+		}
+		if curSymbol != nil {
+			*selectPCs(&curSymbol.ObjectUnit, pcType) = pcs[firstSymbolPC:]
+		}
+	}
+	// Assign compile units to symbols based on unit pc ranges.
+	// Do it one pass as both are sorted.
+	nsymbol := 0
+	rangeIndex := 0
+	for _, s := range symbols {
+		for ; rangeIndex < len(ranges) && ranges[rangeIndex].end <= s.Start; rangeIndex++ {
+		}
+		if rangeIndex == len(ranges) || s.Start < ranges[rangeIndex].start || len(s.PCs) == 0 {
+			continue // drop the symbol
+		}
+		unit := ranges[rangeIndex].unit
+		s.Unit = unit
+		symbols[nsymbol] = s
+		nsymbol++
+	}
+	symbols = symbols[:nsymbol]
+
+	for pcType := range coverPoints {
+		for _, s := range symbols {
+			symbPCs := selectPCs(&s.ObjectUnit, pcType)
+			unitPCs := selectPCs(&s.Unit.ObjectUnit, pcType)
+			pos := len(*unitPCs)
+			*unitPCs = append(*unitPCs, *symbPCs...)
+			*symbPCs = (*unitPCs)[pos:]
+		}
+	}
+	return symbols
+}
+
+type symbolInfo struct {
+	textAddr    uint64
+	tracePC     uint64
+	traceCmp    map[uint64]bool
+	tracePCIdx  map[int]bool
+	traceCmpIdx map[int]bool
+}
+
+type pcRange struct {
+	start uint64
+	end   uint64
+	unit  *CompileUnit
+}
+
+type pcFixFn = (func([2]uint64) ([2]uint64, bool))
+
+func readTextRanges(debugInfo *dwarf.Data, module *Module, pcFix pcFixFn) (
+	[]pcRange, []*CompileUnit, error) {
+	var ranges []pcRange
+	var units []*CompileUnit
+	for r := debugInfo.Reader(); ; {
+		ent, err := r.Next()
+		if err != nil {
+			return nil, nil, err
+		}
+		if ent == nil {
+			break
+		}
+		if ent.Tag != dwarf.TagCompileUnit {
+			return nil, nil, fmt.Errorf("found unexpected tag %v on top level", ent.Tag)
+		}
+		attrName := ent.Val(dwarf.AttrName)
+		if attrName == nil {
+			continue
+		}
+		unit := &CompileUnit{
+			ObjectUnit: ObjectUnit{
+				Name: attrName.(string),
+			},
+		}
+		units = append(units, unit)
+		ranges1, err := debugInfo.Ranges(ent)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var filtered bool
+		for _, r := range ranges1 {
+			if pcFix != nil {
+				r, filtered = pcFix(r)
+				if filtered {
+					continue
+				}
+			}
+			ranges = append(ranges, pcRange{r[0] + module.Addr, r[1] + module.Addr, unit})
+		}
+		r.SkipChildren()
+	}
+	return ranges, units, nil
+}
+
+func symbolizeModule(target *targets.Target, objDir, srcDir, buildDir string,
+	mod *Module, pcs []uint64) ([]Frame, error) {
+	procs := runtime.GOMAXPROCS(0) / 2
+	if need := len(pcs) / 1000; procs > need {
+		procs = need
+	}
+	const (
+		minProcs = 1
+		maxProcs = 4
+	)
+	// addr2line on a beefy vmlinux takes up to 1.6GB of RAM, so don't create too many of them.
+	if procs > maxProcs {
+		procs = maxProcs
+	}
+	if procs < minProcs {
+		procs = minProcs
+	}
+	type symbolizerResult struct {
+		frames []symbolizer.Frame
+		err    error
+	}
+	symbolizerC := make(chan symbolizerResult, procs)
+	pcchan := make(chan []uint64, procs)
+	for p := 0; p < procs; p++ {
+		go func() {
+			symb := symbolizer.NewSymbolizer(target)
+			defer symb.Close()
+			var res symbolizerResult
+			for pcs := range pcchan {
+				for i, pc := range pcs {
+					pcs[i] = pc - mod.Addr
+				}
+				frames, err := symb.SymbolizeArray(mod.Path, pcs)
+				if err != nil {
+					res.err = fmt.Errorf("failed to symbolize: %v", err)
+				}
+				res.frames = append(res.frames, frames...)
+			}
+			symbolizerC <- res
+		}()
+	}
+	for i := 0; i < len(pcs); {
+		end := i + 100
+		if end > len(pcs) {
+			end = len(pcs)
+		}
+		pcchan <- pcs[i:end]
+		i = end
+	}
+	close(pcchan)
+	var err0 error
+	var frames []Frame
+	for p := 0; p < procs; p++ {
+		res := <-symbolizerC
+		if res.err != nil {
+			err0 = res.err
+		}
+		for _, frame := range res.frames {
+			name, path := cleanPath(frame.File, objDir, srcDir, buildDir)
+			frames = append(frames, Frame{
+				Module: mod,
+				PC:     frame.PC + mod.Addr,
+				Name:   name,
+				Path:   path,
+				Range: Range{
+					StartLine: frame.Line,
+					StartCol:  0,
+					EndLine:   frame.Line,
+					EndCol:    LineEnd,
+				},
+			})
+		}
+	}
+	if err0 != nil {
+		return nil, err0
+	}
+	return frames, nil
+}
+
+func symbolize(target *targets.Target, objDir, srcDir, buildDir string,
+	pcs map[*Module][]uint64) ([]Frame, error) {
+	var frames []Frame
+	for mod, pcs1 := range pcs {
+		frames1, err := symbolizeModule(target, objDir, srcDir, buildDir, mod, pcs1)
+		if err != nil {
+			return nil, err
+		}
+		frames = append(frames, frames1...)
+	}
+	return frames, nil
+}
+
+// readCoverPoints finds all coverage points (calls of __sanitizer_cov_trace_*) in the object file.
+// Currently it is [amd64|arm64]-specific: looks for opcode and correct offset.
+// Running objdump on the whole object file is too slow.
+func readCoverPoints(target *targets.Target, info *symbolInfo, data []byte) ([2][]uint64, error) {
+	var pcs [2][]uint64
+	if info.tracePC == 0 {
+		return pcs, fmt.Errorf("no __sanitizer_cov_trace_pc symbol in the object file")
+	}
+
+	type Arch struct {
+		callLen      int
+		opcodeOffset int
+		opcodes      [2]byte
+		target       func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64
+	}
+	arch := map[string]Arch{
+		targets.AMD64: {
+			callLen: 5,
+			opcodes: [2]byte{0xe8, 0xe8},
+			target: func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64 {
+				off := uint64(int64(int32(binary.LittleEndian.Uint32(insn[1:]))))
+				return pc + off + uint64(arch.callLen)
+			},
+		},
+		targets.ARM64: {
+			callLen:      4,
+			opcodeOffset: 3,
+			opcodes:      [2]byte{0x94, 0x97},
+			target: func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64 {
+				off := uint64(binary.LittleEndian.Uint32(insn)) & ((1 << 24) - 1)
+				if opcode == arch.opcodes[1] {
+					off |= 0xffffffffff000000
+				}
+				return pc + 4*off
+			},
+		},
+	}[target.Arch]
+	// Loop that's checking each instruction for the current architectures call
+	// opcode. When found, it compares the call target address with those of the
+	// __sanitizer_cov_trace_* functions we previously collected. When found,
+	// we collect the pc as a coverage point.
+	for i, opcode := range data {
+		if opcode != arch.opcodes[0] && opcode != arch.opcodes[1] {
+			continue
+		}
+		i -= arch.opcodeOffset
+		if i < 0 || i+arch.callLen > len(data) {
+			continue
+		}
+		pc := info.textAddr + uint64(i)
+		target := arch.target(&arch, data[i:], pc, opcode)
+		if target == info.tracePC {
+			pcs[0] = append(pcs[0], pc)
+		} else if info.traceCmp[target] {
+			pcs[1] = append(pcs[1], pc)
+		}
+	}
+	return pcs, nil
+}
+
+func cleanPath(path, objDir, srcDir, buildDir string) (string, string) {
+	filename := ""
+	switch {
+	case strings.HasPrefix(path, objDir):
+		// Assume the file was built there.
+		path = strings.TrimPrefix(path, objDir)
+		filename = filepath.Join(objDir, path)
+	case strings.HasPrefix(path, buildDir):
+		// Assume the file was moved from buildDir to srcDir.
+		path = strings.TrimPrefix(path, buildDir)
+		filename = filepath.Join(srcDir, path)
+	default:
+		// Assume this is relative path.
+		filename = filepath.Join(srcDir, path)
+	}
+	return strings.TrimLeft(filepath.Clean(path), "/\\"), filename
+}
+
+// objdump is an old, slow way of finding coverage points.
+// amd64 uses faster option of parsing binary directly (readCoverPoints).
+// TODO: use the faster approach for all other arches and drop this.
+func objdump(target *targets.Target, mod *Module) ([2][]uint64, error) {
+	var pcs [2][]uint64
+	cmd := osutil.Command(target.Objdump, "-d", "--no-show-raw-insn", mod.Path)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return pcs, err
+	}
+	defer stdout.Close()
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return pcs, err
+	}
+	defer stderr.Close()
+	if err := cmd.Start(); err != nil {
+		return pcs, fmt.Errorf("failed to run objdump on %v: %v", mod.Path, err)
+	}
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+	s := bufio.NewScanner(stdout)
+	callInsns, traceFuncs := archCallInsn(target)
+	for s.Scan() {
+		if pc := parseLine(callInsns, traceFuncs, s.Bytes()); pc != 0 {
+			pcs[0] = append(pcs[0], pc+mod.Addr)
+		}
+	}
+	stderrOut, _ := ioutil.ReadAll(stderr)
+	if err := cmd.Wait(); err != nil {
+		return pcs, fmt.Errorf("failed to run objdump on %v: %v\n%s", mod.Path, err, stderrOut)
+	}
+	if err := s.Err(); err != nil {
+		return pcs, fmt.Errorf("failed to run objdump on %v: %v\n%s", mod.Path, err, stderrOut)
+	}
+	return pcs, nil
+}
+
+func parseLine(callInsns, traceFuncs [][]byte, ln []byte) uint64 {
+	pos := -1
+	for _, callInsn := range callInsns {
+		if pos = bytes.Index(ln, callInsn); pos != -1 {
+			break
+		}
+	}
+	if pos == -1 {
+		return 0
+	}
+	hasCall := false
+	for _, traceFunc := range traceFuncs {
+		if hasCall = bytes.Contains(ln[pos:], traceFunc); hasCall {
+			break
+		}
+	}
+	if !hasCall {
+		return 0
+	}
+	for len(ln) != 0 && ln[0] == ' ' {
+		ln = ln[1:]
+	}
+	colon := bytes.IndexByte(ln, ':')
+	if colon == -1 {
+		return 0
+	}
+	pc, err := strconv.ParseUint(string(ln[:colon]), 16, 64)
+	if err != nil {
+		return 0
+	}
+	return pc
+}
+
+func archCallInsn(target *targets.Target) ([][]byte, [][]byte) {
+	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>")}
+	switch target.Arch {
+	case targets.I386:
+		// c1000102:       call   c10001f0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tcall ")}, callName
+	case targets.ARM64:
+		// ffff0000080d9cc0:       bl      ffff00000820f478 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl\t")}, callName
+	case targets.ARM:
+		// 8010252c:       bl      801c3280 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl\t")}, callName
+	case targets.PPC64LE:
+		// c00000000006d904:       bl      c000000000350780 <.__sanitizer_cov_trace_pc>
+		// This is only known to occur in the test:
+		// 838:   bl      824 <__sanitizer_cov_trace_pc+0x8>
+		// This occurs on PPC64LE:
+		// c0000000001c21a8:       bl      c0000000002df4a0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbl ")}, [][]byte{
+			[]byte("<__sanitizer_cov_trace_pc>"),
+			[]byte("<__sanitizer_cov_trace_pc+0x8>"),
+			[]byte(" <.__sanitizer_cov_trace_pc>"),
+		}
+	case targets.MIPS64LE:
+		// ffffffff80100420:       jal     ffffffff80205880 <__sanitizer_cov_trace_pc>
+		// This is only known to occur in the test:
+		// b58:   bal     b30 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tjal\t"), []byte("\tbal\t")}, callName
+	case targets.S390x:
+		// 1001de:       brasl   %r14,2bc090 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tbrasl\t")}, callName
+	case targets.RiscV64:
+		// ffffffe000200018:       jal     ra,ffffffe0002935b0 <__sanitizer_cov_trace_pc>
+		// ffffffe0000010da:       jalr    1242(ra) # ffffffe0002935b0 <__sanitizer_cov_trace_pc>
+		return [][]byte{[]byte("\tjal\t"), []byte("\tjalr\t")}, callName
+	default:
+		panic(fmt.Sprintf("unknown arch %q", target.Arch))
+	}
+}

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -4,216 +4,44 @@
 package backend
 
 import (
-	"bufio"
-	"bytes"
-	"debug/dwarf"
 	"debug/elf"
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"path/filepath"
-	"runtime"
-	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/log"
-	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
 
 func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
 	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
-	modules, err := discoverModules(target, objDir, moduleObj, hostModules)
+	return makeDWARF(target, objDir, srcDir, buildDir, moduleObj, hostModules,
+		&containerFns{
+			readSymbols:           elfReadSymbols,
+			readTextData:          elfReadTextData,
+			readModuleCoverPoints: elfReadModuleCoverPoints,
+			readTextRanges:        elfReadTextRanges,
+		},
+	)
+}
+
+func elfReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {
+	file, err := elf.Open(module.Path)
 	if err != nil {
 		return nil, err
 	}
-	// Here and below index 0 refers to coverage callbacks (__sanitizer_cov_trace_pc)
-	// and index 1 refers to comparison callbacks (__sanitizer_cov_trace_cmp*).
-	var allCoverPoints [2][]uint64
-	var allSymbols []*Symbol
-	var allRanges []pcRange
-	var allUnits []*CompileUnit
-	var pcBase uint64
-	for _, module := range modules {
-		file, err := elf.Open(module.Path)
-		if err != nil {
-			return nil, err
-		}
-		errc := make(chan error, 1)
-		go func() {
-			symbols, info, err := readSymbols(file, module)
-			if err != nil {
-				errc <- err
-				return
-			}
-			allSymbols = append(allSymbols, symbols...)
-			if module.Name == "" {
-				pcBase = info.textAddr
-			}
-			var coverPoints [2][]uint64
-			if target.Arch != targets.AMD64 && target.Arch != targets.ARM64 {
-				coverPoints, err = objdump(target, module)
-			} else if module.Name == "" {
-				coverPoints, err = readCoverPoints(target, file, info)
-			} else {
-				coverPoints, err = readModuleCoverPoints(file, info, module)
-			}
-			allCoverPoints[0] = append(allCoverPoints[0], coverPoints[0]...)
-			allCoverPoints[1] = append(allCoverPoints[1], coverPoints[1]...)
-			if err == nil && module.Name == "" && len(coverPoints[0]) == 0 {
-				err = fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y)", module.Path)
-			}
-			errc <- err
-		}()
-		ranges, units, err := readTextRanges(file, module)
-		if err != nil {
-			return nil, err
-		}
-		if err := <-errc; err != nil {
-			return nil, err
-		}
-		allRanges = append(allRanges, ranges...)
-		allUnits = append(allUnits, units...)
-	}
-
-	sort.Slice(allSymbols, func(i, j int) bool {
-		return allSymbols[i].Start < allSymbols[j].Start
-	})
-	sort.Slice(allRanges, func(i, j int) bool {
-		return allRanges[i].start < allRanges[j].start
-	})
-	for k := range allCoverPoints {
-		sort.Slice(allCoverPoints[k], func(i, j int) bool {
-			return allCoverPoints[k][i] < allCoverPoints[k][j]
-		})
-	}
-
-	allSymbols = buildSymbols(allSymbols, allRanges, allCoverPoints)
-	nunit := 0
-	for _, unit := range allUnits {
-		if len(unit.PCs) == 0 {
-			continue // drop the unit
-		}
-		// TODO: objDir won't work for out-of-tree modules.
-		unit.Name, unit.Path = cleanPath(unit.Name, objDir, srcDir, buildDir)
-		allUnits[nunit] = unit
-		nunit++
-	}
-	allUnits = allUnits[:nunit]
-	if len(allSymbols) == 0 || len(allUnits) == 0 {
-		return nil, fmt.Errorf("failed to parse DWARF (set CONFIG_DEBUG_INFO=y?)")
-	}
-	if target.OS == targets.FreeBSD {
-		// On FreeBSD .text address in ELF is 0, but .text is actually mapped at 0xffffffff.
-		pcBase = ^uint64(0)
-	}
-	impl := &Impl{
-		Units:   allUnits,
-		Symbols: allSymbols,
-		Symbolize: func(pcs map[*Module][]uint64) ([]Frame, error) {
-			return symbolize(target, objDir, srcDir, buildDir, pcs)
-		},
-		RestorePC: func(pc uint32) uint64 {
-			return PreviousInstructionPC(target, RestorePC(pc, uint32(pcBase>>32)))
-		},
-	}
-	return impl, nil
-}
-
-type pcRange struct {
-	start uint64
-	end   uint64
-	unit  *CompileUnit
-}
-
-func buildSymbols(symbols []*Symbol, ranges []pcRange, coverPoints [2][]uint64) []*Symbol {
-	// Assign coverage point PCs to symbols.
-	// Both symbols and coverage points are sorted, so we do it one pass over both.
-	selectPCs := func(u *ObjectUnit, typ int) *[]uint64 {
-		return [2]*[]uint64{&u.PCs, &u.CMPs}[typ]
-	}
-	for pcType := range coverPoints {
-		pcs := coverPoints[pcType]
-		var curSymbol *Symbol
-		firstSymbolPC, symbolIdx := -1, 0
-		for i := 0; i < len(pcs); i++ {
-			pc := pcs[i]
-			for ; symbolIdx < len(symbols) && pc >= symbols[symbolIdx].End; symbolIdx++ {
-			}
-			var symb *Symbol
-			if symbolIdx < len(symbols) && pc >= symbols[symbolIdx].Start && pc < symbols[symbolIdx].End {
-				symb = symbols[symbolIdx]
-			}
-			if curSymbol != nil && curSymbol != symb {
-				*selectPCs(&curSymbol.ObjectUnit, pcType) = pcs[firstSymbolPC:i]
-				firstSymbolPC = -1
-			}
-			curSymbol = symb
-			if symb != nil && firstSymbolPC == -1 {
-				firstSymbolPC = i
-			}
-		}
-		if curSymbol != nil {
-			*selectPCs(&curSymbol.ObjectUnit, pcType) = pcs[firstSymbolPC:]
-		}
-	}
-	// Assign compile units to symbols based on unit pc ranges.
-	// Do it one pass as both are sorted.
-	nsymbol := 0
-	rangeIndex := 0
-	for _, s := range symbols {
-		for ; rangeIndex < len(ranges) && ranges[rangeIndex].end <= s.Start; rangeIndex++ {
-		}
-		if rangeIndex == len(ranges) || s.Start < ranges[rangeIndex].start || len(s.PCs) == 0 {
-			continue // drop the symbol
-		}
-		unit := ranges[rangeIndex].unit
-		s.Unit = unit
-		symbols[nsymbol] = s
-		nsymbol++
-	}
-	symbols = symbols[:nsymbol]
-
-	for pcType := range coverPoints {
-		for _, s := range symbols {
-			symbPCs := selectPCs(&s.ObjectUnit, pcType)
-			unitPCs := selectPCs(&s.Unit.ObjectUnit, pcType)
-			pos := len(*unitPCs)
-			*unitPCs = append(*unitPCs, *symbPCs...)
-			*symbPCs = (*unitPCs)[pos:]
-		}
-	}
-	return symbols
-}
-
-type symbolInfo struct {
-	textAddr    uint64
-	tracePC     uint64
-	traceCmp    map[uint64]bool
-	tracePCIdx  map[int]bool
-	traceCmpIdx map[int]bool
-}
-
-func readSymbols(file *elf.File, module *Module) ([]*Symbol, *symbolInfo, error) {
 	text := file.Section(".text")
 	if text == nil {
-		return nil, nil, fmt.Errorf("no .text section in the object file")
+		return nil, fmt.Errorf("no .text section in the object file")
 	}
 	allSymbols, err := file.Symbols()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read ELF symbols: %v", err)
+		return nil, fmt.Errorf("failed to read ELF symbols: %v", err)
 	}
+	info.textAddr = text.Addr
 	var symbols []*Symbol
-	info := &symbolInfo{
-		textAddr:    text.Addr,
-		traceCmp:    make(map[uint64]bool),
-		tracePCIdx:  make(map[int]bool),
-		traceCmpIdx: make(map[int]bool),
-	}
 	for i, symb := range allSymbols {
 		text := symb.Value >= text.Addr && symb.Value+symb.Size <= text.Addr+text.Size
 		if text {
@@ -241,10 +69,14 @@ func readSymbols(file *elf.File, module *Module) ([]*Symbol, *symbolInfo, error)
 			}
 		}
 	}
-	return symbols, info, nil
+	return symbols, nil
 }
 
-func readTextRanges(file *elf.File, module *Module) ([]pcRange, []*CompileUnit, error) {
+func elfReadTextRanges(module *Module) ([]pcRange, []*CompileUnit, error) {
+	file, err := elf.Open(module.Path)
+	if err != nil {
+		return nil, nil, err
+	}
 	text := file.Section(".text")
 	if text == nil {
 		return nil, nil, fmt.Errorf("no .text section in the object file")
@@ -256,215 +88,51 @@ func readTextRanges(file *elf.File, module *Module) ([]pcRange, []*CompileUnit, 
 			log.Logf(0, "ignoring module %v without DEBUG_INFO", module.Name)
 			return nil, nil, nil
 		}
-		return nil, nil, fmt.Errorf("failed to parse DWARF: %v (set CONFIG_DEBUG_INFO=y?)", err)
+		return nil, nil, fmt.Errorf("failed to parse DWARF: %v (set CONFIG_DEBUG_INFO=y on linux)", err)
 	}
-	var ranges []pcRange
-	var units []*CompileUnit
-	for r := debugInfo.Reader(); ; {
-		ent, err := r.Next()
-		if err != nil {
-			return nil, nil, err
-		}
-		if ent == nil {
-			break
-		}
-		if ent.Tag != dwarf.TagCompileUnit {
-			return nil, nil, fmt.Errorf("found unexpected tag %v on top level", ent.Tag)
-		}
-		attrName := ent.Val(dwarf.AttrName)
-		if attrName == nil {
-			continue
-		}
-		unit := &CompileUnit{
-			ObjectUnit: ObjectUnit{
-				Name: attrName.(string),
-			},
-		}
-		units = append(units, unit)
-		ranges1, err := debugInfo.Ranges(ent)
-		if err != nil {
-			return nil, nil, err
-		}
-		for _, r := range ranges1 {
+
+	var pcFix pcFixFn
+	if kaslr {
+		pcFix = func(r [2]uint64) ([2]uint64, bool) {
 			if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
-				if kaslr {
-					// Linux kernel binaries with CONFIG_RANDOMIZE_BASE=y are strange.
-					// .text starts at 0xffffffff81000000 and symbols point there as well,
-					// but PC ranges point to addresses around 0.
-					// So try to add text offset and retry the check.
-					// It's unclear if we also need some offset on top of text.Addr,
-					// it gives approximately correct addresses, but not necessary precisely
-					// correct addresses.
-					r[0] += text.Addr
-					r[1] += text.Addr
-					if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
-						continue
-					}
+				// Linux kernel binaries with CONFIG_RANDOMIZE_BASE=y are strange.
+				// .text starts at 0xffffffff81000000 and symbols point there as
+				// well, but PC ranges point to addresses around 0.
+				// So try to add text offset and retry the check.
+				// It's unclear if we also need some offset on top of text.Addr,
+				// it gives approximately correct addresses, but not necessary
+				// precisely correct addresses.
+				r[0] += text.Addr
+				r[1] += text.Addr
+				if r[0] >= r[1] || r[0] < text.Addr || r[1] > text.Addr+text.Size {
+					return r, true
 				}
 			}
-			ranges = append(ranges, pcRange{r[0] + module.Addr, r[1] + module.Addr, unit})
+			return r, false
 		}
-		r.SkipChildren()
 	}
-	return ranges, units, nil
+
+	return readTextRanges(debugInfo, module, pcFix)
 }
 
-func symbolize(target *targets.Target, objDir, srcDir, buildDir string, pcs map[*Module][]uint64) ([]Frame, error) {
-	var frames []Frame
-	for mod, pcs1 := range pcs {
-		frames1, err := symbolizeModule(target, objDir, srcDir, buildDir, mod, pcs1)
-		if err != nil {
-			return nil, err
-		}
-		frames = append(frames, frames1...)
-	}
-	return frames, nil
-}
-
-func symbolizeModule(target *targets.Target, objDir, srcDir, buildDir string,
-	mod *Module, pcs []uint64) ([]Frame, error) {
-	procs := runtime.GOMAXPROCS(0) / 2
-	if need := len(pcs) / 1000; procs > need {
-		procs = need
-	}
-	const (
-		minProcs = 1
-		maxProcs = 4
-	)
-	// addr2line on a beefy vmlinux takes up to 1.6GB of RAM, so don't create too many of them.
-	if procs > maxProcs {
-		procs = maxProcs
-	}
-	if procs < minProcs {
-		procs = minProcs
-	}
-	type symbolizerResult struct {
-		frames []symbolizer.Frame
-		err    error
-	}
-	symbolizerC := make(chan symbolizerResult, procs)
-	pcchan := make(chan []uint64, procs)
-	for p := 0; p < procs; p++ {
-		go func() {
-			symb := symbolizer.NewSymbolizer(target)
-			defer symb.Close()
-			var res symbolizerResult
-			for pcs := range pcchan {
-				for i, pc := range pcs {
-					pcs[i] = pc - mod.Addr
-				}
-				frames, err := symb.SymbolizeArray(mod.Path, pcs)
-				if err != nil {
-					res.err = fmt.Errorf("failed to symbolize: %v", err)
-				}
-				res.frames = append(res.frames, frames...)
-			}
-			symbolizerC <- res
-		}()
-	}
-	for i := 0; i < len(pcs); {
-		end := i + 100
-		if end > len(pcs) {
-			end = len(pcs)
-		}
-		pcchan <- pcs[i:end]
-		i = end
-	}
-	close(pcchan)
-	var err0 error
-	var frames []Frame
-	for p := 0; p < procs; p++ {
-		res := <-symbolizerC
-		if res.err != nil {
-			err0 = res.err
-		}
-		for _, frame := range res.frames {
-			name, path := cleanPath(frame.File, objDir, srcDir, buildDir)
-			frames = append(frames, Frame{
-				Module: mod,
-				PC:     frame.PC + mod.Addr,
-				Name:   name,
-				Path:   path,
-				Range: Range{
-					StartLine: frame.Line,
-					StartCol:  0,
-					EndLine:   frame.Line,
-					EndCol:    LineEnd,
-				},
-			})
-		}
-	}
-	if err0 != nil {
-		return nil, err0
-	}
-	return frames, nil
-}
-
-// readCoverPoints finds all coverage points (calls of __sanitizer_cov_trace_*) in the object file.
-// Currently it is [amd64|arm64]-specific: looks for opcode and correct offset.
-// Running objdump on the whole object file is too slow.
-func readCoverPoints(target *targets.Target, file *elf.File, info *symbolInfo) ([2][]uint64, error) {
-	var pcs [2][]uint64
-	if info.tracePC == 0 {
-		return pcs, fmt.Errorf("no __sanitizer_cov_trace_pc symbol in the object file")
+func elfReadTextData(module *Module) ([]byte, error) {
+	file, err := elf.Open(module.Path)
+	if err != nil {
+		return nil, err
 	}
 	text := file.Section(".text")
 	if text == nil {
-		return pcs, fmt.Errorf("no .text section in the object file")
+		return nil, fmt.Errorf("no .text section in the object file")
 	}
-	data, err := text.Data()
-	if err != nil {
-		return pcs, fmt.Errorf("failed to read .text: %v", err)
-	}
-	type Arch struct {
-		callLen      int
-		opcodeOffset int
-		opcodes      [2]byte
-		target       func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64
-	}
-	arch := map[string]Arch{
-		targets.AMD64: {
-			callLen: 5,
-			opcodes: [2]byte{0xe8, 0xe8},
-			target: func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64 {
-				off := uint64(int64(int32(binary.LittleEndian.Uint32(insn[1:]))))
-				return pc + off + uint64(arch.callLen)
-			},
-		},
-		targets.ARM64: {
-			callLen:      4,
-			opcodeOffset: 3,
-			opcodes:      [2]byte{0x94, 0x97},
-			target: func(arch *Arch, insn []byte, pc uint64, opcode byte) uint64 {
-				off := uint64(binary.LittleEndian.Uint32(insn)) & ((1 << 24) - 1)
-				if opcode == arch.opcodes[1] {
-					off |= 0xffffffffff000000
-				}
-				return pc + 4*off
-			},
-		},
-	}[target.Arch]
-	for i, opcode := range data {
-		if opcode != arch.opcodes[0] && opcode != arch.opcodes[1] {
-			continue
-		}
-		i -= arch.opcodeOffset
-		if i < 0 || i+arch.callLen > len(data) {
-			continue
-		}
-		pc := text.Addr + uint64(i)
-		target := arch.target(&arch, data[i:], pc, opcode)
-		if target == info.tracePC {
-			pcs[0] = append(pcs[0], pc)
-		} else if info.traceCmp[target] {
-			pcs[1] = append(pcs[1], pc)
-		}
-	}
-	return pcs, nil
+	return text.Data()
 }
 
-func readModuleCoverPoints(file *elf.File, info *symbolInfo, mod *Module) ([2][]uint64, error) {
+func elfReadModuleCoverPoints(module *Module, info *symbolInfo) ([2][]uint64, error) {
 	var pcs [2][]uint64
+	file, err := elf.Open(module.Path)
+	if err != nil {
+		return pcs, err
+	}
 	for _, s := range file.Sections {
 		if s.Type != elf.SHT_RELA { // nolint: misspell
 			continue
@@ -478,7 +146,7 @@ func readModuleCoverPoints(file *elf.File, info *symbolInfo, mod *Module) ([2][]
 				return pcs, err
 			}
 			// Note: this assumes that call instruction is 1 byte.
-			pc := mod.Addr + rel.Off - 1
+			pc := module.Addr + rel.Off - 1
 			index := int(elf.R_SYM64(rel.Info)) - 1
 			if info.tracePCIdx[index] {
 				pcs[0] = append(pcs[0], pc)
@@ -488,135 +156,4 @@ func readModuleCoverPoints(file *elf.File, info *symbolInfo, mod *Module) ([2][]
 		}
 	}
 	return pcs, nil
-}
-
-// objdump is an old, slow way of finding coverage points.
-// amd64 uses faster option of parsing binary directly (readCoverPoints).
-// TODO: use the faster approach for all other arches and drop this.
-func objdump(target *targets.Target, mod *Module) ([2][]uint64, error) {
-	var pcs [2][]uint64
-	cmd := osutil.Command(target.Objdump, "-d", "--no-show-raw-insn", mod.Path)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return pcs, err
-	}
-	defer stdout.Close()
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return pcs, err
-	}
-	defer stderr.Close()
-	if err := cmd.Start(); err != nil {
-		return pcs, fmt.Errorf("failed to run objdump on %v: %v", mod.Path, err)
-	}
-	defer func() {
-		cmd.Process.Kill()
-		cmd.Wait()
-	}()
-	s := bufio.NewScanner(stdout)
-	callInsns, traceFuncs := archCallInsn(target)
-	for s.Scan() {
-		if pc := parseLine(callInsns, traceFuncs, s.Bytes()); pc != 0 {
-			pcs[0] = append(pcs[0], pc+mod.Addr)
-		}
-	}
-	stderrOut, _ := ioutil.ReadAll(stderr)
-	if err := cmd.Wait(); err != nil {
-		return pcs, fmt.Errorf("failed to run objdump on %v: %v\n%s", mod.Path, err, stderrOut)
-	}
-	if err := s.Err(); err != nil {
-		return pcs, fmt.Errorf("failed to run objdump on %v: %v\n%s", mod.Path, err, stderrOut)
-	}
-	return pcs, nil
-}
-
-func parseLine(callInsns, traceFuncs [][]byte, ln []byte) uint64 {
-	pos := -1
-	for _, callInsn := range callInsns {
-		if pos = bytes.Index(ln, callInsn); pos != -1 {
-			break
-		}
-	}
-	if pos == -1 {
-		return 0
-	}
-	hasCall := false
-	for _, traceFunc := range traceFuncs {
-		if hasCall = bytes.Contains(ln[pos:], traceFunc); hasCall {
-			break
-		}
-	}
-	if !hasCall {
-		return 0
-	}
-	for len(ln) != 0 && ln[0] == ' ' {
-		ln = ln[1:]
-	}
-	colon := bytes.IndexByte(ln, ':')
-	if colon == -1 {
-		return 0
-	}
-	pc, err := strconv.ParseUint(string(ln[:colon]), 16, 64)
-	if err != nil {
-		return 0
-	}
-	return pc
-}
-
-func cleanPath(path, objDir, srcDir, buildDir string) (string, string) {
-	filename := ""
-	switch {
-	case strings.HasPrefix(path, objDir):
-		// Assume the file was built there.
-		path = strings.TrimPrefix(path, objDir)
-		filename = filepath.Join(objDir, path)
-	case strings.HasPrefix(path, buildDir):
-		// Assume the file was moved from buildDir to srcDir.
-		path = strings.TrimPrefix(path, buildDir)
-		filename = filepath.Join(srcDir, path)
-	default:
-		// Assume this is relative path.
-		filename = filepath.Join(srcDir, path)
-	}
-	return strings.TrimLeft(filepath.Clean(path), "/\\"), filename
-}
-
-func archCallInsn(target *targets.Target) ([][]byte, [][]byte) {
-	callName := [][]byte{[]byte(" <__sanitizer_cov_trace_pc>")}
-	switch target.Arch {
-	case targets.I386:
-		// c1000102:       call   c10001f0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tcall ")}, callName
-	case targets.ARM64:
-		// ffff0000080d9cc0:       bl      ffff00000820f478 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl\t")}, callName
-	case targets.ARM:
-		// 8010252c:       bl      801c3280 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl\t")}, callName
-	case targets.PPC64LE:
-		// c00000000006d904:       bl      c000000000350780 <.__sanitizer_cov_trace_pc>
-		// This is only known to occur in the test:
-		// 838:   bl      824 <__sanitizer_cov_trace_pc+0x8>
-		// This occurs on PPC64LE:
-		// c0000000001c21a8:       bl      c0000000002df4a0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbl ")}, [][]byte{
-			[]byte("<__sanitizer_cov_trace_pc>"),
-			[]byte("<__sanitizer_cov_trace_pc+0x8>"),
-			[]byte(" <.__sanitizer_cov_trace_pc>"),
-		}
-	case targets.MIPS64LE:
-		// ffffffff80100420:       jal     ffffffff80205880 <__sanitizer_cov_trace_pc>
-		// This is only known to occur in the test:
-		// b58:   bal     b30 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tjal\t"), []byte("\tbal\t")}, callName
-	case targets.S390x:
-		// 1001de:       brasl   %r14,2bc090 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tbrasl\t")}, callName
-	case targets.RiscV64:
-		// ffffffe000200018:       jal     ra,ffffffe0002935b0 <__sanitizer_cov_trace_pc>
-		// ffffffe0000010da:       jalr    1242(ra) # ffffffe0002935b0 <__sanitizer_cov_trace_pc>
-		return [][]byte{[]byte("\tjal\t"), []byte("\tjalr\t")}, callName
-	default:
-		panic(fmt.Sprintf("unknown arch %q", target.Arch))
-	}
 }

--- a/pkg/cover/backend/mach-o.go
+++ b/pkg/cover/backend/mach-o.go
@@ -1,0 +1,120 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"debug/macho"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func makeMachO(target *targets.Target, objDir, srcDir, buildDir string,
+	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
+	return makeDWARF(target, objDir, srcDir, buildDir, moduleObj, hostModules,
+		&containerFns{
+			readSymbols:           machoReadSymbols,
+			readTextData:          machoReadTextData,
+			readModuleCoverPoints: machoReadModuleCoverPoints,
+			readTextRanges:        machoReadTextRanges,
+		},
+	)
+}
+
+func machoReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {
+	file, err := macho.Open(module.Path)
+	if err != nil {
+		return nil, err
+	}
+	text := file.Section("__text")
+	if text == nil {
+		return nil, fmt.Errorf("no __text section in the object file")
+	}
+	if file.Symtab == nil {
+		return nil, fmt.Errorf("failed to read Mach-O symbols")
+	}
+	info.textAddr = text.Addr
+
+	// We don't get symbol lengths or symbol ends in Mach-O symbols. So we
+	// guesstimate them by taking the next symbols beginning -1. That only
+	// works after we have sorted them.
+	sort.Slice(file.Symtab.Syms, func(i, j int) bool {
+		return file.Symtab.Syms[i].Value < file.Symtab.Syms[j].Value
+	})
+
+	var symbols []*Symbol
+	for i, symb := range file.Symtab.Syms {
+		// Mach-Os doesn't contain the Symbol size like in ELF
+		symbEnd := text.Addr + text.Size
+		if i < len(file.Symtab.Syms)-1 {
+			symbEnd = file.Symtab.Syms[i+1].Value
+		}
+
+		text := symb.Value >= text.Addr && symbEnd <= text.Addr+text.Size
+		if text {
+			symbStart := symb.Value + module.Addr
+			symbols = append(symbols, &Symbol{
+				Module: module,
+				ObjectUnit: ObjectUnit{
+					Name: symb.Name,
+				},
+				Start: symbStart,
+				End:   symbEnd,
+			})
+		}
+		if strings.HasPrefix(symb.Name, "___sanitizer_cov_trace_") {
+			if symb.Name == "___sanitizer_cov_trace_pc_guard" {
+				info.tracePCIdx[i] = true
+				if text {
+					info.tracePC = symb.Value
+				}
+			} else {
+				info.traceCmpIdx[i] = true
+				if text {
+					info.traceCmp[symb.Value] = true
+				}
+			}
+		}
+	}
+	return symbols, nil
+}
+
+func machoReadTextRanges(module *Module) ([]pcRange, []*CompileUnit, error) {
+	dir, kernel := filepath.Split(module.Path)
+	dSYMPath := filepath.Join(dir, fmt.Sprintf(
+		"%[1]s.dSYM/Contents/Resources/DWARF/%[1]s", kernel))
+	dSYM, err := macho.Open(dSYMPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	debugInfo, err := dSYM.DWARF()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse DWARF: %v", err)
+	}
+	return readTextRanges(debugInfo, module, nil)
+}
+
+func machoReadTextData(module *Module) ([]byte, error) {
+	file, err := macho.Open(module.Path)
+	if err != nil {
+		return nil, err
+	}
+	text := file.Section("__text")
+	if text == nil {
+		return nil, fmt.Errorf("no __text section in the object file")
+	}
+	return text.Data()
+}
+
+func machoReadModuleCoverPoints(module *Module, info *symbolInfo) ([2][]uint64, error) {
+	// TODO: Linux/ELF supports module symbols. We should probably also do that
+	// for XNU/Mach-O. To maximize code re-use we already have a lot of the
+	// plumbing for module support. I think we mainly miss an equivalent to
+	// discoverModules and this function at the moment.
+	return [2][]uint64{}, fmt.Errorf("machoReadModuleCoverPoints not implemented")
+}

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -19,6 +19,7 @@ import (
 func discoverModules(target *targets.Target, objDir string, moduleObj []string, hostModules []host.KernelModule) (
 	[]*Module, error) {
 	modules := []*Module{
+		// A dummy module representing the kernel itself.
 		{Path: filepath.Join(objDir, target.KernelObject)},
 	}
 	if target.OS == targets.Linux {

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -44,13 +44,13 @@ func TestReportGenerator(t *testing.T) {
 			Name:     "no-coverage",
 			CFlags:   []string{"-g"},
 			AddCover: true,
-			Result:   `.* doesn't contain coverage callbacks \(set CONFIG_KCOV=y\)`,
+			Result:   `.* doesn't contain coverage callbacks \(set CONFIG_KCOV=y on linux\)`,
 		},
 		{
 			Name:     "no-debug-info",
 			CFlags:   []string{"-fsanitize-coverage=trace-pc"},
 			AddCover: true,
-			Result:   `failed to parse DWARF.*\(set CONFIG_DEBUG_INFO=y\?\)`,
+			Result:   `failed to parse DWARF.*\(set CONFIG_DEBUG_INFO=y on linux\)`,
 		},
 		{
 			Name:   "no-pcs",

--- a/pkg/host/syscalls.go
+++ b/pkg/host/syscalls.go
@@ -34,7 +34,7 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string) (
 				reason = disabledAttribute
 			case c.CallName == "syz_execute_func":
 				// syz_execute_func caused multiple problems:
-				// 1. First it lead to corpus exploision. The program used existing values in registers
+				// 1. First it lead to corpus explosion. The program used existing values in registers
 				// to pollute output area. We tried to zero registers (though, not reliably).
 				// 2. It lead to explosion again. The exact mechanics are unknown, here is one sample:
 				// syz_execute_func(&(0x7f0000000440)="f2af91930f0124eda133fa20430fbafce842f66188d0d4

--- a/tools/check-commits.sh
+++ b/tools/check-commits.sh
@@ -23,7 +23,7 @@ for HASH in ${HASHES}; do
 	((COMMITS+=1))
 	SUBJECT=$(git show --format="%s" --no-patch ${HASH})
 	BODY=$(git show --format="%B" --no-patch ${HASH})
-	if ! [[ ${SUBJECT} =~ ^(Revert \"|(([a-z0-9/_.-]+|Makefile|CONTRIBUTORS|README.md)(, )?)+:\ [a-z].+[^.]$) ]]; then
+	if ! [[ ${SUBJECT} =~ ^(Revert \"|(([a-z0-9/_.-]+|Makefile|CONTRIBUTORS|README.md)(, )?)+:\ [^A-Z].+[^.]$) ]]; then
 		echo "##[error]Wrong commit subject format: '${SUBJECT}'.\
  Please use 'main/affected/package: short change description'.\
  See docs/contributing.md for details."


### PR DESCRIPTION
This is my first patch set in my ongoing effort to implement XNU/Darwin support in syzkaller: google/syzkaller#2553

I've tested this set as part of my more complete XNU syzkaller POC and can confirm this at least enables me to visit the `/cover` endpoint, after some coverage has been collected, and see some pretty red lines and sometimes even numbers next to those lines. ;)

Let me know what you think.