### PR TITLE
prog: reset sum after assigning priority

### DIFF
--- a/prog/prio.go
+++ b/prog/prio.go
@@ -235,6 +235,7 @@ func (target *Target) BuildChoiceTable(corpus []*Prog, enabled map[*Syscall]bool
 				sum += prios[i][j]
 			}
 			run[i][j] = sum
+			sum = 0
 		}
 	}
 	return &ChoiceTable{target, run, generatableCalls, noGenerateCalls}


### PR DESCRIPTION
Currently the priority values assigned to the runs for each 
system call are monotonically increasing. This results in
syscalls at the end having the highest values, which does
not reflect priorities.

