### PR TITLE
executor: ifconfig destroy wants the interface (not device) name

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -209,7 +209,7 @@ static void initialize_tun(int tun_id)
 	execute_command(0, "ifconfig %s destroy", tun_iface);
 	execute_command(0, "ifconfig %s create", tun_iface);
 #else
-	execute_command(0, "ifconfig %s destroy", tun_device);
+	execute_command(0, "ifconfig %s destroy", tun_iface);
 #endif
 
 	tunfd = open(tun_device, O_RDWR | O_NONBLOCK);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1734,7 +1734,7 @@ static void initialize_tun(int tun_id)
 	execute_command(0, "ifconfig %s destroy", tun_iface);
 	execute_command(0, "ifconfig %s create", tun_iface);
 #else
-	execute_command(0, "ifconfig %s destroy", tun_device);
+	execute_command(0, "ifconfig %s destroy", tun_iface);
 #endif
 
 	tunfd = open(tun_device, O_RDWR | O_NONBLOCK);


### PR DESCRIPTION
At least on OpenBSD this is the behavior:
% doas ifconfig tun5 create
% doas ifconfig tun5 destroy
% doas ifconfig tun5 create
% doas ifconfig /dev/tun5 destroy
ifconfig: SIOCIFDESTROY: Invalid argument
