### PR TITLE
executor: add an ifdef SYZ_* style check

### DIFF
--- a/executor/style_test.go
+++ b/executor/style_test.go
@@ -141,6 +141,14 @@ if (foo) {
 				`failmsg("format %s string", "format")`,
 			},
 		},
+		{
+			pattern: `ifn?def\s+SYZ_`,
+			message: "SYZ_* are always defined, use #if instead of #ifdef",
+			tests: []string{
+				`#ifndef SYZ_EXECUTOR_USES_FORK_SERVER`,
+				`#ifdef SYZ_EXECUTOR_USES_FORK_SERVER`,
+			},
+		},
 	}
 	for _, check := range checks {
 		re := regexp.MustCompile(check.pattern)


### PR DESCRIPTION
SYZ_* constants are always defined and one must not check them via
ifdef. Add a check to prevent such problems during development (inspired
by the discussion in #2882).
