### PR TITLE
vm/gce: adjust log level for timeout-related errors

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -308,13 +308,13 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 			} else if merr, ok := err.(vmimpl.MergerError); ok && merr.R == conRpipe {
 				// Console connection must never fail. If it does, it's either
 				// instance preemption or a GCE bug. In either case, not a kernel bug.
-				log.Logf(1, "%v: gce console connection failed with %v", inst.name, merr.Err)
+				log.Logf(0, "%v: gce console connection failed with %v", inst.name, merr.Err)
 				err = vmimpl.ErrTimeout
 			} else {
 				// Check if the instance was terminated due to preemption or host maintenance.
 				time.Sleep(5 * time.Second) // just to avoid any GCE races
 				if !inst.GCE.IsInstanceRunning(inst.name) {
-					log.Logf(1, "%v: ssh exited but instance is not running", inst.name)
+					log.Logf(0, "%v: ssh exited but instance is not running", inst.name)
 					err = vmimpl.ErrTimeout
 				}
 			}


### PR DESCRIPTION
These messages are of relevance to debugging problems on syz-ci's side,
but due to log level 1 they are not saved to the logs by default. Set their
log level to 0.
