### PR TITLE
dashboard: protect cron endpoints

### DIFF
--- a/dashboard/app/kcidb.go
+++ b/dashboard/app/kcidb.go
@@ -16,7 +16,7 @@ import (
 )
 
 func initKcidb() {
-	http.HandleFunc("/kcidb_poll", handleKcidbPoll)
+	http.HandleFunc("/kcidb_poll", cronWrapper(handleKcidbPoll))
 }
 
 func handleKcidbPoll(w http.ResponseWriter, r *http.Request) {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -61,9 +61,9 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/repos", handlerWrapper(handleRepos))
 		http.Handle("/"+ns+"/bug-stats", handlerWrapper(handleBugStats))
 	}
-	http.HandleFunc("/cache_update", cacheUpdate)
-	http.HandleFunc("/deprecate_assets", handleDeprecateAssets)
-	http.HandleFunc("/retest_repros", handleRetestRepros)
+	http.HandleFunc("/cache_update", cronWrapper(cacheUpdate))
+	http.HandleFunc("/deprecate_assets", cronWrapper(handleDeprecateAssets))
+	http.HandleFunc("/retest_repros", cronWrapper(handleRetestRepros))
 }
 
 type uiMainPage struct {


### PR DESCRIPTION
Authorize requests to cron handlers. Only permit them from the authenticated administrators or from the App Engine itself.

See https://cloud.google.com/appengine/docs/flexible/scheduling-jobs-with-cron-yaml#securing_urls_for_cron