### PR TITLE
executor: fix mounting of cgroups on read-only fs

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3429,6 +3429,7 @@ static void mount_cgroups(const char* dir, const char** controllers, int count)
 {
 	if (mkdir(dir, 0777)) {
 		debug("mkdir(%s) failed: %d\n", dir, errno);
+		return;
 	}
 	// First, probe one-by-one to understand what controllers are present.
 	char enabled[128] = {0};
@@ -3461,6 +3462,39 @@ static void mount_cgroups(const char* dir, const char** controllers, int count)
 	}
 }
 
+static void mount_cgroups2(const char** controllers, int count)
+{
+	if (mkdir("/syzcgroup/unified", 0777)) {
+		debug("mkdir(/syzcgroup/unified) failed: %d\n", errno);
+		return;
+	}
+	if (mount("none", "/syzcgroup/unified", "cgroup2", 0, NULL)) {
+		debug("mount(cgroup2) failed: %d\n", errno);
+		// For all cases when we don't end up mounting cgroup/cgroup2
+		// in /syzcgroup/{unified,net,cpu}, we need to remove the dir.
+		// Otherwise these will end up as normal dirs and the fuzzer may
+		// create huge files there. These files won't be cleaned up
+		// after tests and may easily consume all disk space.
+		// EBUSY usually means that cgroup is already mounted there
+		// by a previous run of e.g. syz-execprog.
+		if (rmdir("/syzcgroup/unified") && errno != EBUSY)
+			fail("rmdir(/syzcgroup/unified) failed");
+		return;
+	}
+	if (chmod("/syzcgroup/unified", 0777)) {
+		debug("chmod(/syzcgroup/unified) failed: %d\n", errno);
+	}
+	int control = open("/syzcgroup/unified/cgroup.subtree_control", O_WRONLY);
+	if (control == -1)
+		return;
+	int i;
+	for (i = 0; i < count; i++)
+		if (write(control, controllers[i], strlen(controllers[i])) < 0) {
+			debug("write(cgroup.subtree_control, %s) failed: %d\n", controllers[i], errno);
+		}
+	close(control);
+}
+
 static void setup_cgroups()
 {
 	// We want to cover both cgroup and cgroup2.
@@ -3475,35 +3509,11 @@ static void setup_cgroups()
 	const char* net_controllers[] = {"net", "net_prio", "devices", "blkio", "freezer"};
 	const char* cpu_controllers[] = {"cpuset", "cpuacct", "hugetlb", "rlimit"};
 	if (mkdir("/syzcgroup", 0777)) {
+		// Can happen due to e.g. read-only file system (EROFS).
 		debug("mkdir(/syzcgroup) failed: %d\n", errno);
+		return;
 	}
-	if (mkdir("/syzcgroup/unified", 0777)) {
-		debug("mkdir(/syzcgroup/unified) failed: %d\n", errno);
-	}
-	if (mount("none", "/syzcgroup/unified", "cgroup2", 0, NULL)) {
-		debug("mount(cgroup2) failed: %d\n", errno);
-		// For all cases when we don't end up mounting cgroup/cgroup2
-		// in /syzcgroup/{unified,net,cpu}, we need to remove the dir.
-		// Otherwise these will end up as normal dirs and the fuzzer may
-		// create huge files there. These files won't be cleaned up
-		// after tests and may easily consume all disk space.
-		// EBUSY usually means that cgroup is already mounted there
-		// by a previous run of e.g. syz-execprog.
-		if (rmdir("/syzcgroup/unified") && errno != EBUSY)
-			fail("rmdir(/syzcgroup/unified) failed");
-	}
-	if (chmod("/syzcgroup/unified", 0777)) {
-		debug("chmod(/syzcgroup/unified) failed: %d\n", errno);
-	}
-	int unified_control = open("/syzcgroup/unified/cgroup.subtree_control", O_WRONLY);
-	if (unified_control != -1) {
-		unsigned i;
-		for (i = 0; i < sizeof(unified_controllers) / sizeof(unified_controllers[0]); i++)
-			if (write(unified_control, unified_controllers[i], strlen(unified_controllers[i])) < 0) {
-				debug("write(cgroup.subtree_control, %s) failed: %d\n", unified_controllers[i], errno);
-			}
-		close(unified_control);
-	}
+	mount_cgroups2(unified_controllers, sizeof(unified_controllers) / sizeof(unified_controllers[0]));
 	mount_cgroups("/syzcgroup/net", net_controllers, sizeof(net_controllers) / sizeof(net_controllers[0]));
 	mount_cgroups("/syzcgroup/cpu", cpu_controllers, sizeof(cpu_controllers) / sizeof(cpu_controllers[0]));
 	write_file("/syzcgroup/cpu/cgroup.clone_children", "1");


### PR DESCRIPTION
If root fs is read-only, mkdir(/syzcgroup) will fail and a later
rmdir(/syzcgroup/unified) will fail with ENOENT which we don't expect and fail.
Return early if mkdir(/syzcgroup) fails.

Fixes #3255