### PR TITLE
dashboard: improve the subsystem report template

### DIFF
--- a/dashboard/app/mail_subsystem.txt
+++ b/dashboard/app/mail_subsystem.txt
@@ -5,8 +5,8 @@ All related reports/information can be found at:
 {{.Link}}
 
 During the period, {{.PeriodStats.Reported}} new issues were detected and {{.PeriodStats.Fixed}} were fixed.
-In total, {{.TotalStats.Reported}} issues have been reported
-{{- if .TotalStats.Fixed}} and {{.TotalStats.Fixed}} fixed{{end}} so far.
+In total, {{.TotalStats.Reported}} issues are still open
+{{- if .TotalStats.Fixed}} and {{.TotalStats.Fixed}} ha{{if eq .TotalStats.Fixed 1}}s{{else}}ve{{end}} been fixed so far{{end}}.
 
 Some of the still happening issues:
 

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -297,7 +297,7 @@ All related reports/information can be found at:
 https://testapp.appspot.com/subsystem-reminders/s/subsystemA
 
 During the period, 3 new issues were detected and 0 were fixed.
-In total, 3 issues have been reported so far.
+In total, 3 issues are still open.
 
 Some of the still happening issues:
 
@@ -328,7 +328,7 @@ All related reports/information can be found at:
 https://testapp.appspot.com/subsystem-reminders/s/subsystemB
 
 During the period, 2 new issues were detected and 0 were fixed.
-In total, 2 issues have been reported so far.
+In total, 2 issues are still open.
 
 Some of the still happening issues:
 
@@ -404,7 +404,7 @@ All related reports/information can be found at:
 https://testapp.appspot.com/subsystem-reminders/s/subsystemA
 
 During the period, 2 new issues were detected and 0 were fixed.
-In total, 2 issues have been reported so far.
+In total, 2 issues are still open.
 
 Some of the still happening issues:
 
@@ -516,7 +516,7 @@ All related reports/information can be found at:
 https://testapp.appspot.com/subsystem-reminders/s/subsystemA
 
 During the period, 9 new issues were detected and 1 were fixed.
-In total, 10 issues have been reported and 1 fixed so far.
+In total, 10 issues are still open and 1 has been fixed so far.
 
 Some of the still happening issues:
 


### PR DESCRIPTION
We do not really know all reported issues per subsystem (e.g. we don't assign labels to invalid bugs), so let's just mention currently open bugs count.
