### PR TITLE
dashboard: add a missing index

### DIFF
--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -23,6 +23,13 @@ indexes:
   properties:
   - name: Namespace
   - name: Status
+  - name: HappenedOn
+  - name: Commits
+
+- kind: Bug
+  properties:
+  - name: Namespace
+  - name: Status
   - name: Commits
 
 - kind: Bug


### PR DESCRIPTION
We currently fail in fetchFixPendingBugs() when the manager filter is used.

Closes https://github.com/google/syzkaller/issues/3225
