### PR TITLE
executor, sys/fuchsia, pkg/csource: fix fuchsia support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dashboard/app/.gcloudignore
 
 # jetbrains goland
 .idea
+
+# vscode
+.vscode

--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -16,16 +16,17 @@ The rest of the document will use the following environment variables:
 
 ## Building Fuchsia
 
-To build fuchsia run:
-
 NOTE: Inside `${SOURCEDIR}/src/testing/fuzzing/syzkaller/BUILD.gnsrc/testing/fuzzing/syzkaller/BUILD.gn`
 you need to replace the line with `"$(src)/executor/kvm.S.h"` by `"${src}/executor/kvm_amd64.S.h"`
+
+To build fuchsia run:
 
 ```shell
 $ fx --dir "out/arm64" set core.arm64 \
   --with-base "//bundles:tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
-  --args=syzkaller_dir='"/full/path/to/syzkaller"'  --variant=kasan
+  --args=syzkaller_dir='"/full/path/to/syzkaller"' \
+  --variant=kasan
 $ fx clean-build
 ```
 
@@ -35,7 +36,8 @@ And
 $ fx --dir "out/x64" set core.x64 \
   --with-base "//bundles:tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
-  --args=syzkaller_dir='"/full/path/to/syzkaller"'  --variant=kasan
+  --args=syzkaller_dir='"/full/path/to/syzkaller"' \
+  --variant=kasan
 $ fx clean-build
 ```
 

--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -18,11 +18,14 @@ The rest of the document will use the following environment variables:
 
 To build fuchsia run:
 
+NOTE: Inside `${SOURCEDIR}/src/testing/fuzzing/syzkaller/BUILD.gnsrc/testing/fuzzing/syzkaller/BUILD.gn`
+you need to replace the line with `"$(src)/executor/kvm.S.h"` by `"${src}/executor/kvm_amd64.S.h"`
+
 ```shell
 $ fx --dir "out/arm64" set core.arm64 \
   --with-base "//bundles:tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
-  --args=syzkaller_dir='"/full/path/to/syzkaller"'
+  --args=syzkaller_dir='"/full/path/to/syzkaller"'  --variant=kasan
 $ fx clean-build
 ```
 
@@ -32,7 +35,7 @@ And
 $ fx --dir "out/x64" set core.x64 \
   --with-base "//bundles:tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
-  --args=syzkaller_dir='"/full/path/to/syzkaller"'
+  --args=syzkaller_dir='"/full/path/to/syzkaller"'  --variant=kasan
 $ fx clean-build
 ```
 
@@ -56,8 +59,8 @@ $ ${SOURCEDIR}/out/x64/host_x64/zbi -o ${SOURCEDIR}/out/x64/fuchsia-ssh.zbi ${SO
 You will also need to extend the `fvm` image:
 
 ```
-$ cp "${SOURCEDIR}/out/x64/obj/build/images/fvm.blk" "${SOURCEDIR}/out/x64/obj/build/images/fvm-extended.blk"
-$ ${SOURCEDIR}/out/x64/host_x64/fvm "${SOURCEDIR}/out/x64/obj/build/images/fvm-extended.blk" extend --length 3G
+$ cp "${SOURCEDIR}/out/x64/obj/build/images/fuchsia/fuchsia/fvm.blk" "${SOURCEDIR}/out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk"
+$ ${SOURCEDIR}/out/x64/host_x64/fvm "${SOURCEDIR}/out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk" extend --length 3G
 ```
 
 Note: This needs to be repeated after each `fx build`.
@@ -71,7 +74,7 @@ Run `syz-manager` with a config along the lines of:
         "workdir": "/workdir.fuchsia",
         "kernel_obj": "/fuchsia/out/x64.zircon/kernel-x64-gcc",
         "syzkaller": "/syzkaller",
-        "image": "/fuchsia/out/x64/obj/build/images/fvm-extended.blk",
+        "image": "/fuchsia/out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk",
         "sshkey": "/fuchsia/.ssh/pkey",
         "reproduce": false,
         "cover": false,

--- a/executor/common.h
+++ b/executor/common.h
@@ -57,11 +57,13 @@ NORETURN void doexit(int status)
 	for (;;) {
 	}
 }
