### PR TITLE
pkg/report: ignore ALSA fatal errors

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -106,17 +106,6 @@ var gvisorOopses = append([]*oops{
 		[]*regexp.Regexp{},
 	},
 	{
-		[]byte("fatal error:"),
-		[]oopsFormat{
-			{
-				title:        compile("fatal error:(.*)"),
-				fmt:          "fatal error:%[1]v",
-				noStackTrace: true,
-			},
-		},
-		[]*regexp.Regexp{},
-	},
-	{
 		[]byte("SIGSEGV:"),
 		[]oopsFormat{
 			{

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -839,6 +839,8 @@ var commonOopses = []*oops{
 				noStackTrace: true,
 			},
 		},
-		[]*regexp.Regexp{},
+		[]*regexp.Regexp{
+			compile("ALSA"),
+		},
 	},
 }

--- a/pkg/report/testdata/all/report/8
+++ b/pkg/report/testdata/all/report/8
@@ -1,0 +1,2 @@
+
+[  471.848871][T11685] ALSA: seq fatal error: cannot create timer (-22)


### PR DESCRIPTION
Of course something in the kernel prints "fatal error"
and it's not a kernel bug.
