### PR TITLE
pkg/auth: check HTTP status from the server

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -78,6 +78,9 @@ func (auth *Endpoint) queryTokenInfo(tokenValue string) (*jwtClaims, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("verification failed %v", resp.StatusCode)
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -116,7 +119,7 @@ func (auth *Endpoint) DetermineAuthSubj(now time.Time, authHeader []string) (str
 		return "", err
 	}
 	if claims.Audience != DashboardAudience {
-		err := fmt.Errorf("unexpected audience %v %v", claims.Audience, claims)
+		err := fmt.Errorf("unexpected audience %v", claims.Audience)
 		return "", err
 	}
 	if claims.Expiration.Before(now) {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -95,3 +95,15 @@ func TestBadHeader(t *testing.T) {
 		t.Errorf("Unexpected error %v %v", got, err)
 	}
 }
+
+func TestBadHttpStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+	}))
+	defer ts.Close()
+	dut := MakeEndpoint(ts.URL)
+	got, err := dut.DetermineAuthSubj(time.Now(), []string{"Bearer x"})
+	if err == nil || !strings.HasSuffix(err.Error(), "400") || got != "" {
+		t.Errorf("Unexpected error %v %v", got, err)
+	}
+}


### PR DESCRIPTION
Previously the reported failure was a nondescript
strconv.ParseInt: parsing "": invalid syntax

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
