### PR TITLE
dashboard: fix the broken AccessTest

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -252,16 +252,35 @@ var testConfig = &GlobalConfig{
 					AccessLevel: AccessUser,
 					Name:        "access-user-reporting1",
 					DailyLimit:  1000,
-					Config: &EmailConfig{
-						Email:            "test@syzkaller.com",
-						HandleListEmails: true,
-					},
+					Config:      &TestConfig{Index: 1},
 				},
 				{
 					Name:       "access-public-reporting2",
 					DailyLimit: 1000,
+					Config:     &TestConfig{Index: 2},
+				},
+			},
+		},
+		"access-public-email": {
+			AccessLevel: AccessPublic,
+			Key:         "publickeypublickeypublickey",
+			Clients: map[string]string{
+				clientPublicEmail: keyPublicEmail,
+			},
+			Repos: []KernelRepo{
+				{
+					URL:    "git://syzkaller.org/access-public-email.git",
+					Branch: "access-public-email",
+					Alias:  "access-public-email",
+				},
+			},
+			Reporting: []Reporting{
+				{
+					AccessLevel: AccessPublic,
+					Name:        "access-public-email-reporting1",
+					DailyLimit:  1000,
 					Config: &EmailConfig{
-						Email:            "test2@syzkaller.com",
+						Email:            "test@syzkaller.com",
 						HandleListEmails: true,
 					},
 				},
@@ -271,16 +290,18 @@ var testConfig = &GlobalConfig{
 }
 
 const (
-	client1      = "client1"
-	client2      = "client2"
-	password1    = "client1keyclient1keyclient1key"
-	password2    = "client2keyclient2keyclient2key"
-	clientAdmin  = "client-admin"
-	keyAdmin     = "clientadminkeyclientadminkey"
-	clientUser   = "client-user"
-	keyUser      = "clientuserkeyclientuserkey"
-	clientPublic = "client-public"
-	keyPublic    = "clientpublickeyclientpublickey"
+	client1           = "client1"
+	client2           = "client2"
+	password1         = "client1keyclient1keyclient1key"
+	password2         = "client2keyclient2keyclient2key"
+	clientAdmin       = "client-admin"
+	keyAdmin          = "clientadminkeyclientadminkey"
+	clientUser        = "client-user"
+	keyUser           = "clientuserkeyclientuserkey"
+	clientPublic      = "client-public"
+	keyPublic         = "clientpublickeyclientpublickey"
+	clientPublicEmail = "client-public-email"
+	keyPublicEmail    = "clientpublicemailkeyclientpublicemailkey"
 
 	restrictedManager     = "restricted-manager"
 	noFixBisectionManager = "no-fix-bisection-manager"

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -880,7 +880,7 @@ func TestBugFromSubjectInference(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	client := c.clientPublic
+	client := c.clientPublicEmail
 
 	build := testBuild(1)
 	client.UploadBuild(build)
@@ -905,7 +905,7 @@ func TestBugFromSubjectInference(t *testing.T) {
 	origSender := upstreamCrash(crashTitle)
 	upstreamCrash("unrelated crash 2")
 
-	mailingList := "<" + config.Namespaces["access-public"].Reporting[1].Config.(*EmailConfig).Email + ">"
+	mailingList := "<" + config.Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email + ">"
 
 	// First try to ping some non-existing bug.
 	subject := "Re: unknown-bug"

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -34,14 +34,14 @@ import (
 )
 
 type Ctx struct {
-	t            *testing.T
-	inst         aetest.Instance
-	ctx          context.Context
-	mockedTime   time.Time
-	emailSink    chan *aemail.Message
-	client       *apiClient
-	client2      *apiClient
-	clientPublic *apiClient
+	t                 *testing.T
+	inst              aetest.Instance
+	ctx               context.Context
+	mockedTime        time.Time
+	emailSink         chan *aemail.Message
+	client            *apiClient
+	client2           *apiClient
+	clientPublicEmail *apiClient
 }
 
 var skipDevAppserverTests = func() bool {
@@ -76,7 +76,7 @@ func NewCtx(t *testing.T) *Ctx {
 	}
 	c.client = c.makeClient(client1, password1, true)
 	c.client2 = c.makeClient(client2, password2, true)
-	c.clientPublic = c.makeClient(clientPublic, keyPublic, true)
+	c.clientPublicEmail = c.makeClient(clientPublicEmail, keyPublicEmail, true)
 	registerContext(r, c)
 	return c
 }


### PR DESCRIPTION
The test config changes needed for the recent incoming email handling changes testing accidentally broke bug access testing.

Fix this by introducing a separate test namespace.
