### PR TITLE
Makefile: split presubmit_arch_other target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [presubmit_arch_linux, presubmit_arch_freebsd, presubmit_arch_other, presubmit_arch_executor]
+        target: [presubmit_arch_linux, presubmit_arch_freebsd, presubmit_arch_netbsd, presubmit_arch_openbsd, presubmit_arch_darwin, presubmit_arch_windows, presubmit_arch_executor]
     steps:
       - name: checkout
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ endif
 	format format_go format_cpp format_sys \
 	tidy test test_race \
 	check_copyright check_language check_whitespace check_links check_diff check_commits check_shebang \
-	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd presubmit_arch_other \
+	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd \
+	presubmit_arch_netbsd presubmit_arch_openbsd presubmit_arch_darwin presubmit_arch_windows \
 	presubmit_arch_executor presubmit_big presubmit_race presubmit_old
 
 all: host target
@@ -288,7 +289,10 @@ presubmit:
 	$(MAKE) presubmit_build
 	$(MAKE) presubmit_arch_linux
 	$(MAKE) presubmit_arch_freebsd
-	$(MAKE) presubmit_arch_other
+	$(MAKE) presubmit_arch_netbsd
+	$(MAKE) presubmit_arch_openbsd
+	$(MAKE) presubmit_arch_darwin
+	$(MAKE) presubmit_arch_windows
 	$(MAKE) presubmit_arch_executor
 	$(MAKE) presubmit_race
 
@@ -319,12 +323,18 @@ presubmit_arch_freebsd: descriptions
 	env TARGETOS=freebsd TARGETARCH=amd64 $(MAKE) target
 	env TARGETOS=freebsd TARGETARCH=386 $(MAKE) target
 
-presubmit_arch_other: descriptions
+presubmit_arch_netbsd: descriptions
 	env HOSTOS=netbsd HOSTARCH=amd64 $(MAKE) host
-	env HOSTOS=openbsd HOSTARCH=amd64 $(MAKE) host
-	env HOSTOS=darwin HOSTARCH=amd64 $(MAKE) host
 	env TARGETOS=netbsd TARGETARCH=amd64 $(MAKE) target
+
+presubmit_arch_openbsd: descriptions
+	env HOSTOS=openbsd HOSTARCH=amd64 $(MAKE) host
 	env TARGETOS=openbsd TARGETARCH=amd64 $(MAKE) target
+
+presubmit_arch_darwin: descriptions
+	env HOSTOS=darwin HOSTARCH=amd64 $(MAKE) host
+
+presubmit_arch_windows: descriptions
 	env TARGETOS=windows TARGETARCH=amd64 $(MAKE) target
 
 presubmit_arch_executor: descriptions


### PR DESCRIPTION
presubmit_arch_other is now the slowest presubmit step taking 7-8 mins.
Split it per OS.
