### PR TITLE
RFC: executor: fail on SEGV during clone()

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -90,6 +90,7 @@ static NORETURN PRINTF(2, 3) void failmsg(const char* err, const char* msg, ...)
 // Just exit (e.g. due to temporal ENOMEM error).
 static NORETURN PRINTF(1, 2) void exitf(const char* msg, ...);
 static NORETURN void doexit(int status);
+static NORETURN void doexit_thread(int status);
 
 // Print debug output that is visible when running syz-manager/execprog with -debug flag.
 // Debug output is supposed to be relatively high-level (syscalls executed, return values, timing, etc)

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -224,6 +224,17 @@ NORETURN void doexit(int status)
 	}
 }
 
+// If we need to kill just a single thread (e.g. after cloning), exit_group is not
+// the right choice - it will kill all threads, which might eventually lead to
+// unnecessary SYZFAIL errors.
+NORETURN void doexit_thread(int status)
+{
+	volatile unsigned i;
+	syscall(__NR_exit, status);
+	for (i = 0;; i++) {
+	}
+}
+
 #define SYZ_HAVE_FEATURES 1
 static feature_t features[] = {
     {"leak", setup_leak},

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -548,6 +548,8 @@ func (ctx *context) postProcess(result []byte) []byte {
 	}
 	result = bytes.Replace(result, []byte("NORETURN"), nil, -1)
 	result = bytes.Replace(result, []byte("doexit("), []byte("exit("), -1)
+	// TODO: Figure out what would be the right replacement for doexit_thread().
+	result = bytes.Replace(result, []byte("doexit_thread("), []byte("exit("), -1)
 	result = regexp.MustCompile(`PRINTF\(.*?\)`).ReplaceAll(result, nil)
 	result = regexp.MustCompile(`\t*debug\((.*\n)*?.*\);\n`).ReplaceAll(result, nil)
 	result = regexp.MustCompile(`\t*debug_dump_data\((.*\n)*?.*\);\n`).ReplaceAll(result, nil)


### PR DESCRIPTION
As was found out in #2921, fork bombs are still possible in Linux-based
instances. One of the possible reasons is described below.

An invalid stack can be passed to the clone() call, thus causing it to stumble
on an invalid memory access right during returning from the clone() call. This
is in turn catched by the NONFAILING() macro and the control actually jumps
over it and eventually both the child and the parent continue executing the
same code.

Prevent it by handling SIGSEGV and SIGBUS differently during the clone process.

Co-authored-by: Andrei Vagin <avagin@google.com>

*******************************************************************************

I'm currently testing if this patch works as intended.
