### PR TITLE
prog: allow to use fixed test seed w/o rebuilding tests

### DIFF
--- a/prog/any_test.go
+++ b/prog/any_test.go
@@ -45,11 +45,20 @@ func TestSquash(t *testing.T) {
 	// nolint: lll
 	tests := []struct {
 		prog     string
-		squashed string
+		squashed string // leave empty if the arg must not be squashed
 	}{
 		{
 			`foo$any0(&(0x7f0000000000)={0x11, 0x11223344, 0x2233, 0x1122334455667788, {0x1, 0x7, 0x1, 0x1, 0x1bc, 0x4}, [{@res32=0x0, @i8=0x44, "aabb"}, {@res64=0x1, @i32=0x11223344, "1122334455667788"}]})`,
 			`foo$any0(&(0x7f0000000000)=ANY=[@ANYBLOB="1100000044332211223300000000000088776655443322117d00bc11", @ANYRES32=0x0, @ANYBLOB="0000000044aabb00", @ANYRES64=0x1, @ANYBLOB="44332211112233445566778800000000"])`,
+		},
+		{
+			// Squashing of structs with out_overlay is not supported yet
+			// (used to panic, see isComplexPtr).
+			`
+overlay_any(&(0x7f0000000000)=@overlay2={0x0, 0x0, <r0=>0x0, 0x0})
+overlay_uses(0x0, 0x0, 0x0, r0)
+`,
+			``,
 		},
 	}
 	for i, test := range tests {
@@ -59,6 +68,12 @@ func TestSquash(t *testing.T) {
 				t.Fatalf("failed to deserialize prog: %v", err)
 			}
 			ptrArg := p.Calls[0].Args[0].(*PointerArg)
+			if test.squashed == "" {
+				if target.isComplexPtr(ptrArg) {
+					t.Fatalf("arg is complex and can be squashed")
+				}
+				return
+			}
 			if !target.isComplexPtr(ptrArg) {
 				t.Fatalf("arg is not complex")
 			}

--- a/prog/export_test.go
+++ b/prog/export_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,6 +28,9 @@ var (
 
 func randSource(t *testing.T) rand.Source {
 	seed := time.Now().UnixNano()
+	if fixed := os.Getenv("SYZ_SEED"); fixed != "" {
+		seed, _ = strconv.ParseInt(fixed, 0, 64)
+	}
 	if os.Getenv("CI") != "" {
 		seed = 0 // required for deterministic coverage reports
 	}

--- a/sys/test/exec.txt
+++ b/sys/test/exec.txt
@@ -253,6 +253,7 @@ resource overlayres64[int64]
 
 overlay_ctor(a ptr[out, overlayres8], b ptr[out, overlayres16], c ptr[out, overlayres32], d ptr[out, overlayres64])
 overlay_uses(a overlayres8, b overlayres16, c overlayres32, d overlayres64)
+overlay_any(a ptr[in, compare_data])
 
 overlayres [
 	res8	overlayres8


### PR DESCRIPTION
Currently reproducing crashed with a particular seed requires
changing sources and rebuilding the test.
Make it possible to provide seed via env var.
