### PR TITLE
dashboard: incoming mail processing improvements

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -322,7 +322,7 @@ Content-Type: text/plain
 
 	{
 		msg := c.pollEmailBug()
-		c.expectEQ(msg.To, []string{"<foo@bar.com>"})
+		c.expectEQ(msg.To, []string{"foo@bar.com"})
 		c.expectEQ(msg.Subject, "Re: title1")
 		c.expectEQ(msg.Headers["In-Reply-To"], []string{"<abcdef>"})
 		if !strings.Contains(msg.Body, `> #syz bad-command
@@ -576,7 +576,7 @@ func TestEmailErrors(t *testing.T) {
 	// If email contains a command we need to reply.
 	c.incomingEmail("syzbot@testapp.appspotmail.com", "#syz invalid")
 	reply := c.pollEmailBug()
-	c.expectEQ(reply.To, []string{"<default@sender.com>"})
+	c.expectEQ(reply.To, []string{"default@sender.com"})
 	c.expectEQ(reply.Body, `> #syz invalid
 
 I see the command but can't find the corresponding bug.

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -80,9 +80,6 @@ func handleTestRequest(c context.Context, args *testReqArgs) string {
 		// We've already stored the job, so just log the error.
 		log.Errorf(c, "failed to update bug: %v", err)
 	}
-	if args.link != "" {
-		reply = "" // don't send duplicate error reply
-	}
 	return reply
 }
 

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -309,9 +309,6 @@ func incomingMail(c context.Context, r *http.Request) error {
 	mailingList := email.CanonicalEmail(emailConfig.Email)
 	mailingListInCC := checkMailingListInCC(c, msg, mailingList)
 	log.Infof(c, "from/cc mailing list: %v/%v", fromMailingList, mailingListInCC)
-	if msg.Command == email.CmdTest {
-		return handleTestCommand(c, bugInfo, msg)
-	}
 	if fromMailingList && msg.BugID != "" && msg.Command != email.CmdNone {
 		// Note that if syzbot was not directly mentioned in To or Cc, this is not really
 		// a duplicate message, so it must be processed. We detect it by looking at BugID.
@@ -320,6 +317,9 @@ func incomingMail(c context.Context, r *http.Request) error {
 		// We don't need to worry about this case, as we won't recognize the bug anyway.
 		log.Infof(c, "duplicate email from mailing list, ignoring")
 		return nil
+	}
+	if msg.Command == email.CmdTest {
+		return handleTestCommand(c, bugInfo, msg)
 	}
 	cmd := &dashapi.BugUpdate{
 		Status: emailCmdToStatus[msg.Command],

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -289,7 +289,8 @@ func incomingMail(c context.Context, r *http.Request) error {
 	}
 	// Ignore any incoming emails from syzbot itself.
 	if ownEmail(c) == msg.From {
-		return nil
+		// But we still want to remember the id of our own message, so just neutralize the command.
+		msg.Command, msg.CommandArgs = email.CmdNone, ""
 	}
 	log.Infof(c, "received email: subject %q, from %q, cc %q, msg %q, bug %q, cmd %q, link %q, sender %q",
 		msg.Subject, msg.From, msg.Cc, msg.MessageID, msg.BugID, msg.Command, msg.Link, msg.Sender)

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -469,6 +469,7 @@ type (
 	EmailOptMessageID int
 	EmailOptSubject   string
 	EmailOptFrom      string
+	EmailOptOrigFrom  string
 	EmailOptCC        []string
 	EmailOptSender    string
 )
@@ -479,6 +480,7 @@ func (c *Ctx) incomingEmail(to, body string, opts ...interface{}) {
 	from := "default@sender.com"
 	cc := []string{"test@syzkaller.com", "bugs@syzkaller.com", "bugs2@syzkaller.com"}
 	sender := ""
+	origFrom := ""
 	for _, o := range opts {
 		switch opt := o.(type) {
 		case EmailOptMessageID:
@@ -487,10 +489,12 @@ func (c *Ctx) incomingEmail(to, body string, opts ...interface{}) {
 			subject = string(opt)
 		case EmailOptFrom:
 			from = string(opt)
-		case EmailOptCC:
-			cc = []string(opt)
 		case EmailOptSender:
 			sender = string(opt)
+		case EmailOptCC:
+			cc = []string(opt)
+		case EmailOptOrigFrom:
+			origFrom = fmt.Sprintf("\nX-Original-From: %v", string(opt))
 		}
 	}
 	if sender == "" {
@@ -502,11 +506,11 @@ Message-ID: <%v>
 Subject: %v
 From: %v
 Cc: %v
-To: %v
+To: %v%v
 Content-Type: text/plain
 
 %v
-`, sender, id, subject, from, strings.Join(cc, ","), to, body)
+`, sender, id, subject, from, strings.Join(cc, ","), to, origFrom, body)
 	log.Infof(c.ctx, "sending %s", email)
 	_, err := c.POST("/_ah/mail/", email)
 	c.expectOK(err)

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -94,7 +94,7 @@ func Parse(r io.Reader, ownEmails []string) (*Email, error) {
 				bugID = context
 			}
 		} else {
-			ccList = append(ccList, cleaned)
+			ccList = append(ccList, CanonicalEmail(cleaned))
 		}
 	}
 	ccList = MergeEmailLists(ccList)
@@ -138,7 +138,7 @@ func Parse(r io.Reader, ownEmails []string) (*Email, error) {
 		MessageID:   msg.Header.Get("Message-ID"),
 		Link:        link,
 		Subject:     subject,
-		From:        from[0].String(),
+		From:        CanonicalEmail(from[0].Address),
 		Cc:          ccList,
 		Sender:      sender,
 		Body:        bodyStr,

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -158,8 +158,8 @@ line1
 #syz fix  bar  	 baz
 line 2
 `,
-		cmd: CmdFix,
-		str: "fix",
+		cmd:  CmdFix,
+		str:  "fix",
 		args: "bar  	 baz",
 	},
 	{
@@ -357,7 +357,7 @@ For more options, visit https://groups.google.com/d/optout.`,
 			MessageID: "<123>",
 			Link:      "https://groups.google.com/d/msgid/syzkaller/abcdef@google.com",
 			Subject:   "test subject",
-			From:      "\"Bob\" <bob@example.com>",
+			From:      "bob@example.com",
 			Cc:        []string{"bob@example.com"},
 			Body: `text body
 second line
@@ -388,7 +388,7 @@ last line`,
 			BugID:     "4564456",
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "\"syzbot\" <foo+4564456@bar.com>",
+			From:      "foo@bar.com",
 			Cc:        []string{"bob@example.com"},
 			Body: `text body
 last line`,
@@ -409,7 +409,7 @@ last line`,
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "\"Bob\" <bob@example.com>",
+			From:      "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `#syz  invalid   	 
 text body
@@ -435,7 +435,7 @@ last line
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "\"Bob\" <bob@example.com>",
+			From:      "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `text body
 second line
@@ -475,7 +475,7 @@ IHQpKSB7CiAJCXNwaW5fdW5sb2NrKCZrY292LT5sb2NrKTsKIAkJcmV0dXJuOwo=
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "\"Bob\" <bob@example.com>",
+			From:      "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
 			Body: `body text
 >#syz test
@@ -563,7 +563,7 @@ or)</div></div></div>
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "\"Bob\" <bob@example.com>",
+			From:      "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
 			Body: `On Mon, May 8, 2017 at 6:47 PM, Bob wrote:
 > body text
@@ -640,7 +640,7 @@ d
 `, Email{
 		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
-		From:      "\"bar\" <bar@foo.com>",
+		From:      "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
 		Sender:    "syzkaller-bugs@googlegroups.com",
 		Body: `On 2018/06/10 4:57, syzbot wrote:
@@ -667,7 +667,7 @@ From: bar@foo.com
 #syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `, Email{
-		From:   "<bar@foo.com>",
+		From:   "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
 		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz dup:
@@ -685,7 +685,7 @@ From: bar@foo.com
 #syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `, Email{
-		From:   "<bar@foo.com>",
+		From:   "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
 		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz fix:
@@ -707,7 +707,7 @@ nothing to see here`,
 			BugID:       "4564456",
 			MessageID:   "<123>",
 			Subject:     "#syz test: git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master",
-			From:        "<bob@example.com>",
+			From:        "bob@example.com",
 			Cc:          []string{"bob@example.com"},
 			Body:        `nothing to see here`,
 			Command:     CmdTest,

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -120,7 +120,8 @@ func TestCanonicalEmail(t *testing.T) {
 func TestParse(t *testing.T) {
 	for i, test := range parseTests {
 		body := func(t *testing.T, test ParseTest) {
-			email, err := Parse(strings.NewReader(test.email), []string{"bot <foo@bar.com>"})
+			email, err := Parse(strings.NewReader(test.email),
+				[]string{"bot <foo@bar.com>"}, []string{"list@googlegroups.com"})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -158,8 +159,8 @@ line1
 #syz fix  bar  	 baz
 line 2
 `,
-		cmd:  CmdFix,
-		str:  "fix",
+		cmd: CmdFix,
+		str: "fix",
 		args: "bar  	 baz",
 	},
 	{
@@ -357,7 +358,7 @@ For more options, visit https://groups.google.com/d/optout.`,
 			MessageID: "<123>",
 			Link:      "https://groups.google.com/d/msgid/syzkaller/abcdef@google.com",
 			Subject:   "test subject",
-			From:      "bob@example.com",
+			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com"},
 			Body: `text body
 second line
@@ -388,7 +389,7 @@ last line`,
 			BugID:     "4564456",
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "foo@bar.com",
+			Author:    "foo@bar.com",
 			Cc:        []string{"bob@example.com"},
 			Body: `text body
 last line`,
@@ -409,7 +410,7 @@ last line`,
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "bob@example.com",
+			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `#syz  invalid   	 
 text body
@@ -435,7 +436,7 @@ last line
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "bob@example.com",
+			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `text body
 second line
@@ -475,7 +476,7 @@ IHQpKSB7CiAJCXNwaW5fdW5sb2NrKCZrY292LT5sb2NrKTsKIAkJcmV0dXJuOwo=
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "bob@example.com",
+			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
 			Body: `body text
 >#syz test
@@ -563,7 +564,7 @@ or)</div></div></div>
 		Email{
 			MessageID: "<123>",
 			Subject:   "test subject",
-			From:      "bob@example.com",
+			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
 			Body: `On Mon, May 8, 2017 at 6:47 PM, Bob wrote:
 > body text
@@ -640,9 +641,8 @@ d
 `, Email{
 		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
-		From:      "bar@foo.com",
+		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
-		Sender:    "syzkaller-bugs@googlegroups.com",
 		Body: `On 2018/06/10 4:57, syzbot wrote:
 > Hello,
 > 
@@ -667,9 +667,8 @@ From: bar@foo.com
 #syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `, Email{
-		From:   "bar@foo.com",
+		Author: "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
-		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `,
@@ -685,9 +684,8 @@ From: bar@foo.com
 #syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `, Email{
-		From:   "bar@foo.com",
+		Author: "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
-		Sender: "syzkaller-bugs@googlegroups.com",
 		Body: `#syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `,
@@ -695,7 +693,6 @@ When freeing a lockf struct that already is part of a linked list, make sure to
 		CommandStr:  "fix:",
 		CommandArgs: "When freeing a lockf struct that already is part of a linked list, make sure to",
 	}},
-
 	{`Date: Sun, 7 May 2017 19:54:00 -0700
 Message-ID: <123>
 Subject: #syz test: git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master
@@ -707,11 +704,62 @@ nothing to see here`,
 			BugID:       "4564456",
 			MessageID:   "<123>",
 			Subject:     "#syz test: git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master",
-			From:        "bob@example.com",
+			Author:      "bob@example.com",
 			Cc:          []string{"bob@example.com"},
 			Body:        `nothing to see here`,
 			Command:     CmdTest,
 			CommandStr:  "test:",
 			CommandArgs: "git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master",
+		}},
+	{`Date: Sun, 7 May 2017 19:54:00 -0700
+Message-ID: <123>
+Sender: list@googlegroups.com
+Subject: Subject
+From: user@mail.com
+To: syzbot <list@googlegroups.com>
+
+nothing to see here`,
+		Email{
+			MessageID:   "<123>",
+			Subject:     "Subject",
+			Author:      "user@mail.com",
+			MailingList: "list@googlegroups.com",
+			Cc:          []string{"list@googlegroups.com", "user@mail.com"},
+			Body:        `nothing to see here`,
+			Command:     CmdNone,
+		}},
+	{`Date: Sun, 7 May 2017 19:54:00 -0700
+Message-ID: <123>
+From: list@googlegroups.com
+X-Original-From: user@mail.com
+Subject: Subject
+To: <user2@mail.com>
+
+nothing to see here`,
+		Email{
+			MessageID:   "<123>",
+			Subject:     "Subject",
+			Author:      "user@mail.com",
+			MailingList: "list@googlegroups.com",
+			Cc:          []string{"list@googlegroups.com", "user2@mail.com", "user@mail.com"},
+			Body:        `nothing to see here`,
+			Command:     CmdNone,
+		}},
+	// A faulty case, just check we handle it normally.
+	{`Date: Sun, 7 May 2017 19:54:00 -0700
+Message-ID: <123>
+From: list@googlegroups.com
+Subject: Subject
+To: <user2@mail.com>
+
+nothing to see here`,
+		Email{
+			MessageID:   "<123>",
+			Subject:     "Subject",
+			Author:      "list@googlegroups.com",
+			MailingList: "list@googlegroups.com",
+			Cc:          []string{"list@googlegroups.com", "user2@mail.com"},
+			Body:        `nothing to see here`,
+			Command:     CmdNone,
 		}},
 }


### PR DESCRIPTION
* Use `From: ` to detect the actual mailing list.
* Use `Reply-To: ` to determine the actual author of the message.
* Relax the email duplicate detection mechanism -- if syzbot was not one of the direct recipients, still handle the command.
* Use canonical email to filter out emails from syzbot itself. Don't ignore such emails completely (otherwise we cannot remember the email we sent).

Closes https://github.com/google/syzkaller/issues/2614