### PR TITLE
prog: support int8 resources in any squashing

### DIFF
--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -1074,6 +1074,7 @@ type optional[T] [
 # prog/any.go knows layout of these types.
 ANYUNION [
 	ANYBLOB		array[int8]
+	ANYRES8		ANYRES8
 	ANYRES16	ANYRES16
 	ANYRES32	ANYRES32
 	ANYRES64	ANYRES64
@@ -1087,15 +1088,17 @@ ANYPTRS [
 	ANYPTR64	ptr64[in, array[ANYUNION]]
 ]
 
+resource ANYRES8[int8]: -1, 0
 resource ANYRES16[int16]: -1, 0
 resource ANYRES32[int32]: -1, 0
 resource ANYRES64[int64]: -1, 0
 
 syz_builtin0(a ptr[in, ANYPTRS]) (disabled)
 syz_builtin1(a ptr[out, ANYUNION]) (disabled)
-syz_builtin2() ANYRES16 (disabled)
-syz_builtin3() ANYRES32 (disabled)
-syz_builtin4() ANYRES64 (disabled)
+syz_builtin2() ANYRES8 (disabled)
+syz_builtin3() ANYRES16 (disabled)
+syz_builtin4() ANYRES32 (disabled)
+syz_builtin5() ANYRES64 (disabled)
 `
 
 func init() {

--- a/prog/any.go
+++ b/prog/any.go
@@ -13,6 +13,7 @@ type anyTypes struct {
 	blob   *BufferType
 	ptrPtr *PtrType
 	ptr64  *PtrType
+	res8   *ResourceType
 	res16  *ResourceType
 	res32  *ResourceType
 	res64  *ResourceType
@@ -38,12 +39,13 @@ func (target *Target) initAnyTypes() {
 	target.any.array = target.any.ptrPtr.Elem.(*ArrayType)
 	target.any.union = target.any.array.Elem.(*UnionType)
 	target.any.blob = target.any.union.Fields[0].Type.(*BufferType)
-	target.any.res16 = target.any.union.Fields[1].Type.(*ResourceType)
-	target.any.res32 = target.any.union.Fields[2].Type.(*ResourceType)
-	target.any.res64 = target.any.union.Fields[3].Type.(*ResourceType)
-	target.any.resdec = target.any.union.Fields[4].Type.(*ResourceType)
-	target.any.reshex = target.any.union.Fields[5].Type.(*ResourceType)
-	target.any.resoct = target.any.union.Fields[6].Type.(*ResourceType)
+	target.any.res8 = target.any.union.Fields[1].Type.(*ResourceType)
+	target.any.res16 = target.any.union.Fields[2].Type.(*ResourceType)
+	target.any.res32 = target.any.union.Fields[3].Type.(*ResourceType)
+	target.any.res64 = target.any.union.Fields[4].Type.(*ResourceType)
+	target.any.resdec = target.any.union.Fields[5].Type.(*ResourceType)
+	target.any.reshex = target.any.union.Fields[6].Type.(*ResourceType)
+	target.any.resoct = target.any.union.Fields[7].Type.(*ResourceType)
 }
 
 func (target *Target) getAnyPtrType(size uint64) *PtrType {
@@ -113,7 +115,8 @@ func (target *Target) isComplexPtr(arg *PointerArg) bool {
 }
 
 func (target *Target) isAnyRes(name string) bool {
-	return name == target.any.res16.TypeName ||
+	return name == target.any.res8.TypeName ||
+		name == target.any.res16.TypeName ||
 		name == target.any.res32.TypeName ||
 		name == target.any.res64.TypeName ||
 		name == target.any.resdec.TypeName ||
@@ -226,21 +229,23 @@ func (target *Target) squashResult(arg *ResultArg, elems *[]Arg) {
 	switch arg.Type().Format() {
 	case FormatNative, FormatBigEndian:
 		switch arg.Size() {
+		case 1:
+			typ, index = target.any.res8, 1
 		case 2:
-			typ, index = target.any.res16, 1
+			typ, index = target.any.res16, 2
 		case 4:
-			typ, index = target.any.res32, 2
+			typ, index = target.any.res32, 3
 		case 8:
-			typ, index = target.any.res64, 3
+			typ, index = target.any.res64, 4
 		default:
-			panic("bad size")
+			panic(fmt.Sprintf("bad size %v", arg.Size()))
 		}
 	case FormatStrDec:
-		typ, index = target.any.resdec, 4
+		typ, index = target.any.resdec, 5
 	case FormatStrHex:
-		typ, index = target.any.reshex, 5
+		typ, index = target.any.reshex, 6
 	case FormatStrOct:
-		typ, index = target.any.resoct, 6
+		typ, index = target.any.resoct, 7
 	default:
 		panic("bad")
 	}

--- a/prog/any_test.go
+++ b/prog/any_test.go
@@ -48,8 +48,8 @@ func TestSquash(t *testing.T) {
 		squashed string // leave empty if the arg must not be squashed
 	}{
 		{
-			`foo$any0(&(0x7f0000000000)={0x11, 0x11223344, 0x2233, 0x1122334455667788, {0x1, 0x7, 0x1, 0x1, 0x1bc, 0x4}, [{@res32=0x0, @i8=0x44, "aabb"}, {@res64=0x1, @i32=0x11223344, "1122334455667788"}]})`,
-			`foo$any0(&(0x7f0000000000)=ANY=[@ANYBLOB="1100000044332211223300000000000088776655443322117d00bc11", @ANYRES32=0x0, @ANYBLOB="0000000044aabb00", @ANYRES64=0x1, @ANYBLOB="44332211112233445566778800000000"])`,
+			`foo$any0(&(0x7f0000000000)={0x11, 0x11223344, 0x2233, 0x1122334455667788, {0x1, 0x7, 0x1, 0x1, 0x1bc, 0x4}, [{@res32=0x0, @i8=0x44, "aabb"}, {@res64=0x1, @i32=0x11223344, "1122334455667788"}, {@res8=0x2, @i8=0x55, "cc"}]})`,
+			`foo$any0(&(0x7f0000000000)=ANY=[@ANYBLOB="1100000044332211223300000000000088776655443322117d00bc11", @ANYRES32=0x0, @ANYBLOB="0000000044aabb00", @ANYRES64=0x1, @ANYBLOB="443322111122334455667788", @ANYRES8=0x2, @ANYBLOB="0000000000000055cc0000"])`,
 		},
 		{
 			// Squashing of structs with out_overlay is not supported yet

--- a/sys/test/any.txt
+++ b/sys/test/any.txt
@@ -1,10 +1,11 @@
 # Copyright 2018 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+resource anyres8[int8]
 resource anyres32[int32]
 resource anyres64[int64]
 
-foo$anyres(a0 ptr[out, anyres32], a1 ptr[out, anyres64])
+foo$anyres(a0 ptr[out, anyres8], a1 ptr[out, anyres32], a2 ptr[out, anyres64])
 
 foo$any0(a ptr[in, any0])
 
@@ -24,6 +25,7 @@ any1 {
 } [packed, align[2]]
 
 anyunion0 [
+	res8	anyres8
 	res32	anyres32
 	res64	anyres64
 ]


### PR DESCRIPTION
We've got the following panic:

--- FAIL: TestMutateRandom (7.77s)
    export_test.go:37: seed=1655724857302243235
    --- FAIL: TestMutateRandom/test/32_shmem (0.00s)
panic: bad size [recovered]
	panic: bad size
goroutine 562 [running]:
panic({0x5ea5a0, 0x8dade8})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/google/syzkaller/prog.(*Target).squashResult(0xc0002a9ba0, 0xc026faa7b0, 0xc026ad1bc8)
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/any.go:236 +0x2d1

This happens because we try to squash resource of size 1.
While we still don't have such resources in real descriptions,
we've got one in test descriptions (added in out_overlay change).

Support int8 resources in squashing procedure.
