### PR TITLE
Run only enabled syscalls as part of syz-fuzzer startup

### DIFF
--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -23,8 +23,12 @@ func TestDetectSupportedSyscalls(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			enabled := make(map[*prog.Syscall]bool)
+			for _, c := range target.Syscalls {
+				enabled[c] = true
+			}
 			// Dump for manual inspection.
-			supp, disabled, err := DetectSupportedSyscalls(target, "none")
+			supp, disabled, err := DetectSupportedSyscalls(target, "none", enabled)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/host/syscalls.go
+++ b/pkg/host/syscalls.go
@@ -10,7 +10,7 @@ import (
 
 // DetectSupportedSyscalls returns list on supported and unsupported syscalls on the host.
 // For unsupported syscalls it also returns reason as to why it is unsupported.
-func DetectSupportedSyscalls(target *prog.Target, sandbox string) (
+func DetectSupportedSyscalls(target *prog.Target, sandbox string, enabled map[*prog.Syscall]bool) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
 	log.Logf(1, "detecting supported syscalls")
 	supported := make(map[*prog.Syscall]bool)
@@ -32,6 +32,9 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string) (
 			case c.Attrs.Disabled:
 				ok = false
 				reason = disabledAttribute
+			case !enabled[c]:
+				ok = false
+				reason = "not in set of enabled calls"
 			case c.CallName == "syz_execute_func":
 				// syz_execute_func caused multiple problems:
 				// 1. First it lead to corpus explosion. The program used existing values in registers

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -58,7 +58,11 @@ func test(t *testing.T, sysTarget *targets.Target) {
 	if err != nil {
 		t.Fatalf("failed to detect host features: %v", err)
 	}
-	calls, _, err := host.DetectSupportedSyscalls(target, "none")
+	enabled := make(map[*prog.Syscall]bool)
+	for _, c := range target.Syscalls {
+		enabled[c] = true
+	}
+	calls, _, err := host.DetectSupportedSyscalls(target, "none", enabled)
 	if err != nil {
 		t.Fatalf("failed to detect supported syscalls: %v", err)
 	}

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -294,7 +294,8 @@ func buildCallList(target *prog.Target, enabledCalls []int, sandbox string) (
 			calls[c] = true
 		}
 	}
-	_, unsupported, err := host.DetectSupportedSyscalls(target, sandbox)
+
+	_, unsupported, err := host.DetectSupportedSyscalls(target, sandbox, calls)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to detect host supported syscalls: %v", err)
 	}

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -70,8 +70,12 @@ func main() {
 		log.Fatalf("failed to connect to verifier: %v", err)
 	}
 
+	enabled := make(map[*prog.Syscall]bool)
+	for _, c := range target.Syscalls {
+		enabled[c] = true
+	}
 	if r.CheckUnsupportedCalls {
-		_, unsupported, err := host.DetectSupportedSyscalls(target, ipc.FlagsToSandbox(config.Flags))
+		_, unsupported, err := host.DetectSupportedSyscalls(target, ipc.FlagsToSandbox(config.Flags), enabled)
 		if err != nil {
 			log.Fatalf("failed to get unsupported system calls: %v", err)
 		}

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -186,30 +186,23 @@ func buildCallList(target *prog.Target, enabled []string) map[*prog.Syscall]bool
 		}
 		return calls
 	}
-	calls, disabled, err := host.DetectSupportedSyscalls(target, "none")
-	if err != nil {
-		log.Fatalf("failed to detect host supported syscalls: %v", err)
-	}
+
+	enabledSyscalls := make(map[*prog.Syscall]bool)
 	if len(enabled) != 0 {
 		syscallsIDs, err := mgrconfig.ParseEnabledSyscalls(target, enabled, nil)
 		if err != nil {
 			log.Fatalf("failed to parse enabled syscalls: %v", err)
 		}
-		enabledSyscalls := make(map[*prog.Syscall]bool)
 		for _, id := range syscallsIDs {
 			enabledSyscalls[target.Syscalls[id]] = true
 		}
-		for c := range calls {
-			if !enabledSyscalls[c] {
-				delete(calls, c)
-			}
-		}
-		for c := range disabled {
-			if !enabledSyscalls[c] {
-				delete(disabled, c)
-			}
-		}
 	}
+
+	calls, disabled, err := host.DetectSupportedSyscalls(target, "none", enabledSyscalls)
+	if err != nil {
+		log.Fatalf("failed to detect host supported syscalls: %v", err)
+	}
+
 	for c, reason := range disabled {
 		log.Logf(0, "unsupported syscall: %v: %v", c.Name, reason)
 	}


### PR DESCRIPTION
When syz-fuzzer starts, it tries all syscalls to filter out any that are
not supported. This process should include only the syscalls that are
enabled using the 'enable_syscalls' and 'disable_syscalls' fields in
syz-manager's config.

This is useful for fuzzing Cuttlefish devices, for example, where the
'vhost_vsock' syscall needs to be excluded from fuzzing and from this
test.
