### PR TITLE
all: fix patch testing for bugs witout C repro

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -398,7 +398,7 @@ func (inst *inst) testRepro() error {
 			opts.FaultCall = -1
 		}
 		cmdSyz := ExecprogCmd(execprogBin, executorBin, cfg.TargetOS, cfg.TargetArch, opts.Sandbox,
-			true, true, true, cfg.Procs, opts.FaultCall, opts.FaultNth, inst.optionalFlags,
+			true, true, opts.Collide, cfg.Procs, opts.FaultCall, opts.FaultNth, inst.optionalFlags,
 			cfg.Timeouts.Slowdown, vmProgFile)
 		if err := inst.testProgram(cmdSyz, cfg.Timeouts.NoOutputRunningTime); err != nil {
 			return err

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -87,7 +87,7 @@ func main() {
 		}
 	}
 	if *flagCollide {
-		log.Fatalf("setting -collide to true is deprecated now")
+		log.Logf(0, "note: setting -collide to true is deprecated now and has no effect")
 	}
 	config, execOpts := createConfig(target, features, featuresFlags)
 	if err = host.Setup(target, features, featuresFlags, config.Executor); err != nil {


### PR DESCRIPTION
Syzbot tests patches with -collide=true in order to trigger more bugs,
but now that -collide flag is deprecated, this no longer makes sense.
Moreover, it actually prevents the testing of bugs with syz repro now -
syz-execprog immediately exits due to -collide=true and env.Test()
accepts it as a normal outcome.

Set -collide=true only for those bugs, where collide was set to true by
the reproducer (and therefore syzkaller at that revision supported it).

Don't exit from syz-execprog immediately if -collide is set to true.
This will prevent such bugs from happening later and make the problem
more visible.

This was initially part of #3083, but seems to be more urgent to merge,
so pushing it as a separate PR.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
