### PR TITLE
executor: better prevent the panic on ext4 errors

### DIFF
--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6799,7 +6799,14 @@ static long syz_mount_image(
 	if (strcmp(fs, "iso9660") == 0) {
 		flags |= MS_RDONLY;
 	} else if (strncmp(fs, "ext", 3) == 0) {
-		if (strstr(opts, "errors=panic") || strstr(opts, "errors=remount-ro") == 0)
+		bool has_remount_ro = false;
+		char* remount_ro_start = strstr(opts, "errors=remount-ro");
+		if (remount_ro_start != NULL) {
+			char after = *(remount_ro_start + strlen("errors=remount-ro"));
+			char before = remount_ro_start == opts ? '\0' : *(remount_ro_start - 1);
+			has_remount_ro = ((before == '\0' || before == ',') && (after == '\0' || after == ','));
+		}
+		if (strstr(opts, "errors=panic") || !has_remount_ro)
 			strcat(opts, ",errors=continue");
 	} else if (strcmp(fs, "xfs") == 0) {
 		strcat(opts, ",nouuid");


### PR DESCRIPTION
We already suppress them, but the current approach fails if syzkaller slightly corrupts the options string. Do the check more rigorously.
