### PR TITLE
pkg/report: use `show panic` output for unscrambled panic message

### DIFF
--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -21,6 +21,7 @@ func ctorOpenbsd(cfg *config) (reporterImpl, []string, error) {
 	suppressions := []string{
 		"panic: vop_generic_badop",
 		"witness: lock order reversal:\\n(.*\\n)*.*[0-9stnd]+ 0x[0-9a-f]+ inode(.*\\n)*.*lock order .* first seen at",
+		"panic:.*send disconnect: Broken pipe",
 	}
 	return ctx, suppressions, nil
 }

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -40,6 +40,10 @@ var openbsdOopses = append([]*oops{
 		[]byte("panic:"),
 		[]oopsFormat{
 			{
+				title: compile(`\nddb\{\d+\}> show panic(?Us:.*)[*]cpu\d+: ([^\n]+)(?Us:.*)\nddb\{\d+\}> trace`),
+				fmt:   "panic: %[1]v",
+			},
+			{
 				title: compile("panic: kernel diagnostic assertion (.+) failed: file \".*/([^\"]+)"),
 				fmt:   "assert %[1]v failed in %[2]v",
 			},

--- a/pkg/report/testdata/openbsd/report/37
+++ b/pkg/report/testdata/openbsd/report/37
@@ -1,0 +1,30 @@
+TITLE: panic: vop_generic_badop
+
+panic: vop_generic_bapdoapn
+iStopped at     db_enter+0x18:  addq    $0x8,%rsp
+    TID    PID    UID     PRFLAGS     PFLAGS  CPU  COMMAND
+ 398284  22754      0           0  0x4000000    1  syz-executor.5
+*248934   9887      0         0x2          0    0  syz-executor.7
+db_enter() at db_enter+0x18
+panic(ffffffff8259599b) at panic+0x177
+vop_generic_badop(ffff80002b00e378) at vop_generic_badop+0x1b
+VOP_STRATEGY(fffffd807ba95960,fffffd807bc216c8) at VOP_STRATEGY+0x9b
+bwrite(fffffd807bc216c8) at bwrite+0x1f0
+VOP_BWRITE(fffffd807bc216c8) at VOP_BWRITE+0x4a
+ufs_mkdir(ffff80002b00e610) at ufs_mkdir+0x6b4
+VOP_MKDIR(fffffd8069ea92c8,ffff80002b00e770,ffff80002b00e7a0,ffff80002b00e6a0) at VOP_MKDIR+0xbf
+domkdirat(ffff8000212f47f0,ffffff9c,7f7fffff5050,1ff) at domkdirat+0x121
+syscall(ffff80002b00e920) at syscall+0x435
+Xsyscall() at Xsyscall+0x128
+end of kernel
+end trace frame: 0x7f7fffff50c0, count: 4
+https://www.openbsd.org/ddb.html describes the minimum info required in bug
+reports.  Insufficient info makes it difficult to find and fix bugs.
+ddb{0}> 
+ddb{0}> set $lines = 0
+ddb{0}> set $maxwidth = 0
+ddb{0}> show panic
+*cpu0: vop_generic_badop
+ cpu1: kernel diagnostic assertion "!_kernel_lock_held()" failed: file "/syzkaller/managers/multicore/kernel/sys/kern/kern_fork.c", line 676
+ddb{0}> trace
+db_enter() at db_enter+0x18

--- a/pkg/report/testdata/openbsd/report/38
+++ b/pkg/report/testdata/openbsd/report/38
@@ -1,0 +1,4 @@
+TITLE: panic: vop_generic_bclient_loop: send disconnect: Broken pipe
+SUPPRESSED: Y
+
+panic: vop_generic_bclient_loop: send disconnect: Broken pipe


### PR DESCRIPTION
The original panic: is printed without logging and is often garbled
by concurrent printing by another core. OTOH, `show panic` is printed
exclusively so we prefer to use that.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
