### PR TITLE
pkg/build, sys/targets: add separate target for Android

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -1,0 +1,18 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+import (
+	"fmt"
+)
+
+type android struct{}
+
+func (a android) build(params Params) (ImageDetails, error) {
+	return ImageDetails{}, fmt.Errorf("not implemented for Android")
+}
+
+func (a android) clean(kernelDir, targetArch string) error {
+	return fmt.Errorf("not implemented for Android")
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -128,6 +128,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		targets.Linux:   linux{},
 		targets.Fuchsia: fuchsia{},
 		targets.Akaros:  akaros{},
+		targets.Android: android{},
 		targets.OpenBSD: openbsd{},
 		targets.NetBSD:  netbsd{},
 		targets.FreeBSD: freebsd{},

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -23,6 +23,9 @@ var flagUpdate = flag.Bool("update", false, "reformat all.txt")
 func TestCompileAll(t *testing.T) {
 	for os, arches := range targets.List {
 		os, arches := os, arches
+		if os == targets.Android {
+			os = targets.Linux
+		}
 		t.Run(os, func(t *testing.T) {
 			t.Parallel()
 			eh := func(pos ast.Pos, msg string) {

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -180,11 +180,12 @@ func buildTestBinary(t *testing.T, target *targets.Target, test Test, dir string
 
 	aslrDefine := "-DNO_ASLR_BASE"
 	if target.OS == targets.Linux || target.OS == targets.OpenBSD ||
-		target.OS == targets.FreeBSD || target.OS == targets.NetBSD {
+		target.OS == targets.FreeBSD || target.OS == targets.NetBSD ||
+		target.OS == targets.Android {
 		aslrDefine = "-DASLR_BASE"
 	}
 	aslrExtraLibs := []string{}
-	if target.OS == targets.Linux {
+	if target.OS == targets.Linux || target.OS == targets.Android {
 		aslrExtraLibs = []string{"-ldl"}
 	}
 

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -178,6 +178,8 @@ func NewRepo(os, vm, dir string, opts ...RepoOpt) (Repo, error) {
 		return newLinux(dir, opts), nil
 	case targets.Akaros:
 		return newAkaros(dir, opts), nil
+	case targets.Android:
+		return newGit(dir, nil, opts), nil
 	case targets.Fuchsia:
 		return newFuchsia(dir, opts), nil
 	case targets.OpenBSD:

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -82,15 +82,19 @@ func main() {
 
 	data := &ExecutorData{}
 	for _, OS := range OSList {
-		descriptions := ast.ParseGlob(filepath.Join(*srcDir, "sys", OS, "*.txt"), nil)
+		descOS := OS
+		if OS == targets.Android {
+			descOS = targets.Linux
+		}
+		descriptions := ast.ParseGlob(filepath.Join(*srcDir, "sys", descOS, "*.txt"), nil)
 		if descriptions == nil {
 			os.Exit(1)
 		}
-		constFile := compiler.DeserializeConstFile(filepath.Join(*srcDir, "sys", OS, "*.const"), nil)
+		constFile := compiler.DeserializeConstFile(filepath.Join(*srcDir, "sys", descOS, "*.const"), nil)
 		if constFile == nil {
 			os.Exit(1)
 		}
-		osutil.MkdirAll(filepath.Join(*outDir, "sys", OS, "gen"))
+		osutil.MkdirAll(filepath.Join(*outDir, "sys", descOS, "gen"))
 
 		var archs []string
 		for arch := range targets.List[OS] {


### PR DESCRIPTION
Android uses some custom build scripts for building the kernel (see
https://source.android.com/setup/build/building-kernels). We'll need a
new pkg/build/builder implementation to do support the Android scripts.

This adds an empty builder implementation and a new target type (e.g.
"android/arm64") to use it.

We want Android to use the same descriptions as Linux as Syzkaller
currently does, so syz-sysgen is updated to do that.

The actual logic for performing the build will be in future changes,
but this will allow us to keep those changes contained more cleanly in
pkg/build/android.go.
