### PR TITLE
dashboard: cosmetic changes to the subsystems list

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -155,10 +155,11 @@ type uiSubsystemPage struct {
 }
 
 type uiSubsystemsPage struct {
-	Header   *uiHeader
-	List     []*uiSubsystem
-	NonEmpty bool
-	EmptyURL string
+	Header       *uiHeader
+	List         []*uiSubsystem
+	Unclassified *uiSubsystem
+	NonEmpty     bool
+	EmptyURL     string
 }
 
 type uiSubsystem struct {
@@ -867,23 +868,24 @@ func handleSubsystemsList(c context.Context, w http.ResponseWriter, r *http.Requ
 		}
 		list = append(list, record)
 	}
-	list = append(list, &uiSubsystem{
+	unclassified := &uiSubsystem{
 		Name: "",
 		Open: uiSubsystemStats{
 			Count: cached.NoSubsystem.Open,
 			Link:  html.AmendURL("/"+hdr.Namespace, "no_subsystem", "true"),
 		},
 		Fixed: uiSubsystemStats{
-			Count: cached.NoSubsystem.Open,
+			Count: cached.NoSubsystem.Fixed,
 			Link:  html.AmendURL("/"+hdr.Namespace+"/fixed", "no_subsystem", "true"),
 		},
-	})
+	}
 	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
 	return serveTemplate(w, "subsystems.html", &uiSubsystemsPage{
-		Header:   hdr,
-		List:     list,
-		NonEmpty: nonEmpty,
-		EmptyURL: html.AmendURL(getCurrentURL(c), "all", "true"),
+		Header:       hdr,
+		List:         list,
+		Unclassified: unclassified,
+		NonEmpty:     nonEmpty,
+		EmptyURL:     html.AmendURL(getCurrentURL(c), "all", "true"),
 	})
 }
 

--- a/dashboard/app/subsystems.html
+++ b/dashboard/app/subsystems.html
@@ -14,30 +14,38 @@ The list of polled trees.
 <body>
 	{{template "header" .Header}}
 	<h2>The list of subsystems</h2><br>
-	<i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br>
+	<i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br><br>
 	{{if .NonEmpty}}
-		Empty subsystems have been hidden from the list. {{link .EmptyURL "Show all"}}. <br />
+		Empty subsystems have been hidden from the list. {{link .EmptyURL "Show all"}}. <br>
 	{{end}}
 	<table class="list_table">
 		<caption>Subsystems list</caption>
-		<tr>
-			<th><a onclick="return sortTable(this, 'Name', textSort)" href="#">Name</a></th>
-			<th>List(s)</th>
-			<th><a onclick="return sortTable(this, 'Open bugs', numSort)" href="#">Open bugs</a></th>
-			<th><a onclick="return sortTable(this, 'Fixed', numSort)" href="#">Fixed</a></th>
-		</tr>
+		<thead>
+			<tr>
+				<th><a onclick="return sortTable(this, 'Name', textSort)" href="#">Name</a></th>
+				<th>List(s)</th>
+				<th><a onclick="return sortTable(this, 'Open bugs', numSort)" href="#">Open bugs</a></th>
+				<th><a onclick="return sortTable(this, 'Fixed', numSort)" href="#">Fixed</a></th>
+			</tr>
+		</thead>
+		<tbody>
 		{{range $item := .List}}
 		<tr>
-			{{if $item.Name}}
-				<td>{{link $item.Open.Link $item.Name}}</td>
-			{{else}}
-				<td><b>{{link $item.Open.Link "no subsystem"}}</b></td>
-			{{end}}
+			<td>{{link $item.Open.Link $item.Name}}</td>
 			<td>{{$item.Lists}}</td>
 			<td>{{link $item.Open.Link (printf "%d" $item.Open.Count)}}</td>
 			<td>{{link $item.Fixed.Link (printf "%d" $item.Fixed.Count)}}</td>
 		</tr>
 		{{end}}
+		</tbody>
+		<tfoot>
+		<tr>
+			<td><b>{{link .Unclassified.Open.Link "unclassified"}}</b></td>
+			<td>-</td>
+			<td>{{link .Unclassified.Open.Link (printf "%d" .Unclassified.Open.Count)}}</td>
+			<td>{{link .Unclassified.Fixed.Link (printf "%d" .Unclassified.Fixed.Count)}}</td>
+		</tr>
+		</tfoot>
 	</table>
 </body>
 </html>


### PR DESCRIPTION
1) Add more space between the lines above the table. 
2) Rename the "no subsystems" row and move it to the bottom. 
3) Display the correct count of fixed unclassified bugs.
