### PR TITLE
tools: create /dev/tap* instead of /dev/tun* in OpenBSD

### DIFF
--- a/tools/create-openbsd-vmm-worker.sh
+++ b/tools/create-openbsd-vmm-worker.sh
@@ -64,7 +64,7 @@ Metadata-Flavor: Google
 
 EOF2
 )
-  cd /dev && for i in `jot - 0 7`; do sh MAKEDEV tun$i; done
+  cd /dev && for i in `jot - 0 7`; do sh MAKEDEV tap$i; done
 EOF
 
 chmod +x install.site


### PR DESCRIPTION
Although it's signified in macros as TUN, in fact common_bsd.h opens
/dev/tap* devices. So create 8 TAP devices instead of 8 TUN devices.
