### PR TITLE
Support clang in linux bisection jobs

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -201,6 +201,11 @@ func runImpl(cfg *Config, repo vcs.Repo, inst instance.Env) (*Result, error) {
 }
 
 func (env *env) bisect() (*Result, error) {
+	err := env.bisecter.PrepareBisect()
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := env.cfg
 	if err := build.Clean(cfg.Manager.TargetOS, cfg.Manager.TargetVMArch,
 		cfg.Manager.Type, cfg.Manager.KernelSrc); err != nil {

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -19,15 +19,16 @@ import (
 )
 
 type Config struct {
-	Trace     debugtracer.DebugTracer
-	Fix       bool
-	BinDir    string
-	Ccache    string
-	Timeout   time.Duration
-	Kernel    KernelConfig
-	Syzkaller SyzkallerConfig
-	Repro     ReproConfig
-	Manager   *mgrconfig.Config
+	Trace          debugtracer.DebugTracer
+	Fix            bool
+	BisectCompiler string
+	BinDir         string
+	Ccache         string
+	Timeout        time.Duration
+	Kernel         KernelConfig
+	Syzkaller      SyzkallerConfig
+	Repro          ReproConfig
+	Manager        *mgrconfig.Config
 }
 
 type KernelConfig struct {
@@ -375,7 +376,7 @@ func (env *env) commitRangeForFix() (*vcs.Commit, *vcs.Commit, *report.Report, [
 
 func (env *env) commitRangeForBug() (*vcs.Commit, *vcs.Commit, *report.Report, []*testResult, error) {
 	cfg := env.cfg
-	tags, err := env.bisecter.PreviousReleaseTags(cfg.Kernel.Commit)
+	tags, err := env.bisecter.PreviousReleaseTags(cfg.Kernel.Commit, cfg.BisectCompiler)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -420,11 +421,11 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		return nil, "", err
 	}
 
-	bisectEnv, err := env.bisecter.EnvForCommit(env.cfg.BinDir, current.Hash, env.kernelConfig)
+	bisectEnv, err := env.bisecter.EnvForCommit(env.cfg.BisectCompiler, env.cfg.BinDir, current.Hash, env.kernelConfig)
 	if err != nil {
 		return current, "", err
 	}
-	env.log("testing commit %v", current.Hash)
+	env.log("testing commit %v %v", current.Hash, env.cfg.BisectCompiler)
 	buildStart := time.Now()
 	mgr := env.cfg.Manager
 	if err := build.Clean(mgr.TargetOS, mgr.TargetVMArch, mgr.Type, mgr.KernelSrc); err != nil {

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -136,13 +136,6 @@ func (ctx *linux) EnvForCommit(binDir, commit string, kernelConfig []byte) (*Bis
 		Compiler:     filepath.Join(binDir, "gcc-"+linuxCompilerVersion(tags), "bin", "gcc"),
 		KernelConfig: cf.Serialize(),
 	}
-	// v4.0 doesn't boot with our config nor with defconfig, it halts on an interrupt in x86_64_start_kernel.
-	if !tags["v4.1"] {
-		_, err := ctx.git.git("cherry-pick", "--no-commit", "99124e4db5b7b70daeaaf1d88a6a8078a0004c6e")
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	return env, nil
 }

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -48,3 +48,7 @@ func (ctx *testos) Minimize(target *targets.Target, original, baseline []byte,
 		return original, nil
 	}
 }
+
+func (ctx *testos) PrepareBisect() error {
+	return nil
+}

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -22,11 +22,11 @@ func newTestos(dir string, opts []RepoOpt) *testos {
 	}
 }
 
-func (ctx *testos) PreviousReleaseTags(commit string) ([]string, error) {
+func (ctx *testos) PreviousReleaseTags(commit, bisectCompiler string) ([]string, error) {
 	return ctx.git.previousReleaseTags(commit, false, false, false)
 }
 
-func (ctx *testos) EnvForCommit(binDir, commit string, kernelConfig []byte) (*BisectEnv, error) {
+func (ctx *testos) EnvForCommit(bisectCompiler, binDir, commit string, kernelConfig []byte) (*BisectEnv, error) {
 	return &BisectEnv{KernelConfig: kernelConfig}, nil
 }
 

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -64,6 +64,10 @@ type Repo interface {
 
 // Bisecter may be optionally implemented by Repo.
 type Bisecter interface {
+	// Can be used for last minute preparations like pulling release tags into the bisected repo, which
+	// is required to determin the compiler version to use on linux. Can be an empty function.
+	PrepareBisect() error
+
 	// Bisect bisects good..bad commit range against the provided predicate (wrapper around git bisect).
 	// The predicate should return an error only if there is no way to proceed
 	// (it will abort the process), if possible it should prefer to return BisectSkip.
@@ -172,10 +176,10 @@ const (
 	OptDontSandbox
 )
 
-func NewRepo(os, vm, dir string, opts ...RepoOpt) (Repo, error) {
+func NewRepo(os, vmType, dir string, opts ...RepoOpt) (Repo, error) {
 	switch os {
 	case targets.Linux:
-		return newLinux(dir, opts), nil
+		return newLinux(dir, opts, vmType), nil
 	case targets.Akaros:
 		return newAkaros(dir, opts), nil
 	case targets.Fuchsia:

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -78,11 +78,11 @@ type Bisecter interface {
 
 	// PreviousReleaseTags returns list of preceding release tags that are reachable from the given commit.
 	// If the commit itself has a release tag, this tag is not included.
-	PreviousReleaseTags(commit string) ([]string, error)
+	PreviousReleaseTags(commit, bisectCompiler string) ([]string, error)
 
 	IsRelease(commit string) (bool, error)
 
-	EnvForCommit(binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
+	EnvForCommit(bisectCompiler, binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
 }
 
 type ConfigMinimizer interface {

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -412,10 +412,11 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		// compete with patch testing jobs (it's bad delaying patch testing).
 		// When/if bisection jobs don't compete with patch testing,
 		// it makes sense to increase this to 12-24h.
-		Timeout: 8 * time.Hour,
-		Fix:     req.Type == dashapi.JobBisectFix,
-		BinDir:  jp.cfg.BisectBinDir,
-		Ccache:  jp.cfg.Ccache,
+		Timeout:        8 * time.Hour,
+		Fix:            req.Type == dashapi.JobBisectFix,
+		BisectCompiler: mgr.mgrcfg.BisectCompiler,
+		BinDir:         jp.cfg.BisectBinDir,
+		Ccache:         jp.cfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:           mgr.mgrcfg.Repo,
 			Branch:         mgr.mgrcfg.Branch,

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -43,10 +43,12 @@ var (
 )
 
 type Config struct {
+	// Currently either 'gcc' or 'clang'. Note that pkg/bisect requires
+	// explicit plumbing for every os/compiler combination.
+	BisectCompiler string `json:"bisect_compiler"`
 	// BinDir must point to a dir that contains compilers required to build
 	// older versions of the kernel. For linux, it needs to include several
-	// gcc versions. A working archive can be downloaded from:
-	// https://storage.googleapis.com/syzkaller/bisect_bin.tar.gz
+	// compiler versions.
 	BinDir        string `json:"bin_dir"`
 	Ccache        string `json:"ccache"`
 	KernelRepo    string `json:"kernel_repo"`
@@ -94,9 +96,10 @@ func main() {
 			TraceWriter: os.Stdout,
 			OutDir:      *flagCrash,
 		},
-		Fix:    *flagFix,
-		BinDir: mycfg.BinDir,
-		Ccache: mycfg.Ccache,
+		Fix:            *flagFix,
+		BisectCompiler: mycfg.BisectCompiler,
+		BinDir:         mycfg.BinDir,
+		Ccache:         mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:      mycfg.KernelRepo,
 			Branch:    mycfg.KernelBranch,

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -101,7 +101,7 @@ func main() {
 		tool.Fail(err)
 	}
 	log.Printf("HEAD is on %v %v", head.Hash, head.Title)
-	tags, err := bisecter.PreviousReleaseTags(head.Hash)
+	tags, err := bisecter.PreviousReleaseTags(head.Hash, "gcc")
 	if err != nil {
 		tool.Fail(err)
 	}
@@ -125,7 +125,7 @@ func main() {
 }
 
 func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.Env, com *vcs.Commit) {
-	bisectEnv, err := bisecter.EnvForCommit(*flagBisectBin, com.Hash, kernelConfig)
+	bisectEnv, err := bisecter.EnvForCommit("gcc", *flagBisectBin, com.Hash, kernelConfig)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
Some outstanding improvements not included in this PR:
- use default compiler, instead of one from the bin_dir, if an old compiler isn't required for the commit under test
- handle vanishing breaking commit (due to rebases) in the fixing commit bisection
- save time while bisecting subtree merges by skipping ahead to subtree merge commit, instead of skipping each subtree commit individually
