### PR TITLE
pkg/vcs: recursively clone git submodules

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -92,6 +92,9 @@ func (git *git) Poll(repo, branch string) (*Commit, error) {
 	if _, err := git.git("checkout", "origin/"+branch); err != nil {
 		return nil, err
 	}
+	if _, err := git.git("submodule", "update", "--init"); err != nil {
+		return nil, err
+	}
 	return git.HeadCommit()
 }
 
@@ -107,6 +110,9 @@ func (git *git) CheckoutBranch(repo, branch string) (*Commit, error) {
 		return nil, err
 	}
 	if _, err := git.git("checkout", "FETCH_HEAD"); err != nil {
+		return nil, err
+	}
+	if _, err := git.git("submodule", "update", "--init"); err != nil {
 		return nil, err
 	}
 	return git.HeadCommit()
@@ -136,6 +142,9 @@ func (git *git) SwitchCommit(commit string) (*Commit, error) {
 		git.git("clean", "-fdx")
 	}
 	if _, err := git.git("checkout", commit); err != nil {
+		return nil, err
+	}
+	if _, err := git.git("submodule", "update", "--init"); err != nil {
 		return nil, err
 	}
 	return git.HeadCommit()


### PR DESCRIPTION
Android kernel source uses Git submodules to separate vendor- or
device-specific kernel modules from the main kernel source.

This calls 'git submodules update --init' after calls to 'git checkout',
which is the equivalent of adding the '--recurse-submodules' flag to
'git clone'.

For cases where submodules aren't used (all other Syzkaller targets)
this additional command is a no-op.
