### PR TITLE
tools/syz-cover: use absolute paths

### DIFF
--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -54,12 +54,15 @@ func main() {
 	if *flagKernelSrc == "" {
 		*flagKernelSrc = "."
 	}
+	*flagKernelSrc = osutil.Abs(*flagKernelSrc)
 	if *flagKernelObj == "" {
 		*flagKernelObj = *flagKernelSrc
 	}
+	*flagKernelObj = osutil.Abs(*flagKernelObj)
 	if *flagKernelBuildSrc == "" {
 		*flagKernelBuildSrc = *flagKernelSrc
 	}
+	*flagKernelBuildSrc = osutil.Abs(*flagKernelBuildSrc)
 	target := targets.Get(*flagOS, *flagArch)
 	if target == nil {
 		tool.Failf("unknown target %v/%v", *flagOS, *flagArch)


### PR DESCRIPTION
pkg/cover expects absolute paths and mis-handles paths if they are relative.
Abs-ulitize all paths.

Fixes #3686
