### PR TITLE
docs/starnix: fix typo in manager config json template

### DIFF
--- a/docs/starnix/README.md
+++ b/docs/starnix/README.md
@@ -51,7 +51,7 @@ Create a manager config like the following, replacing the environment variables 
     "procs": 8,
     "type": "starnix",
     "vm": {
-        "count": 1,
+        "count": 1
     },
     "cover": false
 }


### PR DESCRIPTION
Remove extra comma in the manager config json template that caused the syz-manager run to fail due to error in parsing the config file.