### PR TITLE
syz-ci: don't require a repro for JobTestPatch

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -337,8 +337,10 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 		{"kernel branch", req.KernelBranch != "" || req.Type != dashapi.JobTestPatch},
 		{"kernel config", len(req.KernelConfig) != 0},
 		{"syzkaller commit", req.SyzkallerCommit != ""},
-		{"reproducer options", len(req.ReproOpts) != 0},
-		{"reproducer program", len(req.ReproSyz) != 0},
+		// We either want a normal repro (with options and syz repro text)
+		// or it's a boot time bug, in which case both are empty.
+		{"reproducer consistency", (len(req.ReproOpts) != 0 && len(req.ReproSyz) != 0) ||
+			(len(req.ReproOpts) == 0 && len(req.ReproSyz) == 0)},
 	}
 	for _, req := range required {
 		if !req.ok {


### PR DESCRIPTION
For boot-time bugs there may be no repro, yet we can test it. Only leave
a sanity check (if syz repro is present, then repro options must also
be, and vice versa).
