### PR TITLE
vm/adb: added a new condition to determine localhost

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -503,7 +503,7 @@ func isRemoteCuttlefish(dev string) (bool, string) {
 		return false, ""
 	}
 	ip := strings.Split(dev, ":")[0]
-	if ip == "0.0.0.0" || ip == "127.0.0.1" {
+	if ip == "localhost" || ip == "0.0.0.0" || ip == "127.0.0.1" {
 		return false, ip
 	}
 	return true, ip


### PR DESCRIPTION
vm/adb: added a new condition to determine localhost

When fuzzing via remote device proxy syzkaller identified all crashes as 'lost connection'. It happened because a connected device was treated by syz-manager as a remote Cuttlefish. That means a serial console provide by the actual device wasn't used. When a crash happened ADB was disconnected and a stream from serial console was empty. This was treated as lost connection.

I fixed this issue by adding a new condition into isRemoteCuttlefish which tries to identify local connections. Besides 127.0.0.1 and 0.0.0.0 it also checks for 'localhost'