### PR TITLE
Revert "tools/docker: switch to Clang 15"

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -37,15 +37,15 @@ RUN mkdir -p /syzkaller/gopath/src/github.com/google/syzkaller && \
 # The default clang-11 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main"
 RUN apt-get update --allow-releaseinfo-change
 RUN apt-get remove -y -q clang-11
-RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15
+RUN apt-get install -y -q --no-install-recommends clang-13 clang-format-13 clang-tidy-13
 RUN apt autoremove -y -q
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
-RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
-RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
-RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
+RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
+RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
+RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 100
+RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -38,16 +38,16 @@ ENV PATH /usr/local/go/bin:$PATH
 # The default clang-11 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main"
 RUN apt-get update --allow-releaseinfo-change
 RUN apt-get remove -y -q clang-11
-RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15 lld-15
+RUN apt-get install -y -q --no-install-recommends clang-13 clang-format-13 clang-tidy-13 lld-13
 RUN apt autoremove -y -q
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
-RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
-RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
-RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
-RUN sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-15 100
+RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
+RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
+RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 100
+RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
+RUN sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-13 100
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.


### PR DESCRIPTION
The new compiler introduced some test failures, so we had to roll back the containers. Revert the patch to Docker specs, so that they reflect the actual state of the things.

This reverts commit 3d904c7acdbdd69b8c6e85799af7565955025201.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
