### PR TITLE
syz-manager: don't symbolize reproducer twice

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -67,6 +67,8 @@ type Report struct {
 	guiltyFile string
 	// reportPrefixLen is length of additional prefix lines that we added before actual crash report.
 	reportPrefixLen int
+	// symbolized is set if the report is symbolized.
+	symbolized bool
 }
 
 type Type int
@@ -220,6 +222,10 @@ func (reporter *Reporter) ContainsCrash(output []byte) bool {
 }
 
 func (reporter *Reporter) Symbolize(rep *Report) error {
+	if rep.symbolized {
+		panic("Symbolize is called twice")
+	}
+	rep.symbolized = true
 	if err := reporter.impl.Symbolize(rep); err != nil {
 		return err
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -846,9 +846,6 @@ func (mgr *Manager) saveFailedRepro(rep *report.Report, stats *repro.Stats) {
 
 func (mgr *Manager) saveRepro(res *repro.Result, stats *repro.Stats, hub bool) {
 	rep := res.Report
-	if err := mgr.reporter.Symbolize(rep); err != nil {
-		log.Logf(0, "failed to symbolize repro: %v", err)
-	}
 	opts := fmt.Sprintf("# %+v\n", res.Opts)
 	prog := res.Prog.Serialize()
 


### PR DESCRIPTION
The recent commit 'pkg/mgrconfig: add "interests"' made pkg/repro
symbolize returned reports. But syz-manager symbolizes them as well.
This leads to double symbolization. Don't symbolize second time.

Fixes #2934
