### PR TITLE
pkg/build: try a clean toolchain build on FreeBSD

### DIFF
--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -42,7 +42,7 @@ options 	DIAGNOSTIC
 	}
 
 	objPrefix := filepath.Join(params.KernelDir, "obj")
-	if err := ctx.make(params.KernelDir, objPrefix, "kernel-toolchain", "-DNO_CLEAN"); err != nil {
+	if err := ctx.make(params.KernelDir, objPrefix, "kernel-toolchain"); err != nil {
 		return ImageDetails{}, err
 	}
 	if err := ctx.make(params.KernelDir, objPrefix, "buildkernel", "WITH_EXTRA_TCP_STACKS=",


### PR DESCRIPTION
syzbot has been failing to build FreeBSD for the past few weeks with what looks like a toolchain problem.  Let's try a clean build of the bundled compiler to see if that fixes it.
