### PR TITLE
executor: revert errno logic for fuchsia.

### DIFF
--- a/executor/executor_fuchsia.h
+++ b/executor/executor_fuchsia.h
@@ -22,6 +22,15 @@ static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])
 {
 	intptr_t res = c->call(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
 	if (strncmp(c->name, "zx_", 3) == 0) {
+		// Convert zircon error convention to the libc convention that executor expects.
+		// The following calls return arbitrary integers instead of error codes.
+		if (res == ZX_OK ||
+		    !strcmp(c->name, "zx_debuglog_read") ||
+		    !strcmp(c->name, "zx_clock_get") ||
+		    !strcmp(c->name, "zx_clock_get_monotonic") ||
+		    !strcmp(c->name, "zx_deadline_after") ||
+		    !strcmp(c->name, "zx_ticks_get"))
+			return 0;
 		errno = (-res) & 0x7f;
 		return -1;
 	}


### PR DESCRIPTION
Commit 4ce69996ec362f8dd9762dcc1643d13cebaab44a changed the logic
for processing results for fuchsia system calls. That change seems
to be fault, as it sets syscalls that return with ZX_OK to return -1
instead. I am reverting that commit for now.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
