### PR TITLE
docs/linux: extend and reformat Ubuntu documentation

### DIFF
--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -8,8 +8,14 @@ In the instructions below, the `$VAR` notation (e.g. `$GCC`, `$KERNEL`, etc.) is
 
 If your distro's GCC is older, it's preferable to get the lastest GCC from [this](/docs/syzbot.md#crash-does-not-reproduce) list. Download and unpack into `$GCC`, and you should have GCC binaries in `$GCC/bin/`
 
+>**Ubuntu 20.04 LTS**: You can ignore this section. GCC is up-to-date.
+
+Command:
 ``` bash
-$ ls $GCC/bin/
+ls $GCC/bin/
+```
+Sample output:
+``` bash
 cpp     gcc-ranlib  x86_64-pc-linux-gnu-gcc        x86_64-pc-linux-gnu-gcc-ranlib
 gcc     gcov        x86_64-pc-linux-gnu-gcc-9.0.0
 gcc-ar  gcov-dump   x86_64-pc-linux-gnu-gcc-ar

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -178,14 +178,18 @@ For additional options of `create-image.sh`, please refer to `./create-image.sh 
 
 ## QEMU
 
-Install `QEMU`:
+### Install QEMU
 
+Command:
 ``` bash
-sudo apt-get install qemu-system-x86
+sudo apt install qemu-system-x86
 ```
 
-Make sure the kernel boots and `sshd` starts:
+### Verify
 
+Make sure the kernel boots and `sshd` starts.
+
+Command:
 ``` bash
 qemu-system-x86_64 \
 	-m 2G \
@@ -220,17 +224,21 @@ Booting the kernel.
 [ ok ] Starting OpenBSD Secure Shell server: sshd.
 ```
 
-After that you should be able to ssh to QEMU instance in another terminal:
+After that you should be able to ssh to QEMU instance in another terminal.
 
+Command:
 ``` bash
 ssh -i $IMAGE/stretch.id_rsa -p 10021 -o "StrictHostKeyChecking no" root@localhost
 ```
+
+### Troubleshooting
 
 If this fails with "too many tries", ssh may be passing default keys before
 the one explicitly passed with `-i`. Append option `-o "IdentitiesOnly yes"`.
 
 To kill the running QEMU instance press `Ctrl+A` and then `X` or run:
 
+Command:
 ``` bash
 kill $(cat vm.pid)
 ```

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -129,15 +129,20 @@ ls $KERNEL/arch/x86/boot/bzImage
 
 ## Image
 
-Install debootstrap:
+### Install debootstrap
 
+Command:
 ``` bash
-sudo apt-get install debootstrap
+sudo apt install debootstrap
 ```
 
-To create a Debian Stretch Linux image with the minimal set of required packages do:
+### Create Debian Stretch Linux image
 
+Create a Debian Stretch Linux image with the minimal set of required packages.
+
+Command:
 ```
+mkdir $IMAGE
 cd $IMAGE/
 wget https://raw.githubusercontent.com/google/syzkaller/master/tools/create-image.sh -O create-image.sh
 chmod +x create-image.sh
@@ -146,20 +151,25 @@ chmod +x create-image.sh
 
 The result should be `$IMAGE/stretch.img` disk image.
 
-If you would like to generate an image with Debian Buster, instead of Stretch, do:
+### OR Create Debian Buster Linux image
 
+Command:
 ``` bash
 ./create-image.sh --distribution buster
 ```
 
+### Image exatra tools
+
 Sometimes it's useful to have some additional packages and tools available in the VM even though they are not required to run syzkaller. To install a set of tools we find useful do (feel free to edit the list of tools in the script):
 
+Command:
 ``` bash
 ./create-image.sh --feature full
 ```
 
 To install perf (not required to run syzkaller; requires `$KERNEL` to point to the kernel sources):
 
+Command:
 ``` bash
 ./create-image.sh --add-perf
 ```

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -4,6 +4,16 @@ These are the instructions on how to fuzz the x86-64 kernel in a QEMU with Ubunt
 
 In the instructions below, the `$VAR` notation (e.g. `$GCC`, `$KERNEL`, etc.) is used to denote paths to directories that are either created when executing the instructions (e.g. when unpacking GCC archive, a directory will be created), or that you have to create yourself before running the instructions. Substitute the values for those variables manually.
 
+
+## Install Prerequisites
+
+Command:
+``` bash
+sudo apt update
+sudo apt install make gcc flex bison libncurses-dev libelf-dev libssl-dev
+```
+
+
 ## GCC
 
 If your distro's GCC is older, it's preferable to get the lastest GCC from [this](/docs/syzbot.md#crash-does-not-reproduce) list. Download and unpack into `$GCC`, and you should have GCC binaries in `$GCC/bin/`
@@ -83,10 +93,10 @@ make CC="$GCC/bin/gcc" -j64
 Now you should have `vmlinux` (kernel binary) and `bzImage` (packed kernel image):
 
 ``` bash
-$ ls $KERNEL/vmlinux
-$KERNEL/vmlinux
-$ ls $KERNEL/arch/x86/boot/bzImage
-$KERNEL/arch/x86/boot/bzImage
+ls $KERNEL/vmlinux
+# sample output - $KERNEL/vmlinux
+ls $KERNEL/arch/x86/boot/bzImage
+# sample output - $KERNEL/arch/x86/boot/bzImage
 ```
 
 ## Image

--- a/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
+++ b/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md
@@ -23,37 +23,48 @@ If your distro's GCC is older, it's preferable to get the lastest GCC from [this
 Command:
 ``` bash
 ls $GCC/bin/
-```
-Sample output:
-``` bash
-cpp     gcc-ranlib  x86_64-pc-linux-gnu-gcc        x86_64-pc-linux-gnu-gcc-ranlib
-gcc     gcov        x86_64-pc-linux-gnu-gcc-9.0.0
-gcc-ar  gcov-dump   x86_64-pc-linux-gnu-gcc-ar
-gcc-nm  gcov-tool   x86_64-pc-linux-gnu-gcc-nm
+# Sample output:
+# cpp     gcc-ranlib  x86_64-pc-linux-gnu-gcc        x86_64-pc-linux-gnu-gcc-ranlib
+# gcc     gcov        x86_64-pc-linux-gnu-gcc-9.0.0
+# gcc-ar  gcov-dump   x86_64-pc-linux-gnu-gcc-ar
+# gcc-nm  gcov-tool   x86_64-pc-linux-gnu-gcc-nm
 ```
 
 ## Kernel
 
-Checkout Linux kernel source:
+### Checkout Linux Kernel source
 
+Command:
 ``` bash
-git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git $KERNEL
+git clone --branch v5.14 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git $KERNEL
 ```
 
-Generate default configs:
+>We recommend to start with the latest stable version. v5.14 is an example here.
 
+### Generate default configs
+
+Command:
+``` bash
+cd $KERNEL
+make defconfig
+make kvm_guest.config
+```
+
+Or if you want to specify a compiler.
+
+Command:
 ``` bash
 cd $KERNEL
 make CC="$GCC/bin/gcc" defconfig
 make CC="$GCC/bin/gcc" kvm_guest.config
 ```
 
-Note: If you are using your distro's GCC, you don't need to set `CC` in the `make` command.
+### Enable required config options
 
 Enable kernel config options required for syzkaller as described [here](kernel_configs.md).
 It's not required to enable all of them, but at the very least you need:
 
-```
+``` make
 # Coverage collection.
 CONFIG_KCOV=y
 
@@ -73,25 +84,42 @@ Edit `.config` file manually and enable them (or do that through `make menuconfi
 
 Since enabling these options results in more sub options being available, we need to regenerate config:
 
+Command:
+``` bash
+make olddefconfig
+```
+
+Or if you want to specify a compiler.
+
+Command:
 ``` bash
 make CC="$GCC/bin/gcc" olddefconfig
 ```
 
 You might also be interested in disabling the Predictable Network Interface Names mechanism. This can be disabled either in the syzkaller configuration (see details [here](troubleshooting.md)) or by updating these kernel configuration parameters:
 
-```
+``` make
 CONFIG_CMDLINE_BOOL=y
 CONFIG_CMDLINE="net.ifnames=0"
 ```
 
-Build the kernel:
+### Build the Kernel
 
+Command:
 ```
-make CC="$GCC/bin/gcc" -j64
+make -j`nproc`
+```
+
+Or if you want to specify a compiler.
+
+Command:
+```
+make CC="$GCC/bin/gcc" -j`nproc`
 ```
 
 Now you should have `vmlinux` (kernel binary) and `bzImage` (packed kernel image):
 
+Command:
 ``` bash
 ls $KERNEL/vmlinux
 # sample output - $KERNEL/vmlinux


### PR DESCRIPTION
After this changes into the setup_ubuntu-host_qemu-vm_x86-64-kernel.md we'll:
1. Have prerequisites section.
2. Have smaller steps for a newcomer (used ### for 3 level subcategories).
3. Have the Ubuntu 20.04 LTS manually verified command chain.
4. Reduce the bar for Kernel unaware newcomers (v5.14 is proposed to be base).
5. Use optimized make -j\`nproc\`.
6. Have a simplified copy-paste procedure.

Live preview is available [here](https://github.com/tarasmadan/syzkaller/blob/update-ubuntu-doc/docs/linux/setup_ubuntu-host_qemu-vm_x86-64-kernel.md) .