### PR TITLE
syz-ci/jobs: use linker supplied in syz-ci config

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -23,6 +23,7 @@ type Config struct {
 	Fix             bool
 	DefaultCompiler string
 	CompilerType    string
+	Linker          string
 	BinDir          string
 	Ccache          string
 	Timeout         time.Duration
@@ -478,7 +479,7 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		return current, "", fmt.Errorf("kernel clean failed: %v", err)
 	}
 	kern := &env.cfg.Kernel
-	_, imageDetails, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Ccache, kern.Userspace,
+	_, imageDetails, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Linker, env.cfg.Ccache, kern.Userspace,
 		kern.Cmdline, kern.Sysctl, bisectEnv.KernelConfig)
 	if imageDetails.CompilerID != "" {
 		env.log("compiler: %v", imageDetails.CompilerID)

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -479,8 +479,15 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		return current, "", fmt.Errorf("kernel clean failed: %v", err)
 	}
 	kern := &env.cfg.Kernel
-	_, imageDetails, err := env.inst.BuildKernel(bisectEnv.Compiler, env.cfg.Linker, env.cfg.Ccache, kern.Userspace,
-		kern.Cmdline, kern.Sysctl, bisectEnv.KernelConfig)
+	_, imageDetails, err := env.inst.BuildKernel(&instance.BuildKernelConfig{
+		CompilerBin:  bisectEnv.Compiler,
+		LinkerBin:    env.cfg.Linker,
+		CcacheBin:    env.cfg.Ccache,
+		UserspaceDir: kern.Userspace,
+		CmdlineFile:  kern.Cmdline,
+		SysctlFile:   kern.Sysctl,
+		KernelConfig: bisectEnv.KernelConfig,
+	})
 	if imageDetails.CompilerID != "" {
 		env.log("compiler: %v", imageDetails.CompilerID)
 	}

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -32,7 +32,7 @@ func (env *testEnv) BuildSyzkaller(repo, commit string) (string, error) {
 	return "", nil
 }
 
