### PR TITLE
prog/decodeexec.go: properly handle call props before no-copyin calls

### DIFF
--- a/prog/decodeexec.go
+++ b/prog/decodeexec.go
@@ -116,6 +116,7 @@ func (dec *execDecoder) parse() {
 			dec.commitCall()
 			return
 		case execInstrSetProps:
+			dec.commitCall()
 			dec.readCallProps(&dec.call.Props)
 		default:
 			dec.commitCall()

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -463,9 +463,13 @@ func TestSerializeForExec(t *testing.T) {
 			nil,
 		},
 		{
-			"test() (fail_nth: 3)",
+			`test() (fail_nth: 3)
+test() (fail_nth: 4)
+`,
 			[]uint64{
 				execInstrSetProps, 3,
+				callID("test"), ExecNoCopyout, 0,
+				execInstrSetProps, 4,
 				callID("test"), ExecNoCopyout, 0,
 				execInstrEOF,
 			},
@@ -475,6 +479,11 @@ func TestSerializeForExec(t *testing.T) {
 						Meta:  target.SyscallMap["test"],
 						Index: ExecNoCopyout,
 						Props: CallProps{3},
+					},
+					{
+						Meta:  target.SyscallMap["test"],
+						Index: ExecNoCopyout,
+						Props: CallProps{4},
 					},
 				},
 			},


### PR DESCRIPTION
If a call having non-default call props is followed by a call not having
copyin instructions, the non-default call prop values will be lost.

Fix this by trying to commit the call before processing the call props
structure.

Adjust the call-props-related decodeexec test to emulate that situation as
well.
