### PR TITLE
dashboard/app: set json responses "Content-Type" eq "application/json"

### DIFF
--- a/dashboard/app/getjson_test.go
+++ b/dashboard/app/getjson_test.go
@@ -60,7 +60,10 @@ func TestJSONAPIIntegration(t *testing.T) {
 
 func checkBugPageJSONIs(c *Ctx, ID string, expectedContent []byte) {
 	url := fmt.Sprintf("/bug?extid=%v&json=1", ID)
-	actualContent, _ := c.client.GET(url)
 
+	contentType, _ := c.client.ContentType(url)
+	c.expectEQ(contentType, "application/json")
+
+	actualContent, _ := c.client.GET(url)
 	c.expectEQ(string(actualContent), string(expectedContent))
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -436,6 +436,7 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 	}
 
 	if isJSONRequested(r) {
+		w.Header().Set("Content-Type", "application/json")
 		return writeJSONVersionOf(w, data)
 	}
 


### PR DESCRIPTION
Currently, we return "Content-Type: text/plain; charset=utf-8" for json requests.
After this change, we'll return "Content-Type: application/json".
