### PR TITLE
pkg/report: remove alt title for BUGs

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -2060,7 +2060,6 @@ var linuxOopses = append([]*oops{
 			{
 				title: compile("kernel BUG at (.*)"),
 				fmt:   "kernel BUG in %[2]v",
-				alt:   []string{"kernel BUG at %[1]v"}, // historical title required for merging with existing bugs
 				stack: &stackFmt{
 					parts: []*regexp.Regexp{
 						linuxRipFrame,

--- a/pkg/report/testdata/linux/report/113
+++ b/pkg/report/testdata/linux/report/113
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in esp6_gro_receive
-ALT: kernel BUG at ./include/linux/skbuff.h:LINE!
 
 [  292.653596] ------------[ cut here ]------------
 [  292.658378] kernel BUG at ./include/linux/skbuff.h:2069!

--- a/pkg/report/testdata/linux/report/352
+++ b/pkg/report/testdata/linux/report/352
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in __isolate_free_page
-ALT: kernel BUG at mm/page_alloc.c:LINE!
 
 [ 1191.669874][ T1043] ------------[ cut here ]------------
 [ 1191.678706][ T1043] kernel BUG at mm/page_alloc.c:3112!

--- a/pkg/report/testdata/linux/report/43
+++ b/pkg/report/testdata/linux/report/43
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in corrupted
-ALT: kernel BUG at fs/buffer.c:LINE!
 CORRUPTED: Y
 
 [ 1722.511384] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/44
+++ b/pkg/report/testdata/linux/report/44
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in pte_list_remove
-ALT: kernel BUG at arch/x86/kvm/mmu.c:LINE!
 
 [   34.517718] ------------[ cut here ]------------
 [   34.522456] kernel BUG at arch/x86/kvm/mmu.c:1284!

--- a/pkg/report/testdata/linux/report/448
+++ b/pkg/report/testdata/linux/report/448
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in pfkey_send_acquire
-ALT: kernel BUG at net/core/skbuff.c:LINE!
 
 [  666.846118][T27281] skbuff: skb_over_panic: text:00000000db6cba37 len:1744 put:72 head:0000000092f15526 data:0000000092f15526 tail:0x6d0 end:0x6c0 dev:<NULL>
 [  666.877381][T27281] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/540
+++ b/pkg/report/testdata/linux/report/540
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in xt_rateest_tg_checkentry
-ALT: kernel BUG at lib/string.c:LINE!
 
 [   70.516302][ T8713] detected buffer overflow in strlen
 [   70.527902][ T8713] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/576
+++ b/pkg/report/testdata/linux/report/576
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in rmap_walk_file
-ALT: kernel BUG at mm/internal.h:LINE!
 
 [ 1802.485653][T28126] ------------[ cut here ]------------
 [ 1802.506583][T28126] kernel BUG at mm/internal.h:400!

--- a/pkg/report/testdata/linux/report/577
+++ b/pkg/report/testdata/linux/report/577
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in truncate_inode_partial_page
-ALT: kernel BUG at include/linux/highmem.h:LINE!
 
 [  413.263409][T16632] ------------[ cut here ]------------
 [  413.270117][T16632] kernel BUG at include/linux/highmem.h:202!

--- a/pkg/report/testdata/linux/report/578
+++ b/pkg/report/testdata/linux/report/578
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in free_netdev
-ALT: kernel BUG at net/core/dev.c:LINE!
 
 [  429.970583][T14786] ------------[ cut here ]------------
 [  430.011828][T14786] kernel BUG at net/core/dev.c:10648!

--- a/pkg/report/testdata/linux/report/579
+++ b/pkg/report/testdata/linux/report/579
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in reserve_bootmem_region
-ALT: kernel BUG at include/linux/page-flags.h:LINE!
 
 [    0.834244][    T0] kernel BUG at include/linux/page-flags.h:356!
 [    0.835624][    T0] invalid opcode: 0000 [#1] PREEMPT SMP KASAN

--- a/pkg/report/testdata/linux/report/580
+++ b/pkg/report/testdata/linux/report/580
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in do_journal_end
-ALT: kernel BUG at fs/reiserfs/prints.c:LINE!
 
 [  805.123956][ T8558] ------------[ cut here ]------------
 [  805.129637][ T8558] kernel BUG at fs/reiserfs/prints.c:390!

--- a/pkg/report/testdata/linux/report/581
+++ b/pkg/report/testdata/linux/report/581
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in pfkey_send_acquire
-ALT: kernel BUG at net/core/skbuff.c:LINE!
 
 [  280.626490][T13868] skbuff: skb_over_panic: text:ffffffff87ca4a76 len:232 put:72 head:ffff88801115a800 data:ffff88801115a800 tail:0xe8 end:0xc0 dev:<NULL>
 [  280.661924][T13868] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/582
+++ b/pkg/report/testdata/linux/report/582
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in ipgre_header
-ALT: kernel BUG at net/core/skbuff.c:LINE!
 
 [   34.354336] skbuff: skb_under_panic: text:000000000470095b len:82 put:24 head:00000000f453c8df data:000000007cc2256c tail:0x3a end:0xc0 dev:gre0
 [   34.367572] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/583
+++ b/pkg/report/testdata/linux/report/583
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in sctp_packet_transmit
-ALT: kernel BUG at net/core/skbuff.c:LINE!
 
 [  486.883962] skbuff: skb_over_panic: text:ffffffff847fe683 len:213316 put:213008 head:ffff8801c2fd3340 data:ffff8801c2fd33f8 tail:0x341fc end:0x7ec0 dev:<NULL>
 [  486.904303] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/584
+++ b/pkg/report/testdata/linux/report/584
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in xt_rateest_tg_checkentry
-ALT: kernel BUG at lib/string.c:LINE!
 
 [   70.516302][ T8713] detected buffer overflow in strlen
 [   70.527902][ T8713] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/585
+++ b/pkg/report/testdata/linux/report/585
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in ucma_join_ip_multicast
-ALT: kernel BUG at lib/string.c:LINE!
 
 [   24.127473] ------------[ cut here ]------------
 [   24.132205] kernel BUG at lib/string.c:1052!

--- a/pkg/report/testdata/linux/report/586
+++ b/pkg/report/testdata/linux/report/586
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in do_ip_vs_set_ctl
-ALT: kernel BUG at lib/string.c:LINE!
 
 [ 1392.954057] detected buffer overflow in strlen
 [ 1392.958897] ------------[ cut here ]------------

--- a/pkg/report/testdata/linux/report/587
+++ b/pkg/report/testdata/linux/report/587
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in btree_readpage_end_io_hook
-ALT: kernel BUG at lib/string.c:LINE!
 
 [   61.075073][   T26] ------------[ cut here ]------------
 [   61.081689][   T26] kernel BUG at lib/string.c:1129!

--- a/pkg/report/testdata/linux/report/656
+++ b/pkg/report/testdata/linux/report/656
@@ -1,5 +1,4 @@
 TITLE: kernel BUG in close_ctree
-ALT: kernel BUG at fs/btrfs/ctree.h:LINE!
 
 [  399.850178][T14930] BTRFS info (device loop1): has skinny extents
 [  399.860119][ T3629] kernel BUG at fs/btrfs/ctree.h:3615!


### PR DESCRIPTION
We used to use "kernel BUG at source:line" for BUGs.
Later we switch to "kernel BUG in function" as a better title,
but kept the old title as alt title so that the new titles are
merged with existing bugs.

Now it's causing issues: the following 2 reports got merged together:

kernel BUG at lib/string_helpers.c:983
Call Trace:
__fortify_strlen include/linux/fortify-string.h:144 [inline]
strlcpy include/linux/fortify-string.h:159 [inline]
init_names fs/gfs2/ops_fstype.c:385 [inline]
gfs2_fill_super+0x1226/0x27f0 fs/gfs2/ops_fstype.c:1187

kernel BUG at lib/string_helpers.c:980!
Call Trace:
 __fortify_strlen include/linux/fortify-string.h:128 [inline]
 strlcpy include/linux/fortify-string.h:143 [inline]
 __set_page_owner_handle+0x2b1/0x3e0 mm/page_owner.c:171
 __set_page_owner+0x3e/0x50 mm/page_owner.c:190
 prep_new_page mm/page_alloc.c:2441 [inline]

while they are unrelated.
A BUG in a common ignored helper will glue all reports together.

We added the alt title in Jan 2021 (de4e4f4d8b582).
All existing bugs should have been merged already,
so we can safely remove the alt title now.
