### PR TITLE
pkg/report: improve Go throw/panic parsing

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -17,9 +17,6 @@ func ctorGvisor(cfg *config) (reporterImpl, []string, error) {
 		config: cfg,
 	}
 	suppressions := []string{
-		"fatal error: runtime: out of memory",
-		"fatal error: runtime: cannot allocate memory",
-		"fatal error: newosproc",
 		"panic: ptrace sysemu failed: no such process",                                          // OOM kill
 		`panic: ptrace (s|g)et fpregs.* failed: no such process`,                                // OOM kill
 		`panic: ptrace (s|g)et regs.* failed: no such process`,                                  // OOM kill

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -115,8 +115,6 @@ func ctorLinux(cfg *config) (reporterImpl, []string, error) {
 		[]byte("FAULT_FLAG_ALLOW_RETRY missing"),
 	}
 	suppressions := []string{
-		"fatal error: runtime: out of memory",
-		"fatal error: runtime: cannot allocate memory",
 		"panic: failed to start executor binary",
 		"panic: executor failed: pthread_create failed",
 		"panic: failed to create temp dir",

--- a/pkg/report/testdata/all/report/6
+++ b/pkg/report/testdata/all/report/6
@@ -1,0 +1,10 @@
+TITLE: panic: cannot allocate memory
+SUPPRESSED: Y
+
+panic: cannot allocate memory
+
+goroutine 14 [running]:
+github.com/google/syzkaller/pkg/image.mustDecompress({0xc005ab4c00, 0x583, 0x600})
+syzkaller/pkg/image/compression_optimized.go:65 +0x5cb
+github.com/google/syzkaller/pkg/image.MustDecompress({0xc005ab4c00, 0xc00746d400, 0x0})
+syzkaller/pkg/image/compression.go:36 +0x3b

--- a/pkg/report/testdata/all/report/7
+++ b/pkg/report/testdata/all/report/7
@@ -1,0 +1,15 @@
+TITLE: fatal error: out of memory
+SUPPRESSED: Y
+
+runtime: out of memory: cannot allocate 1073741824-byte block (6446022656 in use)
+fatal error: out of memory
+
+goroutine 1 [running]:
+runtime.throw({0x4772bc?, 0x20000?})
+	runtime/panic.go:1047 +0x5d fp=0xc000184e38 sp=0xc000184e08 pc=0x42ea1d
+runtime.(*mcache).allocLarge(0xc0000b0a00?, 0x40000000, 0x1)
+	runtime/mcache.go:236 +0x178 fp=0xc000184e80 sp=0xc000184e38 pc=0x411318
+runtime.mallocgc(0x40000000, 0x46a9c0, 0x1)
+	runtime/malloc.go:1053 +0x4f7 fp=0xc000184ee8 sp=0xc000184e80 pc=0x40b157
+
+


### PR DESCRIPTION
This several small improvements:
1. Move these patterns into the common part.
   We run Go code on (almost) all OSes and error messages
   are the same for all of them.
2. Detect "fatal error:" as a bug as well.
   This is what I currently see from Go 1.20 runtime,
   but we don't recognize it, so these reports probably
   go into "lost connection" bucket now (bad).
3. Add a pattern for panic(ENOMEM) message.
   pkg/image/compression_optimized.go can produce it
   on mmap failure.
4. Add tests.
