### PR TITLE
vm/adb: wait for Android boot to finish

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4169,11 +4169,7 @@ static int do_sandbox_android(int sandbox_arg)
 	initialize_devlink_pci();
 #endif
 #if SYZ_EXECUTOR || SYZ_NET_INJECTION
-	if (sandbox_arg != 1) {
-		// TODO (gArtmv): investigate why fuzzing fails when the line
-		// below is executed.
-		initialize_tun();
-	}
+	initialize_tun();
 #endif
 #if SYZ_EXECUTOR || SYZ_NET_DEVICES
 	// TODO(dvyukov): unshare net namespace.

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9805,9 +9805,7 @@ static int do_sandbox_android(int sandbox_arg)
 	initialize_devlink_pci();
 #endif
 #if SYZ_EXECUTOR || SYZ_NET_INJECTION
-	if (sandbox_arg != 1) {
-		initialize_tun();
-	}
+	initialize_tun();
 #endif
 #if SYZ_EXECUTOR || SYZ_NET_DEVICES
 	initialize_netdevices();


### PR DESCRIPTION
vm/adb: wait for Android boot to finish
executor: removed condition around 'initialize_tun'

Often after reboot Android devices experience a race condition. When a phone is still on the screen with 'G' logo and a progress bar syz-fuzzer already starts execution. Sometimes the phone doesn't go past this screen and can't start all services and processes. In this case fuzzing continues however it doesn't produce results. I can assume that due to dozens per second syscalls Android can't finalize initialization in time. I do not know what exactly causes this race condition however it doesn't happen if I comment out 'initialize_tun'.

This change determines whether a system initialized by monitoring whether a systemui process has started. Adb waits for 3 minutes and if the process is not found (it changed its name for example) it produces an error message and allows fuzzing to continue.
