### PR TITLE
docs: fix a typo in syz_testbed.md

### DIFF
--- a/docs/syz_testbed.md
+++ b/docs/syz_testbed.md
@@ -13,7 +13,7 @@ other. The tool automates checking out syzkaller repos, building them, running
 {
   "workdir": "/tmp/syz-testbed-workdir/",
   "corpus": "/tmp/corpus.db",
-  "target": "syzkaller",
+  "target": "syz-manager",
   "max_instances": 5,
   "run_time": "24h",
   "http": "0.0.0.0:50000",


### PR DESCRIPTION
The right target name is "syz-manager", not "syzkaller".

Please merge after reviewing.