### PR TITLE
dashboard: support `#syz regenerate` command

### DIFF
--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -650,6 +650,8 @@ func incomingBugListEmail(c context.Context, bugListInfo *bugListInfoResult, msg
 	}
 	if msg.Command == email.CmdUpstream {
 		upd.Command = dashapi.BugListUpstreamCmd
+	} else if msg.Command == email.CmdRegenerate {
+		upd.Command = dashapi.BugListRegenerateCmd
 	} else {
 		upd.Command = dashapi.BugListUpdateCmd
 	}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -489,9 +489,10 @@ type BugListUpdate struct {
 type BugListUpdateCommand string
 
 const (
-	BugListSentCmd     BugListUpdateCommand = "sent"
-	BugListUpdateCmd   BugListUpdateCommand = "update"
-	BugListUpstreamCmd BugListUpdateCommand = "upstream"
+	BugListSentCmd       BugListUpdateCommand = "sent"
+	BugListUpdateCmd     BugListUpdateCommand = "update"
+	BugListUpstreamCmd   BugListUpdateCommand = "upstream"
+	BugListRegenerateCmd BugListUpdateCommand = "regenerate"
 )
 
 type BugUpdate struct {

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -46,6 +46,7 @@ const (
 	CmdInvalid
 	CmdUnCC
 	CmdSet
+	CmdRegenerate
 
 	cmdTest5
 )
@@ -311,6 +312,8 @@ func strToCmd(str string) Command {
 		return CmdUnCC
 	case "set", "set:":
 		return CmdSet
+	case "regenerate":
+		return CmdRegenerate
 	case "test_5_arg_cmd":
 		return cmdTest5
 	}


### PR DESCRIPTION
If the `#syz regenerate` command is sent in response to a bug list, dashboard will schedule its regeneration the next time the corresponding cron job is run.