### PR TITLE
pkg/build: update fuchsia tools target name

### DIFF
--- a/docs/fuchsia/README.md
+++ b/docs/fuchsia/README.md
@@ -40,7 +40,7 @@ To build Fuchsia for x64, run:
 
 ```bash
 fx --dir "out/x64" set core.x64 \
-  --with-base "//bundles:tools" \
+  --with-base "//bundles/tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
   --args=syzkaller_dir='"/full/path/to/syzkaller"' \
   --variant=kasan
@@ -51,7 +51,7 @@ Alternatively, for arm64, run:
 
 ```bash
 fx --dir "out/arm64" set core.arm64 \
-  --with-base "//bundles:tools" \
+  --with-base "//bundles/tools" \
   --with-base "//src/testing/fuzzing/syzkaller" \
   --args=syzkaller_dir='"/full/path/to/syzkaller"' \
   --variant=kasan

--- a/docs/fuchsia/setup.sh
+++ b/docs/fuchsia/setup.sh
@@ -74,7 +74,7 @@ build() {
 
   cd "$fuchsia"
   fx --dir "out/x64" set core.x64 \
-    --with-base "//bundles:tools" \
+    --with-base "//bundles/tools" \
     --with-base "//src/testing/fuzzing/syzkaller" \
     --args=syzkaller_dir="\"$syzkaller\"" \
     --variant=kasan

--- a/pkg/build/fuchsia.go
+++ b/pkg/build/fuchsia.go
@@ -43,7 +43,7 @@ func (fu fuchsia) build(params Params) (ImageDetails, error) {
 		"scripts/fx", "--dir", "out/"+arch,
 		"set", product,
 		"--args", fmt.Sprintf(`syzkaller_dir="%s"`, syzDir),
-		"--with-base", "//bundles:tools",
+		"--with-base", "//bundles/tools",
 		"--with-base", "//src/testing/fuzzing/syzkaller",
 		"--variant", "kasan",
 		"--no-goma",


### PR DESCRIPTION
Fuchsia's //bundles:tools target was renamed to
//bundles/tools.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
