### PR TITLE
vm/qemu: handle QMP events

### DIFF
--- a/vm/qemu/qmp.go
+++ b/vm/qemu/qmp.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+
+	"github.com/google/syzkaller/pkg/log"
 )
 
 type qmpVersion struct {
@@ -40,6 +42,13 @@ type qmpResponse struct {
 		Desc  string
 	}
 	Return interface{}
+
+	Event     string
+	Data      map[string]interface{}
+	Timestamp struct {
+		Seconds      int64
+		Microseconds int64
+	}
 }
 
 func (inst *instance) qmpConnCheck() error {
@@ -74,10 +83,14 @@ func (inst *instance) qmpConnCheck() error {
 }
 
 func (inst *instance) qmpRecv() (*qmpResponse, error) {
-	qmp := new(qmpResponse)
-	err := inst.monDec.Decode(qmp)
-
-	return qmp, err
+	for {
+		qmp := new(qmpResponse)
+		err := inst.monDec.Decode(qmp)
+		if err != nil || qmp.Event == "" {
+			return qmp, err
+		}
+		log.Logf(1, "event: %v", qmp)
+	}
 }
 
 func (inst *instance) doQmp(cmd *qmpCommand) (*qmpResponse, error) {


### PR DESCRIPTION
QEMU occasionally sends events in the same stream used for QMP commands
so from time time the received packet is not a QMP reponse but a QMP event
which breaks the parser. For example, events are send when a machine state
changed.

This adds basic support for event. For now we skip them and wait until
the expected QMP command response arrives.

Signed-off-by: Alexey Kardashevskiy <aik@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
