### PR TITLE
tools/docker: update Clang for KMSAN

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -49,7 +49,7 @@ RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/b
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.
-ENV CLANG_KMSAN_VER 9ffb5944a699
+ENV CLANG_KMSAN_VER 610139d2d9ce
 RUN curl https://storage.googleapis.com/syzkaller/clang-${CLANG_KMSAN_VER}.tar.gz | tar -C /usr/local/ -xz
 RUN ln -s /usr/local/clang-${CLANG_KMSAN_VER} /usr/local/clang-kmsan
 

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -48,7 +48,7 @@ RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/b
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.
-ENV CLANG_KMSAN_VER 9ffb5944a699
+ENV CLANG_KMSAN_VER 610139d2d9ce
 RUN curl https://storage.googleapis.com/syzkaller/clang-${CLANG_KMSAN_VER}.tar.gz | tar -C /usr/local/ -xz
 RUN ln -s /usr/local/clang-${CLANG_KMSAN_VER} /usr/local/clang-kmsan
 


### PR DESCRIPTION
Switch to the upstream Clang version 610139d2d9ce.
This retires the custom -msan-pass-caller-to-runtime flag, but instead
allows us to use -fsanitize-memory-param-retval on syzbot.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
