### PR TITLE
dvyukov coverage restore pc fix

### DIFF
--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/syzkaller/pkg/host"
@@ -17,6 +18,23 @@ import (
 
 func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
 	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
+	var pcFixUpStart, pcFixUpEnd, pcFixUpOffset uint64
+	if target.Arch == targets.ARM64 {
+		// On arm64 as PLT is enabled by default, .text section is loaded after .plt section,
+		// so there is 0x18 bytes offset from module load address for .text section
+		// we need to remove the 0x18 bytes offset in order to correct module symbol address
+		// TODO: obtain these values from the binary instead of hardcoding.
+		file, err := elf.Open(filepath.Join(objDir, target.KernelObject))
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+		if file.Section(".plt") != nil {
+			pcFixUpStart = 0x8000000000000000
+			pcFixUpEnd = 0xffffffd010000000
+			pcFixUpOffset = 0x18
+		}
+	}
 	return makeDWARF(&dwarfParams{
 		target:                target,
 		objDir:                objDir,
@@ -24,6 +42,9 @@ func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
 		buildDir:              buildDir,
 		moduleObj:             moduleObj,
 		hostModules:           hostModules,
+		pcFixUpStart:          pcFixUpStart,
+		pcFixUpEnd:            pcFixUpEnd,
+		pcFixUpOffset:         pcFixUpOffset,
 		readSymbols:           elfReadSymbols,
 		readTextData:          elfReadTextData,
 		readModuleCoverPoints: elfReadModuleCoverPoints,

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -36,6 +36,7 @@ func elfReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	text := file.Section(".text")
 	if text == nil {
 		return nil, fmt.Errorf("no .text section in the object file")
@@ -87,6 +88,7 @@ func elfReadTextRanges(module *Module) ([]pcRange, []*CompileUnit, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	defer file.Close()
 	text := file.Section(".text")
 	if text == nil {
 		return nil, nil, fmt.Errorf("no .text section in the object file")
@@ -130,6 +132,7 @@ func elfReadTextData(module *Module) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	text := file.Section(".text")
 	if text == nil {
 		return nil, fmt.Errorf("no .text section in the object file")
@@ -143,6 +146,7 @@ func elfReadModuleCoverPoints(target *targets.Target, module *Module, info *symb
 	if err != nil {
 		return pcs, err
 	}
+	defer file.Close()
 	callRelocType := arches[target.Arch].callRelocType
 	relaOffset := arches[target.Arch].relaOffset
 	for _, s := range file.Sections {

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -17,14 +17,18 @@ import (
 
 func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
 	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
-	return makeDWARF(target, objDir, srcDir, buildDir, moduleObj, hostModules,
-		&containerFns{
-			readSymbols:           elfReadSymbols,
-			readTextData:          elfReadTextData,
-			readModuleCoverPoints: elfReadModuleCoverPoints,
-			readTextRanges:        elfReadTextRanges,
-		},
-	)
+	return makeDWARF(&dwarfParams{
+		target:                target,
+		objDir:                objDir,
+		srcDir:                srcDir,
+		buildDir:              buildDir,
+		moduleObj:             moduleObj,
+		hostModules:           hostModules,
+		readSymbols:           elfReadSymbols,
+		readTextData:          elfReadTextData,
+		readModuleCoverPoints: elfReadModuleCoverPoints,
+		readTextRanges:        elfReadTextRanges,
+	})
 }
 
 func elfReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {

--- a/pkg/cover/backend/mach-o.go
+++ b/pkg/cover/backend/mach-o.go
@@ -16,14 +16,18 @@ import (
 
 func makeMachO(target *targets.Target, objDir, srcDir, buildDir string,
 	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
-	return makeDWARF(target, objDir, srcDir, buildDir, moduleObj, hostModules,
-		&containerFns{
-			readSymbols:           machoReadSymbols,
-			readTextData:          machoReadTextData,
-			readModuleCoverPoints: machoReadModuleCoverPoints,
-			readTextRanges:        machoReadTextRanges,
-		},
-	)
+	return makeDWARF(&dwarfParams{
+		target:                target,
+		objDir:                objDir,
+		srcDir:                srcDir,
+		buildDir:              buildDir,
+		moduleObj:             moduleObj,
+		hostModules:           hostModules,
+		readSymbols:           machoReadSymbols,
+		readTextData:          machoReadTextData,
+		readModuleCoverPoints: machoReadModuleCoverPoints,
+		readTextRanges:        machoReadTextRanges,
+	})
 }
 
 func machoReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/mgrconfig"
-	"github.com/google/syzkaller/sys/targets"
 )
 
 func (rg *ReportGenerator) DoHTML(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
@@ -510,24 +509,6 @@ func fixUpPCs(target string, progs []Prog, coverFilter map[uint32]uint32) []Prog
 				if coverFilter[uint32(pc)] != 0 {
 					nPCs = append(nPCs, pc)
 				}
-			}
-			progs[i].PCs = nPCs
-		}
-	}
-
-	// On arm64 as PLT is enabled by default, .text section is loaded after .plt section,
-	// so there is 0x18 bytes offset from module load address for .text section
-	// we need to remove the 0x18 bytes offset in order to correct module symbol address
-	if target == targets.ARM64 {
-		for i, prog := range progs {
-			var nPCs []uint64
-			for _, pc := range prog.PCs {
-				// TODO: avoid to hardcode the address
-				// Fix up kernel PCs, but not the test (userspace) PCs.
-				if pc >= 0x8000000000000000 && pc < 0xffffffd010000000 {
-					pc -= 0x18
-				}
-				nPCs = append(nPCs, pc)
 			}
 			progs[i].PCs = nPCs
 		}


### PR DESCRIPTION
- pkg/cover: move a helper function from the top of the file
- pkg/cover: move PC fix up into RestorePC
- pkg/cover/backend: group dwarf parameters in a struct
- pkg/cover/backend: close ELF files
- pkg/cover/backend: apply PC fix up only if .plt section is present
