### PR TITLE
dashboard: fix racy decommission tests

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -361,30 +361,111 @@ var testConfig = &GlobalConfig{
 				SubsystemCc: subsystem.LinuxGetMaintainers,
 			},
 		},
+		"test-decommission": {
+			AccessLevel:      AccessAdmin,
+			Key:              "testdecommissiontestdecommission",
+			SimilarityDomain: testDomain,
+			Clients: map[string]string{
+				clientTestDecomm: keyTestDecomm,
+			},
+			Repos: []KernelRepo{
+				{
+					URL:    "git://syzkaller.org",
+					Branch: "branch10",
+					Alias:  "repo10alias",
+				},
+			},
+			Reporting: []Reporting{
+				{
+					Name:       "reporting1",
+					DailyLimit: 3,
+					Embargo:    14 * 24 * time.Hour,
+					Filter:     skipWithRepro,
+					Config: &TestConfig{
+						Index: 1,
+					},
+				},
+				{
+					Name:       "reporting2",
+					DailyLimit: 3,
+					Config: &TestConfig{
+						Index: 2,
+					},
+				},
+			},
+		},
+		"test-mgr-decommission": {
+			AccessLevel:      AccessAdmin,
+			Key:              "testmgrdecommissiontestmgrdecommission",
+			SimilarityDomain: testDomain,
+			Clients: map[string]string{
+				clientMgrDecommission: keyMgrDecommission,
+			},
+			Managers: map[string]ConfigManager{
+				notYetDecommManger: {},
+				delegateToManager:  {},
+			},
+			Repos: []KernelRepo{
+				{
+					URL:    "git://syzkaller.org",
+					Branch: "branch10",
+					Alias:  "repo10alias",
+				},
+			},
+			Reporting: []Reporting{
+				{
+					Name:       "reporting1",
+					DailyLimit: 5,
+					Embargo:    14 * 24 * time.Hour,
+					Filter:     skipWithRepro,
+					Config: &EmailConfig{
+						Email: "test@syzkaller.com",
+					},
+				},
+				{
+					Name:       "reporting2",
+					DailyLimit: 3,
+					Filter:     skipWithRepro2,
+					Config: &EmailConfig{
+						Email:              "bugs@syzkaller.com",
+						DefaultMaintainers: []string{"default@maintainers.com"},
+						SubjectPrefix:      "[syzbot]",
+						MailMaintainers:    true,
+					},
+				},
+			},
+			RetestRepros: true,
+		},
 	},
 }
 
 const (
-	client1            = "client1"
-	client2            = "client2"
-	password1          = "client1keyclient1keyclient1key"
-	password2          = "client2keyclient2keyclient2key"
-	clientAdmin        = "client-admin"
-	keyAdmin           = "clientadminkeyclientadminkey"
-	clientUser         = "client-user"
-	keyUser            = "clientuserkeyclientuserkey"
-	clientPublic       = "client-public"
-	keyPublic          = "clientpublickeyclientpublickey"
-	clientPublicEmail  = "client-public-email"
-	keyPublicEmail     = "clientpublicemailkeyclientpublicemailkey"
-	clientPublicEmail2 = "client-public-email2"
-	keyPublicEmail2    = "clientpublicemailkeyclientpublicemailkey2"
-	clientPublicFs     = "client-public-fs"
-	keyPublicFs        = "keypublicfskeypublicfskeypublicfs"
+	client1               = "client1"
+	client2               = "client2"
+	password1             = "client1keyclient1keyclient1key"
+	password2             = "client2keyclient2keyclient2key"
+	clientAdmin           = "client-admin"
+	keyAdmin              = "clientadminkeyclientadminkey"
+	clientUser            = "client-user"
+	keyUser               = "clientuserkeyclientuserkey"
+	clientPublic          = "client-public"
+	keyPublic             = "clientpublickeyclientpublickey"
+	clientPublicEmail     = "client-public-email"
+	keyPublicEmail        = "clientpublicemailkeyclientpublicemailkey"
+	clientPublicEmail2    = "client-public-email2"
+	keyPublicEmail2       = "clientpublicemailkeyclientpublicemailkey2"
+	clientPublicFs        = "client-public-fs"
+	keyPublicFs           = "keypublicfskeypublicfskeypublicfs"
+	clientTestDecomm      = "client-test-decomm"
+	keyTestDecomm         = "keyTestDecommkeyTestDecomm"
+	clientMgrDecommission = "client-mgr-decommission"
+	keyMgrDecommission    = "keyMgrDecommissionkeyMgrDecommission"
 
 	restrictedManager     = "restricted-manager"
 	noFixBisectionManager = "no-fix-bisection-manager"
 	specialCCManager      = "special-cc-manager"
+	notYetDecommManger    = "not-yet-decomm-manager"
+	delegateToManager     = "delegate-to-manager"
 
 	testDomain = "test"
 )

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -492,9 +492,9 @@ func TestDelegatedManagerReproRetest(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
-	client := c.client2
-	oldManager := noFixBisectionManager
-	newManager := specialCCManager
+	client := c.makeClient(clientMgrDecommission, keyMgrDecommission, true)
+	oldManager := notYetDecommManger
+	newManager := delegateToManager
 
 	oldBuild := testBuild(1)
 	oldBuild.KernelRepo = "git://delegated.repo/git.git"
@@ -512,10 +512,10 @@ func TestDelegatedManagerReproRetest(t *testing.T) {
 	c.expectOK(err)
 
 	// Deprecate the oldManager.
-	mgrConfig := config.Namespaces["test2"].Managers[oldManager]
+	mgrConfig := config.Namespaces["test-mgr-decommission"].Managers[oldManager]
 	mgrConfig.Decommissioned = true
 	mgrConfig.DelegatedTo = newManager
-	config.Namespaces["test2"].Managers[oldManager] = mgrConfig
+	config.Namespaces["test-mgr-decommission"].Managers[oldManager] = mgrConfig
 
 	// Upload a build for the new manager.
 	c.advanceTime(time.Minute)

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1055,21 +1055,22 @@ func TestReportDecommissionedBugs(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
+	client := c.makeClient(clientTestDecomm, keyTestDecomm, true)
 	build := testBuild(1)
-	c.client.UploadBuild(build)
+	client.UploadBuild(build)
 
 	crash := testCrash(build, 1)
-	c.client.ReportCrash(crash)
-	rep := c.client.pollBug()
+	client.ReportCrash(crash)
+	rep := client.pollBug()
 
-	closed, _ := c.client.ReportingPollClosed([]string{rep.ID})
+	closed, _ := client.ReportingPollClosed([]string{rep.ID})
 	c.expectEQ(len(closed), 0)
 
 	// And now let's decommission the namespace.
 	config.Namespaces[rep.Namespace].Decommissioned = true
 	defer func() { config.Namespaces[rep.Namespace].Decommissioned = false }()
 
-	closed, _ = c.client.ReportingPollClosed([]string{rep.ID})
+	closed, _ = client.ReportingPollClosed([]string{rep.ID})
 	c.expectEQ(len(closed), 1)
 	c.expectEQ(closed[0], rep.ID)
 }


### PR DESCRIPTION
These tests require a change in the global configuration during the test execution, so they at least need their own namespaces in order not to interfere with other tests.

Fixes #3641 
