### PR TITLE
pkg/instance: don't close vmInst in SetupExecProg

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -44,14 +44,12 @@ func SetupExecProg(vmInst *vm.Instance, mgrCfg *mgrconfig.Config, reporter *repo
 	opt *OptionalConfig) (*ExecProgInstance, error) {
 	execprogBin, err := vmInst.Copy(mgrCfg.ExecprogBin)
 	if err != nil {
-		vmInst.Close()
 		return nil, &TestError{Title: fmt.Sprintf("failed to copy syz-execprog to VM: %v", err)}
 	}
 	executorBin := mgrCfg.SysTarget.ExecutorBin
 	if executorBin == "" {
 		executorBin, err = vmInst.Copy(mgrCfg.ExecutorBin)
 		if err != nil {
-			vmInst.Close()
 			return nil, &TestError{Title: fmt.Sprintf("failed to copy syz-executor to VM: %v", err)}
 		}
 	}
@@ -68,7 +66,6 @@ func SetupExecProg(vmInst *vm.Instance, mgrCfg *mgrconfig.Config, reporter *repo
 			var err error
 			ret.StraceBin, err = vmInst.Copy(ret.StraceBin)
 			if err != nil {
-				vmInst.Close()
 				return nil, &TestError{Title: fmt.Sprintf("failed to copy strace bin: %v", err)}
 			}
 		}


### PR DESCRIPTION
That method was not assumed to take ownership of the instance. This
can lead to double-closing of it during bisection/patch testing, and
therefore to panic().

Closes #3210.
