### PR TITLE
openbsd: __syscall is gone by now

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -11,6 +11,20 @@
 #include <string.h>
 #include <sys/syscall.h>
 
+#if GOOS_openbsd
+// Needed syscall libc stubs.
+#include <poll.h>
+#include <sys/event.h>
+#include <sys/ioctl.h>
+#include <sys/ktrace.h>
+#include <sys/mman.h>
+#include <sys/msg.h>
+#include <sys/sem.h>
+#include <sys/shm.h>
+#include <sys/sysctl.h>
+#include <sys/syslog.h>
+#endif
+
 #if GOOS_netbsd
 
 #if SYZ_EXECUTOR || __NR_syz_usb_connect

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -11,10 +11,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if GOOS_openbsd
-#include <sys/sysctl.h>
-#endif
-
 static void os_init(int argc, char** argv, void* data, size_t data_size)
 {
 #if GOOS_openbsd

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -313,11 +313,13 @@ func newSyscallData(target *targets.Target, sc *prog.Syscall, attrs []uint64) Sy
 	if !patchCallName {
 		callName = sc.CallName
 	}
+	needCall := (!target.SyscallNumbers || strings.HasPrefix(sc.CallName, "syz_") ||
+		patchCallName || target.OS == "openbsd") && !sc.Attrs.Disabled
 	return SyscallData{
 		Name:     sc.Name,
 		CallName: callName,
 		NR:       int32(sc.NR),
-		NeedCall: (!target.SyscallNumbers || strings.HasPrefix(sc.CallName, "syz_") || patchCallName) && !sc.Attrs.Disabled,
+		NeedCall: needCall,
 		Attrs:    attrs,
 	}
 }


### PR DESCRIPTION
We therefore need to use the provided libc stubs. This diff forces execute_syscall() to use the supplied function pointer as opposed of using __syscall.