### PR TITLE
syz-verifier: initial prototype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,12 @@ kconf:
 bisect: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-bisect github.com/google/syzkaller/tools/syz-bisect
 
+verifier: descriptions
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-verifier github.com/google/syzkaller/syz-verifier
+
+runner:  descriptions
+	GOOS=$(TARGETGOOS) GOARCH=$(TARGETGOARCH) $(GO) build $(GOTARGETFLAGS) -o ./bin/$(TARGETOS)_$(TARGETVMARCH)/syz-runner$(EXE) github.com/google/syzkaller/syz-runner
+
 # `extract` extracts const files from various kernel sources, and may only
 # re-generate parts of files.
 extract: bin/syz-extract

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -499,3 +499,7 @@ var MakeBin = func() string {
 	}
 	return "make"
 }()
+
+func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int) string {
+	return fmt.Sprintf("%s -addr=%s -os=%s -arch=%s -pool=%v -vm=%v", prog, fwdAddr, os, arch, poolIdx, vmIdx)
+}

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -141,3 +141,38 @@ func TestExecprogCmd(t *testing.T) {
 		t.Errorf("bad slowdown: %v, want: %v", *flagSlowdown, 10)
 	}
 }
+
+func TestRunnerCmd(t *testing.T) {
+	flags := flag.NewFlagSet("", flag.ContinueOnError)
+	flagFwdAddr := flags.String("addr", "", "verifier rpc address")
+	flagOS := flags.String("os", "", "target OS")
+	flagArch := flags.String("arch", "", "target architecture")
+	flagPool := flags.Int("pool", 0, "index of pool that started VM")
+	flagVM := flags.Int("vm", 0, "index of VM that started the Runner")
+
+	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0)
+	args := strings.Split(cmdLine, " ")[1:]
+	if err := flags.Parse(args); err != nil {
+		t.Fatalf("error parsing flags: %v, want: nil", err)
+	}
+
+	if got, want := *flagFwdAddr, "localhost:1234"; got != want {
+		t.Errorf("bad addr: %q, want: %q", got, want)
+	}
+
+	if got, want := *flagOS, targets.Linux; got != want {
+		t.Errorf("bad os: %q, want %q", got, want)
+	}
+
+	if got, want := *flagArch, targets.AMD64; got != want {
+		t.Errorf("bad arch: %q, want: %q", got, want)
+	}
+
+	if got, want := *flagPool, 0; got != want {
+		t.Errorf("bad pool index: %d, want: %d", got, want)
+	}
+
+	if got, want := *flagVM, 0; got != want {
+		t.Errorf("bad vm index: %d, want: %d", got, want)
+	}
+}

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -24,6 +24,11 @@ type RPCCandidate struct {
 	Smashed   bool
 }
 
