### PR TITLE
dashboard: test patches for boot error bugs

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -166,8 +166,11 @@ func addTestJob(c context.Context, bug *Bug, bugKey *db.Key, bugReporting *BugRe
 
 func checkTestJob(c context.Context, bug *Bug, bugReporting *BugReporting, crash *Crash,
 	repo, branch string) string {
+	isBootError := func(crash *Crash) bool {
+		return strings.Contains(crash.Title, "boot error:")
+	}
 	switch {
-	case crash.ReproC == 0 && crash.ReproSyz == 0:
+	case !isBootError(crash) && crash.ReproC == 0 && crash.ReproSyz == 0:
 		return "This crash does not have a reproducer. I cannot test it."
 	case !vcs.CheckRepoAddress(repo):
 		return fmt.Sprintf("%q does not look like a valid git repo address.", repo)

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -422,7 +422,7 @@ func (mgr *Manager) testImage(imageDir string, info *BuildInfo) error {
 		switch err := res.(type) {
 		case *instance.TestError:
 			if rep := err.Report; rep != nil {
-				what := targets.TestOS
+				what := "test"
 				if err.Boot {
 					what = "boot"
 				}


### PR DESCRIPTION
Such bugs don't have an explicit repro, but in fact we can easily test them, even without any changes to the testing code.

Adjust #syz test request validation.