### PR TITLE
tools/docker: add rsync to the syzbot docker

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -26,7 +26,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu \
 	libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-10-dev lib32stdc++-10-dev \
-	apt-transport-https curl gnupg python-is-python3
+	apt-transport-https curl gnupg python-is-python3 \
+	# Needed for building Cuttlefish images.
+	rsync
 
 RUN curl https://dl.google.com/go/go1.17.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH


### PR DESCRIPTION
We need it to build Cuttlefish images.
