### PR TITLE
vm/qemu: initial darwin support

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -201,6 +201,13 @@ var archConfigs = map[string]*archConfig{
 		NetDev:   "e1000",
 		RngDev:   "virtio-rng-pci",
 	},
+	"darwin/amd64": {
+		Qemu:      "qemu-system-x86_64",
+		QemuArgs:  "-enable-kvm -machine q35 -cpu host,migratable=off",
+		TargetDir: "/tmp",
+		NetDev:    "e1000-82545em",
+		RngDev:    "virtio-rng-pci",
+	},
 	"netbsd/amd64": {
 		Qemu:     "qemu-system-x86_64",
 		QemuArgs: "-enable-kvm",

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -389,7 +389,7 @@ func (inst *instance) boot() error {
 	args := []string{
 		"-m", strconv.Itoa(inst.cfg.Mem),
 		"-smp", strconv.Itoa(inst.cfg.CPU),
-		"-chardev", fmt.Sprintf("socket,id=SOCKSYZ,server,nowait,host=localhost,port=%v", inst.monport),
+		"-chardev", fmt.Sprintf("socket,id=SOCKSYZ,server=on,nowait,host=localhost,port=%v", inst.monport),
 		"-mon", "chardev=SOCKSYZ,mode=control",
 		"-display", "none",
 		"-serial", "stdio",


### PR DESCRIPTION
This is my fourth patch set in my ongoing effort to implement XNU/Darwin support in syzkaller: #2553

With this change running XNU in syzkaller should be possible, without requiring further syzkaller patches. Doing so still requires hand crafting a VM, bootloader and messing around with the qemu_args in your syzkaller config though. It's not yet trivial, which is what I'll hopefully tackle next.

Let me know what you think.