### PR TITLE
pkg/report: check for get_maintainer.pl before calling it

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -118,6 +118,7 @@ func NewReporter(cfg *mgrconfig.Config) (*Reporter, error) {
 	}
 	config := &config{
 		target:         cfg.SysTarget,
+		vmType:         cfg.Type,
 		kernelSrc:      cfg.KernelSrc,
 		kernelBuildSrc: cfg.KernelBuildSrc,
 		kernelObj:      cfg.KernelObj,
@@ -161,6 +162,7 @@ var ctors = map[string]fn{
 
 type config struct {
 	target         *targets.Target
+	vmType         string
 	kernelSrc      string
 	kernelBuildSrc string
 	kernelObj      string


### PR DESCRIPTION
For Android kernels, this tool will be in a different location (common/scripts/get_maintainer.pl). Currently this causes the Symbolize() call to fail, which stops reproduction.

In pkg/report we don't have a way to identify that it's an Android kernel instead of mainline Linux, since the "target" is "linux" for both.