### PR TITLE
syz-verifier: add option to create a new execution environment for each program

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -500,8 +500,7 @@ var MakeBin = func() string {
 	return "make"
 }()
 
-func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, collide, threaded bool) string {
+func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, collide, threaded, newEnv bool) string {
 	return fmt.Sprintf("%s -addr=%s -os=%s -arch=%s -pool=%d -vm=%d "+
-		"-collide=%t -threaded=%t", prog, fwdAddr, os, arch, poolIdx, vmIdx,
-		collide, threaded)
+		"-collide=%t -threaded=%t -new-env=%t", prog, fwdAddr, os, arch, poolIdx, vmIdx, collide, threaded, newEnv)
 }

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -151,8 +151,9 @@ func TestRunnerCmd(t *testing.T) {
 	flagVM := flags.Int("vm", 0, "index of VM that started the Runner")
 	flagCollide := flags.Bool("collide", true, "collide syscalls to provoke data races")
 	flagThreaded := flags.Bool("threaded", true, "use threaded mode in executor")
+	flagEnv := flags.Bool("new-env", true, "create a new environment for each program")
 
-	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0, false, false)
+	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0, false, false, false)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatalf("error parsing flags: %v, want: nil", err)
@@ -184,5 +185,9 @@ func TestRunnerCmd(t *testing.T) {
 
 	if got, want := *flagThreaded, false; got != want {
 		t.Errorf("bad threaded: %t, want: %t", got, want)
+	}
+
+	if got, want := *flagEnv, false; got != want {
+		t.Errorf("bad new-env: %t, want: %t", got, want)
 	}
 }


### PR DESCRIPTION
Contributes to #692 

The Runner can now create an `ipc.Env` for every program about to be executed. Experiments have shown that this approach significantly reduced the rate of (supposedly false positive) mismatches:

* if creating an `ipc.Env` *once* per `Runner`, the percentage of `# syscall mismatches / syscall occurences` can be up to 30% for some system calls (e.g. some System V IPC-related system calls, most of them for semaphore operations)

* if creating an `ipc.Env` *every time* a program is executed by the Runner, the rate of `programs executed / minute` drops by ~10%, however the rate of `# syscall mismatches / # syscall occurences` stays below 4.5% for all system calls enabled (i.e. all except those that are causing concurrency, `perf_event_open*`, `prctl*`, `syz-_mount*`, `syz_open_dev*", `ioctl$sock_SIOCDELDLCI`, ioctl$sock_SIOCADDDLCI` curently)