### PR TITLE
executor: ignore async flag in a non-threaded mode

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -871,10 +871,10 @@ void execute_one()
 		thread_t* th = schedule_call(call_index++, call_num, copyout_index,
 					     num_args, args, input_pos, call_props);
 
-		if (call_props.async) {
-			if (!flag_threaded)
-				fail("SYZFAIL: unable to do an async call in a non-threaded mode");
+		if (call_props.async && flag_threaded) {
 			// Don't wait for an async call to finish. We'll wait at the end.
+			// If we're not in the threaded mode, just ignore the async flag - during repro simplification syzkaller
+			// will anyway try to make it non-threaded.
 		} else if (flag_threaded) {
 			// Wait for call completion.
 			uint64 timeout_ms = syscall_timeout_ms + call->attrs.timeout * slowdown_scale;

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -81,6 +81,14 @@ func TestExecutor(t *testing.T) {
 	}
 }
 
+func prepareTestProgram(target *prog.Target) *prog.Prog {
+	p := target.DataMmapProg()
+	if len(p.Calls) > 1 {
+		p.Calls[1].Props.Async = true
+	}
+	return p
+}
+
 func TestExecute(t *testing.T) {
 	target, _, _, useShmem, useForkServer, timeouts := initTest(t)
 
@@ -103,7 +111,7 @@ func TestExecute(t *testing.T) {
 		defer env.Close()
 
 		for i := 0; i < 10; i++ {
-			p := target.DataMmapProg()
+			p := prepareTestProgram(target)
 			opts := &ExecOpts{
 				Flags: flag,
 			}
@@ -114,8 +122,8 @@ func TestExecute(t *testing.T) {
 			if hanged {
 				t.Fatalf("program hanged:\n%s", output)
 			}
-			if len(info.Calls) == 0 {
-				t.Fatalf("no calls executed:\n%s", output)
+			if len(info.Calls) != len(p.Calls) {
+				t.Fatalf("executed less calls (%v) than prog len(%v):\n%s", len(info.Calls), len(p.Calls), output)
 			}
 			if info.Calls[0].Errno != 0 {
 				t.Fatalf("simple call failed: %v\n%s", info.Calls[0].Errno, output)


### PR DESCRIPTION
pkg/repro tries to clear the Threaded flag during repro simplification,
so it's easier just to ignore the remaining async flags in that case -
they won't be in the C repro either.

