### PR TITLE
all: save module offsets in corpus

### DIFF
--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -16,6 +16,7 @@ type RPCInput struct {
 	Prog   []byte
 	Signal signal.Serial
 	Cover  []uint32
+	Offsets map[string][]uint32
 }
 
 type RPCCandidate struct {

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 var getReportGenerator = func() func(cfg *mgrconfig.Config,
@@ -27,10 +29,26 @@ var getReportGenerator = func() func(cfg *mgrconfig.Config,
 	}
 }()
 
-func coverToPCs(rg *cover.ReportGenerator, cov []uint32) []uint64 {
-	pcs := make([]uint64, 0, len(cov))
-	for _, pc := range cov {
-		pcs = append(pcs, rg.RestorePC(pc))
+func coverToPCs(target *targets.Target, modules []host.KernelModule, rg *cover.ReportGenerator, cov map[string][]uint32) []uint64 {
+	var pcs []uint64
+	if len(modules) == 0 {
+		modules = append(modules, host.KernelModule{
+			Name: "",
+		})
+	}
+	for mod, offsets := range cov {
+		for _, offset := range offsets {
+			for _, module := range modules {
+				if module.Name == mod {
+					if module.Name == "" {
+						pcs = append(pcs, backend.NextInstructionPC(target, rg.RestorePC(offset)))
+					} else {
+						pcs = append(pcs, module.Addr+uint64(offset))
+					}
+					break
+				}
+			}
+		}
 	}
 	return pcs
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1084,6 +1084,10 @@ func (mgr *Manager) fuzzerConnect(modules []host.KernelModule) (
 	return corpus, frames, mgr.coverFilter, mgr.coverFilterBitmap, nil
 }
 
+func (mgr *Manager) isModuleInitialized() bool {
+	return mgr.modulesInitialized
+}
+
 func (mgr *Manager) machineChecked(a *rpctype.CheckArgs, enabledSyscalls map[*prog.Syscall]bool) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
@@ -1104,10 +1108,10 @@ func (mgr *Manager) newInput(inp rpctype.RPCInput, sign signal.Signal) bool {
 		// The input is already present, but possibly with diffent signal/coverage/call.
 		sign.Merge(old.Signal.Deserialize())
 		old.Signal = sign.Serialize()
-		var cov cover.Cover
-		cov.Merge(old.Cover)
-		cov.Merge(inp.Cover)
-		old.Cover = cov.Serialize()
+		var cov cover.CoverOffsets
+		cov.Merge(old.Offsets)
+		cov.Merge(inp.Offsets)
+		old.Offsets = cov.Serialize()
 		mgr.corpus[sig] = old
 	} else {
 		mgr.corpus[sig] = inp


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************

Discussion here https://groups.google.com/g/syzkaller/c/1Pnm_BjrZO8

The idea in the PR is to:
1. save 1st connected fuzzer's module info into serv.modules and use it for rg
2. save 1st and following fuzzers' module info into f
3. decode module name and offset from NewInput cov
4. restore to PC related to 1st modules by using module name and offset
