### PR TITLE
Revert "pkg/csource: inline void* cast into generated code"

### DIFF
--- a/executor/common_fuchsia.h
+++ b/executor/common_fuchsia.h
@@ -272,3 +272,7 @@ static int do_sandbox_none(void)
 	return 0;
 }
 #endif
+
+// Ugly way to work around gcc's "error: function called through a non-compatible type".
+// The macro is used in generated C code.
+#define CAST(f) ({void* p = (void*)f; p; })

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4857,6 +4857,10 @@ static void setup_802154()
 
 #if GOARCH_s390x
 #include <sys/mman.h>
+// Ugly way to work around gcc's "error: function called through a non-compatible type".
+// Simply casting via (void*) inline does not work b/c gcc sees through a chain of casts.
+// The macro is used in generated C code.
+#define CAST(f) ({void* p = (void*)f; p; })
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_fuse_handle_req

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -343,7 +343,7 @@ func (ctx *context) emitCallBody(w *bytes.Buffer, call prog.ExecCall, native boo
 		if args != "" {
 			args = args[1:]
 		}
-		fmt.Fprintf(w, "((intptr_t(*)(%v))(void*)(%v))(", args, callName)
+		fmt.Fprintf(w, "((intptr_t(*)(%v))CAST(%v))(", args, callName)
 	}
 	for ai, arg := range call.Args {
 		if native || ai > 0 {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2312,6 +2312,7 @@ static int do_sandbox_none(void)
 	return 0;
 }
 #endif
+#define CAST(f) ({void* p = (void*)f; p; })
 
 #elif GOOS_linux
 
@@ -10413,6 +10414,7 @@ static void setup_802154()
 
 #if GOARCH_s390x
 #include <sys/mman.h>
+#define CAST(f) ({void* p = (void*)f; p; })
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_fuse_handle_req


### PR DESCRIPTION
This reverts commit 922294abb4c0bc72b24d8526d625110d73fa1b5a.

The commit reported to cause old warnings on s390x:
https://github.com/google/syzkaller/commit/922294abb4c0bc72b24d8526d625110d73fa1b5a#commitcomment-83096994
