### PR TITLE
dashboard/config/linux: kmsan: disable auto-initialization

### DIFF
--- a/dashboard/config/linux/bits/kmsan.yml
+++ b/dashboard/config/linux/bits/kmsan.yml
@@ -10,6 +10,10 @@ config:
  # Crash the kernel after the first KMSAN report.
  - CMDLINE: [append, "panic_on_kmsan=1"]
 
+ # Ensure we do not auto-initialize heap allocations.
+ - INIT_ON_ALLOC_DEFAULT_ON: n
+ - INIT_ON_FREE_DEFAULT_ON: n
+
  # Avoid reboot loop in instrumented kernel:
  - PREEMPT_NONE
  - PREEMPT: [n, weak]


### PR DESCRIPTION
Heap auto-initialization is nice, but not when we are trying to find
uninitialized memory.

Signed-off-by: Alexander Potapenko <glider@google.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
