### PR TITLE
pkg/build: don't call fetch_cvd for Android instances

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -96,10 +96,6 @@ func (a android) build(params Params) (ImageDetails, error) {
 	if err := embedFiles(params, func(mountDir string) error {
 		homeDir := filepath.Join(mountDir, "root")
 
-		if _, err := osutil.RunCmd(time.Hour, homeDir, "./fetch_cvd"); err != nil {
-			return err
-		}
-
 		if err := osutil.CopyFile(bzImage, filepath.Join(homeDir, "bzImage")); err != nil {
 			return err
 		}


### PR DESCRIPTION
Since the worker instances don't have network access, they won't be able
to download the Cuttlefish packages using this. Instead, we'll have to
pre-install the Cuttlefish tools in the GCE image.