### PR TITLE
dashboard: move all cron endpoints to cron/

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -25,7 +25,7 @@ handlers:
 - url: /static
   static_dir: static
   secure: always
-- url: /(admin|email_poll|cache_update|kcidb_poll|deprecate_assets)
+- url: /(admin|cron/.*)
   script: auto
   login: admin
   secure: always

--- a/dashboard/app/asset_storage_test.go
+++ b/dashboard/app/asset_storage_test.go
@@ -117,7 +117,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.`,
 
 	// Invalidate the bug.
 	c.client.updateBug(extBugID, dashapi.BugStatusInvalid, "")
-	_, err = c.GET("/deprecate_assets")
+	_, err = c.GET("/cron/deprecate_assets")
 	c.expectOK(err)
 
 	// Query the needed assets once more, so far there should be no change.
@@ -128,7 +128,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.`,
 
 	// Skip one month and deprecate assets.
 	c.advanceTime(time.Hour * 24 * 31)
-	_, err = c.GET("/deprecate_assets")
+	_, err = c.GET("/cron/deprecate_assets")
 	c.expectOK(err)
 
 	// Only the html asset should have persisted.
@@ -194,7 +194,7 @@ func TestCoverReportDeprecation(t *testing.T) {
 	defer c.Close()
 
 	ensureNeeded := func(needed []string) {
-		_, err := c.GET("/deprecate_assets")
+		_, err := c.GET("/cron/deprecate_assets")
 		c.expectOK(err)
 		neededResp, err := c.client.NeededAssetsList()
 		c.expectOK(err)
@@ -270,7 +270,7 @@ func TestFreshBuildAssets(t *testing.T) {
 	defer c.Close()
 
 	ensureNeeded := func(needed []string) {
-		_, err := c.GET("/deprecate_assets")
+		_, err := c.GET("/cron/deprecate_assets")
 		c.expectOK(err)
 		neededResp, err := c.client.NeededAssetsList()
 		c.expectOK(err)
@@ -395,7 +395,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.`,
 
 	// Invalidate the bug.
 	c.client.updateBug(extBugID, dashapi.BugStatusInvalid, "")
-	_, err = c.GET("/deprecate_assets")
+	_, err = c.GET("/cron/deprecate_assets")
 	c.expectOK(err)
 
 	// Query the needed assets once more, so far there should be no change.
@@ -406,7 +406,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.`,
 
 	// Skip one month and deprecate assets.
 	c.advanceTime(time.Hour * 24 * 31)
-	_, err = c.GET("/deprecate_assets")
+	_, err = c.GET("/cron/deprecate_assets")
 	c.expectOK(err)
 
 	// Nothing should have been persisted.

--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -4,13 +4,13 @@
 cron:
 - url: /email_poll
   schedule: every 1 minutes
-- url: /cache_update
+- url: /cron/cache_update
   schedule: every 1 hours
-- url: /deprecate_assets
+- url: /cron/deprecate_assets
   schedule: every 1 hours
-- url: /kcidb_poll
+- url: /cron/kcidb_poll
   schedule: every 5 minutes
-- url: /retest_repros
+- url: /cron/retest_repros
   schedule: every 1 hours
 - url: /_ah/datastore_admin/backup.create?name=backup&filesystem=gs&gs_bucket_name=syzkaller-backups&kind=Bug&kind=Build&kind=Crash&kind=CrashLog&kind=CrashReport&kind=Error&kind=Job&kind=KernelConfig&kind=Manager&kind=ManagerStats&kind=Patch&kind=ReportingState&kind=ReproC&kind=ReproSyz
   schedule: every monday 00:00

--- a/dashboard/app/kcidb.go
+++ b/dashboard/app/kcidb.go
@@ -16,7 +16,7 @@ import (
 )
 
 func initKcidb() {
-	http.HandleFunc("/kcidb_poll", handleKcidbPoll)
+	http.HandleFunc("/cron/kcidb_poll", handleKcidbPoll)
 }
 
 func handleKcidbPoll(w http.ResponseWriter, r *http.Request) {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -61,9 +61,9 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/repos", handlerWrapper(handleRepos))
 		http.Handle("/"+ns+"/bug-stats", handlerWrapper(handleBugStats))
 	}
-	http.HandleFunc("/cache_update", cacheUpdate)
-	http.HandleFunc("/deprecate_assets", handleDeprecateAssets)
-	http.HandleFunc("/retest_repros", handleRetestRepros)
+	http.HandleFunc("/cron/cache_update", cacheUpdate)
+	http.HandleFunc("/cron/deprecate_assets", handleDeprecateAssets)
+	http.HandleFunc("/cron/retest_repros", handleRetestRepros)
 }
 
 type uiMainPage struct {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -364,7 +364,7 @@ func (c *Ctx) expectNoEmail() {
 }
 
 func (c *Ctx) updRetestReproJobs() {
-	_, err := c.GET("/retest_repros")
+	_, err := c.GET("/cron/retest_repros")
 	c.expectOK(err)
 }
 


### PR DESCRIPTION
This lets us keep only one access rule and reliefs from the need to keep handlers and app.yaml in sync for cron jobs that'll be added in the future.