### PR TITLE
executor: bring some order to fd distribution

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -230,7 +230,7 @@ static void initialize_tun(int tun_id)
 	}
 	// Remap tun onto higher fd number to hide it from fuzzer and to keep
 	// fd numbers stable regardless of whether tun is opened or not (also see kMaxFd).
-	const int kTunFd = 240;
+	const int kTunFd = 200;
 	if (dup2(tunfd, kTunFd) < 0)
 		fail("dup2(tunfd, kTunFd) failed");
 	close(tunfd);

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -567,7 +567,7 @@ static void initialize_tun(void)
 	}
 	// Remap tun onto higher fd number to hide it from fuzzer and to keep
 	// fd numbers stable regardless of whether tun is opened or not (also see kMaxFd).
-	const int kTunFd = 240;
+	const int kTunFd = 200;
 	if (dup2(tunfd, kTunFd) < 0)
 		fail("dup2(tunfd, kTunFd) failed");
 	close(tunfd);
@@ -632,7 +632,7 @@ static void initialize_tun(void)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_init_net_socket || SYZ_DEVLINK_PCI
-const int kInitNetNsFd = 239; // see kMaxFd
+const int kInitNetNsFd = 201; // see kMaxFd
 #endif
 
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI || SYZ_NET_DEVICES
@@ -2582,7 +2582,7 @@ static void initialize_vhci()
 
 	// Remap vhci onto higher fd number to hide it from fuzzer and to keep
 	// fd numbers stable regardless of whether vhci is opened or not (also see kMaxFd).
-	const int kVhciFd = 241;
+	const int kVhciFd = 202;
 	if (dup2(vhci_fd, kVhciFd) < 0)
 		fail("dup2(vhci_fd, kVhciFd) failed");
 	close(vhci_fd);

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -72,6 +72,7 @@ const int kReserveCoverFds = 16; // a compromise between extra fds and the likel
 const int kInPipeFd = kMaxFd - 1; // remapped from stdin
 const int kOutPipeFd = kMaxFd - 2; // remapped from stdout
 const int kCoverFd = kOutPipeFd - kMaxThreads;
+const int kExtraCoverFd = kCoverFd - 1;
 const int kMaxArgs = 9;
 const int kCoverSize = 256 << 10;
 const int kFailStatus = 67;
@@ -480,6 +481,7 @@ int main(int argc, char** argv)
 				cover_reserve_fd(&threads[i].cov);
 			}
 		}
+		extra_cov.fd = kExtraCoverFd;
 		cover_open(&extra_cov, true);
 		cover_protect(&extra_cov);
 		if (flag_extra_coverage) {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1757,7 +1757,7 @@ static void initialize_tun(int tun_id)
 		return;
 #endif
 	}
-	const int kTunFd = 240;
+	const int kTunFd = 200;
 	if (dup2(tunfd, kTunFd) < 0)
 		fail("dup2(tunfd, kTunFd) failed");
 	close(tunfd);
@@ -2823,7 +2823,7 @@ static void initialize_tun(void)
 		return;
 #endif
 	}
-	const int kTunFd = 240;
+	const int kTunFd = 200;
 	if (dup2(tunfd, kTunFd) < 0)
 		fail("dup2(tunfd, kTunFd) failed");
 	close(tunfd);
@@ -2875,7 +2875,7 @@ static void initialize_tun(void)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_init_net_socket || SYZ_DEVLINK_PCI
-const int kInitNetNsFd = 239;
+const int kInitNetNsFd = 201;
 #endif
 
 #if SYZ_EXECUTOR || SYZ_DEVLINK_PCI || SYZ_NET_DEVICES
@@ -5973,7 +5973,7 @@ static void initialize_vhci()
 	vhci_fd = open("/dev/vhci", O_RDWR);
 	if (vhci_fd == -1)
 		fail("open /dev/vhci failed");
-	const int kVhciFd = 241;
+	const int kVhciFd = 202;
 	if (dup2(vhci_fd, kVhciFd) < 0)
 		fail("dup2(vhci_fd, kVhciFd) failed");
 	close(vhci_fd);


### PR DESCRIPTION
```

    executor: set fixed fd for extra coverage kcov instance
    
    Currently it is dup2'd to 0, which is quite likely to be closed by the
    fuzzer. Dup2 it to a safer fd instead.
```

```
    executor: spread overlapping fds
    
    There's a chance that the methods from common_bsd.h and common_linux.h
    could dup2 (and thus close) an fd belonging to a kcov instance.
    
    Prevent this by adjusting fd consts.
```