### PR TITLE
dashboard: retest repros on latest config

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -233,6 +233,7 @@ type Job struct {
 	KernelRepo   string
 	KernelBranch string
 	Patch        int64 // reference to Patch text entity
+	KernelConfig int64 // reference to the kernel config entity
 
 	Attempts int // number of times we tried to execute this job
 	Started  time.Time

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -399,6 +399,7 @@ func TestReproRetestJob(t *testing.T) {
 	build.ID = "new-build"
 	build.KernelRepo = "git://mygit.com/new-git.git"
 	build.KernelBranch = "new-main"
+	build.KernelConfig = []byte{0xAB, 0xCD, 0xEF}
 	c.client2.UploadBuild(build)
 
 	// Wait until the bug is upstreamed.
@@ -416,6 +417,7 @@ func TestReproRetestJob(t *testing.T) {
 		c.expectEQ(resp.Type, dashapi.JobTestPatch)
 		c.expectEQ(resp.KernelRepo, build.KernelRepo)
 		c.expectEQ(resp.KernelBranch, build.KernelBranch)
+		c.expectEQ(resp.KernelConfig, build.KernelConfig)
 		c.expectEQ(resp.Patch, []uint8(nil))
 		var done *dashapi.JobDoneReq
 		if resp.ReproC == nil {
@@ -445,6 +447,7 @@ func TestReproRetestJob(t *testing.T) {
 	c.expectEQ(resp.Type, dashapi.JobTestPatch)
 	c.expectEQ(resp.KernelBranch, build.KernelBranch)
 	c.expectEQ(resp.ReproC, []uint8(nil))
+	c.expectEQ(resp.KernelConfig, build.KernelConfig)
 	done := &dashapi.JobDoneReq{
 		ID: resp.ID,
 	}


### PR DESCRIPTION
Over time, new kernel options might have become necessary to
successfully build/run a kernel. The current approach ignores this
possibility.

Take not only the repro/branch from the latest build, but also the
kernel config.

Close #3352.
