### PR TITLE
dashboard: provide correct coverage URLs for the Admin page

### DIFF
--- a/dashboard/app/asset_storage.go
+++ b/dashboard/app/asset_storage.go
@@ -473,9 +473,11 @@ func queryLatestManagerAssets(c context.Context, ns string, assetType dashapi.As
 	period time.Duration) (map[string]Asset, error) {
 	var builds []*Build
 	startTime := timeNow(c).Add(-period)
-	_, err := db.NewQuery("Build").
-		Filter("Namespace=", ns).
-		Filter("Assets.Type=", assetType).
+	query := db.NewQuery("Build")
+	if ns != "" {
+		query = query.Filter("Namespace=", ns)
+	}
+	_, err := query.Filter("Assets.Type=", assetType).
 		Filter("Assets.CreateDate>", startTime).
 		Order("Assets.CreateDate").
 		GetAll(c, &builds)

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -146,6 +146,11 @@ indexes:
 
 - kind: Build
   properties:
+  - name: Assets.Type
+  - name: Assets.CreateDate
+
+- kind: Build
+  properties:
   - name: Namespace
   - name: AssetsLastCheck
 


### PR DESCRIPTION
For the Admin page, we query all managers from all namespaces. That was not supported by queryLatestManagerAssets, so we always returned the fallback coverage URLs.

Make queryLatestManagerAssets support ns="".
