### PR TITLE
pkg/ifuzz/powerpc: update cntlzw instruction

### DIFF
--- a/pkg/ifuzz/powerpc/gen/powerisa31_tex_to_syz
+++ b/pkg/ifuzz/powerpc/gen/powerisa31_tex_to_syz
@@ -251,7 +251,7 @@ print('\tpowerpc.Register(insns)')
 print('}')
 print('')
 print('var insns = []*powerpc.Insn{')
-generate_go(insns, collect_priv(isa_dir + "/Appendices/PPC_ApInstMnem.tex", insns))
+generate_go(insns, collect_priv(isa_dir + "/Appendices/inst-mnem.tex", insns))
 print("}")
 
 pe.pprint("Processed {} instructions".format(len(insns)))

--- a/pkg/ifuzz/powerpc/generated/insns.go
+++ b/pkg/ifuzz/powerpc/generated/insns.go
@@ -93,7 +93,7 @@ var insns = []*powerpc.Insn{
 	{Name: "cntlzd.", Opcode: 0x7c000075, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
 	{Name: "cntlzdm", Opcode: 0x7c000076, Mask: 0xfc0007ff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RB", Bits: []powerpc.InsnBits{{16, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
 	{Name: "cntlzw", Opcode: 0x7c000034, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
-	{Name: "cntlzw.", Opcode: 0x7c000034, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
+	{Name: "cntlzw.", Opcode: 0x7c000035, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
 	{Name: "cnttzd", Opcode: 0x7c000474, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
 	{Name: "cnttzd.", Opcode: 0x7c000475, Mask: 0xfc00ffff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},
 	{Name: "cnttzdm", Opcode: 0x7c000476, Mask: 0xfc0007ff, Fields: []powerpc.InsnField{{Name: "RA", Bits: []powerpc.InsnBits{{11, 5}}}, {Name: "RB", Bits: []powerpc.InsnBits{{16, 5}}}, {Name: "RS", Bits: []powerpc.InsnBits{{6, 5}}}}},


### PR DESCRIPTION
The source PowerISA latex files have updated:
- changed files layout;
- "cntlzw." got corrected.

The fixed are not used by syzkaller in macros so there should be
no huge change in behaviour, if any.

Signed-off-by: Alexey Kardashevskiy <aik@linux.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
