### PR TITLE
prog: increase max number of syscalls

### DIFF
--- a/prog/target.go
+++ b/prog/target.go
@@ -138,6 +138,7 @@ func (target *Target) lazyInit() {
 }
 
 func (target *Target) initTarget() {
+	checkMaxCallID(len(target.Syscalls) - 1)
 	target.ConstMap = make(map[string]uint64)
 	for _, c := range target.Consts {
 		target.ConstMap[c.Name] = c.Value


### PR DESCRIPTION
Currently fallback coverage imposes an implicit 8K limit
on the max number of syscalls. 8K is quite close to the
current number of syscalls we have on Linux.

1. Bump this limit to 2M.
2. Detect limit violation during startup rather than later,
   with an obscure error message and only if fallback coverage is used.
