### PR TITLE
tools/syz-execprog: make suitable for regression testing

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -115,6 +116,22 @@ func TestLarge(t *testing.T) {
 	}
 	if len(db.Records) != nrec {
 		t.Fatalf("wrong record count: %v, want %v", len(db.Records), nrec)
+	}
+}
+
+func TestOpenInvalid(t *testing.T) {
+	f, err := ioutil.TempFile("", "syz-db-test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer f.Close()
+	defer os.Remove(f.Name())
+	if _, err := f.Write([]byte(`some invalid data`)); err != nil {
+		t.Error(err)
+	}
+	if _, err := Open(f.Name()); err == nil {
+		t.Fatal("opened invalid db")
 	}
 }
 

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -33,7 +33,7 @@ var (
 	flagArch      = flag.String("arch", runtime.GOARCH, "target arch")
 	flagCoverFile = flag.String("coverfile", "", "write coverage to the file")
 	flagRepeat    = flag.Int("repeat", 1, "repeat execution that many times (0 for infinite loop)")
-	flagProcs     = flag.Int("procs", 1, "number of parallel processes to execute programs")
+	flagProcs     = flag.Int("procs", 2*runtime.NumCPU(), "number of parallel processes to execute programs")
 	flagOutput    = flag.Bool("output", false, "write programs and results to stdout")
 	flagHints     = flag.Bool("hints", false, "do a hints-generation run")
 	flagEnable    = flag.String("enable", "none", "enable only listed additional features")


### PR DESCRIPTION
- pkg/db: properly handle errors when loading a DB
- tools/syz-execprog: don't store prog.LogEntry's
- tools/syz-execprog: support loading from corpus.db
- tools/syz-execprog: default -procs to 2*NumCPU
