### PR TITLE
RFC: syz-manager: facilitate the removal of unneeded calls from the corpus

### DIFF
--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -141,6 +141,11 @@ type Config struct {
 	// By default the value is 0, i.e. all VMs can be used for all purposes.
 	FuzzingVMs int `json:"fuzzing_vms,omitempty"`
 
+	// Keep existing programs in the corpus even if they no longer pass syscall filters.
+	// By default it is true, as this is the desired behavior when executing syzkaller
+	// locally.
+	PreserveCorpus bool `json:"preserve_corpus"`
+
 	// List of syscalls to test (optional). For example:
 	//	"enable_syscalls": [ "mmap", "openat$ashmem", "ioctl$ASHMEM*" ]
 	EnabledSyscalls []string `json:"enable_syscalls,omitempty"`

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -78,13 +78,14 @@ func LoadPartialFile(filename string) (*Config, error) {
 
 func defaultValues() *Config {
 	return &Config{
-		SSHUser:      "root",
-		Cover:        true,
-		Reproduce:    true,
-		Sandbox:      "none",
-		RPC:          ":0",
-		MaxCrashLogs: 100,
-		Procs:        6,
+		SSHUser:        "root",
+		Cover:          true,
+		Reproduce:      true,
+		Sandbox:        "none",
+		RPC:            ":0",
+		MaxCrashLogs:   100,
+		Procs:          6,
+		PreserveCorpus: true,
 	}
 }
 

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -507,6 +507,13 @@ func (mgr *Manager) writeConfig(buildTag string) (string, error) {
 	}
 	mgrcfg.Tag = buildTag
 	mgrcfg.Workdir = mgr.workDir
+	// There's not much point in keeping disabled progs in the syz-ci corpuses.
+	// If the syscalls on some instance are enabled again, syz-hub will provide
+	// it with the missing progs over time.
+	// And, on the other hand, PreserveCorpus=false lets us disable syscalls in
+	// the least destructive way for the rest of the corpus - calls will be cut
+	// out the of programs and the leftovers will be retriaged.
+	mgrcfg.PreserveCorpus = false
 	if err := instance.SetConfigImage(mgrcfg, mgr.currentDir, false); err != nil {
 		return "", err
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -531,10 +531,12 @@ func (mgr *Manager) loadProg(data []byte, minimized, smashed bool) bool {
 		return false
 	}
 	if disabled {
-		// This program contains a disabled syscall.
-		// We won't execute it, but remember its hash so
-		// it is not deleted during minimization.
-		mgr.disabledHashes[hash.String(data)] = struct{}{}
+		if mgr.cfg.PreserveCorpus {
+			// This program contains a disabled syscall.
+			// We won't execute it, but remember its hash so
+			// it is not deleted during minimization.
+			mgr.disabledHashes[hash.String(data)] = struct{}{}
+		}
 		return true
 	}
 	mgr.candidates = append(mgr.candidates, rpctype.Candidate{


### PR DESCRIPTION
Right now we have two inconveniences:
- If a call is disabled, all progs which contain it are ignored. Even if they might still give some coverage.
- If a program is disabled as indicated above, it remains in the corpus forever. Even if we don't need it anymore.

This PR tries to addresses both of them in such a way that should be beneficial both for local syzkaller execution and for syzbot.