### PR TITLE
sys/fuchsia: add test for vmar syscall descriptions

### DIFF
--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -305,10 +305,13 @@ func parseProg(target *prog.Target, dir, filename string) (*prog.Prog, map[strin
 		"EOPNOTSUPP": 95,
 
 		// Fuchsia specific errors.
+		"ZX_ERR_NO_RESOURCES":   3,
+		"ZX_ERR_INVALID_ARGS":   10,
 		"ZX_ERR_BAD_HANDLE":     11,
 		"ZX_ERR_BAD_STATE":      20,
 		"ZX_ERR_TIMED_OUT":      21,
 		"ZX_ERR_ALREADY_EXISTS": 26,
+		"ZX_ERR_ACCESS_DENIED":  30,
 	}
 	info := &ipc.ProgInfo{Calls: make([]ipc.CallInfo, len(p.Calls))}
 	for i, call := range p.Calls {

--- a/sys/fuchsia/test/vmar
+++ b/sys/fuchsia/test/vmar
@@ -1,0 +1,57 @@
+# TODO: This test assumes that the system page size is 4KiB (or a divisor of 4KiB), since
+# some arguments must be page-aligned, and some tests will fail if the page size is larger.
+
+r0 = syz_vmar_root_self()
+
+# Allocate a vmar with the ZX_VM_CAN_MAP_SPECIFIC permission.
+
+zx_vmar_allocate(r0, 0x40, 0x0, 0x2000, &AUTO=<r1=>0x0, &AUTO)
+
+# Create a vmo and map it into the vmar at a specific offset (of 0 bytes), then unmap the full subregion.
+
+zx_vmo_create(0x1000, 0x0, &AUTO=<r2=>0x0)
+zx_vmar_map(r1, 0x10, 0x0, r2, 0x0, 0x1000, &AUTO=<r3=>0x0)
+zx_vmar_unmap(r1, r3, 0x1000)
+
+# Attempting to map the same vmo should fail when the vmar offset + stated size is larger than the allocated vmar, or the vmar offset is not page-aligned.
+
+zx_vmar_map(r1, 0x10, 0x0, r2, 0x0, 0x3001, &AUTO=<r3=>0x0) # ZX_ERR_INVALID_ARGS
+zx_vmar_map(r1, 0x10, 0x2000, r2, 0x0, 0x1001, &AUTO=<r3=>0x0) # ZX_ERR_INVALID_ARGS
+zx_vmar_map(r1, 0x10, 0x100, r2, 0x0, 0x1000, &AUTO=<r3=>0x0) # ZX_ERR_INVALID_ARGS
+
+# Repeatedly map a vmo into the vmar with the ZX_VM_OFFSET_IS_UPPER_LIMIT option.
+# Mapping should succeed until the upper limit is reached.  
+
+zx_vmar_map(r1, 0x2000, 0x2000, r2, 0x0, 0x1000, &AUTO=<r5=>0x0)
+zx_vmar_map(r1, 0x2000, 0x2000, r2, 0x0, 0x1000, &AUTO=<r6=>0x0)
+zx_vmar_map(r1, 0x2000, 0x2000, r2, 0x0, 0x1000, &AUTO) # ZX_ERR_NO_RESOURCES
+
+# Destroy a vmar. Afterwards, uses of that vmar handle should fail.
+
+zx_vmar_destroy(r1)
+zx_vmar_unmap(r1, r5, 0x1000) # ZX_ERR_BAD_STATE
+zx_vmar_allocate(r1, 0x40, 0x0, 0x1000, &AUTO, &AUTO) # ZX_ERR_BAD_STATE
+
+# Allocate a vmar with the ZX_VM_CAN_MAP_READ and ZX_VM_CAN_MAP_WRITE permissions,
+# then map in a vmo with the ZX_VM_PERM_READ and ZX_VM_PERM_WRITE permissions.
+# Remove the write permission from the mapped region, leaving the read permission.
+# Restore the write permission to the mapped region.
+# Attempt to increase permissions to include ZX_VM_PERM_EXECUTE; this should fail.
+
+zx_vmar_allocate(r0, 0x180, 0x0, 0x3000, &AUTO=<r7=>0x0, &AUTO=<r8=>0x0)
+zx_vmar_map(r7, 0x3, 0x0, r2, 0x0, 0x1000, &AUTO=<r9=>0x0)
+zx_vmar_protect(r7, 0x1, r9, 0x1000)
+zx_vmar_protect(r7, 0x3, r9, 0x1000)
+zx_vmar_protect(r7, 0x7, r9, 0x1000) # ZX_ERR_ACCESS_DENIED
+zx_vmar_unmap(r7, r9, 0x1000)
+
+# Create a vmo and map it into a vmar, leaving part of the vmar unmapped.
+# Verify that a sequence of operations succeeds on the full mapped region and on a page-aligned subregion.
+# An operation on a range including an unmapped region should fail.
+
+zx_vmo_create(0x2000, 0x0, &AUTO=<r10=>0x0)
+zx_vmar_map(r7, 0x3, 0x0, r10, 0x0, 0x2000, &AUTO=<r11=>0x0)
+zx_vmar_op_range(r7, 0x1, r11, 0x2000, 0x0, 0x0)
+zx_vmar_op_range(r7, 0x2, r11, 0x1000, 0x0, 0x0)
+zx_vmar_op_range(r7, 0x3, r11, 0x2000, 0x0, 0x0)
+zx_vmar_op_range(r7, 0x3, r8, 0x3000, 0x0, 0x0) # ZX_ERR_BAD_STATE

--- a/sys/fuchsia/vmar.txt
+++ b/sys/fuchsia/vmar.txt
@@ -7,13 +7,14 @@ include <zircon/syscalls.h>
 include <zircon/types.h>
 
 resource zx_vmar[zx_handle]
+resource zx_vaddr[intptr]
 
-zx_vmar_allocate(parent_vmar zx_vmar, options flags[vmar_allocate_options], offset intptr, size intptr, child_vmar ptr[out, zx_vmar], child_addr ptr[out, intptr])
+zx_vmar_allocate(parent_vmar zx_vmar, options flags[vmar_allocate_options], offset intptr, size intptr, child_vmar ptr[out, zx_vmar], child_addr ptr[out, zx_vaddr])
 zx_vmar_destroy(handle zx_vmar)
-zx_vmar_map(handle zx_vmar, options flags[vmar_map_options], vmar_offset intptr, vmo zx_vmo, vmo_offset int64, len intptr, mapped_addr ptr[out, vma])
-zx_vmar_unmap(handle zx_vmar, addr vma, len len[addr])
-zx_vmar_protect(handle zx_vmar, options flags[vmar_protect_options], addr vma, len len[addr])
-zx_vmar_op_range(handle zx_vmar, op flags[vmar_op_range_options], address vma, size intptr, buffer ptr[inout, array[int8]], buffer_size len[buffer])
+zx_vmar_map(handle zx_vmar, options flags[vmar_map_options], vmar_offset intptr, vmo zx_vmo, vmo_offset int64, len intptr, mapped_addr ptr[out, zx_vaddr])
+zx_vmar_unmap(handle zx_vmar, addr zx_vaddr, len intptr)
+zx_vmar_protect(handle zx_vmar, options flags[vmar_protect_options], addr zx_vaddr, len intptr)
+zx_vmar_op_range(handle zx_vmar, op flags[vmar_op_range_options], address zx_vaddr, size intptr, buffer const[0], buffer_size const[0])
 
 vmar_allocate_options = ZX_VM_COMPACT, ZX_VM_SPECIFIC, ZX_VM_OFFSET_IS_UPPER_LIMIT, ZX_VM_CAN_MAP_SPECIFIC, ZX_VM_CAN_MAP_READ, ZX_VM_CAN_MAP_WRITE, ZX_VM_CAN_MAP_EXECUTE, ZX_VM_ALIGN_1KB, ZX_VM_ALIGN_2KB, ZX_VM_ALIGN_4KB, ZX_VM_ALIGN_8KB, ZX_VM_ALIGN_16KB, ZX_VM_ALIGN_32KB, ZX_VM_ALIGN_64KB, ZX_VM_ALIGN_128KB, ZX_VM_ALIGN_256KB, ZX_VM_ALIGN_512KB, ZX_VM_ALIGN_1MB, ZX_VM_ALIGN_2MB, ZX_VM_ALIGN_4MB, ZX_VM_ALIGN_8MB, ZX_VM_ALIGN_16MB, ZX_VM_ALIGN_32MB, ZX_VM_ALIGN_64MB, ZX_VM_ALIGN_128MB, ZX_VM_ALIGN_256MB, ZX_VM_ALIGN_512MB, ZX_VM_ALIGN_1GB, ZX_VM_ALIGN_2GB, ZX_VM_ALIGN_4GB
 vmar_map_options = ZX_FLAG_SPECIFIC, ZX_FLAG_SPECIFIC_OVERWRITE, ZX_VM_OFFSET_IS_UPPER_LIMIT, ZX_VM_PERM_READ, ZX_VM_PERM_WRITE, ZX_VM_PERM_EXECUTE, ZX_VM_MAP_RANGE, ZX_VM_ALLOW_FAULTS, ZX_VM_PERM_READ_IF_XOM_UNSUPPORTED, ZX_VM_ALIGN_1KB, ZX_VM_ALIGN_2KB, ZX_VM_ALIGN_4KB, ZX_VM_ALIGN_8KB, ZX_VM_ALIGN_16KB, ZX_VM_ALIGN_32KB, ZX_VM_ALIGN_64KB, ZX_VM_ALIGN_128KB, ZX_VM_ALIGN_256KB, ZX_VM_ALIGN_512KB, ZX_VM_ALIGN_1MB, ZX_VM_ALIGN_2MB, ZX_VM_ALIGN_4MB, ZX_VM_ALIGN_8MB, ZX_VM_ALIGN_16MB, ZX_VM_ALIGN_32MB, ZX_VM_ALIGN_64MB, ZX_VM_ALIGN_128MB, ZX_VM_ALIGN_256MB, ZX_VM_ALIGN_512MB, ZX_VM_ALIGN_1GB, ZX_VM_ALIGN_2GB, ZX_VM_ALIGN_4GB


### PR DESCRIPTION
Also made some small updates to the vmar descriptions:
- In a few places, a `len` arg was incorrectly tagged as the length of another arg when it actually represents a region size; fixed.
- The `buffer` and `buffer_size` args to `zx_vmar_op_range` must be null; replaced with constants.
- Added a `zx_vaddr` resource type wrapping `intptr` and used it in place of `vma`, since it's not clear how to use `vma` as the pointee type of an outptr in a program.