### PR TITLE
syz-manager, executor: fix out-of-bound access due to NextInstructionPC

### DIFF
--- a/executor/cov_filter.h
+++ b/executor/cov_filter.h
@@ -31,7 +31,7 @@ static void init_coverage_filter(char* filename)
 	cov_filter = (cov_filter_t*)mmap(preferred, st.st_size, PROT_READ, MAP_PRIVATE, f, 0);
 	if (cov_filter != preferred)
 		failmsg("failed to mmap coverage filter bitmap", "want=%p, got=%p", preferred, cov_filter);
-	if ((uint32)st.st_size != sizeof(uint32) * 2 + ((cov_filter->pcsize >> 4) / 8 + 1))
+	if ((uint32)st.st_size != sizeof(uint32) * 2 + ((cov_filter->pcsize >> 4) / 8 + 2))
 		fail("bad coverage filter bitmap size");
 	close(f);
 }

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -134,9 +134,9 @@ func createCoverageBitmap(target *targets.Target, pcs map[uint32]uint32) []byte 
 	start, size := coverageFilterRegion(pcs)
 	log.Logf(0, "coverage filter from 0x%x to 0x%x, size 0x%x, pcs %v", start, start+size, size, len(pcs))
 	// The file starts with two uint32: covFilterStart and covFilterSize,
-	// and a bitmap with size ((covFilterSize>>4)/8+1 bytes follow them.
+	// and a bitmap with size ((covFilterSize>>4)/8+2 bytes follow them.
 	// 8-bit = 1-byte
-	data := make([]byte, 8+((size>>4)/8+1))
+	data := make([]byte, 8+((size>>4)/8+2))
 	order := binary.ByteOrder(binary.BigEndian)
 	if target.LittleEndian {
 		order = binary.LittleEndian


### PR DESCRIPTION
After introducing NextInstructionPC (fcdb12ba70875c410749932abf39160d19c753d9), in the function `createCoverageBitmap`, if the last  pc is equal to `start+size`, then `NextInstructionPC` will make this out-of-bound.
This bug really occurs in my usage.
