### PR TITLE
all: prevent fork bombs in Linux

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -224,6 +224,16 @@ NORETURN void doexit(int status)
 	}
 }
 
+#define SYZ_HAVE_DOEXIT_THREAD 1
+// See the comment in execute_call().
+static NORETURN void doexit_thread(int status)
+{
+	volatile unsigned i;
+	syscall(__NR_exit, status);
+	for (i = 0;; i++) {
+	}
+}
+
 #define SYZ_HAVE_FEATURES 1
 static feature_t features[] = {
     {"leak", setup_leak},

--- a/prog/types.go
+++ b/prog/types.go
@@ -38,6 +38,7 @@ type SyscallAttrs struct {
 	ProgTimeout   uint64
 	IgnoreReturn  bool
 	BreaksReturns bool
+	Forks         bool
 }
 
 // MaxArgs is maximum number of syscall arguments.

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -293,9 +293,9 @@ utimes(filename ptr[in, filename], times ptr[in, itimerval])
 futimesat(dir fd_dir, pathname ptr[in, filename], times ptr[in, itimerval])
 utimensat(dir fd_dir, pathname ptr[in, filename], times ptr[in, itimerval], flags flags[utimensat_flags])
 
-fork() pid (breaks_returns)
-clone(flags flags[clone_flags], sp buffer[in], parentid ptr[out, int32], childtid ptr[out, int32], tls buffer[in]) (breaks_returns)
-clone3(args ptr[in, clone_args], size bytesize[args]) pid (breaks_returns)
+fork() pid (breaks_returns, forks)
+clone(flags flags[clone_flags], sp buffer[in], parentid ptr[out, int32], childtid ptr[out, int32], tls buffer[in]) (breaks_returns, forks)
+clone3(args ptr[in, clone_args], size bytesize[args]) pid (breaks_returns, forks)
 
 clone_args {
 	flags		flags[clone3_flags, int64]


### PR DESCRIPTION
@dvyukov, what do you think about such an approach?

I'm still testing if it works fine, but just sharing early to check if it's reasonable.

---

As was pointed out in #2921, the current approach of limiting the number
of pids per process does not work on all Linux-based kernels.

Introduce a special attribute to mark syscalls that can fork (clone,
clone3, fork). If such a call returns 0, it means we're in the new child
process/thread and so if we exit, then no fork bomb can occur. And at the
same time, it still allows to fuzz those syscalls.

Use plain exit() as exit_group() will be quite destructive if the
executed syscall created just a thread and not a new process.

