### PR TITLE
vm/adb: unlink symlinks before calling rm

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -158,8 +158,12 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		}
 	}
 	// Remove temp files from previous runs.
-	if _, err := inst.adb("shell", "rm -Rf /data/syzkaller*"); err != nil {
-		return nil, err
+	// rm chokes on bad symlinks so we must remove them first
+	if _, err := inst.adb("shell", "ls /data/syzkaller*"); err == nil {
+		if _, err := inst.adb("shell", "find /data/syzkaller* -type l -exec unlink {} \\;"+
+			" && rm -Rf /data/syzkaller*"); err != nil {
+			return nil, err
+		}
 	}
 	inst.adb("shell", "echo 0 > /proc/sys/kernel/kptr_restrict")
 	closeInst = nil


### PR DESCRIPTION
rm fails if a symlink exists but points to a nonexistent location.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
