### PR TITLE
vm/proxyapp: pass file data when running in tcp mode

### DIFF
--- a/vm/proxyapp/init.go
+++ b/vm/proxyapp/init.go
@@ -68,6 +68,9 @@ type Config struct {
 	// server_tls_cert points a TLS certificate used to authenticate the server.
 	// If not provided, the default system certificate pool will be used.
 	ServerTLSCert string `json:"server_tls_cert"`
+	// transfer_file_content will send the file content as a byte array in
+	// addition to the filename.
+	TransferFileContent bool `json:"transfer_file_content"`
 	// config is an optional remote plugin config
 	ProxyAppConfig json.RawMessage `json:"config"`
 }

--- a/vm/proxyapp/proxyrpc/proxyrpc.go
+++ b/vm/proxyapp/proxyrpc/proxyrpc.go
@@ -27,8 +27,9 @@ type CreatePoolResult struct {
 }
 
 type CreateInstanceParams struct {
-	Workdir string
-	Index   int
+	Workdir     string
+	Index       int
+	WorkdirData map[string][]byte
 }
 
 type CreateInstanceResult struct {
@@ -38,6 +39,7 @@ type CreateInstanceResult struct {
 type CopyParams struct {
 	ID      string
 	HostSrc string
+	Data    []byte
 }
 
 type CopyResult struct {


### PR DESCRIPTION
Instead of just passing the path to the file (on the local machine) to the ProxyApp, we need to pass the file data. This applies for both calls to Copy() and CreateInstance().
