### PR TITLE
executor: add extension point for adding non-mainline pseudo-syscalls

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -458,6 +458,8 @@ static uint16 csum_inet_digest(struct csum_inet* csum)
 #error "unknown OS"
 #endif
 
+#include "common_ext.h"
+
 #if SYZ_EXECUTOR || __NR_syz_execute_func
 // syz_execute_func(text ptr[in, text[taget]])
 static long syz_execute_func(volatile long text)

--- a/executor/common_ext.h
+++ b/executor/common_ext.h
@@ -1,0 +1,6 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// This file is included into executor and C reproducers and can be used to add
+// non-mainline pseudo-syscalls w/o changing any other files.
+// These syscalls should start with syz_ext_.

--- a/pkg/csource/gen.go
+++ b/pkg/csource/gen.go
@@ -39,6 +39,7 @@ func main() {
 		"common_usb_linux.h",
 		"common_usb_netbsd.h",
 		"common_usb.h",
+		"common_ext.h",
 		"android/android_seccomp.h",
 		"kvm.h",
 		"kvm_amd64.S.h",

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -10440,6 +10440,7 @@ static void use_temporary_dir(void)
 #error "unknown OS"
 #endif
 
+
 #if SYZ_EXECUTOR || __NR_syz_execute_func
 static long syz_execute_func(volatile long text)
 {

--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -327,6 +327,14 @@ func isSupportedSyzkall(c *prog.Syscall, target *prog.Target, sandbox string) (b
 			return ok, reason
 		}
 	}
+	if strings.HasPrefix(c.CallName, "syz_ext_") {
+		// Non-mainline pseudo-syscalls in executor/common_ext.h can't have the checking function
+		// and are assumed to be unconditionally supported.
+		if syzkallSupport[c.CallName] != nil {
+			panic("syz_ext_ prefix is reserved for non-mainline pseudo-syscalls")
+		}
+		return true, ""
+	}
 	if isSupported, ok := syzkallSupport[c.CallName]; ok {
 		return isSupported(c, target, sandbox)
 	}

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -235,7 +235,15 @@ func (upd *SyzUpdater) build(commit *vcs.Commit) error {
 		}
 		for _, f := range files {
 			src := filepath.Join(upd.descriptions, f.Name())
-			dst := filepath.Join(upd.syzkallerDir, "sys", targets.Linux, f.Name())
+			dst := ""
+			switch filepath.Ext(src) {
+			case ".txt", ".const":
+				dst = filepath.Join(upd.syzkallerDir, "sys", targets.Linux, f.Name())
+			case ".h":
+				dst = filepath.Join(upd.syzkallerDir, "executor", f.Name())
+			default:
+				continue
+			}
 			if err := osutil.CopyFile(src, dst); err != nil {
 				return err
 			}


### PR DESCRIPTION
Add an empty common_ext.h which is included into executor and C reproducers
and can be used to add non-mainline pseudo-syscalls w/o changing any other files
(by replacing common_ext.h file).

It would be good to finish #2274 which allows to add pseudo-syscalls
along with *.txt descriptions, but #2274 is large and there are several
open design questions. So add this simple extension point for now.
