### PR TITLE
tools/usbgen: handle zero ids count case

### DIFF
--- a/tools/syz-usbgen/usbgen.go
+++ b/tools/syz-usbgen/usbgen.go
@@ -83,6 +83,10 @@ func generateIdsVar(ids []string, name string) []byte {
 		output = append(output, []byte(outputID)...)
 	}
 
+	if len(ids) == 0 {
+		output = append(output, []byte("\"\"")...)
+	}
+
 	fmt.Printf("%v %s ids written\n", len(ids), name)
 
 	return output


### PR DESCRIPTION
I wanted to fuzz only one driver, so I've slightly changed
usb_ids.patch to print ids only for needed driver:

So, I got following vm log:
```
syzkaller login: [   34.303492] hid: USBID: 0300da0b79810000000000000000000000
[   34.303969] hid: USBID: 0300da0b79010000000000000000000000
[   34.304454] hid: USBID: 0300da0b79f10000000000000000000000
[   34.304988] hid: USBID: 0300b80779810000000000000000000000
[   34.305455] hid: USBID: 0300f60d76000000000000000000000000
[   34.305941] hid: USBID: 030001200f330000000000000000000000
[   34.306406] hid: USBID: 0300012010330000000000000000000000
[   34.306893] hid: USBID: 0300012011330000000000000000000000
[   34.307364] hid: USBID: 030001201b330000000000000000000000
[   34.307865] hid: USBID: 03006e0508400000000000000000000000
[   34.308349] hid: USBID: 030057230c010000000000000000000000
[   34.308847] hid: USBID: 0300572311010000000000000000000000
[   34.309328] hid: USBID: 03004e2c02010000000000000000000000
[   34.309826] hid: USBID: 0300050bf0180000000000000000000000
[   34.310307] hid: USBID: 0300927311b80000000000000000000000
QEMU: Terminated
```
There is no HID devices in log at all. Old syz-usbgen generates
following init_vusb_ids.go:
```go
// Code generated by tools/syz-usbgen. DO NOT EDIT.
// See docs/linux/external_fuzzing_usb.md

package linux

var usbIds = "\x03\x00\x01 \x0f3\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\x01 \x103\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\x01 \x113\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\x01 \x1b3\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\x05\v\xf0\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00N,\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00W#\f\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00W#\x11\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00n\x05\b@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\x92s\x11\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\xb8\ay\x81\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\xda\vy\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\xda\vy\x81\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\xda\vy\xf1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
	"\x03\x00\xf6\rv\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"

var hidIds =
```
It obviously causes build errors:
```bash
sys/linux/init_vusb_ids.go:23:1: syntax error: unexpected EOF, expecting expression
make: *** [Makefile:172: mutate] Error 2
make: *** Waiting for unfinished jobs....
sys/linux/init_vusb_ids.go:23:1: syntax error: unexpected EOF, expecting expression
make: *** [Makefile:175: prog2c] Error 2
sys/linux/init_vusb_ids.go:23:1: syntax error: unexpected EOF, expecting expression
sys/linux/init_vusb_ids.go:23:1: syntax error: unexpected EOF, expecting expression
sys/linux/init_vusb_ids.go:23:1: syntax error: unexpected EOF, expecting expression
make: *** [Makefile:169: repro] Error 2
```
Fix it by adding empty string to output when len(ids) is
equal to zero

Signed-off-by: Pavel Skripkin <paskripkin@gmail.com>