### PR TITLE
tools/syz-fmt.go: fix a bug of file info api when updating golang

### DIFF
--- a/tools/syz-fmt/syz-fmt.go
+++ b/tools/syz-fmt/syz-fmt.go
@@ -44,7 +44,8 @@ func main() {
 				if !strings.HasSuffix(file.Name(), ".txt") {
 					continue
 				}
-				processFile(filepath.Join(arg, file.Name()), file.Type())
+				info, _ := file.Info()
+				processFile(filepath.Join(arg, file.Name()), info.Mode())
 			}
 		} else {
 			processFile(arg, st.Mode())


### PR DESCRIPTION
There is a bug when formatting syscall descriptions using syz-fmt, which is because of the wrong api when updating golang.
