### PR TITLE
dashboard: move /email_poll to /cron/email_poll

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 cron:
-- url: /email_poll
+- url: /cron/email_poll
   schedule: every 1 minutes
 - url: /cron/cache_update
   schedule: every 1 hours

--- a/dashboard/app/graphs_test.go
+++ b/dashboard/app/graphs_test.go
@@ -81,7 +81,7 @@ func TestManagersGraphs(t *testing.T) {
 
 	for {
 		c.advanceTime(7 * 25 * time.Hour)
-		_, err := c.GET("/email_poll")
+		_, err := c.GET("/cron/email_poll")
 		c.expectOK(err)
 		if len(c.emailSink) == 0 {
 			break

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -30,7 +30,7 @@ import (
 // Email reporting interface.
 
 func initEmailReporting() {
-	http.HandleFunc("/email_poll", handleEmailPoll)
+	http.HandleFunc("/cron/email_poll", handleEmailPoll)
 	http.HandleFunc("/_ah/mail/", handleIncomingMail)
 	http.HandleFunc("/_ah/bounce", handleEmailBounce)
 

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -187,7 +187,7 @@ func (c *Ctx) Close() {
 			c.expectOK(err)
 		}
 		// No pending emails (tests need to consume them).
-		_, err = c.GET("/email_poll")
+		_, err = c.GET("/cron/email_poll")
 		c.expectOK(err)
 		for len(c.emailSink) != 0 {
 			c.t.Errorf("ERROR: leftover email: %v", (<-c.emailSink).Body)
@@ -344,7 +344,7 @@ func (c *Ctx) checkURLContents(url string, want []byte) {
 }
 
 func (c *Ctx) pollEmailBug() *aemail.Message {
-	_, err := c.GET("/email_poll")
+	_, err := c.GET("/cron/email_poll")
 	c.expectOK(err)
 	if len(c.emailSink) == 0 {
 		c.t.Helper()
@@ -354,7 +354,7 @@ func (c *Ctx) pollEmailBug() *aemail.Message {
 }
 
 func (c *Ctx) expectNoEmail() {
-	_, err := c.GET("/email_poll")
+	_, err := c.GET("/cron/email_poll")
 	c.expectOK(err)
 	if len(c.emailSink) != 0 {
 		msg := <-c.emailSink


### PR DESCRIPTION
Currently it's the only cron job that is still occupying a top level URL.
