### PR TITLE
all: assorted kernel image-related fixes

### DIFF
--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -39,7 +39,7 @@ func (linux linux) build(params Params) (ImageDetails, error) {
 		return details, err
 	}
 
-	kernelPath := filepath.Join(params.KernelDir, filepath.FromSlash(kernelBin(params.TargetArch)))
+	kernelPath := filepath.Join(params.KernelDir, filepath.FromSlash(LinuxKernelImage(params.TargetArch)))
 
 	// Copy the kernel image to let it be uploaded to the asset storage. If the asset storage is not enabled,
 	// let the file just stay in the output folder -- it is usually very small compared to vmlinux anyway.
@@ -54,8 +54,9 @@ func (linux linux) build(params Params) (ImageDetails, error) {
 			return details, err
 		}
 	} else if params.VMType == "qemu" {
-		// If UserspaceDir is a file (image) and we use qemu, we just copy image and kernel to the output dir
-		// assuming that qemu will use injected kernel boot. In this mode we also assume password/key-less ssh.
+		// If UserspaceDir is a file (image) and we use qemu, we just copy image to the output dir assuming
+		// that qemu will use injected kernel boot. In this mode we also assume password/key-less ssh.
+		// The kernel image was already uploaded above.
 		if err := osutil.CopyFile(params.UserspaceDir, filepath.Join(params.OutputDir, "image")); err != nil {
 			return details, err
 		}
@@ -100,7 +101,7 @@ func (linux linux) buildKernel(params Params) error {
 			return err
 		}
 	}
-	target := path.Base(kernelBin(params.TargetArch))
+	target := path.Base(LinuxKernelImage(params.TargetArch))
 	if err := runMake(params, target); err != nil {
 		return err
 	}
@@ -211,7 +212,7 @@ func LinuxMakeArgs(target *targets.Target, compiler, linker, ccache, buildDir st
 	return args
 }
 
-func kernelBin(arch string) string {
+func LinuxKernelImage(arch string) string {
 	// We build only zImage/bzImage as we currently don't use modules.
 	switch arch {
 	case targets.AMD64:

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -674,7 +674,7 @@ func (mgr *Manager) pollCommits(buildCommit string) ([]string, []dashapi.Commit,
 	return present, fixCommits, nil
 }
 
-func (mgr *Manager) uploadBuildAssets(build *dashapi.Build, assetFolder string) ([]dashapi.NewAsset, error) {
+func (mgr *Manager) uploadBuildAssets(buildInfo *dashapi.Build, assetFolder string) ([]dashapi.NewAsset, error) {
 	if mgr.storage == nil {
 		// No reason to continue anyway.
 		return nil, fmt.Errorf("asset storage is not configured")
@@ -685,20 +685,23 @@ func (mgr *Manager) uploadBuildAssets(build *dashapi.Build, assetFolder string) 
 		name      string
 	}
 	pending := []pendingAsset{}
-	bootableDisk := true
 	kernelFile := filepath.Join(assetFolder, "kernel")
 	if osutil.IsExist(kernelFile) {
-		bootableDisk = true
-		pending = append(pending, pendingAsset{kernelFile, dashapi.KernelImage, "kernel"})
+		fileName := "kernel"
+		if buildInfo.OS == targets.Linux {
+			fileName = path.Base(build.LinuxKernelImage(buildInfo.Arch))
+		}
+		pending = append(pending, pendingAsset{kernelFile, dashapi.KernelImage, fileName})
 	}
 	imageFile := filepath.Join(assetFolder, "image")
 	if osutil.IsExist(imageFile) {
-		if bootableDisk {
-			pending = append(pending, pendingAsset{imageFile, dashapi.BootableDisk,
-				"disk.raw"})
-		} else {
+		if mgr.managercfg.Type == "qemu" {
+			// For qemu we currently use non-bootable disk images.
 			pending = append(pending, pendingAsset{imageFile, dashapi.NonBootableDisk,
 				"non_bootable_disk.raw"})
+		} else {
+			pending = append(pending, pendingAsset{imageFile, dashapi.BootableDisk,
+				"disk.raw"})
 		}
 	}
 	target := mgr.managercfg.SysTarget
@@ -736,7 +739,7 @@ func (mgr *Manager) uploadBuildAssets(build *dashapi.Build, assetFolder string) 
 			continue
 		}
 		info, err := mgr.storage.UploadBuildAsset(file, pendingAsset.name,
-			pendingAsset.assetType, build, extra)
+			pendingAsset.assetType, buildInfo, extra)
 		if err != nil {
 			log.Logf(0, "failed to upload an asset: %s, %s",
 				pendingAsset.path, err)


### PR DESCRIPTION
This will let the `kernel` file be uploaded to the asset storage.

Unfortunately we don't keep its proper name in targets, so we have to do a workaround -- determine the name right in the `syz-ci`.

Also, previously the existence of a kernel image was used as an indication of whether the disk image is bootable. Now that we upload it always, make a decision from the VM type.
