### PR TITLE
dashboard: include dashboard link into the missing commit reply

### DIFF
--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -322,6 +322,7 @@ func createNotification(c context.Context, typ dashapi.BugNotif, public bool, te
 		Title:     bug.displayTitle(),
 		Text:      text,
 		Public:    public,
+		Link:      fmt.Sprintf("%v/bug?extid=%v", appURL(c), bugReporting.ID),
 		CC:        kernelRepo.CC.Always,
 	}
 	if public {

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -177,9 +177,10 @@ func emailSendBugNotif(c context.Context, notif *dashapi.BugNotification) error 
 		body = fmt.Sprintf("This bug is marked as fixed by commit:\n%v\n"+
 			"But I can't find it in any tested tree for more than %v days.\n"+
 			"Is it a correct commit? Please update it by replying:\n"+
-			"#syz fix: exact-commit-title\n"+
-			"Until then the bug is still considered open and\n"+
-			"new crashes with the same signature are ignored.\n",
+			"#syz fix: exact-commit-title\n\n"+
+			"Until then the bug is still considered open and "+
+			"new crashes with the same signature are ignored.\n\n"+
+			"Dashboard link: "+notif.Link+"\n",
 			notif.Text, days)
 	case dashapi.BugNotifObsoleted:
 		body = "Auto-closing this bug as obsolete.\n"

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -486,6 +486,7 @@ type BugNotification struct {
 	Text        string   // meaning depends on Type
 	CC          []string // deprecated in favor of Recipients
 	Maintainers []string // deprecated in favor of Recipients
+	Link        string
 	Recipients  Recipients
 	// Public is what we want all involved people to see (e.g. if we notify about a wrong commit title,
 	// people need to see it and provide the right title). Not public is what we want to send only


### PR DESCRIPTION
If the original email thread is lost, it can be hard to get to the original bug.
