### PR TITLE
pkg/report: ignore eibrs mitigation warnings

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1726,6 +1726,7 @@ var linuxOopses = append([]*oops{
 			compile("WARNING: workqueue cpumask: online intersect > possible intersect"),
 			compile("WARNING: [Tt]he mand mount option (is being|has been) deprecated"),
 			compile("WARNING: Unsupported flag value\\(s\\) of 0x%x in DT_FLAGS_1"), // printed when glibc is dumped
+			compile("WARNING: Unprivileged eBPF is enabled with eIBRS"),
 		},
 	},
 	{

--- a/pkg/report/testdata/linux/report/647
+++ b/pkg/report/testdata/linux/report/647
@@ -1,0 +1,9 @@
+TITLE: 
+
+
+[    1.229302][    T0] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    1.230552][    T0] Spectre V2 : WARNING: Unprivileged eBPF is enabled with eIBRS on, data leaks possible via Spectre v2 BHB attacks!
+[    1.232245][    T0] Spectre V2 : Mitigation: Enhanced IBRS
+[    1.232987][    T0] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    1.234308][    T0] Spectre V2 : mitigation: Enabling conditional Indirect Branch Prediction Barrier
+[    1.235587][    T0] Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl


### PR DESCRIPTION
These are not normal warnings, but they look like real warnings for syzkaller.