### PR TITLE
tools/create-buildroot-image.sh: Configure sftp subsystem.

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -180,6 +180,7 @@ PermitRootLogin yes
 PasswordAuthentication yes
 PermitEmptyPasswords yes
 ClientAliveInterval 420
+Subsystem	sftp	/usr/libexec/sftp-server
 EOF
 
 # Generate sshd host keys.


### PR DESCRIPTION
create-buildroot-image.sh creates a minimal sshd_config, which does not
configure sftp.  Thus, if the initial scp to setup syz-fuzzer uses sftp,
it fails with the error below, and syz-manager never starts fuzzing.

  2022/09/06 16:03:44 failed to copy binary: failed to run ["scp" "-P" "14125" ... "/home/ec2-user/syzkaller/bin/linux_amd64/syz-fuzzer" "root@localhost:/syz-fuzzer"]: exit status 255
  Warning: Permanently added '[localhost]:14125' (ED25519) to the list of known hosts.
  subsystem request failed on channel 0
  Connection closed

We can see sftp throws the same sequences by manually running scp in
verbose mode.

  $ scp -v -P 14125 /home/ec2-user/syzkaller/bin/linux_amd64/syz-fuzzer root@localhost:/syz-fuzzer
  Executing: program /usr/bin/ssh host localhost, user root, command sftp
  ...
  debug1: Connecting to localhost [localhost] port 14125.
  debug1: Connection established.
  ...
  debug1: Sending subsystem: sftp
  subsystem request failed on channel 0
  Connection closed

Signed-off-by: Kuniyuki Iwashima <kuniyu@amazon.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
