### PR TITLE
sys/targets: fix -static-pie for s390x arch

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -285,6 +285,7 @@ var List = map[string]map[string]*Target{
 			PtrSize:          8,
 			PageSize:         4 << 10,
 			DataOffset:       0xfffff000,
+			CFlags:           []string{"-fPIE"},
 			LittleEndian:     false,
 			Triple:           "s390x-linux-gnu",
 			KernelArch:       "s390",


### PR DESCRIPTION
On s390x, position independent code needs to be built with -fPIC or -fPIE for pie executables.

How to reproduce on s390x
-------------------------

$ git clone https://github.com/google/syzkaller.git $ cd syzkaller
$ make executor
Makefile:32: run command via tools/syz-env for best compatibility, see: Makefile:33: https://github.com/google/syzkaller/blob/master/docs/contributing.md#using-syz-env go list -f '{{.Stale}}' ./sys/syz-sysgen | grep -q false || go install ./sys/syz-sysgen make .descriptions
make[1]: '.descriptions' is up to date.
mkdir -p ./bin/linux_s390x
gcc -o ./bin/linux_s390x/syz-executor executor/executor.cc \
        -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384 -Wno-stringop-overflow -Wno-array-bounds -Wno-format-overflow -static-pie  -DGOOS_linux=1 -DGOARCH_s390x=1 \
        -DHOSTGOOS_linux=1 -DGIT_REVISION=\"2159e4d29f58ffa1107fc2213dbc87185ff4498f\"
/usr/bin/ld: read-only segment has dynamic relocations collect2: error: ld returned 1 exit status
make: *** [Makefile:143: executor] Error 1

Signed-off-by: Alexander Egorenov <eaibmz@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
