### PR TITLE
prog: add more integers for generator

### DIFF
--- a/prog/rand.go
+++ b/prog/rand.go
@@ -72,6 +72,8 @@ var (
 		(1 << 16) - 1, (1 << 16), (1 << 16) + 1,
 		(1 << 31) - 1, (1 << 31), (1 << 31) + 1,
 		(1 << 32) - 1, (1 << 32), (1 << 32) + 1,
+		(1 << 63) - 1, (1 << 63), (1 << 63) + 1,
+		(1 << 64) - 1,
 	}
 	// The indexes (exclusive) for the maximum specialInts values that fit in 1, 2, ... 8 bytes.
 	specialIntIndex [9]int


### PR DESCRIPTION
Add more special Ints to the array as it supports integers of 64
bytes length.