+#if !GOOS_fuchsia
 NORETURN void doexit_thread(int status)
 {
 	// For BSD systems, _exit seems to do exactly what's needed.
 	doexit(status);
 }
+#endif
 #endif
 
 #if SYZ_EXECUTOR || SYZ_MULTI_PROC || SYZ_REPEAT && SYZ_CGROUPS ||         \

--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -43,7 +43,7 @@ static void segv_handler(void)
 		longjmp(segv_env, 1);
 	}
 	debug("recover: exiting\n");
-	doexit_thread(SIGSEGV);
+	doexit(SIGSEGV);
 }
 
 static zx_status_t update_exception_thread_regs(zx_handle_t exception)

--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -43,7 +43,7 @@ static void segv_handler(void)
 		longjmp(segv_env, 1);
 	}
 	debug("recover: exiting\n");
-	doexit(SIGSEGV);
+	doexit_thread(SIGSEGV);
 }
 
 static zx_status_t update_exception_thread_regs(zx_handle_t exception)
@@ -259,7 +259,7 @@ static long syz_future_time(volatile long when)
 		break;
 	}
 	zx_time_t now = 0;
-	zx_clock_get(ZX_CLOCK_MONOTONIC, &now);
+	zx_clock_read(ZX_CLOCK_MONOTONIC, &now);
 	return now + delta_ms * 1000 * 1000;
 }
 #endif

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -90,7 +90,9 @@ static NORETURN PRINTF(2, 3) void failmsg(const char* err, const char* msg, ...)
 // Just exit (e.g. due to temporal ENOMEM error).
 static NORETURN PRINTF(1, 2) void exitf(const char* msg, ...);
 static NORETURN void doexit(int status);
+#if !GOOS_fuchsia
 static NORETURN void doexit_thread(int status);
+#endif
 
 // Print debug output that is visible when running syz-manager/execprog with -debug flag.
 // Debug output is supposed to be relatively high-level (syscalls executed, return values, timing, etc)

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2054,7 +2054,7 @@ static void segv_handler(void)
 		longjmp(segv_env, 1);
 	}
 	debug("recover: exiting\n");
-	doexit(SIGSEGV);
+	doexit_thread(SIGSEGV);
 }
 
 static zx_status_t update_exception_thread_regs(zx_handle_t exception)
@@ -2268,7 +2268,7 @@ static long syz_future_time(volatile long when)
 		break;
 	}
 	zx_time_t now = 0;
-	zx_clock_get(ZX_CLOCK_MONOTONIC, &now);
+	zx_clock_read(ZX_CLOCK_MONOTONIC, &now);
 	return now + delta_ms * 1000 * 1000;
 }
 #endif

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -51,10 +51,12 @@ NORETURN void doexit(int status)
 	for (;;) {
 	}
 }
+#if !GOOS_fuchsia
 NORETURN void doexit_thread(int status)
 {
 	doexit(status);
 }
+#endif
 #endif
 
 #if SYZ_EXECUTOR || SYZ_MULTI_PROC || SYZ_REPEAT && SYZ_CGROUPS ||         \
@@ -2054,7 +2056,7 @@ static void segv_handler(void)
 		longjmp(segv_env, 1);
 	}
 	debug("recover: exiting\n");
-	doexit_thread(SIGSEGV);
+	doexit(SIGSEGV);
 }
 
 static zx_status_t update_exception_thread_regs(zx_handle_t exception)

