### PR TITLE
syz-verifier: use only system calls supported by all kernels and with no transitive dependencies when building the `prog.ChoiceTable`

### DIFF
--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -82,6 +82,23 @@ type RunnerConnectArgs struct {
 	Pool, VM int
 }
 
+type RunnerConnectRes struct {
+	// CheckUnsupportedCalls is set to true if the Runner needs to query the kernel
+	// for unsupported system calls and report them back to the server.
+	CheckUnsupportedCalls bool
+}
+
+// UpdateUnsupportedArgs contains the data passed from client to server in an
+// UpdateSupported call, namely the system calls not supported by the client's
+// kernel.
+type UpdateUnsupportedArgs struct {
+	// Pool is used to identify the checked kernel.
+	Pool int
+	// UnsupportedCalls contains the ID's of system calls not supported by the
+	// client and the reason for this.
+	UnsupportedCalls []SyscallReason
+}
+
 // NextExchangeArgs contains the data passed from client to server namely
 // identification information of the VM and program execution results.
 type NextExchangeArgs struct {

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -77,7 +77,7 @@ func main() {
 		for c, reason := range unsupported {
 			calls = append(calls, rpctype.SyscallReason{
 				ID:     c.ID,
-				Reason: fmt.Sprintf("Pool %d: %s", rn.pool, reason)})
+				Reason: fmt.Sprintf("%s (not supported on kernel %d)", reason, rn.pool)})
 		}
 		a := &rpctype.UpdateUnsupportedArgs{Pool: rn.pool, UnsupportedCalls: calls}
 		if err := vrf.Call("Verifier.UpdateUnsupported", a, nil); err != nil {

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"runtime"
 
+	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/ipc/ipcconfig"
 	"github.com/google/syzkaller/pkg/rpctype"
@@ -60,16 +62,35 @@ func main() {
 		Pool: rn.pool,
 		VM:   rn.vm,
 	}
-	if err := vrf.Call("Verifier.Connect", a, nil); err != nil {
+	r := &rpctype.RunnerConnectRes{}
+	if err := vrf.Call("Verifier.Connect", a, r); err != nil {
 		log.Fatalf("failed to connect to verifier: %v", err)
 	}
 
-	r := &rpctype.NextExchangeRes{}
-	if err := rn.vrf.Call("Verifier.NextExchange", &rpctype.NextExchangeArgs{Pool: rn.pool, VM: rn.vm}, r); err != nil {
+	if r.CheckUnsupportedCalls {
+		_, unsupported, err := host.DetectSupportedSyscalls(target, ipc.FlagsToSandbox(config.Flags))
+		if err != nil {
+			log.Fatalf("failed to get unsupported system calls: %v", err)
+		}
+
+		calls := make([]rpctype.SyscallReason, 0)
+		for c, reason := range unsupported {
+			calls = append(calls, rpctype.SyscallReason{
+				ID:     c.ID,
+				Reason: fmt.Sprintf("Pool %d: %s", rn.pool, reason)})
+		}
+		a := &rpctype.UpdateUnsupportedArgs{Pool: rn.pool, UnsupportedCalls: calls}
+		if err := vrf.Call("Verifier.UpdateUnsupported", a, nil); err != nil {
+			log.Fatalf("failed to send unsupported system calls: %v", err)
+		}
+	}
+
+	res := &rpctype.NextExchangeRes{}
+	if err := rn.vrf.Call("Verifier.NextExchange", &rpctype.NextExchangeArgs{Pool: rn.pool, VM: rn.vm}, res); err != nil {
 		log.Fatalf("failed to get initial program: %v", err)
 	}
 
-	rn.Run(r.Prog, r.ProgIdx)
+	rn.Run(res.Prog, res.ProgIdx)
 }
 
 // Run is responsible for requesting new programs from the verifier, executing them and then sending back the Result.

--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -50,16 +51,20 @@ type Verifier struct {
 	rnd         *rand.Rand
 	progIdx     int
 	addr        string
+	calls       map[*prog.Syscall]bool
+	reasons     map[*prog.Syscall]string
 }
 
 // RPCServer is a wrapper around the rpc.Server. It communicates with  Runners,
 // generates programs and sends complete Results for verification.
 type RPCServer struct {
-	vrf   *Verifier
-	port  int
-	mu    sync.Mutex
-	pools map[int]*poolInfo
-	progs map[int]*progInfo
+	vrf        *Verifier
+	port       int
+	mu         sync.Mutex
+	cond       *sync.Cond
+	pools      map[int]*poolInfo
+	progs      map[int]*progInfo
+	notChecked int
 }
 
 // poolInfo contains kernel-specific information for spawning virtual machines
@@ -75,7 +80,8 @@ type poolInfo struct {
 	vmRunners map[int][]*progInfo
 	// progs stores the programs that haven't been sent to this kernel yet but
 	// have been sent to at least one kernel.
-	progs []*progInfo
+	progs   []*progInfo
+	checked bool
 }
 
 type progInfo struct {
@@ -173,7 +179,8 @@ func main() {
 		resultsdir:  resultsdir,
 		pools:       pools,
 		target:      target,
-		choiceTable: target.BuildChoiceTable(nil, calls),
+		calls:       calls,
+		reasons:     make(map[*prog.Syscall]string),
 		rnd:         rand.New(rand.NewSource(time.Now().UnixNano() + 1e12)),
 		runnerBin:   runnerBin,
 		executorBin: execBin,
@@ -224,10 +231,12 @@ func main() {
 
 func startRPCServer(vrf *Verifier) (*RPCServer, error) {
 	srv := &RPCServer{
-		vrf:   vrf,
-		pools: vrf.pools,
-		progs: make(map[int]*progInfo),
+		vrf:        vrf,
+		pools:      vrf.pools,
+		progs:      make(map[int]*progInfo),
+		notChecked: len(vrf.pools),
 	}
+	srv.cond = sync.NewCond(&srv.mu)
 
 	s, err := rpctype.NewRPCServer(vrf.addr, "Verifier", srv)
 	if err != nil {
@@ -242,12 +251,76 @@ func startRPCServer(vrf *Verifier) (*RPCServer, error) {
 }
 
 // Connect notifies the RPCServer that a new Runner was started.
-func (srv *RPCServer) Connect(a *rpctype.RunnerConnectArgs, r *int) error {
+func (srv *RPCServer) Connect(a *rpctype.RunnerConnectArgs, r *rpctype.RunnerConnectRes) error {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	pool, vm := a.Pool, a.VM
 	srv.pools[pool].vmRunners[vm] = nil
+	r.CheckUnsupportedCalls = !srv.pools[pool].checked
 	return nil
+}
+
+// UpdateUnsupported communicates to the server the list of system calls not
+// supported by the kernel corresponding to this pool and updates the list of
+// enabled system calls. This function is called once for each kernel.
+// When all kernels have reported the list of unsupported system calls, the
+// choice table will be created using only the system calls supported by all
+// kernels.
+func (srv *RPCServer) UpdateUnsupported(a *rpctype.UpdateUnsupportedArgs, r *int) error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.pools[a.Pool].checked {
+		return nil
+	}
+	srv.pools[a.Pool].checked = true
+	vrf := srv.vrf
+
+	for _, unsupported := range a.UnsupportedCalls {
+		if c := vrf.target.Syscalls[unsupported.ID]; vrf.calls[c] {
+			vrf.reasons[c] = unsupported.Reason
+			break
+		}
+	}
+
+	srv.notChecked--
+	if srv.notChecked == 0 {
+		vrf.finalizeCallSet(os.Stdout)
+		vrf.choiceTable = vrf.target.BuildChoiceTable(nil, vrf.calls)
+		srv.cond.Signal()
+	}
+	return nil
+}
+
+// finalizeCallSet removes the system calls that are not supported from the set
+// of enabled system calls and reports the reason to the io.Writer (either
+// because the call is not supported by one of the kernels or because the call
+// is missing some transitive dependencies). The resulting set of system calls
+// will be used to build the prog.ChoiceTable.
+func (vrf *Verifier) finalizeCallSet(w io.Writer) {
+	if len(vrf.reasons) > 0 {
+		fmt.Fprintln(w, "Calls not supported by kernels:")
+	}
+	for c, reason := range vrf.reasons {
+		fmt.Fprintf(w, "\t%v: %v\n", c.Name, reason)
+		delete(vrf.calls, c)
+	}
+
+	// Find and report to the user all the system calls that need to be
+	// disabled due to missing dependencies.
+	_, disabled := vrf.target.TransitivelyEnabledCalls(vrf.calls)
+
+	if len(disabled) > 0 {
+		fmt.Fprintln(w, "Calls removed due to missing transitive dependencies:")
+	}
+	for c, reason := range disabled {
+		fmt.Fprintf(w, "\tsyscall %v: %v\n", c.Name, reason)
+		delete(vrf.calls, c)
+	}
+
+	if len(vrf.calls) == 0 {
+		log.Fatal("All enabled system calls are missing dependencies or not" +
+			" supported by some kernels, exiting syz-verifier.")
+	}
 }
 
 // NextExchange is called when a Runner requests a new program to execute and,
@@ -282,6 +355,11 @@ func (srv *RPCServer) NextExchange(a *rpctype.NextExchangeArgs, r *rpctype.NextE
 			srv.vrf.processResults(prog.res, prog.prog)
 			delete(srv.progs, a.ProgIdx)
 		}
+	}
+
+	if srv.notChecked > 0 {
+		// Runner is blocked until the choice table is created.
+		srv.cond.Wait()
 	}
 
 	prog, pi := srv.newProgram(a.Pool, a.VM)


### PR DESCRIPTION
Contributes to #692

Implemented functionality that:

* removes the system calls with missing transitive dependencies from the set of enabled system calls, reporting the reason to the user
* finds the intersection of enabled system calls supported by all kernels and builds the choice table only using those