### PR TITLE
pkg/build: configure vm.panic_on_oom on FreeBSD

### DIFF
--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -92,6 +92,7 @@ cc_htcp_load="YES"
 cc_vegas_load="YES"
 
 kern.ipc.tls.enable="1"
+vm.panic_on_oom="1"
 __EOF__
 
 cat | sudo tee -a ${tmpdir}/etc/sysctl.conf <<__EOF__


### PR DESCRIPTION
OOM kills are a source of "lost connection to test machine" and "no
output from test machine reports".  At the point where we start getting
OOM kills, we might as well give up, and turning them into a panic gives
us some extra debugging info as well as a way to distinguish OOM kills
from other causes of these reports.