### PR TITLE
pkg/host: add O_NONBLOCK to isSupportedOpenFile

### DIFF
--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -460,7 +460,7 @@ func isSupportedOpenFile(c *prog.Syscall, filenameArg int, modes []int) (bool, s
 		return true, ""
 	}
 	if len(modes) == 0 {
-		modes = []int{syscall.O_RDONLY, syscall.O_WRONLY, syscall.O_RDWR}
+		modes = []int{syscall.O_RDONLY, syscall.O_WRONLY, syscall.O_RDWR, syscall.O_RDONLY | syscall.O_NONBLOCK}
 	}
 	var err error
 	for _, mode := range modes {


### PR DESCRIPTION
Since commit 4f7e1d0f5e1c ("sys/linux: use openat for /dev/cdrom")
changed syz_open_dev to openat syzkaller tries to open /dev/cdrom
with r,w,rw flags. However, if there is no media in a cdrom
device these attempts will fail resulting in:
> disabling openat$sr: open(/dev/sr0) failed: no medium found

Add O_RDONLY|O_NONBLOCK mode to successfully open cdrom devices
with no media.
