### PR TITLE
docs: update fuchsia README.md

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,3 +102,4 @@ Linaro
  Lee Jones
 Sabyrzhan Tasbolatov
 Adam Goska
+Kouame Behouba Manassé

--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -1,8 +1,8 @@
 # Fuchsia support
 
 For information about checking out and building Fuchsia see
-[Getting Started](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/docs/get-started/)
-and [Source Code](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/docs/get-started/get_fuchsia_source.md).
+[Getting Started](https://fuchsia.dev/fuchsia-src/get-started)
+and [Source Code](https://fuchsia.dev/fuchsia-src/get-started/get_fuchsia_source).
 
 ## Prerequisites
 

--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -1,8 +1,8 @@
 # Fuchsia support
 
 For information about checking out and building Fuchsia see
-[Getting Started](https://fuchsia.googlesource.com/fuchsia/+/master/docs/getting_started.md)
-and [Source Code](https://fuchsia.googlesource.com/fuchsia/+/master/docs/development/source_code/README.md).
+[Getting Started](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/docs/get-started/)
+and [Source Code](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/docs/get-started/get_fuchsia_source.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
The links to get started and install fuchsia are broken.
This commit updates the links with valid ones.
