### PR TITLE
dashboard: improve fs bugs routing

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -834,6 +834,9 @@ func saveCrash(c context.Context, ns string, req *dashapi.Crash, bug *Bug, bugKe
 		ReproOpts: req.ReproOpts,
 		Flags:     int64(req.Flags),
 		Assets:    assets,
+		ReportElements: CrashReportElements{
+			GuiltyFiles: req.GuiltyFiles,
+		},
 	}
 	var err error
 	if crash.Log, err = putText(c, ns, textCrashLog, req.Log, false); err != nil {

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -357,7 +357,7 @@ var testConfig = &GlobalConfig{
 					},
 				},
 			},
-			Subsystems: &SubsystemsConfig{
+			Subsystems: SubsystemsConfig{
 				SubsystemCc: subsystem.LinuxGetMaintainers,
 			},
 		},

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -100,6 +100,15 @@ type Config struct {
 	Repos []KernelRepo
 	// If not nil, bugs in this namespace will be exported to the specified Kcidb.
 	Kcidb *KcidbConfig
+	// Subsystems config.
+	Subsystems SubsystemsConfig
+}
+
+// SubsystemsConfig describes how to generate the list of kernel subsystems and the rules of
+// subsystem inference / bug reporting.
+type SubsystemsConfig struct {
+	// IMPORTANT: this interface is experimental and will likely change in the future.
+	SubsystemCc func(name string) []string
 }
 
 // ObsoletingConfig describes how bugs without reproducer should be obsoleted.
@@ -338,6 +347,9 @@ func checkNamespace(ns string, cfg *Config, namespaces, clientNames map[string]b
 	}
 	if cfg.Kcidb != nil {
 		checkKcidb(ns, cfg.Kcidb)
+	}
+	if cfg.Subsystems.SubsystemCc == nil {
+		cfg.Subsystems.SubsystemCc = func(string) []string { return nil }
 	}
 	checkKernelRepos(ns, cfg)
 	checkNamespaceReporting(ns, cfg)

--- a/dashboard/app/config_linux.go
+++ b/dashboard/app/config_linux.go
@@ -1,0 +1,17 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+// The objective of this file is to collect config parts and routines useful for Linux bugs management,
+// thus reducing the size of the dashboard config file.
+
+// canBeVfsBug determines whether a bug could belong to the VFS subsystem itself.
+func canBeVfsBug(bug *Bug) bool {
+	for _, subsystem := range bug.Tags.Subsystems {
+		if subsystem.Name == "vfs" {
+			return true
+		}
+	}
+	return false
+}