-func (env *testEnv) BuildKernel(compilerBin, cCache, userspaceDir, cmdlineFile, sysctlFile string,
+func (env *testEnv) BuildKernel(compilerBin, linker, cCache, userspaceDir, cmdlineFile, sysctlFile string,
 	kernelConfig []byte) (string, build.ImageDetails, error) {
 	commit := env.headCommit()
 	configHash := hash.String(kernelConfig)

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -32,16 +32,15 @@ func (env *testEnv) BuildSyzkaller(repo, commit string) (string, error) {
 	return "", nil
 }
 
-func (env *testEnv) BuildKernel(compilerBin, linker, cCache, userspaceDir, cmdlineFile, sysctlFile string,
-	kernelConfig []byte) (string, build.ImageDetails, error) {
+func (env *testEnv) BuildKernel(buildCfg *instance.BuildKernelConfig) (string, build.ImageDetails, error) {
 	commit := env.headCommit()
-	configHash := hash.String(kernelConfig)
+	configHash := hash.String(buildCfg.KernelConfig)
 	details := build.ImageDetails{}
 	details.Signature = fmt.Sprintf("%v-%v", commit, configHash)
 	if commit >= env.test.sameBinaryStart && commit <= env.test.sameBinaryEnd {
 		details.Signature = "same-sign-" + configHash
 	}
-	env.config = string(kernelConfig)
+	env.config = string(buildCfg.KernelConfig)
 	if env.config == "baseline-fails" {
 		return "", details, fmt.Errorf("failure")
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -29,7 +29,7 @@ import (
 
 type Env interface {
 	BuildSyzkaller(string, string) (string, error)
-	BuildKernel(string, string, string, string, string, []byte) (string, build.ImageDetails, error)
+	BuildKernel(string, string, string, string, string, string, []byte) (string, build.ImageDetails, error)
 	Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]EnvTestResult, error)
 }
 
@@ -114,7 +114,8 @@ func (env *env) BuildSyzkaller(repoURL, commit string) (string, error) {
 	return buildLog, nil
 }
 
-func (env *env) BuildKernel(compilerBin, ccacheBin, userspaceDir, cmdlineFile, sysctlFile string, kernelConfig []byte) (
+func (env *env) BuildKernel(compilerBin, linkerBin, ccacheBin, userspaceDir, cmdlineFile, sysctlFile string,
+	kernelConfig []byte) (
 	string, build.ImageDetails, error) {
 	imageDir := filepath.Join(env.cfg.Workdir, "image")
 	params := build.Params{
@@ -124,6 +125,7 @@ func (env *env) BuildKernel(compilerBin, ccacheBin, userspaceDir, cmdlineFile, s
 		KernelDir:    env.cfg.KernelSrc,
 		OutputDir:    imageDir,
 		Compiler:     compilerBin,
+		Linker:       linkerBin,
 		Ccache:       ccacheBin,
 		UserspaceDir: userspaceDir,
 		CmdlineFile:  cmdlineFile,

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -553,8 +553,15 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		[]byte("# CONFIG_DEBUG_INFO_BTF is not set"), -1)
 
 	log.Logf(0, "job: building kernel...")
-	kernelConfig, details, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Linker, mgr.mgrcfg.Ccache,
-		mgr.mgrcfg.Userspace, mgr.mgrcfg.KernelCmdline, mgr.mgrcfg.KernelSysctl, req.KernelConfig)
+	kernelConfig, details, err := env.BuildKernel(&instance.BuildKernelConfig{
+		CompilerBin:  mgr.mgrcfg.Compiler,
+		LinkerBin:    mgr.mgrcfg.Linker,
+		CcacheBin:    mgr.mgrcfg.Ccache,
+		UserspaceDir: mgr.mgrcfg.Userspace,
+		CmdlineFile:  mgr.mgrcfg.KernelCmdline,
+		SysctlFile:   mgr.mgrcfg.KernelSysctl,
+		KernelConfig: req.KernelConfig,
+	})
 	resp.Build.CompilerID = details.CompilerID
 	if err != nil {
 		return err

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -417,6 +417,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		DefaultCompiler: mgr.mgrcfg.Compiler,
 		CompilerType:    mgr.mgrcfg.CompilerType,
 		BinDir:          jp.cfg.BisectBinDir,
+		Linker:          mgr.mgrcfg.Linker,
 		Ccache:          jp.cfg.Ccache,
 		Kernel: bisect.KernelConfig{
 			Repo:           mgr.mgrcfg.Repo,
@@ -552,8 +553,8 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		[]byte("# CONFIG_DEBUG_INFO_BTF is not set"), -1)
 
 	log.Logf(0, "job: building kernel...")
-	kernelConfig, details, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Ccache, mgr.mgrcfg.Userspace,
-		mgr.mgrcfg.KernelCmdline, mgr.mgrcfg.KernelSysctl, req.KernelConfig)
+	kernelConfig, details, err := env.BuildKernel(mgr.mgrcfg.Compiler, mgr.mgrcfg.Linker, mgr.mgrcfg.Ccache,
+		mgr.mgrcfg.Userspace, mgr.mgrcfg.KernelCmdline, mgr.mgrcfg.KernelSysctl, req.KernelConfig)
 	resp.Build.CompilerID = details.CompilerID
 	if err != nil {
 		return err

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -125,7 +125,7 @@ func main() {
 }
 
 func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.Env, com *vcs.Commit) {
-	compiler, compilerType := "gcc", "gcc"
+	compiler, compilerType, linker, ccache := "gcc", "gcc", "ld", ""
 	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin, com.Hash, kernelConfig)
 	if err != nil {
 		tool.Fail(err)
@@ -134,7 +134,7 @@ func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instanc
 	if err := build.Clean(*flagOS, *flagArch, vmType, *flagKernelSrc); err != nil {
 		tool.Fail(err)
 	}
-	_, _, err = env.BuildKernel(bisectEnv.Compiler, "", *flagUserspace,
+	_, _, err = env.BuildKernel(bisectEnv.Compiler, linker, ccache, *flagUserspace,
 		*flagKernelCmdline, *flagKernelSysctl, bisectEnv.KernelConfig)
 	if err != nil {
 		if verr, ok := err.(*osutil.VerboseError); ok {

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -134,8 +134,15 @@ func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instanc
 	if err := build.Clean(*flagOS, *flagArch, vmType, *flagKernelSrc); err != nil {
 		tool.Fail(err)
 	}
-	_, _, err = env.BuildKernel(bisectEnv.Compiler, linker, ccache, *flagUserspace,
-		*flagKernelCmdline, *flagKernelSysctl, bisectEnv.KernelConfig)
+	_, _, err = env.BuildKernel(&instance.BuildKernelConfig{
+		CompilerBin:  bisectEnv.Compiler,
+		LinkerBin:    linker,
+		CcacheBin:    ccache,
+		UserspaceDir: *flagUserspace,
+		CmdlineFile:  *flagKernelCmdline,
+		SysctlFile:   *flagKernelSysctl,
+		KernelConfig: bisectEnv.KernelConfig,
+	})
 	if err != nil {
 		if verr, ok := err.(*osutil.VerboseError); ok {
 			log.Printf("BUILD BROKEN: %v", verr.Title)


### PR DESCRIPTION
Previously we only used the linter from the syz-ci config when building the kernel for regular fuzzing. We were missing some plumbing to have this setting reach patch testing and bisection jobs.