### PR TITLE
.github/workflows/ci.yml: stop to use github instances for heavy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,27 +36,6 @@ jobs:
           GITHUB_PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_aux
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
-        with:
-          path: gopath/src/github.com/google/syzkaller
-      - name: cache
-        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # v1
-        with:
-          path: .cache
-          key: cache
-      - name: run
-        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_build
-      # Upload coverage report to codecov.io. For reference see:
-      # https://github.com/codecov/codecov-action/blob/master/README.md
-      - name: codecov
-        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
-        with:
-          file: gopath/src/github.com/google/syzkaller/.coverage.txt
-          flags: unittests
-  build-self-hosted:
     runs-on: self-hosted
     steps:
     - name: checkout
@@ -78,25 +57,6 @@ jobs:
         files: gopath/src/github.com/google/syzkaller/.coverage.txt
         flags: unittests
   dashboard:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
-        with:
-          path: gopath/src/github.com/google/syzkaller
-      - name: cache
-        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # v1
-        with:
-          path: .cache
-          key: cache
-      - name: run
-        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-big-env make presubmit_big
-      - name: codecov
-        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
-        with:
-          file: gopath/src/github.com/google/syzkaller/.coverage.txt
-          flags: dashboard
-  dashboard-self-hosted:
     runs-on: self-hosted
     steps:
     - name: checkout
@@ -133,20 +93,6 @@ jobs:
       - name: run
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-big-env make ${{ matrix.target }}
   race:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
-        with:
-          path: gopath/src/github.com/google/syzkaller
-      - name: cache
-        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # v1
-        with:
-          path: .cache
-          key: cache
-      - name: run
-        run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_race
-  race-self-hosted:
     runs-on: self-hosted
     steps:
     - name: checkout


### PR DESCRIPTION
New self-hosted runners looks stable enough.
Lets remove old ones. We can always switch back changing "self-hosted" to "ubuntu-latest".