### PR TITLE
tools: update buildroot version

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -40,7 +40,7 @@ case "$TARGETARCH" in
 esac
 
 git fetch origin
-git checkout 2021.08.x
+git checkout 2021.11.x
 
 make "${DEFCONFIG}"
 


### PR DESCRIPTION
2021.08.x does not build on Linux 5.15+ due to the following error.

interpret.c:48:10: fatal error: linux/ipx.h: No such file or directory
   48 | #include <linux/ipx.h>

It was fixed in the newer buildroot versions.

