### PR TITLE
tools/syz-cover: allow for exporting source line coverage info

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -85,3 +85,9 @@ You can also export CSV file containing function coverage by:
 ``` bash
 ./bin/syz-cover --kernel_obj <directory where vmlinux is located> --csv <filename where to export>  rawcover
 ```
+
+You can export a JSON file containing line coverage info by:
+
+```bash
+./bin/syz-cover --kernel_obj <directory where vmlinux is located> --json <filename where to export>  rawcover
+```

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -42,6 +42,7 @@ func main() {
 		flagKernelBuildSrc = flag.String("kernel_build_src", "", "path to kernel image's build dir (optional)")
 		flagKernelObj      = flag.String("kernel_obj", "", "path to kernel build/obj dir")
 		flagExportCSV      = flag.String("csv", "", "export coverage data in csv format (optional)")
+		flagExportLineJSON = flag.String("json", "", "export coverage data with source line info in json format (optional)")
 		flagExportHTML     = flag.String("html", "", "save coverage HTML report to file (optional)")
 	)
 	defer tool.Init()()
@@ -83,6 +84,15 @@ func main() {
 			tool.Fail(err)
 		}
 		if err := osutil.WriteFile(*flagExportCSV, buf.Bytes()); err != nil {
+			tool.Fail(err)
+		}
+		return
+	}
+	if *flagExportLineJSON != "" {
+		if err := rg.DoLineJSON(buf, progs, nil); err != nil {
+			tool.Fail(err)
+		}
+		if err := osutil.WriteFile(*flagExportLineJSON, buf.Bytes()); err != nil {
 			tool.Fail(err)
 		}
 		return


### PR DESCRIPTION
Add a `json` CLI flag that allows for writing out a JSON file with the following coverage information.
* Module
* Filename
* Covered source lines
* Uncovered source lines
* Both source lines

This can be used to view syzkaller coverage information on other source browsing/viewing tools.

Usage:
$ ./syz-cover -kernel_obj <path/to/vmlinux> -json <output_json> rawcover
