### PR TITLE
tools/create-gce-image.sh: enable sftp in ssh daemon

### DIFF
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -106,6 +106,7 @@ PermitRootLogin yes
 PasswordAuthentication yes
 PermitEmptyPasswords yes
 ClientAliveInterval 420
+Subsystem sftp /usr/lib/openssh/sftp-server
 EOF
 sudo sed -i "s#^root:\*:#root::#g" disk.mnt/etc/shadow
 

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -149,6 +149,7 @@ PermitRootLogin yes
 PasswordAuthentication yes
 PermitEmptyPasswords yes
 ClientAliveInterval 420
+Subsystem sftp /usr/lib/openssh/sftp-server
 EOF
 # Reset root password.
 sudo sed -i "s#^root:\*:#root::#g" disk.mnt/etc/shadow


### PR DESCRIPTION
If we don't enable SFTP in SSH daemon, then scp will not work w/o -O option.

Fixes:

syz-ci-devel    | 2022/05/10 09:01:23 syz-ci-devel-kasan: VM testing failed with: failed to copy test binary to VM: failed to run ["scp" "-P" "55610" "-F" "/dev/null" "-o" "UserKnownHostsFile=/dev/null" "-o" "BatchMode=yes" "-o" "IdentitiesOnly=yes" "-o" "StrictHostKeyChecking=no" "-o" "ConnectTimeout=10" "/workdir/syzkaller/current/bin/linux_s390x/syz-fuzzer" "root@localhost:/syz-fuzzer"]: exit status 255
syz-ci-devel    | Warning: Permanently added '[localhost]:55610' (ED25519) to the list of known hosts.
syz-ci-devel    | subsystem request failed on channel 0
syz-ci-devel    | scp: Connection closed

Signed-off-by: Alexander Egorenkov <eaibmz@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
