### PR TITLE
pkg/instance: consider the optional flags argument

### DIFF
--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -33,7 +33,7 @@ func TestFuzzerCmd(t *testing.T) {
 	flagDebug := flags.Bool("debug", false, "debug output from executor")
 	flagV := flags.Int("v", 0, "verbosity")
 	cmdLine := OldFuzzerCmd(os.Args[0], "/myexecutor", "myname", targets.Linux, targets.I386, "localhost:1234",
-		"namespace", 3, true, true, false, 0)
+		"namespace", 3, true, true, false, 5)
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := flags.Parse(args); err != nil {
 		t.Fatal(err)

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -694,8 +694,10 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 		Debug:     *flagDebug,
 		Test:      false,
 		Runtest:   false,
-		Slowdown:  mgr.cfg.Timeouts.Slowdown,
-		RawCover:  mgr.cfg.RawCover,
+		Optional: &instance.OptionalFuzzerArgs{
+			Slowdown: mgr.cfg.Timeouts.Slowdown,
+			RawCover: mgr.cfg.RawCover,
+		},
 	}
 	cmd := instance.FuzzerCmd(args)
 	outc, errc, err := inst.Run(mgr.cfg.Timeouts.VMRunningTime, mgr.vmStop, cmd)

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -187,7 +187,9 @@ func (mgr *Manager) boot(name string, index int) (*report.Report, error) {
 		Debug:     mgr.debug,
 		Test:      false,
 		Runtest:   true,
-		Slowdown:  mgr.cfg.Timeouts.Slowdown,
+		Optional: &instance.OptionalFuzzerArgs{
+			Slowdown: mgr.cfg.Timeouts.Slowdown,
+		},
 	}
 	cmd := instance.FuzzerCmd(args)
 	outc, errc, err := inst.Run(time.Hour, mgr.vmStop, cmd)


### PR DESCRIPTION
Otherwise we get problems while testing patches for older syzkaller
versions, which didn't support optional arguments.

Adjust tests so that problems with how OldFuzzerCmd handles such
arguments could be seen.