### PR TITLE
.github/workflows/ci.yml: run dashboard step on the self-hosted instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,25 @@ jobs:
         with:
           file: gopath/src/github.com/google/syzkaller/.coverage.txt
           flags: dashboard
+  dashboard-self-hosted:
+    runs-on: self-hosted
+    steps:
+    - name: checkout
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      with:
+        path: gopath/src/github.com/google/syzkaller
+    - name: cache
+      uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # v1
+      with:
+        path: .cache
+        key: cache
+    - name: run
+      run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-big-env make presubmit_big
+    - name: codecov
+      uses: codecov/codecov-action@2a829b95deaeea2d11d127cc0358005714ff35ea # v3
+      with:
+        files: gopath/src/github.com/google/syzkaller/.coverage.txt
+        flags: dashboard
   arch:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
+use v3 codecov instead
