### PR TITLE
pkg/instance: fix nil derefs in patch testing and bisections

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -368,10 +368,13 @@ func (inst *inst) testRepro() error {
 		return err
 	}
 	transformError := func(res *RunResult, err error) error {
-		if err != nil && res.Report != nil {
+		if err != nil {
+			return err
+		}
+		if res != nil && res.Report != nil {
 			return &CrashError{Report: res.Report}
 		}
-		return err
+		return nil
 	}
 	if len(inst.reproSyz) > 0 {
 		var opts csource.Options


### PR DESCRIPTION
Fix these crashes:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd430ae]
goroutine 875 [running]:
github.com/google/syzkaller/pkg/instance.(*inst).testRepro.func1(...)
        pkg/instance/instance.go:371
github.com/google/syzkaller/pkg/instance.(*inst).testRepro(0xc0005a2c80)
        pkg/instance/instance.go:396 +0x26e
github.com/google/syzkaller/pkg/instance.(*inst).test(0xc0005a2c80)
        pkg/instance/instance.go:293 +0xf2
github.com/google/syzkaller/pkg/instance.(*env).Test.func1()
        pkg/instance/instance.go:237 +0x26
created by github.com/google/syzkaller/pkg/instance.(*env).Test
        pkg/instance/instance.go:237 +0x1d7
syz-ci.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
