### PR TITLE
dashboard: let users manually set subsystems

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -797,7 +797,7 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 			bug.HasReport = true
 		}
 		if calculateSubsystems {
-			bug.SetSubsystems(newSubsystems, now, getSubsystemRevision(c, ns))
+			bug.SetAutoSubsystems(newSubsystems, now, getSubsystemRevision(c, ns))
 		}
 		bug.increaseCrashStats(now)
 		bug.HappenedOn = mergeString(bug.HappenedOn, build.Manager)

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -108,20 +108,7 @@ var testConfig = &GlobalConfig{
 				},
 			},
 			Subsystems: SubsystemsConfig{
-				Service: subsystem.MustMakeService([]*subsystem.Subsystem{
-					{
-						Name:        "subsystemA",
-						PathRules:   []subsystem.PathRule{{IncludeRegexp: `a\.c`}},
-						Lists:       []string{"subsystemA@list.com"},
-						Maintainers: []string{"subsystemA@person.com"},
-					},
-					{
-						Name:        "subsystemB",
-						PathRules:   []subsystem.PathRule{{IncludeRegexp: `b\.c`}},
-						Lists:       []string{"subsystemB@list.com"},
-						Maintainers: []string{"subsystemB@person.com"},
-					},
-				}),
+				Service: subsystem.MustMakeService(testSubsystems),
 			},
 		},
 		"test2": {
@@ -308,6 +295,9 @@ var testConfig = &GlobalConfig{
 					},
 				},
 			},
+			Subsystems: SubsystemsConfig{
+				Service: subsystem.MustMakeService(testSubsystems),
+			},
 		},
 		// The second namespace reporting to the same mailing list.
 		"access-public-email-2": {
@@ -453,6 +443,21 @@ var testConfig = &GlobalConfig{
 			},
 			RetestRepros: true,
 		},
+	},
+}
+
+var testSubsystems = []*subsystem.Subsystem{
+	{
+		Name:        "subsystemA",
+		PathRules:   []subsystem.PathRule{{IncludeRegexp: `a\.c`}},
+		Lists:       []string{"subsystemA@list.com"},
+		Maintainers: []string{"subsystemA@person.com"},
+	},
+	{
+		Name:        "subsystemB",
+		PathRules:   []subsystem.PathRule{{IncludeRegexp: `b\.c`}},
+		Lists:       []string{"subsystemB@list.com"},
+		Maintainers: []string{"subsystemB@person.com"},
 	},
 }
 

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -158,6 +158,15 @@ func (bug *Bug) SetSubsystems(list []BugSubsystem, now time.Time) {
 	bug.SubsystemsTime = now
 }
 
