### PR TITLE
syz-verifier: create a ReturnState structure

### DIFF
--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/google/syzkaller/pkg/instance"
@@ -468,11 +467,7 @@ func createReport(rr *ResultReport, pools int) []byte {
 				continue
 			}
 
-			errnoDesc := "success"
-			if state.Errno != 0 {
-				errnoDesc = syscall.Errno(state.Errno).Error()
-			}
-			data += fmt.Sprintf("\t↳ Pool: %d, Flags: %d, Errno: %d (%s)\n", i, state.Flags, state.Errno, errnoDesc)
+			data += fmt.Sprintf("\t↳ Pool: %d, %s", i, state.String())
 		}
 
 		data += "\n"

--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -464,17 +464,17 @@ func createReport(rr *verf.ResultReport, pools int) []byte {
 
 		// Ensure results are ordered by pool index.
 		for i := 0; i < pools; i++ {
-			errno, ok := cr.Errnos[i]
+			state, ok := cr.States[i]
 			if !ok {
 				// VM crashed so we don't have reports from this pool.
 				continue
 			}
 
 			errnoDesc := "success"
-			if errno != 0 {
-				errnoDesc = syscall.Errno(errno).Error()
+			if state.Errno != 0 {
+				errnoDesc = syscall.Errno(state.Errno).Error()
 			}
-			data += fmt.Sprintf("\t↳ Pool: %d, Flag: %d, Errno: %d (%s)\n", i, cr.Flags[i], errno, errnoDesc)
+			data += fmt.Sprintf("\t↳ Pool: %d, Flags: %d, Errno: %d (%s)\n", i, state.Flags, state.Errno, errnoDesc)
 		}
 
 		data += "\n"

--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -341,9 +341,9 @@ func TestProcessResults(t *testing.T) {
 				TotalMismatches: 1,
 				Progs:           1,
 				Calls: map[string]*CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
-					"test$res0":      makeCallStats("test$res0", 1, 1, map[int]bool{2: true, 5: true}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[ReturnState]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 1, map[ReturnState]bool{{Errno: 2}: true, {Errno: 5}: true}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[ReturnState]bool{}),
 				},
 			},
 		},
@@ -356,9 +356,9 @@ func TestProcessResults(t *testing.T) {
 			wantStats: &Stats{
 				Progs: 1,
 				Calls: map[string]*CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
-					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[ReturnState]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[ReturnState]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 0, map[ReturnState]bool{}),
 				},
 			},
 		},
@@ -462,9 +462,9 @@ func TestCleanup(t *testing.T) {
 			wantStats: &Stats{
 				Progs: 1,
 				Calls: map[string]*CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
-					"test$res0":      makeCallStats("test$res0", 1, 0, map[int]bool{}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[ReturnState]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[ReturnState]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 0, map[ReturnState]bool{}),
 				},
 			},
 			fileExists: false,
@@ -485,9 +485,9 @@ func TestCleanup(t *testing.T) {
 				TotalMismatches: 1,
 				Progs:           1,
 				Calls: map[string]*CallStats{
-					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[int]bool{}),
-					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[int]bool{}),
-					"test$res0":      makeCallStats("test$res0", 1, 1, map[int]bool{22: true, 44: true}),
+					"breaks_returns": makeCallStats("breaks_returns", 1, 0, map[ReturnState]bool{}),
+					"minimize$0":     makeCallStats("minimize$0", 1, 0, map[ReturnState]bool{}),
+					"test$res0":      makeCallStats("test$res0", 1, 1, map[ReturnState]bool{{Errno: 22}: true, {Errno: 44}: true}),
 				},
 			},
 			fileExists: true,

--- a/syz-verifier/stats.go
+++ b/syz-verifier/stats.go
@@ -1,9 +1,7 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// Package stats contains utilities that aid gathering statistics of
-// system call mismatches in the verified programs.
-package stats
+package main
 
 import (
 	"fmt"

--- a/syz-verifier/stats_test.go
+++ b/syz-verifier/stats_test.go
@@ -14,10 +14,10 @@ func dummyStats() *Stats {
 		Progs:           24,
 		TotalMismatches: 10,
 		Calls: map[string]*CallStats{
-			"foo": {"foo", 2, 8, map[int]bool{1: true, 3: true}},
-			"bar": {"bar", 5, 6, map[int]bool{10: true, 22: true}},
-			"tar": {"tar", 3, 4, map[int]bool{5: true, 17: true, 31: true}},
-			"biz": {"biz", 0, 2, map[int]bool{}},
+			"foo": {"foo", 2, 8, map[ReturnState]bool{{Errno: 1}: true, {Errno: 3}: true}},
+			"bar": {"bar", 5, 6, map[ReturnState]bool{{Errno: 10}: true, {Errno: 22}: true}},
+			"tar": {"tar", 3, 4, map[ReturnState]bool{{Errno: 5}: true, {Errno: 17}: true, {Errno: 31}: true}},
+			"biz": {"biz", 0, 2, map[ReturnState]bool{}},
 		},
 	}
 }
