### PR TITLE
pkg/subsystem: take only always present calls from repros

### DIFF
--- a/dashboard/app/subsystem.go
+++ b/dashboard/app/subsystem.go
@@ -128,7 +128,7 @@ func updateBugSubsystems(c context.Context, bugKey *db.Key,
 
 const (
 	// We load the top crashesForInference crashes to determine the bug subsystem(s).
-	crashesForInference = 5
+	crashesForInference = 7
 	// How often we update open bugs.
 	openBugsUpdateTime = time.Hour * 24 * 30
 )

--- a/pkg/subsystem/extractor_test.go
+++ b/pkg/subsystem/extractor_test.go
@@ -13,7 +13,7 @@ import (
 func TestExtractor(t *testing.T) {
 	// Objects used in tests.
 	fsPath := "fs/"
-	extProg, nfsProg := []byte("ext prog"), []byte("nfs prog")
+	extProg, nfsProg, extNfsProg := []byte("ext"), []byte("nfs"), []byte("ext nfs")
 	fs := &Subsystem{Name: "fs"}
 	ext := &Subsystem{Name: "ext", Parents: []*Subsystem{fs}}
 	nfs := &Subsystem{Name: "nfs", Parents: []*Subsystem{fs}}
@@ -46,7 +46,7 @@ func TestExtractor(t *testing.T) {
 			want: []*Subsystem{ext},
 		},
 		{
-			name: `Two equally present children`,
+			name: `Reproducers hint at different subsystems`,
 			crashes: []*Crash{
 				{
 					GuiltyPath: fsPath,
@@ -60,10 +60,10 @@ func TestExtractor(t *testing.T) {
 					SyzRepro:   nfsProg,
 				},
 			},
-			want: []*Subsystem{nfs, ext},
+			want: []*Subsystem{fs},
 		},
 		{
-			name: `One child is more present than another`,
+			name: `One subsystem from reproducers is irrelevant`,
 			crashes: []*Crash{
 				{
 					GuiltyPath: fsPath,
@@ -74,11 +74,7 @@ func TestExtractor(t *testing.T) {
 				},
 				{
 					GuiltyPath: fsPath,
-					SyzRepro:   nfsProg,
-				},
-				{
-					GuiltyPath: fsPath,
-					SyzRepro:   extProg,
+					SyzRepro:   extNfsProg,
 				},
 			},
 			want: []*Subsystem{ext},
@@ -92,6 +88,7 @@ func TestExtractor(t *testing.T) {
 			perProg: []progSubsystems{
 				{extProg, []*Subsystem{ext}},
 				{nfsProg, []*Subsystem{nfs}},
+				{extNfsProg, []*Subsystem{ext, nfs}},
 			},
 		},
 	}


### PR DESCRIPTION
We're not yet perfect at eliminating unneeded calls from reproducers, so let's make the subsystem extraction rules stricter: only take a subsystem from the reproducer if it's present in all reproducers.

Consider more crashes (7 instead of 5) to give more opportunities to drop an unneeded call.
