### PR TITLE
pkg/symbolizer: match kernel symbol size calculation

### DIFF
--- a/pkg/symbolizer/nm_test.go
+++ b/pkg/symbolizer/nm_test.go
@@ -13,6 +13,7 @@ func TestSymbols(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read symbols: %v", err)
 	}
+	t.Logf("symbols: %+v", symbols)
 	if len(symbols) != 5 {
 		t.Fatalf("got %v symbols, want 5", len(symbols))
 	}
@@ -36,11 +37,11 @@ func TestSymbols(t *testing.T) {
 		want := []Symbol{
 			{
 				Addr: 0x4004fa,
-				Size: 0x10,
+				Size: 0xd,
 			},
 			{
 				Addr: 0x4004ed,
-				Size: 0x10,
+				Size: 0xd,
 			},
 		}
 		if !symcmp(want[0], s[0]) && !symcmp(want[0], s[1]) {


### PR DESCRIPTION
Function sizes reported by the Linux kernel do not match symbol tables.
The kernel computes size of a symbol based on the start of the next symbol.
We need to do the same to match kernel sizes to be able to find the right
symbol across multiple symbols with the same name.
