### PR TITLE
dashboard/config/openbsd: fix recreate script

### DIFF
--- a/dashboard/config/openbsd/recreate.sh
+++ b/dashboard/config/openbsd/recreate.sh
@@ -66,7 +66,7 @@ mv  ~/.ssh/known_hosts{.new,}
 
 ssh syzkaller@"${INSTANCE}" mkdir -p /syzkaller/userspace
 ssh syzkaller@"${INSTANCE}" ln -sf /syzkaller/{gopath/src/github.com/google/syzkaller/dashboard/,}config
-scp "${SYZ_DIR}"/config/ci-openbsd/config.ci "${INSTANCE}":/syzkaller/config-openbsd.ci
+scp "${SYZ_DIR}"/dashboard/config/openbsd/config.ci "${INSTANCE}":/syzkaller/config-openbsd.ci
 scp worker_key syzkaller@"${INSTANCE}":/syzkaller/userspace/key
 scp -C worker_disk.raw syzkaller@"${INSTANCE}":/syzkaller/userspace/image
 ssh syzkaller@"${INSTANCE}" 'D=/syzkaller/userspace-multicore && mkdir -p $D && ln -sf ../userspace/{image,key} $D && ln -sf ../config/overlays/ci-openbsd-multicore $D/overlay'


### PR DESCRIPTION
Correct the path to the openbsd config file.
