### PR TITLE
pkg/tools: add empty.go

### DIFF
--- a/pkg/tools/empty.go
+++ b/pkg/tools/empty.go
@@ -1,0 +1,6 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package tools
+
+// Empty file to unbreak bazel+glaze build (tools.go is excluded by build constraints).

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,6 +1,7 @@
 // Copyright 2020 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build tools
 // +build tools
 
 // tools is not a normal package, it's only purpose is tools dependency management.


### PR DESCRIPTION
Add empty.go to unbreak bazel+glaze build.
Otherwise the package does not have any files not excluded by build constraints.
