### PR TITLE
tools/syz-make: limit make concurrency on OpenBSD

### DIFF
--- a/tools/syz-make/make.go
+++ b/tools/syz-make/make.go
@@ -42,6 +42,10 @@ func impl() ([]Var, error) {
 		return nil, fmt.Errorf("unknown target %v/%v", targetOS, targetArch)
 	}
 	parallelism := runtime.NumCPU()
+	if runtime.GOOS == targets.OpenBSD {
+		// Avoids too much concurrency on OpenBSD which can't handle this much.
+		parallelism = 1
+	}
 	if mem := osutil.SystemMemorySize(); mem != 0 {
 		// Ensure that we have at least 1GB per Go compiler/linker invocation.
 		// Go compiler/linker can consume significant amount of memory


### PR DESCRIPTION
We previously observed syz-bot hanging OpenBSD machines. We made the problem
less acute by throwing resources at it. Go builds are good at
exploiting the machines themselves, so limiting make concurrency is a
clear benefit on OpenBSD.
