### PR TITLE
executor: use valid temporary dir on Android

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -220,7 +220,7 @@ static uint64 current_time_ms(void)
 static void use_temporary_dir(void)
 {
 #if SYZ_SANDBOX_ANDROID
-	char tmpdir_template[] = "/data/data/syzkaller/syzkaller.XXXXXX";
+	char tmpdir_template[] = "/data/local/tmp/syzkaller.XXXXXX";
 #elif GOOS_fuchsia
 	char tmpdir_template[] = "/tmp/syzkaller.XXXXXX";
 #else

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -193,7 +193,7 @@ static uint64 current_time_ms(void)
 static void use_temporary_dir(void)
 {
 #if SYZ_SANDBOX_ANDROID
-	char tmpdir_template[] = "/data/data/syzkaller/syzkaller.XXXXXX";
+	char tmpdir_template[] = "/data/local/tmp/syzkaller.XXXXXX";
 #elif GOOS_fuchsia
 	char tmpdir_template[] = "/tmp/syzkaller.XXXXXX";
 #else


### PR DESCRIPTION
The call to mkdtemp() will fail when given
/data/data/syzkaller/syzkaller-XXXXXX, since /data/data/syzkaller/ doesn't exist. The correct temporary dir on Android is /data/local/tmp, which exists by default.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
