### PR TITLE
dashboard: don't retest revoked reproducers

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -311,6 +311,10 @@ func handleRetestForBug(c context.Context, now time.Time, bug *Bug, bugKey *db.K
 		if now.Sub(crash.LastReproRetest) < config.Obsoleting.ReproRetestPeriod {
 			continue
 		}
+		if crash.ReproIsRevoked {
+			// No sense in retesting the already revoked repro.
+			continue
+		}
 		// TODO: check if the manager can do such jobs.
 		if managerHasJob[crash.Manager] {
 			continue


### PR DESCRIPTION
We are already quite cautious re. the retest results -- the reproducer is preserved if we have any type of crash/error. It seems to be highly unlikely that, once the reproducer stopped to cause any crashes at all, that it will start working again.

