### PR TITLE
sys: skip kvm const extraction for non i386/amd64

### DIFF
--- a/executor/common_kvm_amd64.h
+++ b/executor/common_kvm_amd64.h
@@ -267,7 +267,7 @@ struct kvm_opt {
 #define KVM_SETUP_VM (1 << 6)
 
 // syz_kvm_setup_cpu(fd fd_kvmvm, cpufd fd_kvmcpu, usermem vma[24], text ptr[in, array[kvm_text, 1]], ntext len[text], flags flags[kvm_setup_flags], opts ptr[in, array[kvm_setup_opt, 0:2]], nopt len[opts])
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;

--- a/executor/common_kvm_arm64.h
+++ b/executor/common_kvm_arm64.h
@@ -17,7 +17,7 @@ struct kvm_opt {
 };
 
 // syz_kvm_setup_cpu(fd fd_kvmvm, cpufd fd_kvmcpu, usermem vma[24], text ptr[in, array[kvm_text, 1]], ntext len[text], flags flags[kvm_setup_flags], opts ptr[in, array[kvm_setup_opt, 0:2]], nopt len[opts])
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;

--- a/executor/common_kvm_ppc64.h
+++ b/executor/common_kvm_ppc64.h
@@ -147,7 +147,7 @@ static void dump_text(const char* mem, unsigned start, unsigned cw, uint32 debug
 #define KVM_SETUP_PPC64_PID1 (1 << 4) // Set PID=1 i.e. not kernel's PID
 
 // syz_kvm_setup_cpu(fd fd_kvmvm, cpufd fd_kvmcpu, usermem vma[24], text ptr[in, array[kvm_text, 1]], ntext len[text], flags flags[kvm_setup_flags_ppc64], opts ptr[in, array[kvm_setup_opt, 0:2]], nopt len[opts])
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2961,7 +2961,7 @@ error_clear_loop:
 #elif GOARCH_ppc64 || GOARCH_ppc64le
 #include "common_kvm_ppc64.h"
 #elif !GOARCH_arm
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	return 0;
 }

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6639,7 +6639,7 @@ struct kvm_opt {
 #define KVM_SETUP_VIRT86 (1 << 4)
 #define KVM_SETUP_SMM (1 << 5)
 #define KVM_SETUP_VM (1 << 6)
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;
@@ -7181,7 +7181,7 @@ struct kvm_opt {
 	uint64 typ;
 	uint64 val;
 };
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;
@@ -7378,7 +7378,7 @@ static void dump_text(const char* mem, unsigned start, unsigned cw, uint32 debug
 #define KVM_SETUP_PPC64_DR (1 << 2)
 #define KVM_SETUP_PPC64_PR (1 << 3)
 #define KVM_SETUP_PPC64_PID1 (1 << 4)
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	const int vmfd = a0;
 	const int cpufd = a1;
@@ -7602,7 +7602,7 @@ static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long 
 }
 
 #elif !GOARCH_arm
-static long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
+static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volatile long a2, volatile long a3, volatile long a4, volatile long a5, volatile long a6, volatile long a7)
 {
 	return 0;
 }

--- a/sys/syz-extract/linux.go
+++ b/sys/syz-extract/linux.go
@@ -114,11 +114,13 @@ func (*linux) prepareArch(arch *Arch) error {
 
 func (*linux) processFile(arch *Arch, info *compiler.ConstInfo) (map[string]uint64, map[string]bool, error) {
 	if strings.HasSuffix(info.File, "_kvm.txt") &&
-		(arch.target.Arch == targets.ARM || arch.target.Arch == targets.RiscV64) {
-		// Hack: KVM is not supported on ARM anymore. We may want some more official support
-		// for marking descriptions arch-specific, but so far this combination is the only
-		// one. For riscv64, KVM is not supported yet but might be in the future.
-		// Note: syz-sysgen also ignores this file for arm and riscv64.
+		arch.target.Arch != targets.I386 && arch.target.Arch != targets.AMD64 {
+		// Hack:
+		// include/uapi/linux/kvm.h has definitions that can only be compiled under i386
+		// and amd64 (e.g. KVM_SET_CPUID). On all other arches they generate build errors
+		// and therefore this tool is not able to proceed.
+		// TODO: remove this once #2754 is resolved.
+		// Note: syz-sysgen also ignores this file.
 		return nil, nil, nil
 	}
 	headerArch := arch.target.KernelHeaderArch

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -117,8 +117,8 @@ func main() {
 				if OS == targets.Linux && (job.Target.Arch == targets.ARM || job.Target.Arch == targets.RiscV64) {
 					// Hack: KVM is not supported on ARM anymore. On riscv64 it
 					// is not supported yet but might be in the future.
-					// Note: syz-extract also ignores this file for arm and
-					// riscv64.
+					// Note: syz-extract ignores this file on all arches except
+					// i386 and amd64 (due to const extraction problems).
 					top = descriptions.Filter(func(n ast.Node) bool {
 						pos, _, _ := n.Info()
 						return !strings.HasSuffix(pos.File, "_kvm.txt")


### PR DESCRIPTION
It is impossible to compile a number of definitions in `include/uapi/linux/kvm.h` for other platforms, which leads to `syz-extract` not being able to update constants.

Skip processing of this file for all arches except i386 and amd64.

This is a hacky and (hopefully) temporary solution until #2754 is implemented.