### PR TITLE
pkg/build: fix qemu timeouts for netbsd

### DIFF
--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -111,6 +111,7 @@ func (ctx netbsd) copyKernelToDisk(targetArch, vmType, outputDir, kernel string)
 			TargetOS:     targets.NetBSD,
 			TargetArch:   targetArch,
 			TargetVMArch: targetArch,
+			Timeouts:     targets.Get(targets.NetBSD, targetArch).Timeouts(1),
 		},
 	}
 	// Create a VM pool.


### PR DESCRIPTION
netbsd.go uses a hacky way to construct manager config
that skips of all of our verification/completion logic.
As the result the manager config has 0 timeouts and qemu
immidiately timeouts. Fill in timeouts.
