### PR TITLE
dashboard: show more info on the bug page

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -247,7 +247,13 @@ type uiCrash struct {
 	ReproCLink      string
 	ReproIsRevoked  bool
 	MachineInfoLink string
+	Assets          []*uiAsset
 	*uiBuild
+}
+
+type uiAsset struct {
+	Title       string
+	DownloadURL string
 }
 
 type uiCrashTable struct {
@@ -1218,6 +1224,13 @@ func loadFixBisectionsForBug(c context.Context, bug *Bug) ([]*uiCrash, error) {
 }
 
 func makeUICrash(crash *Crash, build *Build) *uiCrash {
+	uiAssets := []*uiAsset{}
+	for _, asset := range createAssetList(build, crash) {
+		uiAssets = append(uiAssets, &uiAsset{
+			Title:       asset.Title,
+			DownloadURL: asset.DownloadURL,
+		})
+	}
 	ui := &uiCrash{
 		Title:           crash.Title,
 		Manager:         crash.Manager,
@@ -1229,6 +1242,7 @@ func makeUICrash(crash *Crash, build *Build) *uiCrash {
 		ReproCLink:      textLink(textReproC, crash.ReproC),
 		ReproIsRevoked:  crash.ReproIsRevoked,
 		MachineInfoLink: textLink(textMachineInfo, crash.MachineInfo),
+		Assets:          uiAssets,
 	}
 	if build != nil {
 		ui.uiBuild = makeUIBuild(build)

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -242,6 +242,7 @@ type uiCrash struct {
 	Time            time.Time
 	Maintainers     string
 	LogLink         string
+	LogHasStrace    bool
 	ReportLink      string
 	ReproSyzLink    string
 	ReproCLink      string
@@ -1237,6 +1238,7 @@ func makeUICrash(crash *Crash, build *Build) *uiCrash {
 		Time:            crash.Time,
 		Maintainers:     strings.Join(crash.Maintainers, ", "),
 		LogLink:         textLink(textCrashLog, crash.Log),
+		LogHasStrace:    dashapi.CrashFlags(crash.Flags)&dashapi.CrashUnderStrace > 0,
 		ReportLink:      textLink(textCrashReport, crash.Report),
 		ReproSyzLink:    textLink(textReproSyz, crash.ReproSyz),
 		ReproCLink:      textLink(textReproC, crash.ReproC),

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -335,6 +335,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<th><a onclick="return sortTable(this, 'Syz repro', reproSort)" href="#">Syz repro</a></th>
 			<th><a onclick="return sortTable(this, 'C repro', textSort)" href="#">C repro</a></th>
 			<th><a onclick="return sortTable(this, 'VM info', textSort)" href="#">VM info</a></th>
+			<th><a onclick="return sortTable(this, 'Assets', textSort)" href="#">Assets</a></th>
 			<th><a onclick="return sortTable(this, 'Title', textSort)" href="#">Title</a></th>
 		</tr>
 		</thead>
@@ -353,6 +354,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
 			<td class="repro">{{if $b.MachineInfoLink}}<a href="{{$b.MachineInfoLink}}">info</a>{{end}}</td>
+			<td class="assets">{{range $i, $asset := .Assets}}
+				<span class="no-break">[<a href="{{$asset.DownloadURL}}">{{$asset.Title}}</a>]</span>
+			{{end}}</td>
 			<td class="manager">{{$b.Title}}</td>
 		</tr>
 		{{end}}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -349,7 +349,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{formatTime $b.KernelCommitDate}}">{{link $b.KernelCommitLink (formatTagHash $b.KernelCommit)}}</td>
 			<td class="tag">{{link $b.SyzkallerCommitLink (formatShortHash $b.SyzkallerCommit)}}</td>
 			<td class="config">{{if $b.KernelConfigLink}}<a href="{{$b.KernelConfigLink}}">.config</a>{{end}}</td>
-			<td class="repro">{{if $b.LogLink}}<a href="{{$b.LogLink}}">log</a>{{end}}</td>
+			<td class="repro">{{if $b.LogLink}}<a href="{{$b.LogLink}}">{{if $b.LogHasStrace}}strace{{else}}console{{end}} log</a>{{end}}</td>
 			<td class="repro">{{if $b.ReportLink}}<a href="{{$b.ReportLink}}">report</a>{{end}}</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -185,6 +185,15 @@ table td, table th {
 	text-decoration: line-through;
 }
 
+.list_table .assets {
+	max-width: 120pt;
+	white-space: normal;
+}
+
+.list_table .assets .no-break {
+	display: inline-block;
+}
+
 .bad {
 	color: #f00;
 	font-weight: bold;


### PR DESCRIPTION
* Display build & crash assets in the crash table.
* Indicate whether the captured log is `console` or `strace` like we do in emails.