### PR TITLE
executor: fail if the first argument isn't a known command

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -407,6 +407,11 @@ int main(int argc, char** argv)
 	if (argc == 2 && strcmp(argv[1], "test") == 0)
 		return run_tests();
 
+	if (argc < 2 || strcmp(argv[1], "exec") != 0) {
+		fprintf(stderr, "unknown command");
+		return 1;
+	}
+
 	start_time_ms = current_time_ms();
 
 	os_init(argc, argv, (char*)SYZ_DATA_OFFSET, SYZ_NUM_PAGES * SYZ_PAGE_SIZE);

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -188,7 +188,7 @@ func MakeEnv(config *Config, pid int) (*Env, error) {
 		out:     outmem,
 		inFile:  inf,
 		outFile: outf,
-		bin:     strings.Split(config.Executor, " "),
+		bin:     append(strings.Split(config.Executor, " "), "exec"),
 		pid:     pid,
 		config:  config,
 	}


### PR DESCRIPTION
We have seen cases when a test program re-execed the current binary:

11:53:29 executing program 0:
openat$zero(0xffffffffffffff9c, &(0x7f0000000040), 0x0, 0x0)
r0 = openat(0xffffffffffffff9c, &(0x7f0000000080)='/proc/self/exe\x00', 0x0, 0x0)
lseek(r0, 0x4000000000000000, 0x4)
execveat(r0, &(0x7f0000000080)='\x00', 0x0, 0x0, 0x1000)

In such cases, we have to be sure that executor will not print SYZFAIL
log messages and will not exit with kFailStatus.

Since a659b3f, syzkaller reports bugs in all these cases.

Fixes: a659b3f ("pkg/report: detect executor failures")