### PR TITLE
pkg/build: try harder to get a clean build on FreeBSD

### DIFF
--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -41,6 +41,9 @@ options 	DIAGNOSTIC
 		return ImageDetails{}, err
 	}
 
+	if _, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "rm", "-rf", "obj"); err != nil {
+		return ImageDetails{}, err
+	}
 	objPrefix := filepath.Join(params.KernelDir, "obj")
 	if err := ctx.make(params.KernelDir, objPrefix, "kernel-toolchain"); err != nil {
 		return ImageDetails{}, err


### PR DESCRIPTION
Commit 6f9c033e1 ("pkg/build: try a clean toolchain build on FreeBSD") doesn't appear to be sufficient, so let's try blowing away the entire object directory.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
