### PR TITLE
osutil: create memfd with the MFD_CLOEXEC flag

### DIFF
--- a/pkg/osutil/sharedmem_memfd.go
+++ b/pkg/osutil/sharedmem_memfd.go
@@ -16,7 +16,7 @@ import (
 // In the case of Linux, we can just use the memfd_create syscall.
 func CreateSharedMemFile(size int) (f *os.File, err error) {
 	// The name is actually irrelevant and can even be the same for all such files.
-	fd, err := unix.MemfdCreate("syz-shared-mem", 0)
+	fd, err := unix.MemfdCreate("syz-shared-mem", unix.MFD_CLOEXEC)
 	if err != nil {
 		err = fmt.Errorf("failed to do memfd_create: %v", err)
 		return


### PR DESCRIPTION
Go-runtime opens all files with CLOEXEC by default.

exec.Cmd doesn't close file descriptors in a child process and so memfd without
CLOEXEC can leak to an executor process where its content can be corrupted by
one of test system calls.


