### PR TITLE
vm/gvisor: fix regex typo

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -157,7 +157,7 @@ var gvisorOopses = append([]*oops{
 		[]oopsFormat{
 			{
 				title:        compile("WARNING: DATA RACE"),
-				report:       compile("WARNING: DATA RACE\n(?:.*\n)*?  (?:[a-zA-Z0-9./-_]+/)([a-zA-Z0-9.()*_]+)\\(\\)\n"),
+				report:       compile("WARNING: DATA RACE\n(?:.*\n)*?  (?:[a-zA-Z0-9./_-]+/)([a-zA-Z0-9.()*_]+)\\(\\)\n"),
 				fmt:          "DATA RACE in %[1]v",
 				noStackTrace: true,
 			},


### PR DESCRIPTION
Ensure that the dash char '-' is treated as a literal instead of as a range in regular expression.