### PR TITLE
sys/fuchsia: fix date in vmar copyright header

### DIFF
--- a/sys/fuchsia/vmar.txt
+++ b/sys/fuchsia/vmar.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 syzkaller project authors. All rights reserved.
+# Copyright 2022 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 # See https://cs.opensource.google/fuchsia/fuchsia/+/main:zircon/vdso/vmar.fidl


### PR DESCRIPTION
This was a new file created in the rename https://github.com/google/syzkaller/commit/b5cdb36a1de3bc4cacdc296b5348fc00e4766a85; just forgot to update the date.