### PR TITLE
My branch

### DIFF
--- a/executor/android/android_seccomp.h
+++ b/executor/android/android_seccomp.h
@@ -101,3 +101,23 @@ static void set_app_seccomp_filter()
 	// Will fail() if anything fails.
 	install_filter(&f);
 }
+
+#if GOARCH_amd64 || GOARCH_386
+// In bionic mkdir calls mkdirat, there is no seccomp hole for mkdir.
+int mkdir(const char* path, mode_t mode)
+{
+	return mkdirat(AT_FDCWD, path, mode);
+}
+
+// In bionic unlinkat calls mkdirat, there is no seccomp hole for rmdir.
+int rmdir(const char* path)
+{
+	return unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+}
+
+// In bionic symlink calls symlinkat, there is no seccomp hole for symlink.
+int symlink(const char* old_path, const char* new_path)
+{
+	return symlinkat(old_path, AT_FDCWD, new_path);
+}
+#endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9126,6 +9126,21 @@ static void set_app_seccomp_filter()
 	install_filter(&f);
 }
 
+#if GOARCH_amd64 || GOARCH_386
+int mkdir(const char* path, mode_t mode)
+{
+	return mkdirat(AT_FDCWD, path, mode);
+}
+int rmdir(const char* path)
+{
+	return unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+}
+int symlink(const char* old_path, const char* new_path)
+{
+	return symlinkat(old_path, AT_FDCWD, new_path);
+}
+#endif
+
 #endif
 #include <fcntl.h>
 #include <grp.h>

--- a/pkg/host/syscalls.go
+++ b/pkg/host/syscalls.go
@@ -27,6 +27,7 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string, enabled map[*p
 		}
 	} else {
 		for _, c := range target.Syscalls {
+			log.Logf(1, "TESTING "+c.Name)
 			ok, reason := false, ""
 			switch {
 			case c.Attrs.Disabled:
@@ -35,7 +36,7 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string, enabled map[*p
 			case !enabled[c]:
 				ok = false
 				reason = "not in set of enabled calls"
-			case c.CallName == "syz_execute_func":
+			case c.CallName == "syz_execute_func" || c.Name == "openat$vhost_vsock":
 				// syz_execute_func caused multiple problems:
 				// 1. First it lead to corpus explosion. The program used existing values in registers
 				// to pollute output area. We tried to zero registers (though, not reliably).
@@ -53,9 +54,11 @@ func DetectSupportedSyscalls(target *prog.Target, sandbox string, enabled map[*p
 				ok = false
 				reason = "always disabled for now"
 			default:
+				log.Logf(1, "CHECKING IF SUPPORTED "+c.Name)
 				ok, reason = isSupported(c, target, sandbox)
 			}
 			if ok {
+				log.Logf(1, "Supported "+c.Name)
 				supported[c] = true
 			} else {
 				if reason == "" {


### PR DESCRIPTION
executor/android/android_seccomp.h: pseudo-syscalls for mkdir, rmdir, symlink for Android cuttlefish runs
pkg/csource/generated.go: pseudo-syscalls for mkdir, rmdir, symlink for Android cuttlefish runs
pkg/host/syscalls.go: hack to fix vsock killing cuttlefish VM



Extended multi-line description that includes
the problem you are solving and how it is solved.