### PR TITLE
pkg/cover/backend/gvisor: kill process to 100% unlock resources

### DIFF
--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -67,6 +67,7 @@ func gvisorSymbolize(bin, srcDir string) ([]Frame, error) {
 		return nil, err
 	}
 	defer cmd.Wait()
+	defer cmd.Process.Kill()
 	var frames []Frame
 	s := bufio.NewScanner(stdout)
 	for s.Scan() {


### PR DESCRIPTION
If code stops reading from process pipe (on error etc.) we get blocked cmd.Wait().
Killing the subprocess guarantees safe cmd.Wait() and prevents unstable subprocess side-effects.