### PR TITLE
pkg/gce, vm/gce: add param to enable nested virtualization

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -43,6 +43,12 @@ type Context struct {
 	apiRateGate <-chan time.Time
 }
 
+type CreateArgs struct {
+	Preemptible   bool
+	DisplayDevice bool
+	NestedVirt    bool
+}
+
 func NewContext(customZoneID string) (*Context, error) {
 	ctx := &Context{
 		apiRateGate: time.NewTicker(time.Second).C,
@@ -103,7 +109,7 @@ func NewContext(customZoneID string) (*Context, error) {
 }
 
 func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
-	preemptible, displayDevice bool) (string, error) {
+	args CreateArgs) (string, error) {
 	prefix := "https://www.googleapis.com/compute/v1/projects/" + ctx.ProjectID
 	sshkeyAttr := "syzkaller:" + sshkey
 	oneAttr := "1"
@@ -143,11 +149,14 @@ func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
 		},
 		Scheduling: &compute.Scheduling{
 			AutomaticRestart:  &falseAttr,
-			Preemptible:       preemptible,
+			Preemptible:       args.Preemptible,
 			OnHostMaintenance: "TERMINATE",
 		},
 		DisplayDevice: &compute.DisplayDevice{
-			EnableDisplay: displayDevice,
+			EnableDisplay: args.DisplayDevice,
+		},
+		AdvancedMachineFeatures: &compute.AdvancedMachineFeatures{
+			EnableNestedVirtualization: args.NestedVirt,
 		},
 	}
 retry:

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -46,6 +46,7 @@ type Config struct {
 	GCEImage      string `json:"gce_image"`      // pre-created GCE image to use
 	Preemptible   bool   `json:"preemptible"`    // use preemptible VMs if available (defaults to true)
 	DisplayDevice bool   `json:"display_device"` // enable a virtual display device
+	NestedVirt    bool   `json:"nested_virt"`    // enable nested virtualization
 }
 
 type Pool struct {
@@ -152,8 +153,13 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		return nil, err
 	}
 	log.Logf(0, "creating instance: %v", name)
+	args := gce.CreateArgs{
+		Preemptible:   pool.cfg.Preemptible,
+		DisplayDevice: pool.cfg.DisplayDevice,
+		NestedVirt:    pool.cfg.NestedVirt,
+	}
 	ip, err := pool.GCE.CreateInstance(name, pool.cfg.MachineType, pool.cfg.GCEImage,
-		string(gceKeyPub), pool.cfg.Preemptible, pool.cfg.DisplayDevice)
+		string(gceKeyPub), args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is needed for Cuttlefish-on-GCE. It adds the field 'nested_virt' to
the config file and then passes it through to the relevant field in the
call to gce.CreateInstance().
