### PR TITLE
dashboard/app: enable readiness check

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -34,3 +34,12 @@ handlers:
 - url: /(|api|bug|text|x/.+|.*)
   script: auto
   secure: always
+
+readiness_check:
+  # https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml#readiness_checks
+  path: "/readiness_check"
+  check_interval_sec: 5
+  timeout_sec: 4
+  failure_threshold: 2
+  success_threshold: 2
+  app_start_timeout_sec: 300

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -351,6 +351,14 @@ func testCrashID(crash *dashapi.Crash) *dashapi.CrashID {
 	}
 }
 
+func TestReadinessCheck(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	_, err := c.GET("/readiness_check")
+	c.expectOK(err)
+}
+
 func TestApp(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/gce"
 	"github.com/google/syzkaller/pkg/html"
 	"github.com/google/syzkaller/pkg/vcs"
 	"golang.org/x/net/context"
@@ -30,6 +31,7 @@ func initHTTPHandlers() {
 	http.Handle("/bug", handlerWrapper(handleBug))
 	http.Handle("/text", handlerWrapper(handleText))
 	http.Handle("/admin", handlerWrapper(handleAdmin))
+	http.Handle("/readiness_check", handlerWrapper(handleReadinessCheck))
 	http.Handle("/x/.config", handlerWrapper(handleTextX(textKernelConfig)))
 	http.Handle("/x/log.txt", handlerWrapper(handleTextX(textCrashLog)))
 	http.Handle("/x/report.txt", handlerWrapper(handleTextX(textCrashReport)))
@@ -333,6 +335,15 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 		MemcacheStats: memcacheStats,
 	}
 	return serveTemplate(w, "admin.html", data)
+}
+
+// handleReadinessCheck is used by the GCP to verify container readiness.
+// The traffic could be migrated to the initialized containers only.
+func handleReadinessCheck(c context.Context, w http.ResponseWriter, r *http.Request) error {
+	if !gce.IsGcpEnvironment() {
+		return nil
+	}
+	return nil
 }
 
 // handleBug serves page about a single bug (which is passed in id argument).

--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -356,4 +357,8 @@ func (ctx *Context) apiCall(fn func() error) error {
 		}
 		return err
 	}
+}
+
+func IsGcpEnvironment() bool {
+	return strings.HasPrefix(os.Getenv("SERVER_SOFTWARE"), "Google App Engine")
 }


### PR DESCRIPTION
The empty readiness check prevents the broken containers deployment.
As a next step, we can add the environment consistency validation here.