@@ -38,7 +38,7 @@ func TestReportCallStats(t *testing.T) {
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
 				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" +
 				"\t↳ 2 distinct states identified: " +
-				"[1 (operation not permitted) 3 (no such process)]\n",
+				"[Errno: 1 (operation not permitted)\n Errno: 3 (no such process)\n]\n",
 		},
 	}
 
@@ -65,17 +65,17 @@ func TestReportGlobalStats(t *testing.T) {
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
 			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+
 			"\t↳ 2 distinct states identified: "+
-			"[10 (no child processes) 22 (invalid argument)]\n\n"+
+			"[Errno: 10 (no child processes)\n Errno: 22 (invalid argument)\n]\n\n"+
 			"statistics for tar:\n"+
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
 			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+
 			"\t↳ 3 distinct states identified: "+
-			"[5 (input/output error) 17 (file exists) 31 (too many links)]\n\n"+
+			"[Errno: 5 (input/output error)\n Errno: 17 (file exists)\n Errno: 31 (too many links)\n]\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
 			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+
 			"\t↳ 2 distinct states identified: "+
-			"[1 (operation not permitted) 3 (no such process)]\n\n"
+			"[Errno: 1 (operation not permitted)\n Errno: 3 (no such process)\n]\n\n"
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)

--- a/syz-verifier/stats_test.go
+++ b/syz-verifier/stats_test.go
@@ -1,7 +1,6 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-
-package stats
+package main
 
 import (
 	"bytes"
@@ -10,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func getTestStats() *Stats {
+func dummyStats() *Stats {
 	return &Stats{
 		Progs:           24,
 		TotalMismatches: 10,
@@ -44,7 +43,7 @@ func TestReportCallStats(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		s := getTestStats()
+		s := dummyStats()
 		t.Run(test.name, func(t *testing.T) {
 			got, want := s.ReportCallStats(test.call), test.report
 			if diff := cmp.Diff(want, got); diff != "" {
@@ -55,7 +54,7 @@ func TestReportCallStats(t *testing.T) {
 }
 
 func TestReportGlobalStats(t *testing.T) {
-	s := getTestStats()
+	s := dummyStats()
 	out := bytes.Buffer{}
 	s.ReportGlobalStats(&out, float64(10))
 	got, want := out.String(),

--- a/syz-verifier/test_utils.go
+++ b/syz-verifier/test_utils.go
@@ -1,0 +1,89 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/prog"
+)
+
+func createTestServer(t *testing.T) *RPCServer {
+	target, err := prog.GetTarget("test", "64")
+	if err != nil {
+		t.Fatalf("failed to initialise test target: %v", err)
+	}
+	vrf := Verifier{
+		target:      target,
+		choiceTable: target.DefaultChoiceTable(),
+		rnd:         rand.New(rand.NewSource(time.Now().UnixNano())),
+		progIdx:     3,
+	}
+	vrf.resultsdir = makeTestResultDirectory(t)
+	vrf.stats = emptyTestStats()
+	srv, err := startRPCServer(&vrf)
+	if err != nil {
+		t.Fatalf("failed to initialise RPC server: %v", err)
+	}
+	return srv
+}
+
+func getTestProgram(t *testing.T) *prog.Prog {
+	p := "breaks_returns()\n" +
+		"minimize$0(0x1, 0x1)\n" +
+		"test$res0()\n"
+	target := prog.InitTargetTest(t, "test", "64")
+	prog, err := target.Deserialize([]byte(p), prog.Strict)
+	if err != nil {
+		t.Fatalf("failed to deserialise test program: %v", err)
+	}
+	return prog
+}
+
+func makeTestResultDirectory(t *testing.T) string {
+	resultsdir := "test"
+	err := osutil.MkdirAll(resultsdir)
+	if err != nil {
+		t.Fatalf("failed to create results directory: %v", err)
+	}
+	resultsdir, err = filepath.Abs(resultsdir)
+	if err != nil {
+		t.Fatalf("failed to get absolute path of resultsdir: %v", err)
+	}
+	return resultsdir
+}
+
+func makeResult(pool int, errnos []int, flags ...int) *Result {
+	r := &Result{Pool: pool, Info: ipc.ProgInfo{Calls: []ipc.CallInfo{}}}
+	for _, e := range errnos {
+		r.Info.Calls = append(r.Info.Calls, ipc.CallInfo{Errno: e})
+	}
+
+	for idx, f := range flags {
+		r.Info.Calls[idx].Flags = ipc.CallFlags(f)
+	}
+	return r
+}
+
+func emptyTestStats() *Stats {
+	return &Stats{
+		Calls: map[string]*CallStats{
+			"breaks_returns": {Name: "breaks_returns", States: map[int]bool{}},
+			"minimize$0":     {Name: "minimize$0", States: map[int]bool{}},
+			"test$res0":      {Name: "test$res0", States: map[int]bool{}},
+		},
+	}
+}
+
+func makeCallStats(name string, occurrences, mismatches int, states map[int]bool) *CallStats {
+	return &CallStats{Name: name,
+		Occurrences: occurrences,
+		Mismatches:  mismatches,
+		States:      states}
+}

--- a/syz-verifier/test_utils.go
+++ b/syz-verifier/test_utils.go
@@ -74,14 +74,14 @@ func makeResult(pool int, errnos []int, flags ...int) *Result {
 func emptyTestStats() *Stats {
 	return &Stats{
 		Calls: map[string]*CallStats{
-			"breaks_returns": {Name: "breaks_returns", States: map[int]bool{}},
-			"minimize$0":     {Name: "minimize$0", States: map[int]bool{}},
-			"test$res0":      {Name: "test$res0", States: map[int]bool{}},
+			"breaks_returns": {Name: "breaks_returns", States: map[ReturnState]bool{}},
+			"minimize$0":     {Name: "minimize$0", States: map[ReturnState]bool{}},
+			"test$res0":      {Name: "test$res0", States: map[ReturnState]bool{}},
 		},
 	}
 }
 
-func makeCallStats(name string, occurrences, mismatches int, states map[int]bool) *CallStats {
+func makeCallStats(name string, occurrences, mismatches int, states map[ReturnState]bool) *CallStats {
 	return &CallStats{Name: name,
 		Occurrences: occurrences,
 		Mismatches:  mismatches,

--- a/syz-verifier/verf/verifier_test.go
+++ b/syz-verifier/verf/verifier_test.go
@@ -56,18 +56,15 @@ func TestVerify(t *testing.T) {
 		{
 			name: "mismatches found in results",
 			res: []*Result{
-				makeResult(1, []int{1, 3, 2}, []int{1, 3, 7}),
-				makeResult(4, []int{1, 3, 5}, []int{1, 3, 3}),
+				makeResult(1, []int{1, 3, 2}, []int{4, 7, 7}),
+				makeResult(4, []int{1, 3, 5}, []int{4, 7, 3}),
 			},
 			wantReport: &ResultReport{
 				Prog: p,
-				Reports: []CallReport{
-					{Call: "breaks_returns", Errnos: map[int]int{1: 1, 4: 1},
-						Flags: map[int]ipc.CallFlags{1: 1, 4: 1}},
-					{Call: "minimize$0", Errnos: map[int]int{1: 3, 4: 3},
-						Flags: map[int]ipc.CallFlags{1: 3, 4: 3}},
-					{Call: "test$res0", Errnos: map[int]int{1: 2, 4: 5},
-						Flags: map[int]ipc.CallFlags{1: 7, 4: 3}, Mismatch: true},
+				Reports: []*CallReport{
+					{Call: "breaks_returns", States: map[int]ReturnState{1: {1, 4}, 4: {1, 4}}},
+					{Call: "minimize$0", States: map[int]ReturnState{1: {3, 7}, 4: {3, 7}}},
+					{Call: "test$res0", States: map[int]ReturnState{1: {2, 7}, 4: {5, 3}}, Mismatch: true},
 				},
 			},
 			wantStats: &stats.Stats{

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -1,14 +1,11 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// Package verf contains utilities for verifying the execution of the same
-// program on different kernels yield the same results.
-package verf
+package main
 
 import (
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/prog"
-	"github.com/google/syzkaller/syz-verifier/stats"
 )
 
 // Result stores the results of executing a program.
@@ -49,7 +46,7 @@ type ReturnState struct {
 // Verify checks whether the Results of the same program, executed on different
 // kernels are the same. If that's not the case, it returns a ResultReport
 // which highlights the differences.
-func Verify(res []*Result, prog *prog.Prog, s *stats.Stats) *ResultReport {
+func Verify(res []*Result, prog *prog.Prog, s *Stats) *ResultReport {
 	rr := &ResultReport{
 		Prog: string(prog.Serialize()),
 	}

--- a/syz-verifier/verifier_test.go
+++ b/syz-verifier/verifier_test.go
@@ -1,33 +1,14 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-package verf
+
+package main
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/prog"
-	"github.com/google/syzkaller/syz-verifier/stats"
 )
-
-func makeResult(pool int, errnos []int, flags []int) *Result {
-	r := &Result{Pool: pool, Info: ipc.ProgInfo{Calls: []ipc.CallInfo{}}}
-	for i := range errnos {
-		r.Info.Calls = append(r.Info.Calls, ipc.CallInfo{Errno: errnos[i], Flags: ipc.CallFlags(flags[i])})
-	}
-	return r
-}
-
-func getTestStats() *stats.Stats {
-	return &stats.Stats{
-		Calls: map[string]*stats.CallStats{
-			"breaks_returns": {Name: "breaks_returns", States: map[int]bool{}},
-			"minimize$0":     {Name: "minimize$0", States: map[int]bool{}},
-			"test$res0":      {Name: "test$res0", States: map[int]bool{}},
-		},
-	}
-}
 
 func TestVerify(t *testing.T) {
 	p := "breaks_returns()\n" +
@@ -37,16 +18,16 @@ func TestVerify(t *testing.T) {
 		name       string
 		res        []*Result
 		wantReport *ResultReport
-		wantStats  *stats.Stats
+		wantStats  *Stats
 	}{
 		{
 			name: "mismatches not found in results",
 			res: []*Result{
-				makeResult(2, []int{11, 33, 22}, []int{1, 3, 3}),
-				makeResult(4, []int{11, 33, 22}, []int{1, 3, 3})},
+				makeResult(2, []int{11, 33, 22}, []int{1, 3, 3}...),
+				makeResult(4, []int{11, 33, 22}, []int{1, 3, 3}...)},
 			wantReport: nil,
-			wantStats: &stats.Stats{
-				Calls: map[string]*stats.CallStats{
+			wantStats: &Stats{
+				Calls: map[string]*CallStats{
 					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
 					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
 					"test$res0":      {Name: "test$res0", Occurrences: 1, States: map[int]bool{}},
@@ -56,8 +37,8 @@ func TestVerify(t *testing.T) {
 		{
 			name: "mismatches found in results",
 			res: []*Result{
-				makeResult(1, []int{1, 3, 2}, []int{4, 7, 7}),
-				makeResult(4, []int{1, 3, 5}, []int{4, 7, 3}),
+				makeResult(1, []int{1, 3, 2}, []int{4, 7, 7}...),
+				makeResult(4, []int{1, 3, 5}, []int{4, 7, 3}...),
 			},
 			wantReport: &ResultReport{
 				Prog: p,
@@ -67,9 +48,9 @@ func TestVerify(t *testing.T) {
 					{Call: "test$res0", States: map[int]ReturnState{1: {2, 7}, 4: {5, 3}}, Mismatch: true},
 				},
 			},
-			wantStats: &stats.Stats{
+			wantStats: &Stats{
 				TotalMismatches: 1,
-				Calls: map[string]*stats.CallStats{
+				Calls: map[string]*CallStats{
 					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
 					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
 					"test$res0":      {Name: "test$res0", Occurrences: 1, Mismatches: 1, States: map[int]bool{2: true, 5: true}},
@@ -85,7 +66,7 @@ func TestVerify(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to deserialise test program: %v", err)
 			}
-			stats := getTestStats()
+			stats := emptyTestStats()
 			got := Verify(test.res, prog, stats)
 			if diff := cmp.Diff(test.wantReport, got); diff != "" {
 				t.Errorf("Verify report mismatch (-want +got):\n%s", diff)

--- a/syz-verifier/verifier_test.go
+++ b/syz-verifier/verifier_test.go
@@ -28,9 +28,9 @@ func TestVerify(t *testing.T) {
 			wantReport: nil,
 			wantStats: &Stats{
 				Calls: map[string]*CallStats{
-					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
-					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
-					"test$res0":      {Name: "test$res0", Occurrences: 1, States: map[int]bool{}},
+					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[ReturnState]bool{}},
+					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[ReturnState]bool{}},
+					"test$res0":      {Name: "test$res0", Occurrences: 1, States: map[ReturnState]bool{}},
 				},
 			},
 		},
@@ -51,9 +51,12 @@ func TestVerify(t *testing.T) {
 			wantStats: &Stats{
 				TotalMismatches: 1,
 				Calls: map[string]*CallStats{
-					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[int]bool{}},
-					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[int]bool{}},
-					"test$res0":      {Name: "test$res0", Occurrences: 1, Mismatches: 1, States: map[int]bool{2: true, 5: true}},
+					"breaks_returns": {Name: "breaks_returns", Occurrences: 1, States: map[ReturnState]bool{}},
+					"minimize$0":     {Name: "minimize$0", Occurrences: 1, States: map[ReturnState]bool{}},
+					"test$res0": {Name: "test$res0", Occurrences: 1,
+						Mismatches: 1, States: map[ReturnState]bool{
+							{Errno: 2, Flags: 7}: true,
+							{Errno: 5, Flags: 3}: true}},
 				},
 			},
 		},


### PR DESCRIPTION
Contributes to #692 

The `ReturnState` structure will store return values and other information resulted from executing a system call. The `Verify` function now checks that the `ReturnState`s of the same system call executed on different kernels are the same.