### PR TITLE
executor: include sched.h for syz_clone

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -5271,6 +5271,8 @@ static long handle_clone_ret(long ret)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_clone
+#include <sched.h>
+
 // syz_clone is mostly needed on kernels which do not suport clone3.
 static long syz_clone(volatile long flags, volatile long stack, volatile long stack_len,
 		      volatile long ptid, volatile long ctid, volatile long tls)

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -10222,6 +10222,7 @@ static long handle_clone_ret(long ret)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_clone
+#include <sched.h>
 static long syz_clone(volatile long flags, volatile long stack, volatile long stack_len,
 		      volatile long ptid, volatile long ctid, volatile long tls)
 {


### PR DESCRIPTION
syzkaller reports the following error when it tries to create a C reproducer:

<stdin>: In function ‘syz_clone’:
<stdin>:289:48: error: ‘CLONE_VM’ undeclared (first use in this
function)
<stdin>:289:48: note: each undeclared identifier is reported only once
for each function it appears in

compiler invocation: gcc [-o /tmp/syz-executor3459695007 -DGOOS_linux=1
-DGOARCH_amd64=1 -DHOSTGOOS_linux=1 -x c - -m64 -O2 -pthread -Wall
-Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384
-Wno-stringop-overflow -Wno-array-bounds -Wno-format-overflow
-static-pie -fpermissive -w]

