### PR TITLE
sys/targets: fix check of compiler flag for clang

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -862,7 +862,7 @@ func (target *Target) lazyInit() {
 }
 
 func checkFlagSupported(target *Target, flag string) bool {
-	cmd := exec.Command(target.CCompiler, "-x", "c++", "-", "-o", "/dev/null", flag)
+	cmd := exec.Command(target.CCompiler, "-x", "c++", "-", "-o", "/dev/null", "-Werror", flag)
 	cmd.Stdin = strings.NewReader(simpleProg)
 	return cmd.Run() == nil
 }


### PR DESCRIPTION
clang doesn't fail if an unknown flag is specified w/o specifying -Werror
as well.

[syzkaller]# clang -x c++ - -o /dev/null -Wtada < test.c
warning: unknown warning option '-Wtada' [-Wunknown-warning-option]
1 warning generated.
[syzkaller]# echo $?
0

[syzkaller]# clang -x c++ - -o /dev/null -Wtada -Werror < test.c
error: unknown warning option '-Wtada' [-Werror,-Wunknown-warning-option]
[syzkaller]# echo $?
1

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
