### PR TITLE
pkg/instance: support older syzkaller revisions

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -81,9 +81,12 @@ func (env *env) BuildSyzkaller(repoURL, commit string) error {
 	env.optionalFlags = optionalFlags
 	cmd := osutil.Command(MakeBin, "target")
 	cmd.Dir = cfg.Syzkaller
-	cmd.Env = append([]string{}, os.Environ()...)
+	goEnvOptions := []string{
+		"GOPATH=" + cfg.Syzkaller[:srcIndex],
+		"GO111MODULE=auto",
+	}
+	cmd.Env = append(append([]string{}, os.Environ()...), goEnvOptions...)
 	cmd.Env = append(cmd.Env,
-		"GOPATH="+cfg.Syzkaller[:srcIndex],
 		"TARGETOS="+cfg.TargetOS,
 		"TARGETVMARCH="+cfg.TargetVMArch,
 		"TARGETARCH="+cfg.TargetArch,
@@ -96,7 +99,7 @@ func (env *env) BuildSyzkaller(repoURL, commit string) error {
 	if _, err := osutil.Run(time.Hour, cmd); err != nil {
 		goEnvCmd := osutil.Command("go", "env")
 		goEnvCmd.Dir = cfg.Syzkaller
-		goEnvCmd.Env = append(append([]string{}, os.Environ()...), "GOPATH="+cfg.Syzkaller[:srcIndex])
+		goEnvCmd.Env = append(append([]string{}, os.Environ()...), goEnvOptions...)
 		goEnvOut, goEnvErr := osutil.Run(time.Hour, goEnvCmd)
 		gitStatusOut, gitStatusErr := osutil.RunCmd(time.Hour, cfg.Syzkaller, "git", "status")
 		return fmt.Errorf("syzkaller build failed: %v\ngo env (err=%v)\n%s\ngit status (err=%v)\n%s",


### PR DESCRIPTION
Now we use go1.16+, but sometimes syz-ci still has to compile and run
old syzkaller revisions, which were not meant to be compiled with modern
Go.

In particular, this leads to the following errors:

syzkaller build failed: failed to run ["make" "target"]: exit status 2
tools/syz-make/make.go:14:2: no required module provides package
github.com/google/syzkaller/pkg/osutil: go.mod file not found in
current directory or any parent directory; see 'go help modules'
tools/syz-make/make.go:15:2: no required module provides package
github.com/google/syzkaller/sys/targets: go.mod file not found in
current directory or any parent directory; see 'go help modules'
Makefile:39: *** syz-make failed.  Stop.

Fix this by adding GO111MODULE=auto to the environment variables.

Reported-by: Taylor R Campbell <riastradh@netbsd.org>

