### PR TITLE
sys/targets: fix darwin reproducers

### DIFF
--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -28,9 +28,9 @@ const (
 func createCommonHeader(p, mmapProg *prog.Prog, replacements map[string]string, opts Options) ([]byte, error) {
 	defines := defineList(p, mmapProg, opts)
 	sysTarget := targets.Get(p.Target.OS, p.Target.Arch)
-	// TODO(HerrSpace): -fdirectives-only isn't supported by clang. This code
-	// is relevant for producing C reproducers. Hence that doesn't work for
-	// darwin at the moment.
+	// Note: -fdirectives-only isn't supported by clang. This code is relevant
+	// for producing C++ reproducers. Hence reproducers don't work when setting
+	// CPP in targets.go to clang++ at the moment.
 	cmd := osutil.Command(sysTarget.CPP, "-nostdinc", "-undef", "-fdirectives-only", "-dDI", "-E", "-P", "-")
 	for _, def := range defines {
 		cmd.Args = append(cmd.Args, "-D"+def)

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -466,14 +466,9 @@ var oses = map[string]osCommon{
 		cflags:                 []string{"-static", "-lc++"},
 	},
 	Darwin: {
-		SyscallNumbers:   true,
-		Int64SyscallArgs: true,
-		SyscallPrefix:    "SYS_",
-		// Note: Seems like darwin really doesn't like MAP_FIXED. Every once in
-		// a while the mmap will fail, causing syz-manager to restart the VM. I
-		// tried mmaping in a loop on linux and darwin. On linux the mmap
-		// always works. On darwin it returns an error in bursts. It used to be
-		// pretty frequent, but now it's so seldom I just ignore it. Beware.
+		SyscallNumbers:    true,
+		Int64SyscallArgs:  true,
+		SyscallPrefix:     "SYS_",
 		ExecutorUsesShmem: true,
 		// FIXME(HerrSpace): ForkServer is b0rked in a peculiar way. I did some
 		// printf debugging in parseOutput in ipc.go. It usually works for a

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -484,8 +484,11 @@ var oses = map[string]osCommon{
 		// go side.
 		ExecutorUsesForkServer: false,
 		KernelObject:           "kernel.kasan",
-		CPP:                    "clang++",
-		cflags:                 []string{"-static", "-lc++"},
+		// Note: We need a real g++ here, not the symlink to clang++ common on
+		// macOS systems. Homebrews gcc package suffixes these with the gcc
+		// version to avoid conflicting with the macOS symlink. Currently -11.
+		CPP:    "g++-11",
+		cflags: []string{"-lc++"},
 	},
 	NetBSD: {
 		BuildOS:                Linux,


### PR DESCRIPTION
This patch is part of my ongoing effort to implement XNU/Darwin support in syzkaller: #2553

Reproducers never worked with Darwin before, as we tried to create them using clang++, as well as with -static. Both is not possible as described in the change.