### PR TITLE
vm/proxyapp: pass kernel image data to ProxyApp

### DIFF
--- a/vm/proxyapp/proxyrpc/proxyrpc.go
+++ b/vm/proxyapp/proxyrpc/proxyrpc.go
@@ -18,8 +18,10 @@ type ProxyAppInterface interface {
 }
 
 type CreatePoolParams struct {
-	Debug bool
-	Param string
+	Debug     bool
+	Param     string
+	Image     string
+	ImageData []byte
 }
 
 type CreatePoolResult struct {


### PR DESCRIPTION
We need the kernel built by Syzkaller to start the VM.

If transfer_file_content is set, pass the image data in addition to the path.
