### PR TITLE
syz-executor: increase the execution rate

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -66,7 +66,8 @@ typedef unsigned char uint8;
 // Note: zircon max fd is 256.
 // Some common_OS.h files know about this constant for RLIMIT_NOFILE.
 const int kMaxFd = 250;
-const int kMaxThreads = 16;
+const int kMaxThreads = 32;
+const int kPreallocCoverThreads = 3; // the number of kcov instances to be set up during init
 const int kInPipeFd = kMaxFd - 1; // remapped from stdin
 const int kOutPipeFd = kMaxFd - 2; // remapped from stdout
 const int kCoverFd = kOutPipeFd - kMaxThreads;
@@ -242,6 +243,7 @@ struct thread_t {
 	uint32 reserrno;
 	bool fault_injected;
 	cover_t cov;
+	bool cov_initialized;
 	bool soft_fail_state;
 };
 
@@ -342,7 +344,8 @@ static void copyout_call_results(thread_t* th);
 static void write_call_output(thread_t* th, bool finished);
 static void write_extra_output();
 static void execute_call(thread_t* th);
-static void thread_create(thread_t* th, int id);
+static void thread_create(thread_t* th, int id, bool need_coverage);
+static void thread_setup_cover(thread_t* th);
 static void* worker_thread(void* arg);
 static uint64 read_input(uint64** input_posp, bool peek = false);
 static uint64 read_arg(uint64** input_posp);
@@ -450,8 +453,10 @@ int main(int argc, char** argv)
 	if (flag_coverage) {
 		for (int i = 0; i < kMaxThreads; i++) {
 			threads[i].cov.fd = kCoverFd + i;
-			cover_open(&threads[i].cov, false);
-			cover_protect(&threads[i].cov);
+			// Pre-setup coverage collection for some threads. This should be enough for almost
+			// all programs, for the remaning few ones coverage will be set up when it's needed.
+			if (i < kPreallocCoverThreads)
+				thread_setup_cover(&threads[i]);
 		}
 		cover_open(&extra_cov, true);
 		cover_protect(&extra_cov);
@@ -881,7 +886,7 @@ thread_t* schedule_call(int call_index, int call_num, bool colliding, uint64 cop
 	for (; i < kMaxThreads; i++) {
 		thread_t* th = &threads[i];
 		if (!th->created)
-			thread_create(th, i);
+			thread_create(th, i, flag_coverage && !colliding);
 		if (event_isset(&th->done)) {
 			if (th->executing)
 				handle_completion(th);
@@ -1115,16 +1120,29 @@ void write_extra_output()
 #endif
 }
 
-void thread_create(thread_t* th, int id)
+void thread_create(thread_t* th, int id, bool need_coverage)
 {
 	th->created = true;
 	th->id = id;
 	th->executing = false;
+	// Lazily set up coverage collection.
+	// It is assumed that actually it's already initialized - with a few rare exceptions.
+	if (need_coverage)
+		thread_setup_cover(th);
 	event_init(&th->ready);
 	event_init(&th->done);
 	event_set(&th->done);
 	if (flag_threaded)
 		thread_start(worker_thread, th);
+}
+
+void thread_setup_cover(thread_t* th)
+{
+	if (th->cov_initialized)
+		return;
+	cover_open(&th->cov, false);
+	cover_protect(&th->cov);
+	th->cov_initialized = true;
 }
 
 void* worker_thread(void* arg)

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -164,6 +164,14 @@ static void cover_collect(cover_t* cov)
 	cov->size = *(uint64*)cov->data;
 }
 
+static void cover_reserve_fd(cover_t* cov)
+{
+	int fd = open("/dev/null", O_RDONLY);
+	if (fd < 0)
+		fail("failed to open /dev/null");
+	dup2(fd, cov->fd);
+}
+
 static bool use_cover_edges(uint64 pc)
 {
 	return true;

--- a/executor/executor_darwin.h
+++ b/executor/executor_darwin.h
@@ -121,3 +121,11 @@ static bool use_cover_edges(uint64 pc)
 {
 	return true;
 }
+
+static void cover_reserve_fd(cover_t* cov)
+{
+	int fd = open("/dev/null", O_RDONLY);
+	if (fd < 0)
+		fail("failed to open /dev/null");
+	dup2(fd, cov->fd);
+}

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -147,6 +147,14 @@ static void cover_collect(cover_t* cov)
 		cov->size = *(uint32*)cov->data;
 }
 
+static void cover_reserve_fd(cover_t* cov)
+{
+	int fd = open("/dev/null", O_RDONLY);
+	if (fd < 0)
+		fail("failed to open /dev/null");
+	dup2(fd, cov->fd);
+}
+
 static bool use_cover_edges(uint32 pc)
 {
 	return true;

--- a/executor/nocover.h
+++ b/executor/nocover.h
@@ -21,6 +21,10 @@ static void cover_protect(cover_t* cov)
 {
 }
 
+static void cover_reserve_fd(cover_t* cov)
+{
+}
+
 #if SYZ_EXECUTOR_USES_SHMEM
 static void cover_unprotect(cover_t* cov)
 {

--- a/pkg/osutil/sharedmem_file.go
+++ b/pkg/osutil/sharedmem_file.go
@@ -1,0 +1,42 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build freebsd || netbsd || openbsd || darwin
+// +build freebsd netbsd openbsd darwin
+
+package osutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+func CreateSharedMemFile(size int) (f *os.File, err error) {
+	f, err = ioutil.TempFile("./", "syzkaller-shm")
+	if err != nil {
+		err = fmt.Errorf("failed to create temp file: %v", err)
+		return
+	}
+	f.Close()
+	fname := f.Name()
+	f, err = os.OpenFile(f.Name(), os.O_RDWR, DefaultFilePerm)
+	if err != nil {
+		err = fmt.Errorf("failed to open shm file: %v", err)
+		os.Remove(fname)
+	}
+	return
+}
+
+func CloseSharedMemFile(f *os.File) error {
+	err1 := f.Close()
+	err2 := os.Remove(f.Name())
+	switch {
+	case err1 != nil:
+		return err1
+	case err2 != nil:
+		return err2
+	default:
+		return nil
+	}
+}

--- a/pkg/osutil/sharedmem_memfd.go
+++ b/pkg/osutil/sharedmem_memfd.go
@@ -1,0 +1,30 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux
+// +build linux
+
+package osutil
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// In the case of Linux, we can just use the memfd_create syscall.
+func CreateSharedMemFile(size int) (f *os.File, err error) {
+	// The name is actually irrelevant and can even be the same for all such files.
+	fd, err := unix.MemfdCreate("syz-shared-mem", 0)
+	if err != nil {
+		err = fmt.Errorf("failed to do memfd_create: %v", err)
+		return
+	}
+	f = os.NewFile(uintptr(fd), fmt.Sprintf("/proc/self/fd/%d", fd))
+	return
+}
+
+func CloseSharedMemFile(f *os.File) error {
+	return f.Close()
+}


### PR DESCRIPTION
This PR includes a set of patches that increate the performance of syz-executor. Experiments with `syz-testbed` have demonstrated a 20-25% increase of the number of executions per second on CGE and a 25-30% speedup when running syzkaller under nested virtualisation. 

Commit descriptions contain more details on the specific changes.