### PR TITLE
.github: decrease the OSS fuzzing time

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'syzkaller'
-        fuzz-seconds: 600
+        fuzz-seconds: 300
         dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
10 minutes looks like a too big number, especially given that other CI
actions finish much faster.

