### PR TITLE
pkg/report: run objdump-related tests only under Linux

### DIFF
--- a/pkg/report/linux_test.go
+++ b/pkg/report/linux_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -374,6 +375,10 @@ func TestParseLinuxOpcodes(t *testing.T) {
 }
 
 func TestDisassemblyInReports(t *testing.T) {
+	if runtime.GOOS != targets.Linux {
+		t.Skipf("the test is meant to be run only under Linux")
+	}
+
 	archPath := filepath.Join("testdata", "linux", "decompile")
 	subFolders, err := ioutil.ReadDir(archPath)
 	if err != nil {


### PR DESCRIPTION
Restrict TestDisassemblyInReports from running on OSes other than
Linux, as the exact resulting disassembly is dependent on that.
