### PR TITLE
syz-ci: support parallel jobs

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -38,6 +38,7 @@ func initAPIHandlers() {
 var apiHandlers = map[string]APIHandler{
 	"log_error":             apiLogError,
 	"job_poll":              apiJobPoll,
+	"job_reset":             apiJobReset,
 	"job_done":              apiJobDone,
 	"reporting_poll_bugs":   apiReportingPollBugs,
 	"reporting_poll_notifs": apiReportingPollNotifications,
@@ -366,12 +367,23 @@ func apiJobPoll(c context.Context, r *http.Request, payload []byte) (interface{}
 	return pollPendingJobs(c, req.Managers)
 }
 
+// nolint: dupl
 func apiJobDone(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
 	req := new(dashapi.JobDoneReq)
 	if err := json.Unmarshal(payload, req); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request: %v", err)
 	}
 	err := doneJob(c, req)
+	return nil, err
+}
+
+// nolint: dupl
+func apiJobReset(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
+	req := new(dashapi.JobResetReq)
+	if err := json.Unmarshal(payload, req); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request: %v", err)
+	}
+	err := resetJobs(c, req)
 	return nil, err
 }
 

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -80,11 +80,6 @@ func TestBisectCause(t *testing.T) {
 			"syncfs(3)"))
 	c.expectEQ(pollResp.ReproC, []byte("int main() { return 3; }"))
 
