### PR TITLE
dashboard: post patch testing jobs externally

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -42,6 +42,7 @@ var apiHandlers = map[string]APIHandler{
 	"reporting_poll_notifs": apiReportingPollNotifications,
 	"reporting_poll_closed": apiReportingPollClosed,
 	"reporting_update":      apiReportingUpdate,
+	"new_test_job":          apiNewTestJob,
 	"needed_assets":         apiNeededAssetsList,
 }
 

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -132,10 +132,6 @@ var testConfig = &GlobalConfig{
 				},
 			},
 			Managers: map[string]ConfigManager{
-				restrictedManager: {
-					RestrictedTestingRepo:   "git://restricted.git/restricted.git",
-					RestrictedTestingReason: "you should test only on restricted.git",
-				},
 				noFixBisectionManager: {
 					FixBisectionDisabled: true,
 				},
@@ -267,6 +263,12 @@ var testConfig = &GlobalConfig{
 			Clients: map[string]string{
 				clientPublicEmail: keyPublicEmail,
 			},
+			Managers: map[string]ConfigManager{
+				restrictedManager: {
+					RestrictedTestingRepo:   "git://restricted.git/restricted.git",
+					RestrictedTestingReason: "you should test only on restricted.git",
+				},
+			},
 			Repos: []KernelRepo{
 				{
 					URL:    "git://syzkaller.org/access-public-email.git",
@@ -282,6 +284,7 @@ var testConfig = &GlobalConfig{
 					Config: &EmailConfig{
 						Email:            "test@syzkaller.com",
 						HandleListEmails: true,
+						SubjectPrefix:    "[syzbot]",
 					},
 				},
 			},

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -46,6 +46,7 @@ func TestJob(t *testing.T) {
 	c.incomingEmail(sender, "#syz test: git://git.git/git.git kernel-branch\n"+sampleGitPatch,
 		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
 	body := c.pollEmailBug().Body
+	t.Logf("body: %s", body)
 	c.expectEQ(strings.Contains(body, "This crash does not have a reproducer"), true)
 
 	// Report crash with repro.

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -388,6 +388,10 @@ func handleTestCommand(c context.Context, info *bugInfoResult, msg *email.Email)
 		return replyTo(c, msg, info.bugReporting.ID,
 			fmt.Sprintf("want 2 args (repo, branch), got %v", len(args)))
 	}
+	if info.bug.sanitizeAccess(AccessPublic) != AccessPublic {
+		log.Warningf(c, "%v: bug is not AccessPublic, patch testing request is denied", info.bug.Title)
+		return nil
+	}
 	reply := ""
 	err := handleTestRequest(c, &testReqArgs{
 		bug: info.bug, bugKey: info.bugKey, bugReporting: info.bugReporting,

--- a/dashboard/app/reporting_external.go
+++ b/dashboard/app/reporting_external.go
@@ -85,3 +85,20 @@ func apiReportingUpdate(c context.Context, r *http.Request, payload []byte) (int
 		Text:  reason,
 	}, nil
 }
+
+func apiNewTestJob(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
+	req := new(dashapi.TestPatchRequest)
+	if err := json.Unmarshal(payload, req); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request: %v", err)
+	}
+	resp := &dashapi.TestPatchReply{}
+	err := handleExternalTestRequest(c, req)
+	if err != nil {
+		resp.ErrorText = err.Error()
+		if _, ok := err.(*BadTestRequestError); !ok {
+			// Log errors that are not related to the invalid input.
+			log.Errorf(c, "external patch posting error: %v", err)
+		}
+	}
+	return resp, nil
+}

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 type Ctx struct {
-	t          *testing.T
-	inst       aetest.Instance
-	ctx        context.Context
-	mockedTime time.Time
-	emailSink  chan *aemail.Message
-	client     *apiClient
-	client2    *apiClient
+	t            *testing.T
+	inst         aetest.Instance
+	ctx          context.Context
+	mockedTime   time.Time
+	emailSink    chan *aemail.Message
+	client       *apiClient
+	client2      *apiClient
+	publicClient *apiClient
 }
 
 var skipDevAppserverTests = func() bool {
@@ -75,6 +76,7 @@ func NewCtx(t *testing.T) *Ctx {
 	}
 	c.client = c.makeClient(client1, password1, true)
 	c.client2 = c.makeClient(client2, password2, true)
+	c.publicClient = c.makeClient(clientPublicEmail, keyPublicEmail, true)
 	registerContext(r, c)
 	return c
 }

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -498,6 +498,19 @@ type PollClosedResponse struct {
 	IDs []string
 }
 
+type TestPatchRequest struct {
+	BugID  string
+	Link   string
+	User   string
+	Repo   string
+	Branch string
+	Patch  []byte
+}
+
+type TestPatchReply struct {
+	ErrorText string
+}
+
 func (dash *Dashboard) ReportingPollBugs(typ string) (*PollBugsResponse, error) {
 	req := &PollBugsRequest{
 		Type: typ,
@@ -534,6 +547,14 @@ func (dash *Dashboard) ReportingPollClosed(ids []string) ([]string, error) {
 func (dash *Dashboard) ReportingUpdate(upd *BugUpdate) (*BugUpdateReply, error) {
 	resp := new(BugUpdateReply)
 	if err := dash.Query("reporting_update", upd, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (dash *Dashboard) NewTestJob(upd *TestPatchRequest) (*TestPatchReply, error) {
+	resp := new(TestPatchReply)
+	if err := dash.Query("new_test_job", upd, resp); err != nil {
 		return nil, err
 	}
 	return resp, nil


### PR DESCRIPTION
Accept patch testing requests not only via email, but also by a direct
dashboard API request.

Introduce a new /add_test_job API call.
Add tests that verify the expected flow and some side cases.