### PR TITLE
tools/create-openbsd-vmm-worker increase worker disk image size

### DIFF
--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -130,7 +130,7 @@ growisofs -M "${ISO_PATCHED}" -l -R -graft-points \
 
 # Initialize disk image.
 rm -f worker_disk.raw
-qemu-img create -f raw worker_disk.raw 1G
+qemu-img create -f raw worker_disk.raw 1500M
 
 # Run the installer to create the disk image.
 expect 2>&1 <<EOF | tee install_log


### PR DESCRIPTION
llvm/clang growth post-6.9 pushed the worker image over the previous
limit. The 1.5 increase gives us room for future growth.

