### PR TITLE
syz-verifier: modify mismatch calculation in the Verify function

### DIFF
--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -88,18 +88,24 @@ func Verify(res []*Result, prog *prog.Prog, s *Stats) *ResultReport {
 	pool0 := res[0].Pool
 	for _, cr := range rr.Reports {
 		cs := s.Calls[cr.Call]
+
+		mismatch := false
 		for _, state := range cr.States {
 			// For each CallReport verify the ReturnStates from all the pools
 			// that executed the program are the same
 			if state0 := cr.States[pool0]; state0 != state {
 				cr.Mismatch = true
 				send = true
+				mismatch = true
 
-				s.TotalMismatches++
-				cs.Mismatches++
 				cs.States[state] = true
 				cs.States[state0] = true
 			}
+		}
+
+		if mismatch {
+			cs.Mismatches++
+			s.TotalMismatches++
 		}
 	}
 


### PR DESCRIPTION
Contributes to #692 

Modify the `Verify` function to only increase the number of mismatches (both total and per system call) when a new different state is found.