### PR TITLE
syz-manager: recover if corpus.db is corrupted

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -446,7 +446,10 @@ func (mgr *Manager) preloadCorpus() {
 	log.Logf(0, "loading corpus...")
 	corpusDB, err := db.Open(filepath.Join(mgr.cfg.Workdir, "corpus.db"))
 	if err != nil {
-		log.Fatalf("failed to open corpus database: %v", err)
+		if corpusDB == nil {
+			log.Fatalf("failed to open corpus database: %v", err)
+		}
+		log.Logf(0, "read %v inputs from corpus and got error: %v", len(corpusDB.Records), err)
 	}
 	mgr.corpusDB = corpusDB
 


### PR DESCRIPTION
corpus.db may get corrupted on an unexpected reset, etc.
Commit a254b0f5 ("pkg/db: properly handle errors when loading a DB")
made these errors fatal and manager never recovers on its own.
If we got a corrupted db, delete it and try again.
