### PR TITLE
Makefile: Allow GOHOSTFLAGS and GOTARGETFLAGS to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ GITREVDATE=$(shell git log -n 1 --format="%cd" --date=format:%Y%m%d-%H%M%S)
 # If you need that, build manually without these flags.
 GOFLAGS := "-ldflags=-s -w -X github.com/google/syzkaller/prog.GitRevision=$(REV) -X 'github.com/google/syzkaller/prog.gitRevisionDate=$(GITREVDATE)'"
 
-GOHOSTFLAGS := $(GOFLAGS)
-GOTARGETFLAGS := $(GOFLAGS)
+GOHOSTFLAGS ?= $(GOFLAGS)
+GOTARGETFLAGS ?= $(GOFLAGS)
 ifneq ("$(GOTAGS)", "")
 	GOHOSTFLAGS += "-tags=$(GOTAGS)"
 endif


### PR DESCRIPTION
Allow the user to override host/target build flags (such as debug info
generation flags). This is useful for example when syzkaller is compiled
by the Yocto build system, as it always generates packages with debug info.

Signed-off-by: Ovidiu Panait <ovpanait@gmail.com>
