### PR TITLE
docs/linux: updated kvm config command

### DIFF
--- a/docs/linux/kernel_configs.md
+++ b/docs/linux/kernel_configs.md
@@ -51,7 +51,7 @@ For `namespace` sandbox:
 CONFIG_USER_NS=y
 ```
 
-For running in VMs `make kvmconfig` is generally required.
+For running in VMs `make kvm_guest.config` is generally required.
 
 Debian images produced by [tools/create-image.sh](/tools/create-image.sh) also require:
 ```


### PR DESCRIPTION
'make kvmconfig' was replaced with 'make kvm_guest.config' after linux 5.10.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
