### PR TITLE
pkg/db: make repair of the db file optional

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -17,7 +17,7 @@ import (
 func TestBasic(t *testing.T) {
 	fn := tempFile(t)
 	defer os.Remove(fn)
-	db, err := Open(fn)
+	db, err := Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestBasic(t *testing.T) {
 	if !reflect.DeepEqual(db.Records, want) {
 		t.Fatalf("bad db after flush: %v, want: %v", db.Records, want)
 	}
-	db, err = Open(fn)
+	db, err = Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestBasic(t *testing.T) {
 func TestModify(t *testing.T) {
 	fn := tempFile(t)
 	defer os.Remove(fn)
-	db, err := Open(fn)
+	db, err := Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestModify(t *testing.T) {
 	if !reflect.DeepEqual(db.Records, want) {
 		t.Fatalf("bad db after flush: %v, want: %v", db.Records, want)
 	}
-	db, err = Open(fn)
+	db, err = Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestModify(t *testing.T) {
 func TestLarge(t *testing.T) {
 	fn := tempFile(t)
 	defer os.Remove(fn)
-	db, err := Open(fn)
+	db, err := Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestLarge(t *testing.T) {
 	if err := db.Flush(); err != nil {
 		t.Fatalf("failed to flush db: %v", err)
 	}
-	db, err = Open(fn)
+	db, err = Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestOpenInvalid(t *testing.T) {
 	if _, err := f.Write([]byte(`some invalid data`)); err != nil {
 		t.Error(err)
 	}
-	if db, err := Open(f.Name()); err == nil {
+	if db, err := Open(f.Name(), true); err == nil {
 		t.Fatal("opened invalid db")
 	} else if db == nil {
 		t.Fatal("db is nil")
@@ -149,7 +149,7 @@ func TestOpenInaccessible(t *testing.T) {
 	os.Chmod(f.Name(), 0)
 	defer os.Chmod(f.Name(), 0777)
 	defer os.Remove(f.Name())
-	if db, err := Open(f.Name()); err == nil {
+	if db, err := Open(f.Name(), false); err == nil {
 		t.Fatal("opened inaccessible db")
 	} else if db != nil {
 		t.Fatal("db is not nil")
@@ -159,7 +159,7 @@ func TestOpenInaccessible(t *testing.T) {
 func TestOpenCorrupted(t *testing.T) {
 	fn := tempFile(t)
 	defer os.Remove(fn)
-	db, err := Open(fn)
+	db, err := Open(fn, false)
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestOpenCorrupted(t *testing.T) {
 	if err := osutil.WriteFile(fn, data); err != nil {
 		t.Fatalf("failed to write db: %v", err)
 	}
-	db, err = Open(fn)
+	db, err = Open(fn, true)
 	if err == nil {
 		t.Fatalf("no error for corrutped db")
 	}

--- a/syz-hub/state/state.go
+++ b/syz-hub/state/state.go
@@ -102,7 +102,7 @@ func (st *State) Flush() {
 
 func loadDB(file, name string, progs bool) (*db.DB, uint64, error) {
 	log.Logf(0, "reading %v...", name)
-	db, err := db.Open(file)
+	db, err := db.Open(file, true)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to open %v database: %v", name, err)
 	}
@@ -198,7 +198,7 @@ func (st *State) Connect(name, domain string, fresh bool, calls []string, corpus
 
 	os.Remove(mgr.corpusFile)
 	var err error
-	mgr.Corpus, err = db.Open(mgr.corpusFile)
+	mgr.Corpus, err = db.Open(mgr.corpusFile, true)
 	if err != nil {
 		log.Logf(0, "failed to open corpus database: %v", err)
 		return err

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -444,7 +444,7 @@ func (mgr *Manager) vmLoop() {
 
 func (mgr *Manager) preloadCorpus() {
 	log.Logf(0, "loading corpus...")
-	corpusDB, err := db.Open(filepath.Join(mgr.cfg.Workdir, "corpus.db"))
+	corpusDB, err := db.Open(filepath.Join(mgr.cfg.Workdir, "corpus.db"), true)
 	if err != nil {
 		if corpusDB == nil {
 			log.Fatalf("failed to open corpus database: %v", err)

--- a/tools/syz-db/syz-db.go
+++ b/tools/syz-db/syz-db.go
@@ -115,7 +115,7 @@ func pack(dir, file string, target *prog.Target, version uint64) {
 }
 
 func unpack(file, dir string) {
-	db, err := db.Open(file)
+	db, err := db.Open(file, false)
 	if err != nil {
 		tool.Failf("failed to open database: %v", err)
 	}
@@ -133,7 +133,7 @@ func unpack(file, dir string) {
 
 func bench(target *prog.Target, file string) {
 	start := time.Now()
-	db, err := db.Open(file)
+	db, err := db.Open(file, false)
 	if err != nil {
 		tool.Failf("failed to open database: %v", err)
 	}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -289,7 +289,7 @@ func (ctx *Context) getProgramIndex() int {
 func loadPrograms(target *prog.Target, files []string) []*prog.Prog {
 	var progs []*prog.Prog
 	for _, fn := range files {
-		if corpus, err := db.Open(fn); err == nil {
+		if corpus, err := db.Open(fn, false); err == nil {
 			for _, rec := range corpus.Records {
 				p, err := target.Deserialize(rec.Val, prog.NonStrict)
 				if err != nil {


### PR DESCRIPTION
It was too radical to repair and overwrite db file unconditionally.
syz-execprog probes if a given file is a database. Usually it's a crash log
or a single program, but db.Open started to overwrite it.

And an explicit repair flag in db.Open and enable it only in
syz-manager and syz-hub.

Fixes #2997
