### PR TITLE
pkg/report: ignore "WARNING: the mand mount option is being deprecated"

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1675,6 +1675,7 @@ var linuxOopses = append([]*oops{
 		[]*regexp.Regexp{
 			compile("WARNING: /etc/ssh/moduli does not exist, using fixed modulus"), // printed by sshd
 			compile("WARNING: workqueue cpumask: online intersect > possible intersect"),
+			compile("WARNING: the mand mount option is being deprecated"),
 		},
 	},
 	{

--- a/pkg/report/testdata/linux/report/618
+++ b/pkg/report/testdata/linux/report/618
@@ -1,0 +1,9 @@
+TITLE: 
+
+[   49.650190][  T126] wlan1: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   49.658919][  T126] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   49.668016][    T5] IPv6: ADDRCONF(NETDEV_CHANGE): wlan1: link becomes ready
+[   49.679506][ T8428] ======================================================
+[   49.679506][ T8428] WARNING: the mand mount option is being deprecated and
+[   49.679506][ T8428]          will be removed in v5.15!
+[   49.679506][ T8428] ======================================================


### PR DESCRIPTION
Ignore this new warning, as it is intentionally added to warn users and
does not indicate a kernel bug:

	https://lkml.kernel.org/r/CAHk-=wgD-SNxB=2iCurEoP=RjrciRgLtXZ7R_DejK+mXF2etfg@mail.gmail.com
