### PR TITLE
vm/cuttlefish: mount debugfs

### DIFF
--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -81,6 +81,11 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		return nil, fmt.Errorf("failed to get root access to device: %s", err)
 	}
 
+	if err := inst.runOnHost(5*time.Minute, fmt.Sprintf("adb shell setprop persist.dbg.keep_debugfs_mounted 1;"+
+		"mount -t debugfs debugfs /sys/kernel/debug; chmod 0755 /sys/kernel/debug")); err != nil {
+		return nil, fmt.Errorf("failed to mount debugfs to /sys/kernel/debug: %s", err)
+	}
+
 	return inst, nil
 }
 


### PR DESCRIPTION
Mounting debugfs to sys/kernel/debug.
Fixing error that /sys/kernel/debug/kcov
does not exist for Cuttlefish.
