### PR TITLE
pkg/build: rename android.go to cuttlefish.go

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -133,7 +133,7 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		if vmType == "gvisor" {
 			return gvisor{}, nil
 		} else if vmType == "cuttlefish" {
-			return android{}, nil
+			return cuttlefish{}, nil
 		}
 	}
 	builders := map[string]builder{


### PR DESCRIPTION
Building images for physical Android devices has different logic and options and should be in separate files. This makes it less ambiguous and frees up android.go for Android device code.
