### PR TITLE
pkg/report: extract guilty files for rcu errors correctly

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -702,7 +702,8 @@ func (ctx *linux) extractGuiltyFileRaw(title string, report []byte) string {
 		// we would need to ignore too many files and that would be fragile.
 		// So instead we try to extract guilty file starting from the known
 		// interrupt entry point first.
-		for _, interruptEnd := range []string{"apic_timer_interrupt+0x", "Exception stack"} {
+		for _, interruptEnd := range []string{"apic_timer_interrupt+0x",
+			"el1h_64_irq+0x", "Exception stack"} {
 			if pos := bytes.Index(report, []byte(interruptEnd)); pos != -1 {
 				if file := ctx.extractGuiltyFileImpl(report[pos:]); file != "" {
 					return file

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -77,6 +77,7 @@ func ctorLinux(cfg *config) (reporterImpl, []string, error) {
 		regexp.MustCompile(`^arch/.*/mm/fault.c`),
 		regexp.MustCompile(`^arch/.*/mm/physaddr.c`),
 		regexp.MustCompile(`^arch/.*/kernel/stacktrace.c`),
+		regexp.MustCompile(`^arch/.*/kernel/apic/apic.c`),
 		regexp.MustCompile(`^arch/arm64/kernel/entry.*.c`),
 		regexp.MustCompile(`^kernel/locking/.*`),
 		regexp.MustCompile(`^kernel/panic.c`),
@@ -701,7 +702,7 @@ func (ctx *linux) extractGuiltyFileRaw(title string, report []byte) string {
 		// we would need to ignore too many files and that would be fragile.
 		// So instead we try to extract guilty file starting from the known
 		// interrupt entry point first.
-		for _, interruptEnd := range []string{" apic_timer_interrupt+0x", "Exception stack"} {
+		for _, interruptEnd := range []string{"apic_timer_interrupt+0x", "Exception stack"} {
 			if pos := bytes.Index(report, []byte(interruptEnd)); pos != -1 {
 				if file := ctx.extractGuiltyFileImpl(report[pos:]); file != "" {
 					return file

--- a/pkg/report/testdata/linux/guilty/58
+++ b/pkg/report/testdata/linux/guilty/58
@@ -1,0 +1,79 @@
+FILE: net/core/devlink.c
+
+rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:
+rcu: 	Tasks blocked on level-0 rcu_node (CPUs 0-1): P28912
+	(detected by 0, t=10502 jiffies, g=275385, q=3760 ncpus=2)
+task:syz-executor.2  state:R  running task     stack:24600 pid:28912 ppid:1      flags:0x00004006
+Call Trace:
+ <IRQ>
+ sched_show_task kernel/sched/core.c:8967 [inline]
+ sched_show_task+0x450/0x5c0 kernel/sched/core.c:8941
+ rcu_print_detail_task_stall_rnp kernel/rcu/tree_stall.h:255 [inline]
+ print_other_cpu_stall kernel/rcu/tree_stall.h:599 [inline]
+ check_cpu_stall kernel/rcu/tree_stall.h:761 [inline]
+ rcu_pending kernel/rcu/tree.c:3858 [inline]
+ rcu_sched_clock_irq+0x21d1/0x2470 kernel/rcu/tree.c:2343
+ update_process_times+0x11e/0x1a0 kernel/time/timer.c:2071
+ tick_sched_handle+0x9b/0x180 kernel/time/tick-sched.c:243
+ tick_sched_timer+0xf2/0x120 kernel/time/tick-sched.c:1480
+ __run_hrtimer kernel/time/hrtimer.c:1685 [inline]
+ __hrtimer_run_queues+0x1c6/0xfb0 kernel/time/hrtimer.c:1749
+ hrtimer_interrupt+0x320/0x790 kernel/time/hrtimer.c:1811
+ local_apic_timer_interrupt arch/x86/kernel/apic/apic.c:1096 [inline]
+ __sysvec_apic_timer_interrupt+0x180/0x640 arch/x86/kernel/apic/apic.c:1113
+ sysvec_apic_timer_interrupt+0x92/0xc0 arch/x86/kernel/apic/apic.c:1107
+ </IRQ>
+ <TASK>
+ asm_sysvec_apic_timer_interrupt+0x1a/0x20 arch/x86/include/asm/idtentry.h:649
+RIP: 0010:kasan_mem_to_shadow include/linux/kasan.h:60 [inline]
+RIP: 0010:memory_is_poisoned_n mm/kasan/generic.c:129 [inline]
+RIP: 0010:memory_is_poisoned mm/kasan/generic.c:159 [inline]
+RIP: 0010:check_region_inline mm/kasan/generic.c:180 [inline]
+RIP: 0010:kasan_check_range+0x53/0x190 mm/kasan/generic.c:189
+Code: ff ff 48 39 c7 0f 86 05 01 00 00 49 83 e9 01 48 89 fd 48 b8 00 00 00 00 00 fc ff df 4d 89 ca 48 c1 ed 03 49 c1 ea 03 48 01 c5 <49> 01 c2 48 89 e8 49 8d 5a 01 48 89 da 48 29 ea 48 83 fa 10 7e 63
+RSP: 0018:ffffc900031af250 EFLAGS: 00000286
+RAX: dffffc0000000000 RBX: 0000000000000003 RCX: ffffffff8163f019
+RDX: 0000000000000000 RSI: 0000000000000008 RDI: ffffffff8e72d650
+RBP: fffffbfff1ce5aca R08: 0000000000000000 R09: ffffffff8e72d657
+R10: 1ffffffff1ce5aca R11: 0000000000000000 R12: ffffffff8c791a80
+R13: ffffc900031af4d8 R14: 0000000000000000 R15: ffffc900031af358
+ instrument_atomic_read include/linux/instrumented.h:72 [inline]
+ _test_bit include/asm-generic/bitops/instrumented-non-atomic.h:141 [inline]
+ cpumask_test_cpu include/linux/cpumask.h:444 [inline]
+ cpu_online include/linux/cpumask.h:1030 [inline]
+ trace_lock_release include/trace/events/lock.h:69 [inline]
+ lock_release+0xd9/0x810 kernel/locking/lockdep.c:5679
+ rcu_lock_release include/linux/rcupdate.h:330 [inline]
+ rcu_read_unlock include/linux/rcupdate.h:797 [inline]
+ xa_find+0x1a0/0x330 lib/xarray.c:2026
+ devlinks_xa_find_get.constprop.0+0x93/0x260 net/core/devlink.c:306
+ devlinks_xa_find_get_first net/core/devlink.c:334 [inline]
+ devlink_nl_cmd_port_get_dumpit+0x11d/0x4e0 net/core/devlink.c:1699
+ netlink_dump+0x570/0xc50 net/netlink/af_netlink.c:2286
+ __netlink_dump_start+0x64b/0x910 net/netlink/af_netlink.c:2391
+ genl_family_rcv_msg_dumpit+0x2be/0x310 net/netlink/genetlink.c:929
+ genl_family_rcv_msg net/netlink/genetlink.c:1045 [inline]
+ genl_rcv_msg+0x419/0x7e0 net/netlink/genetlink.c:1065
+ netlink_rcv_skb+0x165/0x440 net/netlink/af_netlink.c:2564
+ genl_rcv+0x28/0x40 net/netlink/genetlink.c:1076
+ netlink_unicast_kernel net/netlink/af_netlink.c:1330 [inline]
+ netlink_unicast+0x547/0x7f0 net/netlink/af_netlink.c:1356
+ netlink_sendmsg+0x91b/0xe10 net/netlink/af_netlink.c:1932
+ sock_sendmsg_nosec net/socket.c:714 [inline]
+ sock_sendmsg+0xd3/0x120 net/socket.c:734
+ __sys_sendto+0x23a/0x340 net/socket.c:2117
+ __do_sys_sendto net/socket.c:2129 [inline]
+ __se_sys_sendto net/socket.c:2125 [inline]
+ __x64_sys_sendto+0xe1/0x1b0 net/socket.c:2125
+ do_syscall_x64 arch/x86/entry/common.c:50 [inline]
+ do_syscall_64+0x39/0xb0 arch/x86/entry/common.c:80
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7fbf31c3e0dc
+Code: fa fa ff ff 44 8b 4c 24 2c 4c 8b 44 24 20 89 c5 44 8b 54 24 28 48 8b 54 24 18 b8 2c 00 00 00 48 8b 74 24 10 8b 7c 24 08 0f 05 <48> 3d 00 f0 ff ff 77 34 89 ef 48 89 44 24 08 e8 20 fb ff ff 48 8b
+RSP: 002b:00007fff97133d00 EFLAGS: 00000293 ORIG_RAX: 000000000000002c
+RAX: ffffffffffffffda RBX: 00007fbf328d4620 RCX: 00007fbf31c3e0dc
+RDX: 0000000000000034 RSI: 00007fbf328d4670 RDI: 0000000000000005
+RBP: 0000000000000000 R08: 00007fff97133d54 R09: 000000000000000c
+R10: 0000000000000000 R11: 0000000000000293 R12: 00007fff97133dc8
+R13: 00007fbf328d4670 R14: 0000000000000005 R15: 0000000000000000
+ </TASK>

--- a/pkg/report/testdata/linux/guilty/59
+++ b/pkg/report/testdata/linux/guilty/59
@@ -1,0 +1,56 @@
+FILE: kernel/smp.c
+
+
+watchdog: BUG: soft lockup - CPU#1 stuck for 23s! [syz-executor.2:3705]
+Modules linked in:
+irq event stamp: 7238
+hardirqs last  enabled at (7237): [<ffff80000bfb8138>] __exit_to_kernel_mode arch/arm64/kernel/entry-common.c:84 [inline]
+hardirqs last  enabled at (7237): [<ffff80000bfb8138>] exit_to_kernel_mode+0xe8/0x118 arch/arm64/kernel/entry-common.c:94
+hardirqs last disabled at (7238): [<ffff80000bfb6088>] __el1_irq arch/arm64/kernel/entry-common.c:467 [inline]
+hardirqs last disabled at (7238): [<ffff80000bfb6088>] el1_interrupt+0x24/0x68 arch/arm64/kernel/entry-common.c:485
+softirqs last  enabled at (3114): [<ffff8000080102e4>] _stext+0x2e4/0x37c
+softirqs last disabled at (2783): [<ffff800008017c14>] ____do_softirq+0x14/0x20 arch/arm64/kernel/irq.c:79
+CPU: 1 PID: 3705 Comm: syz-executor.2 Not tainted 6.0.0-rc7-syzkaller-18095-gbbed346d5a96 #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/30/2022
+pstate: 80400005 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+pc : csd_lock_wait kernel/smp.c:443 [inline]
+pc : smp_call_function_many_cond+0x958/0xa04 kernel/smp.c:988
+lr : csd_lock_wait kernel/smp.c:443 [inline]
+lr : smp_call_function_many_cond+0x964/0xa04 kernel/smp.c:988
+sp : ffff80001394b9c0
+x29: ffff80001394ba10 x28: 0000000000000008 x27: ffff0001fefefc80
+x26: ffff80000d309000 x25: 0000000000000001 x24: 0000000000000011
+x23: ffff80000d30cf28 x22: 0000000000000008 x21: ffffffffffffffff
+x20: ffff0001fefd7148 x19: 0000000000000000 x18: 00000000000000c0
+x17: ffff80000dd0b198 x16: 0000000000000000 x15: 0000000000000000
+x14: 0000000000000000 x13: 0000000000000406 x12: ffff80000d4552c8
+x11: ff808000082497ec x10: 0000000000000000 x9 : 0000000000000000
+x8 : 0000000000000011 x7 : ffff8000083d3920 x6 : 0000000000000000
+x5 : 0000000000000000 x4 : ffff8000086359b0 x3 : 0000000000000000
+x2 : 0000000000000006 x1 : 0000000000000001 x0 : 0000000000000000
+Call trace:
+ __cmpwait_case_32 arch/arm64/include/asm/cmpxchg.h:252 [inline]
+ __cmpwait arch/arm64/include/asm/cmpxchg.h:278 [inline]
+ csd_lock_wait kernel/smp.c:443 [inline]
+ smp_call_function_many_cond+0x958/0xa04 kernel/smp.c:988
+ on_each_cpu_cond_mask+0x5c/0xa4 kernel/smp.c:1154
+ on_each_cpu_cond include/linux/smp.h:105 [inline]
+ invalidate_bh_lrus+0x34/0x40 fs/buffer.c:1423
+ kill_bdev block/bdev.c:74 [inline]
+ blkdev_flush_mapping+0x84/0x190 block/bdev.c:661
+ blkdev_put_whole block/bdev.c:692 [inline]
+ blkdev_put+0x1e0/0x284 block/bdev.c:952
+ blkdev_close+0x24/0x38 block/fops.c:499
+ __fput+0x198/0x3dc fs/file_table.c:320
+ ____fput+0x20/0x30 fs/file_table.c:353
+ task_work_run+0xc4/0x14c kernel/task_work.c:177
+ exit_task_work include/linux/task_work.h:38 [inline]
+ do_exit+0x26c/0xbe0 kernel/exit.c:795
+ do_group_exit+0x70/0xe8 kernel/exit.c:925
+ get_signal+0xb0c/0xb40 kernel/signal.c:2857
+ do_signal+0x128/0x438 arch/arm64/kernel/signal.c:1071
+ do_notify_resume+0xc0/0x1f0 arch/arm64/kernel/signal.c:1124
+ prepare_exit_to_user_mode arch/arm64/kernel/entry-common.c:137 [inline]
+ exit_to_user_mode arch/arm64/kernel/entry-common.c:142 [inline]
+ asm_exit_to_user_mode+0x70/0x84 arch/arm64/kernel/entry-common.c:149
+ ret_from_fork+0x1c/0x20 arch/arm64/kernel/entry.S:863

--- a/pkg/report/testdata/linux/guilty/60
+++ b/pkg/report/testdata/linux/guilty/60
@@ -1,0 +1,81 @@
+FILE: net/core/skmsg.c
+
+
+rcu: INFO: rcu_sched self-detected stall on CPU
+rcu: 	1-...!: (10499 ticks this GP) idle=9f9/1/0x4000000000000002 softirq=2116/2117 fqs=0 
+	(t=10500 jiffies g=989 q=72)
+rcu: rcu_sched kthread starved for 10500 jiffies! g989 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x0 ->cpu=0
+rcu: 	Unless rcu_sched kthread gets sufficient CPU time, OOM is now expected behavior.
+rcu: RCU grace-period kthread stack dump:
+task:rcu_sched       state:R  running task on cpu   0   stack:    0 pid:   13 ppid:     2 flags:123x00000008
+Call trace:
+ __switch_to+0x330/0x614 arch/arm64/kernel/process.c:123
+ context_switch kernel/sched/core.c:123 [inline]
+ __schedule+0x858/0xfc0 kernel/sched/core.c:123
+ schedule+0x17c/0x37c kernel/sched/core.c:123
+ schedule_timeout+0x1c8/0x334 kernel/time/timer.c:123
+ rcu_gp_fqs_loop+0x238/0x1124 kernel/rcu/tree.c:123
+ rcu_gp_kthread+0xb4/0x240 kernel/rcu/tree.c:123
+ kthread+0x37c/0x4c0 kernel/kthread.c:123
+ ret_from_fork+0x10/0x20 arch/arm64/kernel/entry.S:123
+rcu: Stack dump where RCU GP kthread last ran:
+Task dump for CPU 0:
+task:syz-executor913 state:R  running task on cpu   0   stack:    0 pid: 1432 ppid:  1414 flags:123x00000002
+Call trace:
+ __switch_to+0x330/0x614 arch/arm64/kernel/process.c:123
+ 0x202
+Task dump for CPU 1:
+task:syz-executor913 state:R  running task on cpu   1   stack:    0 pid: 1429 ppid:  1407 flags:123x00000002
+Call trace:
+ walk_stackframe+0xa4/0xa8 arch/arm64/kernel/stacktrace.c:123
+ show_stack+0x2c/0x3c arch/arm64/kernel/stacktrace.c:123
+ _sched_show_task+0x488/0x670
+ sched_show_task kernel/sched/core.c:123 [inline]
+ dump_cpu_task+0x88/0xac kernel/sched/core.c:123
+ rcu_dump_cpu_stacks+0x294/0x518 kernel/rcu/tree_stall.h:123
+ print_cpu_stall+0x4cc/0xc2c kernel/rcu/tree_stall.h:123
+ check_cpu_stall+0x2ec/0x17d0 kernel/rcu/tree_stall.h:123
+ rcu_pending kernel/rcu/tree.c:123 [inline]
+ rcu_sched_clock_irq+0x2e8/0xb38 kernel/rcu/tree.c:123
+ update_process_times+0x190/0x214 kernel/time/timer.c:123
+ tick_sched_handle kernel/time/tick-sched.c:123 [inline]
+ tick_sched_timer+0x22c/0x3c0 kernel/time/tick-sched.c:123
+ __run_hrtimer kernel/time/hrtimer.c:123 [inline]
+ __hrtimer_run_queues+0x3c0/0x864 kernel/time/hrtimer.c:123
+ hrtimer_interrupt+0x2b4/0xbec kernel/time/hrtimer.c:123
+ timer_handler drivers/clocksource/arm_arch_timer.c:123 [inline]
+ arch_timer_handler_virt+0x74/0x88 drivers/clocksource/arm_arch_timer.c:123
+ handle_percpu_devid_irq+0x15c/0x320 kernel/irq/chip.c:123
+ generic_handle_irq_desc include/linux/irqdesc.h:123 [inline]
+ handle_irq_desc kernel/irq/irqdesc.c:123 [inline]
+ handle_domain_irq+0xc8/0x138 kernel/irq/irqdesc.c:123
+ gic_handle_irq+0xac/0x1f4 drivers/irqchip/irq-gic-v3.c:123
+ call_on_irq_stack+0x2c/0x54 arch/arm64/kernel/entry.S:123
+ do_interrupt_handler+0x78/0x98 arch/arm64/kernel/entry-common.c:123
+ el1_interrupt+0x30/0x48 arch/arm64/kernel/entry-common.c:123
+ el1h_64_irq_handler+0x18/0x24 arch/arm64/kernel/entry-common.c:123
+ el1h_64_irq+0x7c/0x80 arch/arm64/kernel/entry.S:123
+ arch_local_irq_restore arch/arm64/include/asm/irqflags.h:123 [inline]
+ lock_acquire+0x214/0x650 kernel/locking/lockdep.c:123
+ __raw_spin_lock_bh include/linux/spinlock_api_smp.h:123 [inline]
+ _raw_spin_lock_bh+0x124/0x1c4 kernel/locking/spinlock.c:123
+ spin_lock_bh include/linux/spinlock.h:123 [inline]
+ sk_psock_peek_msg include/linux/skmsg.h:123 [inline]
+ sk_msg_recvmsg+0x58/0xb7c net/core/skmsg.c:123
+ tcp_bpf_recvmsg_parser+0xdc/0x45c net/ipv4/tcp_bpf.c:123
+ inet_recvmsg+0x128/0x214 net/ipv4/af_inet.c:123
+ ____sys_recvmsg+0x1d0/0xecc
+ ___sys_recvmsg net/socket.c:123 [inline]
+ do_recvmmsg+0x738/0x17a0 net/socket.c:123
+ __sys_recvmmsg net/socket.c:123 [inline]
+ __do_sys_recvmmsg net/socket.c:123 [inline]
+ __se_sys_recvmmsg net/socket.c:123 [inline]
+ __arm64_sys_recvmmsg+0x170/0x22c net/socket.c:123
+ __invoke_syscall arch/arm64/kernel/syscall.c:123 [inline]
+ invoke_syscall+0x94/0x2c8 arch/arm64/kernel/syscall.c:123
+ el0_svc_common+0x144/0x3d0 arch/arm64/kernel/syscall.c:123
+ do_el0_svc+0x58/0x12c arch/arm64/kernel/syscall.c:123
+ el0_svc+0x78/0x200 arch/arm64/kernel/entry-common.c:123
+ el0t_64_sync_handler+0x84/0xe4 arch/arm64/kernel/entry-common.c:123
+ el0t_64_sync+0x1a4/0x1a8 arch/arm64/kernel/entry.S:123
+ 


### PR DESCRIPTION
The existing code is broken - the console output does not contain a whitespace before the apic_timer_interrupt frame. Also, it makes sense to cut not from its first, but rather from its last occurence.

