### PR TITLE
RFC: executor: repair damaged kcov instances in Linux

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4442,8 +4442,15 @@ static void setup_loop()
 
 #if SYZ_EXECUTOR || SYZ_REPEAT && (SYZ_NET_RESET || __NR_syz_mount_image || __NR_syz_read_part_table)
 #define SYZ_HAVE_RESET_LOOP 1
+
+#if SYZ_EXECUTOR
+static void repair_coverage_collection();
+#endif
 static void reset_loop()
 {
+#if SYZ_EXECUTOR
+	repair_coverage_collection();
+#endif
 #if SYZ_EXECUTOR || __NR_syz_mount_image || __NR_syz_read_part_table
 	char buf[64];
 	snprintf(buf, sizeof(buf), "/dev/loop%llu", procid);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9480,8 +9480,15 @@ static void setup_loop()
 
 #if SYZ_EXECUTOR || SYZ_REPEAT && (SYZ_NET_RESET || __NR_syz_mount_image || __NR_syz_read_part_table)
 #define SYZ_HAVE_RESET_LOOP 1
+
+#if SYZ_EXECUTOR
+static void repair_coverage_collection();
+#endif
 static void reset_loop()
 {
+#if SYZ_EXECUTOR
+	repair_coverage_collection();
+#endif
 #if SYZ_EXECUTOR || __NR_syz_mount_image || __NR_syz_read_part_table
 	char buf[64];
 	snprintf(buf, sizeof(buf), "/dev/loop%llu", procid);


### PR DESCRIPTION
On Linux, kcov instances currently can only be mmapped once. Subsequent
mmap invocations silently fail. That needs to be fixed in the kernel,
but we must deal with it for some long time anyway, as that potential
fix will not immediately reach all targets that are of interest.

This all goes contrary to the recently implemented memory-saving approach,
because it complicates on-demand virtual memory allocation. However,
since we rarely need to use more than 3 instances, we can afford it to
recreate them in such a case.

Detect instances that were mmapped by the child process and recreate
them before interpreting the next program. Hopefully, this should also
help detect and recover kcov instances that were damaged by the fuzzer.

