### PR TITLE
syz-verifier: add utility for gathering statistics

### DIFF
--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -411,6 +411,7 @@ func (srv *RPCServer) newResult(res *verf.Result, prog *progInfo) bool {
 // in th workdir/results directory. If writing the results fails, it returns an
 // error.
 func (vrf *Verifier) processResults(res []*verf.Result, prog *prog.Prog) {
+	vrf.stats.Progs++
 	rr := verf.Verify(res, prog, vrf.stats)
 	if rr == nil {
 		return

--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -417,6 +417,7 @@ func TestProcessResults(t *testing.T) {
 			wantExist: true,
 			wantStats: &stats.Stats{
 				TotalMismatches: 1,
+				Progs:           1,
 				Calls: map[string]*stats.CallStats{
 					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
 					"test$res0":      makeCallStats("test$res0", 1, 1, map[int]bool{2: true, 5: true}),
@@ -431,6 +432,7 @@ func TestProcessResults(t *testing.T) {
 				makeResult(3, []int{11, 33, 22}),
 			},
 			wantStats: &stats.Stats{
+				Progs: 1,
 				Calls: map[string]*stats.CallStats{
 					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
 					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
@@ -529,6 +531,7 @@ func TestCleanup(t *testing.T) {
 					},
 				}},
 			wantStats: &stats.Stats{
+				Progs: 1,
 				Calls: map[string]*stats.CallStats{
 					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
 					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
@@ -551,6 +554,7 @@ func TestCleanup(t *testing.T) {
 				}},
 			wantStats: &stats.Stats{
 				TotalMismatches: 1,
+				Progs:           1,
 				Calls: map[string]*stats.CallStats{
 					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
 					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),

--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -418,9 +418,9 @@ func TestProcessResults(t *testing.T) {
 			wantStats: &stats.Stats{
 				TotalMismatches: 1,
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{1: true}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
 					"test$res0":      makeCallStats("test$res0", 1, 1, map[int]bool{2: true, 5: true}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{3: true}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
 				},
 			},
 		},
@@ -432,9 +432,9 @@ func TestProcessResults(t *testing.T) {
 			},
 			wantStats: &stats.Stats{
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{11: true}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{33: true}),
-					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{22: true}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{}),
 				},
 			},
 		},
@@ -530,9 +530,9 @@ func TestCleanup(t *testing.T) {
 				}},
 			wantStats: &stats.Stats{
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{11: true}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{33: true}),
-					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{22: true}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{}),
 				},
 			},
 			fileExists: false,
