### PR TITLE
Fix divergence between Bionic and glibc for syz-executor

### DIFF
--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9126,6 +9126,24 @@ static void set_app_seccomp_filter()
 	install_filter(&f);
 }
 
+
+#if GOARCH_amd64 || GOARCH_386
+inline int mkdir(const char* path, mode_t mode)
+{
+	return mkdirat(AT_FDCWD, path, mode);
+}
+
+inline int rmdir(const char* path)
+{
+	return unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+}
+
+inline int symlink(const char* old_path, const char* new_path)
+{
+	return symlinkat(old_path, AT_FDCWD, new_path);
+}
+#endif
+
 #endif
 #include <fcntl.h>
 #include <grp.h>


### PR DESCRIPTION
executor: overriden implementations of _mkdir_, _rmdir_, _symlink_ when compiled for x86/x64 with Android sandboxing enabled

**The issue**
Syz-executor is linked against glibc when fuzzing runs on Cuttlefish x86-x64. However Android blocks calls into _mkdir_, _rmdir_, _symlink_ which causes syz-executor to crash. When fuzzing runs on Android device this issue is not observed, because syz-executor is linked against Bionic. Under the hood Bionic invokes _mkdirat_, _inlinkat_ and _symlinkat_, which are allowed by _seccomp-bpf_.

_seccomp-bpf_ is a system component on Android (based on seccomp from Linux) that allows filtering of system calls. This approach reduces attack surface on kernel space. When a process in a "secure" state attempts to invoke a syscall outside allowed set it crashes. Bionic instructs 'seccomp-bpf' to allow all syscals listed in [SYSCALLS.txt](https://github.com/aosp-mirror/platform_bionic/blob/master/libc/SYSCALLS.TXT). _mkdir_, _rmdir_ and _symlink_ are not listed, unlike _mkdirat_, _unlinkat_, _symlinkat_. 

Bionic is Android's equivalent of the standard C library. Derived from BSD Unix libc. Not from GNU C lib due to licensing issues. BSD license is more free than LGPL imposed on glibc.

This issue may exist not only in Android, but also in Linux in general where seccomp filtering and Bionic are used.

**The fix**
This change brings uniformity across platforms. A fuzzing program always includes header 'common_linux.h' which silently overrides _mkdir_, _rmdir_ and _symlink_ with Bionic conterparts based on_mkdirat_, _unlinkat_, _symlinkat_. This applies only if the following conditions are met:
- SYZ_EXECUTOR || SYZ_SANDBOX_ANDROID is true AND 
- GOARCH_amd64 || GOARCH_386 is true

Fixes #227363894