### PR TITLE
syz-verifier: don't use -collide in the runner

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -506,7 +506,7 @@ var MakeBin = func() string {
 	return "make"
 }()
 
-func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, collide, threaded, newEnv bool) string {
+func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, threaded, newEnv bool) string {
 	return fmt.Sprintf("%s -addr=%s -os=%s -arch=%s -pool=%d -vm=%d "+
-		"-collide=%t -threaded=%t -new-env=%t", prog, fwdAddr, os, arch, poolIdx, vmIdx, collide, threaded, newEnv)
+		"-threaded=%t -new-env=%t", prog, fwdAddr, os, arch, poolIdx, vmIdx, threaded, newEnv)
 }

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -152,11 +152,10 @@ func TestRunnerCmd(t *testing.T) {
 	flagArch := flags.String("arch", "", "target architecture")
 	flagPool := flags.Int("pool", 0, "index of pool that started VM")
 	flagVM := flags.Int("vm", 0, "index of VM that started the Runner")
-	flagCollide := flags.Bool("collide", true, "collide syscalls to provoke data races")
 	flagThreaded := flags.Bool("threaded", true, "use threaded mode in executor")
 	flagEnv := flags.Bool("new-env", true, "create a new environment for each program")
 
-	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0, false, false, false)
+	cmdLine := RunnerCmd(os.Args[0], "localhost:1234", targets.Linux, targets.AMD64, 0, 0, false, false)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatalf("error parsing flags: %v, want: nil", err)
@@ -180,10 +179,6 @@ func TestRunnerCmd(t *testing.T) {
 
 	if got, want := *flagVM, 0; got != want {
 		t.Errorf("bad vm index: %d, want: %d", got, want)
-	}
-
-	if got, want := *flagCollide, false; got != want {
-		t.Errorf("bad collide: %t, want: %t", got, want)
 	}
 
 	if got, want := *flagThreaded, false; got != want {

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -110,7 +110,7 @@ func (vrf *Verifier) createAndManageInstance(pi *poolInfo, idx int) {
 		log.Fatalf("failed to copy executor binary: %v", err)
 	}
 
-	cmd := instance.RunnerCmd(runnerBin, fwdAddr, vrf.target.OS, vrf.target.Arch, idx, 0, false, false, vrf.newEnv)
+	cmd := instance.RunnerCmd(runnerBin, fwdAddr, vrf.target.OS, vrf.target.Arch, idx, 0, false, vrf.newEnv)
 	outc, errc, err := inst.Run(pi.cfg.Timeouts.VMRunningTime, vrf.vmStop, cmd)
 	if err != nil {
 		log.Fatalf("failed to start runner: %v", err)


### PR DESCRIPTION
syz-runner doesn't use the -collide mode. Lets remove it.