### PR TITLE
tools: set GOCACHE on OpenBSD to the big persistent partition

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -66,6 +66,8 @@ EOF2
     cd /syzkaller
     set -eux
     ulimit -d 8000000
+    export GOCACHE=/syzkaller/go-cache
+    mkdir -p $GOCACHE
     test -x syz-ci || (
          go get github.com/google/syzkaller/syz-ci &&
          go build github.com/google/syzkaller/syz-ci)


### PR DESCRIPTION
This should hopefully make `/` filesystem mostly empty again and avoid the regular occurrence of running out of space in syzkaller builds.