+func (bug *Bug) hasUserSubsystems() bool {
+	for _, item := range bug.Tags.Subsystems {
+		if item.SetBy != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (bug *Bug) hasSubsystem(name string) bool {
 	for _, item := range bug.Tags.Subsystems {
 		if item.Name == name {

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -127,18 +127,35 @@ type BugTags struct {
 type BugSubsystem struct {
 	// For now, let's keep the bare minimum number of fields.
 	// The subsystem names we use now are not stable and should not be relied upon.
-	// Once the subsystem management functionality is fully implemented, we'll
-	// override everything stored here.
 	Name string
+	// The email of the user who manually set this subsystem tag.
+	// If empty, the subsystem was set automatically.
+	SetBy string
 }
 
-func (bug *Bug) SetSubsystems(list []*subsystem.Subsystem, now time.Time, rev int) {
-	bug.Tags.Subsystems = nil
-	bug.SubsystemsTime = now
-	bug.SubsystemsRev = rev
+func (bug *Bug) SetAutoSubsystems(list []*subsystem.Subsystem, now time.Time, rev int) {
+	objects := []BugSubsystem{}
 	for _, item := range list {
-		bug.Tags.Subsystems = append(bug.Tags.Subsystems, BugSubsystem{Name: item.Name})
+		objects = append(objects, BugSubsystem{Name: item.Name})
 	}
+	bug.SubsystemsRev = rev
+	bug.SetSubsystems(objects, now)
+}
+
+func (bug *Bug) SetUserSubsystems(list []*subsystem.Subsystem, now time.Time, user string) {
+	objects := []BugSubsystem{}
+	for _, item := range list {
+		objects = append(objects, BugSubsystem{
+			Name:  item.Name,
+			SetBy: user,
+		})
+	}
+	bug.SetSubsystems(objects, now)
+}
+
+func (bug *Bug) SetSubsystems(list []BugSubsystem, now time.Time) {
+	bug.Tags.Subsystems = list
+	bug.SubsystemsTime = now
 }
 
 func (bug *Bug) hasSubsystem(name string) bool {

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -558,8 +558,9 @@ func fillBugReport(c context.Context, rep *dashapi.BugReport, bug *Bug, bugRepor
 	rep.NoRepro = build.Type == BuildFailed
 	for _, item := range bug.Tags.Subsystems {
 		rep.Subsystems = append(rep.Subsystems, dashapi.BugSubsystem{
-			Name: item.Name,
-			Link: fmt.Sprintf("%v/%s/s/%s", appURL(c), bug.Namespace, item.Name),
+			Name:  item.Name,
+			SetBy: item.SetBy,
+			Link:  fmt.Sprintf("%v/%s/s/%s", appURL(c), bug.Namespace, item.Name),
 		})
 		rep.Maintainers = email.MergeEmailLists(rep.Maintainers,
 			subsystemMaintainers(c, rep.Namespace, item.Name))

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -317,7 +317,12 @@ func emailReport(c context.Context, rep *dashapi.BugReport) error {
 func generateEmailBugTitle(rep *dashapi.BugReport, emailConfig *EmailConfig) string {
 	title := ""
 	for i := len(rep.Subsystems) - 1; i >= 0; i-- {
-		title = fmt.Sprintf("[%s?] %s", rep.Subsystems[i].Name, title)
+		question := ""
+		if rep.Subsystems[i].SetBy == "" {
+			// Include the question mark for automatically created tags.
+			question = "?"
+		}
+		title = fmt.Sprintf("[%s%s] %s", rep.Subsystems[i].Name, question, title)
 	}
 	return title + rep.Title
 }

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -419,8 +419,9 @@ type ReportElements struct {
 }
 
 type BugSubsystem struct {
-	Name string
-	Link string
+	Name  string
+	Link  string
+	SetBy string
 }
 
 type Asset struct {

--- a/docs/syzbot.md
+++ b/docs/syzbot.md
@@ -109,6 +109,31 @@ the supplied patch.
 
 **Note**: see [below](#usb-bugs) for `USB` bugs testing.
 
+## Subsystems
+
+For all its bugs, `syzbot` automatically assigns kernel subsystems tags. For Linux,
+the predefined list of kernel subsystems can be found at
+https://syzkaller.appspot.com/upstream/subsystems.
+
+By clicking on a name in the subsystem list or by following a tag after a bug's
+title, you can get the full list of bugs belonging to the subsystem. For example,
+all `nfc` bugs are listed here: https://syzkaller.appspot.com/upstream/s/nfc.
+
+`syzbot` includes subsystem tags into email subject as well, with `?` indicating
+that it's an automatic guess: `[syzbot] [ntfs?] kernel BUG in ntfs_iget`.
+
+Over time, as we improve the classification rules or as syzbot obtains more
+information about the bug (e.g. finds a reproducer), `syzbot` will update tags.
+
+You can also manually override the automatic guess by replying to the `syzbot` email:
+
+```
+#syz set subsystems: net, mm
+```
+
+Names of subsystems must be taken from the subsystem list page on the syzbot web
+dashboard.
+
 <div id="amend"/>
 <div id="linux-next"/>
 

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -45,6 +45,7 @@ const (
 	CmdTest
 	CmdInvalid
 	CmdUnCC
+	CmdSet
 
 	cmdTest5
 )
@@ -276,6 +277,8 @@ func extractCommand(body string) (cmd Command, str, args string) {
 	switch cmd {
 	case CmdTest:
 		args = extractArgsTokens(body[cmdPos+cmdEnd:], 2)
+	case CmdSet:
+		args = extractArgsLine(body[cmdPos+cmdEnd:])
 	case cmdTest5:
 		args = extractArgsTokens(body[cmdPos+cmdEnd:], 5)
 	case CmdFix, CmdDup:
@@ -306,6 +309,8 @@ func strToCmd(str string) Command {
 		return CmdInvalid
 	case "uncc", "uncc:":
 		return CmdUnCC
+	case "set", "set:":
+		return CmdSet
 	case "test_5_arg_cmd":
 		return cmdTest5
 	}

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -327,6 +327,14 @@ baz
 		cmd: CmdUnknown,
 		str: "foo",
 	},
+	{
+		body: `
+#syz set subsystems: net, fs
+`,
+		cmd:  CmdSet,
+		str:  "set",
+		args: "subsystems: net, fs",
+	},
 }
 
 type ParseTest struct {


### PR DESCRIPTION
1. Introduce a `#syz set subsystems: A, B, C` command
2. Don't overwrite such subsystem assignment automatically.