+type RPCProg struct {
+	Prog    []byte
+	ProgIdx int
+}
+
 type ConnectArgs struct {
 	Name        string
 	MachineInfo []byte
@@ -70,6 +75,33 @@ type PollRes struct {
 	Candidates []RPCCandidate
 	NewInputs  []RPCInput
 	MaxSignal  signal.Serial
+}
+
+type RunnerConnectArgs struct {
+	Pool, VM int
+}
+
+// NextExchangeArgs contains the data passed from client to server namely
+// identification information of the VM and program execution results.
+type NextExchangeArgs struct {
+	// Pool/VM are used to identify the instance on which the client is running.
+	Pool, VM int
+	// ProgIdx is used to uniquely identify the program for which the client is
+	// sending results.
+	ProgIdx int
+	// Hanged is set to true if the program for which we are sending results
+	// was killed due to hanging.
+	Hanged bool
+	// Info contains information about the execution of each system call in the
+	// program.
+	Info ipc.ProgInfo
+}
+
+// NextExchaneRes contains the data passed from server to client namely
+// programs  to execute on the VM.
+type NextExchangeRes struct {
+	// RPCProg contains the serialized program that will be sent to the client.
+	RPCProg
 }
 
 type HubConnectArgs struct {

--- a/pkg/tool/flags.go
+++ b/pkg/tool/flags.go
@@ -6,6 +6,7 @@ package tool
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -121,4 +122,25 @@ func flagUnescape(s string) (string, error) {
 		buf.WriteByte(ch)
 	}
 	return buf.String(), nil
+}
+
+// CfgsFlag allows passing a list of configuration files to the
+// same flag and provides parsing utilities.
+type CfgsFlag []string
+
+// String correctly converts the flag values into a string which is required to // parse them afterwards.
+func (cfgs *CfgsFlag) String() string {
+	return fmt.Sprint(*cfgs)
+}
+
+// Set is used by flag.Parse to correctly parse the command line arguments.
+func (cfgs *CfgsFlag) Set(value string) error {
+	if len(*cfgs) > 0 {
+		return errors.New("configs flag were already set")
+	}
+	for _, cfg := range strings.Split(value, ",") {
+		cfg = strings.TrimSpace(cfg)
+		*cfgs = append(*cfgs, cfg)
+	}
+	return nil
 }

--- a/pkg/tool/flags_test.go
+++ b/pkg/tool/flags_test.go
@@ -60,3 +60,27 @@ func TestParseFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestCfgsFlagString(t *testing.T) {
+	cfgs := &CfgsFlag{"a", "b", "c"}
+	if got, want := cfgs.String(), "[a b c]"; got != want {
+		t.Errorf("cfgs.String got: %s, want: %s", got, want)
+	}
+}
+
+func TestCfgsFlagSet(t *testing.T) {
+	cfgs := &CfgsFlag{}
+	if err := cfgs.Set("a, b, c"); err != nil {
+		t.Fatalf("cfgs.Set got: %v, want: nil", err)
+	}
+	if diff := cmp.Diff(*cfgs, CfgsFlag{"a", "b", "c"}); diff != "" {
+		t.Errorf("*cfgs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCfgsFlagAlreadySet(t *testing.T) {
+	cfgs := &CfgsFlag{"a", "b", "c"}
+	if err := cfgs.Set("a, b, c"); err == nil {
+		t.Errorf("cfgs.Set got: nil, want: error")
+	}
+}

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -1,0 +1,105 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+package main
+
+import (
+	"flag"
+	"log"
+	"runtime"
+
+	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/pkg/ipc/ipcconfig"
+	"github.com/google/syzkaller/pkg/rpctype"
+	"github.com/google/syzkaller/prog"
+)
+
+// Runner is responsible of running programs sent by the host via RPC and
+// reporting the execution results back to the host.
+type Runner struct {
+	vrf      *rpctype.RPCClient
+	target   *prog.Target
+	opts     *ipc.ExecOpts
+	config   *ipc.Config
+	pool, vm int
+}
+
+func main() {
+	flagPool := flag.Int("pool", 0, "index of pool it corresponds to")
+	flagVM := flag.Int("vm", 0, "index of VM that started the Runner")
+	flagAddr := flag.String("addr", "", "verifier rpc address")
+	flagOS := flag.String("os", runtime.GOOS, "target OS")
+	flagArch := flag.String("arch", runtime.GOARCH, "target arch")
+	flag.Parse()
+	target, err := prog.GetTarget(*flagOS, *flagArch)
+	if err != nil {
+		log.Fatalf("failed to configure target: %v", err)
+	}
+	config, opts, err := ipcconfig.Default(target)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	timeouts := config.Timeouts
+	vrf, err := rpctype.NewRPCClient(*flagAddr, timeouts.Scale)
+	if err != nil {
+		log.Fatalf("failed to connect to verifier : %v", err)
+	}
+
+	rn := &Runner{
+		vrf:    vrf,
+		target: target,
+		opts:   opts,
+		config: config,
+		pool:   *flagPool,
+		vm:     *flagVM,
+	}
+
+	a := &rpctype.RunnerConnectArgs{
+		Pool: rn.pool,
+		VM:   rn.vm,
+	}
+	if err := vrf.Call("Verifier.Connect", a, nil); err != nil {
+		log.Fatalf("failed to connect to verifier: %v", err)
+	}
+
+	r := &rpctype.NextExchangeRes{}
+	if err := rn.vrf.Call("Verifier.NextExchange", &rpctype.NextExchangeArgs{Pool: rn.pool, VM: rn.vm}, r); err != nil {
+		log.Fatalf("failed to get initial program: %v", err)
+	}
+
+	rn.Run(r.Prog, r.ProgIdx)
+}
+
+// Run is responsible for requesting new programs from the verifier, executing them and then sending back the Result.
+// TODO: Implement functionality to execute several programs at once and send back a slice of results.
+func (rn *Runner) Run(firstProg []byte, idx int) {
+	p, pIdx := firstProg, idx
+	env, err := ipc.MakeEnv(rn.config, 0)
+	if err != nil {
+		log.Fatalf("failed to create execution environment: %v", err)
+	}
+
+	for {
+		prog, err := rn.target.Deserialize(p, prog.NonStrict)
+		if err != nil {
+			log.Fatalf("failed to deserialise new program: %v", err)
+		}
+
+		_, info, hanged, err := env.Exec(rn.opts, prog)
+		if err != nil {
+			log.Fatalf("failed to execute the program: %v", err)
+		}
+		a := &rpctype.NextExchangeArgs{
+			Pool:    rn.pool,
+			VM:      rn.vm,
+			ProgIdx: pIdx,
+			Hanged:  hanged,
+			Info:    *info,
+		}
+		r := &rpctype.NextExchangeRes{}
+		if err := rn.vrf.Call("Verifier.NextExchange", a, r); err != nil {
+			log.Fatalf("failed to make exchange with verifier: %v", err)
+		}
+		p = r.Prog
+		pIdx = r.ProgIdx
+	}
+}

--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -1,0 +1,331 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+package main
+
+import (
+	"flag"
+	"log"
+	"math/rand"
+	"net"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/rpctype"
+	"github.com/google/syzkaller/pkg/tool"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/syz-verifier/verf"
+	"github.com/google/syzkaller/vm"
+)
+
+// Verifier TODO.
+type Verifier struct {
+	pools  map[int]*poolInfo
+	vmStop chan bool
+	// Location of a working directory for all VMs for the syz-verifier process.
+	// Outputs here include:
+	// - <workdir>/crashes/<OS-Arch>/*: crash output files grouped by OS/Arch
+	// - <workdir>/corpus.db: corpus with interesting programs
+	// - <workdir>/<OS-Arch>/instance-x: per VM instance temporary files
+	// grouped by OS/Arch
+	workdir     string
+	crashdir    string
+	target      *prog.Target
+	runnerBin   string
+	executorBin string
+	choiceTable *prog.ChoiceTable
+	rnd         *rand.Rand
+	progIdx     int
+	addr        string
+}
+
+// RPCServer is a wrapper around the rpc.Server. It communicates with  Runners,
+// generates programs and sends complete Results for verification.
+type RPCServer struct {
+	vrf   *Verifier
+	port  int
+	mu    sync.Mutex
+	pools map[int]*poolInfo
+	progs map[int]*progInfo
+}
+
+// poolInfo contains kernel-specific information for spawning virtual machines
+// and reporting crashes. It also keeps track of the Runners executing on
+// spawned VMs, what programs have been sent to each Runner and what programs
+// have yet to be sent on any of the Runners.
+type poolInfo struct {
+	cfg      *mgrconfig.Config
+	pool     *vm.Pool
+	Reporter report.Reporter
+	//  vmRunners keep track of what programs have been sent to each Runner.
+	//  There is one Runner executing per VM instance.
+	vmRunners map[int][]*progInfo
+	// progs stores the programs that haven't been sent to this kernel yet but
+	// have been sent to at least one kernel.
+	progs []*progInfo
+}
+
+type progInfo struct {
+	prog       *prog.Prog
+	idx        int
+	serialized []byte
+	res        []*verf.Result
+	// left contains the indices of kernels that haven't sent results for this
+	// program yet.
+	left map[int]bool
+}
+
+func main() {
+	var cfgs tool.CfgsFlag
+	flag.Var(&cfgs, "configs", "list of kernel-specific comma-sepatated configuration files ")
+	flagDebug := flag.Bool("debug", false, "dump all VM output to console")
+	flag.Parse()
+	pools := make(map[int]*poolInfo)
+	for idx, cfg := range cfgs {
+		var err error
+		pi := &poolInfo{}
+		pi.cfg, err = mgrconfig.LoadFile(cfg)
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		pi.pool, err = vm.Create(pi.cfg, *flagDebug)
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		pools[idx] = pi
+	}
+
+	cfg := pools[0].cfg
+	workdir, target, sysTarget, addr := cfg.Workdir, cfg.Target, cfg.SysTarget, cfg.RPC
+	for idx := 1; idx < len(pools); idx++ {
+		cfg := pools[idx].cfg
+
+		// TODO: pass the configurations that should be the same for all
+		// kernels in a default config file in order to avoid this checks and
+		// add testing
+		if workdir != cfg.Workdir {
+			log.Fatalf("working directory mismatch")
+		}
+		if target != cfg.Target {
+			log.Fatalf("target mismatch")
+		}
+		if sysTarget != cfg.SysTarget {
+			log.Fatalf("system target mismatch")
+		}
+		if addr != pools[idx].cfg.RPC {
+			log.Fatalf("tcp address mismatch")
+		}
+	}
+
+	exe := sysTarget.ExeExtension
+	runnerBin := filepath.Join(cfg.Syzkaller, "bin", target.OS+"_"+target.Arch, "syz-runner"+exe)
+	if !osutil.IsExist(runnerBin) {
+		log.Fatalf("bad syzkaller config: can't find %v", runnerBin)
+	}
+	execBin := cfg.ExecutorBin
+	if !osutil.IsExist(execBin) {
+		log.Fatalf("bad syzkaller config: can't find %v", execBin)
+	}
+
+	crashdir := filepath.Join(workdir, "crashes")
+	osutil.MkdirAll(crashdir)
+	for idx := range pools {
+		OS, Arch := target.OS, target.Arch
+		targetPath := OS + "-" + Arch + "-" + strconv.Itoa(idx)
+		osutil.MkdirAll(filepath.Join(workdir, targetPath))
+		osutil.MkdirAll(filepath.Join(crashdir, targetPath))
+	}
+
+	for idx, pi := range pools {
+		var err error
+		pi.Reporter, err = report.NewReporter(pi.cfg)
+		if err != nil {
+			log.Fatalf("failed to create reporter for instance-%d: %v", idx, err)
+		}
+		pi.vmRunners = make(map[int][]*progInfo)
+		pi.progs = make([]*progInfo, 0)
+	}
+
+	calls := make(map[*prog.Syscall]bool)
+	for _, id := range cfg.Syscalls {
+		calls[target.Syscalls[id]] = true
+	}
+
+	vrf := &Verifier{
+		workdir:     workdir,
+		crashdir:    crashdir,
+		pools:       pools,
+		target:      target,
+		choiceTable: target.BuildChoiceTable(nil, calls),
+		rnd:         rand.New(rand.NewSource(time.Now().UnixNano() + 1e12)),
+		runnerBin:   runnerBin,
+		executorBin: execBin,
+		addr:        addr,
+	}
+
+	srv, err := startRPCServer(vrf)
+	if err != nil {
+		log.Fatalf("failed to initialise RPC server: %v", err)
+	}
+
+	for idx, pi := range pools {
+		go func(pi *poolInfo, idx int) {
+			for { // TODO: implement support for multiple VMs per Pool.
+				inst, err := pi.pool.Create(0)
+				if err != nil {
+					log.Fatalf("failed to create instance: %v", err)
+				}
+
+				fwdAddr, err := inst.Forward(srv.port)
+				if err != nil {
+					log.Fatalf("failed to set up port forwarding: %v", err)
+				}
+
+				runnerBin, err := inst.Copy(vrf.runnerBin)
+				if err != nil {
+					log.Fatalf(" failed to copy runner binary: %v", err)
+				}
+				_, err = inst.Copy(vrf.executorBin)
+				if err != nil {
+					log.Fatalf("failed to copy executor binary: %v", err)
+				}
+
+				cmd := instance.RunnerCmd(runnerBin, fwdAddr, vrf.target.OS, vrf.target.Arch, idx, 0)
+				outc, errc, err := inst.Run(pi.cfg.Timeouts.VMRunningTime, vrf.vmStop, cmd)
+				if err != nil {
+					log.Fatalf("failed to start runner: %v", err)
+				}
+
+				inst.MonitorExecution(outc, errc, pi.Reporter, vm.ExitTimeout)
+				srv.cleanup(idx, 0)
+			}
+		}(pi, idx)
+	}
+
+	select {}
+}
+
+func startRPCServer(vrf *Verifier) (*RPCServer, error) {
+	srv := &RPCServer{
+		vrf:   vrf,
+		pools: vrf.pools,
+		progs: make(map[int]*progInfo),
+	}
+
+	s, err := rpctype.NewRPCServer(vrf.addr, "Verifier", srv)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("serving rpc on tcp://%v", s.Addr())
+	srv.port = s.Addr().(*net.TCPAddr).Port
+
+	go s.Serve()
+	return srv, nil
+}
+
+// Connect notifies the RPCServer that a new Runner was started.
+func (srv *RPCServer) Connect(a *rpctype.RunnerConnectArgs, r *int) error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	pool, vm := a.Pool, a.VM
+	srv.pools[pool].vmRunners[vm] = nil
+	return nil
+}
+
+// NextExchange is called when a Runner requests a new program to execute and,
+// potentially, wants to send a new Result to the RPCServer.
+func (srv *RPCServer) NextExchange(a *rpctype.NextExchangeArgs, r *rpctype.NextExchangeRes) error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if a.Info.Calls != nil {
+		res := &verf.Result{
+			Pool:   a.Pool,
+			Hanged: a.Hanged,
+			Info:   a.Info,
+		}
+		if srv.newResult(res, a.ProgIdx) {
+			for idx, prog := range srv.progs {
+				if a.ProgIdx == prog.idx {
+					if !verf.Verify(prog.res, prog.prog) {
+						log.Printf("mismatch found for %+v", prog.prog)
+					}
+					delete(srv.progs, idx)
+				}
+			}
+		}
+	}
+
+	prog, pi := srv.newProgram(a.Pool, a.VM)
+	r.RPCProg = rpctype.RPCProg{Prog: prog, ProgIdx: pi}
+	return nil
+}
+
+// newProgram returns a new program for the Runner identified by poolIdx and
+// vmIdx and the program's index.
+func (srv *RPCServer) newProgram(poolIdx, vmIdx int) ([]byte, int) {
+	pool := srv.pools[poolIdx]
+	if len(pool.progs) == 0 {
+		prog, progIdx := srv.vrf.generate()
+		pi := &progInfo{
+			prog:       prog,
+			idx:        progIdx,
+			serialized: prog.Serialize(),
+			res:        make([]*verf.Result, 0),
+			left:       make(map[int]bool),
+		}
+		for idx, pool := range srv.pools {
+			pool.progs = append(pool.progs, pi)
+			pi.left[idx] = true
+		}
+		srv.progs[progIdx] = pi
+	}
+	p := pool.progs[0]
+	pool.vmRunners[vmIdx] = append(pool.vmRunners[vmIdx], p)
+	pool.progs = pool.progs[1:]
+	return p.serialized, p.idx
+}
+
+// generate will return a newly generated program and its index.
+func (vrf *Verifier) generate() (*prog.Prog, int) {
+	vrf.progIdx++
+	return vrf.target.Generate(vrf.rnd, prog.RecommendedCalls, vrf.choiceTable), vrf.progIdx
+}
+
+// newResult is called when a Runner sends a new Result. It returns true if all
+// Results from the corresponding programs have been received and they can be
+// sent for verification. Otherwise, it returns false.
+func (srv *RPCServer) newResult(res *verf.Result, idx int) bool {
+	for _, prog := range srv.progs {
+		if prog.idx == idx {
+			prog.res = append(prog.res, res)
+			delete(prog.left, res.Pool)
+			return len(prog.left) == 0
+		}
+	}
+	return false
+}
+
+// cleanup is called when a vm.Instance crashes.
+func (srv *RPCServer) cleanup(poolIdx, vmIdx int) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	progs := srv.pools[poolIdx].vmRunners[vmIdx]
+	delete(srv.pools[poolIdx].vmRunners, vmIdx)
+	for idx, prog := range progs {
+		delete(prog.left, poolIdx)
+		if len(prog.left) == 0 {
+			if !verf.Verify(prog.res, prog.prog) {
+				log.Printf("mismatch found for %+v", prog.prog)
+			}
+			delete(srv.progs, idx)
+			continue
+		}
+	}
+}

