### PR TITLE
syz-verifier: Initial functionality for persistent storage of mismatching results

### DIFF
--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -5,81 +5,62 @@ package verf
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/prog"
 )
 
-func TestVerify(t *testing.T) {
-	tests := []struct {
-		name      string
-		res       []*Result
-		wantMatch bool
-	}{
-		{
-
-			name: "results should match",
-			res: []*Result{
-				{2, false, ipc.ProgInfo{
-					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 3}}, Extra: ipc.CallInfo{},
-				},
-				},
-				{4, false, ipc.ProgInfo{
-					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 3}},
-					Extra: ipc.CallInfo{},
-				},
-				},
-			},
-
-			wantMatch: true,
-		},
-		{
-			name: "results should not match",
-			res: []*Result{
-				{4, false, ipc.ProgInfo{
-					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
-				},
-				},
-				{8, false, ipc.ProgInfo{
-					Calls: []ipc.CallInfo{{Errno: 1}, {Errno: 3}, {Errno: 5}},
-				},
-				},
-			},
-			wantMatch: false,
-		},
+func makeResult(pool int, errnos []int, flags []int) *Result {
+	r := &Result{Pool: pool, Info: ipc.ProgInfo{Calls: []ipc.CallInfo{}}}
+	for i := range errnos {
+		r.Info.Calls = append(r.Info.Calls, ipc.CallInfo{Errno: errnos[i], Flags: ipc.CallFlags(flags[i])})
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got, want := Verify(test.res, nil), test.wantMatch; got != want {
-				t.Errorf("Verify: got %v, want %v", got, want)
-			}
-		})
-	}
+	return r
 }
 
-func TestVerifyErrno(t *testing.T) {
+func TestVerify(t *testing.T) {
+	p := "breaks_returns()\n" +
+		"minimize$0(0x1, 0x1)\n" +
+		"test$res0()\n"
 	tests := []struct {
-		name      string
-		c1, c2    []ipc.CallInfo
-		wantMatch bool
+		name string
+		res  []*Result
+		want *ResultReport
 	}{
 		{
-			name:      "errno should match",
-			c1:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
-			c2:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
-			wantMatch: true,
+			name: "mismatches not found in results",
+			res: []*Result{
+				makeResult(2, []int{11, 33, 22}, []int{1, 3, 3}),
+				makeResult(4, []int{11, 33, 22}, []int{1, 3, 3})},
+			want: nil,
 		},
 		{
-			name:      "errno should not match",
-			c1:        []ipc.CallInfo{{Errno: 1}, {Errno: 2}, {Errno: 5}},
-			c2:        []ipc.CallInfo{{Errno: 1}, {Errno: 4}, {Errno: 5}},
-			wantMatch: false,
+			name: "mismatches found in results",
+			res: []*Result{
+				makeResult(1, []int{1, 3, 2}, []int{1, 3, 7}),
+				makeResult(4, []int{1, 3, 5}, []int{1, 3, 3}),
+			},
+			want: &ResultReport{
+				Prog: p,
+				Reports: []CallReport{
+					{Call: "breaks_returns", Errnos: map[int]int{1: 1, 4: 1}, Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
+					{Call: "minimize$0", Errnos: map[int]int{1: 3, 4: 3}, Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
+					{Call: "test$res0", Errnos: map[int]int{1: 2, 4: 5}, Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
+				},
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got, want := VerifyErrnos(test.c1, test.c2), test.wantMatch; got != want {
-				t.Errorf("VerifyErrno: got %v, want %v", got, want)
+			target := prog.InitTargetTest(t, "test", "64")
+			prog, err := target.Deserialize([]byte(p), prog.Strict)
+			if err != nil {
+				t.Fatalf("failed to deserialise test program: %v", err)
+			}
+			got := Verify(test.res, prog)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Verify mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Contributes to #692 

Refactored the `verf.Verify` function so that it creates `ResultReport` in case mismatches between returned errno are found and added functionality to store this reports in files for further inspection.