### PR TITLE
make: print warning when make is executed without syz-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,16 @@ define newline
 
 
 endef
+
+RED := $(shell tput setaf 1)
+RESET := $(shell tput sgr0)
+
+ifndef SILENCE_SYZ_ENV_HINT
+$(warning $(RED)run command via tools/syz-env for best compatibility, see:$(RESET))
+$(warning $(RED)https://github.com/google/syzkaller/blob/master/docs/contributing.md#using-syz-env$(RESET))
+export SILENCE_SYZ_ENV_HINT=1
+endif
+
 ENV := $(subst \n,$(newline),$(shell CI=$(CI)\
 	SOURCEDIR=$(SOURCEDIR) HOSTOS=$(HOSTOS) HOSTARCH=$(HOSTARCH) \
 	TARGETOS=$(TARGETOS) TARGETARCH=$(TARGETARCH) TARGETVMARCH=$(TARGETVMARCH) \

--- a/tools/syz-env
+++ b/tools/syz-env
@@ -64,6 +64,7 @@ docker run \
 	--workdir /syzkaller/gopath/src/github.com/google/syzkaller \
 	--env HOME=/syzkaller \
 	--env GOPATH=/syzkaller/gopath:/gopath \
+	--env SILENCE_SYZ_ENV_HINT=1 \
 	--env FUZZIT_API_KEY \
 	--env GITHUB_REF \
 	--env GITHUB_SHA \


### PR DESCRIPTION
- This prints a warning for users calling make without `syz-env`, as we can't guarantee they have a compatible environment and go version.
- We got a report where `make generate` fails with recent go versions with the following error: `internal error: package "context" without types was imported from "github.com/google/syzkaller/vm/proxyapp"`
- We are currently blocked from upgrading to the most recent go version by our GAE deployment.
