### PR TITLE
dashboard: support obsolete KernelRepo entries

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -231,6 +231,9 @@ func apiCommitPoll(c context.Context, ns string, r *http.Request, payload []byte
 		ReportEmail: reportEmail(c, ns),
 	}
 	for _, repo := range config.Namespaces[ns].Repos {
+		if repo.Obsolete {
+			continue
+		}
 		resp.Repos = append(resp.Repos, dashapi.Repo{
 			URL:    repo.URL,
 			Branch: repo.Branch,

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -82,6 +82,12 @@ var testConfig = &GlobalConfig{
 						Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
 					},
 				},
+				{
+					URL:      "git://github.com/google/syzkaller",
+					Branch:   "old_master",
+					Alias:    "repo10alias",
+					Obsolete: true,
+				},
 			},
 			Managers: map[string]ConfigManager{
 				"special-obsoleting": {

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -194,6 +194,9 @@ type KernelRepo struct {
 	ReportingPriority int
 	// CC for all bugs reported on this repo.
 	CC CCConfig
+	// This repository is no longer active and should not be polled for commits.
+	// It will only be used to display kernel aliases for older crashes.
+	Obsolete bool
 }
 
 type CCConfig struct {


### PR DESCRIPTION
There are cases when a previously fuzzed tree was obsoleted and can no longer be polled for commits. At the same time, we still want to display short repo aliases in bug reportings and on the dashboard.

The dashboard tests cover that obsolete repos are not returned from `CommitPoll()`.