### PR TITLE
prog: reject escaping filenames during deserialization

### DIFF
--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -335,6 +335,13 @@ func TestDeserialize(t *testing.T) {
 			In:  `test$str2(&(0x7f0000000000)="$eJwqrqzKTszJSS0CBAAA//8TyQPi`,
 			Err: `want ", got EOF`,
 		},
+		{
+			In: `mutate9(&(0x7f0000000000)='./local/filename\x00')`,
+		},
+		{
+			In:  `mutate9(&(0x7f0000000000)='/escaping/filename\x00')`,
+			Err: `escaping filename`,
+		},
 	})
 }
 

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -182,6 +182,10 @@ func (arg *DataArg) validate(ctx *validCtx) error {
 			return fmt.Errorf("string arg '%v' has size %v, which should be %v",
 				typ.Name(), arg.Size(), typ.TypeSize)
 		}
+	case BufferFilename:
+		if escapingFilename(string(arg.data)) {
+			return fmt.Errorf("escaping filename %q", arg.data)
+		}
 	}
 	return nil
 }

--- a/sys/linux/test/gup_fast
+++ b/sys/linux/test/gup_fast
@@ -7,7 +7,7 @@ r0 = openat$urandom(0xffffffffffffff9c, &AUTO='/dev/urandom\x00', 0x0, 0x0)
 read(r0, &(0x7f0000000000), 0x2000)
 close(r0)
 
-r1 = openat(0xffffffffffffff9c, &AUTO='/proc/self/exe\x00', 0x105000, 0x0)
+r1 = openat(0xffffffffffffff9c, &AUTO='./file1\x00', 0x105042, 0x1ff)
 read(r1, &(0x7f0000000000), 0x2000)
 close(r1)
 munmap(&(0x7f0000000000/0x2000), 0x2000)


### PR DESCRIPTION
We already try as hard as possible to not generate escaping (global) filenames.
However, it's possible we read them from the corpus if it happens to contain some.
Also check for escaping filenames during deserialization.

Fixes #3678
