### PR TITLE
executor: skip mounting binderfs if it is already mounted

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3627,7 +3627,9 @@ static void setup_binderfs()
 		debug("mkdir(/dev/binderfs) failed: %d\n", errno);
 	}
 
-	if (mount("binder", "/dev/binderfs", "binder", 0, NULL)) {
+        // Skip the mount command if the "/dev/binderfs" directory already
+        // exists.
+        if (errno != EEXIST && mount("binder", "/dev/binderfs", "binder", 0, NULL)) {
 		debug("mount of binder at /dev/binderfs failed: %d\n", errno);
 	}
 #if !SYZ_EXECUTOR && !SYZ_USE_TMP_DIR


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
