### PR TITLE
syz-verifier: fix VM reboot every 5 minutes

### DIFF
--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -112,6 +112,7 @@ func (rn *Runner) Run(firstProg []byte, idx, runIdx int) {
 			log.Fatalf("failed to deserialise new program: %v", err)
 		}
 
+		log.Printf("executing program") // watchdog for monitor
 		_, info, hanged, err := env.Exec(rn.opts, prog)
 		if err != nil {
 			log.Fatalf("failed to execute the program: %v", err)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -358,7 +358,7 @@ const (
 )
 
 var (
-	executingProgram1 = []byte("executing program")  // syz-fuzzer output
+	executingProgram1 = []byte("executing program")  // syz-fuzzer, syz-runner output
 	executingProgram2 = []byte("executed programs:") // syz-execprog output
 
 	beforeContext = 1024 << 10


### PR DESCRIPTION
Current state: every 5 minutes VM reboots.
Fix: signal "executing program" to monitor to prevent this reboot.