### PR TITLE
all: ioutil is deprecated since go1.16

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -8,7 +8,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -146,7 +146,7 @@ func handleAPI(c context.Context, r *http.Request) (reply interface{}, err error
 		if err != nil {
 			return nil, fmt.Errorf("failed to ungzip payload: %v", err)
 		}
-		payload, err = ioutil.ReadAll(gr)
+		payload, err = io.ReadAll(gr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to ungzip payload: %v", err)
 		}
@@ -1489,7 +1489,7 @@ func getText(c context.Context, tag string, id int64) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to read text %v: %v", tag, err)
 	}
-	data, err := ioutil.ReadAll(d)
+	data, err := io.ReadAll(d)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to read text %v: %v", tag, err)
 	}

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/mail"
 	"regexp"
@@ -465,7 +465,7 @@ func handleTestCommand(c context.Context, info *bugInfoResult, msg *email.Email)
 
 func handleEmailBounce(w http.ResponseWriter, r *http.Request) {
 	c := appengine.NewContext(r)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf(c, "email bounced: failed to read body: %v", err)
 		return

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -9,7 +9,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -394,7 +394,7 @@ func (c *Ctx) makeClient(client, key string, failOnErrors bool) *apiClient {
 		res := &http.Response{
 			StatusCode: w.Code,
 			Status:     http.StatusText(w.Code),
-			Body:       ioutil.NopCloser(w.Result().Body),
+			Body:       io.NopCloser(w.Result().Body),
 		}
 		return res, nil
 	}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/mail"
 	"net/url"
@@ -808,7 +807,7 @@ func (dash *Dashboard) queryImpl(method string, req, reply interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		data, _ := ioutil.ReadAll(resp.Body)
+		data, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed with %v: %s", resp.Status, data)
 	}
 	if reply != nil {

--- a/executor/style_test.go
+++ b/executor/style_test.go
@@ -5,7 +5,7 @@ package executor
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -160,7 +160,7 @@ if (foo) {
 		}
 	}
 	for _, file := range executorFiles(t) {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/asset/storage_test.go
+++ b/pkg/asset/storage_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -80,7 +79,7 @@ func validateGzip(res *uploadedFile, expected []byte) error {
 		return fmt.Errorf("gzip.NewReader failed: %w", err)
 	}
 	defer reader.Close()
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("read of ungzipped content failed: %w", err)
 	}
@@ -102,7 +101,7 @@ func validateXz(res *uploadedFile, expected []byte) error {
 	if err != nil {
 		return fmt.Errorf("xz reader failed: %w", err)
 	}
-	out, err := ioutil.ReadAll(xzReader)
+	out, err := io.ReadAll(xzReader)
 	if err != nil {
 		return fmt.Errorf("xz decompression failed: %w", err)
 	}

--- a/pkg/ast/parser.go
+++ b/pkg/ast/parser.go
@@ -6,7 +6,7 @@ package ast
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -62,7 +62,7 @@ func ParseGlob(glob string, errorHandler ErrorHandler) *Description {
 	}
 	desc := &Description{}
 	for _, f := range files {
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		if err != nil {
 			errorHandler(Pos{}, fmt.Sprintf("failed to read input file: %v", err))
 			return nil

--- a/pkg/ast/parser_test.go
+++ b/pkg/ast/parser_test.go
@@ -5,7 +5,7 @@ package ast
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -21,7 +21,7 @@ func TestParseAll(t *testing.T) {
 	}
 	files = append(files, filepath.FromSlash("testdata/all.txt"))
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatalf("failed to read file: %v", err)
 		}
@@ -124,7 +124,7 @@ var parseTests = []struct {
 }
 
 func TestErrors(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ast/test_util.go
+++ b/pkg/ast/test_util.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -29,7 +29,7 @@ type errorDesc struct {
 }
 
 func NewErrorMatcher(t *testing.T, file string) *ErrorMatcher {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("failed to open input file: %v", err)
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -29,7 +29,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -81,7 +81,7 @@ func (auth *Endpoint) queryTokenInfo(tokenValue string) (*jwtClaims, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("verification failed %v", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -65,7 +64,7 @@ func retrieveJwtToken(ctor requestCtor, doer requestDoer) (*expiringToken, error
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/cuttlefish.go
+++ b/pkg/build/cuttlefish.go
@@ -7,7 +7,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +58,7 @@ func (c cuttlefish) readCompiler(archivePath string) (string, error) {
 	h, err := tr.Next()
 	for ; err == nil; h, err = tr.Next() {
 		if filepath.Base(h.Name) == "compile.h" {
-			bytes, err := ioutil.ReadAll(tr)
+			bytes, err := io.ReadAll(tr)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -10,7 +10,6 @@ import (
 	"debug/elf"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -114,7 +113,7 @@ func (linux linux) buildKernel(params Params) error {
 }
 
 func (linux) createImage(params Params, kernelPath string) error {
-	tempDir, err := ioutil.TempDir("", "syz-build")
+	tempDir, err := os.MkdirTemp("", "syz-build")
 	if err != nil {
 		return err
 	}
@@ -239,7 +238,7 @@ func LinuxKernelImage(arch string) string {
 var linuxCompilerRegexp = regexp.MustCompile(`#define\s+LINUX_COMPILER\s+"(.*)"`)
 
 func queryLinuxCompiler(kernelDir string) (string, error) {
-	bytes, err := ioutil.ReadFile(filepath.Join(kernelDir, "include", "generated", "compile.h"))
+	bytes, err := os.ReadFile(filepath.Join(kernelDir, "include", "generated", "compile.h"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/linux_linux.go
+++ b/pkg/build/linux_linux.go
@@ -5,7 +5,6 @@ package build
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -37,7 +36,7 @@ func embedFiles(params Params, callback func(mountDir string) error) error {
 	if params.CmdlineFile != "" {
 		return fmt.Errorf("cmdline file is not supported for linux images")
 	}
-	tempDir, err := ioutil.TempDir("", "syz-build")
+	tempDir, err := os.MkdirTemp("", "syz-build")
 	if err != nil {
 		return err
 	}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -112,7 +112,7 @@ func TestData(t *testing.T) {
 				}
 				if formatted := ast.Format(astDesc); !bytes.Equal(em.Data, formatted) {
 					if *flagUpdate {
-						ioutil.WriteFile(fileName, formatted, 0644)
+						os.WriteFile(fileName, formatted, 0644)
 					}
 					t.Fatalf("description is not formatted")
 				}

--- a/pkg/compiler/const_file.go
+++ b/pkg/compiler/const_file.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -168,7 +168,7 @@ func DeserializeConstFile(glob string, eh ast.ErrorHandler) *ConstFile {
 	cf := NewConstFile()
 	oldFormat := regexp.MustCompile(`_([a-z0-9]+)\.const$`)
 	for _, f := range files {
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		if err != nil {
 			eh(ast.Pos{}, fmt.Sprintf("failed to read const file: %v", err))
 			return nil

--- a/pkg/compiler/const_file_test.go
+++ b/pkg/compiler/const_file_test.go
@@ -4,7 +4,6 @@
 package compiler
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -91,7 +90,7 @@ CONST5_SOME_UNDEFINED2 = 100, arch3:???
 		t.Fatal(diff)
 	}
 	{
-		file, err := ioutil.TempFile("", "syz-const")
+		file, err := os.CreateTemp("", "syz-const")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -112,7 +111,7 @@ CONST5_SOME_UNDEFINED2 = 100, arch3:???
 		dir := t.TempDir()
 		for name, arch := range arches {
 			file := filepath.Join(dir, "consts_"+name+".const")
-			if err := ioutil.WriteFile(file, []byte(arch.oldFormat), 0600); err != nil {
+			if err := os.WriteFile(file, []byte(arch.oldFormat), 0600); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/compiler/consts_test.go
+++ b/pkg/compiler/consts_test.go
@@ -4,7 +4,7 @@
 package compiler
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -15,7 +15,7 @@ import (
 )
 
 func TestExtractConsts(t *testing.T) {
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "consts.txt"))
+	data, err := os.ReadFile(filepath.Join("testdata", "consts.txt"))
 	if err != nil {
 		t.Fatalf("failed to read input file: %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 
 	"github.com/google/syzkaller/pkg/osutil"
@@ -17,7 +17,7 @@ func LoadFile(filename string, cfg interface{}) error {
 	if filename == "" {
 		return fmt.Errorf("no config file specified")
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %v", err)
 	}

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -10,7 +10,7 @@ import (
 	"debug/elf"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -503,7 +503,7 @@ func objdump(target *targets.Target, mod *Module) ([2][]uint64, error) {
 			pcs[0] = append(pcs[0], pc+mod.Addr)
 		}
 	}
-	stderrOut, _ := ioutil.ReadAll(stderr)
+	stderrOut, _ := io.ReadAll(stderr)
 	if err := cmd.Wait(); err != nil {
 		return pcs, fmt.Errorf("failed to run objdump on %v: %v\n%s", mod.Path, err, stderrOut)
 	}

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -11,9 +11,9 @@ import (
 	"html"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -721,7 +721,7 @@ func percent(covered, total int) int {
 }
 
 func parseFile(fn string) ([][]byte, error) {
-	data, err := ioutil.ReadFile(fn)
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/csource/build.go
+++ b/pkg/csource/build.go
@@ -6,7 +6,6 @@ package csource
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -68,7 +67,7 @@ func build(target *prog.Target, src []byte, file string, cflags ...string) (stri
 	if err != nil {
 		os.Remove(bin)
 		if file != "" {
-			src, _ = ioutil.ReadFile(file)
+			src, _ = os.ReadFile(file)
 		}
 		return "", fmt.Errorf("failed to build program:\n%s\n%s\ncompiler invocation: %v %v",
 			src, out, compiler, flags)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -15,7 +15,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/syzkaller/pkg/hash"
@@ -265,7 +264,7 @@ func deserializeRecord(r *bufio.Reader) (key string, val []byte, seq uint64, err
 	}
 	if valLen != 0 {
 		fr := flate.NewReader(&io.LimitedReader{R: r, N: int64(valLen)})
-		if val, err = ioutil.ReadAll(fr); err != nil {
+		if val, err = io.ReadAll(fr); err != nil {
 			return
 		}
 		fr.Close()

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -120,7 +119,7 @@ func TestLarge(t *testing.T) {
 }
 
 func TestOpenInvalid(t *testing.T) {
-	f, err := ioutil.TempFile("", "syz-db-test")
+	f, err := os.CreateTemp("", "syz-db-test")
 	if err != nil {
 		t.Error(err)
 	}
@@ -141,7 +140,7 @@ func TestOpenInaccessible(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("opening inaccessible file won't fail under root")
 	}
-	f, err := ioutil.TempFile("", "syz-db-test")
+	f, err := os.CreateTemp("", "syz-db-test")
 	if err != nil {
 		t.Error(err)
 	}
@@ -171,7 +170,7 @@ func TestOpenCorrupted(t *testing.T) {
 	if err := db.Flush(); err != nil {
 		t.Fatalf("failed to flush db: %v", err)
 	}
-	data, err := ioutil.ReadFile(fn)
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		t.Fatalf("failed to read db: %v", err)
 	}

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -367,14 +366,14 @@ func parseBody(r io.Reader, headers mail.Header) ([]byte, [][]byte, error) {
 	}
 	disp, _, _ := mime.ParseMediaType(headers.Get("Content-Disposition"))
 	if disp == "attachment" {
-		attachment, err := ioutil.ReadAll(r)
+		attachment, err := io.ReadAll(r)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read email body: %v", err)
 		}
 		return nil, [][]byte{attachment}, nil
 	}
 	if mediaType == "text/plain" {
-		body, err := ioutil.ReadAll(r)
+		body, err := io.ReadAll(r)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read email body: %v", err)
 		}

--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -13,7 +13,7 @@ package gce
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -342,7 +342,7 @@ func (ctx *Context) getMeta(path string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/host/machine_info_linux.go
+++ b/pkg/host/machine_info_linux.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -86,7 +85,7 @@ func allEqual(slice []string) bool {
 }
 
 func readKVMInfo(buffer *bytes.Buffer) error {
-	files, err := ioutil.ReadDir("/sys/module/")
+	files, err := os.ReadDir("/sys/module/")
 	if err != nil {
 		return err
 	}
@@ -98,7 +97,7 @@ func readKVMInfo(buffer *bytes.Buffer) error {
 		}
 
 		paramPath := filepath.Join("/sys", "module", name, "parameters")
-		params, err := ioutil.ReadDir(paramPath)
+		params, err := os.ReadDir(paramPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -113,7 +112,7 @@ func readKVMInfo(buffer *bytes.Buffer) error {
 		fmt.Fprintf(buffer, "/sys/module/%s:\n", name)
 		for _, key := range params {
 			keyName := key.Name()
-			data, err := ioutil.ReadFile(filepath.Join(paramPath, keyName))
+			data, err := os.ReadFile(filepath.Join(paramPath, keyName))
 			if err != nil {
 				return err
 			}
@@ -127,7 +126,7 @@ func readKVMInfo(buffer *bytes.Buffer) error {
 
 func getModulesInfo() ([]KernelModule, error) {
 	var modules []KernelModule
-	modulesText, _ := ioutil.ReadFile("/proc/modules")
+	modulesText, _ := os.ReadFile("/proc/modules")
 	re := regexp.MustCompile(`(\w+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
 	for _, m := range re.FindAllSubmatch(modulesText, -1) {
 		addr, err := strconv.ParseUint(string(m[2]), 0, 64)

--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -6,7 +6,6 @@ package host
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -58,7 +57,7 @@ func isSupportedSyscall(c *prog.Syscall, target *prog.Target) (bool, string) {
 	// Kallsyms seems to be the most reliable and fast. That's what we use first.
 	// If kallsyms is not present, we fallback to execution of syscalls.
 	kallsymsOnce.Do(func() {
-		kallsyms, _ := ioutil.ReadFile("/proc/kallsyms")
+		kallsyms, _ := os.ReadFile("/proc/kallsyms")
 		if len(kallsyms) == 0 {
 			return
 		}
@@ -390,7 +389,7 @@ func isSupportedSyzOpenDev(sandbox string, c *prog.Syscall) (bool, string) {
 
 func isSupportedLSM(c *prog.Syscall) string {
 	lsmOnce.Do(func() {
-		data, err := ioutil.ReadFile("/sys/kernel/security/lsm")
+		data, err := os.ReadFile("/sys/kernel/security/lsm")
 		if err != nil {
 			// securityfs may not be mounted, but it does not mean
 			// that no LSMs are enabled.
@@ -522,7 +521,7 @@ func isSupportedMount(c *prog.Syscall, sandbox string) (bool, string) {
 
 func isSupportedFilesystem(fstype string) (bool, string) {
 	filesystemsOnce.Do(func() {
-		filesystems, _ = ioutil.ReadFile("/proc/filesystems")
+		filesystems, _ = os.ReadFile("/proc/filesystems")
 	})
 	if !bytes.Contains(filesystems, []byte("\t"+fstype+"\n")) {
 		return false, fmt.Sprintf("/proc/filesystems does not contain %v", fstype)

--- a/pkg/image/compression.go
+++ b/pkg/image/compression.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 func Compress(rawData []byte) []byte {
@@ -37,7 +36,7 @@ func MustDecompress(compressed []byte) (data []byte, dtor func()) {
 }
 
 func DecompressCheck(compressed []byte) error {
-	return decompressWriter(ioutil.Discard, compressed)
+	return decompressWriter(io.Discard, compressed)
 }
 
 func decompressWriter(w io.Writer, compressed []byte) error {

--- a/pkg/image/compression_test.go
+++ b/pkg/image/compression_test.go
@@ -6,8 +6,8 @@ package image_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,7 +51,7 @@ func TestEncode(t *testing.T) {
 
 func BenchmarkDecompress(b *testing.B) {
 	// Extract the largest image seed.
-	data, err := ioutil.ReadFile(filepath.FromSlash("../../sys/linux/test/syz_mount_image_gfs2_0"))
+	data, err := os.ReadFile(filepath.FromSlash("../../sys/linux/test/syz_mount_image_gfs2_0"))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -6,7 +6,6 @@ package ipc
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -551,7 +550,7 @@ type callReply struct {
 
 func makeCommand(pid int, bin []string, config *Config, inFile, outFile *os.File, outmem []byte,
 	tmpDirPath string) (*command, error) {
-	dir, err := ioutil.TempDir(tmpDirPath, "syzkaller-testdir")
+	dir, err := os.MkdirTemp(tmpDirPath, "syzkaller-testdir")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/pkg/kconfig/config.go
+++ b/pkg/kconfig/config.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -105,7 +105,7 @@ func (cf *ConfigFile) Serialize() []byte {
 }
 
 func ParseConfig(file string) (*ConfigFile, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open .config file %v: %v", file, err)
 	}

--- a/pkg/kconfig/kconfig.go
+++ b/pkg/kconfig/kconfig.go
@@ -8,7 +8,7 @@ package kconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -118,7 +118,7 @@ type kconfigParser struct {
 }
 
 func Parse(target *targets.Target, file string) (*KConfig, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open Kconfig file %v: %v", file, err)
 	}
@@ -329,7 +329,7 @@ func (kp *kconfigParser) includeSource(file string) {
 	kp.newCurrent(nil)
 	file = kp.expandString(file)
 	file = filepath.Join(kp.baseDir, file)
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		kp.failf("%v", err)
 		return

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -5,7 +5,6 @@ package mgrconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -123,7 +122,7 @@ func Complete(cfg *Config) error {
 	cfg.Workdir = osutil.Abs(cfg.Workdir)
 	if cfg.WorkdirTemplate != "" {
 		cfg.WorkdirTemplate = osutil.Abs(cfg.WorkdirTemplate)
-		if _, err := ioutil.ReadDir(cfg.WorkdirTemplate); err != nil {
+		if _, err := os.ReadDir(cfg.WorkdirTemplate); err != nil {
 			return fmt.Errorf("failed to read workdir_template: %v", err)
 		}
 	}

--- a/pkg/osutil/fileutil.go
+++ b/pkg/osutil/fileutil.go
@@ -6,7 +6,6 @@ package osutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -54,7 +53,7 @@ func Rename(oldFile, newFile string) error {
 // WriteTempFile writes data to a temp file and returns its name.
 func WriteTempFile(data []byte) (string, error) {
 	// Note: pkg/report knows about "syzkaller" prefix as it appears in crashes as process name.
-	f, err := ioutil.TempFile("", "syzkaller")
+	f, err := os.CreateTemp("", "syzkaller")
 	if err != nil {
 		return "", fmt.Errorf("failed to create a temp file: %v", err)
 	}

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -235,7 +234,7 @@ func CopyDirRecursively(srcDir, dstDir string) error {
 	if err := MkdirAll(dstDir); err != nil {
 		return err
 	}
-	files, err := ioutil.ReadDir(srcDir)
+	files, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err
 	}
@@ -273,7 +272,7 @@ func MkdirAll(dir string) error {
 }
 
 func WriteFile(filename string, data []byte) error {
-	return ioutil.WriteFile(filename, data, DefaultFilePerm)
+	return os.WriteFile(filename, data, DefaultFilePerm)
 }
 
 func WriteGzipStream(filename string, reader io.Reader) error {
@@ -290,13 +289,13 @@ func WriteGzipStream(filename string, reader io.Reader) error {
 
 func WriteExecFile(filename string, data []byte) error {
 	os.Remove(filename)
-	return ioutil.WriteFile(filename, data, DefaultExecPerm)
+	return os.WriteFile(filename, data, DefaultExecPerm)
 }
 
 // TempFile creates a unique temp filename.
 // Note: the file already exists when the function returns.
 func TempFile(prefix string) (string, error) {
-	f, err := ioutil.TempFile("", prefix)
+	f, err := os.CreateTemp("", prefix)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %v", err)
 	}

--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -5,7 +5,6 @@ package osutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +19,7 @@ import (
 
 // RemoveAll is similar to os.RemoveAll, but can handle more cases.
 func RemoveAll(dir string) error {
-	files, _ := ioutil.ReadDir(dir)
+	files, _ := os.ReadDir(dir)
 	for _, f := range files {
 		name := filepath.Join(dir, f.Name())
 		if f.IsDir() {

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -9,7 +9,6 @@ package osutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -54,7 +53,7 @@ func ProcessTempDir(where string) (string, error) {
 }
 
 func cleanupTempDir(path, pidfile string) bool {
-	data, err := ioutil.ReadFile(pidfile)
+	data, err := os.ReadFile(pidfile)
 	if err == nil && len(data) > 0 {
 		pid, err := strconv.Atoi(string(data))
 		if err == nil && pid > 1 {

--- a/pkg/report/linux_test.go
+++ b/pkg/report/linux_test.go
@@ -6,7 +6,7 @@ package report
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -385,7 +385,7 @@ func TestDisassemblyInReports(t *testing.T) {
 	}
 
 	archPath := filepath.Join("testdata", "linux", "decompile")
-	subFolders, err := ioutil.ReadDir(archPath)
+	subFolders, err := os.ReadDir(archPath)
 	if err != nil {
 		t.Fatalf("disassembly reports failed: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestDisassemblyInReports(t *testing.T) {
 		}
 
 		testPath := filepath.Join(archPath, obj.Name())
-		testFiles, err := ioutil.ReadDir(testPath)
+		testFiles, err := os.ReadDir(testPath)
 		if err != nil {
 			t.Fatalf("failed to list tests for %v: %v", obj.Name(), err)
 		}
@@ -420,7 +420,7 @@ func TestDisassemblyInReports(t *testing.T) {
 func testDisassembly(t *testing.T, reporter *Reporter, linuxReporter *linux, testFilePrefix string) {
 	t.Parallel()
 
-	input, err := ioutil.ReadFile(testFilePrefix + ".in")
+	input, err := os.ReadFile(testFilePrefix + ".in")
 	if err != nil {
 		t.Fatalf("failed to read input file: %v", err)
 	}
@@ -435,7 +435,7 @@ func testDisassembly(t *testing.T, reporter *Reporter, linuxReporter *linux, tes
 		osutil.WriteFile(testFilePrefix+".out", result)
 	}
 
-	output, err := ioutil.ReadFile(testFilePrefix + ".out")
+	output, err := os.ReadFile(testFilePrefix + ".out")
 	if err != nil {
 		t.Fatalf("failed to read output file: %v", err)
 	}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -44,7 +44,7 @@ type ParseTest struct {
 }
 
 func testParseFile(t *testing.T, reporter *Reporter, fn string) {
-	data, err := ioutil.ReadFile(fn)
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func updateReportTest(t *testing.T, test *ParseTest, title string, altTitles []s
 	if test.HasReport {
 		fmt.Fprintf(buf, "REPORT:\n%s", test.Report)
 	}
-	if err := ioutil.WriteFile(test.FileName, buf.Bytes(), 0640); err != nil {
+	if err := os.WriteFile(test.FileName, buf.Bytes(), 0640); err != nil {
 		t.Logf("failed to update test file: %v", err)
 	}
 }
@@ -317,7 +317,7 @@ func testRawGuiltyFile(t *testing.T, reporter *Reporter, fn string) {
 }
 
 func parseGuiltyTest(t *testing.T, fn string) (map[string]string, []byte) {
-	data, err := ioutil.ReadFile(fn)
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func readDir(t *testing.T, dir string) (files []string) {
 	if !osutil.IsExist(dir) {
 		return nil
 	}
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -14,7 +14,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -175,7 +174,7 @@ func (ctx *Context) generatePrograms(progs chan *RunRequest) error {
 }
 
 func progFileList(dir, filter string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", dir, err)
 	}
@@ -275,7 +274,7 @@ nextSandbox:
 }
 
 func parseProg(target *prog.Target, dir, filename string) (*prog.Prog, map[string]bool, *ipc.ProgInfo, error) {
-	data, err := ioutil.ReadFile(filepath.Join(dir, filename))
+	data, err := os.ReadFile(filepath.Join(dir, filename))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read %v: %v", filename, err)
 	}
@@ -680,7 +679,7 @@ func RunTest(req *RunRequest, executor string) {
 }
 
 func runTestC(req *RunRequest) {
-	tmpDir, err := ioutil.TempDir("", "syz-runtest")
+	tmpDir, err := os.MkdirTemp("", "syz-runtest")
 	if err != nil {
 		req.Err = fmt.Errorf("failed to create temp dir: %v", err)
 		return

--- a/pkg/tool/flags_test.go
+++ b/pkg/tool/flags_test.go
@@ -6,7 +6,7 @@ package tool
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestParseFlags(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			vals := new(Values)
 			flags := flag.NewFlagSet("", flag.ContinueOnError)
-			flags.SetOutput(ioutil.Discard)
+			flags.SetOutput(io.Discard)
 			flags.BoolVar(&vals.Foo, "foo", false, "")
 			flags.IntVar(&vals.Bar, "bar", 1, "")
 			flags.StringVar(&vals.Baz, "baz", "baz", "")

--- a/sys/syz-extract/extract.go
+++ b/sys/syz-extract/extract.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -187,7 +186,7 @@ func createArches(OS string, archArray, files []string) ([]*Arch, int, error) {
 	for _, archStr := range archArray {
 		buildDir := ""
 		if *flagBuild {
-			dir, err := ioutil.TempDir("", "syzkaller-kernel-build")
+			dir, err := os.MkdirTemp("", "syzkaller-kernel-build")
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to create temp dir: %v", err)
 			}

--- a/sys/syz-extract/fetch.go
+++ b/sys/syz-extract/fetch.go
@@ -8,7 +8,7 @@ import (
 	"debug/elf"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strconv"
@@ -176,7 +176,7 @@ func extractFromELF(binFile string, targetEndian binary.ByteOrder) ([]uint64, er
 		if sec.Name != "syz_extract_data" {
 			continue
 		}
-		data, err := ioutil.ReadAll(sec.Open())
+		data, err := io.ReadAll(sec.Open())
 		if err != nil {
 			return nil, err
 		}

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -340,7 +339,7 @@ func writeExecutorSyscalls(data *ExecutorData) {
 }
 
 func writeSource(file string, data []byte) {
-	if oldSrc, err := ioutil.ReadFile(file); err == nil && bytes.Equal(data, oldSrc) {
+	if oldSrc, err := os.ReadFile(file); err == nil && bytes.Equal(data, oldSrc) {
 		return
 	}
 	writeFile(file, data)

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -460,7 +459,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 	// Read possible baseline for config minimization.
 	if mgr.mgrcfg.KernelBaselineConfig != "" {
 		var err error
-		baseline, err = ioutil.ReadFile(mgr.mgrcfg.KernelBaselineConfig)
+		baseline, err = os.ReadFile(mgr.mgrcfg.KernelBaselineConfig)
 		if err != nil {
 			return fmt.Errorf("failed to read baseline config: %v", err)
 		}
@@ -646,7 +645,7 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		return err
 	}
 	if kernelConfig != "" {
-		resp.Build.KernelConfig, err = ioutil.ReadFile(kernelConfig)
+		resp.Build.KernelConfig, err = os.ReadFile(kernelConfig)
 		if err != nil {
 			return fmt.Errorf("failed to read config file: %v", err)
 		}

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -114,7 +113,7 @@ func createManager(cfg *Config, mgrcfg *ManagerConfig, stop chan struct{},
 	}
 	var configData []byte
 	if mgrcfg.KernelConfig != "" {
-		if configData, err = ioutil.ReadFile(mgrcfg.KernelConfig); err != nil {
+		if configData, err = os.ReadFile(mgrcfg.KernelConfig); err != nil {
 			return nil, err
 		}
 	}
@@ -607,7 +606,7 @@ func (mgr *Manager) createDashboardBuild(info *BuildInfo, imageDir, typ string) 
 	var kernelConfig []byte
 	if kernelConfigFile := filepath.Join(imageDir, "kernel.config"); osutil.IsExist(kernelConfigFile) {
 		var err error
-		if kernelConfig, err = ioutil.ReadFile(kernelConfigFile); err != nil {
+		if kernelConfig, err = os.ReadFile(kernelConfigFile); err != nil {
 			return nil, fmt.Errorf("failed to read kernel.config: %v", err)
 		}
 	}

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -226,7 +225,7 @@ func (upd *SyzUpdater) build(commit *vcs.Commit) error {
 	defer buildSem.Signal()
 
 	if upd.descriptions != "" {
-		files, err := ioutil.ReadDir(upd.descriptions)
+		files, err := os.ReadDir(upd.descriptions)
 		if err != nil {
 			return fmt.Errorf("failed to read descriptions dir: %v", err)
 		}
@@ -347,6 +346,6 @@ func (upd *SyzUpdater) checkLatest() string {
 	if !osutil.FilesExist(upd.latestDir, upd.syzFiles) {
 		return ""
 	}
-	tag, _ := ioutil.ReadFile(filepath.Join(upd.latestDir, "tag"))
+	tag, _ := os.ReadFile(filepath.Join(upd.latestDir, "tag"))
 	return string(tag)
 }

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -211,7 +211,7 @@ func checkRevisions(args *checkArgs) error {
 	executorArgs := strings.Split(args.ipcConfig.Executor, " ")
 	executorArgs = append(executorArgs, "version")
 	cmd := osutil.Command(executorArgs[0], executorArgs[1:]...)
-	cmd.Stderr = ioutil.Discard
+	cmd.Stderr = io.Discard
 	if _, err := cmd.StdinPipe(); err != nil { // for the case executor is wrapped with ssh
 		return err
 	}

--- a/syz-hub/state/state.go
+++ b/syz-hub/state/state.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -73,7 +72,7 @@ func Make(dir string) (*State, error) {
 
 	managersDir := filepath.Join(st.dir, "manager")
 	osutil.MkdirAll(managersDir)
-	managers, err := ioutil.ReadDir(managersDir)
+	managers, err := os.ReadDir(managersDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v dir: %v", managersDir, err)
 	}
@@ -159,7 +158,7 @@ func (st *State) createManager(name string) (*Manager, error) {
 	if st.reproSeq < mgr.reproSeq {
 		st.reproSeq = mgr.reproSeq
 	}
-	domainData, _ := ioutil.ReadFile(mgr.domainFile)
+	domainData, _ := os.ReadFile(mgr.domainFile)
 	mgr.Domain = string(domainData)
 	corpus, _, err := loadDB(mgr.corpusFile, name, false)
 	if err != nil {
@@ -451,7 +450,7 @@ func saveSeqFile(filename string, seq uint64) {
 }
 
 func loadSeqFile(filename string) uint64 {
-	str, _ := ioutil.ReadFile(filename)
+	str, _ := os.ReadFile(filename)
 	seq, _ := strconv.ParseUint(string(str), 10, 64)
 	return seq
 }

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -235,7 +234,7 @@ func (mgr *Manager) httpDownloadCorpus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer file.Close()
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to read corpus : %v", err), http.StatusInternalServerError)
 		return
@@ -513,15 +512,15 @@ func (mgr *Manager) httpReport(w http.ResponseWriter, r *http.Request) {
 	defer mgr.mu.Unlock()
 
 	crashID := r.FormValue("id")
-	desc, err := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "description"))
+	desc, err := os.ReadFile(filepath.Join(mgr.crashdir, crashID, "description"))
 	if err != nil {
 		http.Error(w, "failed to read description file", http.StatusInternalServerError)
 		return
 	}
-	tag, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.tag"))
-	prog, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.prog"))
-	cprog, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.cprog"))
-	rep, _ := ioutil.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.report"))
+	tag, _ := os.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.tag"))
+	prog, _ := os.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.prog"))
+	cprog, _ := os.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.cprog"))
+	rep, _ := os.ReadFile(filepath.Join(mgr.crashdir, crashID, "repro.report"))
 
 	commitDesc := ""
 	if len(tag) != 0 {
@@ -591,7 +590,7 @@ func readCrash(workdir, dir string, repros map[string]bool, start time.Time, ful
 		return nil
 	}
 	defer descFile.Close()
-	descBytes, err := ioutil.ReadAll(descFile)
+	descBytes, err := io.ReadAll(descFile)
 	if err != nil || len(descBytes) == 0 {
 		return nil
 	}
@@ -642,7 +641,7 @@ func readCrash(workdir, dir string, repros map[string]bool, start time.Time, ful
 				crash.Time = stat.ModTime()
 				crash.Active = crash.Time.After(start)
 			}
-			tag, _ := ioutil.ReadFile(filepath.Join(crashdir, dir, "tag"+index))
+			tag, _ := os.ReadFile(filepath.Join(crashdir, dir, "tag"+index))
 			crash.Tag = string(tag)
 			reportFile := filepath.Join("crashes", dir, "report"+index)
 			if osutil.IsExist(filepath.Join(workdir, reportFile)) {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -570,12 +569,12 @@ func (mgr *Manager) preloadCorpus() {
 	mgr.corpusDB = corpusDB
 
 	if seedDir := filepath.Join(mgr.cfg.Syzkaller, "sys", mgr.cfg.TargetOS, "test"); osutil.IsExist(seedDir) {
-		seeds, err := ioutil.ReadDir(seedDir)
+		seeds, err := os.ReadDir(seedDir)
 		if err != nil {
 			log.Fatalf("failed to read seeds dir: %v", err)
 		}
 		for _, seed := range seeds {
-			data, err := ioutil.ReadFile(filepath.Join(seedDir, seed.Name()))
+			data, err := os.ReadFile(filepath.Join(seedDir, seed.Name()))
 			if err != nil {
 				log.Fatalf("failed to read seed %v: %v", seed.Name(), err)
 			}

--- a/tools/syz-benchcmp/benchcmp.go
+++ b/tools/syz-benchcmp/benchcmp.go
@@ -13,7 +13,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -224,7 +223,7 @@ func display(graphs []*Graph) {
 	var outf *os.File
 	var err error
 	if *flagOut == "" {
-		outf, err = ioutil.TempFile("", "*.html")
+		outf, err = os.CreateTemp("", "*.html")
 		if err != nil {
 			tool.Failf("failed to create temp file: %v", err)
 		}

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -86,7 +85,7 @@ func main() {
 		os.Exit(1)
 	}
 	if mgrcfg.Workdir == "" {
-		mgrcfg.Workdir, err = ioutil.TempDir("", "syz-bisect")
+		mgrcfg.Workdir, err = os.MkdirTemp("", "syz-bisect")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
 			os.Exit(1)
@@ -150,7 +149,7 @@ func loadFile(path, file string, dst *[]byte, mandatory bool) {
 	if !mandatory && !osutil.IsExist(filename) {
 		return
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -7,7 +7,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -36,7 +35,7 @@ func main() {
 		fmt.Printf("not running under root, image build may fail\n")
 	}
 	os.Setenv("SYZ_DISABLE_SANDBOXING", "yes")
-	kernelConfig, err := ioutil.ReadFile(*flagKernelConfig)
+	kernelConfig, err := os.ReadFile(*flagKernelConfig)
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -112,7 +111,7 @@ func main() {
 func readPCs(files []string) ([]uint64, error) {
 	var pcs []uint64
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/syz-crush/crush.go
+++ b/tools/syz-crush/crush.go
@@ -9,7 +9,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func runInstance(cfg *mgrconfig.Config, reporter *report.Reporter,
 		res, err = inst.RunSyzProgFile(file, timeout, opts)
 	} else {
 		var src []byte
-		src, err = ioutil.ReadFile(file)
+		src, err = os.ReadFile(file)
 		if err != nil {
 			log.Fatalf("error reading source file from '%s'", file)
 		}

--- a/tools/syz-db/syz-db.go
+++ b/tools/syz-db/syz-db.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,13 +82,13 @@ func usage() {
 }
 
 func pack(dir, file string, target *prog.Target, version uint64) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		tool.Failf("failed to read dir: %v", err)
 	}
 	var records []db.Record
 	for _, file := range files {
-		data, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+		data, err := os.ReadFile(filepath.Join(dir, file.Name()))
 		if err != nil {
 			tool.Failf("failed to read file %v: %v", file.Name(), err)
 		}
@@ -154,7 +153,7 @@ func merge(file string, adds []string, target *prog.Target) {
 		} else if target == nil {
 			tool.Failf("failed to open db %v: %v", add, err)
 		}
-		data, err := ioutil.ReadFile(add)
+		data, err := os.ReadFile(add)
 		if err != nil {
 			tool.Fail(err)
 		}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -299,7 +298,7 @@ func loadPrograms(target *prog.Target, files []string) []*prog.Prog {
 			}
 			continue
 		}
-		data, err := ioutil.ReadFile(fn)
+		data, err := os.ReadFile(fn)
 		if err != nil {
 			log.Fatalf("failed to read log file: %v", err)
 		}

--- a/tools/syz-expand/expand.go
+++ b/tools/syz-expand/expand.go
@@ -8,7 +8,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -34,7 +33,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	data, err := ioutil.ReadFile(*flagProg)
+	data, err := os.ReadFile(*flagProg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read prog file: %v\n", err)
 		os.Exit(1)

--- a/tools/syz-fmt/syz-fmt.go
+++ b/tools/syz-fmt/syz-fmt.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ func main() {
 			os.Exit(1)
 		}
 		if st.IsDir() {
-			files, err := ioutil.ReadDir(arg)
+			files, err := os.ReadDir(arg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to read dir %v: %v\n", arg, err)
 				os.Exit(1)
@@ -45,7 +44,7 @@ func main() {
 				if !strings.HasSuffix(file.Name(), ".txt") {
 					continue
 				}
-				processFile(filepath.Join(arg, file.Name()), file.Mode())
+				processFile(filepath.Join(arg, file.Name()), file.Type())
 			}
 		} else {
 			processFile(arg, st.Mode())
@@ -54,7 +53,7 @@ func main() {
 }
 
 func processFile(file string, mode os.FileMode) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read file %v: %v\n", file, err)
 		os.Exit(1)
@@ -72,7 +71,7 @@ func processFile(file string, mode os.FileMode) {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(file, formatted, mode); err != nil {
+	if err := os.WriteFile(file, formatted, mode); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/tools/syz-hubtool/hubtool.go
+++ b/tools/syz-hubtool/hubtool.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -119,7 +119,7 @@ func loadRepros(target *prog.Target, reproGlob string) [][]byte {
 	var repros [][]byte
 	dedup := make(map[string]bool)
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tools/syz-imagegen/imagegen.go
+++ b/tools/syz-imagegen/imagegen.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -602,7 +601,7 @@ func main() {
 		return
 	}
 	// Create a single template dir for file systems that need the root dir at creation time.
-	templateDir, err := ioutil.TempDir("", "syz-imagegen")
+	templateDir, err := os.MkdirTemp("", "syz-imagegen")
 	if err != nil {
 		tool.Fail(err)
 	}
@@ -810,7 +809,7 @@ func (img *Image) generateSize() error {
 			return fmt.Errorf("image population failed: %v\n%s", err, out)
 		}
 	}
-	data, err := ioutil.ReadFile(img.disk)
+	data, err := os.ReadFile(img.disk)
 	if err != nil {
 		return err
 	}
@@ -843,7 +842,7 @@ func populate(disk, fs string) error {
 	loop := strings.TrimSpace(string(output))
 	defer runCmd("losetup", "-d", loop)
 
-	dir, err := ioutil.TempDir("", "syz-imagegen")
+	dir, err := os.MkdirTemp("", "syz-imagegen")
 	if err != nil {
 		return err
 	}
@@ -866,23 +865,23 @@ func populateDir(dir string) error {
 	if err := os.Mkdir(filepath.Join(dir, "file0"), 0777); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "file0", "file0"), nonzeros(1050), 0777); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "file0", "file0"), nonzeros(1050), 0777); err != nil {
 		return err
 	}
 	os.Symlink(filepath.Join(dir, "file0", "file0"), filepath.Join(dir, "file0", "file1"))
-	if err := ioutil.WriteFile(filepath.Join(dir, "file1"), nonzeros(10), 0777); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "file1"), nonzeros(10), 0777); err != nil {
 		return err
 	}
 	// Note: some errors are not checked because some file systems don't have support for links/attrs.
 	// TODO: does it make sense to create other attribute types (system./trusted./security./btrfs.)?
 	syscall.Setxattr(filepath.Join(dir, "file1"), "user.xattr1", []byte("xattr1"), 0)
 	syscall.Setxattr(filepath.Join(dir, "file1"), "user.xattr2", []byte("xattr2"), 0)
-	if err := ioutil.WriteFile(filepath.Join(dir, "file2"), zeros(9000), 0777); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "file2"), zeros(9000), 0777); err != nil {
 		return err
 	}
 	os.Link(filepath.Join(dir, "file2"), filepath.Join(dir, "file3"))
 	// f2fs considers .cold extension specially.
-	if err := ioutil.WriteFile(filepath.Join(dir, "file.cold"), nonzeros(100), 0777); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "file.cold"), nonzeros(100), 0777); err != nil {
 		return err
 	}
 	return nil

--- a/tools/syz-kcidb/kcidb.go
+++ b/tools/syz-kcidb/kcidb.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/kcidb"
@@ -37,7 +37,7 @@ func main() {
 		tool.Fail(err)
 	}
 
-	cred, err := ioutil.ReadFile(*flagCred)
+	cred, err := os.ReadFile(*flagCred)
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-kconf/kconf.go
+++ b/tools/syz-kconf/kconf.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -168,7 +167,7 @@ type Context struct {
 
 func (ctx *Context) generate() error {
 	var err error
-	if ctx.BuildDir, err = ioutil.TempDir("", "syz-kconf"); err != nil {
+	if ctx.BuildDir, err = os.MkdirTemp("", "syz-kconf"); err != nil {
 		return err
 	}
 	defer os.RemoveAll(ctx.BuildDir)
@@ -460,7 +459,7 @@ func (ctx *Context) replaceVars(str string) string {
 }
 
 func releaseTag(dir string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(dir, "Makefile"))
+	data, err := os.ReadFile(filepath.Join(dir, "Makefile"))
 	if err != nil {
 		return "", err
 	}

--- a/tools/syz-kconf/parser.go
+++ b/tools/syz-kconf/parser.go
@@ -6,7 +6,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -89,7 +89,7 @@ type rawFile struct {
 }
 
 func parseMainSpec(file string) ([]*Instance, []string, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read config file: %v", err)
 	}
@@ -159,7 +159,7 @@ func parseInstance(name, configDir string, features []string, includes []map[str
 }
 
 func parseFile(file string) (*rawFile, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %v: %v", file, err)
 	}

--- a/tools/syz-mutate/mutate.go
+++ b/tools/syz-mutate/mutate.go
@@ -7,7 +7,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -72,7 +71,7 @@ func main() {
 	if flag.NArg() == 0 {
 		p = target.Generate(rs, *flagLen, ct)
 	} else {
-		data, err := ioutil.ReadFile(flag.Arg(0))
+		data, err := os.ReadFile(flag.Arg(0))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to read prog file: %v\n", err)
 			os.Exit(1)

--- a/tools/syz-prog2c/prog2c.go
+++ b/tools/syz-prog2c/prog2c.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -56,7 +55,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	data, err := ioutil.ReadFile(*flagProg)
+	data, err := os.ReadFile(*flagProg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read prog file: %v\n", err)
 		os.Exit(1)

--- a/tools/syz-reporter/reporter.go
+++ b/tools/syz-reporter/reporter.go
@@ -15,7 +15,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -140,7 +139,7 @@ func readCrash(workdir, dir string) *UICrashType {
 		return nil
 	}
 	defer descFile.Close()
-	descBytes, err := ioutil.ReadAll(descFile)
+	descBytes, err := io.ReadAll(descFile)
 	if err != nil || len(descBytes) == 0 {
 		return nil
 	}
@@ -168,7 +167,7 @@ func readCrash(workdir, dir string) *UICrashType {
 		}
 
 		if strings.HasPrefix(f, "tag") {
-			tag, err := ioutil.ReadFile(filepath.Join(crashdir, dir, f))
+			tag, err := os.ReadFile(filepath.Join(crashdir, dir, f))
 			if err == nil {
 				reproducers[string(tag)] = string(tag)
 			}
@@ -179,19 +178,19 @@ func readCrash(workdir, dir string) *UICrashType {
 		}
 
 		if f == "cause.commit" {
-			commits, err := ioutil.ReadFile(filepath.Join(crashdir, dir, f))
+			commits, err := os.ReadFile(filepath.Join(crashdir, dir, f))
 			if err == nil {
 				causingCommits = strings.Split(string(commits), "\n")
 			}
 		}
 		if f == "fix.commit" {
-			commits, err := ioutil.ReadFile(filepath.Join(crashdir, dir, f))
+			commits, err := os.ReadFile(filepath.Join(crashdir, dir, f))
 			if err == nil {
 				fixingCommits = strings.Split(string(commits), "\n")
 			}
 		}
 		if f == kconfig.CauseConfigFile {
-			configs, err := ioutil.ReadFile(filepath.Join(crashdir, dir, f))
+			configs, err := os.ReadFile(filepath.Join(crashdir, dir, f))
 			if err == nil {
 				configsList := strings.Split(string(configs), "\n")
 				// Ignore configuration list longer than 10

--- a/tools/syz-repro/repro.go
+++ b/tools/syz-repro/repro.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -40,7 +39,7 @@ func main() {
 		log.Fatalf("%v: %v", *flagConfig, err)
 	}
 	logFile := flag.Args()[0]
-	data, err := ioutil.ReadFile(logFile)
+	data, err := os.ReadFile(logFile)
 	if err != nil {
 		log.Fatalf("failed to open log file %v: %v", logFile, err)
 	}

--- a/tools/syz-reprolist/reprolist.go
+++ b/tools/syz-reprolist/reprolist.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -103,7 +102,7 @@ func writeRepros(bugchan chan *dashapi.BugReport) {
 		if len(bug.ReproSyz) == 0 {
 			log.Printf("%v: %v: no repro", bug.ID, bug.BugStatus)
 			file := filepath.Join(*flagOutputDir, bug.ID+".norepro")
-			if err := ioutil.WriteFile(file, nil, 0644); err != nil {
+			if err := os.WriteFile(file, nil, 0644); err != nil {
 				log.Fatalf("failed to write file: %v", err)
 			}
 			continue
@@ -114,7 +113,7 @@ func writeRepros(bugchan chan *dashapi.BugReport) {
 				log.Print(err)
 				errText := []byte(err.Error())
 				file := filepath.Join(*flagOutputDir, bug.ID+".error")
-				if err := ioutil.WriteFile(file, errText, 0644); err != nil {
+				if err := os.WriteFile(file, errText, 0644); err != nil {
 					log.Fatalf("failed to write file: %v", err)
 				}
 				continue
@@ -129,7 +128,7 @@ func writeRepros(bugchan chan *dashapi.BugReport) {
 			bug.Title, *flagDashboard, bug.ID, bug.BugStatus, arch))
 		repro = append(repro, bug.ReproC...)
 		file := filepath.Join(*flagOutputDir, bug.ID+".c")
-		if err := ioutil.WriteFile(file, repro, 0644); err != nil {
+		if err := os.WriteFile(file, repro, 0644); err != nil {
 			log.Fatalf("failed to write file: %v", err)
 		}
 	}
@@ -141,7 +140,7 @@ func createCRepro(bug *dashapi.BugReport) error {
 		return fmt.Errorf("failed to deserialize opts: %v", err)
 	}
 	file := filepath.Join(*flagOutputDir, bug.ID+".syz")
-	if err := ioutil.WriteFile(file, bug.ReproSyz, 0644); err != nil {
+	if err := os.WriteFile(file, bug.ReproSyz, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}
 	repo := vcs.NewSyzkallerRepo(*flagSyzkallerDir, vcs.OptPrecious)

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -258,7 +257,7 @@ func (mgr *Manager) Poll(a *rpctype.RunTestPollReq, r *rpctype.RunTestPollRes) e
 	mgr.lastReq[a.Name] = mgr.reqSeq
 	mgr.reqMu.Unlock()
 	if req.Bin != "" {
-		data, err := ioutil.ReadFile(req.Bin)
+		data, err := os.ReadFile(req.Bin)
 		if err != nil {
 			log.Fatalf("failed to read bin file: %v", err)
 		}

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -47,7 +46,7 @@ func main() {
 	if err != nil {
 		tool.Failf("failed to create reporter: %v", err)
 	}
-	text, err := ioutil.ReadFile(flag.Args()[0])
+	text, err := os.ReadFile(flag.Args()[0])
 	if err != nil {
 		tool.Failf("failed to open input file: %v", err)
 	}

--- a/tools/syz-testbed/html.go
+++ b/tools/syz-testbed/html.go
@@ -8,7 +8,6 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -93,7 +92,7 @@ func (ctx *TestbedContext) httpGraph(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: move syz-benchcmp functionality to pkg/ and just import it?
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		http.Error(w, "failed to create temp folder", http.StatusInternalServerError)
 		return
@@ -119,7 +118,7 @@ func (ctx *TestbedContext) httpGraph(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		http.Error(w, "failed to read the temporary file", http.StatusInternalServerError)
 		return

--- a/tools/syz-testbed/instance.go
+++ b/tools/syz-testbed/instance.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -206,7 +205,7 @@ func (inst *SyzReproInstance) FetchResult() (RunResult, error) {
 		CReproFound: osutil.IsExist(inst.CReproFile),
 		Duration:    inst.Uptime(),
 	}
-	outTitle, _ := ioutil.ReadFile(inst.TitleFile)
+	outTitle, _ := os.ReadFile(inst.TitleFile)
 	if outTitle != nil {
 		result.ReproTitle = strings.TrimSpace(string(outTitle))
 		if result.ReproTitle != inst.Input.origTitle {

--- a/tools/syz-testbed/stats.go
+++ b/tools/syz-testbed/stats.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,14 +63,14 @@ func collectBugs(workdir string) ([]BugInfo, error) {
 	bugs := []BugInfo{}
 	for _, dir := range dirs {
 		bugFolder := filepath.Join(crashdir, dir)
-		titleBytes, err := ioutil.ReadFile(filepath.Join(bugFolder, "description"))
+		titleBytes, err := os.ReadFile(filepath.Join(bugFolder, "description"))
 		if err != nil {
 			return nil, err
 		}
 		bug := BugInfo{
 			Title: strings.TrimSpace(string(titleBytes)),
 		}
-		files, err := ioutil.ReadDir(bugFolder)
+		files, err := os.ReadDir(bugFolder)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/syz-testbed/targets.go
+++ b/tools/syz-testbed/targets.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -173,7 +172,7 @@ type SyzReproInput struct {
 }
 
 func (inp *SyzReproInput) QueryTitle(checkout *Checkout, dupsMap map[string]int) error {
-	data, err := ioutil.ReadFile(inp.Path)
+	data, err := os.ReadFile(inp.Path)
 	if err != nil {
 		return fmt.Errorf("failed to read: %s", err)
 	}

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -63,7 +62,7 @@ func main() {
 		tool.Failf("image build will fail, run under root")
 	}
 	os.Setenv("SYZ_DISABLE_SANDBOXING", "yes")
-	dir, err := ioutil.TempDir("", "syz-testbuild")
+	dir, err := os.MkdirTemp("", "syz-testbuild")
 	if err != nil {
 		tool.Fail(err)
 	}
@@ -106,7 +105,7 @@ func main() {
 		tool.Fail(err)
 	}
 	log.Printf("tags: %v", tags)
-	kernelConfig, err := ioutil.ReadFile(*flagKernelConfig)
+	kernelConfig, err := os.ReadFile(*flagKernelConfig)
 	if err != nil {
 		tool.Fail(err)
 	}

--- a/tools/syz-upgrade/upgrade.go
+++ b/tools/syz-upgrade/upgrade.go
@@ -12,7 +12,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,7 +25,7 @@ func main() {
 	if len(os.Args) != 2 {
 		fatalf("usage: syz-upgrade corpus_dir")
 	}
-	files, err := ioutil.ReadDir(os.Args[1])
+	files, err := os.ReadDir(os.Args[1])
 	if err != nil {
 		fatalf("failed to read corpus dir: %v", err)
 	}
@@ -36,7 +35,7 @@ func main() {
 	}
 	for _, f := range files {
 		fname := filepath.Join(os.Args[1], f.Name())
-		data, err := ioutil.ReadFile(fname)
+		data, err := os.ReadFile(fname)
 		if err != nil {
 			fatalf("failed to read program: %v", err)
 		}

--- a/tools/syz-usbgen/usbgen.go
+++ b/tools/syz-usbgen/usbgen.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -23,7 +22,7 @@ func main() {
 		usage()
 	}
 
-	syslog, err := ioutil.ReadFile(args[0])
+	syslog, err := os.ReadFile(args[0])
 	if err != nil {
 		tool.Failf("failed to read file %v: %v", args[0], err)
 	}

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -251,7 +250,7 @@ func findConsoleImpl(adb, dev string) (string, error) {
 				<-done
 				tty.Close()
 			}()
-			*out, _ = ioutil.ReadAll(tty)
+			*out, _ = io.ReadAll(tty)
 			errors <- nil
 		}(con)
 	}
@@ -409,7 +408,7 @@ func (inst *instance) repair() error {
 func (inst *instance) runScript(script string) error {
 	log.Logf(2, "adb: executing %s", script)
 	// Execute the contents of the script.
-	contents, err := ioutil.ReadFile(script)
+	contents, err := os.ReadFile(script)
 	if err != nil {
 		return fmt.Errorf("unable to read %s: %v", script, err)
 	}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -17,7 +17,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,7 +148,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	if out, err := keygen.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("failed to execute ssh-keygen: %v\n%s", err, out)
 	}
-	gceKeyPub, err := ioutil.ReadFile(gceKey + ".pub")
+	gceKeyPub, err := os.ReadFile(gceKey + ".pub")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %v", err)
 	}

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -187,7 +186,7 @@ func (inst *instance) ssh(command string) error {
 	}()
 	if err := cmd.Wait(); err != nil {
 		close(done)
-		out, _ := ioutil.ReadAll(rpipe)
+		out, _ := io.ReadAll(rpipe)
 		if inst.debug {
 			log.Logf(0, "ssh failed: %v\n%s", err, out)
 		}
@@ -224,11 +223,11 @@ func (inst *instance) repair() error {
 		if len(inst.cfg.USBDevNums) > 0 {
 			log.Logf(2, "isolated: trying to reboot by USB authorization")
 			usbAuth := fmt.Sprintf("%s%s%s", "/sys/bus/usb/devices/", inst.cfg.USBDevNums[inst.index], "/authorized")
-			if err := ioutil.WriteFile(usbAuth, []byte("0"), 0); err != nil {
+			if err := os.WriteFile(usbAuth, []byte("0"), 0); err != nil {
 				log.Logf(2, "isolated: failed to turn off the device")
 				return err
 			}
-			if err := ioutil.WriteFile(usbAuth, []byte("1"), 0); err != nil {
+			if err := os.WriteFile(usbAuth, []byte("1"), 0); err != nil {
 				log.Logf(2, "isolated: failed to turn on the device")
 				return err
 			}
@@ -243,7 +242,7 @@ func (inst *instance) repair() error {
 	if inst.cfg.StartupScript != "" {
 		log.Logf(2, "isolated: executing startup_script")
 		// Execute the contents of the StartupScript on the DUT.
-		contents, err := ioutil.ReadFile(inst.cfg.StartupScript)
+		contents, err := os.ReadFile(inst.cfg.StartupScript)
 		if err != nil {
 			return fmt.Errorf("unable to read startup_script: %v", err)
 		}


### PR DESCRIPTION
It is needed to update golangci-lint.
golangci-lint update is needed to uplevel go to 1.20.