### PR TITLE
dashboard: adjust pollClosed behavior for decommissioned namespaces

### DIFF
--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -734,7 +734,8 @@ func reportingPollClosed(c context.Context, ids []string) ([]string, error) {
 				log.Errorf(c, "%v", err)
 				break
 			}
-			if bug.Status >= BugStatusFixed || !bugReporting.Closed.IsZero() {
+			if bug.Status >= BugStatusFixed || !bugReporting.Closed.IsZero() ||
+				config.Namespaces[bug.Namespace].Decommissioned {
 				closed = append(closed, bugReporting.ID)
 			}
 			break

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1005,3 +1005,26 @@ func TestFullBugInfo(t *testing.T) {
 		c.expectEQ(info.Crashes[i].Report, report)
 	}
 }
+
+func TestReportDecommissionedBugs(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	c.client.ReportCrash(crash)
+	rep := c.client.pollBug()
+
+	closed, _ := c.client.ReportingPollClosed([]string{rep.ID})
+	c.expectEQ(len(closed), 0)
+
+	// And now let's decommission the namespace.
+	config.Namespaces[rep.Namespace].Decommissioned = true
+	defer func() { config.Namespaces[rep.Namespace].Decommissioned = false }()
+
+	closed, _ = c.client.ReportingPollClosed([]string{rep.ID})
+	c.expectEQ(len(closed), 1)
+	c.expectEQ(closed[0], rep.ID)
+}


### PR DESCRIPTION
Return bugs from decommissioned namespaces as closed to external reportings.

