### PR TITLE
pkg/report: ignore "WARNING: The mand mount option has been deprecated"

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1675,7 +1675,7 @@ var linuxOopses = append([]*oops{
 		[]*regexp.Regexp{
 			compile("WARNING: /etc/ssh/moduli does not exist, using fixed modulus"), // printed by sshd
 			compile("WARNING: workqueue cpumask: online intersect > possible intersect"),
-			compile("WARNING: the mand mount option is being deprecated"),
+			compile("WARNING: [Tt]he mand mount option (is being|has been) deprecated"),
 		},
 	},
 	{

--- a/pkg/report/testdata/linux/report/619
+++ b/pkg/report/testdata/linux/report/619
@@ -1,0 +1,9 @@
+TITLE: 
+
+[  144.247612][T11794] IPv6: ADDRCONF(NETDEV_CHANGE): lo: link becomes ready
+[  144.274089][T11803] =======================================================
+[  144.274089][T11803] WARNING: The mand mount option has been deprecated and
+[  144.274089][T11803]          and is ignored by this kernel. Remove the mand
+[  144.274089][T11803]          option from the mount to silence this warning.
+[  144.274089][T11803] =======================================================
+[  144.408423][T11794] IPv6: ADDRCONF(NETDEV_CHANGE): vcan0: link becomes ready


### PR DESCRIPTION
In Linux 5.15 the mand mount option will be deprecated, and the warning
text will change accordingly:
https://lkml.kernel.org/r/20210820163919.435135-3-jlayton@kernel.org/

Update regex to also ignore this case.
