### PR TITLE
report: report fuzzer fatal errors

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -94,11 +94,11 @@ func Logf(v int, msg string, args ...interface{}) {
 }
 
 func Fatal(err error) {
-	golog.Fatal(err)
+	golog.Fatal("SYZFATAL: ", err)
 }
 
 func Fatalf(msg string, args ...interface{}) {
-	golog.Fatalf(msg, args...)
+	golog.Fatalf("SYZFATAL: "+msg, args...)
 }
 
 type VerboseWriter int

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -759,6 +759,19 @@ var commonOopses = []*oops{
 		[]*regexp.Regexp{},
 	},
 	{
+		// Errors produced by log.Fatal functions.
+		[]byte("SYZFATAL:"),
+		[]oopsFormat{
+			{
+				title:        compile("SYZFATAL:(.*)()"),
+				alt:          []string{"SYZFATAL%[2]s"},
+				fmt:          "SYZFATAL:%[1]v",
+				noStackTrace: true,
+			},
+		},
+		[]*regexp.Regexp{},
+	},
+	{
 		[]byte("panic:"),
 		[]oopsFormat{
 			{

--- a/pkg/report/testdata/all/report/5
+++ b/pkg/report/testdata/all/report/5
@@ -1,0 +1,4 @@
+TITLE: SYZFATAL: executor NUM failed NUM times: call NUM/NUM/NUM: signal overflow: ADDR/ADDR
+ALT: SYZFATAL
+
+2022/04/21 07:35:27 SYZFATAL: executor 0 failed 11 times: call 15/15/3356: signal overflow: 808464432/16776764

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -327,7 +327,7 @@ func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog, stat Stat) *ipc.P
 				return nil
 			}
 			if try > 10 {
-				log.Fatalf("executor %v failed %v times:\n%v", proc.pid, try, err)
+				log.Fatalf("executor %v failed %v times: %v", proc.pid, try, err)
 			}
 			log.Logf(4, "fuzzer detected executor failure='%v', retrying #%d", err, try+1)
 			debug.FreeOSMemory()


### PR DESCRIPTION
Right now, all fuzzer fatal errors are hidden in "lost connection to test machine"  or "no output from test machine" reports.