### PR TITLE
pkg/bisect: use default compiler during bisection where possible

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -19,16 +19,17 @@ import (
 )
 
 type Config struct {
-	Trace          debugtracer.DebugTracer
-	Fix            bool
-	BisectCompiler string
-	BinDir         string
-	Ccache         string
-	Timeout        time.Duration
-	Kernel         KernelConfig
-	Syzkaller      SyzkallerConfig
-	Repro          ReproConfig
-	Manager        *mgrconfig.Config
+	Trace           debugtracer.DebugTracer
+	Fix             bool
+	DefaultCompiler string
+	CompilerType    string
+	BinDir          string
+	Ccache          string
+	Timeout         time.Duration
+	Kernel          KernelConfig
+	Syzkaller       SyzkallerConfig
+	Repro           ReproConfig
+	Manager         *mgrconfig.Config
 }
 
 type KernelConfig struct {
@@ -420,7 +421,7 @@ func (env *env) commitRangeForFix() (*vcs.Commit, *vcs.Commit, *report.Report, [
 
 func (env *env) commitRangeForBug() (*vcs.Commit, *vcs.Commit, *report.Report, []*testResult, error) {
 	cfg := env.cfg
-	tags, err := env.bisecter.PreviousReleaseTags(cfg.Kernel.Commit, cfg.BisectCompiler)
+	tags, err := env.bisecter.PreviousReleaseTags(cfg.Kernel.Commit, cfg.CompilerType)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -465,11 +466,12 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		return nil, "", err
 	}
 
-	bisectEnv, err := env.bisecter.EnvForCommit(env.cfg.BisectCompiler, env.cfg.BinDir, current.Hash, env.kernelConfig)
+	bisectEnv, err := env.bisecter.EnvForCommit(
+		env.cfg.DefaultCompiler, env.cfg.CompilerType, env.cfg.BinDir, current.Hash, env.kernelConfig)
 	if err != nil {
 		return current, "", err
 	}
-	env.log("testing commit %v %v", current.Hash, env.cfg.BisectCompiler)
+	env.log("testing commit %v %v", current.Hash, env.cfg.CompilerType)
 	buildStart := time.Now()
 	mgr := env.cfg.Manager
 	if err := build.Clean(mgr.TargetOS, mgr.TargetVMArch, mgr.Type, mgr.KernelSrc); err != nil {

--- a/pkg/vcs/linux_test.go
+++ b/pkg/vcs/linux_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClangVersion(t *testing.T) {
+	defaultCompiler := "/some/default/compiler"
+	binDir := "/some/dir/"
+	tags := make(map[string]bool)
+
+	// No tags case.
+	actual := linuxClangPath(tags, binDir, defaultCompiler)
+	expected := binDir + "llvm-9.0.1/bin/clang"
+	assert.Equal(t, actual, expected, "unexpected clang path")
+
+	// Recent tag case.
+	tags["v5.9"] = true
+	actual = linuxClangPath(tags, binDir, defaultCompiler)
+	expected = defaultCompiler
+	assert.Equal(t, actual, expected, "unexpected clang path")
+}
+
+func TestGCCVersion(t *testing.T) {
+	defaultCompiler := "/some/default/compiler"
+	binDir := "/some/dir/"
+	tags := make(map[string]bool)
+
+	// No tags case.
+	actual := linuxGCCPath(tags, binDir, defaultCompiler)
+	expected := binDir + "gcc-5.5.0/bin/gcc"
+	assert.Equal(t, actual, expected, "unexpected gcc path")
+
+	// Somewhat old tag case.
+	tags["v4.12"] = true
+	actual = linuxGCCPath(tags, binDir, defaultCompiler)
+	expected = binDir + "gcc-8.1.0/bin/gcc"
+	assert.Equal(t, actual, expected, "unexpected gcc path")
+
+	// Recent tag case.
+	tags["v5.9"] = true
+	actual = linuxGCCPath(tags, binDir, defaultCompiler)
+	expected = defaultCompiler
+	assert.Equal(t, actual, expected, "unexpected gcc path")
+}

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -22,11 +22,13 @@ func newTestos(dir string, opts []RepoOpt) *testos {
 	}
 }
 
-func (ctx *testos) PreviousReleaseTags(commit, bisectCompiler string) ([]string, error) {
+func (ctx *testos) PreviousReleaseTags(commit, compilerType string) ([]string, error) {
 	return ctx.git.previousReleaseTags(commit, false, false, false)
 }
 
-func (ctx *testos) EnvForCommit(bisectCompiler, binDir, commit string, kernelConfig []byte) (*BisectEnv, error) {
+func (ctx *testos) EnvForCommit(
+	defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte,
+) (*BisectEnv, error) {
 	return &BisectEnv{KernelConfig: kernelConfig}, nil
 }
 

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -79,11 +79,11 @@ type Bisecter interface {
 
 	// PreviousReleaseTags returns list of preceding release tags that are reachable from the given commit.
 	// If the commit itself has a release tag, this tag is not included.
-	PreviousReleaseTags(commit, bisectCompiler string) ([]string, error)
+	PreviousReleaseTags(commit, compilerType string) ([]string, error)
 
 	IsRelease(commit string) (bool, error)
 
-	EnvForCommit(bisectCompiler, binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
+	EnvForCommit(defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
 }
 
 type ConfigMinimizer interface {

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -412,11 +412,12 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		// compete with patch testing jobs (it's bad delaying patch testing).
 		// When/if bisection jobs don't compete with patch testing,
 		// it makes sense to increase this to 12-24h.
-		Timeout:        8 * time.Hour,
-		Fix:            req.Type == dashapi.JobBisectFix,
-		BisectCompiler: mgr.mgrcfg.BisectCompiler,
-		BinDir:         jp.cfg.BisectBinDir,
-		Ccache:         jp.cfg.Ccache,
+		Timeout:         8 * time.Hour,
+		Fix:             req.Type == dashapi.JobBisectFix,
+		DefaultCompiler: mgr.mgrcfg.Compiler,
+		CompilerType:    mgr.mgrcfg.CompilerType,
+		BinDir:          jp.cfg.BisectBinDir,
+		Ccache:          jp.cfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:           mgr.mgrcfg.Repo,
 			Branch:         mgr.mgrcfg.Branch,

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -153,14 +153,14 @@ type ManagerConfig struct {
 	Repo            string `json:"repo"`
 	// Short name of the repo (e.g. "linux-next"), used only for reporting.
 	RepoAlias string `json:"repo_alias"`
+	Branch    string `json:"branch"` // Defaults to "master".
 	// Currently either 'gcc' or 'clang'. Note that pkg/bisect requires
 	// explicit plumbing for every os/compiler combination.
-	BisectCompiler string `json:"bisect_compiler"` // Defaults to "gcc"
-	Branch         string `json:"branch"`          // Defaults to "master".
-	Compiler       string `json:"compiler"`
-	Ccache         string `json:"ccache"`
-	Userspace      string `json:"userspace"`
-	KernelConfig   string `json:"kernel_config"`
+	CompilerType string `json:"compiler_type"` // Defaults to "gcc"
+	Compiler     string `json:"compiler"`
+	Ccache       string `json:"ccache"`
+	Userspace    string `json:"userspace"`
+	KernelConfig string `json:"kernel_config"`
 	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig.
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
 	// File with kernel cmdline values (optional).
@@ -386,8 +386,8 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 	if !managerNameRe.MatchString(mgr.Name) {
 		return fmt.Errorf("param 'managers.name' has bad value: %q", mgr.Name)
 	}
-	if mgr.BisectCompiler == "" {
-		mgr.BisectCompiler = "gcc"
+	if mgr.CompilerType == "" {
+		mgr.CompilerType = "gcc"
 	}
 	if mgr.Branch == "" {
 		mgr.Branch = "master"

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -44,9 +44,10 @@ var (
 )
 
 type Config struct {
+	Compiler string `json:"compiler"`
 	// Currently either 'gcc' or 'clang'. Note that pkg/bisect requires
 	// explicit plumbing for every os/compiler combination.
-	BisectCompiler string `json:"bisect_compiler"`
+	CompilerType string `json:"compiler_type"`
 	// BinDir must point to a dir that contains compilers required to build
 	// older versions of the kernel. For linux, it needs to include several
 	// compiler versions.
@@ -97,10 +98,11 @@ func main() {
 			TraceWriter: os.Stdout,
 			OutDir:      *flagCrash,
 		},
-		Fix:            *flagFix,
-		BisectCompiler: mycfg.BisectCompiler,
-		BinDir:         mycfg.BinDir,
-		Ccache:         mycfg.Ccache,
+		Fix:             *flagFix,
+		DefaultCompiler: mycfg.Compiler,
+		CompilerType:    mycfg.CompilerType,
+		BinDir:          mycfg.BinDir,
+		Ccache:          mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:        mycfg.KernelRepo,
 			Branch:      mycfg.KernelBranch,

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -125,7 +125,8 @@ func main() {
 }
 
 func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.Env, com *vcs.Commit) {
-	bisectEnv, err := bisecter.EnvForCommit("gcc", *flagBisectBin, com.Hash, kernelConfig)
+	compiler, compilerType := "gcc", "gcc"
+	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin, com.Hash, kernelConfig)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
This allows us to bisect at least recently introduced bugs, where the manager that found the bug uses a non standard compiler. This is usefull during development of a new sanitizer for which a compiler with non-upstreamed patches is required.