### PR TITLE
pkg/gce, vm/gce: leave nested virt support up to images

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -46,7 +46,6 @@ type Context struct {
 type CreateArgs struct {
 	Preemptible   bool
 	DisplayDevice bool
-	NestedVirt    bool
 }
 
 func NewContext(customZoneID string) (*Context, error) {
@@ -109,7 +108,7 @@ func NewContext(customZoneID string) (*Context, error) {
 }
 
 func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
-	args CreateArgs) (string, error) {
+	preemptible, displayDevice bool) (string, error) {
 	prefix := "https://www.googleapis.com/compute/v1/projects/" + ctx.ProjectID
 	sshkeyAttr := "syzkaller:" + sshkey
 	oneAttr := "1"
@@ -149,14 +148,11 @@ func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
 		},
 		Scheduling: &compute.Scheduling{
 			AutomaticRestart:  &falseAttr,
-			Preemptible:       args.Preemptible,
+			Preemptible:       preemptible,
 			OnHostMaintenance: "TERMINATE",
 		},
 		DisplayDevice: &compute.DisplayDevice{
-			EnableDisplay: args.DisplayDevice,
-		},
-		AdvancedMachineFeatures: &compute.AdvancedMachineFeatures{
-			EnableNestedVirtualization: args.NestedVirt,
+			EnableDisplay: displayDevice,
 		},
 	}
 retry:

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -46,7 +46,6 @@ type Config struct {
 	GCEImage      string `json:"gce_image"`      // pre-created GCE image to use
 	Preemptible   bool   `json:"preemptible"`    // use preemptible VMs if available (defaults to true)
 	DisplayDevice bool   `json:"display_device"` // enable a virtual display device
-	NestedVirt    bool   `json:"nested_virt"`    // enable nested virtualization
 }
 
 type Pool struct {
@@ -153,13 +152,8 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		return nil, err
 	}
 	log.Logf(0, "creating instance: %v", name)
-	args := gce.CreateArgs{
-		Preemptible:   pool.cfg.Preemptible,
-		DisplayDevice: pool.cfg.DisplayDevice,
-		NestedVirt:    pool.cfg.NestedVirt,
-	}
 	ip, err := pool.GCE.CreateInstance(name, pool.cfg.MachineType, pool.cfg.GCEImage,
-		string(gceKeyPub), args)
+		string(gceKeyPub), pool.cfg.Preemptible, pool.cfg.DisplayDevice)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This can be enabled for all GCE instances which means we can remove the
CreateArgs struct introduced in https://github.com/google/syzkaller/pull/3328.

Created in response to https://github.com/google/syzkaller/pull/3328#issuecomment-1232608941
