### PR TITLE
config/openbsd: upload coverage only via asset storage

### DIFF
--- a/dashboard/config/openbsd/config.ci
+++ b/dashboard/config/openbsd/config.ci
@@ -5,7 +5,6 @@
 	"dashboard_addr": "https://syzkaller.appspot.com",
 	"dashboard_client": "ci-openbsd-ci",
 	"hub_addr": "ci-hub.c.syzkaller.internal:50001",
-	"cover_upload_path": "gs://syzkaller/cover",
 	"syzkaller_repo": "https://github.com/google/syzkaller.git",
 	"managers": [
 		{


### PR DESCRIPTION
syz-ci doesn't support both ways at the same time.

