### PR TITLE
dashboard: minor UX improvements

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -14,13 +14,13 @@ Page with details about a single bug.
 <body>
 	{{template "header" .Header}}
 
-	<b>{{.Bug.Title}}</b><br>
+	<b>{{.Bug.Title}}</b><br><br>
 	Status: {{if .Bug.ExternalLink}}<a href="{{.Bug.ExternalLink}}">{{.Bug.Status}}</a>{{else}}{{.Bug.Status}}{{end}}<br>
 	Reported-by: {{.Bug.CreditEmail}}<br>
 	{{if .Bug.Commits}}
-		Fix commit: {{template "fix_commits" .Bug.Commits}}<br>
+		<b>Fix commit:</b> {{template "fix_commits" .Bug.Commits}}<br>
 		{{if .Bug.ClosedTime.IsZero}}
-			Patched on: {{.Bug.PatchedOn}}, missing on: {{.Bug.MissingOn}}<br>
+			<b>Patched on:</b> {{.Bug.PatchedOn}}, missing on: {{.Bug.MissingOn}}<br>
 		{{end}}
 	{{end}}
 	First crash: {{formatLateness $.Now $.Bug.FirstTime}}, last: {{formatLateness $.Now $.Bug.LastTime}}<br>

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -21,6 +21,19 @@ indexes:
 
 - kind: Bug
   properties:
+  - name: Namespace
+  - name: Status
+  - name: Commits
+
+- kind: Bug
+  properties:
+  - name: Namespace
+  - name: Status
+  - name: Commits
+  - name: HappenedOn
+
+- kind: Bug
+  properties:
   - name: HappenedOn
   - name: Status
 

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -109,15 +109,15 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{if $.DispLastAct}}
 		<th><a onclick="return sortTable(this, 'Last activity', timeSort, desc=true)" href="#">Last activity</a></th>
 		{{end}}
-		{{if $.ShowPatch}}
-			<th><a onclick="return sortTable(this, 'Closed', timeSort)" href="#">Closed</a></th>
-			<th><a onclick="return sortTable(this, 'Patch', textSort)" href="#">Patch</a></th>
-		{{end}}
 		{{if $.ShowPatched}}
 			<th><a onclick="return sortTable(this, 'Patched', patchedSort)" href="#">Patched</a></th>
 		{{end}}
 		{{if $.ShowStatus}}
 			<th><a onclick="return sortTable(this, 'Status', textSort)" href="#">Status</a></th>
+		{{end}}
+		{{if $.ShowPatch}}
+			<th><a onclick="return sortTable(this, 'Closed', timeSort)" href="#">Closed</a></th>
+			<th><a onclick="return sortTable(this, 'Patch', textSort)" href="#">Patch</a></th>
 		{{end}}
 	</tr>
 	</thead>
@@ -141,10 +141,6 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{if $.DispLastAct}}
 			<td class="stat">{{formatLateness $.Now $b.LastActivity}}</td>
 			{{end}}
-			{{if $.ShowPatch}}
-				<td class="stat">{{formatLateness $.Now $b.ClosedTime}}</td>
-				<td class="commit_list">{{template "fix_commits" $b.Commits}}</td>
-			{{end}}
 			{{if $.ShowPatched}}
 				<td class="patched" {{if $b.Commits}}title="{{with $com := index $b.Commits 0}}{{$com.Title}}{{end}}"{{end}}>{{len $b.PatchedOn}}/{{$b.NumManagers}}</td>
 			{{end}}
@@ -156,6 +152,10 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 						{{$b.Status}}
 					{{end}}
 				</td>
+			{{end}}
+			{{if $.ShowPatch}}
+				<td class="stat">{{formatLateness $.Now $b.ClosedTime}}</td>
+				<td class="commit_list">{{template "fix_commits" $b.Commits}}</td>
 			{{end}}
 		</tr>
 	{{end}}


### PR DESCRIPTION
This PR addresses to some degree the complaints that we received on our [mailing list](https://groups.google.com/g/syzkaller/c/-7hzkbArE6k/m/yjM_z9ejEgAJ).
- Let the user choose only one bug group and see it.
- Highlight the fixing commit on the bug info page.
- Highlight the presence of a fixing commit on the bug table.

Ideally we should implement a normal [bug search](https://github.com/google/syzkaller/issues/647) or, even better, somehow classify bugs into subsystems. But it seems that we don't have the necessary bandwidth to do it right now.