--- a/dashboard/app/config_linux_test.go
+++ b/dashboard/app/config_linux_test.go
@@ -2,3 +2,139 @@
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 package main
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
+)
+
+func TestFsSubsystemFlow(t *testing.T) {
+	// Test that we can do the following:
+	// 1. Delay the reporting of possible vfs bugs until we have found a reproducer.
+	// 2. Once the reproducer comes, extract the extra subsystems and report it.
+
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublicFs, keyPublicFs, true)
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	// A. Make sure non-fs bugs are not affected.
+	// -----------------------------------------
+
+	crash := testCrash(build, 1)
+	crash.Title = "WARNING: abcd"
+	crash.Log = []byte("log log log")
+	crash.GuiltyFiles = []string{"kernel/kernel.c"}
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	// We skip the first stage and report the bug right away.
+	reply := c.pollEmailBug()
+	c.expectEQ(reply.Subject, "[syzbot] WARNING: abcd")
+
+	// B. Send a non-vfs bug without a reproducer.
+	// -----------------------------------------
+
+	crash = testCrash(build, 2)
+	crash.Title = "WARNING in nilfs_dat_commit_end"
+	crash.GuiltyFiles = []string{"fs/nilfs2/dat.c"}
+	crash.Log = []byte("log log log")
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	reply = c.pollEmailBug()
+	// We have no means to determine the subsystem now, so it shouldn't be anywhere.
+	c.expectEQ(reply.Subject, "[syzbot] WARNING in nilfs_dat_commit_end")
+
+	// C. Send a possibly vfs bug without a reproducer.
+	// -----------------------------------------
+
+	crash = testCrash(build, 3)
+	crash.Title = "WARNING in do_mkdirat"
+	crash.GuiltyFiles = []string{"fs/namei.c"}
+	crash.Log = []byte("log log log")
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	// As there's no other information, the bug is left at the first reporting.
+	c.client.pollNotifs(0)
+	vfsBug := client.pollBug()
+
+	// D. Now report a reproducer for the (C) bug that does image mounting.
+	// -----------------------------------------
+
+	crash = testCrash(build, 4)
+	crash.Title = "WARNING in do_mkdirat"
+	crash.GuiltyFiles = []string{"fs/namei.c"}
+	crash.Log = []byte("log log log")
+	// nolint: lll
+	crash.ReproSyz = []byte(`syz_mount_image$ntfs3(&(0x7f0000000240), &(0x7f000001f3c0)='./file0\x00', 0xc40, &(0x7f00000005c0)=ANY=[@ANYBLOB="0032"], 0x3, 0x1f398, &(0x7f000003e7c0)="111")
+r0 = openat(0xffffffffffffff9c, &(0x7f0000000040)='.\x00', 0x0, 0x0)
+mkdirat(r0, &(0x7f0000000180)='./bus\x00', 0x0)
+mkdirat(r0, &(0x7f0000000280)='./bus/file0\x00', 0x0)
+renameat2(r0, &(0x7f00000004c0)='./file0\x00', r0, &(0x7f0000000500)='./bus/file0/file0\x00', 0x0)`)
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	// Check that we're ready for upstreaming.
+	c.client.pollNotifs(1)
+	client.updateBug(vfsBug.ID, dashapi.BugStatusUpstream, "")
+	// .. and poll the email.
+	reply = c.pollEmailBug()
+	c.expectEQ(reply.Subject, "[syzbot] [vfs?] [ntfs3?] WARNING in do_mkdirat")
+	// Make sure ntfs3 maintainers are in the recipients.
+	c.expectEQ(reply.To, []string{"almaz.alexandrovich@paragon-software.com",
+		"linux-kernel@vger.kernel.org", "maintainer@kernel.org",
+		"ntfs3@lists.linux.dev", "test@syzkaller.com"})
+}
+
+func TestVfsSubsystemFlow(t *testing.T) {
+	// Test that we can do the following:
+	// 1. Delay the reporting of possible vfs bugs until we have found a reproducer.
+	// 2. Once the reproducer comes, extract the extra subsystems and report it.
+
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublicFs, keyPublicFs, true)
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	// A. Send a possibly vfs bug without a reproducer.
+	// -----------------------------------------
+
+	crash := testCrash(build, 1)
+	crash.Title = "WARNING in do_mkdirat2"
+	crash.GuiltyFiles = []string{"fs/namei.c"}
+	crash.Log = []byte("log log log")
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	// As there's no other information, the bug is left at the first reporting.
+	c.client.pollNotifs(0)
+	vfsBug := client.pollBug()
+
+	// B. Now report a reproducer for the (C) bug that does NO image mounting.
+	// -----------------------------------------
+
+	crash = testCrash(build, 2)
+	crash.Title = "WARNING in do_mkdirat2"
+	crash.GuiltyFiles = []string{"fs/namei.c"}
+	crash.Log = []byte("log log log")
+	crash.ReproSyz = []byte(`r0 = openat(0xffffffffffffff9c, &(0x7f0000000040)='.\x00', 0x0, 0x0)
+mkdirat(r0, &(0x7f0000000180)='./bus\x00', 0x0)
+mkdirat(r0, &(0x7f0000000280)='./bus/file0\x00', 0x0)
+renameat2(r0, &(0x7f00000004c0)='./file0\x00', r0, &(0x7f0000000500)='./bus/file0/file0\x00', 0x0)`)
+	crash.Maintainers = []string{"maintainer@kernel.org"}
+	client.ReportCrash(crash)
+
+	// Check that we're ready for upstreaming.
+	c.client.pollNotifs(1)
+	client.updateBug(vfsBug.ID, dashapi.BugStatusUpstream, "")
+	// .. and poll the email.
+	reply := c.pollEmailBug()
+	c.expectEQ(reply.Subject, "[syzbot] [vfs?] WARNING in do_mkdirat2")
+}

