### PR TITLE
syz-ci: don't duplicate job instance suffixes

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -436,10 +436,8 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	var err error
 	switch req.Type {
 	case dashapi.JobTestPatch:
-		mgrcfg.Name += "-test" + jp.instanceSuffix
 		err = jp.testPatch(job, mgrcfg)
 	case dashapi.JobBisectCause, dashapi.JobBisectFix:
-		mgrcfg.Name += "-bisect" + jp.instanceSuffix
 		err = jp.bisect(job, mgrcfg)
 	}
 	if err != nil {


### PR DESCRIPTION
Currently a suffix is appended twice.