### PR TITLE
sys/targets: Disable some GCC warnings reported for C reproducers

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -554,12 +554,18 @@ var (
 		"-Wparentheses",
 		"-Wunused-const-variable",
 		"-Wframe-larger-than=16384", // executor uses stacks of limited size, so no jumbo frames
+		"-Wno-stringop-overflow",
+		"-Wno-array-bounds",
+		"-Wno-format-overflow",
 	}
 	optionalCFlags = map[string]bool{
 		"-static":                 true, // some distributions don't have static libraries
 		"-static-pie":             true, // this flag is also not supported everywhere
 		"-Wunused-const-variable": true, // gcc 5 does not support this flag
 		"-fsanitize=address":      true, // some OSes don't have ASAN
+		"-Wno-stringop-overflow":  true,
+		"-Wno-array-bounds":       true,
+		"-Wno-format-overflow":    true,
 	}
 	fallbackCFlags = map[string]string{
 		"-static-pie": "-static", // if an ASLR static binary is impossible, build just a static one


### PR DESCRIPTION
Disable GCC warnings:
* stringop-overflow
* array-bounds
* format-overflow

These warnings generate false positives for C reproducers which cause
GCC to fail if -Werror is given.

This commit fixes the following false positives:

/root/test.c: In function ‘main’:
/root/test.c:88:50: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
88 | NONFAILING(*(uint8_t*)0x20000088 = 3);

/root/test.c:85:28: error: ‘memcpy’ offset [0, 23] is out of the bounds [0, 0] [-Werror=array-bounds]
85 | NONFAILING(memcpy((void*)0x20000040, "\001\000\000\000\002\000\000\000\003\000\004\000\000\000\000\000\005\000\000\000\000\000\000\000", 24));

<stdin>:86:40: error: ‘%023llo’ directive writing 23 bytes into a region of size 0 [-Werror=format-overflow=]
<stdin>:43:123: note: in definition of macro ‘NONFAILING’

GCC stringop-overflow bug reports:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88443

syzkaller group discussion:
- https://groups.google.com/g/syzkaller/c/PIEYPflPWhQ

Signed-off-by: Alexander Egorenkov <egorenar@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
