### PR TITLE
executor: fixed fuzzing with System account in Android sandbox

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4228,7 +4228,8 @@ static int do_sandbox_android(int sandbox_arg)
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
 
 	setfilecon(".", SELINUX_LABEL_APP_DATA_FILE);
-	setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
+	if (uid == UNTRUSTED_APP_UID)
+		setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
 
 	loop();
 	doexit(1);

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -9854,7 +9854,8 @@ static int do_sandbox_android(int sandbox_arg)
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
 
 	setfilecon(".", SELINUX_LABEL_APP_DATA_FILE);
-	setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
+	if (uid == UNTRUSTED_APP_UID)
+		setcon(SELINUX_CONTEXT_UNTRUSTED_APP);
 
 	loop();
 	doexit(1);


### PR DESCRIPTION
When Android fuzzing ran under system account it was unable to access some dev nodes because it still had restricted app capabilities.