### PR TITLE
dashboard/app: support . in source file names

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -695,6 +695,7 @@ func TestLinkifyReport(t *testing.T) {
  tipc_topsrv_exit_net+0x149/0x340 net/tipc/topsrv.c:715
 kernel BUG at fs/ext4/inode.c:2753!
 pkg/sentry/fsimpl/fuse/fusefs.go:278 +0x384
+ kvm_vcpu_release+0x4d/0x70 arch/x86/kvm/../../../virt/kvm/kvm_main.c:3713
 	arch/x86/entry/entry_64.S:298
 `
 	// nolint: lll
@@ -703,6 +704,7 @@ pkg/sentry/fsimpl/fuse/fusefs.go:278 +0x384
  tipc_topsrv_exit_net+0x149/0x340 <a href='https://github.com/google/syzkaller/blob/111222/net/tipc/topsrv.c#L715'>net/tipc/topsrv.c:715</a>
 kernel BUG at <a href='https://github.com/google/syzkaller/blob/111222/fs/ext4/inode.c#L2753'>fs/ext4/inode.c:2753</a>!
 <a href='https://github.com/google/syzkaller/blob/111222/pkg/sentry/fsimpl/fuse/fusefs.go#L278'>pkg/sentry/fsimpl/fuse/fusefs.go:278</a> +0x384
+ kvm_vcpu_release+0x4d/0x70 <a href='https://github.com/google/syzkaller/blob/111222/arch/x86/kvm/../../../virt/kvm/kvm_main.c#L3713'>arch/x86/kvm/../../../virt/kvm/kvm_main.c:3713</a>
 	<a href='https://github.com/google/syzkaller/blob/111222/arch/x86/entry/entry_64.S#L298'>arch/x86/entry/entry_64.S:298</a>
 `
 	got := linkifyReport([]byte(input), "https://github.com/google/syzkaller", "111222")

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1017,7 +1017,7 @@ func linkifyReport(report []byte, repo, commit string) template.HTML {
 	}))
 }
 
-var sourceFileRe = regexp.MustCompile("( |\t|\n)([a-zA-Z0-9/_-]+\\.(?:h|c|cc|cpp|s|S|go|rs)):([0-9]+)( |!|\t|\n)")
+var sourceFileRe = regexp.MustCompile("( |\t|\n)([a-zA-Z0-9/_.-]+\\.(?:h|c|cc|cpp|s|S|go|rs)):([0-9]+)( |!|\t|\n)")
 
 func loadFixBisectionsForBug(c context.Context, bug *Bug) ([]*uiCrash, error) {
 	bugKey := bug.key(c)


### PR DESCRIPTION
In some cases Linux build system generates source file names
that contain dots, e.g.:
arch/x86/kvm/../../../virt/kvm/kvm_main.c
Support this in the regexp.
