### PR TITLE
dashboard/app: return 404 instead of 500 for user requests

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -117,7 +117,7 @@ func checkCrashTextAccess(c context.Context, r *http.Request, field string, id i
 	if len(crashes) != 1 {
 		err := fmt.Errorf("checkCrashTextAccess: found %v crashes for %v=%v", len(crashes), field, id)
 		if len(crashes) == 0 {
-			err = ErrDontLog{err}
+			err = fmt.Errorf("%v: %w", err, ErrClientNotFound)
 		}
 		return nil, nil, err
 	}
@@ -142,7 +142,7 @@ func checkJobTextAccess(c context.Context, r *http.Request, field string, id int
 		err := fmt.Errorf("checkJobTextAccess: found %v jobs for %v=%v", len(keys), field, id)
 		if len(keys) == 0 {
 			// This can be triggered by bad user requests, so don't log the error.
-			err = ErrDontLog{err}
+			err = fmt.Errorf("%v: %w", err, ErrClientNotFound)
 		}
 		return err
 	}

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -52,14 +53,18 @@ func handleContext(fn contextHandler) http.Handler {
 				http.Redirect(w, r, redir.Error(), http.StatusFound)
 				return
 			}
+
+			status := http.StatusInternalServerError
 			logf := log.Errorf
-			if _, dontlog := err.(ErrDontLog); dontlog {
+			var clientError *ErrClient
+			if errors.As(err, &clientError) {
 				// We don't log these as errors because they can be provoked
 				// by invalid user requests, so we don't wan't to pollute error log.
 				logf = log.Warningf
+				status = clientError.HTTPStatus()
 			}
 			logf(c, "%v", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(status)
 			if err1 := templates.ExecuteTemplate(w, "error.html", data); err1 != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
@@ -68,9 +73,22 @@ func handleContext(fn contextHandler) http.Handler {
 }
 
 type (
-	ErrDontLog  struct{ error }
+	ErrClient   struct{ error }
 	ErrRedirect struct{ error }
 )
+
+var ErrClientNotFound = &ErrClient{errors.New("resource not found")}
+var ErrClientBadRequest = &ErrClient{errors.New("bad request")}
+
+func (ce *ErrClient) HTTPStatus() int {
+	switch ce {
+	case ErrClientNotFound:
+		return http.StatusNotFound
+	case ErrClientBadRequest:
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
 
 func handleAuth(fn contextHandler) contextHandler {
 	return func(c context.Context, w http.ResponseWriter, r *http.Request) error {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -346,7 +346,7 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error {
 	bug, err := findBugByID(c, r)
 	if err != nil {
-		return ErrDontLog{err}
+		return fmt.Errorf("%v, %w", err, ErrClientNotFound)
 	}
 	accessLevel := accessLevel(c, r)
 	if err := checkAccessLevel(c, r, bug.sanitizeAccess(accessLevel)); err != nil {
@@ -501,14 +501,14 @@ func handleTextImpl(c context.Context, w http.ResponseWriter, r *http.Request, t
 	if x := r.FormValue("x"); x != "" {
 		xid, err := strconv.ParseUint(x, 16, 64)
 		if err != nil || xid == 0 {
-			return ErrDontLog{fmt.Errorf("failed to parse text id: %v", err)}
+			return fmt.Errorf("failed to parse text id: %v: %w", err, ErrClientBadRequest)
 		}
 		id = int64(xid)
 	} else {
 		// Old link support, don't remove.
 		xid, err := strconv.ParseInt(r.FormValue("id"), 10, 64)
 		if err != nil || xid == 0 {
-			return ErrDontLog{fmt.Errorf("failed to parse text id: %v", err)}
+			return fmt.Errorf("failed to parse text id: %v: %w", err, ErrClientBadRequest)
 		}
 		id = xid
 	}
@@ -519,7 +519,7 @@ func handleTextImpl(c context.Context, w http.ResponseWriter, r *http.Request, t
 	data, ns, err := getText(c, tag, id)
 	if err != nil {
 		if strings.Contains(err.Error(), "datastore: no such entity") {
-			err = ErrDontLog{err}
+			err = fmt.Errorf("%v: %w", err, ErrClientBadRequest)
 		}
 		return err
 	}


### PR DESCRIPTION
5xx category signals the Internal Server Errors and require server developers attention.
4xx category means client side problem and doesn't require server developers attention.

The tests are needed for PR.