### PR TITLE
executor: fix remote coverage collection

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1113,8 +1113,6 @@ void thread_create(thread_t* th, int id)
 	th->created = true;
 	th->id = id;
 	th->executing = false;
-	th->cov.data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
-	th->cov.pc_offset = 0;
 	event_init(&th->ready);
 	event_init(&th->done);
 	event_set(&th->done);

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -99,6 +99,8 @@ static void cover_open(cover_t* cov, bool extra)
 		fail("cover mmap failed");
 	cov->data = (char*)mmap_ptr;
 	cov->data_end = cov->data + mmap_alloc_size;
+	cov->data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
+	cov->pc_offset = 0;
 }
 
 static void cover_protect(cover_t* cov)

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -91,6 +91,8 @@ static void cover_open(cover_t* cov, bool extra)
 	if (cov->data == MAP_FAILED)
 		fail("cover mmap failed");
 	cov->data_end = cov->data + mmap_alloc_size;
+	cov->data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
+	cov->pc_offset = 0;
 }
 
 static void cover_protect(cover_t* cov)


### PR DESCRIPTION
Currently the `data_offset` field of `cover_t` is only initialised for per-syscall coverage collection. This is not the case for remote coverage, so it is read from an invalid location, fails to pass sanity checks and is not returned to syzkaller.

This PR fixes this problem.

Reported by @f0rm2l1n in https://github.com/google/syzkaller/issues/2722.
