### PR TITLE
syz-verifier: fix use of the current dir in test

### DIFF
--- a/syz-verifier/test_utils.go
+++ b/syz-verifier/test_utils.go
@@ -6,6 +6,7 @@ package main
 import (
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -52,6 +53,9 @@ func makeTestResultDirectory(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("failed to create results directory: %v", err)
 	}
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
 	return osutil.Abs(dir)
 }
 

--- a/syz-verifier/test_utils.go
+++ b/syz-verifier/test_utils.go
@@ -4,8 +4,8 @@
 package main
 
 import (
+	"io/ioutil"
 	"math/rand"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -48,16 +48,11 @@ func getTestProgram(t *testing.T) *prog.Prog {
 }
 
 func makeTestResultDirectory(t *testing.T) string {
-	resultsdir := "test"
-	err := osutil.MkdirAll(resultsdir)
+	dir, err := ioutil.TempDir("", "syz-verifier")
 	if err != nil {
 		t.Fatalf("failed to create results directory: %v", err)
 	}
-	resultsdir, err = filepath.Abs(resultsdir)
-	if err != nil {
-		t.Fatalf("failed to get absolute path of resultsdir: %v", err)
-	}
-	return resultsdir
+	return osutil.Abs(dir)
 }
 
 func makeExecResult(pool int, errnos []int, flags ...int) *ExecResult {


### PR DESCRIPTION
The current dir is not necessary writable and is generally a bad place for temp files.
Use a temp dir as scratch dir.
