### PR TITLE
pkg/bisect: try to reidentify commit rebased after crash

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -32,12 +32,13 @@ type Config struct {
 }
 
 type KernelConfig struct {
-	Repo    string
-	Branch  string
-	Commit  string
-	Cmdline string
-	Sysctl  string
-	Config  []byte
+	Repo        string
+	Branch      string
+	Commit      string
+	CommitTitle string
+	Cmdline     string
+	Sysctl      string
+	Config      []byte
 	// Baseline configuration is used in commit bisection. If the crash doesn't reproduce
 	// with baseline configuratopm config bisection is run. When triggering configuration
 	// option is found provided baseline configuration is modified according the bisection
@@ -148,6 +149,7 @@ func runImpl(cfg *Config, repo vcs.Repo, inst instance.Env) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer env.repo.SwitchCommit(head.Hash)
 	env.head = head
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -216,11 +218,17 @@ func (env *env) bisect() (*Result, error) {
 	if _, err := env.inst.BuildSyzkaller(cfg.Syzkaller.Repo, cfg.Syzkaller.Commit); err != nil {
 		return nil, err
 	}
-	com, err := env.repo.CheckoutCommit(cfg.Kernel.Repo, cfg.Kernel.Commit)
+
+	cfg.Kernel.Commit, err = env.identifyRewrittenCommit()
+	if err != nil {
+		return nil, err
+	}
+	com, err := env.repo.SwitchCommit(cfg.Kernel.Commit)
 	if err != nil {
 		return nil, err
 	}
 
+	env.log("ensuring issue is reproducible on original commit %v\n", cfg.Kernel.Commit)
 	env.commit = com
 	env.kernelConfig = cfg.Kernel.Config
 	testRes, err := env.test()
@@ -300,6 +308,42 @@ func (env *env) bisect() (*Result, error) {
 		res.NoopChange = noopChange
 	}
 	return res, nil
+}
+
+func (env *env) identifyRewrittenCommit() (string, error) {
+	cfg := env.cfg
+	_, err := env.repo.CheckoutBranch(cfg.Kernel.Repo, cfg.Kernel.Branch)
+	if err != nil {
+		return cfg.Kernel.Commit, err
+	}
+	contained, err := env.repo.Contains(cfg.Kernel.Commit)
+	if err != nil || contained {
+		return cfg.Kernel.Commit, err
+	}
+
+	// We record the tested kernel commit when syzkaller triggers a crash. These commits can become
+	// unreachable after the crash was found, when the history of the tested kernel branch was
+	// rewritten. The commit might have been completely deleted from the branch or just changed in
+	// some way. Some branches like linux-next are often and heavily rewritten (aka rebased).
+	// This can also happen when changing the branch you fuzz in an existing syz-manager config.
+	// This makes sense when a downstream kernel fork rebased on top of a new upstream version and
+	// you don't want syzkaller to report all your old bugs again.
+	if cfg.Kernel.CommitTitle == "" {
+		// This can happen during a manual bisection, when only a hash is given.
+		return cfg.Kernel.Commit, fmt.Errorf(
+			"commit %v not reachable in branch '%v' and no commit title available",
+			cfg.Kernel.Commit, cfg.Kernel.Branch)
+	}
+	commit, err := env.repo.GetCommitByTitle(cfg.Kernel.CommitTitle)
+	if err != nil {
+		return cfg.Kernel.Commit, err
+	}
+	if commit == nil {
+		return cfg.Kernel.Commit, fmt.Errorf(
+			"commit %v not reachable in branch '%v'", cfg.Kernel.Commit, cfg.Kernel.Branch)
+	}
+	env.log("rewritten commit %v reidentified by title '%v'\n", commit.Hash, cfg.Kernel.CommitTitle)
+	return commit.Hash, nil
 }
 
 func (env *env) minimizeConfig() (*testResult, error) {

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -37,9 +37,9 @@ type Repo interface {
 	// HeadCommit returns info about the HEAD commit of the current branch of git repository.
 	HeadCommit() (*Commit, error)
 
-	// GetCommitByTitle finds commit info by the title.
-	// Remote is not fetched, the commit needs to be reachable from the current repo state
-	// (e.g. do CheckoutBranch before). If the commit is not found, nil is returned.
+	// GetCommitByTitle finds commit info by the title. If the commit is not found, nil is returned.
+	// Remote is not fetched and only commits reachable from the checked out HEAD are searched
+	// (e.g. do CheckoutBranch before).
 	GetCommitByTitle(title string) (*Commit, error)
 
 	// GetCommitsByTitles is a batch version of GetCommitByTitle.
@@ -57,8 +57,9 @@ type Repo interface {
 	// ReleaseTag returns the latest release tag that is reachable from the given commit.
 	ReleaseTag(commit string) (string, error)
 
-	// Returns true if the current tree contains the specified commit
-	// (the commit is reachable from the current HEAD).
+	// Returns true if the current tree contains the specified commit.
+	// Remote is not fetched and only commits reachable from the checked out HEAD are searched
+	// (e.g. do CheckoutBranch before).
 	Contains(commit string) (bool, error)
 }
 

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -421,6 +421,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 			Repo:           mgr.mgrcfg.Repo,
 			Branch:         mgr.mgrcfg.Branch,
 			Commit:         req.KernelCommit,
+			CommitTitle:    req.KernelCommitTitle,
 			Cmdline:        mgr.mgrcfg.KernelCmdline,
 			Sysctl:         mgr.mgrcfg.KernelSysctl,
 			Config:         req.KernelConfig,

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -35,11 +35,12 @@ import (
 )
 
 var (
-	flagConfig          = flag.String("config", "", "bisect config file")
-	flagCrash           = flag.String("crash", "", "dir with crash info")
-	flagFix             = flag.Bool("fix", false, "search for crash fix")
-	flagKernelCommit    = flag.String("kernel_commit", "", "original kernel commit")
-	flagSyzkallerCommit = flag.String("syzkaller_commit", "", "original syzkaller commit")
+	flagConfig            = flag.String("config", "", "bisect config file")
+	flagCrash             = flag.String("crash", "", "dir with crash info")
+	flagFix               = flag.Bool("fix", false, "search for crash fix")
+	flagKernelCommit      = flag.String("kernel_commit", "", "original kernel commit")
+	flagKernelCommitTitle = flag.String("kernel_commit_title", "", "original kernel commit title")
+	flagSyzkallerCommit   = flag.String("syzkaller_commit", "", "original syzkaller commit")
 )
 
 type Config struct {
@@ -101,12 +102,13 @@ func main() {
 		BinDir:         mycfg.BinDir,
 		Ccache:         mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
-			Repo:      mycfg.KernelRepo,
-			Branch:    mycfg.KernelBranch,
-			Commit:    *flagKernelCommit,
-			Userspace: mycfg.Userspace,
-			Sysctl:    mycfg.Sysctl,
-			Cmdline:   mycfg.Cmdline,
+			Repo:        mycfg.KernelRepo,
+			Branch:      mycfg.KernelBranch,
+			Commit:      *flagKernelCommit,
+			CommitTitle: *flagKernelCommitTitle,
+			Userspace:   mycfg.Userspace,
+			Sysctl:      mycfg.Sysctl,
+			Cmdline:     mycfg.Cmdline,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   mycfg.SyzkallerRepo,


### PR DESCRIPTION
When bisecting a breaking commit, syzkaller starts the bisection from
the commit recorded in the last crash for the given bug. Previously the
bisection was aborted should the commit no longer exist in the repo.

Now we try to reidentify the breaking commit. For git pretty much the
best we can do is to search a commit reachable from HEAD with the same
title. Other VCS systems might have something better.

Syzkaller will still first validate that the start commit is indeed
broken in the way it expects. This prevents syzkaller from getting
confused should we accidentally pick a completely unrelated commit.