### PR TITLE
pkg/csource: remove calls instead of skipping them

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -58,10 +58,6 @@ func testTarget(t *testing.T, target *prog.Target, full bool) {
 	// Testing 2 programs takes too long since we have lots of options permutations and OS/arch.
 	// So we use the as-is in short tests and minimized version in full tests.
 	syzProg := target.GenerateAllSyzProg(rs)
-	if len(syzProg.Calls) > 0 {
-		// Test fault injection generation as well.
-		p.Calls[0].Props.FailNth = 1
-	}
 	var opts []Options
 	if !full || testing.Short() {
 		p.Calls = append(p.Calls, syzProg.Calls...)
@@ -73,6 +69,10 @@ func testTarget(t *testing.T, target *prog.Target, full bool) {
 		})
 		p.Calls = append(p.Calls, minimized.Calls...)
 		opts = allOptionsPermutations(target.OS)
+	}
+	if len(p.Calls) > 0 {
+		// Test fault injection code generation as well.
+		p.Calls[0].Props.FailNth = 1
 	}
 	for opti, opts := range opts {
 		if testing.Short() && opts.HandleSegv {

--- a/prog/generation.go
+++ b/prog/generation.go
@@ -27,7 +27,7 @@ func (target *Target) Generate(rs rand.Source, ncalls int, ct *ChoiceTable) *Pro
 	// The resources in the last call will be replaced with the default values,
 	// which is exactly what we want.
 	for len(p.Calls) > ncalls {
-		p.removeCall(ncalls - 1)
+		p.RemoveCall(ncalls - 1)
 	}
 	p.sanitizeFix()
 	p.debugValidate()

--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -68,7 +68,7 @@ func removeCalls(p0 *Prog, callIndex0 int, crash bool, pred func(*Prog, int) boo
 			callIndex--
 		}
 		p := p0.Clone()
-		p.removeCall(i)
+		p.RemoveCall(i)
 		if !pred(p, callIndex) {
 			continue
 		}

--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -79,7 +79,7 @@ func (ctx *mutator) splice() bool {
 	idx := r.Intn(len(p.Calls))
 	p.Calls = append(p.Calls[:idx], append(p0c.Calls, p.Calls[idx:]...)...)
 	for i := len(p.Calls) - 1; i >= ctx.ncalls; i-- {
-		p.removeCall(i)
+		p.RemoveCall(i)
 	}
 	return true
 }
@@ -141,7 +141,7 @@ func (ctx *mutator) insertCall() bool {
 	calls := r.generateCall(s, p, idx)
 	p.insertBefore(c, calls)
 	for len(p.Calls) > ctx.ncalls {
-		p.removeCall(idx)
+		p.RemoveCall(idx)
 	}
 	return true
 }
@@ -153,7 +153,7 @@ func (ctx *mutator) removeCall() bool {
 		return false
 	}
 	idx := r.Intn(len(p.Calls))
-	p.removeCall(idx)
+	p.RemoveCall(idx)
 	return true
 }
 
@@ -188,7 +188,7 @@ func (ctx *mutator) mutateArg() bool {
 		idx += len(calls)
 		for len(p.Calls) > ctx.ncalls {
 			idx--
-			p.removeCall(idx)
+			p.RemoveCall(idx)
 		}
 		if idx < 0 || idx >= len(p.Calls) || p.Calls[idx] != c {
 			panic(fmt.Sprintf("wrong call index: idx=%v calls=%v p.Calls=%v ncalls=%v",

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -404,7 +404,7 @@ func removeArg(arg0 Arg) {
 }
 
 // removeCall removes call idx from p.
-func (p *Prog) removeCall(idx int) {
+func (p *Prog) RemoveCall(idx int) {
 	c := p.Calls[idx]
 	for _, arg := range c.Args {
 		removeArg(arg)

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -881,7 +881,7 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 			}
 		})
 		if !includeCall {
-			p.removeCall(idx)
+			p.RemoveCall(idx)
 		} else {
 			for _, res := range newResources {
 				relatedRes[res] = true
@@ -895,7 +895,7 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 
 	// Removes the references that are not used anymore.
 	for i := biasedLen; i < len(calls); i++ {
-		p.removeCall(i)
+		p.RemoveCall(i)
 	}
 
 	return MakeResultArg(t, dir, resource, 0), p.Calls


### PR DESCRIPTION
Currently csource skips calls at the very last moment, which has an
unpleasant consequence - if we make choice of enabled defines depend on
the individual calls or call properties, we may end up with defined yet
unused functions.

The perfect solution would be to untie
syz_emit_ethernet/syz_extract_tcp_res and NetInjection, and also to
untie VhciInjection and syz_emit_vhci.

For the time being, move these checks to the very beginning of csource
processing, so that these calls could be removed before we construct our
defines.

Adjust pkg/csource/csource_test.go to better cover fault injection
generation problems.
