### PR TITLE
dashboard: solve the N+1 query problem

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -888,7 +888,7 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 	var reported time.Time
 	var err error
 	if bug.Status == BugStatusOpen {
-		_, _, _, _, reportingIdx, status, link, err = needReport(c, "", state, bug)
+		_, _, reportingIdx, status, link, err = needReport(c, "", state, bug)
 		reported = bug.Reporting[reportingIdx].Reported
 		if err != nil {
 			status = err.Error()


### PR DESCRIPTION
Do not query crashes from inside needReport, because it's not really needed there and because we query it for each opened bug on the main page.

This should noticeably speed up our main page.

