### PR TITLE
dashboard: change subsystem report polling strategy

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -346,6 +346,8 @@ type Subsystem struct {
 	Name      string
 	// ListsQueried is the last time bug lists were queried for the subsystem.
 	ListsQueried time.Time
+	// LastBugList is the last time we have actually managed to generate a bug list.
+	LastBugList time.Time
 }
 
 // SubsystemReport holds a single report about open bugs in a subsystem.


### PR DESCRIPTION
Try to construct a bug list for each subsystem each cron job execution until we succeed and skip list querying only after we have successfully saved the new SubsystemReport object.

It will force the dashboard to react to subsystem reporting config changes much more quickly.
