### PR TITLE
tools/syz-symbolize: fix a code format issue

### DIFF
--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -37,7 +37,7 @@ func main() {
 		"kernel_obj": "` + *flagKernelObj + `",
 		"kernel_src": "` + *flagKernelSrc + `",
 		"target": "` + *flagOS + "/" + *flagArch + `"
-}`))
+	}`))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Dongliang Mu <mudongliangabcd@gmail.com>

Align "}`))"