### PR TITLE
pkg/report: parse "stack guard page was hit" better

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1239,9 +1239,11 @@ var linuxOopses = append([]*oops{
 				stack: &stackFmt{
 					parts: []*regexp.Regexp{
 						linuxRipFrame,
+						linuxCallTrace,
+						parseStackTrace,
 					},
+					extractor: linuxStallFrameExtractor,
 				},
-				noStackTrace: true,
 			},
 			{
 				title: compile("BUG: Invalid wait context"),

--- a/pkg/report/testdata/linux/report/344
+++ b/pkg/report/testdata/linux/report/344
@@ -1,4 +1,5 @@
-TITLE: BUG: stack guard page was hit in __udp6_lib_lookup
+TITLE: BUG: stack guard page was hit in corrupted
+CORRUPTED: Y
 
 [  760.482711] BUG: stack guard page was hit at 00000000397c6d92 (stack is 00000000a0f6b86a..000000000e6f9570)
 [  760.492602] kernel stack overflow (double-fault): 0000 [#1] PREEMPT SMP

--- a/pkg/report/testdata/linux/report/614
+++ b/pkg/report/testdata/linux/report/614
@@ -1,0 +1,733 @@
+TITLE: BUG: stack guard page was hit in rtnl_newlink
+
+[  733.821133][    C1] BUG: stack guard page was hit at ffffc900190cfff8 (stack is ffffc900190d0000..ffffc900190d7fff)
+[  733.821152][    C1] kernel stack overflow (double-fault): 0000 [#1] PREEMPT SMP KASAN
+[  733.821164][    C1] CPU: 1 PID: 10931 Comm: syz-executor.2 Tainted: G        W         5.13.0-syzkaller #0
+[  733.821176][    C1] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[  733.821187][    C1] RIP: 0010:netdev_next_lower_dev_rcu+0x8/0xb0
+[  733.821200][    C1] Code: fe ff ff 4c 89 f6 48 c7 c7 c0 a5 0a 8d e8 e0 d4 db fc e9 b5 fe ff ff 66 66 2e 0f 1f 84 00 00 00 00 00 41 55 41 54 49 89 f4 55 <53> 48 89 fb e8 0f 91 66 fa 4c 89 e2 48 b8 00 00 00 00 00 fc ff df
+[  733.821217][    C1] RSP: 0018:ffffc900190d0000 EFLAGS: 00010212
+[  733.821233][    C1] RAX: 000000000001dfc3 RBX: 0000000000000000 RCX: ffffc9000e42e000
+[  733.821243][    C1] RDX: 0000000000040000 RSI: ffffc900190d0050 RDI: ffff88806eab4000
+[  733.821253][    C1] RBP: ffff88806eab4000 R08: 0000000000000000 R09: ffffffff8d6aed97
+[  733.821262][    C1] R10: ffffffff84b4e861 R11: 0000000000000000 R12: ffffc900190d0050
+[  733.821272][    C1] R13: dffffc0000000000 R14: ffff88807d7d21c8 R15: 1ffff9200321a006
+[  733.821282][    C1] FS:  00007f1f654df700(0000) GS:ffff8880b9d00000(0000) knlGS:0000000000000000
+[  733.821292][    C1] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  733.821314][    C1] CR2: ffffc900190cfff8 CR3: 000000008652c000 CR4: 00000000001506e0
+[  733.821324][    C1] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[  733.821333][    C1] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[  733.821341][    C1] Call Trace:
+[  733.821347][    C1]  bond_get_lowest_level_rcu+0x12d/0x2e0
+[  733.821355][    C1]  ? unblock_netpoll_tx+0x20/0x20
+[  733.821372][    C1]  ? lock_acquire+0x442/0x510
+[  733.821378][    C1]  ? lock_release+0x720/0x720
+[  733.821384][    C1]  ? lock_acquire+0x442/0x510
+[  733.821390][    C1]  bond_get_stats+0xf5/0x4d0
+[  733.821395][    C1]  ? __sanitizer_cov_trace_cmp4+0x1c/0x70
+[  733.821401][    C1]  ? veth_stats_rx+0x285/0x3c0
+[  733.821406][    C1]  ? bond_should_notify_peers+0x490/0x490
+[  733.821412][    C1]  ? veth_get_stats64+0x469/0x670
+[  733.821418][    C1]  ? veth_set_rx_headroom+0x330/0x330
+[  733.821425][    C1]  ? arch_stack_walk+0x5c/0xe0
+[  733.821431][    C1]  ? deref_stack_reg+0xee/0x150
+[  733.821437][    C1]  ? lock_release+0x720/0x720
+[  733.821442][    C1]  ? do_raw_spin_lock+0x120/0x2b0
+[  733.821448][    C1]  ? rwlock_bug.part.0+0x90/0x90
+[  733.821452][    C1]  dev_get_stats+0xa5/0x2b0
+[  733.821458][    C1]  bond_get_stats+0x1ed/0x4d0
+[  733.821464][    C1]  ? bond_should_notify_peers+0x490/0x490
+[  733.821471][    C1]  ? __sanitizer_cov_trace_const_cmp1+0x22/0x80
+[  733.821478][    C1]  ? dev_get_port_parent_id+0x121/0x420
+[  733.821485][    C1]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[  733.821493][    C1]  ? nla_put_ifalias+0x96/0x170
+[  733.821499][    C1]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[  733.821506][    C1]  ? __sanitizer_cov_trace_cmp4+0x1c/0x70
+[  733.821512][    C1]  ? skb_put+0x134/0x180
+[  733.821518][    C1]  ? memset+0x20/0x40
+[  733.821523][    C1]  dev_get_stats+0xa5/0x2b0
+[  733.821529][    C1]  rtnl_fill_stats+0x48/0xa90
+[  733.821534][    C1]  rtnl_fill_ifinfo+0x1333/0x4250
+[  733.821541][    C1]  ? bond_compute_features+0x56c/0xaa0
+[  733.821547][    C1]  ? notifier_call_chain+0xb5/0x200
+[  733.821553][    C1]  ? call_netdevice_notifiers_info+0xb5/0x130
+[  733.821560][    C1]  ? __netdev_update_features+0x95d/0x17d0
+[  733.821566][    C1]  ? netdev_change_features+0x61/0xb0
+[  733.821571][    C1]  ? rtnl_fill_vf+0x400/0x400
+[  733.821577][    C1]  ? __sanitizer_cov_trace_const_cmp1+0x22/0x80
+[  733.821583][    C1]  ? kcov_remote_start+0x3d0/0x440
+[  733.821588][    C1]  ? __phys_addr+0xc4/0x140
+[  733.821593][    C1]  ? memset+0x20/0x40
+[  733.821599][    C1]  rtmsg_ifinfo_build_skb+0xcd/0x1a0
+[  733.821605][    C1]  rtnetlink_event+0x123/0x1d0
+[  733.821611][    C1]  notifier_call_chain+0xb5/0x200
+[  733.821618][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.821624][    C1]  netdev_change_features+0x7e/0xb0
+[  733.821630][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.821637][    C1]  ? lock_acquire+0x442/0x510
+[  733.821644][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.821651][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.821658][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.821665][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.821672][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.821679][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.821685][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.821691][    C1]  notifier_call_chain+0xb5/0x200
+[  733.821698][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.821705][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.821711][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.821718][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.821726][    C1]  ? __wake_up_common+0x650/0x650
+[  733.821731][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821738][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.821745][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821750][    C1]  netdev_change_features+0x61/0xb0
+[  733.821757][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.821764][    C1]  ? lock_acquire+0x442/0x510
+[  733.821770][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.821777][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.821785][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.821791][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.821798][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.821805][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.821811][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.821817][    C1]  notifier_call_chain+0xb5/0x200
+[  733.821840][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.821847][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.821853][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.821860][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.821865][    C1]  ? __wake_up_common+0x650/0x650
+[  733.821871][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821877][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.821884][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821890][    C1]  netdev_change_features+0x61/0xb0
+[  733.821896][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.821903][    C1]  ? lock_acquire+0x442/0x510
+[  733.821909][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.821914][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.821920][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.821925][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.821931][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.821936][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.821941][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.821947][    C1]  notifier_call_chain+0xb5/0x200
+[  733.821952][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.821958][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.821963][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.821969][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.821975][    C1]  ? __wake_up_common+0x650/0x650
+[  733.821980][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821985][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.821991][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.821996][    C1]  netdev_change_features+0x61/0xb0
+[  733.822002][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822007][    C1]  ? lock_acquire+0x442/0x510
+[  733.822012][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822018][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822024][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822030][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822037][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822044][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822051][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822058][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822065][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822073][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822091][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822098][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822106][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822113][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822120][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822128][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822134][    C1]  netdev_change_features+0x61/0xb0
+[  733.822142][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822149][    C1]  ? lock_acquire+0x442/0x510
+[  733.822156][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822163][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822171][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822179][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822186][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822194][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822200][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822207][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822214][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822222][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822230][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822238][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822246][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822253][    C1]  ? finish_task_switch.isra.0+0x232/0xa50
+[  733.822261][    C1]  netdev_change_features+0x61/0xb0
+[  733.822268][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822274][    C1]  ? lock_acquire+0x442/0x510
+[  733.822282][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822290][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822297][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822305][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822312][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822320][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822327][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822334][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822340][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822347][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822353][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822360][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822367][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822374][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822398][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822404][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822410][    C1]  netdev_change_features+0x61/0xb0
+[  733.822417][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822424][    C1]  ? lock_acquire+0x442/0x510
+[  733.822430][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822438][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822445][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822452][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822459][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822466][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822473][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822480][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822488][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822496][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822503][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822511][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822518][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822526][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822533][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822541][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822548][    C1]  netdev_change_features+0x61/0xb0
+[  733.822555][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822563][    C1]  ? lock_acquire+0x442/0x510
+[  733.822571][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822578][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822584][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822592][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822600][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822608][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822615][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822623][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822630][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822638][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822646][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822654][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822662][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822669][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822676][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822684][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822692][    C1]  netdev_change_features+0x61/0xb0
+[  733.822699][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822707][    C1]  ? lock_acquire+0x442/0x510
+[  733.822714][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822722][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822731][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822739][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822746][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822755][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822762][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822769][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822777][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822785][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822793][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822800][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822809][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822816][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822823][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.822831][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.822838][    C1]  netdev_change_features+0x61/0xb0
+[  733.822844][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.822851][    C1]  ? lock_acquire+0x442/0x510
+[  733.822874][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.822881][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.822889][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.822914][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.822921][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.822929][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.822937][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.822944][    C1]  notifier_call_chain+0xb5/0x200
+[  733.822952][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.822961][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.822968][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.822977][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.822985][    C1]  ? __wake_up_common+0x650/0x650
+[  733.822993][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823000][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823008][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823016][    C1]  netdev_change_features+0x61/0xb0
+[  733.823024][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823032][    C1]  ? lock_acquire+0x442/0x510
+[  733.823040][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823049][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823057][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823066][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823074][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823168][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823175][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823183][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823191][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823199][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823207][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823216][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823224][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823232][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823240][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823247][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823255][    C1]  netdev_change_features+0x61/0xb0
+[  733.823263][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823271][    C1]  ? lock_acquire+0x442/0x510
+[  733.823278][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823287][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823296][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823304][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823313][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823321][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823328][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823336][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823344][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823353][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823361][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823369][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823377][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823385][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823393][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823401][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823408][    C1]  netdev_change_features+0x61/0xb0
+[  733.823415][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823422][    C1]  ? lock_acquire+0x442/0x510
+[  733.823429][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823438][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823446][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823453][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823460][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823481][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823489][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823495][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823503][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823512][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823518][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823525][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823532][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823540][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823546][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823553][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823559][    C1]  netdev_change_features+0x61/0xb0
+[  733.823567][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823573][    C1]  ? lock_acquire+0x442/0x510
+[  733.823580][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823587][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823595][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823603][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823610][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823618][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823625][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823632][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823639][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823645][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823652][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823659][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823666][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823672][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823678][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823685][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823691][    C1]  netdev_change_features+0x61/0xb0
+[  733.823698][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823705][    C1]  ? lock_acquire+0x442/0x510
+[  733.823712][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823720][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823728][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823735][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823743][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823750][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823757][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823763][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823771][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823779][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823787][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823793][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823801][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823808][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823814][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823822][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823828][    C1]  netdev_change_features+0x61/0xb0
+[  733.823836][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823843][    C1]  ? lock_acquire+0x442/0x510
+[  733.823850][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.823858][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.823865][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.823873][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.823880][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.823888][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.823895][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.823902][    C1]  notifier_call_chain+0xb5/0x200
+[  733.823910][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.823916][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.823924][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.823931][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.823939][    C1]  ? __wake_up_common+0x650/0x650
+[  733.823946][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823953][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.823960][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.823967][    C1]  netdev_change_features+0x61/0xb0
+[  733.823985][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.823992][    C1]  ? lock_acquire+0x442/0x510
+[  733.823998][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824006][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824013][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824021][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824029][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824035][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824042][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824049][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824055][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824061][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824068][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824083][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824090][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824096][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824103][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824110][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824116][    C1]  netdev_change_features+0x61/0xb0
+[  733.824123][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824129][    C1]  ? lock_acquire+0x442/0x510
+[  733.824135][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824143][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824150][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824157][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824164][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824171][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824177][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824183][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824190][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824197][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824204][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824211][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824218][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824225][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824231][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824238][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824244][    C1]  netdev_change_features+0x61/0xb0
+[  733.824251][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824258][    C1]  ? lock_acquire+0x442/0x510
+[  733.824264][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824271][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824279][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824286][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824293][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824300][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824306][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824312][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824319][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824326][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824333][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824340][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824347][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824354][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824360][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824367][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824373][    C1]  netdev_change_features+0x61/0xb0
+[  733.824379][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824386][    C1]  ? lock_acquire+0x442/0x510
+[  733.824393][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824400][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824407][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824414][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824421][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824428][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824435][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824440][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824447][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824455][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824461][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824468][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824476][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824482][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824489][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824496][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824502][    C1]  netdev_change_features+0x61/0xb0
+[  733.824508][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824515][    C1]  ? lock_acquire+0x442/0x510
+[  733.824522][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824529][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824536][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824543][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824551][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824558][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824565][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824571][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824578][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824586][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824592][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824599][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824605][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824612][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824618][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824624][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824629][    C1]  netdev_change_features+0x61/0xb0
+[  733.824636][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824643][    C1]  ? lock_acquire+0x442/0x510
+[  733.824649][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824655][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824662][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824669][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824676][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824683][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824690][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824696][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824703][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824711][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824718][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824725][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824731][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824738][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824744][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824751][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824757][    C1]  netdev_change_features+0x61/0xb0
+[  733.824764][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824772][    C1]  ? lock_acquire+0x442/0x510
+[  733.824779][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824786][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824794][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824802][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824809][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824817][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824823][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824830][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824837][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824845][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824852][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824859][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.824866][    C1]  ? __wake_up_common+0x650/0x650
+[  733.824873][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824879][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.824887][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.824893][    C1]  netdev_change_features+0x61/0xb0
+[  733.824900][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.824907][    C1]  ? lock_acquire+0x442/0x510
+[  733.824914][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.824921][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.824929][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.824937][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.824944][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.824951][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.824958][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.824965][    C1]  notifier_call_chain+0xb5/0x200
+[  733.824972][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.824980][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.824987][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.824995][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825002][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825009][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825015][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825023][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825029][    C1]  netdev_change_features+0x61/0xb0
+[  733.825037][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825044][    C1]  ? lock_acquire+0x442/0x510
+[  733.825051][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825058][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825066][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825073][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825085][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825092][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825099][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825106][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825113][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825121][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825128][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825135][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825142][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825149][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825156][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825163][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825170][    C1]  netdev_change_features+0x61/0xb0
+[  733.825177][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825183][    C1]  ? lock_acquire+0x442/0x510
+[  733.825190][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825198][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825206][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825213][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825221][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825228][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825235][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825242][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825249][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825257][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825264][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825271][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825279][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825285][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825293][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825300][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825307][    C1]  netdev_change_features+0x61/0xb0
+[  733.825314][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825321][    C1]  ? lock_acquire+0x442/0x510
+[  733.825327][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825335][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825343][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825350][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825358][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825365][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825371][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825378][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825384][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825391][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825397][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825404][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825411][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825417][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825423][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825430][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825436][    C1]  netdev_change_features+0x61/0xb0
+[  733.825441][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825447][    C1]  ? lock_acquire+0x442/0x510
+[  733.825453][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825460][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825466][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825473][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825479][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825486][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825493][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825499][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825507][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825514][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825520][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825525][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825531][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825536][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825542][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825548][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825553][    C1]  netdev_change_features+0x61/0xb0
+[  733.825559][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825565][    C1]  ? lock_acquire+0x442/0x510
+[  733.825571][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825577][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825583][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825589][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825595][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825601][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825606][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825612][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825618][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825625][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825632][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825639][    C1]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[  733.825647][    C1]  ? __wake_up_common+0x650/0x650
+[  733.825653][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825660][    C1]  ? cfg80211_register_netdevice+0x320/0x320
+[  733.825668][    C1]  ? kfree_skbmem+0xef/0x1b0
+[  733.825675][    C1]  netdev_change_features+0x61/0xb0
+[  733.825682][    C1]  ? netdev_update_features+0xd0/0xd0
+[  733.825689][    C1]  ? lock_acquire+0x442/0x510
+[  733.825696][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.825704][    C1]  ? netdev_increment_features+0x87/0xa0
+[  733.825712][    C1]  ? netdev_lower_get_next_private+0x80/0xb0
+[  733.825718][    C1]  bond_compute_features+0x56c/0xaa0
+[  733.825725][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825732][    C1]  ? bond_fix_features+0x2f0/0x2f0
+[  733.825739][    C1]  bond_netdev_event+0x81b/0xac0
+[  733.825744][    C1]  notifier_call_chain+0xb5/0x200
+[  733.825751][    C1]  call_netdevice_notifiers_info+0xb5/0x130
+[  733.825758][    C1]  __netdev_update_features+0x95d/0x17d0
+[  733.825765][    C1]  ? dev_change_xdp_fd+0x300/0x300
+[  733.825772][    C1]  ? __sanitizer_cov_trace_const_cmp1+0x22/0x80
+[  733.825779][    C1]  ? __sanitizer_cov_trace_cmp8+0x1d/0x70
+[  733.825786][    C1]  ? bond_opt_parse+0x2fd/0x860
+[  733.825792][    C1]  netdev_update_features+0x63/0xd0
+[  733.825799][    C1]  ? __netdev_update_features+0x17d0/0x17d0
+[  733.825806][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.825814][    C1]  bond_option_xmit_hash_policy_set+0x209/0x320
+[  733.825821][    C1]  __bond_opt_set+0x28a/0x560
+[  733.825827][    C1]  bond_changelink+0xefc/0x1bf0
+[  733.825833][    C1]  ? entry_SYSCALL_64_after_hwframe+0x44/0xae
+[  733.825840][    C1]  ? bond_slave_changelink+0x1c0/0x1c0
+[  733.825846][    C1]  ? lock_acquire+0x442/0x510
+[  733.825852][    C1]  ? __nla_parse+0x3d/0x50
+[  733.825858][    C1]  ? bond_slave_changelink+0x1c0/0x1c0
+[  733.825864][    C1]  __rtnl_newlink+0xcff/0x1760
+[  733.825870][    C1]  ? __kernel_text_address+0x9/0x30
+[  733.825877][    C1]  ? rtnl_setlink+0x3c0/0x3c0
+[  733.825883][    C1]  ? arch_stack_walk+0x93/0xe0
+[  733.825889][    C1]  ? lock_release+0x522/0x720
+[  733.825895][    C1]  ? is_bpf_text_address+0xa9/0x160
+[  733.825902][    C1]  ? lock_downgrade+0x6e0/0x6e0
+[  733.825908][    C1]  ? unwind_next_frame+0xec8/0x1ce0
+[  733.825915][    C1]  ? entry_SYSCALL_64_after_hwframe+0x44/0xae
+[  733.825922][    C1]  ? __sanitizer_cov_trace_cmp4+0x1c/0x70
+[  733.825929][    C1]  ? bpf_ksym_find+0x171/0x1c0
+[  733.825935][    C1]  ? is_bpf_text_address+0xcb/0x160
+[  733.825942][    C1]  ? kernel_text_address+0xbd/0xf0
+[  733.825948][    C1]  ? __kernel_text_address+0x9/0x30
+[  733.825955][    C1]  ? unwind_get_return_address+0x51/0x90
+[  733.825961][    C1]  ? create_prof_cpu_mask+0x20/0x20
+[  733.825967][    C1]  ? arch_stack_walk+0x93/0xe0
+[  733.825974][    C1]  ? lock_release+0x522/0x720
+[  733.825980][    C1]  ? fs_reclaim_release+0x9c/0xf0
+[  733.825987][    C1]  ? lock_downgrade+0x6e0/0x6e0
+[  733.825993][    C1]  ? rtnetlink_rcv_msg+0x3f9/0xb70
+[  733.825999][    C1]  rtnl_newlink+0x64/0xa0
+[  733.826005][    C1]  ? __rtnl_newlink+0x1760/0x1760
+[  733.826029][    C1]  rtnetlink_rcv_msg+0x44e/0xb70
+[  733.826035][    C1]  ? rtnl_newlink+0xa0/0xa0
+[  733.826042][    C1]  ? do_syscall_64+0x35/0xb0
+[  733.826048][    C1]  ? entry_SYSCALL_64_after_hwframe+0x44/0xae
+[  733.826057][    C1]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[  733.826064][    C1]  ? netdev_core_pick_tx+0x2e0/0x2e0
+[  733.826071][    C1]  ? __slab_alloc.constprop.0+0xaf/0xf0
+[  733.826084][    C1]  netlink_rcv_skb+0x153/0x420
+[  733.826090][    C1]  ? rtnl_newlink+0xa0/0xa0
+[  733.826097][    C1]  ? netlink_ack+0xa60/0xa60
+[  733.826103][    C1]  ? netlink_deliver_tap+0x227/0xba0
+[  733.826111][    C1]  ? netlink_deliver_tap+0x236/0xba0
+[  733.826117][    C1]  netlink_unicast+0x533/0x7d0
+[  733.826124][    C1]  ? netlink_attachskb+0x890/0x890
+[  733.826131][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.826140][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.826147][    C1]  ? __phys_addr_symbol+0x2c/0x70
+[  733.826166][    C1]  ? __sanitizer_cov_trace_cmp8+0x1d/0x70
+[  733.826172][    C1]  ? __check_object_size+0x16e/0x3f0
+[  733.826179][    C1]  netlink_sendmsg+0x85b/0xda0
+[  733.826185][    C1]  ? netlink_unicast+0x7d0/0x7d0
+[  733.826192][    C1]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[  733.826199][    C1]  ? netlink_unicast+0x7d0/0x7d0
+[  733.826205][    C1]  sock_sendmsg+0xcf/0x120
+[  733.826211][    C1]  ____sys_sendmsg+0x6e8/0x810
+[  733.826217][    C1]  ? kernel_sendmsg+0x50/0x50
+[  733.826223][    C1]  ? do_recvmmsg+0x6d0/0x6d0
+[  733.826229][    C1]  ? lock_acquire+0x442/0x510
+[  733.826235][    C1]  ___sys_sendmsg+0xf3/0x170
+[  733.826241][    C1]  ? sendmsg_copy_msghdr+0x160/0x160
+[  733.826248][    C1]  ? __fget_files+0x266/0x3d0
+[  733.826254][    C1]  ? lock_downgrade+0x6e0/0x6e0
+[  733.826261][    C1]  ? futex_exit_release+0x220/0x220
+[  733.826267][    C1]  ? _copy_to_user+0xdc/0x150
+[  733.826273][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.826281][    C1]  ? __fget_files+0x288/0x3d0
+[  733.826286][    C1]  ? __fget_light+0xea/0x280
+[  733.826293][    C1]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[  733.826300][    C1]  __sys_sendmsg+0xe5/0x1b0
+[  733.826306][    C1]  ? __sys_sendmsg_sock+0x30/0x30
+[  733.826313][    C1]  ? syscall_enter_from_user_mode+0x21/0x70
+[  733.826320][    C1]  ? trace_hardirqs_on+0x5b/0x1c0
+[  733.826326][    C1]  do_syscall_64+0x35/0xb0
+[  733.826332][    C1]  entry_SYSCALL_64_after_hwframe+0x44/0xae
+[  733.826339][    C1] RIP: 0033:0x4665d9
+[  733.826349][    C1] Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 bc ff ff ff f7 d8 64 89 01 48
+[  733.826366][    C1] RSP: 002b:00007f1f654df188 EFLAGS: 00000246 ORIG_RAX: 000000000000002e
+[  733.826382][    C1] RAX: ffffffffffffffda RBX: 000000000056bf80 RCX: 00000000004665d9
+[  733.826391][    C1] RDX: 0000000000000000 RSI: 0000000020000140 RDI: 0000000000000003
+[  733.826399][    C1] RBP: 00000000004bfcb9 R08: 0000000000000000 R09: 0000000000000000
+[  733.826408][    C1] R10: 0000000000000000 R11: 0000000000000246 R12: 000000000056bf80
+[  733.826418][    C1] R13: 00007ffe9e7905cf R14: 00007f1f654df300 R15: 0000000000022000
+[  733.826426][    C1] Modules linked in:
+[  737.720017][    C1] ---[ end trace c7333c57bb52e2a5 ]---
+[  737.720027][    C1] RIP: 0010:netdev_next_lower_dev_rcu+0x8/0xb0
+[  737.720037][    C1] Code: fe ff ff 4c 89 f6 48 c7 c7 c0 a5 0a 8d e8 e0 d4 db fc e9 b5 fe ff ff 66 66 2e 0f 1f 84 00 00 00 00 00 41 55 41 54 49 89 f4 55 <53> 48 89 fb e8 0f 91 66 fa 4c 89 e2 48 b8 00 00 00 00 00 fc ff df
+[  737.720050][    C1] RSP: 0018:ffffc900190d0000 EFLAGS: 00010212
+[  737.720061][    C1] RAX: 000000000001dfc3 RBX: 0000000000000000 RCX: ffffc9000e42e000
+[  737.720069][    C1] RDX: 0000000000040000 RSI: ffffc900190d0050 RDI: ffff88806eab4000
+[  737.720076][    C1] RBP: ffff88806eab4000 R08: 0000000000000000 R09: ffffffff8d6aed97
+[  737.720084][    C1] R10: ffffffff84b4e861 R11: 0000000000000000 R12: ffffc900190d0050
+[  737.720092][    C1] R13: dffffc0000000000 R14: ffff88807d7d21c8 R15: 1ffff9200321a006
+[  737.720100][    C1] FS:  00007f1f654df700(0000) GS:ffff8880b9d00000(0000) knlGS:0000000000000000
+[  737.720107][    C1] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  737.720114][    C1] CR2: ffffc900190cfff8 CR3: 000000008652c000 CR4: 00000000001506e0
+[  737.720122][    C1] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[  737.720130][    C1] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[  737.720137][    C1] Kernel panic - not syncing: Fatal exception in interrupt
+[  737.721525][    C1] Kernel Offset: disabled

--- a/pkg/report/testdata/linux/report/615
+++ b/pkg/report/testdata/linux/report/615
@@ -1,0 +1,746 @@
+TITLE: BUG: stack guard page was hit in rtnl_newlink
+
+[ 2331.755198][    C0] BUG: stack guard page was hit at ffffc9001a6e7fe8 (stack is ffffc9001a6e8000..ffffc9001a6effff)
+[ 2331.755221][    C0] kernel stack overflow (double-fault): 0000 [#1] PREEMPT SMP KASAN
+[ 2331.755233][    C0] CPU: 0 PID: 9061 Comm: syz-executor.4 Tainted: G        W         5.13.0-syzkaller #0
+[ 2331.755246][    C0] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[ 2331.755256][    C0] RIP: 0010:arch_stack_walk+0x57/0xe0
+[ 2331.755268][    C0] Code: 0f 84 84 00 00 00 48 8b b1 80 00 00 00 4c 89 e7 ff d3 84 c0 74 58 49 8b 8d 98 00 00 00 48 8d bd 78 ff ff ff 4c 89 ea 4c 89 f6 <e8> 24 aa 07 00 8b 95 78 ff ff ff 85 d2 75 21 eb 33 4c 89 e7 ff d3
+[ 2331.755285][    C0] RSP: 0018:ffffc9001a6e7ff0 EFLAGS: 00010246
+[ 2331.755301][    C0] RAX: ffff888170d88000 RBX: ffffffff8163fc30 RCX: ffffc9001a6e8078
+[ 2331.755312][    C0] RDX: 0000000000000000 RSI: ffff888170d88000 RDI: ffffc9001a6e7ff0
+[ 2331.755323][    C0] RBP: ffffc9001a6e8078 R08: 0000000000002000 R09: ffffed102b604c00
+[ 2331.755334][    C0] R10: ffffffff81346f2a R11: 000000000000003f R12: ffffc9001a6e80a8
+[ 2331.755345][    C0] R13: 0000000000000000 R14: ffff888170d88000 R15: 0000000000000000
+[ 2331.755356][    C0] FS:  00007fae3a1d6700(0000) GS:ffff8880b9c00000(0000) knlGS:0000000000000000
+[ 2331.755367][    C0] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 2331.755377][    C0] CR2: ffffc9001a6e7fe8 CR3: 00000001a2d9b000 CR4: 00000000001506f0
+[ 2331.755388][    C0] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[ 2331.755399][    C0] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[ 2331.755408][    C0] Call Trace:
+[ 2331.755414][    C0]  ? netdev_next_lower_dev_rcu+0x80/0xb0
+[ 2331.755421][    C0]  ? kfree+0xeb/0x670
+[ 2331.755428][    C0]  stack_trace_save+0x8c/0xc0
+[ 2331.755435][    C0]  ? stack_trace_consume_entry+0x160/0x160
+[ 2331.755443][    C0]  ? arch_stack_walk+0x5c/0xe0
+[ 2331.755450][    C0]  ? memset+0x20/0x40
+[ 2331.755457][    C0]  ? __snmp6_fill_stats64.constprop.0+0x1f9/0x260
+[ 2331.755465][    C0]  kasan_save_stack+0x1b/0x40
+[ 2331.755472][    C0]  ? bond_get_stats+0x379/0x4d0
+[ 2331.755479][    C0]  ? if6_seq_show+0x190/0x190
+[ 2331.755486][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.755493][    C0]  ? lock_release+0x522/0x720
+[ 2331.755500][    C0]  ? debug_check_no_obj_freed+0x20c/0x420
+[ 2331.755508][    C0]  ? lock_downgrade+0x6e0/0x6e0
+[ 2331.755515][    C0]  ? rwlock_bug.part.0+0x90/0x90
+[ 2331.755522][    C0]  ? memset+0x20/0x40
+[ 2331.755529][    C0]  ? _raw_spin_unlock_irqrestore+0x50/0x70
+[ 2331.755537][    C0]  ? trace_hardirqs_on+0x5b/0x1c0
+[ 2331.755545][    C0]  ? _raw_spin_unlock_irqrestore+0x3d/0x70
+[ 2331.755554][    C0]  ? debug_check_no_obj_freed+0x20c/0x420
+[ 2331.755562][    C0]  ? __sanitizer_cov_trace_const_cmp1+0x22/0x80
+[ 2331.755571][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.755578][    C0]  kasan_set_track+0x1c/0x30
+[ 2331.755585][    C0]  kasan_set_free_info+0x20/0x30
+[ 2331.755592][    C0]  __kasan_slab_free+0xfb/0x130
+[ 2331.755600][    C0]  slab_free_freelist_hook+0xdf/0x240
+[ 2331.755607][    C0]  kfree+0xeb/0x670
+[ 2331.755614][    C0]  ? pskb_expand_head+0xb0b/0x1060
+[ 2331.755621][    C0]  ? __sanitizer_cov_trace_const_cmp1+0x22/0x80
+[ 2331.755630][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.755638][    C0]  ? __phys_addr+0xc4/0x140
+[ 2331.755645][    C0]  pskb_expand_head+0xb0b/0x1060
+[ 2331.755652][    C0]  netlink_trim+0x1ea/0x240
+[ 2331.755659][    C0]  netlink_broadcast_filtered+0x65/0xdc0
+[ 2331.755667][    C0]  ? rtmsg_ifinfo_build_skb+0xcd/0x1a0
+[ 2331.755674][    C0]  nlmsg_notify+0x90/0x250
+[ 2331.755681][    C0]  rtnetlink_event+0x193/0x1d0
+[ 2331.755688][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.755696][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.755705][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.755712][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.755720][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.755728][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.755735][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.755742][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.755750][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.755757][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.755766][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.755773][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.755781][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.755789][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.755798][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.755806][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.755814][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.755842][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.755849][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.755856][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.755864][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.755872][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.755880][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.755888][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.755896][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.755903][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.755911][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.755919][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.755926][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.755934][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.755941][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.755949][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.755958][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.755966][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.755975][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.755983][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.755991][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.755998][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756006][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756014][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756021][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756030][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756038][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756046][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756053][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756061][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756068][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756075][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756083][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756091][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756098][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756107][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756115][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756123][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756131][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756139][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756147][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756160][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756167][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756175][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756184][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756191][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756200][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756207][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756214][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756222][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756229][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756237][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756245][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756253][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756262][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756270][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756279][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756287][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756295][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756303][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756310][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756317][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756326][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756333][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756341][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756349][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756355][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756362][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756369][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756376][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756384][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756390][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756398][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756406][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756414][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756421][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756429][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756437][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756444][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756452][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756459][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756467][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756475][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756482][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756490][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756497][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756505][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756513][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756520][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756528][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756535][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756542][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756550][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756558][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756565][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756573][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756581][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756588][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756595][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756602][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756611][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756618][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756626][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756633][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756640][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756647][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756654][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756661][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756669][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756676][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756683][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756691][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756699][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756707][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756714][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756722][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756730][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756737][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756745][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756753][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756761][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756769][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756777][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756783][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756790][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756799][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756805][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756812][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756819][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.756827][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.756835][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.756843][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.756852][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.756877][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.756886][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.756893][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.756900][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.756908][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.756917][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.756925][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.756933][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.756941][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.756960][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756967][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.756974][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.756981][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.756988][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.756996][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757002][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757011][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757019][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757027][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757035][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757043][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757059][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757066][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757073][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757081][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757089][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757097][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757105][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757112][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757119][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757127][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757134][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757141][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757149][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757160][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757168][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757176][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757185][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757192][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757200][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757207][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757215][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757222][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757230][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757237][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757245][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757253][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757259][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757267][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757275][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757282][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757289][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757297][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757304][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757313][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757320][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757328][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757336][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757344][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757352][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757359][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757367][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757375][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757383][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757390][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757398][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757406][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757413][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757421][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757427][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757435][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757443][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757450][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757458][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757466][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757474][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757481][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757488][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757495][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757502][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757509][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757518][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757525][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757534][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757543][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757550][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757557][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757565][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757573][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757581][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757588][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757596][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757604][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757612][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757620][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757628][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757637][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757644][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757651][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757658][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757665][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757673][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757682][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757690][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757697][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757705][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757713][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757720][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757728][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757735][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757743][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757751][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757759][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757768][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757776][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757785][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757792][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757800][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757807][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757816][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.757824][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.757832][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.757841][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.757854][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757862][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.757870][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.757877][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.757885][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.757892][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.757918][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.757927][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.757936][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.757945][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.757953][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.757962][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.757970][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.757978][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.757986][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.757995][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758004][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758012][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758020][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758028][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758035][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758043][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758051][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758059][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758067][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758075][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758084][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758092][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758100][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758109][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758117][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758125][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758133][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758141][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758155][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758163][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758171][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758180][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758187][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758195][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758203][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758210][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758218][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758226][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758234][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758243][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758252][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758261][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758269][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758277][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758285][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758293][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758301][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758310][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758318][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758326][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758335][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758342][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758350][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758357][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758365][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758373][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758380][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758389][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758398][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758406][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758415][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758423][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758431][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758439][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758447][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758455][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758463][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758471][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758479][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758488][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758495][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758503][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758511][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758519][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758527][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758535][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758543][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758552][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758561][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758569][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758576][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758584][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758591][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758598][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758606][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758613][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758621][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758629][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758637][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758645][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758652][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758660][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758667][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758675][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758683][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758691][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758699][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758707][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758716][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758724][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758732][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758740][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758748][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758755][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758763][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758771][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758779][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758787][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758794][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758802][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758809][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758817][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758824][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758832][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758839][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758848][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.758856][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.758864][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.758872][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.758880][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.758888][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.758895][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.758902][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.758911][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.758920][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.758928][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.758936][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.758943][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758950][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.758959][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.758966][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.758973][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.758981][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.758986][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.758994][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759002][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759010][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759018][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759026][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759034][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759041][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759063][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759071][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759079][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759088][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759096][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.759103][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759110][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759118][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759125][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759132][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759162][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.759170][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759179][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759186][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759195][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759202][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759211][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759219][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759226][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759233][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759241][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759249][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759257][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759265][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.759272][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759280][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759287][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759295][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759302][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759310][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.759317][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759326][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759334][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759342][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759350][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759359][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759366][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759373][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759381][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759390][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759397][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759405][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759413][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.759421][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759428][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759436][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759443][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759451][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759458][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.759466][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759475][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759484][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759491][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759499][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759507][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759516][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759523][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759530][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759539][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759547][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759555][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759562][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.759570][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759578][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759587][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759593][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759601][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759609][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.759617][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759625][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759634][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759643][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759651][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759659][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759666][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759673][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759681][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759689][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759696][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759704][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759713][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.759720][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759728][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759736][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.759743][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759751][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759759][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.759768][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759777][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759785][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759794][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759802][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759811][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759819][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759826][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759835][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.759843][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.759851][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.759859][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.759869][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.759878][    C0]  ? finish_task_switch.isra.0+0x232/0xa50
+[ 2331.759886][    C0]  ? trace_hardirqs_on+0x5b/0x1c0
+[ 2331.759894][    C0]  ? finish_task_switch.isra.0+0x232/0xa50
+[ 2331.759902][    C0]  ? __switch_to+0x57c/0x1100
+[ 2331.759910][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.759918][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.759926][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.759935][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.759943][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.759952][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.759960][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.759968][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.759976][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.759984][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.759992][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.760000][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.760009][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.760018][    C0]  ? cfg80211_netdev_notifier_call+0x171/0x1270
+[ 2331.760026][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.760034][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.760042][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.760049][    C0]  ? kfree_skbmem+0xef/0x1b0
+[ 2331.760056][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.760064][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.760072][    C0]  ? lock_acquire+0x442/0x510
+[ 2331.760080][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760089][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.760098][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.760106][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.760114][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.760123][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.760130][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.760138][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.760146][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.760160][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.760168][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.760189][    C0]  ? __wake_up_common+0x650/0x650
+[ 2331.760197][    C0]  ? cfg80211_register_netdevice+0x320/0x320
+[ 2331.760205][    C0]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[ 2331.760214][    C0]  ? asm_sysvec_apic_timer_interrupt+0x12/0x20
+[ 2331.760222][    C0]  ? trace_hardirqs_on+0x5b/0x1c0
+[ 2331.760230][    C0]  netdev_change_features+0x61/0xb0
+[ 2331.760237][    C0]  ? netdev_update_features+0xd0/0xd0
+[ 2331.760246][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760255][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.760263][    C0]  ? netdev_lower_get_next_private+0x80/0xb0
+[ 2331.760271][    C0]  bond_compute_features+0x56c/0xaa0
+[ 2331.760279][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.760288][    C0]  ? bond_fix_features+0x2f0/0x2f0
+[ 2331.760295][    C0]  bond_netdev_event+0x5d6/0xa80
+[ 2331.760302][    C0]  notifier_call_chain+0xb5/0x200
+[ 2331.760310][    C0]  call_netdevice_notifiers_info+0xb5/0x130
+[ 2331.760319][    C0]  __netdev_update_features+0x95d/0x17d0
+[ 2331.760327][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.760335][    C0]  ? udp_tunnel_nic_netdevice_event+0x15f/0x1a20
+[ 2331.760344][    C0]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[ 2331.760352][    C0]  ? ip6_route_dev_notify+0xdc/0x7a0
+[ 2331.760360][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760368][    C0]  ? netdev_increment_features+0x87/0xa0
+[ 2331.760376][    C0]  __netdev_update_features+0x906/0x17d0
+[ 2331.760384][    C0]  ? dev_change_xdp_fd+0x300/0x300
+[ 2331.760393][    C0]  ? __netdev_adjacent_dev_insert+0xa50/0xa50
+[ 2331.760401][    C0]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[ 2331.760410][    C0]  ? nbp_switchdev_mark_set+0x12d/0x3f0
+[ 2331.760417][    C0]  dev_disable_lro+0x8d/0x3e0
+[ 2331.760424][    C0]  ? register_netdev+0x50/0x50
+[ 2331.760432][    C0]  ? mutex_is_locked+0xe/0x40
+[ 2331.760440][    C0]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[ 2331.760448][    C0]  ? netdev_is_rx_handler_busy+0x82/0x140
+[ 2331.760456][    C0]  br_add_if+0xa4e/0x1c70
+[ 2331.760463][    C0]  ? mutex_is_locked+0xe/0x40
+[ 2331.760470][    C0]  ? br_del_slave+0x20/0x20
+[ 2331.760476][    C0]  do_set_master+0x1c8/0x220
+[ 2331.760483][    C0]  __rtnl_newlink+0x13af/0x1760
+[ 2331.760490][    C0]  ? __kernel_text_address+0x9/0x30
+[ 2331.760498][    C0]  ? rtnl_setlink+0x3c0/0x3c0
+[ 2331.760505][    C0]  ? arch_stack_walk+0x93/0xe0
+[ 2331.760512][    C0]  ? lock_release+0x522/0x720
+[ 2331.760519][    C0]  ? is_bpf_text_address+0xa9/0x160
+[ 2331.760527][    C0]  ? lock_downgrade+0x6e0/0x6e0
+[ 2331.760534][    C0]  ? unwind_next_frame+0xec8/0x1ce0
+[ 2331.760542][    C0]  ? entry_SYSCALL_64_after_hwframe+0x44/0xae
+[ 2331.760551][    C0]  ? __sanitizer_cov_trace_cmp4+0x1c/0x70
+[ 2331.760559][    C0]  ? bpf_ksym_find+0x171/0x1c0
+[ 2331.760566][    C0]  ? is_bpf_text_address+0xcb/0x160
+[ 2331.760574][    C0]  ? kernel_text_address+0xbd/0xf0
+[ 2331.760581][    C0]  ? __kernel_text_address+0x9/0x30
+[ 2331.760589][    C0]  ? unwind_get_return_address+0x51/0x90
+[ 2331.760598][    C0]  ? create_prof_cpu_mask+0x20/0x20
+[ 2331.760605][    C0]  ? arch_stack_walk+0x93/0xe0
+[ 2331.760612][    C0]  ? lock_release+0x522/0x720
+[ 2331.760619][    C0]  ? fs_reclaim_release+0x9c/0xf0
+[ 2331.760627][    C0]  ? lock_downgrade+0x6e0/0x6e0
+[ 2331.760634][    C0]  ? rtnetlink_rcv_msg+0x3f9/0xb70
+[ 2331.760641][    C0]  rtnl_newlink+0x64/0xa0
+[ 2331.760649][    C0]  ? __rtnl_newlink+0x1760/0x1760
+[ 2331.760656][    C0]  rtnetlink_rcv_msg+0x44e/0xb70
+[ 2331.760663][    C0]  ? rtnl_newlink+0xa0/0xa0
+[ 2331.760670][    C0]  ? do_syscall_64+0x35/0xb0
+[ 2331.760677][    C0]  ? entry_SYSCALL_64_after_hwframe+0x44/0xae
+[ 2331.760686][    C0]  ? __sanitizer_cov_trace_cmp8+0x1d/0x70
+[ 2331.760694][    C0]  ? __sanitizer_cov_trace_switch+0x63/0xf0
+[ 2331.760702][    C0]  ? netdev_core_pick_tx+0x2e0/0x2e0
+[ 2331.760710][    C0]  ? lock_acquire+0x350/0x510
+[ 2331.760717][    C0]  netlink_rcv_skb+0x153/0x420
+[ 2331.760724][    C0]  ? rtnl_newlink+0xa0/0xa0
+[ 2331.760731][    C0]  ? netlink_ack+0xa60/0xa60
+[ 2331.760738][    C0]  ? netlink_deliver_tap+0x227/0xba0
+[ 2331.760746][    C0]  ? netlink_deliver_tap+0x236/0xba0
+[ 2331.760753][    C0]  netlink_unicast+0x533/0x7d0
+[ 2331.760760][    C0]  ? netlink_attachskb+0x890/0x890
+[ 2331.760767][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760775][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760783][    C0]  ? __phys_addr_symbol+0x2c/0x70
+[ 2331.760791][    C0]  ? __sanitizer_cov_trace_cmp8+0x1d/0x70
+[ 2331.760798][    C0]  ? __check_object_size+0x16e/0x3f0
+[ 2331.760805][    C0]  netlink_sendmsg+0x85b/0xda0
+[ 2331.760812][    C0]  ? netlink_unicast+0x7d0/0x7d0
+[ 2331.760820][    C0]  ? __sanitizer_cov_trace_const_cmp4+0x1c/0x70
+[ 2331.760829][    C0]  ? netlink_unicast+0x7d0/0x7d0
+[ 2331.760836][    C0]  sock_sendmsg+0xcf/0x120
+[ 2331.760842][    C0]  ____sys_sendmsg+0x6e8/0x810
+[ 2331.760849][    C0]  ? kernel_sendmsg+0x50/0x50
+[ 2331.760856][    C0]  ? do_recvmmsg+0x6d0/0x6d0
+[ 2331.760863][    C0]  ? futex_wait_restart+0x200/0x200
+[ 2331.760870][    C0]  ? fs_reclaim_release+0x9c/0xf0
+[ 2331.760877][    C0]  ? lock_release+0x522/0x720
+[ 2331.760885][    C0]  ? fs_reclaim_release+0x9c/0xf0
+[ 2331.760892][    C0]  ? lock_downgrade+0x6e0/0x6e0
+[ 2331.760898][    C0]  ___sys_sendmsg+0xf3/0x170
+[ 2331.760905][    C0]  ? sendmsg_copy_msghdr+0x160/0x160
+[ 2331.760912][    C0]  ? __fget_files+0x266/0x3d0
+[ 2331.760918][    C0]  ? lock_downgrade+0x6e0/0x6e0
+[ 2331.760925][    C0]  ? __might_fault+0xd3/0x180
+[ 2331.760933][    C0]  ? futex_exit_release+0x220/0x220
+[ 2331.760940][    C0]  ? __fget_files+0x288/0x3d0
+[ 2331.760946][    C0]  ? __fget_light+0xea/0x280
+[ 2331.760953][    C0]  ? __sanitizer_cov_trace_const_cmp8+0x1d/0x70
+[ 2331.760962][    C0]  __sys_sendmsg+0xe5/0x1b0
+[ 2331.760968][    C0]  ? __sys_sendmsg_sock+0x30/0x30
+[ 2331.760976][    C0]  ? syscall_enter_from_user_mode+0x21/0x70
+[ 2331.760984][    C0]  ? trace_hardirqs_on+0x5b/0x1c0
+[ 2331.760991][    C0]  do_syscall_64+0x35/0xb0
+[ 2331.760998][    C0]  entry_SYSCALL_64_after_hwframe+0x44/0xae
+[ 2331.761006][    C0] RIP: 0033:0x4665d9
+[ 2331.761016][    C0] Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 bc ff ff ff f7 d8 64 89 01 48
+[ 2331.761034][    C0] RSP: 002b:00007fae3a1d6188 EFLAGS: 00000246 ORIG_RAX: 000000000000002e
+[ 2331.761053][    C0] RAX: ffffffffffffffda RBX: 000000000056c038 RCX: 00000000004665d9
+[ 2331.761063][    C0] RDX: 0000000000000000 RSI: 0000000020000300 RDI: 0000000000000007
+[ 2331.761074][    C0] RBP: 00000000004bfcb9 R08: 0000000000000000 R09: 0000000000000000
+[ 2331.761084][    C0] R10: 0000000000000000 R11: 0000000000000246 R12: 000000000056c038
+[ 2331.761094][    C0] R13: 00007fff95e3765f R14: 00007fae3a1d6300 R15: 0000000000022000
+[ 2331.761103][    C0] Modules linked in:
+[ 2331.977170][ T9165] x_tables: ip6_tables: realm match: used from hooks PREROUTING, but only valid from INPUT/FORWARD/OUTPUT/POSTROUTING
+[ 2331.980837][    C0] ---[ end trace 0e3920d6a9af969b ]---
+[ 2331.980848][    C0] RIP: 0010:arch_stack_walk+0x57/0xe0
+[ 2331.980859][    C0] Code: 0f 84 84 00 00 00 48 8b b1 80 00 00 00 4c 89 e7 ff d3 84 c0 74 58 49 8b 8d 98 00 00 00 48 8d bd 78 ff ff ff 4c 89 ea 4c 89 f6 <e8> 24 aa 07 00 8b 95 78 ff ff ff 85 d2 75 21 eb 33 4c 89 e7 ff d3
+[ 2331.980876][    C0] RSP: 0018:ffffc9001a6e7ff0 EFLAGS: 00010246
+[ 2331.980890][    C0] RAX: ffff888170d88000 RBX: ffffffff8163fc30 RCX: ffffc9001a6e8078
+[ 2331.980899][    C0] RDX: 0000000000000000 RSI: ffff888170d88000 RDI: ffffc9001a6e7ff0
+[ 2331.980908][    C0] RBP: ffffc9001a6e8078 R08: 0000000000002000 R09: ffffed102b604c00
+[ 2331.980918][    C0] R10: ffffffff81346f2a R11: 000000000000003f R12: ffffc9001a6e80a8
+[ 2331.980927][    C0] R13: 0000000000000000 R14: ffff888170d88000 R15: 0000000000000000
+[ 2331.980949][    C0] FS:  00007fae3a1d6700(0000) GS:ffff8880b9c00000(0000) knlGS:0000000000000000
+[ 2331.980958][    C0] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 2331.980965][    C0] CR2: ffffc9001a6e7fe8 CR3: 00000001a2d9b000 CR4: 00000000001506f0
+[ 2331.980975][    C0] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[ 2331.980983][    C0] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[ 2331.980992][    C0] Kernel panic - not syncing: Fatal exception in interrupt
+[ 2331.987130][    C0] Kernel Offset: disabled


### PR DESCRIPTION
Now that we increased CONFIG_PRINTK_SAFE_LOG_BUF_SHIFT to 16
we started getting full parsable "stack guard page was hit" crashes.
Extract the anchor frame as we do for stalls.
This makes reports deterministic rather than point to a random top frame.
