### PR TITLE
all: add raw coverage collection option

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -14,14 +14,16 @@ import (
 )
 
 type ReportGenerator struct {
-	target    *targets.Target
-	srcDir    string
-	buildDir  string
-	subsystem []mgrconfig.Subsystem
+	target          *targets.Target
+	srcDir          string
+	buildDir        string
+	subsystem       []mgrconfig.Subsystem
+	rawCoverEnabled bool
 	*backend.Impl
 }
 
 type Prog struct {
+	Sig  string
 	Data string
 	PCs  []uint64
 }
@@ -29,7 +31,7 @@ type Prog struct {
 var RestorePC = backend.RestorePC
 
 func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string, subsystem []mgrconfig.Subsystem,
-	moduleObj []string, modules []host.KernelModule) (*ReportGenerator, error) {
+	moduleObj []string, modules []host.KernelModule, rawCover bool) (*ReportGenerator, error) {
 	impl, err := backend.Make(target, vm, objDir, srcDir, buildDir, moduleObj, modules)
 	if err != nil {
 		return nil, err
@@ -39,11 +41,12 @@ func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir st
 		Paths: []string{""},
 	})
 	rg := &ReportGenerator{
-		target:    target,
-		srcDir:    srcDir,
-		buildDir:  buildDir,
-		subsystem: subsystem,
-		Impl:      impl,
+		target:          target,
+		srcDir:          srcDir,
+		buildDir:        buildDir,
+		subsystem:       subsystem,
+		rawCoverEnabled: rawCover,
+		Impl:            impl,
 	}
 	return rg, nil
 }

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -265,7 +265,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 		},
 	}
 
