### PR TITLE
Makefile: run vet only once during presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,12 +349,12 @@ presubmit_big: descriptions
 	# but these OSes use fixed toolchains and are not affected by SYZ_CLANG=yes.
 	# This way we get maximum coverage: smoke run tests Linux/gcc,
 	# while this run tests Linux/clang + the additional OSes.
-	SYZ_CLANG=yes $(GO) test -short -coverprofile=.coverage.txt ./dashboard/app ./pkg/csource ./pkg/cover
+	SYZ_CLANG=yes $(GO) test -short -vet=off -coverprofile=.coverage.txt ./dashboard/app ./pkg/csource ./pkg/cover
 
 presubmit_race: descriptions
 	# -race requires cgo
 	env CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
-	env CGO_ENABLED=1 $(GO) test -race -short -bench=.* -benchtime=.2s ./... ;\
+	env CGO_ENABLED=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
 	fi
 
 presubmit_old: descriptions


### PR DESCRIPTION
Go test runs vet tool on source files.
Vet tool takes insane amount of time on our auto-generated files.
We run go test in 3 presubmit stages, disable vet with -vet=off
in all but one presubmit stage. It should give the same coverage,
but save some latency and maybe reduce OOMs in race stage.

syzkaller$ TIME="%e %M" taskset -c 0 time go test -run=nothing ./prog
ok  	github.com/google/syzkaller/prog	0.162s [no tests to run]
88.59 6766736

syzkaller$ TIME="%e %M" taskset -c 0 time go test -run=nothing -vet=off ./prog
ok  	github.com/google/syzkaller/prog	0.159s [no tests to run]
40.22 5256900
