### PR TITLE
syz-verifier: added flags to disable collide and threaded mode in Runner

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -500,6 +500,8 @@ var MakeBin = func() string {
 	return "make"
 }()
 
-func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int) string {
-	return fmt.Sprintf("%s -addr=%s -os=%s -arch=%s -pool=%v -vm=%v", prog, fwdAddr, os, arch, poolIdx, vmIdx)
+func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, collide, threaded bool) string {
+	return fmt.Sprintf("%s -addr=%s -os=%s -arch=%s -pool=%d -vm=%d "+
+		"-collide=%t -threaded=%t", prog, fwdAddr, os, arch, poolIdx, vmIdx,
+		collide, threaded)
 }

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -149,8 +149,10 @@ func TestRunnerCmd(t *testing.T) {
 	flagArch := flags.String("arch", "", "target architecture")
 	flagPool := flags.Int("pool", 0, "index of pool that started VM")
 	flagVM := flags.Int("vm", 0, "index of VM that started the Runner")
+	flagCollide := flags.Bool("collide", true, "collide syscalls to provoke data races")
+	flagThreaded := flags.Bool("threaded", true, "use threaded mode in executor")
 
-	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0)
+	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0, false, false)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatalf("error parsing flags: %v, want: nil", err)
@@ -174,5 +176,13 @@ func TestRunnerCmd(t *testing.T) {
 
 	if got, want := *flagVM, 0; got != want {
 		t.Errorf("bad vm index: %d, want: %d", got, want)
+	}
+
+	if got, want := *flagCollide, false; got != want {
+		t.Errorf("bad collide: %t, want: %t", got, want)
+	}
+
+	if got, want := *flagThreaded, false; got != want {
+		t.Errorf("bad threaded: %t, want: %t", got, want)
 	}
 }

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -30,14 +30,17 @@ func main() {
 	flagOS := flag.String("os", runtime.GOOS, "target OS")
 	flagArch := flag.String("arch", runtime.GOARCH, "target arch")
 	flag.Parse()
+
 	target, err := prog.GetTarget(*flagOS, *flagArch)
 	if err != nil {
 		log.Fatalf("failed to configure target: %v", err)
 	}
+
 	config, opts, err := ipcconfig.Default(target)
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Fatalf("failed to create default ipc config: %v", err)
 	}
+
 	timeouts := config.Timeouts
 	vrf, err := rpctype.NewRPCClient(*flagAddr, timeouts.Scale)
 	if err != nil {

--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -206,7 +206,7 @@ func main() {
 					log.Fatalf("failed to copy executor binary: %v", err)
 				}
 
-				cmd := instance.RunnerCmd(runnerBin, fwdAddr, vrf.target.OS, vrf.target.Arch, idx, 0)
+				cmd := instance.RunnerCmd(runnerBin, fwdAddr, vrf.target.OS, vrf.target.Arch, idx, 0, false, false)
 				outc, errc, err := inst.Run(pi.cfg.Timeouts.VMRunningTime, vrf.vmStop, cmd)
 				if err != nil {
 					log.Fatalf("failed to start runner: %v", err)


### PR DESCRIPTION
Contributes to #692 

The initial experiments we ran using `syz-verifier` consisted of generating programs with only `open`, `read`, `pipe`, `write` and `close` and executing them on two instances of the same version of Linux kernel. One main source of false positives was due to timeouts caused by threaded execution. 

Example program:
```
pipe(r1,r2)
write(r2, ...)
```
With threaded mode enabled, `pipe` and `write` might run in parallel. If on `vm-1` the `pipe` call blocks while on `vm-2` it doesn't, `syz-verifier` will report an errno mismatch at `write` because  on `vm-1` the `write` will finish with errno 9 (bad file descriptor). With threaded execution disabled, the `write` will have to wait until `pipe` completes so it can't operate on a file descriptor that hasn't been properly configured yet.