### PR TITLE
syz-verifier: use int64 instead of int for statistics

### DIFF
--- a/syz-verifier/monitoring_api.go
+++ b/syz-verifier/monitoring_api.go
@@ -44,11 +44,11 @@ func (monitor *Monitor) initHTTPHandlers() {
 // statsJSON provides information for the "/api/stats.json" render.
 type statsJSON struct {
 	StartTime        time.Time
-	TotalMismatches  int
-	TotalProgs       int
-	FlakyProgs       int
-	MismatchingProgs int
-	AverExecSpeed    int
+	TotalMismatches  int64
+	TotalProgs       int64
+	FlakyProgs       int64
+	MismatchingProgs int64
+	AverExecSpeed    int64
 }
 
 // handleStats renders the statsJSON object.
@@ -60,7 +60,7 @@ func (monitor *Monitor) renderStats() interface{} {
 		TotalProgs:       stats.TotalProgs,
 		FlakyProgs:       stats.FlakyProgs,
 		MismatchingProgs: stats.MismatchingProgs,
-		AverExecSpeed:    60 * stats.TotalProgs / int(1+time.Since(stats.StartTime).Seconds()),
+		AverExecSpeed:    60 * stats.TotalProgs / int64(1+time.Since(stats.StartTime).Seconds()),
 	}
 }
 

--- a/syz-verifier/stats.go
+++ b/syz-verifier/stats.go
@@ -17,10 +17,10 @@ import (
 type Stats struct {
 	// Calls stores statistics for all supported system calls.
 	Calls            map[string]*CallStats
-	TotalMismatches  int
-	TotalProgs       int
-	FlakyProgs       int
-	MismatchingProgs int
+	TotalMismatches  int64
+	TotalProgs       int64
+	FlakyProgs       int64
+	MismatchingProgs int64
 	StartTime        time.Time
 }
 
@@ -31,10 +31,10 @@ type CallStats struct {
 	Name string
 	// Mismatches stores the number of errno mismatches identified in the
 	// verified programs for this system call.
-	Mismatches int
+	Mismatches int64
 	// Occurrences is the number of times the system call appeared in a
 	// verified program.
-	Occurrences int
+	Occurrences int64
 	// States stores the kernel return state that caused mismatches.
 	States map[ReturnState]bool
 }
@@ -95,8 +95,8 @@ func (stats *Stats) getCallStatsTextDescription(call string) string {
 		getPercentage(mismatches, stats.TotalMismatches), len(syscallStat.States), stats.getOrderedStates(syscallName))
 }
 
-func (stats *Stats) totalCallsExecuted() int {
-	t := 0
+func (stats *Stats) totalCallsExecuted() int64 {
+	var t int64
 	for _, cs := range stats.Calls {
 		t += cs.Occurrences
 	}
@@ -128,6 +128,6 @@ func (stats *Stats) getOrderedStates(call string) []string {
 	return ss
 }
 
-func getPercentage(value, total int) float64 {
+func getPercentage(value, total int64) float64 {
 	return float64(value) / float64(total) * 100
 }

--- a/syz-verifier/utils_test.go
+++ b/syz-verifier/utils_test.go
@@ -85,7 +85,7 @@ func emptyTestStats() *Stats {
 	}
 }
 
-func makeCallStats(name string, occurrences, mismatches int, states map[ReturnState]bool) *CallStats {
+func makeCallStats(name string, occurrences, mismatches int64, states map[ReturnState]bool) *CallStats {
 	return &CallStats{Name: name,
 		Occurrences: occurrences,
 		Mismatches:  mismatches,


### PR DESCRIPTION
Currently we use int to aggregate statistics.
Counters update require the lock() operation.
Lets relax it and move to int64 + atomic.AddInt64().