### PR TITLE
sys/linux/init_alg_test.go: change package name to linux_test

### DIFF
--- a/sys/linux/init_images_test.go
+++ b/sys/linux/init_images_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package linux
+package linux_test
 
 import (
 	"flag"


### PR DESCRIPTION
It is an external test. It uses only exported "linux" package functions.
