### PR TITLE
dashboard/app: store daily stats for individual bugs

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -726,7 +726,6 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 		if err := db.Get(c, bugKey, bug); err != nil {
 			return fmt.Errorf("failed to get bug: %v", err)
 		}
-		bug.NumCrashes++
 		bug.LastTime = now
 		if save {
 			bug.LastSavedCrash = now
@@ -741,6 +740,7 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 		if len(req.Report) != 0 {
 			bug.HasReport = true
 		}
+		bug.increaseCrashStats(now)
 		bug.HappenedOn = mergeString(bug.HappenedOn, build.Manager)
 		// Migration of older entities (for new bugs Title is always in MergedTitles).
 		bug.MergedTitles = mergeString(bug.MergedTitles, bug.Title)


### PR DESCRIPTION
Remember how many crashes are caused by each particular bug each day.

We need this statistics to evaluate the results of our changes to
descriptions and fuzzing engine. For now, let them just be in the DB,
some time later the support on the UI side will also follow.