### PR TITLE
Makefile: do not remove empty files from sys/*/gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,8 @@ test: descriptions
 	$(GO) test -short -coverprofile=.coverage.txt ./...
 
 clean:
-	rm -rf ./bin .descriptions sys/*/gen executor/defs.h executor/syscalls.h
+	rm -rf ./bin .descriptions executor/defs.h executor/syscalls.h
+	find sys/*/gen -type f -not -name empty.go -delete
 
 # For a tupical Ubuntu/Debian distribution.
 # We use "|| true" for apt-get install because packages are all different on different distros.


### PR DESCRIPTION
The existing "make clean" removes all directories with generated files,
even "empty.go" which are tracked by git.

This relaxes the clean rule to keep empty.go to stop these warnings:

|| package github.com/google/syzkaller/tools/syz-stress
||      imports github.com/google/syzkaller/pkg/csource
||      imports github.com/google/syzkaller/pkg/mgrconfig
||      imports github.com/google/syzkaller/sys
||      imports github.com/google/syzkaller/sys/windows/gen: \
build constraints exclude all Go files in \
/home/aik/p/go/src/github.com/google/syzkaller/sys/windows/gen

Fixes: 95777977ade5 ("sys: commit empty source files")
Signed-off-by: Alexey Kardashevskiy <aik@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
