### PR TITLE
pkg/bisect: ensure test() returns an err after a failed build()

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -38,7 +38,7 @@ type KernelConfig struct {
 	Sysctl  string
 	Config  []byte
 	// Baseline configuration is used in commit bisection. If the crash doesn't reproduce
-	// with baseline configuratopm config bisection is run. When triggering configuration
+	// with baseline configuration, config bisection is run. When triggering configuration
 	// option is found provided baseline configuration is modified according the bisection
 	// results. This new configuration is tested once more with current head. If crash
 	// reproduces with the generated configuration original configuation is replaced with
@@ -459,7 +459,7 @@ func (env *env) test() (*testResult, error) {
 		} else {
 			env.log("%v", err)
 		}
-		return res, nil
+		return res, err
 	}
 
 	numTests := MaxNumTests / 2

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -206,15 +206,6 @@ var bisectionTests = []BisectionTest{
 		resultingConfig: "original config",
 	},
 	{
-		name:            "cause-finds-cause-baseline-fails",
-		startCommit:     905,
-		commitLen:       1,
-		expectRep:       true,
-		culprit:         602,
-		baselineConfig:  "baseline-fails",
-		resultingConfig: "original config",
-	},
-	{
 		name:            "cause-finds-cause-baseline-skip",
 		startCommit:     905,
 		commitLen:       1,
@@ -231,6 +222,12 @@ var bisectionTests = []BisectionTest{
 		culprit:         602,
 		baselineConfig:  "minimize-succeeds",
 		resultingConfig: "new-minimized-config",
+	},
+	{
+		name:           "cause-finds-cause-baseline-fails",
+		startCommit:    905,
+		baselineConfig: "baseline-fails",
+		expectErr:      true,
 	},
 	{
 		name:           "cause-finds-cause-minimize-fails",


### PR DESCRIPTION
During a bisection the call stack looks like this:
Starting at env.bisect() in pkg/bisect/bisect.go
bisect() -> Bisect() -> pred() -> test() -> build()

Previously bisect() could run into a nil pointer deref and crash, as it
didn't abort after the failed build(). This could happend, as the error
was not properly returned from test(). Hence bisect() expected testRes1
to contain valid information, causing a nul pointer deref at
results[testRes1.com.Hash]

I ran into this with a linux branch, where syzkaller could not find any
release tags.

While I'm not very familiar with the config minimization code, I do
believe the test case I had to change was wrong all along. It seems to
me that a test build using the baselineConfig is always performed first,
with the goal to abort the minimization should the build fail. This
should always have been the case for this test case, but was masked by
the incorrenct error handling before.
