### PR TITLE
dashboard: change the title for subsystem reports

### DIFF
--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -371,7 +371,7 @@ func emailListReport(c context.Context, rep *dashapi.BugListReport, cfg *EmailCo
 		templateName: "mail_subsystem.txt",
 		templateArg:  args,
 		cfg:          cfg,
-		title:        fmt.Sprintf("[%s] Monthly Report", rep.Subsystem),
+		title:        fmt.Sprintf("Monthly %s report", rep.Subsystem),
 		reportID:     rep.ID,
 		maintainers:  rep.Maintainers,
 	})

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -287,7 +287,7 @@ func TestPeriodicSubsystemReminders(t *testing.T) {
 
 	// Expect the reminder for subsystemA.
 	reply := client.pollEmailBug()
-	c.expectEQ(reply.Subject, "[moderation] [subsystemA] Monthly Report")
+	c.expectEQ(reply.Subject, "[moderation] Monthly subsystemA report")
 	c.expectEQ(reply.To, []string{"moderation@syzkaller.com"})
 	c.expectEQ(reply.Cc, []string(nil))
 	c.expectEQ(reply.Body, fmt.Sprintf(`Hello subsystemA maintainers/developers,
@@ -318,7 +318,7 @@ syzbot engineers can be reached at syzkaller@googlegroups.com.
 
 	// Expect the reminder for subsystemB.
 	reply = client.pollEmailBug()
-	c.expectEQ(reply.Subject, "[moderation] [subsystemB] Monthly Report")
+	c.expectEQ(reply.Subject, "[moderation] Monthly subsystemB report")
 	c.expectEQ(reply.To, []string{"moderation@syzkaller.com"})
 	c.expectEQ(reply.Cc, []string(nil))
 	c.expectEQ(reply.Body, fmt.Sprintf(`Hello subsystemB maintainers/developers,
@@ -386,7 +386,7 @@ func TestSubsystemRemindersModeration(t *testing.T) {
 
 	// Expect the reminder for subsystemA.
 	replyA := client.pollEmailBug()
-	c.expectEQ(replyA.Subject, "[moderation] [subsystemA] Monthly Report")
+	c.expectEQ(replyA.Subject, "[moderation] Monthly subsystemA report")
 
 	// Moderate the subsystemA list.
 	c.advanceTime(time.Hour)
@@ -398,7 +398,7 @@ func TestSubsystemRemindersModeration(t *testing.T) {
 
 	// Expect the normal report.
 	reply := client.pollEmailBug()
-	c.expectEQ(reply.Subject, "[syzbot] [subsystemA] Monthly Report")
+	c.expectEQ(reply.Subject, "[syzbot] Monthly subsystemA report")
 	c.expectEQ(reply.To, []string{"bugs@syzkaller.com", "subsystemA@list.com", "subsystemA@person.com"})
 	c.expectEQ(reply.Cc, []string(nil))
 	c.expectEQ(reply.Body, fmt.Sprintf(`Hello subsystemA maintainers/developers,
@@ -510,7 +510,7 @@ func TestSubsystemReportGeneration(t *testing.T) {
 	c.expectOK(err)
 
 	reply := client.pollEmailBug()
-	c.expectEQ(reply.Subject, "[moderation] [subsystemA] Monthly Report")
+	c.expectEQ(reply.Subject, "[moderation] Monthly subsystemA report")
 	c.expectEQ(reply.To, []string{"moderation@syzkaller.com"})
 	c.expectEQ(reply.Cc, []string(nil))
 	c.expectEQ(reply.Body, fmt.Sprintf(`Hello subsystemA maintainers/developers,


### PR DESCRIPTION
Google groups do not seem to adequately parse the existing `[syzbot] [subsystemName] Monthly Report` format. Instead, the service just combines all such email threads into one big thread.

Use the `[syzbot] Monthly subsystemName report` format.

