### PR TITLE
syz-verifier: log only the first mismatch

### DIFF
--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -309,11 +309,14 @@ func (vrf *Verifier) finalizeCallSet(w io.Writer) {
 	}
 }
 
+// AddCallsExecutionStat ignore all the calls after the first mismatch.
 func (vrf *Verifier) AddCallsExecutionStat(results []*ExecResult, program *prog.Prog) {
 	rr := CompareResults(results, program)
 	for _, cr := range rr.Reports {
 		vrf.stats.Calls.IncCallOccurrenceCount(cr.Call)
+	}
 
+	for _, cr := range rr.Reports {
 		if !cr.Mismatch {
 			continue
 		}
@@ -324,6 +327,7 @@ func (vrf *Verifier) AddCallsExecutionStat(results []*ExecResult, program *prog.
 				vrf.stats.Calls.AddState(cr.Call, state0)
 			}
 		}
+		break
 	}
 }
 


### PR DESCRIPTION
Closes [#3054](https://github.com/google/syzkaller/issues/3054)
