### PR TITLE
vm/gce: make zone_id configurable

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1331,7 +1331,7 @@ func publicWebAddr(addr string) string {
 		if host, err := os.Hostname(); err == nil {
 			addr = net.JoinHostPort(host, port)
 		}
-		if GCE, err := gce.NewContext(); err == nil {
+		if GCE, err := gce.NewContext(""); err == nil {
 			addr = net.JoinHostPort(GCE.ExternalIP, port)
 		}
 	}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -40,6 +40,7 @@ func init() {
 
 type Config struct {
 	Count         int    `json:"count"`          // number of VMs to use
+	ZoneID        string `json:"zone_id"`        // GCE zone (if it's different from that of syz-manager)
 	MachineType   string `json:"machine_type"`   // GCE machine type (e.g. "n1-highcpu-2")
 	GCSPath       string `json:"gcs_path"`       // GCS path to upload image
 	GCEImage      string `json:"gce_image"`      // pre-created GCE image to use
@@ -99,7 +100,7 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("both image and gce_image are specified")
 	}
 
-	GCE, err := gce.NewContext()
+	GCE, err := gce.NewContext(cfg.ZoneID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init gce: %v", err)
 	}


### PR DESCRIPTION
Now syzkaller can only use the zone where it's running. Make it a
configurable option instead (with the old behavior as a fallback).
