### PR TITLE
docs/freebsd: update README.md executor compile command on guest

### DIFF
--- a/docs/freebsd/README.md
+++ b/docs/freebsd/README.md
@@ -40,7 +40,7 @@ make manager fuzzer execprog TARGETOS=freebsd
 ```
 To build C `syz-executor` binary, copy `executor/*` files to a FreeBSD machine and build there with:
 ```
-c++ executor/executor_freebsd.cc -o syz-executor -O1 -lpthread -DGOOS=\"freebsd\" -DGIT_REVISION=\"CURRENT_GIT_REVISION\"
+c++ executor/executor.cc -o syz-executor -O1 -lpthread -DGOOS_freebsd=1 -DGOARCH_amd64=1 -DGIT_REVISION=\"CURRENT_GIT_REVISION\"
 ```
 Then, copy out the binary back to host into `bin/freebsd_amd64` dir.
 


### PR DESCRIPTION
The instructions for compiling the executor files on the guest machine
referenced executor_freebsd.cc which no longer exists and is now
executor.cc. The DGOOS=freebsd flag is changed to DGOOS_freebsd=1 and
DGOARCH_amd64=1 added to compile syz-executor successfully

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
