### PR TITLE
prog: don't materialize uncompressed image in Deserialize

### DIFF
--- a/prog/compression.go
+++ b/prog/compression.go
@@ -29,18 +29,22 @@ func Compress(rawData []byte) []byte {
 }
 
 func Decompress(compressedData []byte) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := DecompressWriter(buf, compressedData)
+	return buf.Bytes(), err
+}
+
+func DecompressWriter(w io.Writer, compressedData []byte) error {
 	zlibReader, err := zlib.NewReader(bytes.NewReader(compressedData))
 	if err != nil {
-		return nil, fmt.Errorf("could not initialise zlib: %v", err)
+		return fmt.Errorf("could not initialise zlib: %v", err)
 	}
 
-	data, err := io.ReadAll(zlibReader)
-	if err != nil {
-		return nil, fmt.Errorf("could not read data with zlib: %v", err)
+	if _, err := io.Copy(w, zlibReader); err != nil {
+		return fmt.Errorf("could not read data with zlib: %v", err)
 	}
 
-	err = zlibReader.Close()
-	return data, err
+	return zlibReader.Close()
 }
 
 func DecodeB64(b64Data []byte) ([]byte, error) {

--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"strconv"
 	"strings"
@@ -603,11 +604,10 @@ func (p *parser) parseArgString(t Type, dir Dir) (Arg, error) {
 	}
 	// Check compressed data for validity.
 	if typ.IsCompressed() {
-		_, err = Decompress(data)
-		if err != nil {
+		if err := DecompressWriter(ioutil.Discard, data); err != nil {
 			p.strictFailf("invalid compressed data in arg: %v", err)
 			// In non-strict mode, empty the data slice.
-			data = Compress([]byte{})
+			data = Compress(nil)
 		}
 	}
 	size := ^uint64(0)

--- a/sys/linux/init_images.go
+++ b/sys/linux/init_images.go
@@ -24,11 +24,11 @@ func (arch *arch) extractSyzMountImage(c *prog.Call) (io.Reader, error) {
 	} else if len(data) == 0 {
 		return nil, fmt.Errorf("an empty image")
 	}
-	decompressedData, err := prog.Decompress(data)
-	if err != nil {
+	buf := new(bytes.Buffer)
+	if err := prog.DecompressWriter(buf, data); err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(decompressedData), nil
+	return buf, nil
 }
 
 func (arch *arch) fixUpSyzMountImage(c *prog.Call, fixStructure bool) error {


### PR DESCRIPTION
Currently we uncompress all images in Deserialize to check that the data is valid.
As the result deserializing all seeds we have takes ~40 seconds of real time
and ~125 seconds of CPU time. And we do this during every syz-manager start.

Don't materialize the uncompressed image.
This reduces real time to ~15 seconds and CPU time to 18 seconds (no garbage collections).
In syz-manager the benefit is even larger since garbage collections take longer (larger heap).
