### PR TITLE
vm/gvisor: implement vmimpl.Infoer for runsc instances

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,6 +37,7 @@ Google Inc.
  Christian Resell
  Hrutvik Kanabar
  Zachary O'Keefe
+ Etienne Perot
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -210,7 +210,7 @@ func (inst *instance) waitBoot() error {
 	}
 }
 
-func (inst *instance) runscCmd(add ...string) *exec.Cmd {
+func (inst *instance) args() []string {
 	args := []string{
 		"-root", inst.rootDir,
 		"-watchdog-action=panic",
@@ -223,8 +223,16 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	if inst.cfg.RunscArgs != "" {
 		args = append(args, strings.Split(inst.cfg.RunscArgs, " ")...)
 	}
-	args = append(args, add...)
-	cmd := osutil.Command(inst.image, args...)
+	return args
+}
+
+func (inst *instance) Info() ([]byte, error) {
+	info := fmt.Sprintf("%v %v\n", inst.image, strings.Join(inst.args(), " "))
+	return []byte(info), nil
+}
+
+func (inst *instance) runscCmd(add ...string) *exec.Cmd {
+	cmd := osutil.Command(inst.image, append(inst.args(), add...)...)
 	cmd.Env = []string{
 		"GOTRACEBACK=all",
 		"GORACE=halt_on_error=1",


### PR DESCRIPTION
This adds VM info for runsc (gVisor) instances, showing the flags passed to runsc.