### PR TITLE
dvyukov dashboard show uptime

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1096,14 +1096,6 @@ func loadManagers(c context.Context, accessLevel AccessLevel, ns, manager string
 			TotalExecs:            stats.TotalExecs,
 			TotalExecsBad:         stats.TotalExecs == 0,
 		}
-		if config.Namespaces[mgr.Namespace].Decommissioned {
-			// Don't show bold red highlight for decommissioned namespaces.
-			ui.Link = ""
-			ui.FailedBuildBugLink = ""
-			ui.FailedSyzBuildBugLink = ""
-			ui.CurrentUpTime = 0
-			ui.TotalExecsBad = false
-		}
 		results = append(results, ui)
 	}
 	sort.Slice(results, func(i, j int) bool {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -90,7 +90,6 @@ type uiManager struct {
 	FailedBuildBugLink    string
 	FailedSyzBuildBugLink string
 	LastActive            time.Time
-	LastActiveBad         bool // highlight LastActive in red
 	CurrentUpTime         time.Duration
 	MaxCorpus             int64
 	MaxCover              int64
@@ -1075,6 +1074,10 @@ func loadManagers(c context.Context, accessLevel AccessLevel, ns, manager string
 		if accessLevel < AccessUser {
 			link = ""
 		}
+		uptime := mgr.CurrentUpTime
+		if now.Sub(mgr.LastAlive) > 6*time.Hour {
+			uptime = 0
+		}
 		ui := &uiManager{
 			Now:                   timeNow(c),
 			Namespace:             mgr.Namespace,
@@ -1085,8 +1088,7 @@ func loadManagers(c context.Context, accessLevel AccessLevel, ns, manager string
 			FailedBuildBugLink:    bugLink(mgr.FailedBuildBug),
 			FailedSyzBuildBugLink: bugLink(mgr.FailedSyzBuildBug),
 			LastActive:            mgr.LastAlive,
-			LastActiveBad:         now.Sub(mgr.LastAlive) > 6*time.Hour,
-			CurrentUpTime:         mgr.CurrentUpTime,
+			CurrentUpTime:         uptime,
 			MaxCorpus:             stats.MaxCorpus,
 			MaxCover:              stats.MaxCover,
 			TotalFuzzingTime:      stats.TotalFuzzingTime,
@@ -1100,7 +1102,6 @@ func loadManagers(c context.Context, accessLevel AccessLevel, ns, manager string
 			ui.FailedBuildBugLink = ""
 			ui.FailedSyzBuildBugLink = ""
 			ui.CurrentUpTime = 0
-			ui.LastActiveBad = false
 			ui.TotalExecsBad = false
 		}
 		results = append(results, ui)

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -181,7 +181,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th>Coverage {{template "info_link" "https://github.com/google/syzkaller/blob/master/docs/coverage.md"}}</th>
 		<th>Crashes</th>
 		<th>Execs</th>
-		<th colspan="3">Kernel build</th>
+		<th colspan="4">Kernel build</th>
 		<th colspan="3">syzkaller build</th>
 	</tr>
 	<tr>
@@ -193,6 +193,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th></th>
 		<th></th>
 		<th>Commit</th>
+		<th>Config</th>
 		<th>Freshness</th>
 		<th>Status</th>
 		<th>Commit</th>
@@ -224,12 +225,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{end}}
 			{{with $build := $mgr.CurrentBuild}}
 				<td class="stat" title="[{{$build.KernelAlias}}] {{$build.KernelCommitTitle}}">{{link $build.KernelCommitLink (formatTagHash $build.KernelCommit)}}</td>
+				<td class="stat">{{link $build.KernelConfigLink ".config"}}</td>
 				<td class="stat" title="{{formatTime $build.KernelCommitDate}}" {{if $mgr.FailedBuildBugLink}}class="bad"{{end}}>{{formatLateness $mgr.Now $build.KernelCommitDate}}</td>
 				<td class="stat">{{if $mgr.FailedBuildBugLink}}<a href="{{$mgr.FailedBuildBugLink}}" class="bad">failing</a>{{end}}</td>
 				<td class="stat">{{link $build.SyzkallerCommitLink (formatShortHash $build.SyzkallerCommit)}}</td>
 				<td class="stat" title="{{formatTime $build.SyzkallerCommitDate}}" {{if $mgr.FailedSyzBuildBugLink}}class="bad"{{end}}>{{formatLateness $mgr.Now $build.SyzkallerCommitDate}}</td>
 				<td class="stat">{{if $mgr.FailedSyzBuildBugLink}}<a href="{{$mgr.FailedSyzBuildBugLink}}" class="bad">failing</a>{{end}}</td>
 			{{else}}
+				<td></td>
 				<td></td>
 				<td></td>
 				<td></td>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -175,7 +175,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	<thead>
 	<tr>
 		<th>Name</th>
-		<th>Active</th>
+		<th>Last active</th>
 		<th>Uptime</th>
 		<th>Corpus</th>
 		<th>Coverage {{template "info_link" "https://github.com/google/syzkaller/blob/master/docs/coverage.md"}}</th>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -204,7 +204,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{range $mgr := .}}
 		<tr>
 			<td>{{link $mgr.Link $mgr.Name}}</td>
-			<td class="stat {{if $mgr.LastActiveBad}}bad{{end}}">{{formatLateness $mgr.Now $mgr.LastActive}}</td>
+			<td class="stat {{if not $mgr.CurrentUpTime}}bad{{end}}">{{formatLateness $mgr.Now $mgr.LastActive}}</td>
 			<td class="stat">{{formatDuration $mgr.CurrentUpTime}}</td>
 			<td class="stat">{{formatStat $mgr.MaxCorpus}}</td>
 			<td class="stat">


### PR DESCRIPTION
- dashboard/app: don't show Uptime is manager is inactive
- dashboard/app: remove dead code
- dashboard/app: rename Active to Last active
- dashboard/app: show kernel config for the current manager build
