### PR TITLE
tools/mockery.sh: suppress output noise

### DIFF
--- a/tools/mockery.sh
+++ b/tools/mockery.sh
@@ -2,4 +2,4 @@
 # Copyright 2022 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-go run github.com/vektra/mockery/v2@v2.12.3 "$@"
+go run github.com/vektra/mockery/v2@v2.12.3 --log-level=error "$@"


### PR DESCRIPTION
Set mockery log level to error.
By default we get 10 lines of some internal INFO/WARN messages.
