### PR TITLE
Detect default compiler versions

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -410,24 +410,23 @@ func (env *env) build() (*vcs.Commit, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	compilerID, err := build.CompilerIdentity(bisectEnv.Compiler)
-	if err != nil {
-		return nil, "", err
-	}
-	env.log("testing commit %v with %v", current.Hash, compilerID)
+	env.log("testing commit %v", current.Hash)
 	buildStart := time.Now()
 	mgr := env.cfg.Manager
 	if err := build.Clean(mgr.TargetOS, mgr.TargetVMArch, mgr.Type, mgr.KernelSrc); err != nil {
 		return nil, "", fmt.Errorf("kernel clean failed: %v", err)
 	}
 	kern := &env.cfg.Kernel
-	_, kernelSign, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Ccache, kern.Userspace,
+	_, imageDetails, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Ccache, kern.Userspace,
 		kern.Cmdline, kern.Sysctl, bisectEnv.KernelConfig)
-	if kernelSign != "" {
-		env.log("kernel signature: %v", kernelSign)
+	if imageDetails.CompilerID != "" {
+		env.log("compiler: %v", imageDetails.CompilerID)
+	}
+	if imageDetails.Signature != "" {
+		env.log("kernel signature: %v", imageDetails.Signature)
 	}
 	env.buildTime += time.Since(buildStart)
-	return current, kernelSign, err
+	return current, imageDetails.Signature, err
 }
 
 func (env *env) test() (*testResult, error) {

--- a/pkg/build/akaros.go
+++ b/pkg/build/akaros.go
@@ -16,7 +16,7 @@ import (
 
 type akaros struct{}
 
-func (ctx akaros) build(params *Params) error {
+func (ctx akaros) build(params Params) error {
 	configFile := filepath.Join(params.KernelDir, ".config")
 	if err := osutil.WriteFile(configFile, params.Config); err != nil {
 		return fmt.Errorf("failed to write config file: %v", err)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -75,7 +75,7 @@ func Image(params Params) (details ImageDetails, err error) {
 			return
 		}
 	}
-	err = builder.build(params)
+	details, err = builder.build(params)
 	if err != nil {
 		err = extractRootCause(err, params.TargetOS, params.KernelDir)
 		return
@@ -83,12 +83,6 @@ func Image(params Params) (details ImageDetails, err error) {
 	if key := filepath.Join(params.OutputDir, "key"); osutil.IsExist(key) {
 		if err := os.Chmod(key, 0600); err != nil {
 			return details, fmt.Errorf("failed to chmod 0600 %v: %v", key, err)
-		}
-	}
-	if signer, ok := builder.(signer); ok {
-		details.Signature, err = signer.sign(params)
-		if err != nil {
-			return
 		}
 	}
 	if details.CompilerID == "" {
@@ -120,12 +114,8 @@ func (err *KernelError) Error() string {
 }
 
 type builder interface {
-	build(params Params) error
+	build(params Params) (ImageDetails, error)
 	clean(kernelDir, targetArch string) error
-}
-
-type signer interface {
-	sign(params Params) (string, error)
 }
 
 func getBuilder(targetOS, targetArch, vmType string) (builder, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -51,7 +51,7 @@ type Params struct {
 // behavior. Binary equal builds, or builds that differ only in e.g. debug info,
 // have the same ID. The ID may be empty if OS implementation does not have
 // a way to calculate such IDs.
-func Image(params *Params) (string, error) {
+func Image(params Params) (string, error) {
 	builder, err := getBuilder(params.TargetOS, params.TargetArch, params.VMType)
 	if err != nil {
 		return "", err
@@ -104,12 +104,12 @@ func (err *KernelError) Error() string {
 }
 
 type builder interface {
-	build(params *Params) error
+	build(params Params) error
 	clean(kernelDir, targetArch string) error
 }
 
 type signer interface {
-	sign(params *Params) (string, error)
+	sign(params Params) (string, error)
 }
 
 func getBuilder(targetOS, targetArch, vmType string) (builder, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -34,6 +34,12 @@ type Params struct {
 	Config       []byte
 }
 
+// Information that is returned from the Image function.
+type ImageDetails struct {
+	Signature  string
+	CompilerID string
+}
+
 // Image creates a disk image for the specified OS/ARCH/VM.
 // Kernel is taken from KernelDir, userspace system is taken from UserspaceDir.
 // If CmdlineFile is not empty, contents of the file are appended to the kernel command line.
@@ -46,42 +52,52 @@ type Params struct {
 //  - kernel.config: actual kernel config used during build
 //  - obj/: directory with kernel object files (this should match KernelObject
 //    specified in sys/targets, e.g. vmlinux for linux)
-// The returned string is a kernel ID that will be the same for kernels with the
-// same runtime behavior, and different for kernels with different runtime
+// The returned structure contains a kernel ID that will be the same for kernels
+// with the same runtime behavior, and different for kernels with different runtime
 // behavior. Binary equal builds, or builds that differ only in e.g. debug info,
 // have the same ID. The ID may be empty if OS implementation does not have
 // a way to calculate such IDs.
-func Image(params Params) (string, error) {
+// Also that structure provides a compiler ID field that contains the name and
+// the version of the compiler/toolchain that was used to build the kernel.
+// The CompilerID field is not guaranteed to be non-empty.
+func Image(params Params) (details ImageDetails, err error) {
 	builder, err := getBuilder(params.TargetOS, params.TargetArch, params.VMType)
 	if err != nil {
-		return "", err
+		return
 	}
-	if err := osutil.MkdirAll(filepath.Join(params.OutputDir, "obj")); err != nil {
-		return "", err
+	if err = osutil.MkdirAll(filepath.Join(params.OutputDir, "obj")); err != nil {
+		return
 	}
 	if len(params.Config) != 0 {
 		// Write kernel config early, so that it's captured on build failures.
-		if err := osutil.WriteFile(filepath.Join(params.OutputDir, "kernel.config"), params.Config); err != nil {
-			return "", fmt.Errorf("failed to write config file: %v", err)
+		if err = osutil.WriteFile(filepath.Join(params.OutputDir, "kernel.config"), params.Config); err != nil {
+			err = fmt.Errorf("failed to write config file: %v", err)
+			return
 		}
 	}
 	err = builder.build(params)
 	if err != nil {
-		return "", extractRootCause(err, params.TargetOS, params.KernelDir)
+		err = extractRootCause(err, params.TargetOS, params.KernelDir)
+		return
 	}
 	if key := filepath.Join(params.OutputDir, "key"); osutil.IsExist(key) {
 		if err := os.Chmod(key, 0600); err != nil {
-			return "", fmt.Errorf("failed to chmod 0600 %v: %v", key, err)
+			return details, fmt.Errorf("failed to chmod 0600 %v: %v", key, err)
 		}
 	}
-	sign := ""
 	if signer, ok := builder.(signer); ok {
-		sign, err = signer.sign(params)
+		details.Signature, err = signer.sign(params)
 		if err != nil {
-			return "", err
+			return
 		}
 	}
-	return sign, nil
+	if details.CompilerID == "" {
+		details.CompilerID, err = compilerIdentity(params.Compiler)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 func Clean(targetOS, targetArch, vmType, kernelDir string) error {
@@ -147,7 +163,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 	return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
 }
 
-func CompilerIdentity(compiler string) (string, error) {
+func compilerIdentity(compiler string) (string, error) {
 	if compiler == "" {
 		return "", nil
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -19,7 +19,7 @@ func TestCompilerIdentity(t *testing.T) {
 			if _, err := exec.LookPath(compiler); err != nil {
 				t.Skipf("compiler '%v' is not found: %v", compiler, err)
 			}
-			id, err := CompilerIdentity(compiler)
+			id, err := compilerIdentity(compiler)
 			if err != nil {
 				t.Fatalf("failed: %v", err)
 			}

--- a/pkg/build/darwin.go
+++ b/pkg/build/darwin.go
@@ -9,9 +9,9 @@ import (
 
 type darwin struct{}
 
-func (ctx darwin) build(params Params) error {
+func (ctx darwin) build(params Params) (ImageDetails, error) {
 	// TODO(HerrSpace): Implement this.
-	return fmt.Errorf("pkg/build: darwin.build not implemented")
+	return ImageDetails{}, fmt.Errorf("pkg/build: darwin.build not implemented")
 }
 
 func (ctx darwin) clean(kernelDir, targetArch string) error {

--- a/pkg/build/darwin.go
+++ b/pkg/build/darwin.go
@@ -9,7 +9,7 @@ import (
 
 type darwin struct{}
 
-func (ctx darwin) build(params *Params) error {
+func (ctx darwin) build(params Params) error {
 	// TODO(HerrSpace): Implement this.
 	return fmt.Errorf("pkg/build: darwin.build not implemented")
 }

--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -16,7 +16,7 @@ import (
 
 type freebsd struct{}
 
-func (ctx freebsd) build(params *Params) error {
+func (ctx freebsd) build(params Params) error {
 	confDir := fmt.Sprintf("%v/sys/%v/conf/", params.KernelDir, params.TargetArch)
 	confFile := "SYZKALLER"
 

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -27,15 +27,15 @@ func syzRoot() (string, error) {
 	return filepath.Abs(filepath.Join(filepath.Dir(selfPath), "../.."))
 }
 
-func (fu fuchsia) build(params Params) error {
+func (fu fuchsia) build(params Params) (ImageDetails, error) {
 	syzDir, err := syzRoot()
 	if err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 
 	sysTarget := targets.Get(targets.Fuchsia, params.TargetArch)
 	if sysTarget == nil {
-		return fmt.Errorf("unsupported fuchsia arch %v", params.TargetArch)
+		return ImageDetails{}, fmt.Errorf("unsupported fuchsia arch %v", params.TargetArch)
 	}
 	arch := sysTarget.KernelHeaderArch
 	product := fmt.Sprintf("%s.%s", "core", arch)
@@ -48,16 +48,16 @@ func (fu fuchsia) build(params Params) error {
 		"--variant", "kasan",
 		"--no-goma",
 	); err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 	if _, err := runSandboxed(time.Hour*2, params.KernelDir, "scripts/fx", "clean-build"); err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 
 	// Add ssh keys to the zbi image so syzkaller can access the fuchsia vm.
 	_, sshKeyPub, err := genSSHKeys(params.OutputDir)
 	if err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 
 	sshZBI := filepath.Join(params.OutputDir, "initrd")
@@ -66,7 +66,7 @@ func (fu fuchsia) build(params Params) error {
 
 	if _, err := osutil.RunCmd(time.Minute, params.KernelDir, "out/"+arch+"/host_x64/zbi",
 		"-o", sshZBI, kernelZBI, "--entry", authorizedKeys); err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 
 	// Copy and extend the fvm.
@@ -74,10 +74,10 @@ func (fu fuchsia) build(params Params) error {
 	fvmDst := filepath.Join(params.OutputDir, "image")
 	fvmSrc := filepath.Join(params.KernelDir, "out", arch, "obj/build/images/fvm.blk")
 	if err := osutil.CopyFile(fvmSrc, fvmDst); err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 	if _, err := osutil.RunCmd(time.Minute*5, params.KernelDir, fvmTool, fvmDst, "extend", "--length", "3G"); err != nil {
-		return err
+		return ImageDetails{}, err
 	}
 
 	for src, dst := range map[string]string{
@@ -87,10 +87,10 @@ func (fu fuchsia) build(params Params) error {
 		fullSrc := filepath.Join(params.KernelDir, filepath.FromSlash(src))
 		fullDst := filepath.Join(params.OutputDir, filepath.FromSlash(dst))
 		if err := osutil.CopyFile(fullSrc, fullDst); err != nil {
-			return fmt.Errorf("failed to copy %v: %v", src, err)
+			return ImageDetails{}, fmt.Errorf("failed to copy %v: %v", src, err)
 		}
 	}
-	return nil
+	return ImageDetails{}, nil
 }
 
 func (fu fuchsia) clean(kernelDir, targetArch string) error {

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -27,7 +27,7 @@ func syzRoot() (string, error) {
 	return filepath.Abs(filepath.Join(filepath.Dir(selfPath), "../.."))
 }
 
-func (fu fuchsia) build(params *Params) error {
+func (fu fuchsia) build(params Params) error {
 	syzDir, err := syzRoot()
 	if err != nil {
 		return err

--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -19,7 +19,7 @@ type gvisor struct{}
 
 var bazelTargetPath = regexp.MustCompile(`(?sm:.*^)\s*Outputs: \[(.*)\](?sm:$.*)`)
 
-func (gvisor gvisor) build(params *Params) error {
+func (gvisor gvisor) build(params Params) error {
 	if params.Compiler == "" {
 		params.Compiler = "bazel"
 	}

--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -26,7 +26,7 @@ type linux struct{}
 
 var _ signer = linux{}
 
-func (linux linux) build(params *Params) error {
+func (linux linux) build(params Params) error {
 	if err := linux.buildKernel(params); err != nil {
 		return err
 	}
@@ -47,11 +47,11 @@ func (linux linux) build(params *Params) error {
 	return embedLinuxKernel(params, kernelPath)
 }
 
-func (linux linux) sign(params *Params) (string, error) {
+func (linux linux) sign(params Params) (string, error) {
 	return elfBinarySignature(filepath.Join(params.OutputDir, "obj", "vmlinux"))
 }
 
-func (linux linux) buildKernel(params *Params) error {
+func (linux linux) buildKernel(params Params) error {
 	configFile := filepath.Join(params.KernelDir, ".config")
 	if err := linux.writeFile(configFile, params.Config); err != nil {
 		return fmt.Errorf("failed to write config file: %v", err)
@@ -96,7 +96,7 @@ func (linux linux) buildKernel(params *Params) error {
 	return nil
 }
 
-func (linux) createImage(params *Params, kernelPath string) error {
+func (linux) createImage(params Params, kernelPath string) error {
 	tempDir, err := ioutil.TempDir("", "syz-build")
 	if err != nil {
 		return err
@@ -162,7 +162,7 @@ func runMakeImpl(arch, compiler, ccache, kernelDir string, addArgs ...string) er
 	return err
 }
 
-func runMake(params *Params, addArgs ...string) error {
+func runMake(params Params, addArgs ...string) error {
 	return runMakeImpl(params.TargetArch, params.Compiler, params.Ccache, params.KernelDir, addArgs...)
 }
 

--- a/pkg/build/linux_linux.go
+++ b/pkg/build/linux_linux.go
@@ -22,7 +22,7 @@ import (
 // - ssh works without password (we don't copy the key)
 // - cmdline file is not supported (should be moved to kernel config)
 // - the kernel is stored in the image in /vmlinuz file.
-func embedLinuxKernel(params *Params, kernelPath string) error {
+func embedLinuxKernel(params Params, kernelPath string) error {
 	if params.CmdlineFile != "" {
 		return fmt.Errorf("cmdline file is not supported for linux images")
 	}

--- a/pkg/build/linux_nolinux.go
+++ b/pkg/build/linux_nolinux.go
@@ -10,6 +10,6 @@ import (
 	"errors"
 )
 
-func embedLinuxKernel(params *Params, kernelPath string) error {
+func embedLinuxKernel(params Params, kernelPath string) error {
 	return errors.New("building linux image is only supported on linux")
 }

--- a/pkg/build/linux_test.go
+++ b/pkg/build/linux_test.go
@@ -22,6 +22,23 @@ func TestElfBinarySignature(t *testing.T) {
 	enumerateFlags(t, nil, []string{"-g", "-O1", "-O2", "-no-pie", "-static"})
 }
 
+func TestQueryLinuxCompiler(t *testing.T) {
+	const goodDir = "./testdata/linux_compiler_ok"
+	const expectedCompiler = "gcc (Debian 10.2.1-6+build2) 10.2.1 20210110, GNU ld (GNU Binutils for Debian) 2.35.2"
+	ret, err := queryLinuxCompiler(goodDir)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if ret != expectedCompiler {
+		t.Fatalf("got: %T, expected: %T", ret, expectedCompiler)
+	}
+	const badDir = "./testingData/non_existing_folder"
+	_, err = queryLinuxCompiler(badDir)
+	if err == nil {
+		t.Fatalf("Expected an error, got none")
+	}
+}
+
 func enumerateFlags(t *testing.T, flags, allFlags []string) {
 	if len(allFlags) != 0 {
 		enumerateFlags(t, flags, allFlags[1:])

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -22,7 +22,7 @@ import (
 
 type netbsd struct{}
 
-func (ctx netbsd) build(params *Params) error {
+func (ctx netbsd) build(params Params) error {
 	const kernelName = "GENERIC_SYZKALLER"
 	confDir := fmt.Sprintf("%v/sys/arch/%v/conf", params.KernelDir, params.TargetArch)
 	compileDir := fmt.Sprintf("%v/sys/arch/%v/compile/obj/%v", params.KernelDir, params.TargetArch, kernelName)

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -15,7 +15,7 @@ import (
 
 type openbsd struct{}
 
-func (ctx openbsd) build(params *Params) error {
+func (ctx openbsd) build(params Params) error {
 	const kernelName = "SYZKALLER"
 	confDir := fmt.Sprintf("%v/sys/arch/%v/conf", params.KernelDir, params.TargetArch)
 	compileDir := fmt.Sprintf("%v/sys/arch/%v/compile/%v", params.KernelDir, params.TargetArch, kernelName)

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -5,8 +5,8 @@ package build
 
 type test struct{}
 
-func (tb test) build(params Params) error {
-	return nil
+func (tb test) build(params Params) (ImageDetails, error) {
+	return ImageDetails{}, nil
 }
 
 func (tb test) clean(string, string) error {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -5,7 +5,7 @@ package build
 
 type test struct{}
 
-func (tb test) build(params *Params) error {
+func (tb test) build(params Params) error {
 	return nil
 }
 

--- a/pkg/build/testdata/linux_compiler_ok/include/generated/compile.h
+++ b/pkg/build/testdata/linux_compiler_ok/include/generated/compile.h
@@ -1,0 +1,7 @@
+/* This file is auto generated, version 3 */
+/* SMP PREEMPT */
+#define UTS_MACHINE "x86_64"
+#define UTS_VERSION "#3 SMP PREEMPT Tue Jul 6 10:38:03 UTC 2021"
+#define LINUX_COMPILE_BY "user"
+#define LINUX_COMPILE_HOST "localhost"
+#define LINUX_COMPILER "gcc (Debian 10.2.1-6+build2) 10.2.1 20210110, GNU ld (GNU Binutils for Debian) 2.35.2"

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -108,7 +108,7 @@ func (env *env) BuildSyzkaller(repoURL, commit string) error {
 func (env *env) BuildKernel(compilerBin, ccacheBin, userspaceDir, cmdlineFile, sysctlFile string, kernelConfig []byte) (
 	string, string, error) {
 	imageDir := filepath.Join(env.cfg.Workdir, "image")
-	params := &build.Params{
+	params := build.Params{
 		TargetOS:     env.cfg.TargetOS,
 		TargetArch:   env.cfg.TargetVMArch,
 		VMType:       env.cfg.Type,

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -311,7 +311,6 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	switch req.Type {
 	case dashapi.JobTestPatch:
 		mgrcfg.Name += "-test-job"
-		resp.Build.CompilerID = mgr.compilerID
 		resp.Build.KernelRepo = req.KernelRepo
 		resp.Build.KernelBranch = req.KernelBranch
 		resp.Build.KernelCommit = "[unknown]"
@@ -548,11 +547,12 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		[]byte("# CONFIG_DEBUG_INFO_BTF is not set"), -1)
 
 	log.Logf(0, "job: building kernel...")
-	kernelConfig, _, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Ccache, mgr.mgrcfg.Userspace,
+	kernelConfig, details, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Ccache, mgr.mgrcfg.Userspace,
 		mgr.mgrcfg.KernelCmdline, mgr.mgrcfg.KernelSysctl, req.KernelConfig)
 	if err != nil {
 		return err
 	}
+	resp.Build.CompilerID = details.CompilerID
 	if kernelConfig != "" {
 		resp.Build.KernelConfig, err = ioutil.ReadFile(kernelConfig)
 		if err != nil {

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -304,7 +304,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 	if err := config.SaveFile(filepath.Join(tmpDir, "tag"), info); err != nil {
 		return fmt.Errorf("failed to write tag file: %v", err)
 	}
-	params := &build.Params{
+	params := build.Params{
 		TargetOS:     mgr.managercfg.TargetOS,
 		TargetArch:   mgr.managercfg.TargetVMArch,
 		VMType:       mgr.managercfg.Type,

--- a/tools/check-copyright.sh
+++ b/tools/check-copyright.sh
@@ -6,7 +6,7 @@ FILES=0
 FAILED=""
 for F in $(find . -name "*.go" -o -name "*.sh" -o -name "*.cc" -o -name "*.h" \
 	-o -name "*.S" -o -name "*.py" -o -name "*.yml" -o -name "*.yaml" \
-	-o \( -path "./sys/*/*.txt" \) | egrep -v "/vendor/|/gen/"); do
+	-o \( -path "./sys/*/*.txt" \) | egrep -v "/vendor/|/gen/|/testdata/"); do
 	((FILES+=1))
 	cat $F | tr '\n' '_' | egrep "(//|#) Copyright 20[0-9]{2}(/20[0-9]{2})? syzkaller project authors\. All rights reserved\._(//|#) Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file\." >/dev/null
 	if [ $? -eq 0 ]; then continue; fi

--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -34,7 +34,7 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	params := &build.Params{
+	params := build.Params{
 		TargetOS:     *flagOS,
 		TargetArch:   *flagArch,
 		VMType:       "gce",


### PR DESCRIPTION
Closes https://github.com/google/syzkaller/issues/2498

This PR makes it possible for syzkaller to extract information about compiler identity in those cases, when no exact compiler is specified in the syz-ci config file. It affects only those platforms where it is possible to specify a custom compiler.

This PR also contains a number of refactorings that let implement this changes in a more straightforward way. See details in the corresponding commit descriptions.