### PR TITLE
pkg/report: skip the rcu_barrier frame for hung tasks

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -906,7 +906,8 @@ func linuxHangTaskFrameExtractor(frames []string) string {
 		}
 	}
 	skip := []string{"sched", "_lock", "_slowlock", "down", "rwsem", "completion", "kthread",
-		"wait", "synchronize", "context_switch", "__switch_to", "cancel_delayed_work"}
+		"wait", "synchronize", "context_switch", "__switch_to", "cancel_delayed_work",
+		"rcu_barrier"}
 nextFrame:
 	for _, frame := range frames {
 		for _, ignore := range skip {

--- a/pkg/report/testdata/linux/report/692
+++ b/pkg/report/testdata/linux/report/692
@@ -1,0 +1,75 @@
+TITLE: INFO: task hung in netdev_run_todo
+ALT: hang in netdev_run_todo
+TYPE: HANG
+
+INFO: task kworker/u4:6:5166 blocked for more than 143 seconds.
+      Not tainted 6.0.0-syzkaller-09589-g55be6084c8e0 #0
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+task:kworker/u4:6    state:D stack:26848 pid:5166  ppid:2      flags:0x00004000
+Workqueue: netns cleanup_net
+Call Trace:
+ <TASK>
+ context_switch kernel/sched/core.c:5178 [inline]
+ __schedule+0xadf/0x5270 kernel/sched/core.c:6490
+ schedule+0xda/0x1b0 kernel/sched/core.c:6566
+ schedule_preempt_disabled+0xf/0x20 kernel/sched/core.c:6625
+ __mutex_lock_common kernel/locking/mutex.c:679 [inline]
+ __mutex_lock+0xa44/0x1350 kernel/locking/mutex.c:747
+ rcu_barrier+0x44/0x710 kernel/rcu/tree.c:3951
+ netdev_run_todo+0x2a5/0x1100 net/core/dev.c:10331
+ vti6_exit_batch_net+0x3a5/0x670 net/ipv6/ip6_vti.c:1191
+ ops_exit_list+0x125/0x170 net/core/net_namespace.c:167
+ cleanup_net+0x4ea/0xb00 net/core/net_namespace.c:594
+ process_one_work+0x991/0x1610 kernel/workqueue.c:2289
+ worker_thread+0x665/0x1080 kernel/workqueue.c:2436
+ kthread+0x2e4/0x3a0 kernel/kthread.c:376
+ ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:306
+ </TASK>
+INFO: lockdep is turned off.
+NMI backtrace for cpu 0
+CPU: 0 PID: 29 Comm: khungtaskd Not tainted 6.0.0-syzkaller-09589-g55be6084c8e0 #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022
+Call Trace:
+ <TASK>
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0xcd/0x134 lib/dump_stack.c:106
+ nmi_cpu_backtrace.cold+0x46/0x14f lib/nmi_backtrace.c:111
+ nmi_trigger_cpumask_backtrace+0x206/0x250 lib/nmi_backtrace.c:62
+ trigger_all_cpu_backtrace include/linux/nmi.h:148 [inline]
+ check_hung_uninterruptible_tasks kernel/hung_task.c:220 [inline]
+ watchdog+0xbf9/0xf30 kernel/hung_task.c:377
+ kthread+0x2e4/0x3a0 kernel/kthread.c:376
+ ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:306
+ </TASK>
+Sending NMI from CPU 0 to CPUs 1:
+NMI backtrace for cpu 1
+CPU: 1 PID: 22 Comm: ksoftirqd/1 Not tainted 6.0.0-syzkaller-09589-g55be6084c8e0 #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022
+RIP: 0010:div_u64_rem include/linux/math64.h:29 [inline]
+RIP: 0010:div_u64 include/linux/math64.h:128 [inline]
+RIP: 0010:pie_calculate_probability+0x27d/0x7c0 net/sched/sch_pie.c:345
+Code: 89 c6 4c 89 6c 24 38 e8 e1 00 ef f9 47 8d 24 a4 31 d2 4c 89 ff 43 8d 0c 24 48 c1 ed 02 48 b8 ff ff ff ff ff ff ff 00 48 f7 f1 <49> 89 c5 48 89 c6 48 c1 eb 02 49 89 cc e8 11 fd ee f9 4d 39 ef 73
+RSP: 0018:ffffc900001c7b40 EFLAGS: 00000203
+RAX: 000000a7c5ac471b RBX: 000000000abcc771 RCX: 00000000000186a0
+RDX: 0000000000006d1f RSI: ffffffff878c495f RDI: 0000000000000000
+RBP: 000000000044b82f R08: 0000000000000005 R09: 00000000000f4240
+R10: 0000000000002710 R11: 0000000000000001 R12: 000000000000c350
+R13: 0000068db8bac710 R14: 0000000000000003 R15: 0000000000000000
+FS:  0000000000000000(0000) GS:ffff8880b9b00000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00005582be373680 CR3: 000000001d0f0000 CR4: 00000000003506e0
+Call Trace:
+ <TASK>
+ fq_pie_timer+0x170/0x2a0 net/sched/sch_fq_pie.c:380
+ call_timer_fn+0x1a0/0x6b0 kernel/time/timer.c:1474
+ expire_timers kernel/time/timer.c:1519 [inline]
+ __run_timers.part.0+0x674/0xa80 kernel/time/timer.c:1790
+ __run_timers kernel/time/timer.c:1768 [inline]
+ run_timer_softirq+0xb3/0x1d0 kernel/time/timer.c:1803
+ __do_softirq+0x1d0/0x9c8 kernel/softirq.c:571
+ run_ksoftirqd kernel/softirq.c:934 [inline]
+ run_ksoftirqd+0x2d/0x60 kernel/softirq.c:926
+ smpboot_thread_fn+0x645/0x9c0 kernel/smpboot.c:164
+ kthread+0x2e4/0x3a0 kernel/kthread.c:376
+ ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:306
+ </TASK>


### PR DESCRIPTION
Its caller is much more informative.