@@ -552,8 +552,8 @@ func TestCleanup(t *testing.T) {
 			wantStats: &stats.Stats{
 				TotalMismatches: 1,
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{11: true}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{33: true}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
 					"test$res0":      makeCallStats("test$res0", 1, 1, map[int]bool{22: true, 44: true}),
 				},
 			},

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -1,0 +1,111 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package stats contains utilities that aid gathering statistics of
+// system call mismatches in the verified programs.
+package stats
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+
+	"github.com/google/syzkaller/prog"
+)
+
+// Stats encapsulates data for creating statistics related to the results
+// of the verification process.
+type Stats struct {
+	// Calls stores statistics for all supported system calls.
+	Calls           map[string]*CallStats
+	TotalMismatches int
+}
+
+// CallStats stores information used to generate statistics for the
+// system call.
+type CallStats struct {
+	// Name is the system call name.
+	Name string
+	// Mismatches stores the number of errno mismatches identifed in the
+	// verified programs for this system call.
+	Mismatches int
+	// Occurrences is the number of times the system call appeared in a
+	// verified program.
+	Occurrences int
+}
+
+// InitStats creates a stats object that will report verification
+// statistics when an os.Interrupt occurs.
+func InitStats(calls map[*prog.Syscall]bool, w io.Writer) *Stats {
+	s := &Stats{Calls: make(map[string]*CallStats)}
+	for c := range calls {
+		s.Calls[c.Name] = &CallStats{Name: c.Name}
+	}
+
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		s.ReportGlobalStats(w)
+		os.Exit(0)
+	}()
+
+	return s
+}
+
+// ReportCallStats creates a report with the current statistics for call.
+func (s *Stats) ReportCallStats(call string) string {
+	cs, ok := s.Calls[call]
+	if !ok {
+		return ""
+	}
+	name, m, o := cs.Name, cs.Mismatches, cs.Occurrences
+	data := fmt.Sprintf("statistics for %s:\n"+
+		"\t↳ mismatches of %s / occurrences of %s: %d / %d (%0.2f %%)\n"+
+		"\t↳ mismatches of %s / total number of mismatches: "+
+		"%d / %d (%0.2f %%)\n", name, name, name, m, o,
+		getPercentage(m, o), name, m, s.TotalMismatches, getPercentage(m, s.TotalMismatches))
+	return data
+}
+
+func getPercentage(value, total int) float64 {
+	return float64(value) / float64(total) * 100
+}
+
+// ReportGlobalStats creates a report with statistics about all the
+// supported system calls for which errno mismatches were identified in
+// the verified programs, shown in decreasing order.
+func (s *Stats) ReportGlobalStats(w io.Writer) {
+	tc := s.totalCallsExecuted()
+	fmt.Fprintf(w, "total number of mismatches / total number of calls "+
+		"executed: %d / %d (%0.2f %%)\n\n", s.TotalMismatches, tc, getPercentage(s.TotalMismatches, tc))
+	cs := s.getOrderedStats()
+	for _, c := range cs {
+		fmt.Fprintf(w, "%s\n", s.ReportCallStats(c.Name))
+	}
+}
+
+func (s *Stats) totalCallsExecuted() int {
+	t := 0
+	for _, cs := range s.Calls {
+		t += cs.Occurrences
+	}
+	return t
+}
+
+func (s *Stats) getOrderedStats() []*CallStats {
+	css := make([]*CallStats, 0)
+	for _, cs := range s.Calls {
+		if cs.Mismatches > 0 {
+			css = append(css, cs)
+		}
+	}
+
+	sort.Slice(css, func(i, j int) bool {
+		return css[i].Mismatches > css[j].Mismatches
+	})
+
+	return css
+}

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -112,7 +112,7 @@ func (s *Stats) getOrderedStats() []*CallStats {
 	}
 
 	sort.Slice(css, func(i, j int) bool {
-		return css[i].Mismatches > css[j].Mismatches
+		return getPercentage(css[i].Mismatches, css[i].Occurrences) > getPercentage(css[j].Mismatches, css[j].Occurrences)
 	})
 
 	return css

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -34,7 +34,7 @@ type CallStats struct {
 	// Occurrences is the number of times the system call appeared in a
 	// verified program.
 	Occurrences int
-	// States stores all possible kernel return values identified for the 
+	// States stores all possible kernel return values identified for the
 	// system call.
 	States map[int]bool
 }