--- a/sys/fuchsia/hypervisor_guests.txt
+++ b/sys/fuchsia/hypervisor_guests.txt
@@ -12,7 +12,7 @@ zx_guest_set_trap(guest zx_guest, kind int32, vaddr intptr, len intptr, port con
 
 zx_vcpu_create(guest zx_guest, options int32, vaddr intptr, out ptr[out, zx_vcpu])
 # TODO: teach this about the port_packet_t struct
-zx_vcpu_resume(vcpu zx_vcpu, port_packet ptr[out, zx_port_packet])
+zx_vcpu_enter(vcpu zx_vcpu, port_packet ptr[out, zx_port_packet])
 zx_vcpu_interrupt(vcpu zx_vcpu, vector int32)
 zx_vcpu_read_state(vcpu zx_vcpu, kind int32, buffer buffer[in], buflen len[buffer])
 zx_vcpu_write_state(vcpu zx_vcpu, kind int32, buffer buffer[out], buflen len[buffer])

--- a/sys/fuchsia/sockets.txt
+++ b/sys/fuchsia/sockets.txt
@@ -8,7 +8,7 @@ resource zx_socket[zx_handle]
 zx_socket_create(options flags[socket_create_options], out0 ptr[out, zx_socket], out1 ptr[out, zx_socket])
 zx_socket_read(handle zx_socket, options flags[socket_read_options], buffer ptr[out, array[int8]], size len[buffer], actual ptr[out, intptr])
 zx_socket_write(handle zx_socket, options flags[socket_write_options], buffer ptr[in, array[int8]], size len[buffer], actual ptr[out, intptr])
-zx_socket_shutdown(handlez zx_socket, options flags[socket_shutdown_options])
+zx_socket_set_disposition(handlez zx_socket, options flags[socket_shutdown_options])
 
 socket_create_options = ZX_SOCKET_STREAM, ZX_SOCKET_DATAGRAM
 socket_read_options = ZX_SOCKET_CREATE_MASK

--- a/sys/fuchsia/time.txt
+++ b/sys/fuchsia/time.txt
@@ -6,7 +6,7 @@ include <zircon/syscalls.h>
 resource zx_time[int64]: 0, ZX_TIME_INFINITE
 
 zx_nanosleep(deadline zx_time)
-zx_clock_get(clock_id flags[clock_id], zx_time ptr[out, intptr]) (ignore_return)
+zx_clock_read(clock_id flags[clock_id], zx_time ptr[out, intptr]) (ignore_return)
 zx_clock_get_monotonic() (ignore_return)
 zx_ticks_get() (ignore_return)
 zx_ticks_per_second()


### PR DESCRIPTION
Hello,
Syzkaller is broken on fuchsia because of the latest updates to fuchsia (check this [discussion](https://groups.google.com/a/fuchsia.dev/g/discuss/c/AcUyILZ4ouQ)).
I am trying to fix it. 
I made the current changes to syzkaller and also made a change in fuchsia.
In fuchsia checkout I modified this file `src/testing/fuzzing/syzkaller/BUILD.gnsrc/testing/fuzzing/syzkaller/BUILD.gn`
by simply replacing one line. 
This is the output of `git diff src/testing/fuzzing/syzkaller/BUILD.gnsrc/testing/fuzzing/syzkaller/BUILD.gn`

```bash
diff --git a/src/testing/fuzzing/syzkaller/BUILD.gn b/src/testing/fuzzing/syzkaller/BUILD.gn
index 9cb2a1866b5..df1c652b30a 100644
--- a/src/testing/fuzzing/syzkaller/BUILD.gn
+++ b/src/testing/fuzzing/syzkaller/BUILD.gn
@@ -64,7 +64,7 @@ executable("syz-executor") {
     "${src}/executor/executor_linux.h",
     "${src}/executor/executor_test.h",
     "${src}/executor/executor_windows.h",
-    "${src}/executor/kvm.S.h",
+    "${src}/executor/kvm_amd64.S.h",
     "${src}/executor/kvm.h",
     "${src}/executor/nocover.h",
     "${src}/executor/test.h",
```
I just replaced `"$(src)/executor/kvm.S.h"` with `"${src}/executor/kvm_amd64.S.h"`


After that, I build a fuchsia image by following fuchsia [REAMDE.md](https://github.com/google/syzkaller/tree/master/docs/fuchsia) (Inside fuchsia checkout folder)

```bash
$ fx --dir "out/x64" set core.x64 --with-base "//bundles:tools" --with-base "//src/testing/fuzzing/syzkaller"  --args=syzkaller_dir='"/home/behouba/Desktop/fuzzing/syzkaller"'
```
and 

```bash
$ fx clean-build
``````
The build succeeded (at least this is what I think).
I got this output after the build
```bash
Generating compile_commands took 380ms
Generating rust-project.json took 341ms
Done. Made 227407 targets from 5703 files in 19761ms
ninja: Entering directory `/home/behouba/fuchsia/out/x64'
[0/1] Regenerating ninja files
[60268/60268] STAMP obj/default.stamp
```
Then, I build syzkaller for fuchsia (inside my local syzkaller repo):
```bash
 $ make TARGETOS=fuchsia TARGETARCH=amd64 SOURCEDIR=~/fuchsia
```
The build was successful.

Then, I added the ssh keys to the fuchsia.zbi image (Inside fuchsia checkout folder): 

```bash
$ out/x64/host_x64/zbi -o out/x64/fuchsia-ssh.zbi out/x64/fuchsia.zbi --entry "data/ssh/authorized_keys=.ssh/authorized_keys"
```
And I extended fvm image (I believe that the location of fvm.blk has changed from `out/x64/obj/build/images/` to `out/x64/obj/build/images/fuchsia/fuchsia/`)

```bash
$ cp out/x64/obj/build/images/fuchsia/fuchsia/fvm.blk out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk
$ out/x64/host_x64/fvm "out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk" extend --length 3G
```
Finally, I started syz-manager. 
My config file look like this: 
```json
{
    "name": "fuchsia",
    "target": "fuchsia/amd64",
    "http": ":12345",
    "workdir": "workdir.fuchsia",
    "syzkaller": "/home/behouba/Desktop/fuzzing/syzkaller",
    "image": "/home/behouba/fuchsia/out/x64/obj/build/images/fuchsia/fuchsia/fvm-extended.blk",
    "sshkey": "/home/behouba/fuchsia/.ssh/pkey",
    "reproduce": false,
    "cover": false,
    "procs": 4,
    "type": "qemu",
    "vm": {
            "count": 2,
            "cpu": 2,
            "mem": 2048,
            "kernel": "/home/behouba/fuchsia/out/x64/multiboot.bin",
            "initrd": "/home/behouba/fuchsia/out/x64/fuchsia-ssh.zbi"
    }
}
```

```bash
$ ./bin/syz-manager -config=fuchsia.cfg
```
I am getting this error in the console output: 

```bash
2022/06/18 17:03:38 loading corpus...
2022/06/18 17:03:38 serving http on http://:12345
2022/06/18 17:03:38 serving rpc on tcp://[::]:38783
2022/06/18 17:03:38 booting test machines...
2022/06/18 17:03:38 wait for the connection from test machine...
2022/06/18 17:03:48 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:03:58 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:03:58 vm-0: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:08 vm-1: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:09 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:18 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:19 vm-0: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:29 vm-1: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:29 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:39 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:39 vm-0: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:49 vm-1: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:04:49 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:59 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:04:59 vm-0: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:05:09 vm-1: crash: SYZFATAL: Manager.Check call failed: machine check failed: mismatching fuzzer/executor git revisions: ADDR vs ADDR
2022/06/18 17:05:10 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:05:20 machine check failed: mismatching fuzzer/executor git revisions: f7b2c28e7d1fa0a21e3e2d0ad540f6b13fc972f7 vs 7ec32531cb0651a608a8ae0b8701bc779c04f31e
2022/06/18 17:05:20 SYZFATAL: machine check failing
```
What could be the source of this error ?

