### PR TITLE
docs/syzbot.md: add gcc 10.2

### DIFF
--- a/docs/syzbot.md
+++ b/docs/syzbot.md
@@ -264,6 +264,7 @@ Older compilers used by `syzbot` can be found here:
 - [gcc 8.0.1 20180412](https://storage.googleapis.com/syzkaller/gcc-8.0.1-20180412.tar.gz) (33MB)
 - [gcc 9.0.0 20181231](https://storage.googleapis.com/syzkaller/gcc-9.0.0-20181231.tar.gz) (30MB)
 - [gcc 10.1.0-syz (20200507)](https://storage.googleapis.com/syzkaller/gcc-10.1.0-syz.tar.xz) (220MB)
+- [gcc 10.2.0](https://storage.googleapis.com/syzkaller/gcc-10.2.0.tar.gz) (165MB)
 - [clang 7.0.0 (trunk 329060)](https://storage.googleapis.com/syzkaller/clang-kmsan-329060.tar.gz) (44MB)
 - [clang 7.0.0 (trunk 334104)](https://storage.googleapis.com/syzkaller/clang-kmsan-334104.tar.gz) (44MB)
 - [clang 8.0.0 (trunk 343298)](https://storage.googleapis.com/syzkaller/clang-kmsan-343298.tar.gz) (45MB)


### PR DESCRIPTION
Built by https://github.com/tarasmadan/gcc-10.2/blob/8a0c67cd9474ab3bf02bf236467f4e01396e342a/build_scripts/build_gcc_10.sh
