### PR TITLE
executor: do exitf instead of fail on kcov shortage

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -78,7 +78,7 @@ const int kFailStatus = 67;
 // Two approaches of dealing with kcov memory.
 const int kCoverOptimizedCount = 12; // the number of kcov instances to be opened inside main()
 const int kCoverOptimizedPreMmap = 3; // this many will be mmapped inside main(), others - when needed.
-const int kCoverDefaultCount = 5; // otherwise we only init kcov instances inside main()
+const int kCoverDefaultCount = 6; // otherwise we only init kcov instances inside main()
 
 // Logical error (e.g. invalid input program), use as an assert() alternative.
 // If such error happens 10+ times in a row, it will be detected as a bug by syz-fuzzer.
@@ -1208,7 +1208,7 @@ void thread_create(thread_t* th, int id, bool need_coverage)
 	// It is assumed that actually it's already initialized - with a few rare exceptions.
 	if (need_coverage) {
 		if (!th->cov.fd)
-			fail("out of opened kcov threads");
+			exitf("out of opened kcov threads");
 		thread_mmap_cover(th);
 	}
 	event_init(&th->ready);


### PR DESCRIPTION
Set new kcov count limits: 6 for the default mode and 16 for the
optimized mode (when the instances are mmapped a needed). Don't generate
SYZFAIL when these limits are exhausted.

Just increasing those limits won't help as syzkaller will anyway come up
with programs that overcome them.

