### PR TITLE
sys/targets: do not set -static-pie for OpenBSD

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -367,7 +367,8 @@ var List = map[string]map[string]*Target{
 			PageSize:     4 << 10,
 			LittleEndian: true,
 			CCompiler:    "c++",
-			CFlags:       []string{"-m64", "-static-pie", "-lutil"},
+			// PIE is enabled on OpenBSD by default, so no need for -static-pie.
+			CFlags: []string{"-m64", "-static", "-lutil"},
 			NeedSyscallDefine: func(nr uint64) bool {
 				switch nr {
 				case 8: // SYS___tfork


### PR DESCRIPTION
In this case, executables are PIE by default and clang starts to compain
about "error: argument unused during compilation: '-static-pie'
[-Werror,-Wunused-command-line-argument]".

