### PR TITLE
executor: initialize scope in fault_ioc_info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Johannes Wellhöfer
 Microsoft Corporation
 Muhammad Usama Anjum
 ANSSI
+Chuck Silvers

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -93,3 +93,4 @@ Microsoft Corporation
 ANSSI
  Vincent Dagonneau
 Desmond Cheong Zhi Xi
+Chuck Silvers

--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -73,6 +73,7 @@ static int fault_injected(int fd)
 	struct fault_ioc_disable dis;
 	int res;
 
+	info.scope = FAULT_SCOPE_LWP;
 	if (ioctl(fd, FAULT_IOC_GETINFO, &info) != 0)
 		fail("FAULT_IOC_GETINFO failed");
 	res = (info.nfaults > 0);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1613,6 +1613,7 @@ static int fault_injected(int fd)
 	struct fault_ioc_disable dis;
 	int res;
 
+	info.scope = FAULT_SCOPE_LWP;
 	if (ioctl(fd, FAULT_IOC_GETINFO, &info) != 0)
 		fail("FAULT_IOC_GETINFO failed");
 	res = (info.nfaults > 0);


### PR DESCRIPTION
The "scope" field of struct fault_ioc_info is an input to the ioctl,
so initialize it to FAULT_SCOPE_LWP to match other fault_ioc_* usage.