### PR TITLE
vm/gce: avoid ssh-rsa for user, for now allow it as host-key

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -224,6 +224,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	conAddr := fmt.Sprintf("%v.%v.%v.syzkaller.port=1@ssh-serialport.googleapis.com",
 		inst.GCE.ProjectID, inst.GCE.ZoneID, inst.name)
 	conArgs := append(vmimpl.SSHArgs(inst.debug, inst.gceKey, 9600), conAddr)
+	// TODO: remove this later (see also a comment in getSerialPortOutput).
+	conArgs = append(conArgs, "-o", "HostKeyAlgorithms=+ssh-rsa")
 	con := osutil.Command("ssh", conArgs...)
 	con.Env = []string{}
 	con.Stdout = conWpipe

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -135,7 +135,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	name := fmt.Sprintf("%v-%v", pool.env.Name, index)
 	// Create SSH key for the instance.
 	gceKey := filepath.Join(workdir, "key")
-	keygen := osutil.Command("ssh-keygen", "-t", "rsa", "-b", "2048", "-N", "", "-C", "syzkaller", "-f", gceKey)
+	keygen := osutil.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "syzkaller", "-f", gceKey)
 	if out, err := keygen.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("failed to execute ssh-keygen: %v\n%s", err, out)
 	}
@@ -400,6 +400,9 @@ func (pool *Pool) getSerialPortOutput(name, gceKey string) ([]byte, error) {
 	conAddr := fmt.Sprintf("%v.%v.%v.syzkaller.port=1.replay-lines=10000@ssh-serialport.googleapis.com",
 		pool.GCE.ProjectID, pool.GCE.ZoneID, name)
 	conArgs := append(vmimpl.SSHArgs(pool.env.Debug, gceKey, 9600), conAddr)
+	// TODO(blackgnezdo): Remove this once ssh-serialport.googleapis.com stops using
+	// host key algorithm: ssh-rsa.
+	conArgs = append(conArgs, "-o", "HostKeyAlgorithms=+ssh-rsa")
 	con := osutil.Command("ssh", conArgs...)
 	con.Env = []string{}
 	con.Stdout = conWpipe


### PR DESCRIPTION
OpenSSH 8.8 release disables RSA signatures using the SHA-1 hash
algorithm by default.

Sadly, the ssh-serialport.googleapis.com:9600 uses the deprecated
algorithm for host-key. The end-point identifies itself as:

debug1: Remote protocol version 2.0, remote software version Go
debug1: no match: Go
...
debug1: kex: algorithm: curve25519-sha256@libssh.org
debug1: kex: host key algorithm: ssh-rsa

This should be fixed on the server side, but for now I added a
workaround of enabling this deprecated algorithm.
