### PR TITLE
fix: "mmap_alloc_size"->"cov->mmap_alloc_size"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ Muhammad Usama Anjum
 ANSSI
 Chuck Silvers
 Lee Jones
+Junquan Zhou

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -103,3 +103,5 @@ Linaro
 Sabyrzhan Tasbolatov
 Adam Goska
 Kouame Behouba Manassé
+Junquan Zhou
+

--- a/executor/executor_darwin.h
+++ b/executor/executor_darwin.h
@@ -80,7 +80,7 @@ static void cover_mmap(cover_t* cov)
 
 	// Sanity check to make sure our assumptions in the max_entries calculation
 	// hold up.
-	if (mmap_alloc_size > kCoverSize)
+	if (cov->mmap_alloc_size > kCoverSize)
 		fail("mmap allocation size larger than anticipated");
 
 	cov->data = (char*)mmap_ptr;


### PR DESCRIPTION

Hey everyone, I fixed a bug.
The bug causes the following error.
```
...
mkdir -p ./bin/darwin_arm64
clang -o ./bin/darwin_arm64/syz-executor executor/executor.cc \
    -arch arm64 -I /Volumes/NewAPFS/kernel/xnu-7195.81.3/san -Wno-deprecated-declarations -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384 -Wno-array-bounds -lc++  -DGOOS_darwin=1 -DGOARCH_arm64=1 \
    -DHOSTGOOS_darwin=1 -DGIT_REVISION=\"52e8932e8dedd6eae5817814c84c07948141e86e+\"
In file included from executor/executor.cc:401:
executor/executor_darwin.h:83:6: error: use of undeclared identifier 'mmap_alloc_size'
        if (mmap_alloc_size > kCoverSize)
            ^
1 error generated.
make: *** [executor] Error 1
make: *** Waiting for unfinished jobs....
...
```