--- a/dashboard/app/config_linux_test.go
+++ b/dashboard/app/config_linux_test.go
@@ -1,0 +1,4 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main

--- a/dashboard/app/config_linux_test.go
+++ b/dashboard/app/config_linux_test.go
@@ -46,8 +46,15 @@ func TestFsSubsystemFlow(t *testing.T) {
 	client.ReportCrash(crash)
 
 	reply = c.pollEmailBug()
-	// We have no means to determine the subsystem now, so it shouldn't be anywhere.
-	c.expectEQ(reply.Subject, "[syzbot] WARNING in nilfs_dat_commit_end")
+	// The subsystem should have been taken from the guilty path.
+	c.expectEQ(reply.Subject, "[syzbot] [nilfs2?] WARNING in nilfs_dat_commit_end")
+	c.expectEQ(reply.To, []string{
+		"konishi.ryusuke@gmail.com",
+		"linux-kernel@vger.kernel.org",
+		"linux-nilfs@vger.kernel.org",
+		"maintainer@kernel.org",
+		"test@syzkaller.com",
+	})
 
 	// C. Send a possibly vfs bug without a reproducer.
 	// -----------------------------------------

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -859,6 +859,12 @@ func TestSubjectTitleParser(t *testing.T) {
 			outTitle:  "",
 			outSeq:    0,
 		},
+		{
+			// Make sure we delete filesystem tags.
+			inSubject: "Re: [syzbot] [ntfs3?] [ext4?] kernel BUG in blk_mq_dispatch_rq_list (4)",
+			outTitle:  "kernel BUG in blk_mq_dispatch_rq_list",
+			outSeq:    3,
+		},
 	}
 
 	p := subjectTitleParser{}

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -114,6 +114,19 @@ type Bug struct {
 	// bit 1 - don't want to publish it (syzkaller build/test errors)
 	KcidbStatus int64
 	DailyStats  []BugDailyStats
+	Tags        BugTags
+}
+
+type BugTags struct {
+	Subsystems []BugSubsystem
+}
+
+type BugSubsystem struct {
+	// For now, let's keep the bare minimum number of fields.
+	// The subsystem names we use now are not stable and should not be relied upon.
+	// Once the subsystem management functionality is fully implemented, we'll
+	// override everything stored here.
+	Name string
 }
 
 func (bug *Bug) Load(ps []db.Property) error {

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -193,22 +193,27 @@ type Crash struct {
 	Time            time.Time
 	Reported        time.Time // set if this crash was ever reported
 	References      []CrashReference
-	Maintainers     []string  `datastore:",noindex"`
-	Log             int64     // reference to CrashLog text entity
-	Flags           int64     // properties of the Crash
-	Report          int64     // reference to CrashReport text entity
-	ReproOpts       []byte    `datastore:",noindex"`
-	ReproSyz        int64     // reference to ReproSyz text entity
-	ReproC          int64     // reference to ReproC text entity
-	ReproIsRevoked  bool      // the repro no longer triggers the bug on HEAD
-	LastReproRetest time.Time // the last time when the repro was re-checked
-	MachineInfo     int64     // Reference to MachineInfo text entity.
+	Maintainers     []string            `datastore:",noindex"`
+	Log             int64               // reference to CrashLog text entity
+	Flags           int64               // properties of the Crash
+	Report          int64               // reference to CrashReport text entity
+	ReportElements  CrashReportElements // parsed parts of the crash report
+	ReproOpts       []byte              `datastore:",noindex"`
+	ReproSyz        int64               // reference to ReproSyz text entity
+	ReproC          int64               // reference to ReproC text entity
+	ReproIsRevoked  bool                // the repro no longer triggers the bug on HEAD
+	LastReproRetest time.Time           // the last time when the repro was re-checked
+	MachineInfo     int64               // Reference to MachineInfo text entity.
 	// Custom crash priority for reporting (greater values are higher priority).
 	// For example, a crash in mainline kernel has higher priority than a crash in a side branch.
 	// For historical reasons this is called ReportLen.
 	ReportLen       int64
 	Assets          []Asset   // crash-related assets
 	AssetsLastCheck time.Time // the last time we checked the assets for deprecation
+}
+
+type CrashReportElements struct {
+	GuiltyFiles []string // guilty files as determined during the crash report parsing
 }
 
 type CrashReferenceType string

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -129,6 +129,15 @@ type BugSubsystem struct {
 	Name string
 }
 
+func (bug *Bug) addSubsystem(subsystem BugSubsystem) {
+	for _, item := range bug.Tags.Subsystems {
+		if item.Name == subsystem.Name {
+			return
+		}
+	}
+	bug.Tags.Subsystems = append(bug.Tags.Subsystems, subsystem)
+}
+
 func (bug *Bug) Load(ps []db.Property) error {
 	if err := db.LoadStruct(bug, ps); err != nil {
 		return err

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -591,12 +591,14 @@ func fillBugReport(c context.Context, rep *dashapi.BugReport, bug *Bug, bugRepor
 	rep.KernelConfigLink = externalLink(c, textKernelConfig, build.KernelConfig)
 	rep.SyzkallerCommit = build.SyzkallerCommit
 	rep.NoRepro = build.Type == BuildFailed
+	for _, item := range bug.Tags.Subsystems {
+		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{Name: item.Name})
+		rep.Maintainers = email.MergeEmailLists(rep.Maintainers,
+			subsystemMaintainers(rep.Namespace, item.Name))
+	}
 	for _, addr := range bug.UNCC {
 		rep.CC = email.RemoveFromEmailList(rep.CC, addr)
 		rep.Maintainers = email.RemoveFromEmailList(rep.Maintainers, addr)
-	}
-	for _, item := range bug.Tags.Subsystems {
-		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{Name: item.Name})
 	}
 	return nil
 }

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -595,6 +595,9 @@ func fillBugReport(c context.Context, rep *dashapi.BugReport, bug *Bug, bugRepor
 		rep.CC = email.RemoveFromEmailList(rep.CC, addr)
 		rep.Maintainers = email.RemoveFromEmailList(rep.Maintainers, addr)
 	}
+	for _, item := range bug.Tags.Subsystems {
+		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{Name: item.Name})
+	}
 	return nil
 }
 

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -400,6 +400,11 @@ type BugReport struct {
 	BisectCause    *BisectResult
 	BisectFix      *BisectResult
 	Assets         []Asset
+	Subsystems     []BugSubsystem
+}
+
+type BugSubsystem struct {
+	Name string
 }
 
 type Asset struct {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -285,6 +285,7 @@ type Crash struct {
 	Report      []byte
 	MachineInfo []byte
 	Assets      []NewAsset
+	GuiltyFiles []string
 	// The following is optional and is filled only after repro.
 	ReproOpts []byte
 	ReproSyz  []byte

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -378,9 +378,9 @@ func (ctx *linux) Symbolize(rep *Report) error {
 
 	// We still do this even if we did not symbolize,
 	// because tests pass in already symbolized input.
-	rep.guiltyFile = ctx.extractGuiltyFile(rep)
-	if rep.guiltyFile != "" {
-		maintainers, err := ctx.getMaintainers(rep.guiltyFile)
+	rep.GuiltyFile = ctx.extractGuiltyFile(rep)
+	if rep.GuiltyFile != "" {
+		maintainers, err := ctx.getMaintainers(rep.GuiltyFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -63,8 +63,8 @@ type Report struct {
 	CorruptedReason string
 	// Recipients is a list of RecipientInfo with Email, Display Name, and type.
 	Recipients vcs.Recipients
-	// guiltyFile is the source file that we think is to blame for the crash  (filled in by Symbolize).
-	guiltyFile string
+	// GuiltyFile is the source file that we think is to blame for the crash  (filled in by Symbolize).
+	GuiltyFile string
 	// reportPrefixLen is length of additional prefix lines that we added before actual crash report.
 	reportPrefixLen int
 	// symbolized is set if the report is symbolized.
@@ -242,7 +242,7 @@ func (reporter *Reporter) isInteresting(rep *Report) bool {
 		return true
 	}
 	if matchesAnyString(rep.Title, reporter.interests) ||
-		matchesAnyString(rep.guiltyFile, reporter.interests) {
+		matchesAnyString(rep.GuiltyFile, reporter.interests) {
 		return true
 	}
 	for _, title := range rep.AltTitles {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -318,8 +318,8 @@ func testGuiltyFile(t *testing.T, reporter *Reporter, fn string) {
 	if err := reporter.Symbolize(rep); err != nil {
 		t.Fatalf("failed to symbolize report: %v", err)
 	}
-	if rep.guiltyFile != file {
-		t.Fatalf("got guilty %q, want %q", rep.guiltyFile, file)
+	if rep.GuiltyFile != file {
+		t.Fatalf("got guilty %q, want %q", rep.GuiltyFile, file)
 	}
 }
 

--- a/pkg/subsystem/extract.go
+++ b/pkg/subsystem/extract.go
@@ -24,6 +24,7 @@ type Crash struct {
 func MakeLinuxSubsystemExtractor() *SubsystemExtractor {
 	return &SubsystemExtractor{
 		pathToSubsystems: linuxPathToSubsystems,
+		callToSubsystems: linuxCallToSubsystems,
 	}
 }
 
@@ -58,6 +59,58 @@ func linuxPathToSubsystems(path string) []string {
 		ret = append(ret, "vfs")
 	}
 	return ret
+}
+
+func linuxCallToSubsystems(call string) []string {
+	name := linuxCallToSubsystemsMap[call]
+	if name != "" {
+		return []string{name}
+	}
+	return nil
+}
+
+var linuxCallToSubsystemsMap = map[string]string{
+	"syz_mount_image$adfs":     "adfs",
+	"syz_mount_image$affs":     "affs",
+	"syz_mount_image$befs":     "befs",
+	"syz_mount_image$bfs":      "bfs",
+	"syz_mount_image$btrfs":    "btrfs",
+	"syz_mount_image$cramfs":   "cramfs",
+	"syz_mount_image$efs":      "efs",
+	"syz_mount_image$erofs":    "erofs",
+	"syz_mount_image$exfat":    "exfat",
+	"syz_mount_image$ext4":     "ext4",
+	"syz_mount_image$f2fs":     "f2fs",
+	"syz_mount_image$gfs2":     "gfs2",
+	"syz_mount_image$gfs2meta": "gfs2",
+	"syz_mount_image$hfs":      "hfs",
+	"syz_mount_image$hfsplus":  "hfsplus",
+	"syz_mount_image$hpfs":     "hpfs",
+	"syz_mount_image$iso9660":  "iso9660",
+	"syz_mount_image$jffs2":    "jffs2",
+	"syz_mount_image$jfs":      "jfs",
+	"syz_mount_image$minix":    "minix",
+	"syz_mount_image$msdos":    "fat",
+	"syz_mount_image$nilfs2":   "nilfs2",
+	"syz_mount_image$ntfs":     "ntfs",
+	"syz_mount_image$ntfs3":    "ntfs3",
+	"syz_mount_image$ocfs2":    "ocfs2",
+	"syz_mount_image$omfs":     "omfs",
+	"syz_mount_image$qnx4":     "qnx4",
+	"syz_mount_image$qnx6":     "qnx6",
+	"syz_mount_image$reiserfs": "reiserfs",
+	"syz_mount_image$romfs":    "romfs",
+	"syz_mount_image$squashfs": "squashfs",
+	"syz_mount_image$sysv":     "sysv",
+	"syz_mount_image$tmpfs":    "tmpfs",
+	"syz_mount_image$ubifs":    "ubifs",
+	"syz_mount_image$udf":      "udf",
+	"syz_mount_image$ufs":      "ufs",
+	"syz_mount_image$v7":       "v7",
+	"syz_mount_image$vfat":     "vfat",
+	"syz_mount_image$vxfs":     "vxfs",
+	"syz_mount_image$xfs":      "xfs",
+	"syz_mount_image$zonefs":   "zonefs",
 }
 
 var (

--- a/pkg/subsystem/extract.go
+++ b/pkg/subsystem/extract.go
@@ -1,0 +1,52 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package subsystem
+
+import (
+	"regexp"
+
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type SubsystemExtractor struct {
+	CallToSubsystems func(call string) []string
+}
+
+// Crash contains the subset of Crash fields relevant for subsystem extraction.
+type Crash struct {
+	OS          string
+	GuiltyFiles []string
+	SyzRepro    string
+}
+
+func (se *SubsystemExtractor) Extract(crash *Crash) []string {
+	retMap := map[string]bool{}
+	// Currently we only have the dumbest possible implementation of subsystem detection.
+	if crash.OS == targets.Linux {
+		for _, guiltyPath := range crash.GuiltyFiles {
+			if vfsPathRegexp.MatchString(guiltyPath) {
+				retMap["vfs"] = true
+				break
+			}
+		}
+	}
+	if se.CallToSubsystems != nil {
+		callSet, _, _ := prog.CallSet([]byte(crash.SyzRepro))
+		for call := range callSet {
+			for _, subsystem := range se.CallToSubsystems(call) {
+				retMap[subsystem] = true
+			}
+		}
+	}
+	retSlice := []string{}
+	for name := range retMap {
+		retSlice = append(retSlice, name)
+	}
+	return retSlice
+}
+
+var (
+	vfsPathRegexp = regexp.MustCompile(`^fs/[^/]+\.c`)
+)

--- a/pkg/subsystem/extract.go
+++ b/pkg/subsystem/extract.go
@@ -107,7 +107,7 @@ var linuxCallToSubsystemsMap = map[string]string{
 	"syz_mount_image$udf":      "udf",
 	"syz_mount_image$ufs":      "ufs",
 	"syz_mount_image$v7":       "v7",
-	"syz_mount_image$vfat":     "vfat",
+	"syz_mount_image$vfat":     "fat",
 	"syz_mount_image$vxfs":     "vxfs",
 	"syz_mount_image$xfs":      "xfs",
 	"syz_mount_image$zonefs":   "zonefs",

--- a/pkg/subsystem/extract_test.go
+++ b/pkg/subsystem/extract_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSimpleLinuxExtract(t *testing.T) {
-	se := &SubsystemExtractor{}
+	se := MakeLinuxSubsystemExtractor()
 
 	ret := se.Extract(&Crash{
 		OS: targets.Linux,
@@ -34,7 +34,8 @@ func TestSimpleLinuxExtract(t *testing.T) {
 
 func TestProgCallRules(t *testing.T) {
 	se := &SubsystemExtractor{
-		CallToSubsystems: func(call string) []string {
+		pathToSubsystems: linuxPathToSubsystems,
+		callToSubsystems: func(call string) []string {
 			ret := map[string][]string{
 				// Intentionally add some that are not present in the test below.
 				"test":               {"test"},

--- a/pkg/subsystem/extract_test.go
+++ b/pkg/subsystem/extract_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package subsystem
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleLinuxExtract(t *testing.T) {
+	se := &SubsystemExtractor{}
+
+	ret := se.Extract(&Crash{
+		OS: targets.Linux,
+		GuiltyFiles: []string{
+			"fs/ext4/abc.c",
+		},
+	})
+	assert.Empty(t, ret, "the test should have found 0 subsystems")
+
+	ret = se.Extract(&Crash{
+		OS: targets.Linux,
+		GuiltyFiles: []string{
+			"fs/ext4/abc.c",
+			"fs/def.c",
+		},
+	})
+	assert.Exactly(t, ret, []string{"vfs"}, "the test should have only found vfs")
+}
+
+func TestProgCallRules(t *testing.T) {
+	se := &SubsystemExtractor{
+		CallToSubsystems: func(call string) []string {
+			ret := map[string][]string{
+				// Intentionally add some that are not present in the test below.
+				"test":               {"test"},
+				"syz_io_uring_setup": {"io_uring"},
+				"ioctl$TIOCSETD":     {"tty_ioctls", "tty"},
+				// Some calls are also omitted to verify that the code works fine this way.
+			}
+			return ret[call]
+		},
+	}
+
+	ret := se.Extract(&Crash{
+		OS: targets.Linux,
+		GuiltyFiles: []string{
+			"mm/page-writeback.c",
+		},
+		// nolint: lll
+		SyzRepro: `# https://syzkaller.appspot.com/bug?id=708185e841adf6ca28fc50b126fdf9825fd8ae43
+# See https://goo.gl/kgGztJ for information about syzkaller reproducers.
+#{"repeat":true,"procs":1,"slowdown":1,"sandbox":"","close_fds":false}
+r0 = syz_io_uring_setup(0x3ee4, &(0x7f0000000240), &(0x7f0000002000/0x2000)=nil, &(0x7f0000ffd000/0x3000)=nil, &(0x7f0000000100)=<r1=>0x0, &(0x7f0000000140)=<r2=>0x0)
+socket$inet_udplite(0x2, 0x2, 0x88)
+r3 = openat$ptmx(0xffffffffffffff9c, &(0x7f0000000040), 0x8a04, 0x0)
+syz_io_uring_submit(r1, r2, &(0x7f0000000000)=@IORING_OP_READ=@pass_buffer={0x16, 0x0, 0x0, @fd_index=0x5, 0x0, 0x0}, 0x0)
+ioctl$TIOCSETD(r3, 0x5423, &(0x7f0000000580)=0x3)
+io_uring_enter(r0, 0x2ff, 0x0, 0x0, 0x0, 0x0)`,
+	})
+	sort.Strings(ret)
+	assert.Exactlyf(t, ret, []string{"io_uring", "tty", "tty_ioctls"},
+		"invalid resulting subsystems: %s", ret)
+}

--- a/pkg/subsystem/maintainers.go
+++ b/pkg/subsystem/maintainers.go
@@ -1,0 +1,56 @@
+// Copyright 2022 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package subsystem
+
+func LinuxGetMaintainers(subsystemName string) []string {
+	return linuxSubsystems[subsystemName].cc
+}
+
+type linuxSubsystemInfo struct {
+	path string
+	cc   []string
+}
+
+// These are taken from Linux v6.1. There will be no need to store them here once we
+// begin to automatically parse the MAINTAINERS file.
+
+// nolint:lll
+var linuxSubsystems = map[string]linuxSubsystemInfo{
+	"adfs":     {path: "fs/adfs/", cc: []string{}},
+	"affs":     {path: "fs/affs/", cc: []string{"linux-fsdevel@vger.kernel.org", "dsterba@suse.com"}},
+	"befs":     {path: "fs/befs/", cc: []string{"luisbg@kernel.org", "salah.triki@gmail.com"}},
+	"bfs":      {path: "fs/bfs/", cc: []string{"aivazian.tigran@gmail.com"}},
+	"btrfs":    {path: "fs/btrfs/", cc: []string{"josef@toxicpanda.com", "dsterba@suse.com", "linux-btrfs@vger.kernel.org", "clm@fb.com"}},
+	"cramfs":   {path: "fs/cramfs/", cc: []string{"nico@fluxnic.net"}},
+	"efs":      {path: "fs/efs/", cc: []string{}},
+	"erofs":    {path: "fs/erofs/", cc: []string{"xiang@kernel.org", "chao@kernel.org", "linux-erofs@lists.ozlabs.org"}},
+	"exfat":    {path: "fs/exfat/", cc: []string{"linkinjeon@kernel.org", "sj1557.seo@samsung.com", "linux-fsdevel@vger.kernel.org"}},
+	"ext4":     {path: "fs/ext4/", cc: []string{"linux-ext4@vger.kernel.org", "tytso@mit.edu", "adilger.kernel@dilger.ca"}},
+	"f2fs":     {path: "fs/f2fs/", cc: []string{"linux-f2fs-devel@lists.sourceforge.net", "jaegeuk@kernel.org", "chao@kernel.org"}},
+	"gfs2":     {path: "fs/gfs2/", cc: []string{"cluster-devel@redhat.com", "rpeterso@redhat.com", "agruenba@redhat.com"}},
+	"hfs":      {path: "fs/hfs/", cc: []string{"linux-fsdevel@vger.kernel.org"}},
+	"hfsplus":  {path: "fs/hfsplus/", cc: []string{"linux-fsdevel@vger.kernel.org"}},
+	"hpfs":     {path: "fs/hpfs/", cc: []string{"mikulas@artax.karlin.mff.cuni.cz"}},
+	"iso9660":  {path: "fs/isofs/", cc: []string{}},
+	"jffs2":    {path: "fs/jffs2/", cc: []string{"linux-mtd@lists.infradead.org", "dwmw2@infradead.org", "richard@nod.at"}},
+	"jfs":      {path: "fs/jfs/", cc: []string{"jfs-discussion@lists.sourceforge.net", "shaggy@kernel.org"}},
+	"minix":    {path: "fs/minix/", cc: []string{}},
+	"nilfs2":   {path: "fs/nilfs2/", cc: []string{"linux-nilfs@vger.kernel.org", "konishi.ryusuke@gmail.com"}},
+	"ntfs":     {path: "fs/ntfs/", cc: []string{"linux-ntfs-dev@lists.sourceforge.net", "anton@tuxera.com"}},
+	"ntfs3":    {path: "fs/ntfs3/", cc: []string{"ntfs3@lists.linux.dev", "almaz.alexandrovich@paragon-software.com"}},
+	"ocfs2":    {path: "fs/ocfs2/", cc: []string{"ocfs2-devel@oss.oracle.com", "mark@fasheh.com", "jlbec@evilplan.org", "joseph.qi@linux.alibaba.com"}},
+	"omfs":     {path: "fs/omfs/", cc: []string{"linux-karma-devel@lists.sourceforge.net", "me@bobcopeland.com"}},
+	"qnx4":     {path: "fs/qnx4/", cc: []string{"al@alarsen.net"}},
+	"qnx6":     {path: "fs/qnx6/", cc: []string{}},
+	"reiserfs": {path: "fs/reiserfs/", cc: []string{"reiserfs-devel@vger.kernel.org"}},
+	"romfs":    {path: "fs/romfs/", cc: []string{}},
+	"squashfs": {path: "fs/squashfs/", cc: []string{"phillip@squashfs.org.uk", "squashfs-devel@lists.sourceforge.net"}},
+	"sysv":     {path: "fs/sysv/", cc: []string{"hch@infradead.org"}},
+	"tmpfs":    {path: "mm/shmem.c", cc: []string{"linux-mm@kvack.org", "akpm@linux-foundation.org", "hughd@google.com"}},
+	"ubifs":    {path: "fs/ubifs/", cc: []string{"linux-mtd@lists.infradead.org", "richard@nod.at"}},
+	"udf":      {path: "fs/udf/", cc: []string{"jack@suse.com"}},
+	"ufs":      {path: "fs/ufs/", cc: []string{"dushistov@mail.ru"}},
+	"vxfs":     {path: "fs/freevxfs/", cc: []string{"hch@infradead.org"}},
+	"xfs":      {path: "fs/xfs/", cc: []string{"linux-xfs@vger.kernel.org", "djwong@kernel.org"}},
+	"zonefs":   {path: "fs/zonefs/", cc: []string{"linux-fsdevel@vger.kernel.org", "damien.lemoal@opensource.wdc.com", "naohiro.aota@wdc.com"}}}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -881,6 +881,7 @@ func (mgr *Manager) saveCrash(crash *Crash) bool {
 			Log:         crash.Output,
 			Report:      crash.Report.Report,
 			MachineInfo: crash.machineInfo,
+			GuiltyFiles: []string{crash.Report.GuiltyFile},
 		}
 		resp, err := mgr.dash.ReportCrash(dc)
 		if err != nil {


### PR DESCRIPTION
This set of patches should enable us to change syzbot routing rules to the following:

1. If the guilty file of the crash is `fs/*.c`, don't report it until we have found a reproducer. Otherwise (even if the guilty file is in e.g. `fs/*/*.c`) do as we do now.
2. Once the reproducer is found, determine the exact filesystems from the `syz_mount_image$` calls.
3. Use this information to augment the Cc list and the title (e.g. `[syzbot] [ntf3?] WARNING in ...`).

For now, use the hard-coded Cc values. Some time later I'll publish a PR that parses the fresh version of the MAINTAINERS file, so it'll not be needed.

Also note that this PR contains tiny parts of the subsystem management infrastructure that's planned for implementation in the future, so the changes to database entities are more global than seems necessary. The reason for that is that it'll be much harder to alter the DB structure later, so it's better to err on the side of flexibility.