### PR TITLE
executor: bump on FreeBSD the maximum number of tun devices to 256

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -131,6 +131,11 @@ static int tunfd = -1;
 // Increased number of tap and tun devices if image script is used
 #define MAX_TUN 64
 
+#elif GOOS_freebsd
+// The maximum number of tun devices is limited by the way IP addresses
+// are assigned. Based on this, the limit is 256.
+#define MAX_TUN 256
+
 #else
 // Maximum number of tun devices in the default install.
 #define MAX_TUN 4

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -1668,6 +1668,9 @@ static int tunfd = -1;
 #if GOOS_netbsd
 #define MAX_TUN 64
 
+#elif GOOS_freebsd
+#define MAX_TUN 256
+
 #else
 #define MAX_TUN 4
 #endif


### PR DESCRIPTION
syz-execprog now uses twice the number of CPU cores as the number
of processes. Each process might use a tun device. So bump the
maximum number of tun devices to the maximum of 256, which allows
syz-execprog to run with default settings on systems with up to
128 cores.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
