### PR TITLE
dashboard: do patch testing for build errors

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -186,7 +186,8 @@ func addTestJob(c context.Context, args *testJobArgs, now time.Time) error {
 func checkTestJob(c context.Context, bug *Bug, bugReporting *BugReporting, crash *Crash,
 	repo, branch string) string {
 	needRepro := !strings.Contains(crash.Title, "boot error:") &&
-		!strings.Contains(crash.Title, "test error:")
+		!strings.Contains(crash.Title, "test error:") &&
+		!strings.Contains(crash.Title, "build error")
 	switch {
 	case needRepro && crash.ReproC == 0 && crash.ReproSyz == 0:
 		return "This crash does not have a reproducer. I cannot test it."


### PR DESCRIPTION
We can test them even though there's no explicit reproducer.
