### PR TITLE
dashboard: include subsystem links in BugReport

### DIFF
--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -557,7 +557,10 @@ func fillBugReport(c context.Context, rep *dashapi.BugReport, bug *Bug, bugRepor
 	rep.SyzkallerCommit = build.SyzkallerCommit
 	rep.NoRepro = build.Type == BuildFailed
 	for _, item := range bug.Tags.Subsystems {
-		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{Name: item.Name})
+		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{
+			Name: item.Name,
+			Link: fmt.Sprintf("%v/%s/s/%s", appURL(c), bug.Namespace, item.Name),
+		})
 		rep.Maintainers = email.MergeEmailLists(rep.Maintainers,
 			subsystemMaintainers(c, rep.Namespace, item.Name))
 	}

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -32,6 +32,7 @@ func TestReportBug(t *testing.T) {
 		Flags:       dashapi.CrashUnderStrace,
 		Report:      []byte("report1"),
 		MachineInfo: []byte("machine info 1"),
+		GuiltyFiles: []string{"a.c"},
 	}
 	c.client.ReportCrash(crash1)
 
@@ -59,7 +60,7 @@ func TestReportBug(t *testing.T) {
 		Title:             "title1",
 		Link:              fmt.Sprintf("https://testapp.appspot.com/bug?extid=%v", rep.ID),
 		CreditEmail:       fmt.Sprintf("syzbot+%v@testapp.appspotmail.com", rep.ID),
-		Maintainers:       []string{"bar@foo.com", "foo@bar.com"},
+		Maintainers:       []string{"bar@foo.com", "foo@bar.com", "subsystemA@list.com", "subsystemA@person.com"},
 		CompilerID:        "compiler1",
 		BuildID:           "build1",
 		BuildTime:         timeNow(c.ctx),
@@ -85,7 +86,13 @@ func TestReportBug(t *testing.T) {
 		NumCrashes:        1,
 		HappenedOn:        []string{"repo1 branch1"},
 		Assets:            []dashapi.Asset{},
-		ReportElements:    &dashapi.ReportElements{},
+		ReportElements:    &dashapi.ReportElements{GuiltyFiles: []string{"a.c"}},
+		Subsystems: []dashapi.BugSubsystem{
+			{
+				Name: "subsystemA",
+				Link: "https://testapp.appspot.com/test1/s/subsystemA",
+			},
+		},
 	}
 	c.expectEQ(want, rep)
 

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -421,6 +421,7 @@ type ReportElements struct {
 
 type BugSubsystem struct {
 	Name string
+	Link string
 }
 
 type Asset struct {


### PR DESCRIPTION
Include the link to the subsystem page on the dashboard.

