### PR TITLE
tools/docker: switch to Clang 15

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -37,15 +37,15 @@ RUN mkdir -p /syzkaller/gopath/src/github.com/google/syzkaller && \
 # The default clang-11 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
 RUN apt-get update --allow-releaseinfo-change
 RUN apt-get remove -y -q clang-11
-RUN apt-get install -y -q --no-install-recommends clang-13 clang-format-13 clang-tidy-13
+RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15
 RUN apt autoremove -y -q
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
-RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
-RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 100
-RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
+RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
+RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
+RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
+RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -1,10 +1,7 @@
 # Copyright 2021 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-# syzbot container is used to run syz-ci on syzbot, use as:
-# docker build -t gcr.io/syzkaller/syzbot tools/docker/syzbot
-# docker push gcr.io/syzkaller/syzbot
-# docker run -it gcr.io/syzkaller/syzbot
+# See /tools/docker/README.md for details.
 
 FROM debian:bullseye
 
@@ -38,16 +35,16 @@ ENV PATH /usr/local/go/bin:$PATH
 # The default clang-11 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
 RUN apt-get update --allow-releaseinfo-change
 RUN apt-get remove -y -q clang-11
-RUN apt-get install -y -q --no-install-recommends clang-13 clang-format-13 clang-tidy-13 lld-13
+RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15 lld-15
 RUN apt autoremove -y -q
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
-RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
-RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 100
-RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
-RUN sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-13 100
+RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
+RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
+RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
+RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
+RUN sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-15 100
 
 # Download and install the custom Clang required to build KMSAN.
 # TODO(@ramosian-glider): switch to stable Clang once KMSAN is upstreamed.


### PR DESCRIPTION
This is a prerequisite for building KMSAN-instrumented kernels.
Now that https://github.com/google/syzkaller/pull/3649 is landed, the tests should be passing.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
