### PR TITLE
dashboard: refresh subsystems more often

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1567,7 +1567,7 @@ func handleRetestRepros(w http.ResponseWriter, r *http.Request) {
 
 func handleRefreshSubsystems(w http.ResponseWriter, r *http.Request) {
 	c := appengine.NewContext(r)
-	const updateBugsCount = 20
+	const updateBugsCount = 25
 	for ns := range config.Namespaces {
 		err := reassignBugSubsystems(c, ns, updateBugsCount)
 		if err != nil {

--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -13,7 +13,7 @@ cron:
 - url: /cron/retest_repros
   schedule: every 1 hours
 - url: /cron/refresh_subsystems
-  schedule: every 20 minutes
+  schedule: every 15 minutes
 - url: /_ah/datastore_admin/backup.create?name=backup&filesystem=gs&gs_bucket_name=syzkaller-backups&kind=Bug&kind=Build&kind=Crash&kind=CrashLog&kind=CrashReport&kind=Error&kind=Job&kind=KernelConfig&kind=Manager&kind=ManagerStats&kind=Patch&kind=ReportingState&kind=ReproC&kind=ReproSyz
   schedule: every monday 00:00
   target: ah-builtin-python-bundle


### PR DESCRIPTION
Increase the rate by 66% to ~2400 bugs per day.
