### PR TITLE
/docs: update instructions for source checkout

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,3 +101,4 @@ Pavel Skripkin
 Linaro
  Lee Jones
 Sabyrzhan Tasbolatov
+Adam Goska

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,14 +85,13 @@ in the same commit.
 [github.com/google/syzkaller](https://github.com/google/syzkaller) and press `Fork` button in the top-right corner of
 the page. This will create `https://github.com/YOUR_GITHUB_USERNAME/syzkaller` repository.
 
-- Checkout main syzkaller repository if you have not already. To work with `go` command the checkout must be under
-`$GOPATH`. The simplest way to do it is to run `go get -u -d github.com/google/syzkaller/prog`, this will checkout
-the repository in `$GOPATH/src/github.com/google/syzkaller`.
+- Checkout main syzkaller repository if you have not already. The simplest way to do it is to run `git clone https://github.com/google/syzkaller`, this will checkout
+the repository in the current working directory.
 - Remember to `export PATH=$GOPATH/bin:$PATH` if you have not already.
 - Then add your repository as an additional origin:
 
     ```shell
-    cd $GOPATH/src/github.com/google/syzkaller
+    cd syzkaller
     git remote add my-origin https://github.com/YOUR_GITHUB_USERNAME/syzkaller.git
     git fetch my-origin
     git checkout -b my-branch my-origin/master

--- a/docs/darwin/README.md
+++ b/docs/darwin/README.md
@@ -218,12 +218,11 @@ Shut down your VM now. We'll let syzkaller boot it back up soon.
 ```
 export GOPATH=/Users/user/go
 export PATH=$GOPATH/bin:$PATH
-export GO111MODULE=off
 ```
 - Relogin and build syzkaller like this:
 ```
-go get -u -d github.com/google/syzkaller/prog
-cd go/src/github.com/google/syzkaller
+git clone https://github.com/google/syzkaller
+cd syzkaller
 make HOSTOS=darwin HOSTARCH=amd64 TARGETOS=darwin TARGETARCH=amd64 SOURCEDIR=/Users/user/115/src/Users/user/kernel/xnu-7195.141.2
 ```
 

--- a/docs/executing_syzkaller_programs.md
+++ b/docs/executing_syzkaller_programs.md
@@ -13,7 +13,7 @@ export GOPATH=$HOME/gopath
 
 2. Download syzkaller sources:
 ``` bash
-GO111MODULE=off go get -u -d github.com/google/syzkaller/prog
+git clone https://github.com/google/syzkaller
 ```
 
 Note that your syzkaller revision must be the same as the one that generated the
@@ -21,7 +21,7 @@ program you're trying to execute.
 
 3. Build necessary syzkaller binaries:
 ``` bash
-cd $GOPATH/src/github.com/google/syzkaller
+cd syzkaller
 make
 ```
 

--- a/docs/freebsd/README.md
+++ b/docs/freebsd/README.md
@@ -22,11 +22,11 @@ When using bhyve as the VM backend, a DHCP server must also be installed:
 ```
 To checkout the syzkaller sources, run:
 ```console
-$ go get -u -d github.com/google/syzkaller/prog
+$ git clone https://github.com/google/syzkaller
 ```
 and the binaries can be built by running:
 ```console
-$ cd go/src/github.com/google/syzkaller/
+$ cd syzkaller
 $ gmake
 ```
 

--- a/docs/linux/external_fuzzing_usb.md
+++ b/docs/linux/external_fuzzing_usb.md
@@ -154,8 +154,8 @@ index 451b2a7b..64af45c7 100644
 ```
 
 ``` bash
-go get -u -d github.com/google/syzkaller/prog
-cd ~/gopath/src/github.com/google/syzkaller
+git clone https://github.com/google/syzkaller
+cd syzkaller
 # Put the patch above into ./syzkaller.patch
 git apply ./syzkaller.patch
 make executor

--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -47,8 +47,8 @@ See [Go: Download and install](https://golang.org/doc/install) for other options
 To download and build `syzkaller`:
 
 ``` bash
-go get -u -d github.com/google/syzkaller/prog
-cd gopath/src/github.com/google/syzkaller/
+git clone https://github.com/google/syzkaller
+cd syzkaller
 make
 ```
 

--- a/docs/netbsd/README.md
+++ b/docs/netbsd/README.md
@@ -30,8 +30,8 @@ At this point you should have a NetBSD distribution in `$HOME/netbsd/dest`.
 
 2. Clone the syzkaller repository.
 	```sh
-	host$ go get -u -d github.com/google/syzkaller/prog
-	host$ cd ~/go/src/github.com/google/syzkaller
+	host$ git clone https://github.com/google/syzkaller
+	host$ cd syzkaller
 	```
 
 3. Compile syzkaller for NetBSD.

--- a/docs/openbsd/setup.md
+++ b/docs/openbsd/setup.md
@@ -31,8 +31,8 @@ Variables used throughout the instructions:
 2. Clone repository:
 
    ```sh
-   $ go get -u -d github.com/google/syzkaller/prog
-   $ cd ~/go/src/github.com/google/syzkaller
+   $ git clone https://github.com/google/syzkaller
+   $ cd syzkaller
    $ gmake all
    ```
 


### PR DESCRIPTION
Updated documentation regarding source code checkout from the legacy gopath
mode 'go get' to 'git clone'.
Fixes #2828

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
