### PR TITLE
dashboard: adjust the upstream notification email

### DIFF
--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -302,7 +302,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 			msg := c.pollEmailBug()
 			if i < 3 {
 				c.expectEQ(msg.Subject, subjects[i])
-				c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+				c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 			} else {
 				c.expectEQ(msg.Subject, "[syzbot] "+subjects[i])
 				c.expectTrue(strings.Contains(msg.Body, "syzbot found the following issue on"))
@@ -683,7 +683,7 @@ func TestBisectWrong(t *testing.T) {
 			// Auto-upstreamming.
 			c.advanceTime(31 * 24 * time.Hour)
 			msg := c.pollEmailBug()
-			c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream"))
+			c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 			msg = c.pollEmailBug()
 			c.expectTrue(strings.Contains(msg.Body, "syzbot found the following issue on:"))
 			if i == 0 {
@@ -1036,7 +1036,7 @@ func TestBugBisectionResults(t *testing.T) {
 		msg := c.client2.pollEmailBug()
 		c.expectTrue(strings.Contains(msg.Body, "syzbot has bisected this issue to:"))
 		msg = c.client2.pollEmailBug()
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 		msg = c.client2.pollEmailBug()
 		c.expectTrue(strings.Contains(msg.Body, "syzbot found the following issue"))
 	}
@@ -1149,7 +1149,7 @@ func TestBugBisectionStatus(t *testing.T) {
 		msg := c.client2.pollEmailBug()
 		c.expectTrue(strings.Contains(msg.Body, "syzbot has bisected this issue to:"))
 		msg = c.client2.pollEmailBug()
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 		msg = c.client2.pollEmailBug()
 		c.expectTrue(strings.Contains(msg.Body, "syzbot found the following issue"))
 	}

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -554,7 +554,7 @@ func TestBisectFixJob(t *testing.T) {
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "title1")
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 
 		msg = c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "[syzbot] title1")
@@ -599,7 +599,7 @@ func TestBisectFixRetry(t *testing.T) {
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "title1")
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 
 		msg = c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "[syzbot] title1")
@@ -664,7 +664,7 @@ func TestNotReportingAlreadyFixed(t *testing.T) {
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "title1")
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 
 		msg = c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "[syzbot] title1")
@@ -755,7 +755,7 @@ func TestFixBisectionsListed(t *testing.T) {
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "title1")
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 
 		msg = c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "[syzbot] title1")
@@ -833,7 +833,7 @@ func TestFixBisectionsDisabled(t *testing.T) {
 		c.advanceTime(30 * 24 * time.Hour)
 		msg := c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "title20")
-		c.expectTrue(strings.Contains(msg.Body, "Sending this report upstream."))
+		c.expectTrue(strings.Contains(msg.Body, "Sending this report to the next reporting stage."))
 
 		msg = c.client2.pollEmailBug()
 		c.expectEQ(msg.Subject, "[syzbot] title20")

--- a/dashboard/app/notifications_test.go
+++ b/dashboard/app/notifications_test.go
@@ -36,7 +36,7 @@ func TestEmailNotifUpstreamEmbargo(t *testing.T) {
 	upstreamReport := c.pollEmailBug()
 	c.expectEQ(notifUpstream.Subject, crash.Title)
 	c.expectEQ(notifUpstream.Sender, report.Sender)
-	c.expectEQ(notifUpstream.Body, "Sending this report upstream.")
+	c.expectEQ(notifUpstream.Body, "Sending this report to the next reporting stage.")
 	c.expectEQ(upstreamReport.Subject, "[syzbot] "+crash.Title)
 	c.expectNE(upstreamReport.Sender, report.Sender)
 	c.expectEQ(upstreamReport.To, []string{"bugs@syzkaller.com", "default@maintainers.com"})
@@ -65,7 +65,7 @@ func TestEmailNotifUpstreamSkip(t *testing.T) {
 	notifUpstream := c.pollEmailBug()
 	upstreamReport := c.pollEmailBug()
 	c.expectEQ(notifUpstream.Sender, report.Sender)
-	c.expectEQ(notifUpstream.Body, "Sending this report upstream.")
+	c.expectEQ(notifUpstream.Body, "Sending this report to the next reporting stage.")
 	c.expectNE(upstreamReport.Sender, report.Sender)
 	c.expectEQ(upstreamReport.To, []string{"bugs@syzkaller.com", "default@maintainers.com"})
 }

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -170,7 +170,7 @@ func emailSendBugNotif(c context.Context, notif *dashapi.BugNotification) error 
 	var statusReason dashapi.BugStatusReason
 	switch notif.Type {
 	case dashapi.BugNotifUpstream:
-		body = "Sending this report upstream."
+		body = "Sending this report to the next reporting stage."
 		status = dashapi.BugStatusUpstream
 	case dashapi.BugNotifBadCommit:
 		var err error


### PR DESCRIPTION
Make it more clear - de facto we're just sending the report to the next reporting stage. It does not always have to be "upstream", what implies some public mailing lists.