### PR TITLE
tools/create-buildroot-image.sh: remove bogus mounts

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -166,10 +166,7 @@ selinuxfs /sys/fs/selinux selinuxfs defaults 0 0
 fusectl /sys/fs/fuse/connections fusectl defaults 0 0
 pstore /sys/fs/pstore pstore defaults 0 0
 bpf /sys/fs/bpf bpf defaults 0 0
-mqueue /dev/mqueue mqueue defaults 0 0
-hugetlbfs /dev/hugepages hugetlbfs defaults 0 0
 tracefs /sys/kernel/tracing tracefs defaults 0 0
-fuse.lxcfs /var/lib/lxcfs fuse.lxcfs defaults 0 0
 EOF
 
 # Setup ssh without key/password.


### PR DESCRIPTION
Currently the following errors happen during boot:

mount: mounting mqueue on /dev/mqueue failed: No such file or directory
mount: mounting hugetlbfs on /dev/hugepages failed: No such file or directory
mount: mounting fuse.lxcfs on /var/lib/lxcfs failed: No such file or directory

Remove these mounts.

Mounting of /dev/mqueue and /dev/hugepages fails because these dirs don't exist
and the buildroot init does not create them for some reason. We can't pre-create
them because /dev is itself mounted as devtmpfs.
But we also don't need these mounts. Both mqueue and hugetlbfs are trivial to mount
and the fuzzer does not have problems mounting them locally and using (we have good
coverage anyway).

fuse.lxcfs is simply a fuse filesystem (".lxcfs" is ignored). We don't need to mount
an empty global fuse filesystem. And it won't work w/o a userspace server anyway.
