### PR TITLE
pkg/mgrconfig: add "interests"

### DIFF
--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -153,6 +153,10 @@ type Config struct {
 	// Completely ignore reports matching these regexps (don't save nor reboot),
 	// must match the first line of crash message.
 	Ignores []string `json:"ignores,omitempty"`
+	// List of regexps to select bugs of interest.
+	// If this list is not empty and none of the regexps match a bug, it's suppressed.
+	// Regexps are matched against bug title, guilty file and maintainer emails.
+	Interests []string `json:"interests,omitempty"`
 
 	// Type of virtual machine to use, e.g. "qemu", "gce", "android", "isolated", etc.
 	Type string `json:"type"`

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -631,6 +631,9 @@ func (ctx *context) testImpl(inst *vm.Instance, command string, duration time.Du
 		ctx.reproLogf(2, "program did not crash")
 		return false, nil
 	}
+	if err := ctx.reporter.Symbolize(rep); err != nil {
+		return false, fmt.Errorf("failed to symbolize report: %v", err)
+	}
 	if rep.Suppressed {
 		ctx.reproLogf(2, "suppressed program crash: %v", rep.Title)
 		return false, nil

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -664,6 +664,9 @@ func (mgr *Manager) emailCrash(crash *Crash) {
 }
 
 func (mgr *Manager) saveCrash(crash *Crash) bool {
+	if err := mgr.reporter.Symbolize(crash.Report); err != nil {
+		log.Logf(0, "failed to symbolize report: %v", err)
+	}
 	if crash.Type == report.MemoryLeak {
 		mgr.mu.Lock()
 		mgr.memoryLeakFrames[crash.Frame] = true
@@ -688,9 +691,6 @@ func (mgr *Manager) saveCrash(crash *Crash) bool {
 		// e.g. if there are some spikes in suppressed reports.
 		crash.Title = "suppressed report"
 		mgr.stats.crashSuppressed.inc()
-	}
-	if err := mgr.reporter.Symbolize(crash.Report); err != nil {
-		log.Logf(0, "failed to symbolize report: %v", err)
 	}
 
 	mgr.stats.crashes.inc()


### PR DESCRIPTION
We have "suppressions" parameter to suppress non-interesting reports.
Add "interests" parameter which is an opposite of "suppressions" --
everything that's not in "interests" is suppressed.
It's matched against bug title, guilty file an maintainer emails.
