### PR TITLE
Adjust Kernel Build Commit column width

### DIFF
--- a/dashboard/app/static/style.css
+++ b/dashboard/app/static/style.css
@@ -151,7 +151,6 @@ table td, table th {
 
 .list_table .stat {
 	width: 55pt;
-	max-width: 55pt;
 	font-family: monospace;
 	text-align: right;
 }

--- a/pkg/html/generated.go
+++ b/pkg/html/generated.go
@@ -155,7 +155,6 @@ table td, table th {
 
 .list_table .stat {
 	width: 55pt;
-	max-width: 55pt;
 	font-family: monospace;
 	text-align: right;
 }


### PR DESCRIPTION
After 12 digit kernel commit hashes were introduced, it turned out that there remains one HTML table that cannot accommodate such values.

Fix this by removing the max-width property from .list_table .stat. This class is not used for data that needs to be truncated anyway.
