### PR TITLE
prog: fix out-of-bounds access in any blob mutation

### DIFF
--- a/prog/any.go
+++ b/prog/any.go
@@ -60,11 +60,16 @@ func (target *Target) isAnyPtr(typ Type) bool {
 	return ok && ptr.Elem == target.any.array
 }
 
-func (p *Prog) complexPtrs() (res []*PointerArg) {
+type complexPtr struct {
+	arg  *PointerArg
+	call *Call
+}
+
+func (p *Prog) complexPtrs() (res []complexPtr) {
 	for _, c := range p.Calls {
 		ForeachArg(c, func(arg Arg, ctx *ArgCtx) {
 			if ptrArg, ok := arg.(*PointerArg); ok && p.Target.isComplexPtr(ptrArg) {
-				res = append(res, ptrArg)
+				res = append(res, complexPtr{ptrArg, c})
 				ctx.Stop = true
 			}
 		})

--- a/prog/any_test.go
+++ b/prog/any_test.go
@@ -28,7 +28,7 @@ func TestIsComplexPtr(t *testing.T) {
 			calls := r.generateParticularCall(s, meta)
 			p := &Prog{Target: target, Calls: calls}
 			for _, arg := range p.complexPtrs() {
-				compl[arg.Res.Type().String()] = true
+				compl[arg.arg.Res.Type().String()] = true
 			}
 		}
 	}

--- a/prog/test/fuzz_test.go
+++ b/prog/test/fuzz_test.go
@@ -23,6 +23,13 @@ mutate7()
 mutate8()
 `,
 		`E`,
+		`
+test$str0(&(0x7f0000ffffd5)=ANY=[0])
+test$res2()
+test$res2()
+test$res2()
+test$res2()
+`,
 	} {
 		t.Logf("test #%v: %q", i, data)
 		inp := []byte(data)[:len(data):len(data)]


### PR DESCRIPTION
If we grow any blob during mutation, we allocate a new address for it
(so that it does not overlap with other data).
To do this we call analyze after the mutation.
However, after mutation the blob can grow out of bounds of the data area
and analyze will cause out-of-bounds access during marking of existing
allocations.

Fix this by calling analyze before we mutate the blob.

Also while we are here use the proper call for analyze.
Currently we always analyze only the first call,
which is wrong (probably a latent TODO from initial implementation).

Fixes #3206
