### PR TITLE
pkg/report: set SysTarget before fuzzing

### DIFF
--- a/pkg/report/fuzz.go
+++ b/pkg/report/fuzz.go
@@ -70,8 +70,13 @@ var fuzzReporters = func() map[string]*Reporter {
 		if os == targets.Windows {
 			continue
 		}
+		target := targets.Get(os, targets.AMD64)
+		if target == nil {
+			continue
+		}
 		cfg := &mgrconfig.Config{
 			Derived: mgrconfig.Derived{
+				SysTarget:  target,
 				TargetOS:   os,
 				TargetArch: targets.AMD64,
 			},


### PR DESCRIPTION
This is important when opcode decompilation is involved.

Closes #3229.
