### PR TITLE
syz-verifier/stats: ensure stats tests pass on OpenBSD

### DIFF
--- a/syz-verifier/stats/stats_test.go
+++ b/syz-verifier/stats/stats_test.go
@@ -15,9 +15,9 @@ func getTestStats() *Stats {
 		Progs:           24,
 		TotalMismatches: 10,
 		Calls: map[string]*CallStats{
-			"foo": {"foo", 2, 8, map[int]bool{11: true, 3: true}},
+			"foo": {"foo", 2, 8, map[int]bool{1: true, 3: true}},
 			"bar": {"bar", 5, 6, map[int]bool{10: true, 22: true}},
-			"tar": {"tar", 3, 4, map[int]bool{31: true, 100: true, 101: true}},
+			"tar": {"tar", 3, 4, map[int]bool{5: true, 17: true, 31: true}},
 			"biz": {"biz", 0, 2, map[int]bool{}},
 		},
 	}
@@ -39,7 +39,7 @@ func TestReportCallStats(t *testing.T) {
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
 				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" +
 				"\t↳ 2 distinct states identified: " +
-				"[3 (no such process) 11 (resource temporarily unavailable)]\n",
+				"[1 (operation not permitted) 3 (no such process)]\n",
 		},
 	}
 
@@ -47,7 +47,7 @@ func TestReportCallStats(t *testing.T) {
 		s := getTestStats()
 		t.Run(test.name, func(t *testing.T) {
 			got, want := s.ReportCallStats(test.call), test.report
-			if diff := cmp.Diff(got, want); diff != "" {
+			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("s.ReportCallStats mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -71,14 +71,14 @@ func TestReportGlobalStats(t *testing.T) {
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
 			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+
 			"\t↳ 3 distinct states identified: "+
-			"[31 (too many links) 100 (network is down) 101 (network is unreachable)]\n\n"+
+			"[5 (input/output error) 17 (file exists) 31 (too many links)]\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
 			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+
 			"\t↳ 2 distinct states identified: "+
-			"[3 (no such process) 11 (resource temporarily unavailable)]\n\n"
+			"[1 (operation not permitted) 3 (no such process)]\n\n"
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Contributes to #692 

Ensure `TestReportCallStats` and `TestReportGlobalStats` pass on OpenBSD as well. This was not the case before as `errno 11` is `resource deadlock avoided` on OpenBSD and `resource temporarily unavailable` on Linux.
