### PR TITLE
pkg/csource: fix unit tests for arches with non-default DataOffset

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -188,18 +188,23 @@ csource4(&AUTO)
 csource5(&AUTO)
 csource6(&AUTO)
 `,
-			output: `
-NONFAILING(memcpy((void*)0x20000040, "\x12\x34\x56\x78", 4));
-syscall(SYS_csource2, 0x20000040ul);
-NONFAILING(memset((void*)0x20000080, 0, 10));
-syscall(SYS_csource3, 0x20000080ul);
-NONFAILING(memset((void*)0x200000c0, 48, 10));
-syscall(SYS_csource4, 0x200000c0ul);
-NONFAILING(memcpy((void*)0x20000100, "0101010101", 10));
-syscall(SYS_csource5, 0x20000100ul);
-NONFAILING(memcpy((void*)0x20000140, "101010101010", 12));
-syscall(SYS_csource6, 0x20000140ul);
+			output: fmt.Sprintf(`
+NONFAILING(memcpy((void*)0x%x, "\x12\x34\x56\x78", 4));
+syscall(SYS_csource2, 0x%xul);
+NONFAILING(memset((void*)0x%x, 0, 10));
+syscall(SYS_csource3, 0x%xul);
+NONFAILING(memset((void*)0x%x, 48, 10));
+syscall(SYS_csource4, 0x%xul);
+NONFAILING(memcpy((void*)0x%x, "0101010101", 10));
+syscall(SYS_csource5, 0x%xul);
+NONFAILING(memcpy((void*)0x%x, "101010101010", 12));
+syscall(SYS_csource6, 0x%xul);
 `,
+				target.DataOffset+0x40, target.DataOffset+0x40,
+				target.DataOffset+0x80, target.DataOffset+0x80,
+				target.DataOffset+0xc0, target.DataOffset+0xc0,
+				target.DataOffset+0x100, target.DataOffset+0x100,
+				target.DataOffset+0x140, target.DataOffset+0x140),
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
The problem was introduced in 4620c2d9bc4f ("sys/targets: take DataOffset from reference targets").

Example of the problem on s390x
-------------------------------

--- FAIL: TestSource (0.00s)
    --- FAIL: TestSource/1 (0.00s)
        csource_test.go:221: input:

            csource2(&AUTO="12345678")
            csource3(&AUTO)
            csource4(&AUTO)
            csource5(&AUTO)
            csource6(&AUTO)

            want:

            NONFAILING(memcpy((void*)0x20000040, "\x12\x34\x56\x78", 4));
            syscall(SYS_csource2, 0x20000040ul);
            NONFAILING(memset((void*)0x20000080, 0, 10));
            syscall(SYS_csource3, 0x20000080ul);
            NONFAILING(memset((void*)0x200000c0, 48, 10));
            syscall(SYS_csource4, 0x200000c0ul);
            NONFAILING(memcpy((void*)0x20000100, "0101010101", 10));
            syscall(SYS_csource5, 0x20000100ul);
            NONFAILING(memcpy((void*)0x20000140, "101010101010", 12));
            syscall(SYS_csource6, 0x20000140ul);

            got:

            NONFAILING(memcpy((void*)0xfffff040, "\x12\x34\x56\x78", 4));
            syscall(SYS_csource2, 0xfffff040ul);
            NONFAILING(memset((void*)0xfffff080, 0, 10));
            syscall(SYS_csource3, 0xfffff080ul);
            NONFAILING(memset((void*)0xfffff0c0, 48, 10));
            syscall(SYS_csource4, 0xfffff0c0ul);
            NONFAILING(memcpy((void*)0xfffff100, "0101010101", 10));
            syscall(SYS_csource5, 0xfffff100ul);
            NONFAILING(memcpy((void*)0xfffff140, "101010101010", 12));
            syscall(SYS_csource6, 0xfffff140ul);
FAIL
coverage: 79.6% of statements
FAIL    github.com/google/syzkaller/pkg/csource 9.930s

Fixes: 4620c2d9bc4f ("sys/targets: take DataOffset from reference targets")
Signed-off-by: Alexander Egorenkov <eaibmz@gmail.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
