### PR TITLE
support TCP proxyapp plugin endpoint

### DIFF
--- a/vm/proxyapp/init.go
+++ b/vm/proxyapp/init.go
@@ -6,8 +6,10 @@ package proxyapp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"time"
 
@@ -52,8 +54,15 @@ type subProcessCmd interface {
 	Wait() error
 }
 
+// Config is valid if at least cmd or rpc_server_uri specified.
 type Config struct {
-	Command        string          `json:"cmd"`
+	// cmd is the optional command needed to initialize plugin.
+	// By default we'll connect to its std[in, out, err].
+	Command string `json:"cmd"`
+	// rpc_server_uri is used to specify plugin endpoint address.
+	// if not specified, we'll connect to the plugin by std[in, out, err].
+	RPCServerURI string `json:"rpc_server_uri"`
+	// config is an optional remote plugin config
 	ProxyAppConfig json.RawMessage `json:"config"`
 }
 
@@ -62,5 +71,22 @@ func parseConfig(conf []byte) (*Config, error) {
 	if err := config.LoadData(conf, vmCfg); err != nil {
 		return nil, fmt.Errorf("failed to parseConfig(): %w", err)
 	}
+
+	if vmCfg.RPCServerURI == "" && vmCfg.Command == "" {
+		return nil, errors.New("failed to parseConfig(): neither 'cmd' nor 'rpc_server_uri' specified for plugin")
+	}
+
+	if vmCfg.RPCServerURI != "" && URIParseErr(vmCfg.RPCServerURI) != nil {
+		return nil, fmt.Errorf("failed to parseConfig(): %w", URIParseErr(vmCfg.RPCServerURI))
+	}
+
 	return vmCfg, nil
+}
+
+func URIParseErr(uri string) error {
+	dest, err := url.Parse("http://" + uri)
+	if err != nil || dest.Port() == "" || dest.Host != uri {
+		return fmt.Errorf("bad uri (%v), host:port were expected", uri)
+	}
+	return nil
 }

