### PR TITLE
dashboard: infer bug info from subject and mailing list

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -252,12 +252,16 @@ var testConfig = &GlobalConfig{
 					AccessLevel: AccessUser,
 					Name:        "access-user-reporting1",
 					DailyLimit:  1000,
-					Config:      &TestConfig{Index: 1},
+					Config: &EmailConfig{
+						Email: "test@syzkaller.com",
+					},
 				},
 				{
 					Name:       "access-public-reporting2",
 					DailyLimit: 1000,
-					Config:     &TestConfig{Index: 2},
+					Config: &EmailConfig{
+						Email: "test2@syzkaller.com",
+					},
 				},
 			},
 		},

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -253,14 +253,16 @@ var testConfig = &GlobalConfig{
 					Name:        "access-user-reporting1",
 					DailyLimit:  1000,
 					Config: &EmailConfig{
-						Email: "test@syzkaller.com",
+						Email:            "test@syzkaller.com",
+						HandleListEmails: true,
 					},
 				},
 				{
 					Name:       "access-public-reporting2",
 					DailyLimit: 1000,
 					Config: &EmailConfig{
-						Email: "test2@syzkaller.com",
+						Email:            "test2@syzkaller.com",
+						HandleListEmails: true,
 					},
 				},
 			},

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -65,6 +65,7 @@ var mailingLists map[string]bool
 
 type EmailConfig struct {
 	Email              string
+	HandleListEmails   bool // This is a temporary option to simplify the feature deployment.
 	MailMaintainers    bool
 	DefaultMaintainers []string
 	SubjectPrefix      string
@@ -510,6 +511,10 @@ func matchBugFromList(c context.Context, sender, subject string) (*bugInfoResult
 		emailConfig, ok := reporting.Config.(*EmailConfig)
 		if !ok {
 			log.Infof(c, "reporting is not EmailConfig (%q)", subject)
+			continue
+		}
+		if !emailConfig.HandleListEmails {
+			log.Infof(c, "the feature is disabled for the config")
 			continue
 		}
 		if emailConfig.Email != sender {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -28,18 +28,20 @@ import (
 	"google.golang.org/appengine/v2"
 	"google.golang.org/appengine/v2/aetest"
 	db "google.golang.org/appengine/v2/datastore"
+	"google.golang.org/appengine/v2/log"
 	aemail "google.golang.org/appengine/v2/mail"
 	"google.golang.org/appengine/v2/user"
 )
 
 type Ctx struct {
-	t          *testing.T
-	inst       aetest.Instance
-	ctx        context.Context
-	mockedTime time.Time
-	emailSink  chan *aemail.Message
-	client     *apiClient
-	client2    *apiClient
+	t            *testing.T
+	inst         aetest.Instance
+	ctx          context.Context
+	mockedTime   time.Time
+	emailSink    chan *aemail.Message
+	client       *apiClient
+	client2      *apiClient
+	clientPublic *apiClient
 }
 
 var skipDevAppserverTests = func() bool {
@@ -74,6 +76,7 @@ func NewCtx(t *testing.T) *Ctx {
 	}
 	c.client = c.makeClient(client1, password1, true)
 	c.client2 = c.makeClient(client2, password2, true)
+	c.clientPublic = c.makeClient(clientPublic, keyPublic, true)
 	registerContext(r, c)
 	return c
 }
@@ -467,6 +470,7 @@ type (
 	EmailOptSubject   string
 	EmailOptFrom      string
 	EmailOptCC        []string
+	EmailOptSender    string
 )
 
 func (c *Ctx) incomingEmail(to, body string, opts ...interface{}) {
@@ -474,6 +478,7 @@ func (c *Ctx) incomingEmail(to, body string, opts ...interface{}) {
 	subject := "crash1"
 	from := "default@sender.com"
 	cc := []string{"test@syzkaller.com", "bugs@syzkaller.com", "bugs2@syzkaller.com"}
+	sender := ""
 	for _, o := range opts {
 		switch opt := o.(type) {
 		case EmailOptMessageID:
@@ -484,7 +489,12 @@ func (c *Ctx) incomingEmail(to, body string, opts ...interface{}) {
 			from = string(opt)
 		case EmailOptCC:
 			cc = []string(opt)
+		case EmailOptSender:
+			sender = string(opt)
 		}
+	}
+	if sender == "" {
+		sender = from
 	}
 	email := fmt.Sprintf(`Sender: %v
 Date: Tue, 15 Aug 2017 14:59:00 -0700
@@ -496,7 +506,8 @@ To: %v
 Content-Type: text/plain
 
 %v
-`, from, id, subject, from, strings.Join(cc, ","), to, body)
+`, sender, id, subject, from, strings.Join(cc, ","), to, body)
+	log.Infof(c.ctx, "sending %s", email)
 	_, err := c.POST("/_ah/mail/", email)
 	c.expectOK(err)
 }

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -24,6 +24,7 @@ type Email struct {
 	Subject     string
 	From        string
 	Cc          []string
+	Sender      string
 	Body        string  // text/plain part
 	Patch       string  // attached patch, if any
 	Command     Command // command to bot
@@ -97,6 +98,17 @@ func Parse(r io.Reader, ownEmails []string) (*Email, error) {
 		}
 	}
 	ccList = MergeEmailLists(ccList)
+
+	sender := ""
+	senders, err := msg.Header.AddressList("Sender")
+	if err != nil {
+		if err != mail.ErrHeaderNotPresent {
+			return nil, err
+		}
+	} else if len(senders) > 0 {
+		sender = senders[0].Address
+	}
+
 	body, attachments, err := parseBody(msg.Body, msg.Header)
 	if err != nil {
 		return nil, err
@@ -128,6 +140,7 @@ func Parse(r io.Reader, ownEmails []string) (*Email, error) {
 		Subject:     subject,
 		From:        from[0].String(),
 		Cc:          ccList,
+		Sender:      sender,
 		Body:        bodyStr,
 		Patch:       patch,
 		Command:     cmd,

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -642,6 +642,7 @@ d
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		From:      "\"bar\" <bar@foo.com>",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		Sender:    "syzkaller-bugs@googlegroups.com",
 		Body: `On 2018/06/10 4:57, syzbot wrote:
 > Hello,
 > 
@@ -666,8 +667,9 @@ From: bar@foo.com
 #syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `, Email{
-		From: "<bar@foo.com>",
-		Cc:   []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		From:   "<bar@foo.com>",
+		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `,
@@ -683,8 +685,9 @@ From: bar@foo.com
 #syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `, Email{
-		From: "<bar@foo.com>",
-		Cc:   []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		From:   "<bar@foo.com>",
+		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `,


### PR DESCRIPTION
Currently we only determine the bug by looking at the hash encoded after
'+' in syzbot's email address. Users tend to forget to Cc the right
email address while interacting with the bot. Also, it turns out that if
the bug was only sent to Google Groups, any reply to the email thread
does not include the topic starter email address.

Instead of only relying on the right address, try to infer the bug that
was meant by looking more closely at the incoming email.

* Parse the mail subject to extract thee title and the sequence number of the bug.
* Extract the mailing list through which the bug was routed to syzbot.
* Fetch and filter matching bugs.
* If only one matches, handle the command as if it the bug were explicitly specified.

Closes #2614