### PR TITLE
pkg/report: add one new field - Frames in Report

### DIFF
--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -56,7 +56,7 @@ func (ctx *freebsd) Parse(output []byte) *Report {
 	if oops == nil {
 		return nil
 	}
-	title, corrupted, altTitles, _ := extractDescription(output[rep.StartPos:], oops, freebsdStackParams)
+	title, corrupted, altTitles, _, _ := extractDescription(output[rep.StartPos:], oops, freebsdStackParams)
 	rep.Title = title
 	rep.AltTitles = altTitles
 	rep.Corrupted = corrupted != ""

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -147,11 +147,11 @@ func (ctx *linux) Parse(output []byte) *Report {
 		}
 		endPos, reportEnd, report, prefix := ctx.findReport(output, oops, startPos, context, questionable)
 		rep.EndPos = endPos
-		title, corrupted, altTitles, format := extractDescription(report[:reportEnd], oops, linuxStackParams)
+		title, corrupted, altTitles, frames, format := extractDescription(report[:reportEnd], oops, linuxStackParams)
 		if title == "" {
 			prefix = nil
 			report = output[rep.StartPos:rep.EndPos]
-			title, corrupted, altTitles, format = extractDescription(report, oops, linuxStackParams)
+			title, corrupted, altTitles, frames, format = extractDescription(report, oops, linuxStackParams)
 			if title == "" {
 				panic(fmt.Sprintf("non matching oops for %q context=%q in:\n%s\n",
 					oops.header, context, report))
@@ -159,6 +159,7 @@ func (ctx *linux) Parse(output []byte) *Report {
 		}
 		rep.Title = title
 		rep.AltTitles = altTitles
+		rep.Frames = frames
 		rep.Corrupted = corrupted != ""
 		rep.CorruptedReason = corrupted
 		for _, line := range prefix {

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -37,7 +37,7 @@ func main() {
 		"kernel_obj": "` + *flagKernelObj + `",
 		"kernel_src": "` + *flagKernelSrc + `",
 		"target": "` + *flagOS + "/" + *flagArch + `"
-}`))
+	}`))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
To compare the similarity of two crash reports, we should first extract the stack frames from the crash reports. So this patch adds one new field - Frames into Report, and then fill the frames extracted from extractStackFrameImpl to this field.
Note: I am not very familiar with golang. If there is any simple implementation, please let me know. Thanks in advance.