### PR TITLE
syz-ci: don't set asset storage for image testing

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -524,6 +524,7 @@ func (mgr *Manager) writeConfig(buildTag string) (string, error) {
 		mgrcfg.DashboardClient = mgr.dash.Client
 		mgrcfg.DashboardAddr = mgr.dash.Addr
 		mgrcfg.DashboardKey = mgr.dash.Key
+		mgrcfg.AssetStorage = mgr.cfg.AssetStorage
 	}
 	if mgr.cfg.HubAddr != "" {
 		mgrcfg.HubClient = mgr.cfg.Name

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -403,7 +403,6 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 	if (mgr.Jobs.BisectCause || mgr.Jobs.BisectFix) && cfg.BisectBinDir == "" {
 		return fmt.Errorf("manager %v: enabled bisection but no bisect_bin_dir", mgr.Name)
 	}
-	managercfg.AssetStorage = cfg.AssetStorage
 	mgr.managercfg = managercfg
 	managercfg.Syzkaller = filepath.FromSlash("syzkaller/current")
 	if managercfg.HTTP == "" {


### PR DESCRIPTION
Otherwise it leads to `failed to create manager config: bad manager config: asset storage also requires dashboard client` errors.

Don't set the config. It's not necessary anyway.
