### PR TITLE
Be more lenient when parsing Bazel's build log.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -307,7 +307,7 @@ var buildFailureCauses = [...]buildFailureCause{
 	{weak: true, pattern: regexp.MustCompile(`: not found`)},
 	{weak: true, pattern: regexp.MustCompile(`: final link failed: `)},
 	{weak: true, pattern: regexp.MustCompile(`collect2: error: `)},
-	{weak: true, pattern: regexp.MustCompile(`FAILED: Build did NOT complete`)},
+	{weak: true, pattern: regexp.MustCompile(`(ERROR|FAILED): Build did NOT complete`)},
 }
 
 var fileRes = []*regexp.Regexp{


### PR DESCRIPTION
When Bazel is released with https://github.com/bazelbuild/bazel/commit/c9f9b0b84c4863b5b19220679e610efa17e972f0 the message on build failures changes. In general, we advise not to read the output but use the build protocol instead.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
