### PR TITLE
syz-verifier: include crashes in the verification process

### DIFF
--- a/syz-verifier/main_test.go
+++ b/syz-verifier/main_test.go
@@ -40,13 +40,13 @@ func TestNewProgram(t *testing.T) {
 			srv := createTestServer(t)
 			srv.pools = map[int]*poolInfo{
 				1: {
-					vmRunners: map[int][]*progInfo{
-						0: {{idx: 1}},
+					vmRunners: map[int]runnerProgs{
+						1: {1: {}},
 					},
 					progs: []*progInfo{{idx: 3}},
 				},
-				2: {vmRunners: map[int][]*progInfo{
-					2: {{idx: 1}}},
+				2: {vmRunners: map[int]runnerProgs{
+					2: {1: {}}},
 					progs: []*progInfo{},
 				},
 			}
@@ -108,9 +108,8 @@ func TestConnect(t *testing.T) {
 	srv := createTestServer(t)
 	srv.pools = map[int]*poolInfo{
 		1: {
-			vmRunners: map[int][]*progInfo{
-				0: {{
-					idx: 1}},
+			vmRunners: map[int]runnerProgs{
+				0: {1: {idx: 1}},
 			},
 			progs: []*progInfo{{
 				idx: 3}},
@@ -126,9 +125,9 @@ func TestConnect(t *testing.T) {
 	if diff := cmp.Diff(&rpctype.RunnerConnectRes{CheckUnsupportedCalls: true}, r); diff != "" {
 		t.Errorf("Connect result mismatch (-want +got):\n%s", diff)
 	}
-	want, got := map[int][]*progInfo{
-		0: {{idx: 1}},
-		1: nil,
+	want, got := map[int]runnerProgs{
+		0: {1: {idx: 1}},
+		1: {},
 	}, srv.pools[a.Pool].vmRunners
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(progInfo{})); diff != "" {
 		t.Errorf("srv.progs[a.Name] mismatch (-want +got):\n%s", diff)
@@ -277,8 +276,8 @@ func TestUpdateUnsupported(t *testing.T) {
 func TestUpdateUnsupportedNotCalledTwice(t *testing.T) {
 	vrf := Verifier{
 		pools: map[int]*poolInfo{
-			0: {vmRunners: map[int][]*progInfo{0: nil, 1: nil}, checked: false},
-			1: {vmRunners: map[int][]*progInfo{}, checked: false},
+			0: {vmRunners: map[int]runnerProgs{0: nil, 1: nil}, checked: false},
+			1: {vmRunners: map[int]runnerProgs{}, checked: false},
 		},
 	}
 	srv, err := startRPCServer(&vrf)
@@ -302,8 +301,8 @@ func TestUpdateUnsupportedNotCalledTwice(t *testing.T) {
 	}
 
 	wantPools := map[int]*poolInfo{
-		0: {vmRunners: map[int][]*progInfo{0: nil, 1: nil}, checked: true},
-		1: {vmRunners: map[int][]*progInfo{}, checked: false},
+		0: {vmRunners: map[int]runnerProgs{0: nil, 1: nil}, checked: true},
+		1: {vmRunners: map[int]runnerProgs{}, checked: false},
 	}
 	if diff := cmp.Diff(wantPools, srv.pools, cmp.AllowUnexported(poolInfo{}, progInfo{})); diff != "" {
 		t.Errorf("srv.pools mismatch (-want +got):\n%s", diff)
@@ -493,8 +492,8 @@ func TestCleanup(t *testing.T) {
 			srv := createTestServer(t)
 			srv.progs = test.progs
 			srv.pools = map[int]*poolInfo{
-				0: {vmRunners: map[int][]*progInfo{
-					0: {srv.progs[4]}},
+				0: {vmRunners: map[int]runnerProgs{
+					0: {4: srv.progs[4]}},
 				}, 1: {}, 2: {}}
 			resultFile := filepath.Join(srv.vrf.resultsdir, "result-0")
 

--- a/syz-verifier/stats.go
+++ b/syz-verifier/stats.go
@@ -128,17 +128,10 @@ func (s *Stats) getOrderedStats() []*CallStats {
 
 func (s *Stats) getOrderedStates(call string) []string {
 	states := s.Calls[call].States
-	ss := make([]ReturnState, 0, len(states))
+	ss := make([]string, 0, len(states))
 	for s := range states {
-		ss = append(ss, s)
+		ss = append(ss, fmt.Sprintf("%q", s))
 	}
-	sort.Slice(ss, func(i, j int) bool {
-		return ss[i].Errno < ss[j].Errno
-	})
-
-	descs := make([]string, 0, len(states))
-	for _, s := range ss {
-		descs = append(descs, s.String())
-	}
-	return descs
+	sort.Strings(ss)
+	return ss
 }

--- a/syz-verifier/stats_test.go
+++ b/syz-verifier/stats_test.go
@@ -14,9 +14,17 @@ func dummyStats() *Stats {
 		Progs:           24,
 		TotalMismatches: 10,
 		Calls: map[string]*CallStats{
-			"foo": {"foo", 2, 8, map[ReturnState]bool{{Errno: 1}: true, {Errno: 3}: true}},
-			"bar": {"bar", 5, 6, map[ReturnState]bool{{Errno: 10}: true, {Errno: 22}: true}},
-			"tar": {"tar", 3, 4, map[ReturnState]bool{{Errno: 5}: true, {Errno: 17}: true, {Errno: 31}: true}},
+			"foo": {"foo", 2, 8, map[ReturnState]bool{
+				returnState(1, 7): true,
+				returnState(3, 7): true}},
+			"bar": {"bar", 5, 6, map[ReturnState]bool{
+				crashedReturnState(): true,
+				returnState(10, 7):   true,
+				returnState(22, 7):   true}},
+			"tar": {"tar", 3, 4, map[ReturnState]bool{
+				returnState(31, 7): true,
+				returnState(17, 7): true,
+				returnState(5, 7):  true}},
 			"biz": {"biz", 0, 2, map[ReturnState]bool{}},
 		},
 	}
@@ -38,7 +46,7 @@ func TestReportCallStats(t *testing.T) {
 				"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n" +
 				"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n" +
 				"\t↳ 2 distinct states identified: " +
-				"[Errno: 1 (operation not permitted)\n Errno: 3 (no such process)\n]\n",
+				"[\"Flags: 7, Errno: 1 (operation not permitted)\" \"Flags: 7, Errno: 3 (no such process)\"]\n",
 		},
 	}
 
@@ -64,18 +72,21 @@ func TestReportGlobalStats(t *testing.T) {
 			"statistics for bar:\n"+
 			"\t↳ mismatches of bar / occurrences of bar: 5 / 6 (83.33 %)\n"+
 			"\t↳ mismatches of bar / total number of mismatches: 5 / 10 (50.00 %)\n"+
-			"\t↳ 2 distinct states identified: "+
-			"[Errno: 10 (no child processes)\n Errno: 22 (invalid argument)\n]\n\n"+
+			"\t↳ 3 distinct states identified: "+
+			"[\"Crashed\" \"Flags: 7, Errno: 10 (no child processes)\" "+
+			"\"Flags: 7, Errno: 22 (invalid argument)\"]\n\n"+
 			"statistics for tar:\n"+
 			"\t↳ mismatches of tar / occurrences of tar: 3 / 4 (75.00 %)\n"+
 			"\t↳ mismatches of tar / total number of mismatches: 3 / 10 (30.00 %)\n"+
 			"\t↳ 3 distinct states identified: "+
-			"[Errno: 5 (input/output error)\n Errno: 17 (file exists)\n Errno: 31 (too many links)\n]\n\n"+
+			"[\"Flags: 7, Errno: 17 (file exists)\" "+
+			"\"Flags: 7, Errno: 31 (too many links)\" "+
+			"\"Flags: 7, Errno: 5 (input/output error)\"]\n\n"+
 			"statistics for foo:\n"+
 			"\t↳ mismatches of foo / occurrences of foo: 2 / 8 (25.00 %)\n"+
 			"\t↳ mismatches of foo / total number of mismatches: 2 / 10 (20.00 %)\n"+
 			"\t↳ 2 distinct states identified: "+
-			"[Errno: 1 (operation not permitted)\n Errno: 3 (no such process)\n]\n\n"
+			"[\"Flags: 7, Errno: 1 (operation not permitted)\" \"Flags: 7, Errno: 3 (no such process)\"]\n\n"
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("s.ReportGlobalStats mismatch (-want +got):\n%s", diff)

--- a/syz-verifier/test_utils.go
+++ b/syz-verifier/test_utils.go
@@ -71,6 +71,10 @@ func makeResult(pool int, errnos []int, flags ...int) *Result {
 	return r
 }
 
+func makeResultCrashed(pool int) *Result {
+	return &Result{Pool: pool, Crashed: true}
+}
+
 func emptyTestStats() *Stats {
 	return &Stats{
 		Calls: map[string]*CallStats{
@@ -86,4 +90,16 @@ func makeCallStats(name string, occurrences, mismatches int, states map[ReturnSt
 		Occurrences: occurrences,
 		Mismatches:  mismatches,
 		States:      states}
+}
+
+func returnState(errno int, flags ...int) ReturnState {
+	rs := ReturnState{Errno: errno}
+	if flags != nil {
+		rs.Flags = ipc.CallFlags(flags[0])
+	}
+	return rs
+}
+
+func crashedReturnState() ReturnState {
+	return ReturnState{Crashed: true}
 }


### PR DESCRIPTION
Updates #692, depends on #2677

Added VM crashes as a possible `ReturnState` and included them in the logic of the `Verify` function. 
* Having a kernel crashing and the other ones producing results for a program  is considered a mismatch
*  Having all kernels crashing is a match