### PR TITLE
vm/proxyapp: enable logging over rpc

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -59,9 +59,14 @@ func CachedLogOutput() string {
 	return buf.String()
 }
 
+// V reports whether verbosity at the call site is at least the requested level.
+// See https://pkg.go.dev/github.com/golang/glog#V for details.
+func V(level int) bool {
+	return level <= *flagV
+}
+
 func Logf(v int, msg string, args ...interface{}) {
 	mu.Lock()
-	doLog := v <= *flagV
 	if cacheEntries != nil && v <= 1 {
 		cacheMem -= len(cacheEntries[cachePos])
 		if cacheMem < 0 {
@@ -88,7 +93,7 @@ func Logf(v int, msg string, args ...interface{}) {
 	}
 	mu.Unlock()
 
-	if doLog {
+	if V(v) {
 		golog.Printf(msg, args...)
 	}
 }

--- a/vm/proxyapp/mocks/ProxyAppInterface.go
+++ b/vm/proxyapp/mocks/ProxyAppInterface.go
@@ -96,6 +96,20 @@ func (_m *ProxyAppInterface) Forward(in proxyrpc.ForwardParams, out *proxyrpc.Fo
 	return r0
 }
 
+// PoolLogs provides a mock function with given fields: in, out
+func (_m *ProxyAppInterface) PoolLogs(in proxyrpc.PoolLogsParam, out *proxyrpc.PoolLogsReply) error {
+	ret := _m.Called(in, out)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(proxyrpc.PoolLogsParam, *proxyrpc.PoolLogsReply) error); ok {
+		r0 = rf(in, out)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RunReadProgress provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) RunReadProgress(in proxyrpc.RunReadProgressParams, out *proxyrpc.RunReadProgressReply) error {
 	ret := _m.Called(in, out)

--- a/vm/proxyapp/proxyappclient.go
+++ b/vm/proxyapp/proxyappclient.go
@@ -42,11 +42,8 @@ func ctor(params *proxyAppParams, env *vmimpl.Env) (vmimpl.Pool, error) {
 			select {
 			case <-p.close:
 				p.mu.Lock()
-				if p.proxy != nil {
-					p.proxy.terminate()
-					<-p.proxy.onTerminated
-				}
-				p.proxy = nil
+				p.closeProxy()
+
 				p.onClosed <- nil
 				p.mu.Unlock()
 				return
@@ -78,16 +75,14 @@ func (p *pool) init(params *proxyAppParams, cfg *Config) error {
 		return fmt.Errorf("failed to run ProxyApp: %w", err)
 	}
 
+	p.proxy.doLogPooling(params.LogOutput)
+
 	count, err := p.proxy.CreatePool(string(cfg.ProxyAppConfig), p.env.Debug)
 	if err != nil || count == 0 || (p.count != 0 && p.count != count) {
 		if err == nil {
 			err = fmt.Errorf("wrong pool size %v, prev was %v", count, p.count)
 		}
-
-		p.proxy.terminate()
-		<-p.proxy.onTerminated
-		p.proxy = nil
-
+		p.closeProxy()
 		return fmt.Errorf("failed to construct pool: %w", err)
 	}
 
@@ -95,6 +90,23 @@ func (p *pool) init(params *proxyAppParams, cfg *Config) error {
 		p.count = count
 	}
 	return nil
+}
+
+func (p *pool) closeProxy() {
+	if p.proxy != nil {
+		if p.proxy.stopLogPooling != nil {
+			p.proxy.stopLogPooling <- true
+			<-p.proxy.logPoolingDone
+		}
+		if p.proxy.Client != nil {
+			p.proxy.Client.Close()
+		}
+		if p.proxy.terminate != nil {
+			p.proxy.terminate()
+			<-p.proxy.onTerminated
+		}
+	}
+	p.proxy = nil
 }
 
 func (p *pool) Count() int {
@@ -122,8 +134,10 @@ func (p *pool) Close() error {
 
 type ProxyApp struct {
 	*rpc.Client
-	terminate    context.CancelFunc
-	onTerminated chan bool
+	terminate      context.CancelFunc
+	onTerminated   chan bool
+	stopLogPooling chan bool
+	logPoolingDone chan bool
 }
 
 func runProxyApp(params *proxyAppParams, cmd string) (*ProxyApp, error) {
@@ -183,6 +197,38 @@ func runProxyApp(params *proxyAppParams, cmd string) (*ProxyApp, error) {
 		terminate:    cancelContext,
 		onTerminated: onTerminated,
 	}, nil
+}
+
+func (proxy *ProxyApp) doLogPooling(writer io.Writer) {
+	proxy.stopLogPooling = make(chan bool, 1)
+	proxy.logPoolingDone = make(chan bool, 1)
+	go func() {
+		defer func() { proxy.logPoolingDone <- true }()
+		for {
+			var reply proxyrpc.PoolLogsReply
+			call := proxy.Go(
+				"ProxyVM.PoolLogs",
+				&proxyrpc.PoolLogsParam{},
+				&reply,
+				nil,
+			)
+			select {
+			case <-proxy.stopLogPooling:
+				return
+			case c := <-call.Done:
+				if c.Error != nil {
+					// possible errors here are:
+					// "unexpected EOF"
+					// "read tcp 127.0.0.1:56886->127.0.0.1:34603: use of closed network connection"
+					log.Logf(0, "error pooling ProxyApp logs: %v", c.Error)
+					return
+				}
+				if log.V(reply.Verbosity) {
+					writer.Write([]byte(fmt.Sprintf("ProxyAppLog: %v", reply.Log)))
+				}
+			}
+		}
+	}()
 }
 
 func (proxy *ProxyApp) CreatePool(config string, debug bool) (int, error) {

--- a/vm/proxyapp/proxyappclient_mocks_test.go
+++ b/vm/proxyapp/proxyappclient_mocks_test.go
@@ -43,3 +43,15 @@ func (cmd *mockCommandRunner) Wait() error {
 	cmd.onWaitCalled <- true
 	return cmd.SubProcessCmd.Wait()
 }
+
+type mockProxyAppInterface struct {
+	*mocks.ProxyAppInterface
+	OnLogsReceived chan bool
+}
+
+func makeMockProxyAppInterface(t mocks.NewProxyAppInterfaceT) *mockProxyAppInterface {
+	return &mockProxyAppInterface{
+		ProxyAppInterface: mocks.NewProxyAppInterface(t),
+		OnLogsReceived:    make(chan bool, 1), // 1 is enough as we read it just once
+	}
+}

--- a/vm/proxyapp/proxyappclient_test.go
+++ b/vm/proxyapp/proxyappclient_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/report"
-	"github.com/google/syzkaller/vm/proxyapp/mocks"
 	"github.com/google/syzkaller/vm/proxyapp/proxyrpc"
 	"github.com/google/syzkaller/vm/vmimpl"
 	"github.com/stretchr/testify/assert"
@@ -35,18 +34,19 @@ func makeTestParams() *proxyAppParams {
 	return &proxyAppParams{
 		CommandRunner:  osutilCommandContext,
 		InitRetryDelay: 0,
+		LogOutput:      io.Discard,
 	}
 }
 
 func makeMockProxyAppProcess(t *testing.T) (
-	*mock.Mock, io.WriteCloser, io.ReadCloser, io.ReadCloser) {
+	*mockProxyAppInterface, io.WriteCloser, io.ReadCloser, io.ReadCloser) {
 	rStdin, wStdin := io.Pipe()
 	rStdout, wStdout := io.Pipe()
 	rStderr, wStderr := io.Pipe()
 	wStderr.Close()
 
 	server := rpc.NewServer()
-	handler := mocks.NewProxyAppInterface(t)
+	handler := makeMockProxyAppInterface(t)
 	server.RegisterName("ProxyVM", struct{ proxyrpc.ProxyAppInterface }{handler})
 
 	go server.ServeCodec(jsonrpc.NewServerCodec(stdInOutCloser{
@@ -54,7 +54,7 @@ func makeMockProxyAppProcess(t *testing.T) (
 		wStdout,
 	}))
 
-	return &handler.Mock, wStdin, rStdout, rStderr
+	return handler, wStdin, rStdout, rStderr
 }
 
 type nopWriteCloser struct {
@@ -142,7 +142,10 @@ func TestCtor_FailedConstructPool(t *testing.T) {
 
 	mProxyAppServer.
 		On("CreatePool", mock.Anything, mock.Anything).
-		Return(fmt.Errorf("failed to construct pool"))
+		Return(fmt.Errorf("failed to construct pool")).
+		On("PoolLogs", mock.Anything, mock.Anything).
+		Return(nil).
+		Maybe() // on CreatePool error we close logger. This close makes PoolLogs racy.
 
 	mCmdRunner, params := makeMockCommandRunner(t)
 	mCmdRunner.
@@ -165,19 +168,37 @@ func TestCtor_FailedConstructPool(t *testing.T) {
 	assert.Nil(t, p)
 }
 
-// TODO: to remove duplicate see TestCtor_FailedConstructPool() comment
-//  nolint: dupl
-func proxyAppServerFixture(t *testing.T) (*mock.Mock, *mockCommandRunner, *proxyAppParams) {
-	mProxyAppServer, stdin, stdout, stderr :=
-		makeMockProxyAppProcess(t)
-
+func initProxyAppServerFixture(mProxyAppServer *mockProxyAppInterface) *mockProxyAppInterface {
 	mProxyAppServer.
 		On("CreatePool", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			out := args.Get(1).(*proxyrpc.CreatePoolResult)
 			out.Count = 2
 		}).
-		Return(nil)
+		Return(nil).
+		Once().
+		On("PoolLogs", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			select {
+			case mProxyAppServer.OnLogsReceived <- true:
+			default:
+			}
+		}).
+		Return(nil).
+		// PoolLogs is optional as we can call .closeProxy any time.
+		// If PoolLogs call is expected we are checking for OnLogsReceived.
+		// TODO: refactor it once Mock.Unset() is available.
+		Maybe()
+
+	return mProxyAppServer
+}
+
+// TODO: to remove duplicate see TestCtor_FailedConstructPool() comment
+//  nolint: dupl
+func proxyAppServerFixture(t *testing.T) (*mockProxyAppInterface, *mockCommandRunner, *proxyAppParams) {
+	mProxyAppServer, stdin, stdout, stderr :=
+		makeMockProxyAppProcess(t)
+	initProxyAppServerFixture(mProxyAppServer)
 
 	mCmdRunner, params := makeMockCommandRunner(t)
 	mCmdRunner.
@@ -200,7 +221,7 @@ func proxyAppServerFixture(t *testing.T) (*mock.Mock, *mockCommandRunner, *proxy
 	return mProxyAppServer, mCmdRunner, params
 }
 
-func poolFixture(t *testing.T) (*mock.Mock, *mockCommandRunner, vmimpl.Pool) {
+func poolFixture(t *testing.T) (*mockProxyAppInterface, *mockCommandRunner, vmimpl.Pool) {
 	mProxyAppServer, mCmdRunner, params := proxyAppServerFixture(t)
 	p, _ := ctor(params, testEnv)
 	return mProxyAppServer, mCmdRunner, p
@@ -215,6 +236,11 @@ func TestPool_Create_Ok(t *testing.T) {
 	inst, err := p.Create("workdir", 0)
 	assert.NotNil(t, inst)
 	assert.Nil(t, err)
+}
+
+func TestPool_Logs_Ok(t *testing.T) {
+	mockServer, _, _ := poolFixture(t)
+	<-mockServer.OnLogsReceived
 }
 
 func TestPool_Create_ProxyNilError(t *testing.T) {
@@ -272,7 +298,7 @@ func createInstanceFixture(t *testing.T) (*mock.Mock, vmimpl.Instance) {
 	assert.Nil(t, err)
 	assert.NotNil(t, inst)
 
-	return mockServer, inst
+	return &mockServer.Mock, inst
 }
 
 func TestInstance_Close(t *testing.T) {

--- a/vm/proxyapp/proxyrpc/proxyrpc.go
+++ b/vm/proxyapp/proxyrpc/proxyrpc.go
@@ -14,6 +14,7 @@ type ProxyAppInterface interface {
 	RunStop(in RunStopParams, out *RunStopReply) error
 	RunReadProgress(in RunReadProgressParams, out *RunReadProgressReply) error
 	Close(in CloseParams, out *CloseReply) error
+	PoolLogs(in PoolLogsParam, out *PoolLogsReply) error
 }
 
 type CreatePoolParams struct {
@@ -96,4 +97,15 @@ type DiagnoseParams struct {
 
 type DiagnoseReply struct {
 	Diagnosis string
+}
+
+type PoolLogsParam struct {
+}
+
+type PoolLogsReply struct {
+	Log string
+	// Verbosity follows pkg/log rules.
+	// Messages with Verbosity 0 are printed by default.
+	// The higher is this value - the lower is importance of the message.
+	Verbosity int
 }


### PR DESCRIPTION
To be #3395 prepared, we need logs over rpc.
Disconnect case will be tested in #3395.