### PR TITLE
dashboard: display subsystems on the bug page

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -16,6 +16,12 @@ Page with details about a single bug.
 
 	<b>{{.Bug.Title}}</b><br><br>
 	Status: {{if .Bug.ExternalLink}}<a href="{{.Bug.ExternalLink}}">{{.Bug.Status}}</a>{{else}}{{.Bug.Status}}{{end}}<br>
+	{{if .Subsystems}}
+		Subsystems: {{range .Subsystems}}
+			<span class="subsystem">{{link .Link .Name}}</span>
+		{{- end}}
+		<br>
+	{{- end}}
 	Reported-by: {{.Bug.CreditEmail}}<br>
 	{{if .Bug.Commits}}
 		<b>Fix commit:</b> {{template "fix_commits" .Bug.Commits}}<br>

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -190,6 +190,7 @@ type uiBugPage struct {
 	Crashes       *uiCrashTable
 	FixBisections *uiCrashTable
 	TestPatchJobs *uiJobList
+	Subsystems    []*uiBugSubsystem
 }
 
 type uiBugGroup struct {
@@ -558,6 +559,12 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 			PerBug: true,
 			Jobs:   testPatchJobs,
 		},
+	}
+	for _, entry := range bug.Tags.Subsystems {
+		data.Subsystems = append(data.Subsystems, &uiBugSubsystem{
+			Name: entry.Name,
+			Link: html.AmendURL("/"+bug.Namespace, "subsystem", entry.Name),
+		})
 	}
 	// bug.BisectFix is set to BisectNot in two cases :
 	// - no fix bisections have been performed on the bug

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -194,7 +194,7 @@ table td, table th {
 	display: inline-block;
 }
 
-.list_table .subsystem {
+.subsystem {
 	background: white;
 	border: 1pt solid black;
 	display: inline-block;
@@ -204,7 +204,7 @@ table td, table th {
 	font-size: small;
 }
 
-.list_table .subsystem a {
+.subsystem a {
 	text-decoration: none;
 	color: black;
 }


### PR DESCRIPTION
Currently the information is only displayed on the main page, which is not very convenient.