### PR TITLE
tools/syz-env: automatically remove the container on exit

### DIFF
--- a/tools/syz-env
+++ b/tools/syz-env
@@ -56,6 +56,7 @@ fi
 
 # Run everything as the host user, this is important for created/modified files.
 docker run \
+	--rm \
 	--user $(id -u ${USER}):$(id -g ${USER}) \
 	--volume "$SCRIPT_DIR/..:/syzkaller/gopath/src/github.com/google/syzkaller" \
 	--volume "$HOME/.cache:/syzkaller/.cache" \


### PR DESCRIPTION
To see you stopped containers, call "docker ps -a | grep Exit".
To clean your system, use "docker container prune". In my case ~9GB.