-	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, nil)
+	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, nil, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -452,6 +452,7 @@ type FuzzerCmdArgs struct {
 	Test      bool
 	Runtest   bool
 	Slowdown  int
+	RawCover  bool
 }
 
 func FuzzerCmd(args *FuzzerCmdArgs) string {
@@ -470,11 +471,16 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 	if args.Verbosity != 0 {
 		verbosityArg = fmt.Sprintf(" -vv=%v", args.Verbosity)
 	}
-	optionalArg := ""
+	flags := []tool.Flag{}
 	if args.Slowdown > 0 {
-		optionalArg = " " + tool.OptionalFlags([]tool.Flag{
-			{Name: "slowdown", Value: fmt.Sprint(args.Slowdown)},
-		})
+		flags = append(flags, tool.Flag{Name: "slowdown", Value: fmt.Sprint(args.Slowdown)})
+	}
+	if args.RawCover {
+		flags = append(flags, tool.Flag{Name: "raw_cover", Value: "true"})
+	}
+	optionalArg := ""
+	if len(flags) > 0 {
+		optionalArg += " " + tool.OptionalFlags(flags)
 	}
 	return fmt.Sprintf("%v -executor=%v -name=%v -arch=%v%v -manager=%v -sandbox=%v"+
 		" -procs=%v -cover=%v -debug=%v -test=%v%v%v%v",

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -289,7 +289,7 @@ func (env *Env) Exec(opts *ExecOpts, p *prog.Prog) (output []byte, info *ProgInf
 		return
 	}
 
-	info, err0 = env.parseOutput(p)
+	info, err0 = env.parseOutput(p, opts)
 	if info != nil && env.config.Flags&FlagSignal == 0 {
 		addFallbackSignal(p, info)
 	}
@@ -323,7 +323,7 @@ func addFallbackSignal(p *prog.Prog, info *ProgInfo) {
 	}
 }
 
-func (env *Env) parseOutput(p *prog.Prog) (*ProgInfo, error) {
+func (env *Env) parseOutput(p *prog.Prog, opts *ExecOpts) (*ProgInfo, error) {
 	out := env.out
 	ncmd, ok := readUint32(&out)
 	if !ok {
@@ -372,19 +372,27 @@ func (env *Env) parseOutput(p *prog.Prog) (*ProgInfo, error) {
 	if len(extraParts) == 0 {
 		return info, nil
 	}
-	info.Extra = convertExtra(extraParts)
+	info.Extra = convertExtra(extraParts, opts.Flags&FlagDedupCover > 0)
 	return info, nil
 }
 
-func convertExtra(extraParts []CallInfo) CallInfo {
+func convertExtra(extraParts []CallInfo, dedupCover bool) CallInfo {
 	var extra CallInfo
-	extraCover := make(cover.Cover)
+	if dedupCover {
+		extraCover := make(cover.Cover)
+		for _, part := range extraParts {
+			extraCover.Merge(part.Cover)
+		}
+		extra.Cover = extraCover.Serialize()
+	} else {
+		for _, part := range extraParts {
+			extra.Cover = append(extra.Cover, part.Cover...)
+		}
+	}
 	extraSignal := make(signal.Signal)
 	for _, part := range extraParts {
-		extraCover.Merge(part.Cover)
 		extraSignal.Merge(signal.FromRaw(part.Signal, 0))
 	}
-	extra.Cover = extraCover.Serialize()
 	extra.Signal = make([]uint32, len(extraSignal))
 	i := 0
 	for s := range extraSignal {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -132,6 +132,11 @@ type Config struct {
 	// eg. "0xffffffff81000000:0x10\n"
 	CovFilter covFilterCfg `json:"cover_filter,omitempty"`
 
+	// For each prog in the corpus, remember the raw array of PCs obtained from the kernel.
+	// It can be useful for debugging syzkaller descriptions and syzkaller itself.
+	// Disabled by default as it slows down fuzzing.
+	RawCover bool `json:"raw_cover"`
+
 	// Reproduce, localize and minimize crashers (default: true).
 	Reproduce bool `json:"reproduce"`
 

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -14,10 +14,12 @@ import (
 )
 
 type Input struct {
-	Call   string
-	Prog   []byte
-	Signal signal.Serial
-	Cover  []uint32
+	Call     string
+	Prog     []byte
+	Signal   signal.Serial
+	Cover    []uint32
+	CallID   int // seq number of call in the prog to which the item is related (-1 for extra)
+	RawCover []uint32
 }
 
 type Candidate struct {

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -48,6 +48,7 @@ type Fuzzer struct {
 
 	faultInjectionEnabled    bool
 	comparisonTracingEnabled bool
+	fetchRawCover            bool
 
 	corpusMu     sync.RWMutex
 	corpus       []*prog.Prog
@@ -138,14 +139,15 @@ func main() {
 	debug.SetGCPercent(50)
 
 	var (
-		flagName    = flag.String("name", "test", "unique name for manager")
-		flagOS      = flag.String("os", runtime.GOOS, "target OS")
-		flagArch    = flag.String("arch", runtime.GOARCH, "target arch")
-		flagManager = flag.String("manager", "", "manager rpc address")
-		flagProcs   = flag.Int("procs", 1, "number of parallel test processes")
-		flagOutput  = flag.String("output", "stdout", "write programs to none/stdout/dmesg/file")
-		flagTest    = flag.Bool("test", false, "enable image testing mode")      // used by syz-ci
-		flagRunTest = flag.Bool("runtest", false, "enable program testing mode") // used by pkg/runtest
+		flagName     = flag.String("name", "test", "unique name for manager")
+		flagOS       = flag.String("os", runtime.GOOS, "target OS")
+		flagArch     = flag.String("arch", runtime.GOARCH, "target arch")
+		flagManager  = flag.String("manager", "", "manager rpc address")
+		flagProcs    = flag.Int("procs", 1, "number of parallel test processes")
+		flagOutput   = flag.String("output", "stdout", "write programs to none/stdout/dmesg/file")
+		flagTest     = flag.Bool("test", false, "enable image testing mode")      // used by syz-ci
+		flagRunTest  = flag.Bool("runtest", false, "enable program testing mode") // used by pkg/runtest
+		flagRawCover = flag.Bool("raw_cover", false, "fetch raw coverage")
 	)
 	defer tool.Init()()
 	outputType := parseOutputType(*flagOutput)
@@ -159,6 +161,9 @@ func main() {
 	config, execOpts, err := ipcconfig.Default(target)
 	if err != nil {
 		log.Fatalf("failed to create default ipc config: %v", err)
+	}
+	if *flagRawCover {
+		execOpts.Flags &^= ipc.FlagDedupCover
 	}
 	timeouts := config.Timeouts
 	sandbox := ipc.FlagsToSandbox(config.Flags)
@@ -264,6 +269,7 @@ func main() {
 		comparisonTracingEnabled: r.CheckResult.Features[host.FeatureComparisons].Enabled,
 		corpusHashes:             make(map[hash.Sig]struct{}),
 		checkResult:              r.CheckResult,
+		fetchRawCover:            *flagRawCover,
 	}
 	gateCallback := fuzzer.useBugFrames(r, *flagProcs)
 	fuzzer.gate = ipc.NewGate(2**flagProcs, gateCallback)

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -21,7 +21,7 @@ var getReportGenerator = func() func(cfg *mgrconfig.Config,
 		once.Do(func() {
 			log.Logf(0, "initializing coverage information...")
 			rg, err = cover.MakeReportGenerator(cfg.SysTarget, cfg.Type, cfg.KernelObj, cfg.KernelSrc,
-				cfg.KernelBuildSrc, cfg.KernelSubsystem, cfg.ModuleObj, modules)
+				cfg.KernelBuildSrc, cfg.KernelSubsystem, cfg.ModuleObj, modules, cfg.RawCover)
 		})
 		return rg, err
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -658,9 +658,23 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 	atomic.AddUint32(&mgr.numFuzzing, 1)
 	defer atomic.AddUint32(&mgr.numFuzzing, ^uint32(0))
 
-	cmd := instance.FuzzerCmd(fuzzerBin, executorBin, instanceName,
-		mgr.cfg.TargetOS, mgr.cfg.TargetArch, fwdAddr, mgr.cfg.Sandbox, procs, fuzzerV,
-		mgr.cfg.Cover, *flagDebug, false, false, true, mgr.cfg.Timeouts.Slowdown)
+	args := &instance.FuzzerCmdArgs{
+		Fuzzer:    fuzzerBin,
+		Executor:  executorBin,
+		Name:      instanceName,
+		OS:        mgr.cfg.TargetOS,
+		Arch:      mgr.cfg.TargetArch,
+		FwdAddr:   fwdAddr,
+		Sandbox:   mgr.cfg.Sandbox,
+		Procs:     procs,
+		Verbosity: fuzzerV,
+		Cover:     mgr.cfg.Cover,
+		Debug:     *flagDebug,
+		Test:      false,
+		Runtest:   false,
+		Slowdown:  mgr.cfg.Timeouts.Slowdown,
+	}
+	cmd := instance.FuzzerCmd(args)
 	outc, errc, err := inst.Run(mgr.cfg.Timeouts.VMRunningTime, mgr.vmStop, cmd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to run fuzzer: %v", err)

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -302,6 +302,7 @@ func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 		serv.stats.corpusSignal.set(serv.corpusSignal.Len())
 
 		a.Input.Cover = nil // Don't send coverage back to all fuzzers.
+		a.Input.RawCover = nil
 		for _, other := range serv.fuzzers {
 			if other == f || other.rotated {
 				continue

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -68,7 +68,7 @@ func main() {
 		tool.Fail(err)
 	}
 	rg, err := cover.MakeReportGenerator(target, *flagVM, *flagKernelObj,
-		*flagKernelSrc, *flagKernelBuildSrc, nil, nil, nil)
+		*flagKernelSrc, *flagKernelBuildSrc, nil, nil, nil, false)
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -173,9 +173,23 @@ func (mgr *Manager) boot(name string, index int) (*report.Report, error) {
 			return nil, fmt.Errorf("failed to copy binary: %v", err)
 		}
 	}
-	cmd := instance.FuzzerCmd(fuzzerBin, executorBin, name,
-		mgr.cfg.TargetOS, mgr.cfg.TargetArch, fwdAddr, mgr.cfg.Sandbox, mgr.cfg.Procs, 0,
-		mgr.cfg.Cover, mgr.debug, false, true, true, mgr.cfg.Timeouts.Slowdown)
+	args := &instance.FuzzerCmdArgs{
+		Fuzzer:    fuzzerBin,
+		Executor:  executorBin,
+		Name:      name,
+		OS:        mgr.cfg.TargetOS,
+		Arch:      mgr.cfg.TargetArch,
+		FwdAddr:   fwdAddr,
+		Sandbox:   mgr.cfg.Sandbox,
+		Procs:     mgr.cfg.Procs,
+		Verbosity: 0,
+		Cover:     mgr.cfg.Cover,
+		Debug:     mgr.debug,
+		Test:      false,
+		Runtest:   true,
+		Slowdown:  mgr.cfg.Timeouts.Slowdown,
+	}
+	cmd := instance.FuzzerCmd(args)
 	outc, errc, err := inst.Run(time.Hour, mgr.vmStop, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run fuzzer: %v", err)


### PR DESCRIPTION
Raw coverage might be important when e.g. analysing the origins of
out-of-place coverage in coverage reports or understanding why the
fuzzer could not reach deeper code.

If "raw_cover" in syz-manager config is set to `true`, syzkaller will
remember unsorted and unduplicated coverage (PCs) for each its
corpus program.

```
<...>
"raw_cover": true,
<...>
```

Raw coverage can be accessed by following HTML links from `/corpus` and `/cover`.

The resulting sequences of PCs can be symbolized e.g. via
`cat cover.txt | addr2line -i -afe ./vmlinux`

Also, this PR includes some minor refactoring.