### PR TITLE
all: use `t.TempDir` to create temporary test directory

### DIFF
--- a/pkg/compiler/const_file_test.go
+++ b/pkg/compiler/const_file_test.go
@@ -109,11 +109,7 @@ CONST5_SOME_UNDEFINED2 = 100, arch3:???
 		}
 	}
 	{
-		dir, err := ioutil.TempDir("", "syz-const")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		for name, arch := range arches {
 			file := filepath.Join(dir, "consts_"+name+".const")
 			if err := ioutil.WriteFile(file, []byte(arch.oldFormat), 0600); err != nil {

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -11,7 +11,6 @@ package cover
 import (
 	"bytes"
 	"encoding/csv"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -249,11 +248,7 @@ func buildTestBinary(t *testing.T, target *targets.Target, test Test, dir string
 }
 
 func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []byte, error) {
-	dir, err := ioutil.TempDir("", "syz-cover-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	bin := buildTestBinary(t, target, test, dir)
 	subsystem := []mgrconfig.Subsystem{
 		{

--- a/pkg/host/machine_info_linux_test.go
+++ b/pkg/host/machine_info_linux_test.go
@@ -7,8 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -385,11 +383,7 @@ power management:
 }
 
 func TestGetGlobsInfo(t *testing.T) {
-	dir, err := ioutil.TempDir("", "syz-host-globstest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	if err := osutil.MkdirAll(filepath.Join(dir, "a", "b", "c", "d")); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/osutil/fileutil_test.go
+++ b/pkg/osutil/fileutil_test.go
@@ -5,8 +5,6 @@ package osutil
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -16,11 +14,7 @@ import (
 func TestProcessTempDir(t *testing.T) {
 	for try := 0; try < 10; try++ {
 		func() {
-			tmp, err := ioutil.TempDir("", "syz")
-			if err != nil {
-				t.Fatalf("failed to create a temp dir: %v", err)
-			}
-			defer os.RemoveAll(tmp)
+			tmp := t.TempDir()
 			const P = 16
 			// Pre-create half of the instances with stale pid.
 			var dirs []string

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -5,7 +5,6 @@ package osutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,11 +80,7 @@ func TestCopyFiles(t *testing.T) {
 		t.Run(fnName, func(t *testing.T) {
 			for i, test := range tests {
 				t.Run(fmt.Sprint(i), func(t *testing.T) {
-					dir, err := ioutil.TempDir("", "syz-osutil-test")
-					if err != nil {
-						t.Fatal(err)
-					}
-					defer os.RemoveAll(dir)
+					dir := t.TempDir()
 					src := filepath.Join(dir, "src")
 					dst := filepath.Join(dir, "dst")
 					for _, file := range test.files {

--- a/pkg/vcs/git_repo_test.go
+++ b/pkg/vcs/git_repo_test.go
@@ -5,7 +5,6 @@ package vcs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,11 +21,7 @@ func init() {
 
 func TestGitRepo(t *testing.T) {
 	t.Parallel()
-	baseDir, err := ioutil.TempDir("", "syz-git-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(baseDir)
+	baseDir := t.TempDir()
 	repo1 := CreateTestRepo(t, baseDir, "repo1")
 	repo2 := CreateTestRepo(t, baseDir, "repo2")
 	repo := newGit(filepath.Join(baseDir, "repo"), nil, nil)
@@ -140,11 +135,7 @@ func TestGitRepo(t *testing.T) {
 
 func TestMetadata(t *testing.T) {
 	t.Parallel()
-	repoDir, err := ioutil.TempDir("", "syz-git-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(repoDir)
+	repoDir := t.TempDir()
 	repo := MakeTestRepo(t, repoDir)
 	prevHash := ""
 	for i, test := range metadataTests {
@@ -329,11 +320,7 @@ Comment out an assertion that's now bogus and add a comment.
 
 func TestBisect(t *testing.T) {
 	t.Parallel()
-	repoDir, err := ioutil.TempDir("", "syz-git-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(repoDir)
+	repoDir := t.TempDir()
 	repo := MakeTestRepo(t, repoDir)
 	var commits []string
 	for i := 0; i < 5; i++ {

--- a/syz-verifier/utils_test.go
+++ b/syz-verifier/utils_test.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/ipc"
@@ -46,14 +44,7 @@ func getTestProgram(t *testing.T) *prog.Prog {
 }
 
 func makeTestResultDirectory(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "syz-verifier")
-	if err != nil {
-		t.Fatalf("failed to create results directory: %v", err)
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
-	return osutil.Abs(dir)
+	return osutil.Abs(t.TempDir())
 }
 
 func makeExecResult(pool int, errnos []int, flags ...int) *ExecResult {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -6,8 +6,6 @@ package vm
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -333,11 +331,7 @@ func TestMonitorExecution(t *testing.T) {
 }
 
 func testMonitorExecution(t *testing.T, test *Test) {
-	dir, err := ioutil.TempDir("", "syz-vm-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	cfg := &mgrconfig.Config{
 		Derived: mgrconfig.Derived{
 			TargetOS:     targets.Linux,


### PR DESCRIPTION
A testing cleanup. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir