### PR TITLE
tools/create-openbsd-vmm-worker: allow dt

### DIFF
--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -45,6 +45,7 @@ cat >etc/sysctl.conf <<EOF
 ddb.max_line=0
 ddb.max_width=0
 hw.smt=1
+kern.allowdt=1
 EOF
 
 cat >etc/installurl <<EOF


### PR DESCRIPTION
Must happen before cranking securelevel. This makes it possible to fuzz btrace
if we ever want that but more importantly: I have a pending request of running
btrace on the workers in order to investigate a recent performance regression.