### PR TITLE
dashboard/app: add last activity info to bug list

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -92,3 +92,4 @@ Microsoft Corporation
  Mickaël Salaün
 ANSSI
  Vincent Dagonneau
+Desmond Cheong Zhi Xi

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -136,6 +136,7 @@ type uiBugGroup struct {
 	ShowStatus    bool
 	ShowIndex     int
 	Bugs          []*uiBug
+	DispLastAct   bool
 }
 
 type uiJobList struct {
@@ -164,6 +165,7 @@ type uiBug struct {
 	PatchedOn      []string
 	MissingOn      []string
 	NumManagers    int
+	LastActivity   time.Time
 }
 
 type uiCrash struct {
@@ -229,6 +231,9 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 	groups, err := fetchNamespaceBugs(c, accessLevel, hdr.Namespace, manager)
 	if err != nil {
 		return err
+	}
+	for _, group := range groups {
+		group.DispLastAct = true
 	}
 	data := &uiMainPage{
 		Header:         hdr,
@@ -846,6 +851,7 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 		ExternalLink:   link,
 		CreditEmail:    creditEmail,
 		NumManagers:    len(managers),
+		LastActivity:   bug.LastActivity,
 	}
 	updateBugBadness(c, uiBug)
 	if len(bug.Commits) != 0 {

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -98,6 +98,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Count', numSort)" href="#">Count</a></th>
 		<th><a onclick="return sortTable(this, 'Last', timeSort)" href="#">Last</a></th>
 		<th><a onclick="return sortTable(this, 'Reported', timeSort)" href="#">Reported</a></th>
+		{{if $.DispLastAct}}
+		<th><a onclick="return sortTable(this, 'Last activity', timeSort, desc=true)" href="#">Last activity</a></th>
+		{{end}}
 		{{if $.ShowPatch}}
 			<th><a onclick="return sortTable(this, 'Closed', timeSort)" href="#">Closed</a></th>
 			<th><a onclick="return sortTable(this, 'Patch', textSort)" href="#">Patch</a></th>
@@ -127,6 +130,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					{{formatLateness $.Now $b.ReportedTime}}
 				{{end}}
 			</td>
+			{{if $.DispLastAct}}
+			<td class="stat">{{formatLateness $.Now $b.LastActivity}}</td>
+			{{end}}
 			{{if $.ShowPatch}}
 				<td class="stat">{{formatLateness $.Now $b.ClosedTime}}</td>
 				<td class="commit_list">{{template "fix_commits" $b.Commits}}</td>


### PR DESCRIPTION
This information allows users to quickly scan the bug list to identify
bugs that are receiving attention and those that are neglected.