### PR TITLE
dashboard: don't show Reported-by for never reported bugs

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -22,7 +22,9 @@ Page with details about a single bug.
 		{{- end}}
 		<a href="https://github.com/google/syzkaller/blob/master/docs/syzbot.md#subsystems">(incorrect?)</a><br>
 	{{- end}}
+	{{if .Bug.CreditEmail}}
 	Reported-by: {{.Bug.CreditEmail}}<br>
+	{{- end}}
 	{{if .Bug.Commits}}
 		<b>Fix commit:</b> {{template "fix_commits" .Bug.Commits}}<br>
 		{{if .Bug.ClosedTime.IsZero}}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1345,9 +1345,14 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 			}
 		}
 	}
-	creditEmail, err := email.AddAddrContext(ownEmail(c), bug.Reporting[reportingIdx].ID)
-	if err != nil {
-		log.Errorf(c, "failed to generate credit email: %v", err)
+	creditEmail := ""
+	if bug.Reporting[reportingIdx].ID != "" {
+		// If the bug was never reported to the public, sanitizeReporting() would clear IDs
+		// for non-authorized users. In such case, don't show CreditEmail at all.
+		creditEmail, err = email.AddAddrContext(ownEmail(c), bug.Reporting[reportingIdx].ID)
+		if err != nil {
+			log.Errorf(c, "failed to generate credit email: %v", err)
+		}
 	}
 	id := bug.keyHash()
 	uiBug := &uiBug{


### PR DESCRIPTION
Some bugs were fixed/invalidated before they could be publicly reported. Don't show an ambiguous `Reported-by: syzbot+@syzkaller.appspotmail.com` in this case.