### PR TITLE
vm/qemu: fix nil deref in qmp

### DIFF
--- a/vm/qemu/qmp.go
+++ b/vm/qemu/qmp.go
@@ -93,10 +93,10 @@ func (inst *instance) qmp(cmd *qmpCommand) (interface{}, error) {
 	}
 	resp, err := inst.doQmp(cmd)
 	if err != nil {
-		return resp.Return, err
+		return nil, err
 	}
 	if resp.Error.Desc != "" {
-		return resp.Return, fmt.Errorf("error %v", resp.Error)
+		return nil, fmt.Errorf("error %v", resp.Error)
 	}
 	if resp.Return == nil {
 		return nil, fmt.Errorf(`no "return" nor "error" in [%v]`, resp)


### PR DESCRIPTION
A user has reported the following crash:

panic: runtime error: invalid memory address or nil pointer dereference

goroutine 1021 [running]:
github.com/google/syzkaller/vm/qemu.(*instance).qmp()
	vm/qemu/qmp.go:96 +0x1c9
github.com/google/syzkaller/vm/qemu.(*instance).hmp()
	vm/qemu/qmp.go:115 +0xbd
github.com/google/syzkaller/vm/qemu.(*instance).Diagnose()
	vm/qemu/qemu.go:662 +0x18d

qmp function accesses resp even if doQmp returns an error
and doQmp can return a nil resp in this case if inst.monEnc.Encode fails.
Don't access resp if error is returned. The only caller hmp
does not use the returned object is an error is returned.
