### PR TITLE
prog: handle broken base64 strings

### DIFF
--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -978,15 +978,15 @@ func (p *parser) deserializeData() ([]byte, bool, error) {
 			// Read Base64 data.
 			p.consume()
 			var rawData []byte
-			for p.Char() != '"' {
+			for !p.EOF() && p.Char() != '"' {
 				v := p.consume()
 				rawData = append(rawData, v)
 			}
+			p.Parse('"')
 			decoded, err := DecodeB64(rawData)
 			if err != nil {
 				return nil, false, fmt.Errorf("data arg is corrupt: %v", err)
 			}
-			p.Parse('"')
 			return decoded, true, nil
 		}
 		val := ""

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -331,6 +331,10 @@ func TestDeserialize(t *testing.T) {
 			In:  `test$opt2(0x0) (fail_nth: 0)`,
 			Out: `test$opt2(0x0)`,
 		},
+		{
+			In:  `test$str2(&(0x7f0000000000)="$eJwqrqzKTszJSS0CBAAA//8TyQPi`,
+			Err: `want ", got EOF`,
+		},
 	})
 }
 


### PR DESCRIPTION
Currently it can fail if there's never a closing quote.

Add a test to verify this behavior.
*
