### PR TITLE
pkg/build: added build configs for android

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -6,6 +6,7 @@ package build
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ type Params struct {
 	SysctlFile   string
 	Config       []byte
 	Tracer       debugtracer.DebugTracer
+	Build        json.RawMessage
 }
 
 // Information that is returned from the Image function.

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -331,6 +331,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 		CmdlineFile:  mgr.mgrcfg.KernelCmdline,
 		SysctlFile:   mgr.mgrcfg.KernelSysctl,
 		Config:       mgr.configData,
+		Build:        mgr.mgrcfg.Build,
 	}
 	details, err := build.Image(params)
 	info := mgr.createBuildInfo(kernelCommit, details.CompilerID)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -165,6 +165,9 @@ type ManagerConfig struct {
 	Ccache       string `json:"ccache"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
+	// Build-type-specific parameters.
+	// Parameters for concrete types are in Config type in pkg/build/TYPE.go, e.g. pkg/build/android.go.
+	Build json.RawMessage `json:"build"`
 	// Baseline config for bisection, see pkg/bisect.KernelConfig.BaselineConfig.
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
 	// File with kernel cmdline values (optional).


### PR DESCRIPTION
Added config structure in build/Android to allow specifying specific Android targets.

Build config is optional and extensible for individual build instances.