### PR TITLE
sys/fuchsia: add test for job syscalls

### DIFF
--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -305,8 +305,10 @@ func parseProg(target *prog.Target, dir, filename string) (*prog.Prog, map[strin
 		"EOPNOTSUPP": 95,
 
 		// Fuchsia specific errors.
-		"ZX_ERR_BAD_HANDLE": 11,
-		"ZX_ERR_TIMED_OUT":  21,
+		"ZX_ERR_BAD_HANDLE":     11,
+		"ZX_ERR_BAD_STATE":      20,
+		"ZX_ERR_TIMED_OUT":      21,
+		"ZX_ERR_ALREADY_EXISTS": 26,
 	}
 	info := &ipc.ProgInfo{Calls: make([]ipc.CallInfo, len(p.Calls))}
 	for i, call := range p.Calls {

--- a/sys/fuchsia/job.txt
+++ b/sys/fuchsia/job.txt
@@ -12,7 +12,7 @@ zx_job_create(job zx_job, options const[0], out ptr[out, zx_job])
 
 zx_job_set_policy$BASIC_V1(job_handle zx_job, options flags[job_policy_options], topic const[ZX_JOB_POL_BASIC_V1], policy ptr[in, array[zx_policy_basic_v1]], count len[policy])
 zx_job_set_policy$BASIC_V2(job_handle zx_job, options flags[job_policy_options], topic const[ZX_JOB_POL_BASIC_V2], policy ptr[in, array[zx_policy_basic_v2]], count len[policy])
-zx_job_set_policy$TIMER_SLACK(job_handle zx_job, options flags[job_policy_options], topic const[ZX_JOB_POL_TIMER_SLACK], policy ptr[in, array[zx_policy_timer_slack]], count len[policy])
+zx_job_set_policy$TIMER_SLACK(job_handle zx_job, options flags[job_policy_options], topic const[ZX_JOB_POL_TIMER_SLACK], policy ptr[in, array[zx_policy_timer_slack, 1]], count len[policy])
 zx_job_set_critical(job zx_job, options flags[job_critical_options], process zx_process)
 
 zx_policy_basic_v1 {
@@ -30,7 +30,7 @@ zx_policy_timer_slack {
 	min_slack	int64
 	default_mode	flags[zx_policy_timer_mode, int32]
 # not mentioned in `job.fidl` but present in `policy.h`
-# padding1 array[int8, 4]
+	padding1	array[int8, 4]
 }
 
 job_policy_options = ZX_JOB_POL_RELATIVE, ZX_JOB_POL_ABSOLUTE

--- a/sys/fuchsia/test/job
+++ b/sys/fuchsia/test/job
@@ -1,0 +1,46 @@
+# Expect failure when creating a job from an invalid handle.
+
+zx_job_create(0x0, 0x0, &AUTO) # ZX_ERR_BAD_HANDLE
+
+# Create a valid job handle and several child jobs.
+
+r1 = syz_job_default()
+zx_job_create(r1, 0x0, &AUTO=<r2=>0x0)
+zx_job_create(r1, 0x0, &AUTO=<r3=>0x0)
+zx_job_create(r1, 0x0, &AUTO=<r4=>0x0)
+
+# With policy format ZX_JOB_POL_BASIC_V1, set policy ZX_POL_ACTION_ALLOW for condition ZX_POL_NEW_ANY.
+
+zx_job_set_policy$BASIC_V1(r2, 0x0, 0x0, &AUTO=[{0x3, 0x0}], 0x1)
+
+# With policy format ZX_JOB_POL_TIMER_SLACK, set a min slack of 256ns with a default mode of ZX_TIMER_SLACK_CENTER.
+
+zx_job_set_policy$TIMER_SLACK(r4, 0x0, 0x1, &AUTO=[{0x100, 0x0, "00000000"}], 0x1)
+
+# With policy format ZX_JOB_POL_BASIC_V2, set policy ZX_POL_ACTION_DENY for condition ZX_POL_NEW_ANY with flag ZX_POLICY_OVERRIDE_DENY.
+
+zx_job_set_policy$BASIC_V2(r3, 0x0, 0x01000000, &AUTO=[{0x3, 0x1, 0x1}], 0x1)
+
+# Setting the same policy again should succeed with either the ZX_JOB_POL_ABSOLUTE or ZX_JOB_POL_RELATIVE option.
+
+zx_job_set_policy$BASIC_V2(r3, 0x0, 0x01000000, &AUTO=[{0x3, 0x1, 0x1}], 0x1)
+
+# Setting a conflicting policy with the ZX_JOB_POL_RELATIVE option should succeed.
+
+zx_job_set_policy$BASIC_V2(r3, 0x0, 0x01000000, &AUTO=[{0x3, 0x0, 0x1}], 0x1)
+
+# Setting a conflicting policy with the ZX_JOB_POL_ABSOLUTE option should fail.
+
+zx_job_set_policy$BASIC_V2(r3, 0x1, 0x01000000, &AUTO=[{0x3, 0x0, 0x1}], 0x1) # ZX_ERR_ALREADY_EXISTS
+
+# Create a grandchild job. Expect failure when setting a previously allowed policy once a job has a child job.
+
+zx_job_create(r3, 0x0, &AUTO=<r5=>0x0)
+zx_job_set_policy$BASIC_V2(r3, 0x0, 0x01000000, &AUTO=[{0x3, 0x1, 0x1}], 0x1) # ZX_ERR_BAD_STATE
+
+# Create a process and set it as critical for a job.
+# TODO: when possible, create a non-self process and test that the parent job dies when the process handle is closed.
+
+r6 = syz_job_default()
+r7 = syz_process_self()
+zx_job_set_critical(r6, 0x0, r7)


### PR DESCRIPTION
This change also makes a couple of small updates to job.txt:
- Express the documented limit of 1 policy struct when using the TIMER_SLACK option to set policy
- Include padding in policy struct definition