-	// Since we did not reply, we should get the same response.
-	c.advanceTime(5 * 24 * time.Hour)
-	pollResp2 := c.client2.pollJobs(build.Manager)
-	c.expectEQ(pollResp, pollResp2)
-
 	// Bisection failed with an error.
 	done := &dashapi.JobDoneReq{
 		ID:    pollResp.ID,
@@ -95,6 +90,7 @@ func TestBisectCause(t *testing.T) {
 	c.expectNoEmail()
 
 	// BisectCause #2
+	pollResp2 := pollResp
 	pollResp = c.client2.pollJobs(build.Manager)
 	c.expectNE(pollResp.ID, pollResp2.ID)
 	c.expectEQ(pollResp.ReproOpts, []byte("repro opts 2"))
@@ -316,8 +312,6 @@ https://goo.gl/tpsmEJ#testing-patches`,
 	c.expectEQ(pollResp.Type, dashapi.JobBisectFix)
 	c.expectEQ(pollResp.ReproOpts, []byte("repro opts 2"))
 	c.advanceTime(5 * 24 * time.Hour)
-	pollResp2 = c.client2.pollJobs(build.Manager)
-	c.expectEQ(pollResp, pollResp2)
 	done = &dashapi.JobDoneReq{
 		ID:    pollResp.ID,
 		Log:   []byte("bisect log 2"),

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -328,9 +328,10 @@ type Job struct {
 	Patch        int64 // reference to Patch text entity
 	KernelConfig int64 // reference to the kernel config entity
 
-	Attempts int // number of times we tried to execute this job
-	Started  time.Time
-	Finished time.Time // if set, job is finished
+	Attempts    int       // number of times we tried to execute this job
+	IsRunning   bool      // the job might have been started, but never finished
+	LastStarted time.Time `datastore:"Started"`
+	Finished    time.Time // if set, job is finished
 
 	// Result of execution:
 	CrashTitle  string // if empty, we did not hit crash during testing
@@ -343,6 +344,10 @@ type Job struct {
 	Flags       JobFlags
 
 	Reported bool // have we reported result back to user?
+}
+
+func (job *Job) IsFinished() bool {
+	return !job.Finished.IsZero()
 }
 
 type JobType int

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -177,6 +177,7 @@ indexes:
 - kind: Job
   properties:
   - name: Finished
+  - name: IsRunning
   - name: Attempts
   - name: Created
 

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1478,9 +1478,7 @@ func loadPendingJobs(c context.Context) ([]*uiJob, error) {
 func loadRunningJobs(c context.Context) ([]*uiJob, error) {
 	var jobs []*Job
 	keys, err := db.NewQuery("Job").
-		Filter("Finished=", time.Time{}).
-		Filter("Started>", time.Time{}).
-		Order("-Started").
+		Filter("IsRunning=", true).
 		Limit(50).
 		GetAll(c, &jobs)
 	if err != nil {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1542,7 +1542,7 @@ func makeUIJob(job *Job, jobKey *db.Key, bug *Bug, crash *Crash, build *Build) *
 		KernelCommitLink: vcs.CommitLink(kernelRepo, kernelCommit),
 		PatchLink:        textLink(textPatch, job.Patch),
 		Attempts:         job.Attempts,
-		Started:          job.Started,
+		Started:          job.LastStarted,
 		Finished:         job.Finished,
 		CrashTitle:       job.CrashTitle,
 		CrashLogLink:     textLink(textCrashLog, job.CrashLog),
@@ -1552,7 +1552,7 @@ func makeUIJob(job *Job, jobKey *db.Key, bug *Bug, crash *Crash, build *Build) *
 		Reported:         job.Reported,
 	}
 	if !job.Finished.IsZero() {
-		ui.Duration = job.Finished.Sub(job.Started)
+		ui.Duration = job.Finished.Sub(job.LastStarted)
 	}
 	if job.Type == JobBisectCause || job.Type == JobBisectFix {
 		// We don't report these yet (or at all), see pollCompletedJobs.

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -147,6 +147,8 @@ func (dash *Dashboard) BuilderPoll(manager string) (*BuilderPollResp, error) {
 }
 
 // Jobs workflow:
+//   - syz-ci sends JobResetReq to indicate that no previously started jobs
+//     are any longer in progress.
 //   - syz-ci sends JobPollReq periodically to check for new jobs,
 //     request contains list of managers that this syz-ci runs.
 //   - dashboard replies with JobPollResp that contains job details,
@@ -154,6 +156,10 @@ func (dash *Dashboard) BuilderPoll(manager string) (*BuilderPollResp, error) {
 //   - when syz-ci finishes the job, it sends JobDoneReq which contains
 //     job execution result (Build, Crash or Error details),
 //     ID must match JobPollResp.ID.
+
+type JobResetReq struct {
+	Managers []string
+}
 
 type JobPollReq struct {
 	Managers map[string]ManagerJobs
@@ -226,6 +232,10 @@ func (dash *Dashboard) JobPoll(req *JobPollReq) (*JobPollResp, error) {
 
 func (dash *Dashboard) JobDone(req *JobDoneReq) error {
 	return dash.Query("job_done", req, nil)
+}
+
+func (dash *Dashboard) JobReset(req *JobResetReq) error {
+	return dash.Query("job_reset", req, nil)
 }
 
 type BuildErrorReq struct {

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -31,6 +31,7 @@ type Config struct {
 	Syzkaller       SyzkallerConfig
 	Repro           ReproConfig
 	Manager         *mgrconfig.Config
+	BuildSemaphore  *instance.Semaphore
 }
 
 type KernelConfig struct {
@@ -120,7 +121,7 @@ func Run(cfg *Config) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	inst, err := instance.NewEnv(cfg.Manager)
+	inst, err := instance.NewEnv(cfg.Manager, cfg.BuildSemaphore)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -32,6 +32,7 @@ type Config struct {
 	Repro           ReproConfig
 	Manager         *mgrconfig.Config
 	BuildSemaphore  *instance.Semaphore
+	TestSemaphore   *instance.Semaphore
 }
 
 type KernelConfig struct {
@@ -121,7 +122,7 @@ func Run(cfg *Config) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	inst, err := instance.NewEnv(cfg.Manager, cfg.BuildSemaphore)
+	inst, err := instance.NewEnv(cfg.Manager, cfg.BuildSemaphore, cfg.TestSemaphore)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -571,12 +571,6 @@ func (s *Semaphore) Wait() {
 	<-s.ch
 }
 
-func (s *Semaphore) WaitAll() {
-	for i := 0; i < cap(s.ch); i++ {
-		s.Wait()
-	}
-}
-
 func (s *Semaphore) WaitC() <-chan struct{} {
 	return s.ch
 }

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
@@ -26,68 +27,119 @@ import (
 	"github.com/google/syzkaller/vm"
 )
 
-type JobProcessor struct {
+type JobManager struct {
 	cfg             *Config
-	name            string
-	managers        []*Manager
-	knownCommits    map[string]bool
-	stop            chan struct{}
-	shutdownPending chan struct{}
 	dash            *dashapi.Dashboard
-	syzkallerRepo   string
-	syzkallerBranch string
+	managers        []*Manager
+	shutdownPending <-chan struct{}
 }
 
-func newJobProcessor(cfg *Config, managers []*Manager, stop, shutdownPending chan struct{}) (*JobProcessor, error) {
+type JobProcessor struct {
+	*JobManager
+	name           string
+	instanceSuffix string
+	knownCommits   map[string]bool
+	baseDir        string
+	jobFilter      *ManagerJobs
+	jobTicker      <-chan time.Time
+	commitTicker   <-chan time.Time
+}
+
+func newJobManager(cfg *Config, managers []*Manager, shutdownPending chan struct{}) (*JobManager, error) {
 	dash, err := dashapi.New(cfg.DashboardClient, cfg.DashboardAddr, cfg.DashboardKey)
 	if err != nil {
 		return nil, err
 	}
-	return &JobProcessor{
+	return &JobManager{
 		cfg:             cfg,
-		name:            fmt.Sprintf("%v-job", cfg.Name),
-		managers:        managers,
-		knownCommits:    make(map[string]bool),
-		stop:            stop,
-		shutdownPending: shutdownPending,
 		dash:            dash,
-		syzkallerRepo:   cfg.SyzkallerRepo,
-		syzkallerBranch: cfg.SyzkallerBranch,
+		managers:        managers,
+		shutdownPending: shutdownPending,
 	}, nil
 }
 
-func (jp *JobProcessor) loop() {
-	jobTicker := time.NewTicker(time.Duration(jp.cfg.JobPollPeriod) * time.Second)
-	commitTicker := time.NewTicker(time.Duration(jp.cfg.CommitPollPeriod) * time.Second)
-	defer jobTicker.Stop()
+func (jm *JobManager) loop(stop chan struct{}) {
+	if err := jm.resetJobs(); err != nil {
+		if jm.dash != nil {
+			jm.dash.LogError("syz-ci", "reset jobs failed: %v", err)
+		}
+		return
+	}
+	commitTicker := time.NewTicker(time.Duration(jm.cfg.CommitPollPeriod) * time.Second)
 	defer commitTicker.Stop()
+	jobTicker := time.NewTicker(time.Duration(jm.cfg.JobPollPeriod) * time.Second)
+	defer jobTicker.Stop()
+	var wg sync.WaitGroup
+	for main := true; ; main = false {
+		jp := &JobProcessor{
+			JobManager: jm,
+			jobTicker:  jobTicker.C,
+		}
+		if main {
+			jp.instanceSuffix = "-job"
+			jp.baseDir = osutil.Abs("jobs")
+			jp.commitTicker = commitTicker.C
+			jp.knownCommits = make(map[string]bool)
+		} else {
+			jp.instanceSuffix = "-job-parallel"
+			jp.baseDir = osutil.Abs("jobs-2")
+			// For now let's only parallelize patch testing requests.
+			jp.jobFilter = &ManagerJobs{TestPatches: true}
+		}
+		jp.name = fmt.Sprintf("%v%v", jm.cfg.Name, jp.instanceSuffix)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			jp.loop(stop)
+		}()
+		if main != jm.cfg.ParallelJobs {
+			break
+		}
+	}
+	wg.Wait()
+}
+
+func (jm *JobManager) resetJobs() error {
+	managerNames := []string{}
+	for _, mgr := range jm.managers {
+		if mgr.mgrcfg.Jobs.AnyEnabled() {
+			managerNames = append(managerNames, mgr.name)
+		}
+	}
+	if len(managerNames) > 0 {
+		return jm.dash.JobReset(&dashapi.JobResetReq{Managers: managerNames})
+	}
+	return nil
+}
+
+func (jp *JobProcessor) loop(stop chan struct{}) {
 loop:
 	for {
 		// Check jp.stop separately first, otherwise if stop signal arrives during a job execution,
 		// we can still grab the next job with 50% probability.
 		select {
-		case <-jp.stop:
+		case <-stop:
 			break loop
 		default:
 		}
 		// Similar for commit polling: if we grab 2-3 bisect jobs in a row,
 		// it can delay commit polling by days.
 		select {
-		case <-commitTicker.C:
+		case <-jp.commitTicker:
 			jp.pollCommits()
 		default:
 		}
 		select {
-		case <-jobTicker.C:
+		case <-jp.jobTicker:
 			if buildSem.Available() == 0 {
 				// If normal kernel build is in progress (usually on start), don't query jobs.
 				// Otherwise we claim a job, but can't start it for a while.
 				continue loop
 			}
 			jp.pollJobs()
-		case <-commitTicker.C:
+		case <-jp.commitTicker:
 			jp.pollCommits()
-		case <-jp.stop:
+		case <-stop:
 			break loop
 		}
 	}
@@ -174,7 +226,7 @@ func (jp *JobProcessor) pollManagerCommits(mgr *Manager) error {
 }
 
 func (jp *JobProcessor) pollRepo(mgr *Manager, URL, branch, reportEmail string) ([]*vcs.Commit, error) {
-	dir := osutil.Abs(filepath.Join("jobs", mgr.managercfg.TargetOS, "kernel"))
+	dir := filepath.Join(jp.baseDir, mgr.managercfg.TargetOS, "kernel")
 	repo, err := vcs.NewRepo(mgr.managercfg.TargetOS, mgr.managercfg.Type, dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kernel repo: %v", err)
@@ -186,7 +238,7 @@ func (jp *JobProcessor) pollRepo(mgr *Manager, URL, branch, reportEmail string) 
 }
 
 func (jp *JobProcessor) getCommitInfo(mgr *Manager, URL, branch string, commits []string) ([]*vcs.Commit, error) {
-	dir := osutil.Abs(filepath.Join("jobs", mgr.managercfg.TargetOS, "kernel"))
+	dir := filepath.Join(jp.baseDir, mgr.managercfg.TargetOS, "kernel")
 	repo, err := vcs.NewRepo(mgr.managercfg.TargetOS, mgr.managercfg.Type, dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kernel repo: %v", err)
@@ -209,15 +261,17 @@ func (jp *JobProcessor) pollJobs() {
 		Managers: make(map[string]dashapi.ManagerJobs),
 	}
 	for _, mgr := range jp.managers {
-		if !mgr.mgrcfg.Jobs.TestPatches &&
-			!mgr.mgrcfg.Jobs.BisectCause &&
-			!mgr.mgrcfg.Jobs.BisectFix {
-			continue
+		jobs := &mgr.mgrcfg.Jobs
+		if jp.jobFilter != nil {
+			jobs = jobs.Filter(jp.jobFilter)
 		}
-		poll.Managers[mgr.name] = dashapi.ManagerJobs{
-			TestPatches: mgr.mgrcfg.Jobs.TestPatches,
-			BisectCause: mgr.mgrcfg.Jobs.BisectCause,
-			BisectFix:   mgr.mgrcfg.Jobs.BisectFix,
+		apiJobs := dashapi.ManagerJobs{
+			TestPatches: jobs.TestPatches,
+			BisectCause: jobs.BisectCause,
+			BisectFix:   jobs.BisectFix,
+		}
+		if apiJobs.TestPatches || apiJobs.BisectCause || apiJobs.BisectFix {
+			poll.Managers[mgr.name] = apiJobs
 		}
 	}
 	if len(poll.Managers) == 0 {
@@ -280,7 +334,7 @@ type Job struct {
 func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	req, mgr := job.req, job.mgr
 
-	dir := osutil.Abs(filepath.Join("jobs", mgr.managercfg.TargetOS))
+	dir := filepath.Join(jp.baseDir, mgr.managercfg.TargetOS)
 	mgrcfg := new(mgrconfig.Config)
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Workdir = filepath.Join(dir, "workdir")
@@ -303,12 +357,12 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	job.resp = resp
 	switch req.Type {
 	case dashapi.JobTestPatch:
-		mgrcfg.Name += "-test-job"
+		mgrcfg.Name += "-test" + jp.instanceSuffix
 		resp.Build.KernelRepo = req.KernelRepo
 		resp.Build.KernelBranch = req.KernelBranch
 		resp.Build.KernelCommit = "[unknown]"
 	case dashapi.JobBisectCause, dashapi.JobBisectFix:
-		mgrcfg.Name += "-bisect-job"
+		mgrcfg.Name += "-bisect" + jp.instanceSuffix
 		resp.Build.KernelRepo = mgr.mgrcfg.Repo
 		resp.Build.KernelBranch = mgr.mgrcfg.Branch
 		resp.Build.KernelCommit = req.KernelCommit
@@ -351,10 +405,10 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	var err error
 	switch req.Type {
 	case dashapi.JobTestPatch:
-		mgrcfg.Name += "-test-job"
+		mgrcfg.Name += "-test" + jp.instanceSuffix
 		err = jp.testPatch(job, mgrcfg)
 	case dashapi.JobBisectCause, dashapi.JobBisectFix:
-		mgrcfg.Name += "-bisect-job"
+		mgrcfg.Name += "-bisect" + jp.instanceSuffix
 		err = jp.bisect(job, mgrcfg)
 	}
 	if err != nil {
@@ -424,7 +478,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 			Userspace:      mgr.mgrcfg.Userspace,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
-			Repo:   jp.syzkallerRepo,
+			Repo:   jp.cfg.SyzkallerRepo,
 			Commit: req.SyzkallerCommit,
 		},
 		Repro: bisect.ReproConfig{
@@ -498,7 +552,7 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		return err
 	}
 	log.Logf(0, "job: building syzkaller on %v...", req.SyzkallerCommit)
-	syzBuildLog, syzBuildErr := env.BuildSyzkaller(jp.syzkallerRepo, req.SyzkallerCommit)
+	syzBuildLog, syzBuildErr := env.BuildSyzkaller(jp.cfg.SyzkallerRepo, req.SyzkallerCommit)
 	if syzBuildErr != nil {
 		return syzBuildErr
 	}

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -488,6 +488,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		},
 		Manager:        mgrcfg,
 		BuildSemaphore: buildSem,
+		TestSemaphore:  testSem,
 	}
 
 	res, err := bisect.Run(cfg)
@@ -547,7 +548,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 
 func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	req, resp, mgr := job.req, job.resp, job.mgr
-	env, err := instance.NewEnv(mgrcfg, buildSem)
+	env, err := instance.NewEnv(mgrcfg, buildSem, testSem)
 	if err != nil {
 		return err
 	}

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -236,6 +236,7 @@ func main() {
 		case <-updatePending:
 		}
 		buildSem.WaitAll() // wait for all current builds
+		testSem.WaitAll()
 		close(stop)
 		wg.Done()
 	}()

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -219,7 +219,7 @@ func main() {
 		case <-shutdownPending:
 		case <-updatePending:
 		}
-		kernelBuildSem <- struct{}{} // wait for all current builds
+		buildSem.WaitAll() // wait for all current builds
 		close(stop)
 		wg.Done()
 	}()

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -28,8 +28,9 @@ const (
 
 // SyzUpdater handles everything related to syzkaller updates.
 // As kernel builder, it maintains 2 builds:
-//  - latest: latest known good syzkaller build
-//  - current: currently used syzkaller build
+//   - latest: latest known good syzkaller build
+//   - current: currently used syzkaller build
+//
 // Additionally it updates and restarts the current executable as necessary.
 // Current executable is always built on the same revision as the rest of syzkaller binaries.
 type SyzUpdater struct {
@@ -109,8 +110,8 @@ func NewSyzUpdater(cfg *Config) *SyzUpdater {
 }
 
 // UpdateOnStart does 3 things:
-//  - ensures that the current executable is fresh
-//  - ensures that we have a working syzkaller build in current
+//   - ensures that the current executable is fresh
+//   - ensures that we have a working syzkaller build in current
 func (upd *SyzUpdater) UpdateOnStart(autoupdate bool, shutdown chan struct{}) {
 	os.RemoveAll(upd.currentDir)
 	latestTag := upd.checkLatest()
@@ -221,8 +222,8 @@ func (upd *SyzUpdater) build(commit *vcs.Commit) error {
 	// syzkaller testing may be slowed down by concurrent kernel builds too much
 	// and cause timeout failures, so we serialize it with other builds:
 	// https://groups.google.com/forum/#!msg/syzkaller-openbsd-bugs/o-G3vEsyQp4/f_nFpoNKBQAJ
-	kernelBuildSem <- struct{}{}
-	defer func() { <-kernelBuildSem }()
+	buildSem.Wait()
+	defer buildSem.Signal()
 
 	if upd.descriptions != "" {
 		files, err := ioutil.ReadDir(upd.descriptions)

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -296,7 +296,7 @@ func (pass *Pass) logFormatArg(n *ast.CallExpr) (arg int, newLine, sure bool) {
 		return -1, false, false
 	}
 	switch fmt.Sprintf("%v.%v", fun.X, fun.Sel) {
-	case "log.Print", "log.Printf", "log.Fatal", "log.Fatalf", "fmt.Error", "fmt.Errorf":
+	case "log.Print", "log.Printf", "log.Fatal", "log.Fatalf", "fmt.Error", "fmt.Errorf", "jp.Logf":
 		return 0, false, true
 	case "log.Logf":
 		return 1, false, true

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -110,7 +110,7 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	env, err := instance.NewEnv(cfg, nil)
+	env, err := instance.NewEnv(cfg, nil, nil)
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -8,12 +8,12 @@
 // The kernel checkout given to the tool will be cleaned and used for in-tree builds.
 // Example invocation:
 //
-// sudo syz-testbuild -kernel_src $LINUX_CHECKOUT \
-//	-config dashboard/config/upstream-kasan.config \
-//	-sysctl dashboard/config/upstream.sysctl \
-//	-cmdline dashboard/config/upstream-apparmor.cmdline \
-//	-userspace $WHEEZY_USERSPACE \
-//	-bisect_bin $BISECT_BIN
+//	sudo syz-testbuild -kernel_src $LINUX_CHECKOUT \
+//		-config dashboard/config/upstream-kasan.config \
+//		-sysctl dashboard/config/upstream.sysctl \
+//		-cmdline dashboard/config/upstream-apparmor.cmdline \
+//		-userspace $WHEEZY_USERSPACE \
+//		-bisect_bin $BISECT_BIN
 //
 // A suitable wheezy userspace can be downloaded from:
 // https://storage.googleapis.com/syzkaller/wheezy.tar.gz
@@ -110,7 +110,7 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	env, err := instance.NewEnv(cfg)
+	env, err := instance.NewEnv(cfg, nil)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
Main issue: https://github.com/google/syzkaller/issues/1770

Resolve the problem of long patch test processing delays because of bisections (or other kinds of long jobs) by allowing up to 2 job processing threads per syz-ci.
* Modify job_poll never to return already started jobs.
* Introduce a special job_reset API call to clear the "started" flag for the specified list of managers.
* Introduce a new ParallelJobs configuration parameter. If set, syz-ci will execute the specified kinds of jobs in parallel to the main job processing thread.