### PR TITLE
.github/workflows/ci.yml: run race step on the self-hosted instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,20 @@ jobs:
           key: cache
       - name: run
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_race
+  race-self-hosted:
+    runs-on: self-hosted
+    steps:
+    - name: checkout
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      with:
+        path: gopath/src/github.com/google/syzkaller
+    - name: cache
+      uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # v1
+      with:
+        path: .cache
+        key: cache
+    - name: run
+      run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_race
   old:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Race step takes ~8 minutes and is the 3rd longest after "build" and "dashboard".
