### PR TITLE
pkg/build: increase bazel aquery timeout

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -74,7 +74,7 @@ func (gvisor gvisor) build(params Params) (ImageDetails, error) {
 	aqueryArgs := append([]string{"aquery"}, args...)
 	aqueryArgs = append(aqueryArgs, fmt.Sprintf("mnemonic(\"GoLink\", %s)", target))
 	log.Logf(0, "bazel: %v", aqueryArgs)
-	out, err := osutil.RunCmd(time.Minute, params.KernelDir, params.Compiler, aqueryArgs...)
+	out, err := osutil.RunCmd(10*time.Minute, params.KernelDir, params.Compiler, aqueryArgs...)
 	if err != nil {
 		return ImageDetails{}, err
 	}

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -62,7 +62,7 @@ func Run(timeout time.Duration, cmd *exec.Cmd) ([]byte, error) {
 	if err != nil {
 		text := fmt.Sprintf("failed to run %q: %v", cmd.Args, err)
 		if <-timedout {
-			text = fmt.Sprintf("timedout %q", cmd.Args)
+			text = fmt.Sprintf("timedout after %v %q", timeout, cmd.Args)
 		}
 		exitCode := 0
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
We've got a timeout of "bazel aquery". It's currently set to 1 minute.
On an overloaded machine it can fire falsely, I guess bazel can start
only for 1 minute. Increase to 10 minutes.
