### PR TITLE
dashboard/config: fix sybsystems.yml, DAMON support

### DIFF
--- a/dashboard/config/linux/bits/subsystems.yml
+++ b/dashboard/config/linux/bits/subsystems.yml
@@ -538,6 +538,6 @@ config:
  - THERMAL_NETLINK: [v5.8]
  - VMWARE_VMCI: [x86_64]
  - W1: n
- - DAMON
- - DAMON-VADDR
- - DAMON-DBGFS
+ - DAMON: [v5.15]
+ - DAMON_VADDR: [v5.15]
+ - DAMON_DBGFS: [v5.15]


### PR DESCRIPTION
Currently, "syz-env make configs..." command generate errors because:
1. DAMON config options doesn't exist in Linux kernel versions < 5.15.
2. "-" was used instead of the "_" in the description.