### PR TITLE
executor: fix kcov mmaping in the non-optimized mode 

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1222,8 +1222,6 @@ void thread_mmap_cover(thread_t* th)
 {
 	if (th->cov.data != NULL)
 		return;
-	if (!flag_delay_kcov_mmap)
-		fail("out of mmapped kcov threads");
 	cover_mmap(&th->cov);
 	cover_protect(&th->cov);
 }


### PR DESCRIPTION
Otherwise, machine checks can fail.
