### PR TITLE
dashboard: include polled repos to the bad commit message

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -68,8 +68,20 @@ type uiMainPage struct {
 	Header         *uiHeader
 	Now            time.Time
 	Decommissioned bool
-	Managers       []*uiManager
+	Managers       *uiManagerList
 	Groups         []*uiBugGroup
+}
+
+type uiManagerList struct {
+	RepoLink string
+	List     []*uiManager
+}
+
+func makeManagerList(managers []*uiManager, ns string) *uiManagerList {
+	return &uiManagerList{
+		RepoLink: fmt.Sprintf("/%s/repos", ns),
+		List:     managers,
+	}
 }
 
 type uiTerminalPage struct {
@@ -115,7 +127,7 @@ type uiRepo struct {
 type uiAdminPage struct {
 	Header        *uiHeader
 	Log           []byte
-	Managers      []*uiManager
+	Managers      *uiManagerList
 	RecentJobs    *uiJobList
 	PendingJobs   *uiJobList
 	RunningJobs   *uiJobList
@@ -295,7 +307,7 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 		Decommissioned: config.Namespaces[hdr.Namespace].Decommissioned,
 		Now:            timeNow(c),
 		Groups:         groups,
-		Managers:       managers,
+		Managers:       makeManagerList(managers, hdr.Namespace),
 	}
 	return serveTemplate(w, "main.html", data)
 }
@@ -418,7 +430,7 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 	data := &uiAdminPage{
 		Header:        hdr,
 		Log:           errorLog,
-		Managers:      managers,
+		Managers:      makeManagerList(managers, hdr.Namespace),
 		RecentJobs:    &uiJobList{Title: "Recent jobs:", Jobs: recentJobs},
 		RunningJobs:   &uiJobList{Title: "Running jobs:", Jobs: runningJobs},
 		PendingJobs:   &uiJobList{Title: "Pending jobs:", Jobs: pendingJobs},

--- a/dashboard/app/repos.html
+++ b/dashboard/app/repos.html
@@ -1,0 +1,31 @@
+{{/*
+Copyright 2022 syzkaller project authors. All rights reserved.
+Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+The list of polled trees.
+*/}}
+
+<!doctype html>
+<html>
+<head>
+	{{template "head" .Header}}
+	<title>syzbot</title>
+</head>
+<body>
+	{{template "header" .Header}}
+
+	<table class="list_table">
+		<caption>The fixing commit must reach the following trees (<a href="https://github.com/google/syzkaller/blob/master/docs/syzbot.md#bug-status-tracking">more info</a>):</caption>
+		<tr>
+			<th>URL</th>
+			<th>Branch</th>
+		</tr>
+		{{range $repo := .Repos}}
+		<tr>
+			<td>{{$repo.URL}}</td>
+			<td>{{$repo.Branch}}</td>
+		</tr>
+		{{end}}
+	</table>
+</body>
+</html>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -169,7 +169,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{define "manager_list"}}
 {{if .}}
 <table class="list_table">
-	<caption id="managers"><a class="plain" href="managers">Instances:</a></caption>
+	<caption id="managers">Instances [{{link .RepoLink "tested repos"}}]:</caption>
 	<thead>
 	<tr>
 		<th>Name</th>
@@ -200,7 +200,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	</tr>
 	</thead>
 	<tbody>
-	{{range $mgr := .}}
+	{{range $mgr := .List}}
 		<tr>
 			<td>{{link $mgr.Link $mgr.Name}}</td>
 			<td class="stat {{if not $mgr.CurrentUpTime}}bad{{end}}">{{formatLateness $mgr.Now $mgr.LastActive}}</td>


### PR DESCRIPTION
Let's include e.g. top 4 and let users see the rest by following a link.