### PR TITLE
tools/docker: download custom clang to build KMSAN

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -35,6 +35,11 @@ RUN mkdir -p /syzkaller/gopath/src/github.com/google/syzkaller && \
 	mkdir -p /syzkaller/.cache && \
 	chmod -R 0777 /syzkaller
 
+# Download and install the custom Clang required to build KMSAN.
+# TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.
+RUN curl https://storage.googleapis.com/syzkaller/clang-2b554920f11c-patched.tar.gz | tar -C /syzkaller -xz
+RUN ln -s /syzkaller/clang-2b554920f11c-patched /syzkaller/clang-kmsan
+
 # The default Docker prompt is too ugly and takes the whole line:
 # I have no name!@0f3331d2fb54:~/gopath/src/github.com/google/syzkaller$
 RUN echo "export PS1='syz-env🈴 '" > /syzkaller/.bashrc

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -32,6 +32,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 RUN curl https://dl.google.com/go/go1.17.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
+# Download and install the custom Clang required to build KMSAN.
+# TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.
+RUN mkdir -p /syzkaller
+RUN curl https://storage.googleapis.com/syzkaller/clang-2b554920f11c-patched.tar.gz | tar -C /syzkaller -xz
+RUN ln -s /syzkaller/clang-2b554920f11c-patched /syzkaller/clang-kmsan
+
 # Not really GRTE, but it's enough to run some scripts that hardcode the path.
 RUN mkdir -p /usr/grte/v5/bin && ln -s /usr/bin/python3 /usr/grte/v5/bin/python2.7
 


### PR DESCRIPTION
Until KMSAN compiler API is finalized, we often need to use ToT Clang to
build the kernel. Download the latest compiler build from GS, and put it
under /syzkaller/clang-kmsan.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
