### PR TITLE
tools/docker: create syzkaller home

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -62,5 +62,5 @@ RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 RUN apt-get update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get install -y -q bazel
 
 # pkg/osutil uses syzkaller user for sandboxing.
-RUN useradd syzkaller
+RUN useradd --create-home syzkaller
 RUN echo "export PS1='\n\W🤖 '" >> /root/.bashrc


### PR DESCRIPTION
Fuchsia build fails inside of syzbot container
b/c syzkaller user does not have home dir:

$ out/x64/host_x64/fpublish --help
Could not initialize SDK mkdir /home/syzkaller

Create syzkaller home.
