### PR TITLE
dashboard/config/openbsd: increase the number of procs

### DIFF
--- a/dashboard/config/openbsd/config.ci
+++ b/dashboard/config/openbsd/config.ci
@@ -23,7 +23,7 @@
 				"target": "openbsd/amd64",
 				"cover": true,
 				"reproduce": false,
-				"procs": 2,
+				"procs": 8,
 				"type": "gce",
 				"vm": {
 					"count": 10,
@@ -46,7 +46,7 @@
 				"target": "openbsd/amd64",
 				"cover": true,
 				"reproduce": false,
-				"procs": 2,
+				"procs": 8,
 				"type": "gce",
 				"vm": {
 					"count": 10,
@@ -70,7 +70,7 @@
 				"sandbox": "setuid",
 				"cover": true,
 				"reproduce": false,
-				"procs": 2,
+				"procs": 8,
 				"type": "gce",
 				"vm": {
 					"count": 10,

--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -130,12 +130,12 @@ static int tunfd = -1;
 #if GOOS_netbsd
 // Increased number of tap and tun devices if image script is used
 #define MAX_TUN 64
-
 #elif GOOS_freebsd
 // The maximum number of tun devices is limited by the way IP addresses
 // are assigned. Based on this, the limit is 256.
 #define MAX_TUN 256
-
+#elif GOOS_openbsd
+#define MAX_TUN 8
 #else
 // Maximum number of tun devices in the default install.
 #define MAX_TUN 4

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1671,10 +1671,10 @@ static int tunfd = -1;
 
 #if GOOS_netbsd
 #define MAX_TUN 64
-
 #elif GOOS_freebsd
 #define MAX_TUN 256
-
+#elif GOOS_openbsd
+#define MAX_TUN 8
 #else
 #define MAX_TUN 4
 #endif

--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -52,18 +52,19 @@ cat >etc/installurl <<EOF
 https://${MIRROR}/pub/OpenBSD
 EOF
 
-cat >etc/rc.local <<EOF
+cat >etc/rc.local <<'EOF'
 (
   nc metadata.google.internal 80 <<EOF2 | tail -n1 > /etc/myname.gce \
   && echo >> /etc/myname.gce \
   && mv /etc/myname{.gce,} \
-  && hostname \$(cat /etc/myname)
+  && hostname $(cat /etc/myname)
 GET /computeMetadata/v1/instance/hostname HTTP/1.0
 Host: metadata.google.internal
 Metadata-Flavor: Google
 
 EOF2
 )
+  cd /dev && for i in `jot - 0 7`; do sh MAKEDEV tun$i; done
 EOF
 
 chmod +x install.site


### PR DESCRIPTION
Currently OpenBSD instances are underutilized because of using only 2
syz-executor processes per VM. Change it to 6 to match the number of
procs on other syzbot instances.
