### PR TITLE
sys/trusty/gen: add empty.go

### DIFF
--- a/sys/sys.go
+++ b/sys/sys.go
@@ -13,5 +13,6 @@ import (
 	_ "github.com/google/syzkaller/sys/netbsd/gen"
 	_ "github.com/google/syzkaller/sys/openbsd/gen"
 	_ "github.com/google/syzkaller/sys/test/gen"
+	_ "github.com/google/syzkaller/sys/trusty/gen"
 	_ "github.com/google/syzkaller/sys/windows/gen"
 )

--- a/sys/trusty/gen/empty.go
+++ b/sys/trusty/gen/empty.go
@@ -1,0 +1,6 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package gen
+
+// Empty file to unbreak build while descriptions are not generated.


### PR DESCRIPTION
It was missing and we forgot to import it in sys.
