### PR TITLE
syz-verifier: improved readability of result reports

### DIFF
--- a/syz-verifier/verf/verifier.go
+++ b/syz-verifier/verf/verifier.go
@@ -29,8 +29,6 @@ type ResultReport struct {
 }
 
 type CallReport struct {
-	// Call is the name of the system call.
-	Call string
 	// Errno is a map between pools and the errno returned by executing the
 	// system call on a VM spawned by the respective pool.
 	Errnos map[int]int
@@ -48,9 +46,8 @@ func Verify(res []*Result, prog *prog.Prog) *ResultReport {
 		Prog: string(prog.Serialize()),
 	}
 	c0 := res[0].Info.Calls
-	for idx, c := range c0 {
+	for _, c := range c0 {
 		cr := CallReport{
-			Call:   prog.Calls[idx].Meta.Name,
 			Errnos: map[int]int{res[0].Pool: c.Errno},
 			Flags:  map[int]ipc.CallFlags{res[0].Pool: c.Flags},
 		}

--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -43,9 +43,9 @@ func TestVerify(t *testing.T) {
 			want: &ResultReport{
 				Prog: p,
 				Reports: []CallReport{
-					{Call: "breaks_returns", Errnos: map[int]int{1: 1, 4: 1}, Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
-					{Call: "minimize$0", Errnos: map[int]int{1: 3, 4: 3}, Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
-					{Call: "test$res0", Errnos: map[int]int{1: 2, 4: 5}, Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
+					{Errnos: map[int]int{1: 1, 4: 1}, Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
+					{Errnos: map[int]int{1: 3, 4: 3}, Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
+					{Errnos: map[int]int{1: 2, 4: 5}, Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
 				},
 			},
 		},


### PR DESCRIPTION
The result reports for errno mismatches now outputs results under each system call in increasing order (from kernel `0` to kernel `N` for all kernels that returned results).

Example output  from a program ran on two kernels:
```
ERRNO mismatches found for program:

[✓] newfstatat(0xffffffffffffff9c, &(0x7f0000000100)='./file0\x00', &(0x7f0000000140)={0x0, 0x0, 0x0, 0x0, <r0=>0x0}, 0x0)
        ↳ Pool: 0, Errno: 2, Flag: 3
        ↳ Pool: 1, Errno: 2, Flag: 3

[✓] fstat(0xffffffffffffffff, &(0x7f00000001c0)={0x0, 0x0, 0x0, 0x0, <r1=>0x0})
        ↳ Pool: 0, Errno: 9, Flag: 3
        ↳ Pool: 1, Errno: 9, Flag: 3

[✗] syz_mount_image$hfsplus(&(0x7f0000000000), &(0x7f0000000040)='./file0\x00', 0x3, 0x1, &(0x7f00000000c0)=[{&(0x7f0000000080)="2fb0463911bbab13d96006a1e91c8e02f8ae5ff7bfe5660de0d90d", 0x1b, 0xffffffff}], 0x80000, &(0x7f0000000240)={[{@force}, {@nobarrier}, {@umask={'umask', 0x3d, 0x3ff}}], [{@defcontext={'defcontext', 0x3d, 'sysadm_u'}}, {@audit}, {@smackfstransmute={'smackfstransmute', 0x3d, '['}}, {@subj_user={'subj_user', 0x3d, '-/-@+\xc8*'}}, {@obj_user={'obj_user', 0x3d, '[..-!%,:\\;.+'}}, {@appraise_type}, {@fowner_eq={'fowner', 0x3d, r0}}, {@uid_eq={'uid', 0x3d, r1}}, {@measure}]})
        ↳ Pool: 0, Errno: 22, Flag: 3
        ↳ Pool: 1, Errno: 16, Flag: 3

[✓] syz_mount_image$udf(&(0x7f0000000340), &(0x7f0000000380)='./file0\x00', 0x5, 0x0, &(0x7f00000003c0), 0x2880000, &(0x7f0000000400)={[{@uid_ignore}, {@partition={'partition', 0x3d, 0x3ff8}}], [{@appraise_type}, {@hash}, {@obj_user={'obj_user', 0x3d, 'force'}}, {@uid_gt={'uid>', r0}}, {@fsmagic={'fsmagic', 0x3d, 0x7a}}, {@fowner_gt={'fowner>', r1}}, {@appraise_type}, {@appraise}]})
        ↳ Pool: 0, Errno: 16, Flag: 3
        ↳ Pool: 1, Errno: 16, Flag: 3

[✓] ioctl$DRM_IOCTL_PVR_SRVKM_CMD_PVRSRV_BRIDGE_SRVCORE_EVENTOBJECTOPEN(0xffffffffffffffff, 0xc0206440, &(0x7f0000000580)={0x1, 0x4, &(0x7f0000000500), &(0x7f0000000540)={<r2=>0x0}, 0x8, 0xc})
        ↳ Pool: 0, Errno: 9, Flag: 3
        ↳ Pool: 1, Errno: 9, Flag: 3

...
 ```