--- a/vm/proxyapp/init_test.go
+++ b/vm/proxyapp/init_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package proxyapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       string
+		wantConfig *Config
+		wantErr    bool
+	}{
+		{
+			name: "test cmd and rpc_server_uri specified Ok",
+			data: `{
+				"cmd": "/path/to/proxyapp_binary",
+				"rpc_server_uri": "127.0.0.1:1234"}`,
+			wantConfig: &Config{
+				Command:      "/path/to/proxyapp_binary",
+				RPCServerURI: "127.0.0.1:1234",
+			},
+			wantErr: false,
+		},
+		{
+			name: "only cmd specified Ok",
+			data: `{"cmd": "/path/to/proxyapp_binary"}`,
+			wantConfig: &Config{
+				Command:      "/path/to/proxyapp_binary",
+				RPCServerURI: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "only rpc_server_uri specified Ok",
+			data: `{"rpc_server_uri": "127.0.0.1:1234"}`,
+			wantConfig: &Config{
+				Command:      "",
+				RPCServerURI: "127.0.0.1:1234",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "cmd OR rpc_server_uri are needed",
+			data:       `{}`,
+			wantConfig: nil,
+			wantErr:    true,
+		},
+		{
+			name:       "rpc address format Ok",
+			data:       `{"rpc_server_uri": "127.0.0.1:1234"}`,
+			wantConfig: &Config{RPCServerURI: "127.0.0.1:1234"},
+			wantErr:    false,
+		},
+		{
+			name:       "rpc address format bad",
+			data:       `{"rpc_server_uri": "http://127.0.0.1:1234"}`,
+			wantConfig: nil,
+			wantErr:    true,
+		},
+		{
+			name: "remote plugin config Ok",
+			data: `{"rpc_server_uri": "127.0.0.1:1234",
+						  "config": {"param": 1}}`,
+			wantConfig: &Config{
+				RPCServerURI:   "127.0.0.1:1234",
+				ProxyAppConfig: []byte(`{"param": 1}`),
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote plugin config is optional",
+			data: `{"rpc_server_uri": "127.0.0.1:1234"}`,
+			wantConfig: &Config{
+				RPCServerURI:   "127.0.0.1:1234",
+				ProxyAppConfig: nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			cfg, err := parseConfig([]byte(test.data))
+			assert.Equal(tt, err != nil, test.wantErr)
+			assert.Equal(tt, test.wantConfig, cfg)
+		})
+	}
+}
+
+func TestURIParseErr(t *testing.T) {
+	assert.Nil(t, URIParseErr("127.0.0.1:1234"))
+	assert.Nil(t, URIParseErr("domain_name:1234"))
+
+	assert.NotNil(t, URIParseErr("http://domain_name:1234"))
+	assert.NotNil(t, URIParseErr("http://127.0.0.1:1234"))
+	assert.NotNil(t, URIParseErr("127.0.0.1"))
+}

--- a/vm/proxyapp/proxyappclient_tcp_test.go
+++ b/vm/proxyapp/proxyappclient_tcp_test.go
@@ -1,0 +1,150 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package proxyapp
+
+import (
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/google/syzkaller/vm/proxyapp/proxyrpc"
+	"github.com/google/syzkaller/vm/vmimpl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func testTCPEnv(port string) *vmimpl.Env {
+	return &vmimpl.Env{
+		Config: []byte(`
+{
+		"rpc_server_uri": "127.0.0.1:` + port + `",
+		"config": {
+			"internal_values": 123
+		}
+	}
+`)}
+}
+
+func proxyAppServerTCPFixture(t *testing.T) (*mockProxyAppInterface, string, *proxyAppParams) {
+	mProxyAppServer, port, _ := makeMockProxyAppServer(t)
+	return initProxyAppServerFixture(mProxyAppServer), port, makeTestParams()
+}
+
+func TestCtor_TCP_Ok(t *testing.T) {
+	_, port, params := proxyAppServerTCPFixture(t)
+	p, err := ctor(params, testTCPEnv(port))
+
+	assert.Nil(t, err)
+	assert.Equal(t, 2, p.Count())
+}
+
+func TestCtor_TCP_WrongPort(t *testing.T) {
+	p, err := ctor(makeTestParams(), testTCPEnv("5"))
+
+	assert.NotNil(t, err)
+	assert.Nil(t, p)
+}
+
+func TestCtor_TCP_Reconnect_On_LostConnection(t *testing.T) {
+	mProxyAppServer, port, closeServerConnections := makeMockProxyAppServer(t)
+	onConnect := make(chan bool, 1)
+	mProxyAppServer.
+		On("CreatePool", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			out := args.Get(1).(*proxyrpc.CreatePoolResult)
+			out.Count = 2
+			onConnect <- true
+		}).
+		Return(nil).
+		Times(2).
+		On("PoolLogs", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			select {
+			case mProxyAppServer.OnLogsReceived <- true:
+			default:
+			}
+		}).
+		Return(nil)
+
+	ctor(makeTestParams(), testTCPEnv(port))
+	<-onConnect
+	closeServerConnections()
+	<-onConnect
+}
+
+func TestCtor_TCP_Reconnect_PoolChanged(t *testing.T) {
+	mProxyAppServer, port, closeServerConnections := makeMockProxyAppServer(t)
+	onConnect := make(chan bool, 1)
+	mProxyAppServer.
+		On("CreatePool", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			out := args.Get(1).(*proxyrpc.CreatePoolResult)
+			out.Count = 2
+			onConnect <- true
+		}).
+		Return(nil).
+		Once().
+		On("CreatePool", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			out := args.Get(1).(*proxyrpc.CreatePoolResult)
+			out.Count = 1
+			onConnect <- true
+		}).
+		Return(nil).
+		On("PoolLogs", mock.Anything, mock.Anything).
+		Return(nil)
+
+	p, _ := ctor(makeTestParams(), testTCPEnv(port))
+	<-onConnect
+	closeServerConnections()
+	for i := 0; i < 10; i++ {
+		<-onConnect
+		p.(*pool).mu.Lock()
+		assert.Nil(t, p.(*pool).proxy) // still can't initialize
+		p.(*pool).mu.Unlock()
+	}
+}
+
+func makeMockProxyAppServer(t *testing.T) (*mockProxyAppInterface, string, func()) {
+	handler := makeMockProxyAppInterface(t)
+	server := rpc.NewServer()
+	server.RegisterName("ProxyVM", struct{ proxyrpc.ProxyAppInterface }{handler})
+
+	l, e := net.Listen("tcp", ":0")
+	if e != nil {
+		t.Fatalf("listen error: %v", e)
+	}
+	dest, err := url.Parse("http://" + l.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to get server endpoint addr: %v", err)
+	}
+
+	connsMu := sync.Mutex{}
+	var conns []net.Conn
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				panic("failed to accept connection")
+			}
+			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
+
+			connsMu.Lock()
+			conns = append(conns, conn)
+			connsMu.Unlock()
+		}
+	}()
+
+	return handler, dest.Port(), func() {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		for _, conn := range conns {
+			conn.Close()
+		}
+	}
+}

--- a/vm/proxyapp/proxyappclient_test.go
+++ b/vm/proxyapp/proxyappclient_test.go
@@ -97,7 +97,10 @@ func TestCtor_FailedPipes(t *testing.T) {
 		On("StdoutPipe").
 		Return(io.NopCloser(strings.NewReader("")), nil).
 		On("StderrPipe").
-		Return(nil, fmt.Errorf("stderrpipe error"))
+		Return(nil, fmt.Errorf("stderrpipe error")).
+		Once().
+		On("StderrPipe").
+		Return(io.NopCloser(strings.NewReader("")), nil)
 
 	for i := 0; i < 3; i++ {
 		p, err := ctor(params, testEnv)


### PR DESCRIPTION
Currently we communicate with plugin by stdin, stdout and stderr pipes.
Stdin and stdout are used to support RPC server. Stderr is used to route logs.
Kris asked to support TCP endpoints. Let's enable it.

1. TCP channel instead of stdin+stdout will be used for RPC calls.
2. Second optional TCP channel will be used for errors.

Minimal valid config specifies cmd OR RPC server host:port then.