### PR TITLE
pkg/mgrconfig: add "ReproInstances"

### DIFF
--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -140,6 +140,9 @@ type Config struct {
 	// Reproduce, localize and minimize crashers (default: true).
 	Reproduce bool `json:"reproduce"`
 
+	// The number of VMs used to reproduce a crasher (default: 4).
+	ReproInstances int `json:"repro_instances,omitempty"`
+
 	// The number of VMs that are reserved to only perform fuzzing and nothing else.
 	// Can be helpful e.g. to ensure that the pool of fuzzing VMs is never exhaused and
 	// the manager continues fuzzing no matter how many new bugs are encountered.

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -81,6 +81,7 @@ func defaultValues() *Config {
 		SSHUser:        "root",
 		Cover:          true,
 		Reproduce:      true,
+		ReproInstances: 4,
 		Sandbox:        "none",
 		RPC:            ":0",
 		MaxCrashLogs:   100,

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -308,7 +308,7 @@ type ReproResult struct {
 func (mgr *Manager) vmLoop() {
 	log.Logf(0, "booting test machines...")
 	log.Logf(0, "wait for the connection from test machine...")
-	instancesPerRepro := 4
+	instancesPerRepro := mgr.cfg.ReproInstances
 	vmCount := mgr.vmPool.Count()
 	maxReproVMs := vmCount - mgr.cfg.FuzzingVMs
 	if instancesPerRepro > maxReproVMs && maxReproVMs > 0 {


### PR DESCRIPTION
Extended the configuration file to allow changes on how many VMs are used to reproduce a crash.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
