### PR TITLE
dashboard: remove accidental whitespace from C Repro cell

### DIFF
--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -351,7 +351,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="repro">{{if $b.LogLink}}<a href="{{$b.LogLink}}">log</a>{{end}}</td>
 			<td class="repro">{{if $b.ReportLink}}<a href="{{$b.ReportLink}}">report</a>{{end}}</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}</td>
-			<td class="repro {{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
+			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
 			<td class="repro">{{if $b.MachineInfoLink}}<a href="{{$b.MachineInfoLink}}">info</a>{{end}}</td>
 			<td class="manager">{{$b.Title}}</td>
 		</tr>


### PR DESCRIPTION
Commit 2f3b44ea4 ("dashboard: visualize stale repros") inadvertently added a single space in the "<td class=repro>" tag.  This will break tooling which relies on HTML scraping and pattern matching.  This patch ensures the formatting is kept consistent whilst honouring the author's true intentions.

Fixes: 2f3b44ea4 ("dashboard: visualize stale repros")
Signed-off-by: Lee Jones <joneslee@google.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
