### PR TITLE
vm/cuttlefish: implement forward function

### DIFF
--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -69,27 +69,33 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 
 	// Start a Cuttlefish device on the GCE instance
 	// TODO: pass it the specific kernel artifact using -kernel_path and -initramfs_path flags
-	if err := inst.runOnHost(10*time.Minute, "./bin/launch_cvd -daemon"); err != nil {
+	if err := inst.runOnHost(10*time.Minute, "./bin/launch_cvd -daemon", false); err != nil {
 		return nil, fmt.Errorf("failed to start cuttlefish: %s", err)
 	}
 
-	if err := inst.runOnHost(10*time.Minute, "adb wait-for-device"); err != nil {
+	if err := inst.runOnHost(10*time.Minute, "adb wait-for-device", false); err != nil {
 		return nil, fmt.Errorf("failed while waiting for device: %s", err)
 	}
 
-	if err := inst.runOnHost(5*time.Minute, "adb root"); err != nil {
+	if err := inst.runOnHost(5*time.Minute, "adb root", false); err != nil {
 		return nil, fmt.Errorf("failed to get root access to device: %s", err)
 	}
 
 	return inst, nil
 }
 
-func (inst *instance) runOnHost(timeout time.Duration, cmd string) error {
-	outc, errc, err := inst.gceInst.Run(timeout, nil, cmd)
+func (inst *instance) runOnHost(timeout time.Duration, cmd string, background bool) error {
+	taskTimeout := timeout
+	if background {
+		taskTimeout = 24 * time.Hour
+	}
+
+	outc, errc, err := inst.gceInst.Run(taskTimeout, nil, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to run command: %s", err)
 	}
 
+	timer := time.NewTimer(timeout)
 	for {
 		select {
 		case <-vmimpl.Shutdown:
@@ -102,6 +108,12 @@ func (inst *instance) runOnHost(timeout time.Duration, cmd string) error {
 		case out, ok := <-outc:
 			if ok && inst.debug {
 				log.Logf(1, "%s", out)
+			}
+		case <-timer.C:
+			// When running processes in the background, we assume that everything is fine if the timer
+			// expires and it hasn't given any errors.
+			if background {
+				return nil
 			}
 		}
 	}
@@ -116,7 +128,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	deviceDst := filepath.Join(deviceRoot, filepath.Base(hostSrc))
 	pushCmd := fmt.Sprintf("adb push %s %s", gceDst, deviceDst)
 
-	if err := inst.runOnHost(5*time.Minute, pushCmd); err != nil {
+	if err := inst.runOnHost(5*time.Minute, pushCmd, false); err != nil {
 		return "", fmt.Errorf("error pushing to device: %s", err)
 	}
 
@@ -124,7 +136,25 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 }
 
 func (inst *instance) Forward(port int) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	hostForward, err := inst.gceInst.Forward(port)
+	if err != nil {
+		return "", fmt.Errorf("failed to get IP/port from GCE instance: %s", err)
+	}
+	cmd := fmt.Sprintf("socat TCP-LISTEN:%d,fork TCP:%s", port, hostForward)
+	if err := inst.runOnHost(60*time.Second, cmd, true); err != nil {
+		return "", fmt.Errorf("unable to forward port on host: %s", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		devicePort := vmimpl.RandomPort()
+		cmd := fmt.Sprintf("adb reverse tcp:%d tcp:%d", devicePort, port)
+		err = inst.runOnHost(10*time.Second, cmd, false)
+		if err == nil {
+			return fmt.Sprintf("127.0.0.1:%d", devicePort), nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to forward port on device: %s", err)
 }
 
 func (inst *instance) Close() {

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -127,7 +127,7 @@ func (inst *instance) Forward(port int) (string, error) {
 	}
 
 	cmd := fmt.Sprintf("nohup socat TCP-LISTEN:%d,fork TCP:%s", port, hostForward)
-	if err := inst.runOnHost(10*time.Second, cmd); err != nil && err != vmimpl.ErrTimeout {
+	if err := inst.runOnHost(time.Second, cmd); err != nil && err != vmimpl.ErrTimeout {
 		return "", fmt.Errorf("unable to forward port on host: %s", err)
 	}
 


### PR DESCRIPTION
We need to tunnel ports from the Manager instance all the way through to the virtual device. We do
this by tunneling from the Manager to the worker GCE instance using 'socat' on the worker instance
and 'adb reverse' to forward the port on the device.

We need the 'socat' process to keep running for the tunnel to stay open. We can check for an error
on launch, but to check if the process is still running we send it a zero signal after waiting an
appropriate amount of time.

The 'adb reverse' command, by comparison returns immediately after the connection is established and
keeps the tunnel open. We loop until we find a valid/available port, similar to what is done in
vm/adb/adb.go. In practice, this nearly always finds a valid port on the first attempt.