--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -1,0 +1,155 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+package main
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/syzkaller/pkg/rpctype"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/syz-verifier/verf"
+)
+
+var (
+	srv *RPCServer
+)
+
+func setup(t *testing.T) {
+	target, err := prog.GetTarget("test", "64")
+	if err != nil {
+		t.Fatalf("failed to initialise test target: %v", err)
+	}
+	vrf := Verifier{
+		target:      target,
+		choiceTable: target.DefaultChoiceTable(),
+		rnd:         rand.New(rand.NewSource(time.Now().UnixNano())),
+		progIdx:     3,
+	}
+	srv, err = startRPCServer(&vrf)
+	if err != nil {
+		t.Fatalf("failed to initialise RPC server: %v", err)
+	}
+	srv.pools = map[int]*poolInfo{
+		1: {
+			vmRunners: map[int][]*progInfo{
+				0: {&progInfo{idx: 1, left: map[int]bool{1: true, 2: true}}},
+			},
+			progs: []*progInfo{{idx: 3, left: map[int]bool{1: true}}},
+		},
+		2: {vmRunners: map[int][]*progInfo{
+			2: {&progInfo{idx: 1, left: map[int]bool{1: true, 2: true}}},
+		},
+			progs: []*progInfo{},
+		},
+	}
+	srv.progs = map[int]*progInfo{
+		1: {idx: 1, left: map[int]bool{1: true, 2: true}},
+		3: {idx: 3, left: map[int]bool{1: true}},
+	}
+}
+
+func TestNewProgram(t *testing.T) {
+	tests := []struct {
+		name                             string
+		pool, vm, retProgIdx, vrfProgIdx int
+		progs                            map[int]*progInfo
+	}{
+		{
+			name:       "NewProgram doesn't generate new program",
+			pool:       1,
+			vm:         1,
+			retProgIdx: 3,
+			vrfProgIdx: 3,
+			progs: map[int]*progInfo{
+				1: {idx: 1, left: map[int]bool{1: true, 2: true}},
+				3: {idx: 3, left: map[int]bool{2: true}},
+			},
+		},
+		{
+			name:       "NewProgram generates new program",
+			pool:       2,
+			vm:         2,
+			retProgIdx: 4,
+			vrfProgIdx: 4,
+			progs: map[int]*progInfo{
+				1: {idx: 1, left: map[int]bool{1: true, 2: true}},
+				3: {idx: 3, left: map[int]bool{2: true}},
+				4: {idx: 4, left: map[int]bool{1: true, 2: true}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setup(t)
+			_, gotProgIdx := srv.newProgram(test.pool, test.vm)
+			if gotProgIdx != test.retProgIdx {
+				t.Errorf("srv.newProgram returned idx: got %d, want %d", gotProgIdx, test.retProgIdx)
+			}
+			if srv.vrf.progIdx != test.vrfProgIdx {
+				t.Errorf("srv.progIdx: got %d, want %d", srv.vrf.progIdx, test.vrfProgIdx)
+			}
+		})
+	}
+}
+
+func TestNewResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		idx       int
+		res       verf.Result
+		left      map[int]bool
+		wantReady bool
+	}{
+		{
+			name:      "Results ready for verification",
+			idx:       3,
+			res:       verf.Result{Pool: 1},
+			wantReady: true,
+			left:      map[int]bool{},
+		},
+		{
+			name:      "No results ready for verification",
+			idx:       1,
+			res:       verf.Result{Pool: 1},
+			wantReady: false,
+			left: map[int]bool{
+				2: true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setup(t)
+			gotReady := srv.newResult(&test.res, test.idx)
+			if test.wantReady != gotReady {
+				t.Errorf("srv.newResult: got %v want %v", gotReady, test.wantReady)
+			}
+			if diff := cmp.Diff(test.left, srv.progs[test.idx].left); diff != "" {
+				t.Errorf("srv.left mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConnect(t *testing.T) {
+	setup(t)
+	a := &rpctype.RunnerConnectArgs{
+		Pool: 1,
+		VM:   1,
+	}
+	if err := srv.Connect(a, nil); err != nil {
+		t.Fatalf("srv.Connect failed: %v", err)
+	}
+	want, got := map[int][]*progInfo{
+		0: {&progInfo{idx: 1, left: map[int]bool{1: true, 2: true}}},
+		1: nil,
+	}, srv.pools[a.Pool].vmRunners
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(progInfo{})); diff != "" {
+		t.Errorf("srv.progs[a.Name] mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TODO: add integration tests for NewExchange and cleanup.

--- a/syz-verifier/verf/verifier.go
+++ b/syz-verifier/verf/verifier.go
@@ -1,0 +1,45 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package verf contains utilities for verifying the execution of the same
+// program on different kernels yield the same results.
+package verf
+
+import (
+	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/prog"
+)
+
+// Result stores the results of executing a program.
+type Result struct {
+	// Pool is the index of the pool.
+	Pool int
+	// Hanged is set to true when a program was killed due to hanging.
+	Hanged bool
+	// Info contains information about the execution of each system call
+	// in the generated programs.
+	Info ipc.ProgInfo
+}
+
+// Verify checks whether the Results of the same program, executed on different
+// kernels are the same. If that's the case, it returns true, otherwise it
+// returns false.
+func Verify(res []*Result, prog *prog.Prog) bool {
+	for i := 1; i < len(res); i++ {
+		if !VerifyErrnos(res[0].Info.Calls, res[i].Info.Calls) {
+			return false
+		}
+	}
+	return true
+}
+
+// VerifyErrnos checks whether the returned system call errnos of the same
+// program, executed on two different kernels, are the same.
+func VerifyErrnos(c1, c2 []ipc.CallInfo) bool {
+	for idx, c := range c1 {
+		if c.Errno != c2[idx].Errno {
+			return false
+		}
+	}
+	return true
+}

--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+package verf
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/ipc"
+)
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		name      string
+		res       []*Result
+		wantMatch bool
+	}{
+		{
+
+			name: "results should match",
+			res: []*Result{
+				{2, false, ipc.ProgInfo{
+					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 3}}, Extra: ipc.CallInfo{},
+				},
+				},
+				{4, false, ipc.ProgInfo{
+					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 3}},
+					Extra: ipc.CallInfo{},
+				},
+				},
+			},
+
+			wantMatch: true,
+		},
+		{
+			name: "results should not match",
+			res: []*Result{
+				{4, false, ipc.ProgInfo{
+					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
+				},
+				},
+				{8, false, ipc.ProgInfo{
+					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 3}, {Errno: 5}},
+				},
+				},
+			},
+			wantMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := Verify(test.res, nil), test.wantMatch; got != want {
+				t.Errorf("Verify: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestVerifyErrno(t *testing.T) {
+	tests := []struct {
+		name      string
+		c1, c2    []ipc.CallInfo
+		wantMatch bool
+	}{
+		{
+			name:      "errno should match",
+			c1:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
+			c2:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
+			wantMatch: true,
+		},
+		{
+			name:      "errno should not match",
+			c1:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
+			c2:        []ipc.CallInfo{{Errno: 1}, {Errno: 4}, {Errno: 5}},
+			wantMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := VerifyErrnos(test.c1, test.c2), test.wantMatch; got != want {
+				t.Errorf("VerifyErrno: got %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Created initial prototype for syz-verifier. This includes functionality for:
- parsing multiple configuration files
- creating VM instances from different VM pools
- establishing RPC communication between server on the host and clients on the guests
- sending an infinite stream of program to clients from the host
- sending an infinite stream of execution trace back to the host (for now, just in ipc.ProgInfo)
-  verifying the returned errnos match between different executions of the same program