### PR TITLE
dashboard: switch recreate.sh to the new openbsd overlay location

### DIFF
--- a/dashboard/config/openbsd/recreate.sh
+++ b/dashboard/config/openbsd/recreate.sh
@@ -69,5 +69,5 @@ ssh syzkaller@"${INSTANCE}" ln -sf /syzkaller/{gopath/src/github.com/google/syzk
 scp "${SYZ_DIR}"/dashboard/config/openbsd/config.ci "${INSTANCE}":/syzkaller/config-openbsd.ci
 scp worker_key syzkaller@"${INSTANCE}":/syzkaller/userspace/key
 scp -C worker_disk.raw syzkaller@"${INSTANCE}":/syzkaller/userspace/image
-ssh syzkaller@"${INSTANCE}" 'D=/syzkaller/userspace-multicore && mkdir -p $D && ln -sf ../userspace/{image,key} $D && ln -sf ../config/overlays/ci-openbsd-multicore $D/overlay'
+ssh syzkaller@"${INSTANCE}" 'D=/syzkaller/userspace-multicore && mkdir -p $D && ln -sf ../userspace/{image,key} $D && ln -sf ../config/openbsd/overlays/ci-openbsd-multicore $D/overlay'
 ssh root@"${INSTANCE}" reboot


### PR DESCRIPTION
Once this is submitted, the changed line should be run to update ci-openbsd.
