### PR TITLE
docs/freebsd: update the default branch of freebsd-src

### DIFF
--- a/docs/freebsd/README.md
+++ b/docs/freebsd/README.md
@@ -61,7 +61,7 @@ This will create a memory device for the VM file and allow host to install the c
 To get a copy of the current development sources:
 ```console
 # pkg install git
-# git clone --depth=1 --branch=master https://github.com/freebsd/freebsd /usr/src
+# git clone --depth=1 --branch=main https://github.com/freebsd/freebsd-src /usr/src
 ```
 To create a custom kernel configuration file for syzkaller and build a new kernel, run:
 


### PR DESCRIPTION
The git link and branch of freebsd in the documentation are outdated, so update this to the main branch of [freebsd-src](https://github.com/freebsd/freebsd-src.git).
