### PR TITLE
all: adapt to how mmapping a kcov instance works on Linux

### DIFF
--- a/pkg/host/features.go
+++ b/pkg/host/features.go
@@ -19,6 +19,7 @@ const (
 	FeatureCoverage = iota
 	FeatureComparisons
 	FeatureExtraCoverage
+	FeatureDelayKcovMmap
 	FeatureSandboxSetuid
 	FeatureSandboxNamespace
 	FeatureSandboxAndroid
@@ -60,6 +61,7 @@ func Check(target *prog.Target) (*Features, error) {
 		FeatureCoverage:         {Name: "code coverage", Reason: unsupported},
 		FeatureComparisons:      {Name: "comparison tracing", Reason: unsupported},
 		FeatureExtraCoverage:    {Name: "extra coverage", Reason: unsupported},
+		FeatureDelayKcovMmap:    {Name: "delay kcov mmap", Reason: unsupported},
 		FeatureSandboxSetuid:    {Name: "setuid sandbox", Reason: unsupported},
 		FeatureSandboxNamespace: {Name: "namespace sandbox", Reason: unsupported},
 		FeatureSandboxAndroid:   {Name: "Android sandbox", Reason: unsupported},

--- a/pkg/host/host_freebsd.go
+++ b/pkg/host/host_freebsd.go
@@ -14,5 +14,6 @@ func isSupported(c *prog.Syscall, target *prog.Target, sandbox string) (bool, st
 func init() {
 	checkFeature[FeatureCoverage] = unconditionallyEnabled
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
+	checkFeature[FeatureDelayKcovMmap] = unconditionallyEnabled
 	checkFeature[FeatureNetInjection] = unconditionallyEnabled
 }

--- a/pkg/host/host_netbsd.go
+++ b/pkg/host/host_netbsd.go
@@ -23,6 +23,7 @@ func init() {
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
 	checkFeature[FeatureUSBEmulation] = checkUSBEmulation
 	checkFeature[FeatureExtraCoverage] = checkUSBEmulation
+	checkFeature[FeatureDelayKcovMmap] = unconditionallyEnabled
 	checkFeature[FeatureFault] = checkFault
 }
 

--- a/pkg/host/host_openbsd.go
+++ b/pkg/host/host_openbsd.go
@@ -32,6 +32,7 @@ func init() {
 	checkFeature[FeatureCoverage] = unconditionallyEnabled
 	checkFeature[FeatureComparisons] = unconditionallyEnabled
 	checkFeature[FeatureExtraCoverage] = unconditionallyEnabled
+	checkFeature[FeatureDelayKcovMmap] = unconditionallyEnabled
 	checkFeature[FeatureNetInjection] = unconditionallyEnabled
 	checkFeature[FeatureSandboxSetuid] = unconditionallyEnabled
 }

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -42,6 +42,7 @@ const (
 	FlagEnableDevlinkPCI                         // setup devlink PCI device
 	FlagEnableVhciInjection                      // setup and use /dev/vhci for hci packet injection
 	FlagEnableWifi                               // setup and use mac80211_hwsim for wifi emulation
+	FlagDelayKcovMmap                            // manage kcov memory in an optimized way
 )
 
 // Per-exec flags for ExecOpts.Flags.

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -412,6 +412,9 @@ func (ctx *Context) createSyzTest(p *prog.Prog, sandbox string, threaded, cov bo
 	if ctx.Features[host.FeatureExtraCoverage].Enabled {
 		cfg.Flags |= ipc.FlagExtraCover
 	}
+	if ctx.Features[host.FeatureDelayKcovMmap].Enabled {
+		cfg.Flags |= ipc.FlagDelayKcovMmap
+	}
 	if ctx.Features[host.FeatureNetInjection].Enabled {
 		cfg.Flags |= ipc.FlagEnableTun
 	}

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -108,6 +108,9 @@ func createIPCConfig(features *host.Features, config *ipc.Config) {
 	if features[host.FeatureExtraCoverage].Enabled {
 		config.Flags |= ipc.FlagExtraCover
 	}
+	if features[host.FeatureDelayKcovMmap].Enabled {
+		config.Flags |= ipc.FlagDelayKcovMmap
+	}
 	if features[host.FeatureNetInjection].Enabled {
 		config.Flags |= ipc.FlagEnableTun
 	}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -305,6 +305,9 @@ func createConfig(target *prog.Target, features *host.Features, featuresFlags cs
 	if features[host.FeatureExtraCoverage].Enabled {
 		config.Flags |= ipc.FlagExtraCover
 	}
+	if features[host.FeatureDelayKcovMmap].Enabled {
+		config.Flags |= ipc.FlagDelayKcovMmap
+	}
 	if featuresFlags["tun"].Enabled && features[host.FeatureNetInjection].Enabled {
 		config.Flags |= ipc.FlagEnableTun
 	}


### PR DESCRIPTION
It turns out that the current Linux implementation of KCOV does not
properly handle multiple mmap invocations on the same instance. The
first one succeedes, but the subsequent ones do not actually mmap
anything, yet returning no error at all.

The ability to mmap that memory multiple times allows us to increase
syz-executor performance and it would be a pity to completely lose it
(especially given that mmapping kcov works fine on *BSD).

In some time a patch will be prepared, but still we will have to support
both versions at the same time - the buggy one and the correct one.

Detect whether the bug is present by writing a value at the pointer
returned by mmap. If it is present, disable dynamic kcov mmapping and
pre-mmap 6 instances in the main() function - it should be enough for
all reasonable uses. Otherwise, pre-mmap 3 and let syz-executor mmap
them as needed.

