### PR TITLE
tools/syz-testbed: only score repros with the same title

### DIFF
--- a/tools/syz-testbed/instance.go
+++ b/tools/syz-testbed/instance.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/config"
@@ -194,16 +196,26 @@ type SyzReproInstance struct {
 	Input      *SyzReproInput
 	ReproFile  string
 	CReproFile string
-	// TODO: we also want to extract source and new bug titles
+	TitleFile  string
 }
 
 func (inst *SyzReproInstance) FetchResult() (RunResult, error) {
-	return &SyzReproResult{
+	result := &SyzReproResult{
 		Input:       inst.Input,
 		ReproFound:  osutil.IsExist(inst.ReproFile),
 		CReproFound: osutil.IsExist(inst.CReproFile),
 		Duration:    inst.Uptime(),
-	}, nil
+	}
+	outTitle, _ := ioutil.ReadFile(inst.TitleFile)
+	if outTitle != nil {
+		result.ReproTitle = strings.TrimSpace(string(outTitle))
+		if result.ReproTitle != inst.Input.origTitle {
+			// If we found a different bug, treat the reproduction as unsuccessful.
+			result.ReproFound = false
+			result.CReproFound = false
+		}
+	}
+	return result, nil
 }
 
 func (t *SyzReproTarget) newSyzReproInstance(slotName, uniqName string, input *SyzReproInput,
@@ -216,6 +228,7 @@ func (t *SyzReproTarget) newSyzReproInstance(slotName, uniqName string, input *S
 
 	reproFile := filepath.Join(folder, "repro.txt")
 	cReproFile := filepath.Join(folder, "crepro.txt")
+	titleFile := filepath.Join(folder, "title.txt")
 	newExecLog := filepath.Join(folder, "execution-log.txt")
 	err = osutil.CopyFile(input.Path, newExecLog)
 	if err != nil {
@@ -230,6 +243,7 @@ func (t *SyzReproTarget) newSyzReproInstance(slotName, uniqName string, input *S
 				"-config", common.CfgFile,
 				"-output", reproFile,
 				"-crepro", cReproFile,
+				"-title", titleFile,
 				newExecLog,
 			},
 			stopChannel: make(chan bool, 1),
@@ -238,5 +252,6 @@ func (t *SyzReproTarget) newSyzReproInstance(slotName, uniqName string, input *S
 		Input:         input,
 		ReproFile:     reproFile,
 		CReproFile:    cReproFile,
+		TitleFile:     titleFile,
 	}, nil
 }

--- a/tools/syz-testbed/stats.go
+++ b/tools/syz-testbed/stats.go
@@ -33,6 +33,7 @@ type SyzReproResult struct {
 	Input       *SyzReproInput
 	ReproFound  bool
 	CReproFound bool
+	ReproTitle  string
 	Duration    time.Duration
 }
 
@@ -393,7 +394,7 @@ func (view StatView) GenerateReproDurationTable() (*Table, error) {
 
 // List all repro attempts.
 func (view StatView) GenerateReproAttemptsTable() (*Table, error) {
-	table := NewTable("Result #", "Bug", "Checkout", "Repro found", "C repro found", "Duration")
+	table := NewTable("Result #", "Bug", "Checkout", "Repro found", "C repro found", "Repro title", "Duration")
 	for gid, group := range view.Groups {
 		for rid, result := range group.SyzReproResults() {
 			table.AddRow(
@@ -402,6 +403,7 @@ func (view StatView) GenerateReproAttemptsTable() (*Table, error) {
 				group.Name,
 				NewBoolCell(result.ReproFound),
 				NewBoolCell(result.CReproFound),
+				result.ReproTitle,
 				result.Duration.Round(time.Second).String(),
 			)
 		}


### PR DESCRIPTION
It's more correct to evaluate whether we managed to reproduce the
original bug rather than just any bug.

Retrieve the title information from syz-repro and pretent that the
reproduction failed if the title does not match.