### PR TITLE
syz-verifier: add errno descriptions to reports

### DIFF
--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/syzkaller/pkg/instance"
@@ -465,7 +466,11 @@ func createReport(rr *verf.ResultReport, pools int) []byte {
 				continue
 			}
 
-			data += fmt.Sprintf("\t↳ Pool: %d, Errno: %d, Flag: %d\n", i, errno, cr.Flags[i])
+			errnoDesc := "success"
+			if errno != 0 {
+				errnoDesc = syscall.Errno(errno).Error()
+			}
+			data += fmt.Sprintf("\t↳ Pool: %d, Flag: %d, Errno: %d (%s)\n", i, cr.Flags[i], errno, errnoDesc)
 		}
 
 		data += "\n"

--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -481,14 +481,14 @@ func TestCreateReport(t *testing.T) {
 	got := string(createReport(&rr, 3))
 	want := "ERRNO mismatches found for program:\n\n" +
 		"[=] breaks_returns()\n" +
-		"\t↳ Pool: 1, Errno: 1, Flag: 1\n" +
-		"\t↳ Pool: 2, Errno: 1, Flag: 1\n\n" +
+		"\t↳ Pool: 1, Flag: 1, Errno: 1 (operation not permitted)\n" +
+		"\t↳ Pool: 2, Flag: 1, Errno: 1 (operation not permitted)\n\n" +
 		"[=] minimize$0(0x1, 0x1)\n" +
-		"\t↳ Pool: 1, Errno: 3, Flag: 3\n" +
-		"\t↳ Pool: 2, Errno: 3, Flag: 3\n\n" +
+		"\t↳ Pool: 1, Flag: 3, Errno: 3 (no such process)\n" +
+		"\t↳ Pool: 2, Flag: 3, Errno: 3 (no such process)\n\n" +
 		"[!] test$res0()\n" +
-		"\t↳ Pool: 1, Errno: 2, Flag: 7\n" +
-		"\t↳ Pool: 2, Errno: 5, Flag: 3\n\n"
+		"\t↳ Pool: 1, Flag: 7, Errno: 2 (no such file or directory)\n" +
+		"\t↳ Pool: 2, Flag: 3, Errno: 5 (input/output error)\n\n"
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("createReport: (-want +got):\n%s", diff)
 	}

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"time"
 	"syscall"
+	"time"
 
 	"github.com/google/syzkaller/prog"
 )

--- a/syz-verifier/stats/stats.go
+++ b/syz-verifier/stats/stats.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"sort"
 	"time"
+	"syscall"
 
 	"github.com/google/syzkaller/prog"
 )
@@ -126,12 +127,21 @@ func (s *Stats) getOrderedStats() []*CallStats {
 	return css
 }
 
-func (s *Stats) getOrderedStates(call string) []int {
+func (s *Stats) getOrderedStates(call string) []string {
 	states := s.Calls[call].States
 	ss := make([]int, 0, len(states))
 	for s := range states {
 		ss = append(ss, s)
 	}
 	sort.Ints(ss)
-	return ss
+
+	descs := make([]string, 0, len(states))
+	for _, s := range ss {
+		desc := "succes"
+		if s != 0 {
+			desc = syscall.Errno(s).Error()
+		}
+		descs = append(descs, fmt.Sprintf("%d (%s)", s, desc))
+	}
+	return descs
 }

--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -38,7 +38,8 @@ func TestReportCallStats(t *testing.T) {
 			report: "statistics for foo:\n" +
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
 				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" +
-				"\t↳ 2 distinct states identified: [3 11]\n",
+				"\t↳ 2 distinct states identified: " +
+				"[3 (no such process) 11 (resource temporarily unavailable)]\n",
 		},
 	}
 
@@ -64,15 +65,18 @@ func TestReportGlobalStats(t *testing.T) {
 			"statistics for bar:\n"+
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
 			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+
-			"\t↳ 2 distinct states identified: [10 22]\n\n"+
+			"\t↳ 2 distinct states identified: "+
+			"[10 (no child processes) 22 (invalid argument)]\n\n"+
 			"statistics for tar:\n"+
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
 			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+
-			"\t↳ 3 distinct states identified: [31 100 101]\n\n"+
+			"\t↳ 3 distinct states identified: "+
+			"[31 (too many links) 100 (network is down) 101 (network is unreachable)]\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
 			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+
-			"\t↳ 2 distinct states identified: [3 11]\n\n"
+			"\t↳ 2 distinct states identified: "+
+			"[3 (no such process) 11 (resource temporarily unavailable)]\n\n"
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Contributes to #692 

Make use of the `syscall` package to add the errno descriptions in the result reports and global stats in order to have a more detailed output.