### PR TITLE
pkg/build: update kernel headers path

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -91,7 +91,7 @@ func (a android) build(params Params) (ImageDetails, error) {
 	config := filepath.Join(buildOutDir, "common", ".config")
 
 	var err error
-	details.CompilerID, err = a.readCompiler(filepath.Join(buildOutDir, "kernel-headers.tar.gz"))
+	details.CompilerID, err = a.readCompiler(filepath.Join(buildDistDir, "kernel-headers.tar.gz"))
 	if err != nil {
 		return details, err
 	}


### PR DESCRIPTION
The upstream kernel headers path was changed to the dist directory.
