### PR TITLE
tools/syz-testbed: support syz-repro and other enhancements

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -9,7 +9,7 @@ import (
 
 // Unfortunately, if we want to apply a JSON patch to some configuration, we cannot just unmarshal
 // it twice - in that case json.RawMessage objects will be completely replaced, but not merged.
-func MergeJSONData(left, right []byte) ([]byte, error) {
+func MergeJSONs(left, right []byte) ([]byte, error) {
 	vLeft, err := parseFragment(left)
 	if err != nil {
 		return nil, err
@@ -18,8 +18,17 @@ func MergeJSONData(left, right []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	merged := mergeRecursive(vLeft, vRight)
-	return json.Marshal(merged)
+	return json.Marshal(mergeRecursive(vLeft, vRight))
+}
+
+// Recursively apply a patch to a raw JSON data.
+// Patch is supposed to be a map, which possibly nests other map objects.
+func PatchJSON(left []byte, patch map[string]interface{}) ([]byte, error) {
+	vLeft, err := parseFragment(left)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(mergeRecursive(vLeft, patch))
 }
 
 func parseFragment(input []byte) (parsed interface{}, err error) {

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/syzkaller/pkg/config"
 )
 
-func TestMergeJSONData(t *testing.T) {
+func TestMergeJSONs(t *testing.T) {
 	tests := []struct {
 		left   string
 		right  string
@@ -38,7 +38,52 @@ func TestMergeJSONData(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		res, err := config.MergeJSONData([]byte(test.left), []byte(test.right))
+		res, err := config.MergeJSONs([]byte(test.left), []byte(test.right))
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if !bytes.Equal(res, []byte(test.result)) {
+			t.Errorf("expected %s, got %s", test.result, res)
+		}
+	}
+}
+
+func TestPatchJSON(t *testing.T) {
+	tests := []struct {
+		left   string
+		patch  map[string]interface{}
+		result string
+	}{
+		{
+			`{"a":1,"b":2}`,
+			map[string]interface{}{"b": "string val"},
+			`{"a":1,"b":"string val"}`,
+		},
+		{
+			`{"a":1,"b":2}`,
+			map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": 5,
+					},
+				},
+			},
+			`{"a":{"b":{"c":5}},"b":2}`,
+		},
+		{
+			`{}`,
+			map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": 0,
+					},
+				},
+			},
+			`{"a":{"b":{"c":0}}}`,
+		},
+	}
+	for _, test := range tests {
+		res, err := config.PatchJSON([]byte(test.left), test.patch)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -8,6 +8,7 @@ package html
 import (
 	"fmt"
 	"html/template"
+	"io/fs"
 	"reflect"
 	"strings"
 	texttemplate "text/template"
@@ -17,8 +18,7 @@ import (
 )
 
 func CreatePage(page string) *template.Template {
-	const headTempl = `<style type="text/css" media="screen">%v</style><script>%v</script>`
-	page = strings.Replace(page, "{{HEAD}}", fmt.Sprintf(headTempl, style, js), 1)
+	page = strings.Replace(page, "{{HEAD}}", getHeadTemplate(), 1)
 	return template.Must(template.New("").Funcs(Funcs).Parse(page))
 }
 
@@ -26,8 +26,18 @@ func CreateGlob(glob string) *template.Template {
 	return template.Must(template.New("").Funcs(Funcs).ParseGlob(glob))
 }
 
+func CreateFromFS(fs fs.FS, patterns ...string) *template.Template {
+	t := template.Must(template.New("syz-head").Funcs(Funcs).Parse(getHeadTemplate()))
+	return template.Must(t.New("").Funcs(Funcs).ParseFS(fs, patterns...))
+}
+
 func CreateTextGlob(glob string) *texttemplate.Template {
 	return texttemplate.Must(texttemplate.New("").Funcs(texttemplate.FuncMap(Funcs)).ParseGlob(glob))
+}
+
+func getHeadTemplate() string {
+	const headTempl = `<style type="text/css" media="screen">%v</style><script>%v</script>`
+	return fmt.Sprintf(headTempl, style, js)
 }
 
 var Funcs = template.FuncMap{

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -145,7 +145,7 @@ var (
 	noPeriodComment   = regexp.MustCompile(`^// [A-Z][a-z].+[a-z]$`)
 	lowerCaseComment  = regexp.MustCompile(`^// [a-z]+ `)
 	onelineExceptions = regexp.MustCompile(`// want \"|http:|https:`)
-	specialComment    = regexp.MustCompile(`//go:generate|//go:build|// nolint:`)
+	specialComment    = regexp.MustCompile(`//go:generate|//go:build|//go:embed|// nolint:`)
 )
 
 // checkStringLenCompare checks for string len comparisons with 0.

--- a/tools/syz-testbed/checkout.go
+++ b/tools/syz-testbed/checkout.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	syz_instance "github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/pkg/vcs"
 )
 
@@ -24,7 +27,26 @@ type Checkout struct {
 	Running       map[Instance]bool
 	Completed     []RunResult
 	LastRunning   time.Time
+	reporter      *report.Reporter
 	mu            sync.Mutex
+}
+
+func (checkout *Checkout) GetReporter() *report.Reporter {
+	checkout.mu.Lock()
+	defer checkout.mu.Unlock()
+	if checkout.reporter == nil {
+		// Unfortunately, we have no other choice but to parse the config to use our own parser.
+		// TODO: add some tool to syzkaller that would just parse logs and then execute it here?
+		mgrCfg, err := mgrconfig.LoadPartialData(checkout.ManagerConfig)
+		if err != nil {
+			tool.Failf("failed to parse mgr config for %s: %s", checkout.Name, err)
+		}
+		checkout.reporter, err = report.NewReporter(mgrCfg)
+		if err != nil {
+			tool.Failf("failed to get reporter for %s: %s", checkout.Name, err)
+		}
+	}
+	return checkout.reporter
 }
 
 func (checkout *Checkout) AddRunning(instance Instance) {

--- a/tools/syz-testbed/checkout.go
+++ b/tools/syz-testbed/checkout.go
@@ -4,13 +4,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"path/filepath"
 	"time"
 
 	syz_instance "github.com/google/syzkaller/pkg/instance"
-	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/vcs"
 )
@@ -18,7 +18,7 @@ import (
 type Checkout struct {
 	Path          string
 	Name          string
-	ManagerConfig *mgrconfig.Config
+	ManagerConfig json.RawMessage
 	Running       []*Instance
 	Completed     []*RunResult
 }
@@ -35,7 +35,7 @@ func (checkout *Checkout) ArchiveRunning() error {
 	return nil
 }
 
-func (ctx *TestbedContext) NewCheckout(config *CheckoutConfig, mgrConfig *mgrconfig.Config) (*Checkout, error) {
+func (ctx *TestbedContext) NewCheckout(config *CheckoutConfig, mgrConfig json.RawMessage) (*Checkout, error) {
 	checkout := &Checkout{
 		Name:          config.Name,
 		Path:          filepath.Join(ctx.Config.Workdir, "checkouts", config.Name),

--- a/tools/syz-testbed/html.go
+++ b/tools/syz-testbed/html.go
@@ -166,10 +166,16 @@ type uiMainPage struct {
 }
 
 func (ctx *TestbedContext) getTableTypes() []uiTableType {
-	typeList := []uiTableType{
+	allTypeList := []uiTableType{
 		{HTMLStatsTable, "Statistics", ctx.httpMainStatsTable},
 		{HTMLBugsTable, "Bugs", ctx.genSimpleTableController((StatView).GenerateBugTable, true)},
 		{HTMLBugCountsTable, "Bug Counts", ctx.genSimpleTableController((StatView).GenerateBugCountsTable, false)},
+	}
+	typeList := []uiTableType{}
+	for _, t := range allTypeList {
+		if ctx.Target.SupportsHTMLView(t.Key) {
+			typeList = append(typeList, t)
+		}
 	}
 	return typeList
 }

--- a/tools/syz-testbed/html.go
+++ b/tools/syz-testbed/html.go
@@ -137,9 +137,13 @@ type uiTable struct {
 }
 
 const (
-	HTMLStatsTable     = "stats"
-	HTMLBugsTable      = "bugs"
-	HTMLBugCountsTable = "bug_counts"
+	HTMLStatsTable         = "stats"
+	HTMLBugsTable          = "bugs"
+	HTMLBugCountsTable     = "bug_counts"
+	HTMLReprosTable        = "repros"
+	HTMLCReprosTable       = "crepros"
+	HTMLReproAttemptsTable = "repro_attempts"
+	HTMLReproDurationTable = "repro_duration"
 )
 
 type uiTableGenerator = func(urlPrefix string, view StatView, r *http.Request) (*uiTable, error)
@@ -170,6 +174,10 @@ func (ctx *TestbedContext) getTableTypes() []uiTableType {
 		{HTMLStatsTable, "Statistics", ctx.httpMainStatsTable},
 		{HTMLBugsTable, "Bugs", ctx.genSimpleTableController((StatView).GenerateBugTable, true)},
 		{HTMLBugCountsTable, "Bug Counts", ctx.genSimpleTableController((StatView).GenerateBugCountsTable, false)},
+		{HTMLReprosTable, "Repros", ctx.genSimpleTableController((StatView).GenerateReproSuccessTable, true)},
+		{HTMLCReprosTable, "C Repros", ctx.genSimpleTableController((StatView).GenerateCReproSuccessTable, true)},
+		{HTMLReproAttemptsTable, "All Repros", ctx.genSimpleTableController((StatView).GenerateReproAttemptsTable, false)},
+		{HTMLReproDurationTable, "Duration", ctx.genSimpleTableController((StatView).GenerateReproDurationTable, true)},
 	}
 	typeList := []uiTableType{}
 	for _, t := range allTypeList {

--- a/tools/syz-testbed/instance.go
+++ b/tools/syz-testbed/instance.go
@@ -63,7 +63,10 @@ func (inst *Instance) Run() error {
 }
 
 func (inst *Instance) Stop() {
-	inst.stopChannel <- true
+	select {
+	case inst.stopChannel <- true:
+	default:
+	}
 }
 
 func (inst *Instance) FetchResult() (*RunResult, error) {

--- a/tools/syz-testbed/instance.go
+++ b/tools/syz-testbed/instance.go
@@ -38,8 +38,9 @@ func (inst *Instance) Run() error {
 	cmd.Stderr = logfile
 
 	complete := make(chan error)
+	cmd.Start()
 	go func() {
-		complete <- cmd.Run()
+		complete <- cmd.Wait()
 	}()
 
 	select {

--- a/tools/syz-testbed/instance.go
+++ b/tools/syz-testbed/instance.go
@@ -14,28 +14,35 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 )
 
+type Instance interface {
+	Run() error
+	Stop()
+	FetchResult() (RunResult, error)
+}
+
 // The essential information about an active instance.
-type Instance struct {
+type InstanceCommon struct {
 	Name            string
-	Workdir         string
-	BenchFile       string
 	LogFile         string
 	ExecCommand     string
 	ExecCommandArgs []string
 	stopChannel     chan bool
 }
 
-func (inst *Instance) Run() error {
+func (inst *InstanceCommon) Run() error {
 	const stopDelay = time.Minute
 
-	logfile, err := os.Create(inst.LogFile)
-	if err != nil {
-		return fmt.Errorf("[%s] failed to create logfile: %s", inst.Name, err)
-	}
 	log.Printf("[%s] starting", inst.Name)
 	cmd := osutil.GraciousCommand(inst.ExecCommand, inst.ExecCommandArgs...)
-	cmd.Stdout = logfile
-	cmd.Stderr = logfile
+
+	if inst.LogFile != "" {
+		logfile, err := os.Create(inst.LogFile)
+		if err != nil {
+			return fmt.Errorf("[%s] failed to create logfile: %s", inst.Name, err)
+		}
+		cmd.Stdout = logfile
+		cmd.Stderr = logfile
+	}
 
 	complete := make(chan error)
 	cmd.Start()
@@ -44,8 +51,8 @@ func (inst *Instance) Run() error {
 	}()
 
 	select {
-	case err := <-complete:
-		return fmt.Errorf("[%s] stopped: %s", inst.Name, err)
+	case <-complete:
+		return nil
 	case <-inst.stopChannel:
 		// TODO: handle other OSes?
 		cmd.Process.Signal(os.Interrupt)
@@ -62,14 +69,20 @@ func (inst *Instance) Run() error {
 	}
 }
 
-func (inst *Instance) Stop() {
+func (inst *InstanceCommon) Stop() {
 	select {
 	case inst.stopChannel <- true:
 	default:
 	}
 }
 
-func (inst *Instance) FetchResult() (*RunResult, error) {
+type SyzManagerInstance struct {
+	InstanceCommon
+	SyzkallerInfo
+	RunTime time.Duration
+}
+
+func (inst *SyzManagerInstance) FetchResult() (RunResult, error) {
 	bugs, err := collectBugs(inst.Workdir)
 	if err != nil {
 		return nil, err
@@ -78,39 +91,45 @@ func (inst *Instance) FetchResult() (*RunResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &RunResult{
-		Workdir:     inst.Workdir,
+	return &SyzManagerResult{
 		Bugs:        bugs,
 		StatRecords: records,
 	}, nil
 }
 
-func (ctx *TestbedContext) NewInstance(checkout *Checkout, mgrName string) (*Instance, error) {
-	defer func() {
-		ctx.NextInstanceID++
+func (inst *SyzManagerInstance) Run() error {
+	ret := make(chan error, 1)
+	go func() {
+		ret <- inst.InstanceCommon.Run()
 	}()
-	name := fmt.Sprintf("%s-%d", checkout.Name, ctx.NextInstanceID)
-	managerCfgPath := filepath.Join(checkout.Path, fmt.Sprintf("syz-%d.cnf", ctx.NextInstanceID))
-	workdir := filepath.Join(checkout.Path, fmt.Sprintf("workdir_%d", ctx.NextInstanceID))
-	bench := filepath.Join(checkout.Path, fmt.Sprintf("bench-%d.txt", ctx.NextInstanceID))
-	logFile := filepath.Join(checkout.Path, fmt.Sprintf("log-%d.txt", ctx.NextInstanceID))
 
-	log.Printf("[%s] Generating workdir", name)
+	select {
+	case err := <-ret:
+		// Syz-managers are not supposed to stop themselves under normal circumstances.
+		// If one of them did stop, there must have been a very good reason to do so.
+		return fmt.Errorf("[%s] stopped: %v", inst.Name, err)
+	case <-time.After(inst.RunTime):
+		inst.Stop()
+		<-ret
+		return nil
+	}
+}
+
+type SyzkallerInfo struct {
+	Workdir   string
+	CfgFile   string
+	BenchFile string
+}
+
+func SetupSyzkallerInstance(mgrName, folder string, checkout *Checkout) (*SyzkallerInfo, error) {
+	workdir := filepath.Join(folder, "workdir")
+	log.Printf("[%s] Generating workdir", mgrName)
 	err := osutil.MkdirAll(workdir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workdir %s", workdir)
 	}
-
-	if ctx.Config.Corpus != "" {
-		log.Printf("[%s] Copying corpus", name)
-		corpusPath := filepath.Join(workdir, "corpus.db")
-		err = osutil.CopyFile(ctx.Config.Corpus, corpusPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy corpus from %s: %s", ctx.Config.Corpus, err)
-		}
-	}
-
-	log.Printf("[%s] Generating syz-manager config", name)
+	log.Printf("[%s] Generating syz-manager config", mgrName)
+	cfgFile := filepath.Join(folder, "manager.cfg")
 	managerCfg, err := config.PatchJSON(checkout.ManagerConfig, map[string]interface{}{
 		"name":      mgrName,
 		"workdir":   workdir,
@@ -119,19 +138,40 @@ func (ctx *TestbedContext) NewInstance(checkout *Checkout, mgrName string) (*Ins
 	if err != nil {
 		return nil, fmt.Errorf("failed to patch mgr config")
 	}
-
-	err = osutil.WriteFile(managerCfgPath, managerCfg)
+	err = osutil.WriteFile(cfgFile, managerCfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save manager config to %s: %s", managerCfgPath, err)
+		return nil, fmt.Errorf("failed to save manager config to %s: %s", cfgFile, err)
 	}
+	return &SyzkallerInfo{
+		Workdir:   workdir,
+		CfgFile:   cfgFile,
+		BenchFile: filepath.Join(folder, "bench.txt"),
+	}, nil
+}
 
-	return &Instance{
-		Name:            name,
-		Workdir:         workdir,
-		BenchFile:       bench,
-		LogFile:         logFile,
-		ExecCommand:     filepath.Join(checkout.Path, "bin", "syz-manager"),
-		ExecCommandArgs: []string{"-config", managerCfgPath, "-bench", bench},
-		stopChannel:     make(chan bool, 1),
+func (t *SyzManagerTarget) newSyzManagerInstance(slotName, uniqName string, checkout *Checkout) (Instance, error) {
+	folder := filepath.Join(checkout.Path, fmt.Sprintf("run-%s", uniqName))
+	common, err := SetupSyzkallerInstance(slotName, folder, checkout)
+	if err != nil {
+		return nil, err
+	}
+	if t.config.Corpus != "" {
+		log.Printf("[%s] Copying corpus", uniqName)
+		corpusPath := filepath.Join(common.Workdir, "corpus.db")
+		err = osutil.CopyFile(t.config.Corpus, corpusPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to copy corpus from %s: %s", t.config.Corpus, err)
+		}
+	}
+	return &SyzManagerInstance{
+		InstanceCommon: InstanceCommon{
+			Name:            uniqName,
+			LogFile:         filepath.Join(folder, "log.txt"),
+			ExecCommand:     filepath.Join(checkout.Path, "bin", "syz-manager"),
+			ExecCommandArgs: []string{"-config", common.CfgFile, "-bench", common.BenchFile},
+			stopChannel:     make(chan bool, 1),
+		},
+		SyzkallerInfo: *common,
+		RunTime:       t.config.RunTime.Duration,
 	}, nil
 }

--- a/tools/syz-testbed/stats.go
+++ b/tools/syz-testbed/stats.go
@@ -142,7 +142,7 @@ func (view StatView) GenerateBugTable() (*Table, error) {
 	for _, bug := range summaries {
 		for _, group := range view.Groups {
 			if bug.found[group.Name] {
-				table.Set(bug.title, group.Name, "YES")
+				table.Set(bug.title, group.Name, NewBoolCell(true))
 			}
 		}
 	}

--- a/tools/syz-testbed/stats.go
+++ b/tools/syz-testbed/stats.go
@@ -18,6 +18,7 @@ import (
 
 type BugInfo struct {
 	Title string
+	Logs  []string
 }
 
 type RunResult interface{}
@@ -61,12 +62,24 @@ func collectBugs(workdir string) ([]BugInfo, error) {
 	}
 	bugs := []BugInfo{}
 	for _, dir := range dirs {
-		titleBytes, err := ioutil.ReadFile(filepath.Join(crashdir, dir, "description"))
+		bugFolder := filepath.Join(crashdir, dir)
+		titleBytes, err := ioutil.ReadFile(filepath.Join(bugFolder, "description"))
 		if err != nil {
 			return nil, err
 		}
-		title := strings.TrimSpace(string(titleBytes))
-		bugs = append(bugs, BugInfo{title})
+		bug := BugInfo{
+			Title: strings.TrimSpace(string(titleBytes)),
+		}
+		files, err := ioutil.ReadDir(bugFolder)
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range files {
+			if strings.HasPrefix(f.Name(), "log") {
+				bug.Logs = append(bug.Logs, filepath.Join(bugFolder, f.Name()))
+			}
+		}
+		bugs = append(bugs, bug)
 	}
 	return bugs, nil
 }

--- a/tools/syz-testbed/table.go
+++ b/tools/syz-testbed/table.go
@@ -30,6 +30,11 @@ type ValueCell struct {
 	PValue        *float64
 }
 
+type RatioCell struct {
+	TrueCount  int
+	TotalCount int
+}
+
 func NewValueCell(sample *stats.Sample) *ValueCell {
 	return &ValueCell{Value: sample.Median(), Sample: sample}
 }
@@ -40,6 +45,14 @@ func (c *ValueCell) String() string {
 		return fmt.Sprintf("%.1f", c.Value)
 	}
 	return fmt.Sprintf("%.0f", math.Round(c.Value))
+}
+
+func NewRatioCell(trueCount, totalCount int) *RatioCell {
+	return &RatioCell{trueCount, totalCount}
+}
+
+func (c *RatioCell) String() string {
+	return fmt.Sprintf("%d / %d", c.TrueCount, c.TotalCount)
 }
 
 func NewTable(topLeft string, columns ...string) *Table {

--- a/tools/syz-testbed/table.go
+++ b/tools/syz-testbed/table.go
@@ -35,6 +35,10 @@ type RatioCell struct {
 	TotalCount int
 }
 
+type BoolCell struct {
+	Value bool
+}
+
 func NewValueCell(sample *stats.Sample) *ValueCell {
 	return &ValueCell{Value: sample.Median(), Sample: sample}
 }
@@ -53,6 +57,19 @@ func NewRatioCell(trueCount, totalCount int) *RatioCell {
 
 func (c *RatioCell) String() string {
 	return fmt.Sprintf("%d / %d", c.TrueCount, c.TotalCount)
+}
+
+func NewBoolCell(value bool) *BoolCell {
+	return &BoolCell{
+		Value: value,
+	}
+}
+
+func (c *BoolCell) String() string {
+	if c.Value {
+		return "YES"
+	}
+	return "NO"
 }
 
 func NewTable(topLeft string, columns ...string) *Table {

--- a/tools/syz-testbed/targets.go
+++ b/tools/syz-testbed/targets.go
@@ -1,0 +1,83 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+// TestbedTarget represents all behavioral differences between specific testbed targets.
+type TestbedTarget interface {
+	NewJob(slotName string, checkouts []*Checkout) (*Checkout, Instance, error)
+	SaveStatView(view StatView, dir string) error
+	SupportsHTMLView(key string) bool
+}
+
+type SyzManagerTarget struct {
+	config         *TestbedConfig
+	nextCheckoutID int
+	nextInstanceID int
+	mu             sync.Mutex
+}
+
+var targetConstructors = map[string]func(cfg *TestbedConfig) TestbedTarget{
+	"syz-manager": func(cfg *TestbedConfig) TestbedTarget {
+		return &SyzManagerTarget{
+			config: cfg,
+		}
+	},
+}
+
+func (t *SyzManagerTarget) NewJob(slotName string, checkouts []*Checkout) (*Checkout, Instance, error) {
+	// Round-robin strategy should suffice.
+	t.mu.Lock()
+	checkout := checkouts[t.nextCheckoutID%len(checkouts)]
+	instanceID := t.nextInstanceID
+	t.nextCheckoutID++
+	t.nextInstanceID++
+	t.mu.Unlock()
+	uniqName := fmt.Sprintf("%s-%d", checkout.Name, instanceID)
+	instance, err := t.newSyzManagerInstance(slotName, uniqName, checkout)
+	if err != nil {
+		return nil, nil, err
+	}
+	return checkout, instance, nil
+}
+
+func (t *SyzManagerTarget) SupportsHTMLView(key string) bool {
+	supported := map[string]bool{
+		HTMLBugsTable:      true,
+		HTMLBugCountsTable: true,
+		HTMLStatsTable:     true,
+	}
+	return supported[key]
+}
+
+func (t *SyzManagerTarget) SaveStatView(view StatView, dir string) error {
+	benchDir := filepath.Join(dir, "benches")
+	err := osutil.MkdirAll(benchDir)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %s", benchDir, err)
+	}
+	tableStats := map[string]func(view StatView) (*Table, error){
+		"bugs.csv":           (StatView).GenerateBugTable,
+		"checkout_stats.csv": (StatView).StatsTable,
+		"instance_stats.csv": (StatView).InstanceStatsTable,
+	}
+	for fileName, genFunc := range tableStats {
+		table, err := genFunc(view)
+		if err == nil {
+			table.SaveAsCsv(filepath.Join(dir, fileName))
+		} else {
+			log.Printf("stat generation error: %s", err)
+		}
+	}
+	_, err = view.SaveAvgBenches(benchDir)
+	return err
+}

--- a/tools/syz-testbed/targets.go
+++ b/tools/syz-testbed/targets.go
@@ -5,11 +5,14 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/tool"
 )
 
 // TestbedTarget represents all behavioral differences between specific testbed targets.
@@ -30,6 +33,35 @@ var targetConstructors = map[string]func(cfg *TestbedConfig) TestbedTarget{
 	"syz-manager": func(cfg *TestbedConfig) TestbedTarget {
 		return &SyzManagerTarget{
 			config: cfg,
+		}
+	},
+	"syz-repro": func(cfg *TestbedConfig) TestbedTarget {
+		inputs := []*SyzReproInput{}
+		if cfg.InputLogs != "" {
+			err := filepath.Walk(cfg.InputLogs, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if !info.IsDir() {
+					inputs = append(inputs, &SyzReproInput{
+						Path:  path,
+						runBy: make(map[*Checkout]int),
+					})
+				}
+				return nil
+			})
+			if err != nil {
+				tool.Failf("failed to read logs file directory: %s", err)
+			}
+			// TODO: shuffle?
+		}
+		if len(inputs) == 0 {
+			tool.Failf("no inputs given")
+		}
+		return &SyzReproTarget{
+			config:     cfg,
+			dedupTitle: make(map[string]int),
+			inputs:     inputs,
 		}
 	},
 }
@@ -80,4 +112,116 @@ func (t *SyzManagerTarget) SaveStatView(view StatView, dir string) error {
 	}
 	_, err = view.SaveAvgBenches(benchDir)
 	return err
+}
+
+// TODO: consider other repro testing modes.
+// E.g. group different logs by title. Then we could also set different sets of inputs
+// for each checkout. It can be important if we improve executor logging.
+type SyzReproTarget struct {
+	config     *TestbedConfig
+	inputs     []*SyzReproInput
+	seqID      int
+	dedupTitle map[string]int
+	mu         sync.Mutex
+}
+
+type SyzReproInput struct {
+	Path      string
+	Title     string
+	Skip      bool
+	origTitle string
+	runBy     map[*Checkout]int
+}
+
+func (inp *SyzReproInput) QueryTitle(checkout *Checkout, dupsMap map[string]int) error {
+	data, err := ioutil.ReadFile(inp.Path)
+	if err != nil {
+		return fmt.Errorf("failed to read: %s", err)
+	}
+	report := checkout.GetReporter().Parse(data)
+	if report == nil {
+		return fmt.Errorf("found no crash")
+	}
+	if inp.Title == "" {
+		inp.origTitle = report.Title
+		inp.Title = report.Title
+		// Some bug titles may be present in multiple log files.
+		// Ensure they are all distict to the user.
+		dupsMap[inp.origTitle]++
+		if dupsMap[inp.Title] > 1 {
+			inp.Title += fmt.Sprintf(" (%d)", dupsMap[inp.origTitle])
+		}
+	}
+	return nil
+}
+
+func (t *SyzReproTarget) NewJob(slotName string, checkouts []*Checkout) (*Checkout, Instance, error) {
+	t.mu.Lock()
+	seqID := t.seqID
+	checkout := checkouts[t.seqID%len(checkouts)]
+	t.seqID++
+	// This may be not the most efficient algorithm, but it guarantees even distribution of
+	// resources and CPU time is negligible in comparison with the amount of time each instance runs.
+	var input *SyzReproInput
+	for _, candidate := range t.inputs {
+		if candidate.Skip {
+			continue
+		}
+		if candidate.runBy[checkout] == 0 {
+			// This is the first time we'll attempt to give this log to the checkout.
+			// Check if it can handle it.
+			err := candidate.QueryTitle(checkout, t.dedupTitle)
+			if err != nil {
+				log.Printf("[log %s]: %s, skipping", candidate.Path, err)
+				candidate.Skip = true
+				continue
+			}
+		}
+		if input == nil || input.runBy[checkout] > candidate.runBy[checkout] {
+			// Pick the least executed one.
+			input = candidate
+		}
+	}
+
+	if input == nil {
+		t.mu.Unlock()
+		return nil, nil, fmt.Errorf("no available inputs")
+	}
+	input.runBy[checkout]++
+	t.mu.Unlock()
+
+	uniqName := fmt.Sprintf("%s-%d", checkout.Name, seqID)
+	instance, err := t.newSyzReproInstance(slotName, uniqName, input, checkout)
+	if err != nil {
+		return nil, nil, err
+	}
+	return checkout, instance, nil
+}
+
+func (t *SyzReproTarget) SupportsHTMLView(key string) bool {
+	supported := map[string]bool{
+		HTMLReprosTable:        true,
+		HTMLCReprosTable:       true,
+		HTMLReproAttemptsTable: true,
+		HTMLReproDurationTable: true,
+	}
+	return supported[key]
+}
+
+func (t *SyzReproTarget) SaveStatView(view StatView, dir string) error {
+	tableStats := map[string]func(view StatView) (*Table, error){
+		"repro_success.csv":   (StatView).GenerateReproSuccessTable,
+		"crepros_success.csv": (StatView).GenerateCReproSuccessTable,
+		"repro_attempts.csv":  (StatView).GenerateReproAttemptsTable,
+		"repro_duration.csv":  (StatView).GenerateReproDurationTable,
+	}
+	for fileName, genFunc := range tableStats {
+		table, err := genFunc(view)
+		if err == nil {
+			table.SaveAsCsv(filepath.Join(dir, fileName))
+		} else {
+			log.Printf("stat generation error: %s", err)
+		}
+	}
+	return nil
 }

--- a/tools/syz-testbed/templates/table.html
+++ b/tools/syz-testbed/templates/table.html
@@ -1,0 +1,79 @@
+{{define "PrintValue"}}
+	{{if or (lt . -100.0) (gt . 100.0)}}
+		{{printf "%.0f" .}}
+	{{else}}
+		{{printf "%.1f" .}}
+	{{end}}
+{{end}}
+
+{{define "PrintExtra"}}
+	{{if .PercentChange}}
+		{{$numVal := (dereference .PercentChange)}}
+		{{if ge $numVal 0.0}}
+			<span class="positive-delta">
+		{{else}}
+			<span class="negative-delta">
+		{{end}}
+		{{printf "%+.1f" $numVal}}%
+		</span>
+	{{end}}
+	{{if .PValue}}
+		p={{printf "%.2f" (dereference .PValue)}}
+	{{end}}
+{{end}}
+
+{{$uiTable := .}}
+{{if .Table}}
+{{if $uiTable.AlignedBy}}
+	The data are aligned by {{$uiTable.AlignedBy}} <br />
+{{end}}
+<table class="list_table">
+	<thead><tr>
+	<th>{{.Table.TopLeftHeader}}</th>
+	{{range $c := .Table.ColumnHeaders}}
+		<th>
+		{{$url := ""}}
+                {{if $uiTable.ColumnURL}}{{$url = (call $uiTable.ColumnURL $c)}}{{end}}
+			{{if $url}}<a href="{{$url}}">{{$c}}</a>
+			{{else}}
+			{{$c}}
+			{{end}}
+		</th>
+		{{if $uiTable.Extra}}
+		<th>Δ</th>
+		{{end}}
+	{{end}}
+	</tr></thead>
+	<tbody>
+	{{range $r := .Table.SortedRows}}
+	<tr>
+		<td>
+		{{$url := ""}}
+                {{if $uiTable.RowURL}}{{$url = (call $uiTable.RowURL $r)}}{{end}}
+			{{if $url}}<a href="{{$url}}">{{$r}}</a>
+			{{else}}
+			{{$r}}
+			{{end}}
+		</td>
+		{{range $c := $uiTable.Table.ColumnHeaders}}
+			{{$cell := ($uiTable.Table.Get $r $c)}}
+			{{if and $cell $uiTable.Extra}}
+			<td>{{template "PrintValue" $cell.Value}}</td>
+			<td>{{template "PrintExtra" $cell}}</td>
+			{{else}}
+			<td>{{$cell}}</td>
+			{{end}}
+		{{end}}
+	</tr>
+	{{end}}
+	{{if $uiTable.HasFooter}}
+		<tr>
+			<td>-</td>
+			{{range $c := $uiTable.Table.ColumnHeaders}}
+				<td>{{$uiTable.Table.GetFooterValue $c}}</td>
+			{{end}}
+		</tr>
+	{{end}}
+	</tbody>
+</table>
+{{end}}

--- a/tools/syz-testbed/templates/testbed.html
+++ b/tools/syz-testbed/templates/testbed.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+	<title>{{.Name }} syzkaller</title>
+	{{template "syz-head"}}
+	<style>
+	.positive-delta {
+		color:darkgreen;
+	}
+	.negative-delta {
+		color:darkred;
+	}
+	</style>
+</head>
+<body>
+  <header id="topbar">
+    <table class="position_table">
+      <tbody>
+	<tr>
+          <td>
+	    <h1>
+              <a href="/">syz-testbed "{{.Name }}"</a></h1>
+	  </td>
+        </tr>
+      </tbody>
+    </table>
+    <table class="position_table">
+      <tbody>
+	<td class="navigation">
+Views:
+{{with $main := .}}
+{{range $view := .Views}}
+<a
+{{if eq $view.Name $main.ActiveView.Name}}
+class="navigation_tab_selected"
+{{else}}
+class="navigation_tab"
+{{end}}
+href="?view={{$view.Name}}">█ {{$view.Name}}</a>
+&nbsp;
+{{end}}
+{{end}}
+	</td>
+      </tbody>
+    </table>
+  </header>
+
+  {{template "table.html" .Summary}}
+  {{$activeView := $.ActiveView}}
+  <h2>Stat view "{{$activeView.Name}}"</h2>
+  <b>Tables:
+    {{range $typeKey, $type := $activeView.TableTypes}}
+    {{if eq $typeKey $activeView.ActiveTableType}}
+    {{$type.Title}}
+    {{else}}
+    <a href="{{call $activeView.GenTableURL $type}}">{{$type.Title}}</a>
+    {{end}}
+    &nbsp;
+    {{end}}
+  </b> <br />
+  <a href="/graph?view={{$.ActiveView.Name}}&over=fuzzing">Graph over time</a> /
+  <a href="/graph?view={{$.ActiveView.Name}}&over=exec+total">Graph over executions</a> <br />
+  {{template "table.html" $.ActiveView.ActiveTable}}
+</body>
+</html>

--- a/tools/syz-testbed/testbed.go
+++ b/tools/syz-testbed/testbed.go
@@ -33,6 +33,7 @@ type TestbedConfig struct {
 	Target        string           `json:"target"`         // what application to test
 	MaxInstances  int              `json:"max_instances"`  // max # of simultaneously running instances
 	RunTime       DurationConfig   `json:"run_time"`       // lifetime of an instance (default "24h")
+	InputLogs     string           `json:"input_logs"`     // folder with logs to be processed by syz-repro
 	HTTP          string           `json:"http"`           // on which port to set up a simple web dashboard
 	BenchCmp      string           `json:"benchcmp"`       // path to the syz-benchcmp executable
 	Corpus        string           `json:"corpus"`         // path to the corpus file


### PR DESCRIPTION
This PR introduces the following changes:
- Table footers that further automatise data aggregation.
- Configurations are not plain JSONs (at least for normal runs with syzkaller), otherwise it was problematic when branches with new options were tested.
- The tool now supports different modes of operation - for now these are `syzkaller` (check out and run syzkaller instances for the specified time, then again and again) and `syz-repro` (check out and run `syz-repro` on crash logs from the specified directory).
- Numerous minor enhancements.