### PR TITLE
dashboard: make expectOK more elaborate

### DIFF
--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -85,7 +85,7 @@ func NewCtx(t *testing.T) *Ctx {
 func (c *Ctx) expectOK(err error) {
 	if err != nil {
 		c.t.Helper()
-		c.t.Fatal(err)
+		c.t.Fatalf("expected OK, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Now it's quite difficult to recognize it in the dashboard testing logs, especially when the error message itself is not very clear.

