### PR TITLE
vm/qemu: return Fuchsia heartbeat period to default

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -239,7 +239,6 @@ var archConfigs = map[string]*archConfig{
 			// (For more context, see fxbug.dev/109612.)
 			"kernel.lockup-detector.critical-section-threshold-ms=300000",
 			"kernel.lockup-detector.critical-section-fatal-threshold-ms=300000",
-			"kernel.lockup-detector.heartbeat-period-ms=300000",
 			"kernel.lockup-detector.heartbeat-age-threshold-ms=300000",
 			"kernel.lockup-detector.heartbeat-age-fatal-threshold-ms=300000",
 		},


### PR DESCRIPTION
PR #3387 inadvertently set the heartbeat period to the same value as the heartbeat age threshold, which is incorrect. This removes that configuration line, allowing the period to revert to its default of 1sec.