### PR TITLE
dashboard: display running and pending jobs on the admin page

### DIFF
--- a/dashboard/app/admin.html
+++ b/dashboard/app/admin.html
@@ -47,6 +47,8 @@ Main page.
 	{{end}}
 
 	{{template "manager_list" $.Managers}}
-	{{template "job_list" $.Jobs}}
+	{{template "job_list" $.RunningJobs}}
+	{{template "job_list" $.PendingJobs}}
+	{{template "job_list" $.RecentJobs}}
 </body>
 </html>

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -186,6 +186,12 @@ indexes:
   - name: Finished
 
 - kind: Job
+  properties:
+  - name: Finished
+  - name: Started
+    direction: desc
+
+- kind: Job
   ancestor: yes
   properties:
   - name: Type

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -81,7 +81,9 @@ type uiAdminPage struct {
 	Header        *uiHeader
 	Log           []byte
 	Managers      []*uiManager
-	Jobs          *uiJobList
+	RecentJobs    *uiJobList
+	PendingJobs   *uiJobList
+	RunningJobs   *uiJobList
 	MemcacheStats *memcache.Statistics
 }
 
@@ -156,6 +158,7 @@ type uiBugGroup struct {
 }
 
 type uiJobList struct {
+	Title  string
 	PerBug bool
 	Jobs   []*uiJob
 }
@@ -344,7 +347,15 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 	if err != nil {
 		return err
 	}
-	jobs, err := loadRecentJobs(c)
+	recentJobs, err := loadRecentJobs(c)
+	if err != nil {
+		return err
+	}
+	pendingJobs, err := loadPendingJobs(c)
+	if err != nil {
+		return err
+	}
+	runningJobs, err := loadRunningJobs(c)
 	if err != nil {
 		return err
 	}
@@ -352,7 +363,9 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 		Header:        hdr,
 		Log:           errorLog,
 		Managers:      managers,
-		Jobs:          &uiJobList{Jobs: jobs},
+		RecentJobs:    &uiJobList{Title: "Recent jobs:", Jobs: recentJobs},
+		RunningJobs:   &uiJobList{Title: "Running jobs:", Jobs: runningJobs},
+		PendingJobs:   &uiJobList{Title: "Pending jobs:", Jobs: pendingJobs},
 		MemcacheStats: memcacheStats,
 	}
 	return serveTemplate(w, "admin.html", data)
@@ -441,6 +454,7 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 		SampleReport: sampleReport,
 		Crashes:      crashesTable,
 		TestPatchJobs: &uiJobList{
+			Title:  "Patch testing requests:",
 			PerBug: true,
 			Jobs:   testPatchJobs,
 		},
@@ -1226,11 +1240,41 @@ func loadRecentJobs(c context.Context) ([]*uiJob, error) {
 	if err != nil {
 		return nil, err
 	}
+	return getUIJobs(keys, jobs), nil
+}
+
+func loadPendingJobs(c context.Context) ([]*uiJob, error) {
+	var jobs []*Job
+	keys, err := db.NewQuery("Job").
+		Filter("Started=", time.Time{}).
+		Limit(50).
+		GetAll(c, &jobs)
+	if err != nil {
+		return nil, err
+	}
+	return getUIJobs(keys, jobs), nil
+}
+
+func loadRunningJobs(c context.Context) ([]*uiJob, error) {
+	var jobs []*Job
+	keys, err := db.NewQuery("Job").
+		Filter("Finished=", time.Time{}).
+		Filter("Started>", time.Time{}).
+		Order("-Started").
+		Limit(50).
+		GetAll(c, &jobs)
+	if err != nil {
+		return nil, err
+	}
+	return getUIJobs(keys, jobs), nil
+}
+
+func getUIJobs(keys []*db.Key, jobs []*Job) []*uiJob {
 	var results []*uiJob
 	for i, job := range jobs {
 		results = append(results, makeUIJob(job, keys[i], nil, nil, nil))
 	}
-	return results, nil
+	return results
 }
 
 func loadTestPatchJobs(c context.Context, bug *Bug) ([]*uiJob, error) {

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -391,7 +391,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				</td>
 				<td>
 					{{if eq $job.Type 0}}
-						{{$job.User}}
+						{{if $job.User}}{{$job.User}}{{else}}retest repro{{end}}
 					{{else if eq $job.Type 1}}
 						bisect
 					{{else if eq $job.Type 2}}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -368,7 +368,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{define "job_list"}}
 {{if $.Jobs}}
 	<table class="list_table">
-		<caption id="jobs"><a class="plain" href="#jobs">{{if $.PerBug}}Patch testing requests:{{else}}Recent jobs:{{end}}</a></caption>
+		<caption id="jobs"><a class="plain" href="#jobs">{{$.Title}}</a></caption>
 		<thead>
 		<tr>
 			{{if not $.PerBug}}<th>Bug</th>{{end}}


### PR DESCRIPTION
This reflects the situation more adequately than just displaying the recent jobs.

There are times when failed jobs are retried or manually restarted and the current page just does not show such jobs.
