### PR TITLE
vm/qemu: prevent network device renaming on s390x arch

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -200,6 +200,10 @@ var archConfigs = map[string]*archConfig{
 		RngDev:   "virtio-rng-ccw",
 		CmdLine: []string{
 			"root=/dev/vda",
+			// The following kernel parameters is a temporary
+			// work-around for not having CONFIG_CMDLINE on s390x.
+			"net.ifnames=0",
+			"biosdevname=0",
 		},
 	},
 	"freebsd/amd64": {


### PR DESCRIPTION
Failing to do so might cause a failure to establish a SSH connection when syz-ci tests a built image.

syz-ci output:
--------------

building kernel...
testing image...
VM boot failed with: can't ssh into the instance

failure log:
------------

failed to run ["ssh" "-p" "34490" ... "root@localhost" "pwd"]: exit status 255 Connection timed out during banner exchange
Connection to 127.0.0.1 port 34490 timed out

qemu dmesg
----------

[    6.646475] virtio_net virtio0 eno1: renamed from eth0

Signed-off-by: Alexander Egorenov <eaibmz@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
