### PR TITLE
tools/syz-trace2syz: fix a panic in tests

### DIFF
--- a/tools/syz-trace2syz/proggen/call_selector.go
+++ b/tools/syz-trace2syz/proggen/call_selector.go
@@ -145,7 +145,10 @@ func (cs *openCallSelector) matchOpen(meta *prog.Syscall, call *parser.Syscall) 
 	if _, ok := syzFileArg.(*prog.PtrType); !ok {
 		return false, -1
 	}
-	syzBuf := syzFileArg.(*prog.PtrType).Elem.(*prog.BufferType)
+	syzBuf, ok := syzFileArg.(*prog.PtrType).Elem.(*prog.BufferType)
+	if !ok {
+		return false, -1
+	}
 	if syzBuf.Kind != prog.BufferString {
 		return false, -1
 	}


### PR DESCRIPTION
The openat filename argument is not necessary a pointer to a string.
It can be a pointer to a struct that builds a string by pieces.
