### PR TITLE
pkg/report: skip allocation frames in KMSAN origin stacks

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1057,6 +1057,7 @@ var linuxStackParams = &stackParams{
 		"kzalloc",
 		"krealloc",
 		"kmem_cache",
+		"allocate_slab",
 		"slab_",
 		"debug_object",
 		"timer_is_static_object",

--- a/pkg/report/testdata/linux/report/670
+++ b/pkg/report/testdata/linux/report/670
@@ -1,0 +1,191 @@
+TITLE: KMSAN: uninit-value in native_apic_mem_write
+ALT: KMSAN origin in inet_reqsk_alloc
+ALT: bad-access in native_apic_mem_write
+
+[  663.629383][    C1] =====================================================
+[  663.636461][    C1] BUG: KMSAN: uninit-value in native_apic_mem_write+0x6e/0x90
+[  663.643970][    C1]  native_apic_mem_write+0x6e/0x90
+[  663.649144][    C1]  sysvec_reschedule_ipi+0x31/0x110
+[  663.654395][    C1]  asm_sysvec_reschedule_ipi+0x12/0x20
+[  663.659900][    C1]  kmsan_get_metadata+0x7/0x220
+[  663.664784][    C1]  kmsan_get_shadow_origin_ptr+0x9b/0xf0
+[  663.670443][    C1]  __msan_metadata_ptr_for_load_8+0x20/0x30
+[  663.676379][    C1]  inet_csk_complete_hashdance+0x34b/0x12b0
+[  663.682318][    C1]  dccp_check_req+0x9a9/0xa30
+[  663.687038][    C1]  dccp_v6_rcv+0x130f/0x25b0
+[  663.691658][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  663.697417][    C1]  ip6_input+0x25a/0x540
+[  663.701694][    C1]  ip6_rcv_finish+0x67b/0x850
+[  663.706402][    C1]  ipv6_rcv+0x1d1/0x460
+[  663.710585][    C1]  __netif_receive_skb+0x1ec/0x630
+[  663.715727][    C1]  process_backlog+0x4f7/0xb70
+[  663.720523][    C1]  __napi_poll+0x14c/0xc00
+[  663.724965][    C1]  net_rx_action+0x7e2/0x1820
+[  663.729677][    C1]  __do_softirq+0x1ee/0x7c5
+[  663.734210][    C1]  do_softirq+0x16d/0x220
+[  663.738574][    C1]  __local_bh_enable_ip+0xd5/0xe0
+[  663.743634][    C1]  local_bh_enable+0x36/0x40
+[  663.748255][    C1]  ip6_finish_output2+0x240a/0x2c40
+[  663.753487][    C1]  __ip6_finish_output+0xf64/0x10b0
+[  663.758720][    C1]  ip6_finish_output+0x15c/0x590
+[  663.763687][    C1]  ip6_output+0x4b9/0x800
+[  663.768045][    C1]  ip6_xmit+0x20f8/0x28b0
+[  663.772402][    C1]  inet6_csk_xmit+0x5c1/0x730
+[  663.777102][    C1]  dccp_transmit_skb+0x172c/0x1aa0
+[  663.782237][    C1]  dccp_send_ack+0x2dd/0x540
+[  663.786848][    C1]  dccp_rcv_request_sent_state_process+0xdd3/0xf40
+[  663.793398][    C1]  dccp_rcv_state_process+0xba1/0xf60
+[  663.798812][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  663.803607][    C1]  __release_sock+0x256/0x640
+[  663.808308][    C1]  release_sock+0x98/0x2e0
+[  663.812762][    C1]  __inet_stream_connect+0xd72/0x1830
+[  663.818167][    C1]  inet_stream_connect+0xff/0x180
+[  663.823217][    C1]  __sys_connect+0x7bb/0x830
+[  663.827837][    C1]  __x64_sys_connect+0xd8/0x120
+[  663.832721][    C1]  do_syscall_64+0x3d/0x90
+[  663.837168][    C1]  entry_SYSCALL_64_after_hwframe+0x44/0xae
+[  663.843102][    C1] 
+[  663.845423][    C1] Uninit was stored to memory at:
+[  663.850500][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  663.855378][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  663.860696][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  663.866111][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  663.870905][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  663.875884][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  663.880515][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  663.886272][    C1]  ip6_input+0x25a/0x540
+[  663.890546][    C1]  ip6_rcv_finish+0x67b/0x850
+[  663.895252][    C1]  ipv6_rcv+0x1d1/0x460
+[  663.899437][    C1]  __netif_receive_skb+0x1ec/0x630
+[  663.904583][    C1]  process_backlog+0x4f7/0xb70
+[  663.909380][    C1]  __napi_poll+0x14c/0xc00
+[  663.913822][    C1]  net_rx_action+0x7e2/0x1820
+[  663.918529][    C1]  __do_softirq+0x1ee/0x7c5
+[  663.923061][    C1] 
+[  663.925382][    C1] Uninit was stored to memory at:
+[  663.930456][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  663.935331][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  663.940655][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  663.946074][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  663.950870][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  663.955846][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  663.960464][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  663.966221][    C1]  ip6_input+0x25a/0x540
+[  663.970493][    C1]  ip6_rcv_finish+0x67b/0x850
+[  663.975203][    C1]  ipv6_rcv+0x1d1/0x460
+[  663.979386][    C1]  __netif_receive_skb+0x1ec/0x630
+[  663.984529][    C1]  process_backlog+0x4f7/0xb70
+[  663.989324][    C1]  __napi_poll+0x14c/0xc00
+[  663.993773][    C1]  net_rx_action+0x7e2/0x1820
+[  663.998479][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.003024][    C1] 
+[  664.005342][    C1] Uninit was stored to memory at:
+[  664.010420][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  664.015297][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.020617][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.026031][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.030824][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.035807][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.040430][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.046186][    C1]  ip6_input+0x25a/0x540
+[  664.050457][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.055164][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.059348][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.064489][    C1]  process_backlog+0x4f7/0xb70
+[  664.069283][    C1]  __napi_poll+0x14c/0xc00
+[  664.073727][    C1]  net_rx_action+0x7e2/0x1820
+[  664.078433][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.082984][    C1] 
+[  664.085309][    C1] Uninit was stored to memory at:
+[  664.090384][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  664.095260][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.100576][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.105993][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.110792][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.115770][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.120392][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.126151][    C1]  ip6_input+0x25a/0x540
+[  664.130421][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.135129][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.139313][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.144455][    C1]  process_backlog+0x4f7/0xb70
+[  664.149251][    C1]  __napi_poll+0x14c/0xc00
+[  664.153693][    C1]  net_rx_action+0x7e2/0x1820
+[  664.158437][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.162999][    C1] 
+[  664.165325][    C1] Uninit was stored to memory at:
+[  664.170405][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  664.175283][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.180606][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.186020][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.190815][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.195793][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.200417][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.206177][    C1]  ip6_input+0x25a/0x540
+[  664.210449][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.215160][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.219345][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.224494][    C1]  process_backlog+0x4f7/0xb70
+[  664.229292][    C1]  __napi_poll+0x14c/0xc00
+[  664.233737][    C1]  net_rx_action+0x7e2/0x1820
+[  664.238446][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.243005][    C1] 
+[  664.245325][    C1] Uninit was stored to memory at:
+[  664.250400][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  664.255276][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.260596][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.266009][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.270803][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.275782][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.280401][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.286174][    C1]  ip6_input+0x25a/0x540
+[  664.290447][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.295153][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.299335][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.304480][    C1]  process_backlog+0x4f7/0xb70
+[  664.309285][    C1]  __napi_poll+0x14c/0xc00
+[  664.313728][    C1]  net_rx_action+0x7e2/0x1820
+[  664.318438][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.322972][    C1] 
+[  664.325293][    C1] Uninit was stored to memory at:
+[  664.330370][    C1]  inet_reqsk_alloc+0x71e/0x8d0
+[  664.335246][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.340564][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.345980][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.350874][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.355872][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.360494][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.366251][    C1]  ip6_input+0x25a/0x540
+[  664.370519][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.375225][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.379410][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.384554][    C1]  process_backlog+0x4f7/0xb70
+[  664.389349][    C1]  __napi_poll+0x14c/0xc00
+[  664.393793][    C1]  net_rx_action+0x7e2/0x1820
+[  664.398498][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.403030][    C1] 
+[  664.405350][    C1] Uninit was created at:
+[  664.409635][    C1]  __alloc_pages+0xbbf/0x1090
+[  664.414332][    C1]  alloc_pages+0xa08/0xd50
+[  664.418783][    C1]  allocate_slab+0x295/0x1c50
+[  664.423492][    C1]  ___slab_alloc+0xb3a/0x1d70
+[  664.428196][    C1]  kmem_cache_alloc+0xb8a/0x11a0
+[  664.433161][    C1]  inet_reqsk_alloc+0xa9/0x8d0
+[  664.437951][    C1]  dccp_v6_conn_request+0x932/0x18c0
+[  664.443278][    C1]  dccp_rcv_state_process+0x2e4/0xf60
+[  664.448694][    C1]  dccp_v6_do_rcv+0x652/0x11b0
+[  664.453487][    C1]  __sk_receive_skb+0x61e/0x11b0
+[  664.458467][    C1]  dccp_v6_rcv+0x21b7/0x25b0
+[  664.463085][    C1]  ip6_protocol_deliver_rcu+0x142f/0x28b0
+[  664.468841][    C1]  ip6_input+0x25a/0x540
+[  664.473111][    C1]  ip6_rcv_finish+0x67b/0x850
+[  664.477817][    C1]  ipv6_rcv+0x1d1/0x460
+[  664.482003][    C1]  __netif_receive_skb+0x1ec/0x630
+[  664.487145][    C1]  process_backlog+0x4f7/0xb70
+[  664.492110][    C1]  __napi_poll+0x14c/0xc00
+[  664.496554][    C1]  net_rx_action+0x7e2/0x1820
+[  664.501261][    C1]  __do_softirq+0x1ee/0x7c5
+[  664.505793][    C1] 
+[  664.508115][    C1] CPU: 1 PID: 15398 Comm: syz-executor.5 Not tainted 5.18.0-rc4-syzkaller #0
+[  664.516901][    C1] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[  664.526976][    C1] =====================================================

--- a/pkg/report/testdata/linux/report/671
+++ b/pkg/report/testdata/linux/report/671
@@ -1,0 +1,38 @@
+TITLE: KMSAN: uninit-value in flush_to_ldisc
+ALT: KMSAN origin in __pskb_copy_fclone
+ALT: bad-access in flush_to_ldisc
+
+[ 1725.922949][   T52] =====================================================
+[ 1725.930075][   T52] BUG: KMSAN: uninit-value in flush_to_ldisc+0x95d/0xdf0
+[ 1725.937350][   T52]  flush_to_ldisc+0x95d/0xdf0
+[ 1725.942227][   T52]  process_one_work+0xb27/0x13e0
+[ 1725.947420][   T52]  worker_thread+0x1076/0x1d60
+[ 1725.952396][   T52]  kthread+0x31b/0x430
+[ 1725.956595][   T52]  ret_from_fork+0x1f/0x30
+[ 1725.961161][   T52] 
+[ 1725.963603][   T52] Uninit was created at:
+[ 1725.968026][   T52]  __alloc_pages+0x9f1/0xe80
+[ 1725.972815][   T52]  alloc_pages+0xaae/0xd80
+[ 1725.977380][   T52]  allocate_slab+0x19b/0xef0
+[ 1725.982149][   T52]  ___slab_alloc+0xa85/0x1c60
+[ 1725.986951][   T52]  __kmalloc_node_track_caller+0x911/0x1250
+[ 1725.993036][   T52]  __alloc_skb+0x346/0xcf0
+[ 1725.997643][   T52]  __pskb_copy_fclone+0xd1/0x1700
+[ 1726.002870][   T52]  tipc_clone_to_loopback+0x151/0x920
+[ 1726.008449][   T52]  tipc_node_xmit+0x977/0x1600
+[ 1726.013405][   T52]  __tipc_sendstream+0x159d/0x1fa0
+[ 1726.018708][   T52]  tipc_send_packet+0xa7/0x100
+[ 1726.023671][   T52]  sock_write_iter+0x495/0x5e0
+[ 1726.028567][   T52]  io_write+0xb7c/0x2300
+[ 1726.033034][   T52]  io_issue_sqe+0x3b1/0x11d0
+[ 1726.037802][   T52]  io_submit_sqe+0xb40/0x1be0
+[ 1726.042689][   T52]  io_submit_sqes+0x542/0xd50
+[ 1726.047502][   T52]  __se_sys_io_uring_enter+0x597/0x1d30
+[ 1726.053260][   T52]  __x64_sys_io_uring_enter+0x117/0x190
+[ 1726.058980][   T52]  do_syscall_64+0x3d/0xb0
+[ 1726.063635][   T52]  entry_SYSCALL_64_after_hwframe+0x63/0xcd
+[ 1726.069713][   T52] 
+[ 1726.072158][   T52] CPU: 1 PID: 52 Comm: kworker/u4:3 Not tainted 6.0.0-rc5-syzkaller-48543-g968c2729e576 #0
+[ 1726.082328][   T52] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022
+[ 1726.092555][   T52] Workqueue: events_unbound flush_to_ldisc
+[ 1726.098534][   T52] =====================================================

--- a/pkg/report/testdata/linux/report/672
+++ b/pkg/report/testdata/linux/report/672
@@ -1,0 +1,52 @@
+TITLE: KMSAN: uninit-value in ext4_evict_inode
+ALT: KMSAN origin in ext4_alloc_inode
+ALT: bad-access in ext4_evict_inode
+
+[  345.516988][ T3516] =====================================================
+[  345.524532][ T3516] BUG: KMSAN: uninit-value in ext4_evict_inode+0xdd/0x26b0
+[  345.532072][ T3516]  ext4_evict_inode+0xdd/0x26b0
+[  345.537093][ T3516]  evict+0x365/0x9a0
+[  345.541148][ T3516]  iput+0x985/0xdd0
+[  345.545260][ T3516]  ext4_mb_release+0x1058/0x1910
+[  345.550343][ T3516]  ext4_put_super+0x42b/0x1a60
+[  345.555440][ T3516]  generic_shutdown_super+0x18c/0x570
+[  345.561002][ T3516]  kill_block_super+0x8d/0x180
+[  345.566076][ T3516]  deactivate_locked_super+0xb1/0x120
+[  345.571600][ T3516]  deactivate_super+0x13a/0x150
+[  345.580327][ T3516]  cleanup_mnt+0x6b5/0x730
+[  345.586098][ T3516]  __cleanup_mnt+0x1e/0x30
+[  345.590660][ T3516]  task_work_run+0x229/0x2c0
+[  345.595548][ T3516]  exit_to_user_mode_loop+0x2a9/0x320
+[  345.601140][ T3516]  exit_to_user_mode_prepare+0x16e/0x220
+[  345.607049][ T3516]  syscall_exit_to_user_mode+0x23/0x40
+[  345.612752][ T3516]  __do_fast_syscall_32+0xb1/0x100
+[  345.618025][ T3516]  do_fast_syscall_32+0x33/0x70
+[  345.623137][ T3516]  do_SYSENTER_32+0x1b/0x20
+[  345.627774][ T3516]  entry_SYSENTER_compat_after_hwframe+0x70/0x82
+[  345.634443][ T3516] 
+[  345.636838][ T3516] Uninit was created at:
+[  345.641300][ T3516]  __alloc_pages+0x9f1/0xe80
+[  345.646181][ T3516]  alloc_pages+0xaae/0xd80
+[  345.650772][ T3516]  allocate_slab+0x1b5/0x1010
+[  345.655716][ T3516]  ___slab_alloc+0x10c3/0x2d60
+[  345.660656][ T3516]  kmem_cache_alloc_lru+0x6f3/0xb30
+[  345.666130][ T3516]  ext4_alloc_inode+0x5f/0x860
+[  345.671074][ T3516]  alloc_inode+0x83/0x440
+[  345.675635][ T3516]  new_inode+0x3b/0x430
+[  345.679946][ T3516]  ext4_mb_init+0x2227/0x3210
+[  345.684875][ T3516]  ext4_fill_super+0xbed2/0xd7d0
+[  345.689966][ T3516]  get_tree_bdev+0x8a3/0xd30
+[  345.694723][ T3516]  ext4_get_tree+0x30/0x40
+[  345.699278][ T3516]  vfs_get_tree+0xa1/0x500
+[  345.703819][ T3516]  do_new_mount+0x694/0x1580
+[  345.708476][ T3516]  path_mount+0x71a/0x1eb0
+[  345.713007][ T3516]  __se_sys_mount+0x734/0x840
+[  345.717751][ T3516]  __ia32_sys_mount+0xdf/0x140
+[  345.722637][ T3516]  __do_fast_syscall_32+0xa2/0x100
+[  345.727819][ T3516]  do_fast_syscall_32+0x33/0x70
+[  345.732789][ T3516]  do_SYSENTER_32+0x1b/0x20
+[  345.737355][ T3516]  entry_SYSENTER_compat_after_hwframe+0x70/0x82
+[  345.743838][ T3516] 
+[  345.746194][ T3516] CPU: 0 PID: 3516 Comm: syz-executor.1 Not tainted 6.1.0-rc4-syzkaller-62818-gb1376a14297d #0
+[  345.756646][ T3516] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 10/26/2022
+[  345.766805][ T3516] =====================================================

--- a/pkg/report/testdata/linux/report/673
+++ b/pkg/report/testdata/linux/report/673
@@ -1,0 +1,56 @@
+TITLE: KMSAN: uninit-value in nilfs_bmap_lookup_at_level
+ALT: KMSAN origin in nilfs_alloc_inode
+ALT: bad-access in nilfs_bmap_lookup_at_level
+
+[  231.715107][ T3795] =====================================================
+[  231.723837][ T3795] BUG: KMSAN: uninit-value in nilfs_bmap_lookup_at_level+0x22e/0x4c0
+[  231.732205][ T3795]  nilfs_bmap_lookup_at_level+0x22e/0x4c0
+[  231.738098][ T3795]  nilfs_mdt_submit_block+0x2c3/0xec0
+[  231.743719][ T3795]  nilfs_mdt_read_block+0x89/0x5f0
+[  231.748981][ T3795]  nilfs_mdt_get_block+0x77/0x1b0
+[  231.754229][ T3795]  nilfs_palloc_get_block+0x19b/0x380
+[  231.759760][ T3795]  nilfs_palloc_get_entry_block+0x242/0x310
+[  231.765946][ T3795]  nilfs_ifile_get_inode_block+0x12a/0x2c0
+[  231.771981][ T3795]  nilfs_iget+0x29e/0xcf0
+[  231.776457][ T3795]  nilfs_get_root_dentry+0x46/0x580
+[  231.781878][ T3795]  nilfs_fill_super+0x77a/0x9f0
+[  231.786862][ T3795]  nilfs_mount+0xb17/0x1200
+[  231.791499][ T3795]  legacy_get_tree+0x10c/0x280
+[  231.796545][ T3795]  vfs_get_tree+0xa1/0x500
+[  231.801109][ T3795]  do_new_mount+0x694/0x1580
+[  231.805985][ T3795]  path_mount+0x71a/0x1f00
+[  231.810539][ T3795]  __se_sys_mount+0x734/0x840
+[  231.815492][ T3795]  __ia32_sys_mount+0xdf/0x140
+[  231.820475][ T3795]  __do_fast_syscall_32+0xa2/0x100
+[  231.825855][ T3795]  do_fast_syscall_32+0x33/0x70
+[  231.830854][ T3795]  do_SYSENTER_32+0x1b/0x20
+[  231.835616][ T3795]  entry_SYSENTER_compat_after_hwframe+0x70/0x82
+[  231.842206][ T3795] 
+[  231.844598][ T3795] Uninit was created at:
+[  231.849029][ T3795]  __alloc_pages+0x9f1/0xe80
+[  231.853915][ T3795]  alloc_pages+0xaae/0xd80
+[  231.858498][ T3795]  allocate_slab+0x19b/0xef0
+[  231.863382][ T3795]  ___slab_alloc+0xa85/0x1c60
+[  231.868242][ T3795]  kmem_cache_alloc_lru+0x70a/0xba0
+[  231.873773][ T3795]  nilfs_alloc_inode+0x5f/0x1c0
+[  231.878776][ T3795]  alloc_inode+0x83/0x440
+[  231.883333][ T3795]  iget5_locked+0xa5/0x200
+[  231.887913][ T3795]  nilfs_iget_locked+0xe2/0x120
+[  231.893051][ T3795]  nilfs_dat_read+0x150/0x590
+[  231.897877][ T3795]  load_nilfs+0x71a/0x1ac0
+[  231.902539][ T3795]  nilfs_fill_super+0x364/0x9f0
+[  231.907526][ T3795]  nilfs_mount+0xb17/0x1200
+[  231.912245][ T3795]  legacy_get_tree+0x10c/0x280
+[  231.917180][ T3795]  vfs_get_tree+0xa1/0x500
+[  231.921827][ T3795]  do_new_mount+0x694/0x1580
+[  231.926572][ T3795]  path_mount+0x71a/0x1f00
+[  231.931118][ T3795]  __se_sys_mount+0x734/0x840
+[  231.936039][ T3795]  __ia32_sys_mount+0xdf/0x140
+[  231.940946][ T3795]  __do_fast_syscall_32+0xa2/0x100
+[  231.946298][ T3795]  do_fast_syscall_32+0x33/0x70
+[  231.951287][ T3795]  do_SYSENTER_32+0x1b/0x20
+[  231.956025][ T3795]  entry_SYSENTER_compat_after_hwframe+0x70/0x82
+[  231.962619][ T3795] 
+[  231.965009][ T3795] CPU: 0 PID: 3795 Comm: syz-executor.3 Not tainted 6.0.0-rc5-syzkaller-48543-g968c2729e576 #0
+[  231.975574][ T3795] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 10/11/2022
+[  231.985843][ T3795] =====================================================

--- a/pkg/report/testdata/linux/report/674
+++ b/pkg/report/testdata/linux/report/674
@@ -1,0 +1,47 @@
+TITLE: KMSAN: uninit-value in ntfs_iget5
+ALT: KMSAN origin in ntfs_alloc_inode
+ALT: bad-access in ntfs_iget5
+
+[  493.519926][ T7865] =====================================================
+[  493.527002][ T7865] BUG: KMSAN: uninit-value in ntfs_iget5+0x6cf/0x6510
+[  493.533804][ T7865]  ntfs_iget5+0x6cf/0x6510
+[  493.538257][ T7865]  ntfs_fill_super+0x4e66/0x6830
+[  493.543243][ T7865]  get_tree_bdev+0x9ee/0xdd0
+[  493.547926][ T7865]  ntfs_fs_get_tree+0x50/0x60
+[  493.552651][ T7865]  vfs_get_tree+0xd8/0x5d0
+[  493.557114][ T7865]  do_new_mount+0x7b5/0x16f0
+[  493.561759][ T7865]  path_mount+0x1021/0x28b0
+[  493.566296][ T7865]  __se_sys_mount+0x8a8/0x9d0
+[  493.571011][ T7865]  __ia32_sys_mount+0x157/0x1b0
+[  493.575901][ T7865]  __do_fast_syscall_32+0x96/0xf0
+[  493.580978][ T7865]  do_fast_syscall_32+0x34/0x70
+[  493.585869][ T7865]  do_SYSENTER_32+0x1b/0x20
+[  493.590421][ T7865]  entry_SYSENTER_compat_after_hwframe+0x4d/0x5c
+[  493.596799][ T7865] 
+[  493.599130][ T7865] Uninit was created at:
+[  493.603459][ T7865]  __alloc_pages+0xbbf/0x1090
+[  493.608173][ T7865]  alloc_pages+0xa08/0xd50
+[  493.612638][ T7865]  allocate_slab+0x295/0x1c50
+[  493.613989][ T7871] loop0: detected capacity change from 0 to 262128
+[  493.617357][ T7865]  ___slab_alloc+0xb3a/0x1d70
+[  493.617411][ T7865]  kmem_cache_alloc_lru+0x80d/0xf10
+[  493.633746][ T7865]  ntfs_alloc_inode+0x7c/0x160
+[  493.638552][ T7865]  alloc_inode+0xad/0x4b0
+[  493.642949][ T7865]  iget5_locked+0x158/0x300
+[  493.647490][ T7865]  ntfs_iget5+0xf6/0x6510
+[  493.651849][ T7865]  ntfs_fill_super+0x2fe8/0x6830
+[  493.656837][ T7865]  get_tree_bdev+0x9ee/0xdd0
+[  493.661477][ T7865]  ntfs_fs_get_tree+0x50/0x60
+[  493.666194][ T7865]  vfs_get_tree+0xd8/0x5d0
+[  493.670645][ T7865]  do_new_mount+0x7b5/0x16f0
+[  493.675261][ T7865]  path_mount+0x1021/0x28b0
+[  493.679790][ T7865]  __se_sys_mount+0x8a8/0x9d0
+[  493.684499][ T7865]  __ia32_sys_mount+0x157/0x1b0
+[  493.689380][ T7865]  __do_fast_syscall_32+0x96/0xf0
+[  493.694448][ T7865]  do_fast_syscall_32+0x34/0x70
+[  493.699335][ T7865]  do_SYSENTER_32+0x1b/0x20
+[  493.703873][ T7865]  entry_SYSENTER_compat_after_hwframe+0x4d/0x5c
+[  493.710243][ T7865] 
+[  493.712567][ T7865] CPU: 1 PID: 7865 Comm: syz-executor.2 Not tainted 5.18.0-rc4-syzkaller #0
+[  493.721268][ T7865] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+[  493.731336][ T7865] =====================================================


### PR DESCRIPTION
Turns out a lot of KMSAN bugs get merged because of some insignificant origin like "allocate_slab".
Ensure we skip all allocation-related frames when parsing KMSAN reports.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
