### PR TITLE
ipc: add magic in a call reply

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -329,6 +329,7 @@ const uint32 call_flag_fault_injected = 1 << 3;
 
 struct call_reply {
 	execute_reply header;
+	uint32 magic;
 	uint32 call_index;
 	uint32 call_num;
 	uint32 reserrno;
@@ -1104,6 +1105,7 @@ void write_call_output(thread_t* th, bool finished)
 			      (th->fault_injected ? call_flag_fault_injected : 0);
 	}
 #if SYZ_EXECUTOR_USES_SHMEM
+	write_output(kOutMagic);
 	write_output(th->call_index);
 	write_output(th->call_num);
 	write_output(reserrno);
@@ -1148,6 +1150,7 @@ void write_call_output(thread_t* th, bool finished)
 	reply.header.magic = kOutMagic;
 	reply.header.done = 0;
 	reply.header.status = 0;
+	reply.magic = kOutMagic;
 	reply.call_index = th->call_index;
 	reply.call_num = th->call_num;
 	reply.reserrno = reserrno;

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -338,6 +338,9 @@ func (env *Env) parseOutput(p *prog.Prog, opts *ExecOpts) (*ProgInfo, error) {
 		reply := *(*callReply)(unsafe.Pointer(&out[0]))
 		out = out[unsafe.Sizeof(callReply{}):]
 		var inf *CallInfo
+		if reply.magic != outMagic {
+			return nil, fmt.Errorf("bad reply magic 0x%x", reply.magic)
+		}
 		if reply.index != extraReplyIndex {
 			if int(reply.index) >= len(info.Calls) {
 				return nil, fmt.Errorf("bad call %v index %v/%v", i, reply.index, len(info.Calls))
@@ -532,6 +535,7 @@ type executeReply struct {
 }
 
 type callReply struct {
+	magic      uint32
 	index      uint32 // call index in the program
 	num        uint32 // syscall number (for cross-checking)
 	errno      uint32


### PR DESCRIPTION
When a shared memory is used, the executor can corrupt reply messages,
so let's add magic to detect such cases.

It is an attempt to debug issues like this one:
https://syzkaller.appspot.com/bug?id=faca64c3182e9f130ca94b7931dd771be390ef67

