### PR TITLE
docs/fuchsia: building without cleaning

### DIFF
--- a/docs/fuchsia/setup.sh
+++ b/docs/fuchsia/setup.sh
@@ -78,7 +78,7 @@ build() {
     --with-base "//src/testing/fuzzing/syzkaller" \
     --args=syzkaller_dir="\"$syzkaller\"" \
     --variant=kasan
-  fx clean-build
+  fx build
 
   cd "$syzkaller"
   make TARGETOS=fuchsia TARGETARCH=amd64 SOURCEDIR="$fuchsia"


### PR DESCRIPTION
Preventing Fuchsia to be forcibly rebuilt
even if changes only happened on the syzkaller side.