### PR TITLE
vm/qemu: Add net.ifnames=0 to linux cmdline by default

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -132,6 +132,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/sda",
 			"console=ttyS0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/386": {
@@ -141,6 +142,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/sda",
 			"console=ttyS0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/arm64": {
@@ -151,6 +153,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/vda",
 			"console=ttyAMA0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/arm": {
@@ -162,6 +165,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/vda",
 			"console=ttyAMA0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/mips64le": {
@@ -172,6 +176,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/sda",
 			"console=ttyS0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/ppc64le": {
@@ -189,6 +194,7 @@ var archConfigs = map[string]*archConfig{
 		CmdLine: []string{
 			"root=/dev/vda",
 			"console=ttyS0",
+			"net.ifnames=0",
 		},
 	},
 	"linux/s390x": {
@@ -198,6 +204,7 @@ var archConfigs = map[string]*archConfig{
 		RngDev:   "virtio-rng-ccw",
 		CmdLine: []string{
 			"root=/dev/vda",
+			"net.ifnames=0",
 		},
 	},
 	"freebsd/amd64": {


### PR DESCRIPTION
Add `net.ifnames=0` to disable network interface renaming behavior.
We already add it in `tools/create-gce-image.sh` and in
`dashboard/config/linux`. However, if someone uses custom `.config`
file he may miss it and get a vm (e.g. Debian 11) with no network
access because `tools/create-image.sh` explicitly uses eth0.
```
$ grep eth0 tools/create-image.sh
printf '\nauto eth0\niface eth0 inet dhcp\n' | sudo tee -a $DIR/etc/network/interfaces
```
Signed-off-by: Denis Efremov <denis.e.efremov@oracle.com>
