### PR TITLE
dashboard: assign lts tag to lts bugs

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -61,6 +61,7 @@ var testConfig = &GlobalConfig{
 			Key:                   "test1keytest1keytest1key",
 			FixBisectionAutoClose: true,
 			SimilarityDomain:      testDomain,
+			LtsNamespace:          "subsystem-reminders",
 			Clients: map[string]string{
 				client1: password1,
 				"oauth": auth.OauthMagic + "111111122222222",

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -105,6 +105,8 @@ type Config struct {
 	Kcidb *KcidbConfig
 	// Subsystems config.
 	Subsystems SubsystemsConfig
+	// If there's a bug in the LtsNamespace with the same title, syzbot will tag such bug as "lts".
+	LtsNamespace string
 }
 
 // SubsystemsConfig describes where to take the list of subsystems and how to infer them.
@@ -313,8 +315,14 @@ func checkConfig(cfg *GlobalConfig) {
 	if cfg.Namespaces[cfg.DefaultNamespace] == nil {
 		panic(fmt.Sprintf("default namespace %q is not found", cfg.DefaultNamespace))
 	}
-	for ns, cfg := range cfg.Namespaces {
-		checkNamespace(ns, cfg, namespaces, clientNames)
+	for ns, nsCfg := range cfg.Namespaces {
+		checkNamespace(ns, nsCfg, namespaces, clientNames)
+		if nsCfg.LtsNamespace != "" {
+			if cfg.Namespaces[nsCfg.LtsNamespace] == nil {
+				panic(fmt.Sprintf("%v: lts namespace %s is not found",
+					ns, nsCfg.LtsNamespace))
+			}
+		}
 	}
 }
 

--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -16,6 +16,8 @@ cron:
   schedule: every 5 minutes
 - url: /cron/subsystem_reports
   schedule: every 8 hours
+- url: /cron/refresh_lts
+  schedule: every 12 hours
 - url: /_ah/datastore_admin/backup.create?name=backup&filesystem=gs&gs_bucket_name=syzkaller-backups&kind=Bug&kind=Build&kind=Crash&kind=CrashLog&kind=CrashReport&kind=Error&kind=Job&kind=KernelConfig&kind=Manager&kind=ManagerStats&kind=Patch&kind=ReportingState&kind=ReproC&kind=ReproSyz
   schedule: every monday 00:00
   target: ah-builtin-python-bundle

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -122,6 +122,7 @@ type Bug struct {
 
 type BugTags struct {
 	Subsystems []BugSubsystem
+	Lts        bool
 }
 
 type BugSubsystem struct {

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -105,6 +105,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{if .Filter.NoSubsystem}}
 		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem") "drop"}})
 	{{end}}
+	{{if .Filter.Lts}}
+		Lts={{.Filter.Lts}} ({{link (call .DropURL "lts") "drop"}})
+	{{end}}
 	<br>
 {{end}}
 {{end}}
@@ -157,6 +160,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{if $.ShowNamespace}}<td>{{$b.Namespace}}</td>{{end}}
 			<td class="title">
 				<a href="{{$b.Link}}">{{$b.Title}}</a>
+				{{if $b.Lts}}<span class="lts">{{link .LtsLink "lts"}}</span> {{end}}
 				{{- range $b.Subsystems}}
 					<span class="subsystem">{{link .Link .Name}}</span>
 				{{- end}}

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -214,6 +214,20 @@ table td, table th {
 	color: black;
 }
 
+.lts {
+        background: black;
+        display: inline-block;
+        padding-left: 2pt;
+        padding-right: 2pt;
+        margin-left: 4pt;
+        font-size: small;
+}
+
+.lts a {
+        text-decoration: none;
+        color: white;
+}
+
 .bad {
 	color: #f00;
 	font-weight: bold;


### PR DESCRIPTION
If the reference LtsNamespace is specified, automatically assign the "lts" labels to individual bugs. Display the label on the dashboard and let users filter on it.

The criteria for the lable assignment is the presence of a bug with the same title (alt title) in the corresponding lts namespace.