@@ -44,7 +44,7 @@ type CallStats struct {
 func InitStats(calls map[*prog.Syscall]bool, w io.Writer) *Stats {
 	s := &Stats{Calls: make(map[string]*CallStats)}
 	for c := range calls {
-		s.Calls[c.Name] = &CallStats{Name: c.Name}
+		s.Calls[c.Name] = &CallStats{Name: c.Name, States: make(map[int]bool)}
 	}
 
 	c := make(chan os.Signal)

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -34,8 +34,7 @@ type CallStats struct {
 	// Occurrences is the number of times the system call appeared in a
 	// verified program.
 	Occurrences int
-	// States stores all possible kernel return values identified for the
-	// system call.
+	// States stores the kernel return values that caused mismatches.
 	States map[int]bool
 }
 

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -34,6 +34,9 @@ type CallStats struct {
 	// Occurrences is the number of times the system call appeared in a
 	// verified program.
 	Occurrences int
+	// States stores all possible kernel return values identified for the 
+	// system call.
+	States map[int]bool
 }
 
 // InitStats creates a stats object that will report verification
@@ -65,8 +68,9 @@ func (s *Stats) ReportCallStats(call string) string {
 	data := fmt.Sprintf("statistics for %s:\n"+
 		"\t↳ mismatches of %s / occurrences of %s: %d / %d (%0.2f %%)\n"+
 		"\t↳ mismatches of %s / total number of mismatches: "+
-		"%d / %d (%0.2f %%)\n", name, name, name, m, o,
-		getPercentage(m, o), name, m, s.TotalMismatches, getPercentage(m, s.TotalMismatches))
+		"%d / %d (%0.2f %%)\n"+
+		"\t↳ %d distinct states identified\n", name, name, name, m, o,
+		getPercentage(m, o), name, m, s.TotalMismatches, getPercentage(m, s.TotalMismatches), len(cs.States))
 	return data
 }
 

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -12,6 +12,7 @@ import (
 
 func getTestStats() *Stats {
 	return &Stats{
+		Progs:           24,
 		TotalMismatches: 10,
 		Calls: map[string]*CallStats{
 			"foo": {"foo", 2, 8, map[int]bool{11: true, 3: true}},
@@ -55,10 +56,11 @@ func TestReportCallStats(t *testing.T) {
 func TestReportGlobalStats(t *testing.T) {
 	s := getTestStats()
 	out := bytes.Buffer{}
-	s.ReportGlobalStats(&out)
+	s.ReportGlobalStats(&out, float64(10))
 	got, want := out.String(),
 		"total number of mismatches / total number of calls "+
 			"executed: 10 / 20 (50.00 %)\n\n"+
+			"programs / minute: 2.40\n\n"+
 			"statistics for bar:\n"+
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
 			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package stats
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func getTestStats() *Stats {
+	return &Stats{
+		TotalMismatches: 11,
+		Calls: map[string]*CallStats{
+			"foo": {"foo", 2, 8},
+			"bar": {"bar", 5, 6},
+			"tar": {"tar", 3, 4},
+			"biz": {"biz", 0, 2},
+		},
+	}
+}
+
+func TestReportCallStats(t *testing.T) {
+	tests := []struct {
+		name, call, report string
+	}{
+		{
+			name:   "report for unsupported call",
+			call:   "read",
+			report: "",
+		},
+		{
+			name: "report for supported call",
+			call: "foo",
+			report: "statistics for foo:\n" +
+				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
+				"\t↳ mismatches of foo / total number of mismatches: 2 / 11 (18.18 %)\n",
+		},
+	}
+
+	for _, test := range tests {
+		s := getTestStats()
+		t.Run(test.name, func(t *testing.T) {
+			got, want := s.ReportCallStats(test.call), test.report
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("s.ReportCallStats mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReportGlobalStats(t *testing.T) {
+	s := getTestStats()
+	out := bytes.Buffer{}
+	s.ReportGlobalStats(&out)
+	got, want := out.String(),
+		"total number of mismatches / total number of calls "+
+			"executed: 11 / 20 (55.00 %)\n\n"+
+			"statistics for bar:\n"+
+			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
+			"\t↳ mismatches of bar / total number of mismatches: 5 / 11 (45.45 %)\n\n"+
+			"statistics for tar:\n"+
+			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
+			"\t↳ mismatches of tar / total number of mismatches: 3 / 11 (27.27 %)\n\n"+
+			"statistics for foo:\n"+
+			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
+			"\t↳ mismatches of foo / total number of mismatches: 2 / 11 (18.18 %)\n\n"
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -36,7 +36,8 @@ func TestReportCallStats(t *testing.T) {
 			call: "foo",
 			report: "statistics for foo:\n" +
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
-				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" + "\t↳ 2 distinct states identified\n",
+				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" +
+				"\t↳ 2 distinct states identified: [3 11]\n",
 		},
 	}
 
@@ -60,13 +61,16 @@ func TestReportGlobalStats(t *testing.T) {
 			"executed: 10 / 20 (50.00 %)\n\n"+
 			"statistics for bar:\n"+
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
-			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+"\t↳ 2 distinct states identified\n\n"+
+			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+
+			"\t↳ 2 distinct states identified: [10 22]\n\n"+
 			"statistics for tar:\n"+
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
-			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+"\t↳ 3 distinct states identified\n\n"+
+			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+
+			"\t↳ 3 distinct states identified: [31 100 101]\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
-			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+"\t↳ 2 distinct states identified\n\n"
+			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+
+			"\t↳ 2 distinct states identified: [3 11]\n\n"
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -12,12 +12,12 @@ import (
 
 func getTestStats() *Stats {
 	return &Stats{
-		TotalMismatches: 11,
+		TotalMismatches: 10,
 		Calls: map[string]*CallStats{
-			"foo": {"foo", 2, 8},
-			"bar": {"bar", 5, 6},
-			"tar": {"tar", 3, 4},
-			"biz": {"biz", 0, 2},
+			"foo": {"foo", 2, 8, map[int]bool{11: true, 3: true}},
+			"bar": {"bar", 5, 6, map[int]bool{10: true, 22: true}},
+			"tar": {"tar", 3, 4, map[int]bool{31: true, 100: true, 101: true}},
+			"biz": {"biz", 0, 2, map[int]bool{4: true}},
 		},
 	}
 }
@@ -36,7 +36,7 @@ func TestReportCallStats(t *testing.T) {
 			call: "foo",
 			report: "statistics for foo:\n" +
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
-				"\t↳ mismatches of foo / total number of mismatches: 2 / 11 (18.18 %)\n",
+				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" + "\t↳ 2 distinct states identified\n",
 		},
 	}
 
@@ -57,16 +57,16 @@ func TestReportGlobalStats(t *testing.T) {
 	s.ReportGlobalStats(&out)
 	got, want := out.String(),
 		"total number of mismatches / total number of calls "+
-			"executed: 11 / 20 (55.00 %)\n\n"+
+			"executed: 10 / 20 (50.00 %)\n\n"+
 			"statistics for bar:\n"+
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
-			"\t↳ mismatches of bar / total number of mismatches: 5 / 11 (45.45 %)\n\n"+
+			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+"\t↳ 2 distinct states identified\n\n"+
 			"statistics for tar:\n"+
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
-			"\t↳ mismatches of tar / total number of mismatches: 3 / 11 (27.27 %)\n\n"+
+			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+"\t↳ 3 distinct states identified\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
-			"\t↳ mismatches of foo / total number of mismatches: 2 / 11 (18.18 %)\n\n"
+			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+"\t↳ 2 distinct states identified\n\n"
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -17,7 +17,7 @@ func getTestStats() *Stats {
 			"foo": {"foo", 2, 8, map[int]bool{11: true, 3: true}},
 			"bar": {"bar", 5, 6, map[int]bool{10: true, 22: true}},
 			"tar": {"tar", 3, 4, map[int]bool{31: true, 100: true, 101: true}},
-			"biz": {"biz", 0, 2, map[int]bool{4: true}},
+			"biz": {"biz", 0, 2, map[int]bool{}},
 		},
 	}
 }

--- a/syz-verifier/verf/verifier.go
+++ b/syz-verifier/verf/verifier.go
@@ -59,7 +59,6 @@ func Verify(res []*Result, prog *prog.Prog, s *stats.Stats) *ResultReport {
 		rr.Reports = append(rr.Reports, cr)
 		cs := s.Calls[call]
 		cs.Occurrences++
-		cs.States[c.Errno] = true
 	}
 
 	var send bool
@@ -76,6 +75,7 @@ func Verify(res []*Result, prog *prog.Prog, s *stats.Stats) *ResultReport {
 				s.TotalMismatches++
 				cs.Mismatches++
 				cs.States[c.Errno] = true
+				cs.States[c0[idx].Errno] = true
 			}
 
 			cr.Errnos[resi.Pool] = c.Errno

--- a/syz-verifier/verf/verifier.go
+++ b/syz-verifier/verf/verifier.go
@@ -29,6 +29,7 @@ type ResultReport struct {
 }
 
 type CallReport struct {
+	Call string
 	// Errno is a map between pools and the errno returned by executing the
 	// system call on a VM spawned by the respective pool.
 	Errnos map[int]int
@@ -46,8 +47,9 @@ func Verify(res []*Result, prog *prog.Prog) *ResultReport {
 		Prog: string(prog.Serialize()),
 	}
 	c0 := res[0].Info.Calls
-	for _, c := range c0 {
+	for idx, c := range c0 {
 		cr := CallReport{
+			Call:   prog.Calls[idx].Meta.Name,
 			Errnos: map[int]int{res[0].Pool: c.Errno},
 			Flags:  map[int]ipc.CallFlags{res[0].Pool: c.Flags},
 		}

--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -47,9 +47,9 @@ func TestVerify(t *testing.T) {
 			wantReport: nil,
 			wantStats: &stats.Stats{
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{11: true}},
-					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{33: true}},
-					"test$res0":      {Name: "test$res0", Occurrences: 1, States: map[int]bool{22: true}},
+					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
+					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
+					"test$res0":      {Name: "test$res0", Occurrences: 1, States: map[int]bool{}},
 				},
 			},
 		},
@@ -73,8 +73,8 @@ func TestVerify(t *testing.T) {
 			wantStats: &stats.Stats{
 				TotalMismatches: 1,
 				Calls: map[string]*stats.CallStats{
-					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{1: true}},
-					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{3: true}},
+					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
+					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
 					"test$res0":      {Name: "test$res0", Occurrences: 1, Mismatches: 1, States: map[int]bool{2: true, 5: true}},
 				},
 			},

--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -43,9 +43,12 @@ func TestVerify(t *testing.T) {
 			want: &ResultReport{
 				Prog: p,
 				Reports: []CallReport{
-					{Errnos: map[int]int{1: 1, 4: 1}, Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
-					{Errnos: map[int]int{1: 3, 4: 3}, Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
-					{Errnos: map[int]int{1: 2, 4: 5}, Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
+					{Call: "breaks_returns", Errnos: map[int]int{1: 1, 4: 1},
+						Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
+					{Call: "minimize$0", Errnos: map[int]int{1: 3, 4: 3},
+						Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
+					{Call: "test$res0", Errnos: map[int]int{1: 2, 4: 5},
+						Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
 				},
 			},
 		},


### PR DESCRIPTION
Contributes to #692

Created a `stats` package, used to compute statistics about `syz-verifier` runs. Statistics for the calls that produced mismatches in the program will be added to the result reports while general statistics will be shown when the program exits