### PR TITLE
prog: add a new DupCallCollide collide type

### DIFF
--- a/prog/clone.go
+++ b/prog/clone.go
@@ -20,19 +20,23 @@ func (p *Prog) Clone() *Prog {
 func cloneCalls(origCalls []*Call, newargs map[*ResultArg]*ResultArg) []*Call {
 	calls := make([]*Call, len(origCalls))
 	for ci, c := range origCalls {
-		c1 := new(Call)
-		c1.Meta = c.Meta
-		if c.Ret != nil {
-			c1.Ret = clone(c.Ret, newargs).(*ResultArg)
-		}
-		c1.Args = make([]Arg, len(c.Args))
-		for ai, arg := range c.Args {
-			c1.Args[ai] = clone(arg, newargs)
-		}
-		c1.Props = c.Props
-		calls[ci] = c1
+		calls[ci] = cloneCall(c, newargs)
 	}
 	return calls
+}
+
+func cloneCall(c *Call, newargs map[*ResultArg]*ResultArg) *Call {
+	c1 := new(Call)
+	c1.Meta = c.Meta
+	if c.Ret != nil {
+		c1.Ret = clone(c.Ret, newargs).(*ResultArg)
+	}
+	c1.Args = make([]Arg, len(c.Args))
+	for ai, arg := range c.Args {
+		c1.Args[ai] = clone(arg, newargs)
+	}
+	c1.Props = c.Props
+	return c1
 }
 
 func clone(arg Arg, newargs map[*ResultArg]*ResultArg) Arg {

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -294,9 +294,16 @@ func (proc *Proc) executeAndCollide(execOpts *ipc.ExecOpts, p *prog.Prog, flags 
 }
 
 func (proc *Proc) randomCollide(origP *prog.Prog) *prog.Prog {
-	// Old-styl collide with a 33% probability.
-	if proc.rnd.Intn(3) == 0 {
+	if proc.rnd.Intn(5) == 0 {
+		// Old-style collide with a 20% probability.
 		p, err := prog.DoubleExecCollide(origP, proc.rnd)
+		if err == nil {
+			return p
+		}
+	}
+	if proc.rnd.Intn(4) == 0 {
+		// Duplicate random calls with a 20% probability (25% * 80%).
+		p, err := prog.DupCallCollide(origP, proc.rnd)
 		if err == nil {
 			return p
 		}


### PR DESCRIPTION
It duplicates random calls in a program and makes the duplicated copies async.

E.g. it could transform
```
r0 = test()
test2(r0)
```
to
```
r0 = test()
test2(r0) (async)
test2(r0)
```
or
```
test() (async)
r0 = test()
test2(r0)
```
