### PR TITLE
dashboard/app: hide decommissioned items

### DIFF
--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -144,6 +144,9 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 			}
 			continue
 		}
+		if cfg.Decommissioned {
+			continue
+		}
 		if ns1 == ns {
 			found = true
 		}


### PR DESCRIPTION
Currently we show the decommissioned namespaces.
Lets hide this information to let users focus on more actionable things.