### PR TITLE
dashboard: better handle non-classified bugs and empty subsystems

### DIFF
--- a/dashboard/app/cache.go
+++ b/dashboard/app/cache.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Cached struct {
-	Total      CachedBugStats
-	Subsystems map[string]CachedBugStats
+	Total       CachedBugStats
+	Subsystems  map[string]CachedBugStats
+	NoSubsystem CachedBugStats
 }
 
 type CachedBugStats struct {
@@ -75,6 +76,9 @@ func buildAndStoreCached(c context.Context, bugs []*Bug, ns string, accessLevel 
 			stats := v.Subsystems[subsystem.Name]
 			stats.Record(bug)
 			v.Subsystems[subsystem.Name] = stats
+		}
+		if len(bug.Tags.Subsystems) == 0 {
+			v.NoSubsystem.Record(bug)
 		}
 	}
 	item := &memcache.Item{

--- a/dashboard/app/main_test.go
+++ b/dashboard/app/main_test.go
@@ -169,6 +169,7 @@ func TestMainBugFilters(t *testing.T) {
 	client.UploadBuild(build1)
 
 	crash1 := testCrash(build1, 1)
+	crash1.Title = "my-crash-title"
 	client.ReportCrash(crash1)
 	client.pollBugs(1)
 
@@ -182,6 +183,11 @@ func TestMainBugFilters(t *testing.T) {
 	c.expectOK(err)
 	assert.NotContains(t, string(reply), build1.Manager) // managers are hidden
 	assert.Contains(t, string(reply), "Applied filters") // we're seeing a prompt to disable the filter
+	assert.NotContains(t, string(reply), crash1.Title)   // the bug does not belong to the subsystem
+
+	reply, err = c.AuthGET(AccessAdmin, "/test1?no_subsystem=true")
+	c.expectOK(err)
+	assert.Contains(t, string(reply), crash1.Title) // the bug has no subsystems
 }
 
 func TestSubsystemsList(t *testing.T) {

--- a/dashboard/app/main_test.go
+++ b/dashboard/app/main_test.go
@@ -208,6 +208,11 @@ func TestSubsystemsList(t *testing.T) {
 	reply, err := c.AuthGET(AccessAdmin, "/test1/subsystems")
 	c.expectOK(err)
 	assert.Contains(t, string(reply), "subsystemA")
+	assert.NotContains(t, string(reply), "subsystemB")
+
+	reply, err = c.AuthGET(AccessAdmin, "/test1/subsystems?all=true")
+	c.expectOK(err)
+	assert.Contains(t, string(reply), "subsystemA")
 	assert.Contains(t, string(reply), "subsystemB")
 }
 

--- a/dashboard/app/subsystems.html
+++ b/dashboard/app/subsystems.html
@@ -28,7 +28,11 @@ The list of polled trees.
 		</tr>
 		{{range $item := .List}}
 		<tr>
-			<td>{{link $item.Open.Link $item.Name}}</td>
+			{{if $item.Name}}
+				<td>{{link $item.Open.Link $item.Name}}</td>
+			{{else}}
+				<td><b>{{link $item.Open.Link "no subsystem"}}</b></td>
+			{{end}}
 			<td>{{$item.Lists}}</td>
 			<td>{{link $item.Open.Link (printf "%d" $item.Open.Count)}}</td>
 			<td>{{link $item.Fixed.Link (printf "%d" $item.Fixed.Count)}}</td>

--- a/dashboard/app/subsystems.html
+++ b/dashboard/app/subsystems.html
@@ -13,8 +13,11 @@ The list of polled trees.
 </head>
 <body>
 	{{template "header" .Header}}
-        <h2>The list of subsystems</h2><br>
-        <i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br>
+	<h2>The list of subsystems</h2><br>
+	<i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br>
+	{{if .NonEmpty}}
+		Empty subsystems have been hidden from the list. {{link .EmptyURL "Show all"}}. <br />
+	{{end}}
 	<table class="list_table">
 		<caption>Subsystems list</caption>
 		<tr>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -102,6 +102,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{if .Filter.Subsystem}}
 		Subsystem={{.Filter.Subsystem}} ({{link (call .DropURL "subsystem") "drop"}})
 	{{end}}
+	{{if .Filter.NoSubsystem}}
+		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem") "drop"}})
+	{{end}}
 	<br>
 {{end}}
 {{end}}


### PR DESCRIPTION
1. By default, hide empty subsystems from the subsystem list.
2. Count the number of bugs without a subsystem and let users filter them.