### PR TITLE
pkg/build: increse timeout for bazel

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -162,11 +162,12 @@ func compilerIdentity(compiler string) (string, error) {
 
 	bazel := strings.HasSuffix(compiler, "bazel")
 
-	arg := "--version"
+	arg, timeout := "--version", time.Minute
 	if bazel {
-		arg = ""
+		// Bazel episodically fails with 1 min timeout.
+		arg, timeout = "", 10*time.Minute
 	}
-	output, err := osutil.RunCmd(time.Minute, "", compiler, arg)
+	output, err := osutil.RunCmd(timeout, "", compiler, arg)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We've just got a timeout failure for TestCompilerIdentity test:

--- FAIL: TestCompilerIdentity (0.00s)
    --- FAIL: TestCompilerIdentity/bazel (60.19s)
        build_test.go:24: failed: timedout ["bazel" ""]
FAIL
