### PR TITLE
executor: fixed sandbox mode 'android'

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4163,6 +4163,8 @@ static int do_sandbox_android(void)
 	if (setresgid(UNTRUSTED_APP_GID, UNTRUSTED_APP_GID, UNTRUSTED_APP_GID) != 0)
 		fail("do_sandbox_android: setresgid failed");
 
+	setup_binderfs();
+
 #if GOARCH_arm || GOARCH_arm64 || GOARCH_386 || GOARCH_amd64
 	// Will fail() if anything fails.
 	// Must be called when the new process still has CAP_SYS_ADMIN, in this case,
@@ -4179,7 +4181,6 @@ static int do_sandbox_android(void)
 	setfilecon(".", SELINUX_LABEL_APP_DATA_FILE);
 	setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
 
-	setup_binderfs();
 	loop();
 	doexit(1);
 }

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9242,6 +9242,8 @@ static int do_sandbox_android(void)
 	if (setresgid(UNTRUSTED_APP_GID, UNTRUSTED_APP_GID, UNTRUSTED_APP_GID) != 0)
 		fail("do_sandbox_android: setresgid failed");
 
+	setup_binderfs();
+
 #if GOARCH_arm || GOARCH_arm64 || GOARCH_386 || GOARCH_amd64
 	set_app_seccomp_filter();
 #endif
@@ -9253,7 +9255,6 @@ static int do_sandbox_android(void)
 	setfilecon(".", SELINUX_LABEL_APP_DATA_FILE);
 	setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
 
-	setup_binderfs();
 	loop();
 	doexit(1);
 }


### PR DESCRIPTION
executor: _setup_binderfs_ rearranged to be called before seccomp filters installation 

**The issue:** when syzkaller starts with sandbox mode 'android' it doesn't work because syz-executor crashes during invocation of 'mount(...)' syscall. This causes sys-manager to reboot the phone and the process repeats itself. The issue is not observed in sandbox mode 'setuid'. 

**The solution:** The crash happens because seccomp filters created for sandbox mode 'android' block mount(...) syscall. To fix the issue I moved a call of the failing function (_setup_binderfs_) prior to seccomp filters installation in _do_sandbox_android_.

Bugs:  233650668, 233755379
