### PR TITLE
vm/adb: Mount debugfs on Android if it is not mounted.

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -291,7 +291,7 @@ func (inst *instance) repair() error {
 	}
 	// Switch to root for userdebug builds.
 	inst.adb("root")
-
+	inst.waitForSSH()
 	// Mount debugfs.
 	if _, err := inst.adb("shell", "ls /sys/kernel/debug/kcov"); err != nil {
 		log.Logf(2, "debugfs was unmounted mounting")
@@ -302,7 +302,6 @@ func (inst *instance) repair() error {
 			return err
 		}
 	}
-	inst.waitForSSH()
 	if inst.cfg.StartupScript != "" {
 		if err := inst.runScript(inst.cfg.StartupScript); err != nil {
 			return err

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -291,6 +291,17 @@ func (inst *instance) repair() error {
 	}
 	// Switch to root for userdebug builds.
 	inst.adb("root")
+
+	// Mount debugfs.
+	if _, err := inst.adb("shell", "ls /sys/kernel/debug/kcov"); err != nil {
+		log.Logf(2, "debugfs was unmounted mounting")
+		// This prop only exist on Android 12+
+		inst.adb("shell", "setprop persist.dbg.keep_debugfs_mounted 1")
+		if _, err := inst.adb("shell", "mount -t debugfs debugfs /sys/kernel/debug "+
+			"&& chmod 0755 /sys/kernel/debug"); err != nil {
+			return err
+		}
+	}
 	inst.waitForSSH()
 	if inst.cfg.StartupScript != "" {
 		if err := inst.runScript(inst.cfg.StartupScript); err != nil {


### PR DESCRIPTION
On Android 12+ debugfs gets unmounted after boot.  This remounts it as
part of reset.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
