### PR TITLE
dashboard: collect and display bug-related discussions

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -54,6 +54,9 @@ var testConfig = &GlobalConfig{
 		NonFinalMaxPeriod: 60 * 24 * time.Hour,
 		ReproRetestPeriod: 100 * 24 * time.Hour,
 	},
+	DiscussionEmails: []DiscussionEmailConfig{
+		{"lore@email.com", dashapi.DiscussionLore},
+	},
 	DefaultNamespace: "test1",
 	Namespaces: map[string]*Config{
 		"test1": {

--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -36,6 +36,7 @@ Page with details about a single bug.
 	{{template "bisect_results" .BisectCause}}
 	{{template "bisect_results" .BisectFix}}
 
+	{{template "discussions_list" .Discussions}}
 	{{template "bug_list" .DupOf}}
 	{{template "bug_list" .Dups}}
 	{{template "bug_list" .Similar}}

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -57,6 +57,9 @@ type GlobalConfig struct {
 	AppURL string
 	// The email address to display on all web pages.
 	ContactEmail string
+	// Emails received via the addresses below will be attributed to the corresponding
+	// kind of Discussion.
+	DiscussionEmails []DiscussionEmailConfig
 }
 
 // Per-namespace config.
@@ -105,6 +108,14 @@ type Config struct {
 	Kcidb *KcidbConfig
 	// Subsystems config.
 	Subsystems SubsystemsConfig
+}
+
+// DiscussionEmailConfig defines the correspondence between an email and a DiscussionSource.
+type DiscussionEmailConfig struct {
+	// The address at which syzbot has received the message.
+	ReceiveAddress string
+	// The associated DiscussionSource.
+	Source dashapi.DiscussionSource
 }
 
 // SubsystemsConfig describes where to take the list of subsystems and how to infer them.
@@ -315,6 +326,18 @@ func checkConfig(cfg *GlobalConfig) {
 	}
 	for ns, cfg := range cfg.Namespaces {
 		checkNamespace(ns, cfg, namespaces, clientNames)
+	}
+	checkDiscussionEmails(cfg.DiscussionEmails)
+}
+
+func checkDiscussionEmails(list []DiscussionEmailConfig) {
+	dup := map[string]struct{}{}
+	for _, item := range list {
+		email := item.ReceiveAddress
+		if _, ok := dup[email]; ok {
+			panic(fmt.Sprintf("duplicate %s in DiscussionEmails", email))
+		}
+		dup[email] = struct{}{}
 	}
 }
 

--- a/dashboard/app/discussion.go
+++ b/dashboard/app/discussion.go
@@ -1,0 +1,250 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
+	"golang.org/x/net/context"
+	db "google.golang.org/appengine/v2/datastore"
+)
+
+type newDiscussionMessage struct {
+	id        string
+	subject   string
+	msgSource dashapi.DiscussionSource
+	msgType   dashapi.DiscussionType
+	bugIDs    []string
+	inReplyTo string
+	external  bool
+	time      time.Time
+}
+
+// saveDiscussionMessage is meant to be called after each received E-mail message,
+// for which we know the BugID.
+func saveDiscussionMessage(c context.Context, msg *newDiscussionMessage) error {
+	discUpdate := &dashapi.Discussion{
+		Source: msg.msgSource,
+		Type:   msg.msgType,
+		BugIDs: msg.bugIDs,
+	}
+	if msg.inReplyTo != "" {
+		d, err := discussionByMessageID(c, msg.msgSource, msg.inReplyTo)
+		if err == nil {
+			discUpdate.ID = d.ID
+			discUpdate.Type = dashapi.DiscussionType(d.Type)
+		}
+		// If the original discussion is not in the DB, it means we
+		// were likely only mentioned in some further discussion.
+		// Remember then only the sub-thread visible to us.
+	}
+	if discUpdate.ID == "" {
+		// Use the current message as the discussion's head.
+		discUpdate.ID = msg.id
+		discUpdate.Subject = msg.subject
+	}
+	discUpdate.Messages = append(discUpdate.Messages, dashapi.DiscussionMessage{
+		ID:       msg.id,
+		Time:     msg.time,
+		External: msg.external,
+	})
+	return mergeDiscussion(c, discUpdate)
+}
+
+// mergeDiscussion either creates a new discussion or updates the existing one.
+// It is assumed that the input is valid.
+func mergeDiscussion(c context.Context, update *dashapi.Discussion) error {
+	if len(update.Messages) == 0 {
+		return fmt.Errorf("no messages")
+	}
+	newBugKeys, err := getBugKeys(c, update.BugIDs)
+	if err != nil {
+		return nil
+	}
+	// First update the discussion itself.
+	d := new(Discussion)
+	tx := func(c context.Context) error {
+		err := db.Get(c, discussionKey(c, string(update.Source), update.ID), d)
+		if err != nil && err != db.ErrNoSuchEntity {
+			return fmt.Errorf("failed to query Discussion: %w", err)
+		} else if err == db.ErrNoSuchEntity {
+			d.ID = update.ID
+			d.Source = string(update.Source)
+			d.Type = string(update.Type)
+			d.Subject = update.Subject
+		}
+		d.BugKeys = unique(append(d.BugKeys, newBugKeys...))
+		diff := d.addMessages(update.Messages)
+		if d.Type == string(dashapi.DiscussionPatch) {
+			diff.LastPatchMessage = diff.LastMessage
+		}
+		d.Summary.merge(diff)
+		_, err = db.Put(c, d.key(c), d)
+		if err != nil {
+			return fmt.Errorf("failed to put Discussion: %w", err)
+		}
+		// Update individual bug statistics.
+		for _, key := range d.BugKeys {
+			err := mergeDiscussionSummary(c, key, d.Source, diff)
+			if err != nil {
+				return fmt.Errorf("failed to put update summary for %s: %w", key, err)
+			}
+		}
+		return nil
+	}
+	return db.RunInTransaction(c, tx, &db.TransactionOptions{Attempts: 15, XG: true})
+}
+
+func mergeDiscussionSummary(c context.Context, key, source string, diff DiscussionSummary) error {
+	bug := new(Bug)
+	bugKey := db.NewKey(c, "Bug", key, 0, nil)
+	if err := db.Get(c, bugKey, bug); err != nil {
+		return fmt.Errorf("failed to get bug: %v", err)
+	}
+	var record *BugDiscussionInfo
+	for i, item := range bug.DiscussionInfo {
+		if item.Source == source {
+			record = &bug.DiscussionInfo[i]
+		}
+	}
+	if record == nil {
+		bug.DiscussionInfo = append(bug.DiscussionInfo, BugDiscussionInfo{
+			Source: source,
+		})
+		record = &bug.DiscussionInfo[len(bug.DiscussionInfo)-1]
+	}
+	record.Summary.merge(diff)
+	if _, err := db.Put(c, bugKey, bug); err != nil {
+		return fmt.Errorf("failed to put bug: %v", err)
+	}
+	return nil
+}
+
+func (ds *DiscussionSummary) merge(diff DiscussionSummary) {
+	ds.AllMessages += diff.AllMessages
+	ds.ExternalMessages += diff.ExternalMessages
+	if ds.LastMessage.Before(diff.LastMessage) {
+		ds.LastMessage = diff.LastMessage
+	}
+	if ds.LastPatchMessage.Before(diff.LastPatchMessage) {
+		ds.LastPatchMessage = diff.LastPatchMessage
+	}
+}
+
+func (bug *Bug) discussionSummary() DiscussionSummary {
+	// TODO: if there ever appear any non-public DiscussionSource, we'll need to consider
+	// their accessLevel as well.
+	var ret DiscussionSummary
+	for _, item := range bug.DiscussionInfo {
+		ret.merge(item.Summary)
+	}
+	return ret
+}
+
+const maxMessagesInDiscussion = 1500
+
+func (d *Discussion) addMessages(messages []dashapi.DiscussionMessage) DiscussionSummary {
+	var diff DiscussionSummary
+	existingIDs := d.messageIDs()
+	for _, m := range messages {
+		if _, ok := existingIDs[m.ID]; ok {
+			continue
+		}
+		existingIDs[m.ID] = struct{}{}
+		diff.AllMessages++
+		if m.External {
+			diff.ExternalMessages++
+		}
+		if diff.LastMessage.Before(m.Time) {
+			diff.LastMessage = m.Time
+		}
+		d.Messages = append(d.Messages, DiscussionMessage{
+			ID:       m.ID,
+			External: m.External,
+			Time:     m.Time,
+		})
+	}
+	sort.Slice(d.Messages, func(i, j int) bool {
+		return d.Messages[i].Time.Before(d.Messages[j].Time)
+	})
+	if len(d.Messages) > maxMessagesInDiscussion {
+		d.Messages = d.Messages[len(d.Messages)-maxMessagesInDiscussion:]
+	}
+	return diff
+}
+
+func (d *Discussion) messageIDs() map[string]struct{} {
+	ret := map[string]struct{}{}
+	for _, m := range d.Messages {
+		ret[m.ID] = struct{}{}
+	}
+	return ret
+}
+
+func (d *Discussion) link() string {
+	switch dashapi.DiscussionSource(d.Source) {
+	case dashapi.DiscussionLore:
+		return fmt.Sprintf("https://lore.kernel.org/all/%s/T/", strings.Trim(d.ID, "<>"))
+	}
+	return ""
+}
+
+func discussionByMessageID(c context.Context, source dashapi.DiscussionSource,
+	msgID string) (*Discussion, error) {
+	var discussions []*Discussion
+	keys, err := db.NewQuery("Discussion").
+		Filter("Source=", source).
+		Filter("Messages.ID=", msgID).
+		Limit(2).
+		GetAll(c, &discussions)
+	if err != nil {
+		return nil, err
+	} else if len(keys) == 0 {
+		return nil, db.ErrNoSuchEntity
+	} else if len(keys) == 2 {
+		// TODO: consider merging discussions in this case.
+		return nil, fmt.Errorf("message %s is present in several discussions", msgID)
+	}
+	return discussions[0], nil
+}
+
+func discussionsForBug(c context.Context, bugKey *db.Key) ([]*Discussion, error) {
+	var discussions []*Discussion
+	_, err := db.NewQuery("Discussion").
+		Filter("BugKeys=", bugKey.StringID()).
+		GetAll(c, &discussions)
+	if err != nil {
+		return nil, err
+	}
+	return discussions, nil
+}
+
+func getBugKeys(c context.Context, bugIDs []string) ([]string, error) {
+	keys := []string{}
+	for _, id := range bugIDs {
+		_, bugKey, err := findBugByReportingID(c, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find bug for %s: %w", id, err)
+		}
+		keys = append(keys, bugKey.StringID())
+	}
+	return keys, nil
+}
+
+func unique(items []string) []string {
+	dup := map[string]struct{}{}
+	ret := []string{}
+	for _, item := range items {
+		if _, ok := dup[item]; ok {
+			continue
+		}
+		dup[item] = struct{}{}
+		ret = append(ret, item)
+	}
+	return ret
+}

--- a/dashboard/app/discussion_test.go
+++ b/dashboard/app/discussion_test.go
@@ -1,0 +1,325 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/google/syzkaller/pkg/email"
+)
+
+func TestDiscussionAccess(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublic, keyPublic, true)
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	// Bug at the first (AccesUser) stage of reporting.
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	rep1 := client.pollBug()
+
+	// Bug at the second (AccessPublic) stage.
+	crash2 := testCrash(build, 2)
+	client.ReportCrash(crash2)
+	rep2user := client.pollBug()
+	client.updateBug(rep2user.ID, dashapi.BugStatusUpstream, "")
+	rep2 := client.pollBug()
+
+	// Patch to both bugs.
+	firstTime := timeNow(c.ctx)
+	c.advanceTime(time.Hour)
+	c.expectOK(client.SaveDiscussion(&dashapi.SaveDiscussionReq{
+		Discussion: &dashapi.Discussion{
+			ID:      "123",
+			Source:  dashapi.DiscussionLore,
+			Type:    dashapi.DiscussionPatch,
+			Subject: "Patch for both bugs",
+			BugIDs:  []string{rep1.ID, rep2.ID},
+			Messages: []dashapi.DiscussionMessage{
+				{
+					ID:       "123",
+					External: true,
+					Time:     firstTime,
+				},
+			},
+		},
+	}))
+
+	// Discussion about the second bug.
+	secondTime := timeNow(c.ctx)
+	c.advanceTime(time.Hour)
+	c.expectOK(client.SaveDiscussion(&dashapi.SaveDiscussionReq{
+		Discussion: &dashapi.Discussion{
+			ID:      "456",
+			Source:  dashapi.DiscussionLore,
+			Type:    dashapi.DiscussionReport,
+			Subject: "Second bug reported",
+			BugIDs:  []string{rep2.ID},
+			Messages: []dashapi.DiscussionMessage{
+				{
+					ID:       "456",
+					External: false,
+					Time:     secondTime,
+				},
+			},
+		},
+	}))
+
+	firstBug, _, err := findBugByReportingID(c.ctx, rep1.ID)
+	c.expectOK(err)
+
+	// Verify discussion that spans only one bug.
+	got, err := getBugDiscussionsUI(c.ctx, firstBug)
+	c.expectOK(err)
+	if diff := cmp.Diff([]*uiBugDiscussion{
+		{
+			Subject:  "Patch for both bugs",
+			Link:     "https://lore.kernel.org/all/123/T/",
+			Total:    1,
+			External: 1,
+			Last:     firstTime,
+		},
+	}, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+	secondBug, _, err := findBugByReportingID(c.ctx, rep2.ID)
+	c.expectOK(err)
+
+	// Verify that we also show discussions for several bugs.
+	got, err = getBugDiscussionsUI(c.ctx, secondBug)
+	c.expectOK(err)
+	if diff := cmp.Diff([]*uiBugDiscussion{
+		{
+			Subject:  "Second bug reported",
+			Link:     "https://lore.kernel.org/all/456/T/",
+			Total:    1,
+			External: 0,
+			Last:     secondTime,
+		},
+		{
+			Subject:  "Patch for both bugs",
+			Link:     "https://lore.kernel.org/all/123/T/",
+			Total:    1,
+			External: 1,
+			Last:     firstTime,
+		},
+	}, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Verify the summary.
+	summary := secondBug.discussionSummary()
+	if diff := cmp.Diff(DiscussionSummary{
+		AllMessages:      2,
+		ExternalMessages: 1,
+		LastMessage:      secondTime,
+		LastPatchMessage: firstTime,
+	}, summary); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEmailOwnDiscussions(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	msg := client.pollEmailBug()
+	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
+	c.expectOK(err)
+
+	// Start a discussion.
+	incoming1 := fmt.Sprintf(`Sender: syzkaller@googlegroups.com
+Date: Tue, 15 Aug 2017 14:59:00 -0700
+Message-ID: <1234>
+Subject: Bug reported
+From: %v
+To: foo@bar.com, linux-kernel@vger.kernel.org
+Content-Type: text/plain
+
+Hello`, msg.Sender)
+	_, err = c.POST("/_ah/mail/lore@email.com", incoming1)
+	c.expectOK(err)
+
+	bug, _, err := findBugByReportingID(c.ctx, extBugID)
+	c.expectOK(err)
+
+	zone := time.FixedZone("", -7*60*60)
+	got, err := getBugDiscussionsUI(c.ctx, bug)
+	c.expectOK(err)
+	if diff := cmp.Diff([]*uiBugDiscussion{
+		{
+			Subject:  "Bug reported",
+			Link:     "https://lore.kernel.org/all/1234/T/",
+			Total:    1,
+			External: 0,
+			Last:     time.Date(2017, time.August, 15, 14, 59, 0, 0, zone),
+		},
+	}, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Emulate some user-reply to the discussion.
+	incoming2 := fmt.Sprintf(`Sender: user@user.com
+Date: Tue, 16 Aug 2017 14:59:00 -0700
+Message-ID: <2345>
+Subject: Re. Bug reported
+From: user@user.com
+In-Reply-To: <1234>
+Cc: %v, linux-kernel@vger.kernel.org
+Content-Type: text/plain
+
+Hello`, msg.Sender)
+	_, err = c.POST("/_ah/mail/lore@email.com", incoming2)
+	c.expectOK(err)
+
+	bug, _, err = findBugByReportingID(c.ctx, extBugID)
+	c.expectOK(err)
+
+	got, err = getBugDiscussionsUI(c.ctx, bug)
+	c.expectOK(err)
+	if diff := cmp.Diff([]*uiBugDiscussion{
+		{
+			Subject:  "Bug reported",
+			Link:     "https://lore.kernel.org/all/1234/T/",
+			Total:    2,
+			External: 1,
+			Last:     time.Date(2017, time.August, 16, 14, 59, 0, 0, zone),
+		},
+	}, got); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEmailUnrelatedDiscussion(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	msg := client.pollEmailBug()
+	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
+	c.expectOK(err)
+
+	// An email that's not sent to the target email address.
+	incoming1 := fmt.Sprintf(`Date: Tue, 15 Aug 2017 14:59:00 -0700
+Message-ID: <1234>
+Subject: Some discussion
+In-Reply-To: <2345>
+From: user@user.com
+To: %v, lore@email.com
+Content-Type: text/plain
+
+Hello`, msg.Sender)
+	_, err = c.POST("/_ah/mail/"+msg.Sender, incoming1)
+	c.expectOK(err)
+
+	bug, _, err := findBugByReportingID(c.ctx, extBugID)
+	c.expectOK(err)
+
+	// The discussion should go ignored.
+	got, err := getBugDiscussionsUI(c.ctx, bug)
+	c.expectOK(err)
+	if diff := cmp.Diff([]*uiBugDiscussion(nil), got); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEmailSubdiscussion(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	msg := client.pollEmailBug()
+	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
+	c.expectOK(err)
+
+	incoming1 := fmt.Sprintf(`Date: Tue, 15 Aug 2017 14:59:00 -0700
+Message-ID: <2345>
+Subject: Some discussion
+In-Reply-To: <1234>
+From: user@user.com
+To: %v
+Cc: lore@email.com
+Content-Type: text/plain
+
+Hello`, msg.Sender)
+	_, err = c.POST("/_ah/mail/lore@email.com", incoming1)
+	c.expectOK(err)
+
+	bug, _, err := findBugByReportingID(c.ctx, extBugID)
+	c.expectOK(err)
+
+	// We have not seen the start of the discussion, but it should not go ignored.
+	got, err := getBugDiscussionsUI(c.ctx, bug)
+	c.expectOK(err)
+	client.expectEQ(len(got), 1)
+	client.expectEQ(got[0].Link, "https://lore.kernel.org/all/2345/T/")
+}
+
+func TestEmailPatchWithLink(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	msg := client.pollEmailBug()
+	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
+	c.expectOK(err)
+
+	incoming1 := fmt.Sprintf(`Date: Tue, 15 Aug 2017 14:59:00 -0700
+Message-ID: <2345>
+Subject: [PATCH v3] A lot of fixes
+From: user@user.com
+To: lore@email.com
+Content-Type: text/plain
+
+Hello,
+
+Link: https://testapp.appspot.com/bug?extid=%v
+`, extBugID)
+	_, err = c.POST("/_ah/mail/lore@email.com", incoming1)
+	c.expectOK(err)
+
+	bug, _, err := findBugByReportingID(c.ctx, extBugID)
+	c.expectOK(err)
+
+	// We have not seen the start of the discussion, but it should not go ignored.
+	got, err := getBugDiscussionsUI(c.ctx, bug)
+	c.expectOK(err)
+	client.expectEQ(len(got), 1)
+	client.expectEQ(got[0].Link, "https://lore.kernel.org/all/2345/T/")
+	client.expectEQ(got[0].Subject, "[PATCH v3] A lot of fixes")
+}

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -197,6 +197,11 @@ indexes:
   - name: Time
     direction: desc
 
+- kind: Discussion
+  properties:
+  - name: Source
+  - name: Messages.ID
+
 - kind: Job
   properties:
   - name: Finished

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -545,6 +545,7 @@ func processIncomingEmail(c context.Context, msg *email.Email) error {
 }
 
 func processDiscussionEmail(c context.Context, msg *email.Email, source dashapi.DiscussionSource) error {
+	log.Debugf(c, "processDiscussionEmail: %#v, source %v", msg, source)
 	if len(msg.BugIDs) == 0 {
 		return nil
 	}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -504,3 +504,28 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		</div>
 	</div>
 {{end}}
+
+{{/* List of discussions, invoked with []*uiBugDiscussion */}}
+{{define "discussions_list"}}
+{{if .}}
+<table class="list_table">
+	<caption id="managers">Discussions:</caption>
+	<thead>
+	<tr>
+		<th>Title</th>
+		<th>Replies (including bot)</th>
+		<th>Last reply</th>
+	</tr>
+	</thead>
+	<tbody>
+	{{range $item := .}}
+		<tr>
+			<td>{{link $item.Link $item.Subject}}</td>
+			<td class="stat">{{$item.External}} ({{$item.Total}})</td>
+			<td class="stat">{{formatTime $item.Last}}</td>
+		</tr>
+	{{end}}
+	</tbody>
+</table>
+{{end}}
+{{end}}

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -552,7 +552,7 @@ Content-Type: text/plain
 %v
 `, sender, id, subject, from, strings.Join(cc, ","), to, origFrom, body)
 	log.Infof(c.ctx, "sending %s", email)
-	_, err := c.POST("/_ah/mail/", email)
+	_, err := c.POST("/_ah/mail/email@server.com", email)
 	c.expectOK(err)
 }
 

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -570,6 +570,44 @@ type PollClosedResponse struct {
 	IDs []string
 }
 
+type DiscussionSource string
+
+const (
+	NoDiscussion   DiscussionSource = ""
+	DiscussionLore DiscussionSource = "lore"
+)
+
+type DiscussionType string
+
+const (
+	DiscussionReport DiscussionType = "report"
+	DiscussionPatch  DiscussionType = "patch"
+)
+
+type Discussion struct {
+	ID       string
+	Source   DiscussionSource
+	Type     DiscussionType
+	Subject  string
+	BugIDs   []string
+	Messages []DiscussionMessage
+}
+
+type DiscussionMessage struct {
+	ID       string
+	External bool // true if the message is not from the bot itself
+	Time     time.Time
+}
+
+type SaveDiscussionReq struct {
+	// If the discussion already exists, Messages and BugIDs will be appended to it.
+	Discussion *Discussion
+}
+
+func (dash *Dashboard) SaveDiscussion(req *SaveDiscussionReq) error {
+	return dash.Query("save_discussion", req, nil)
+}
+
 type TestPatchRequest struct {
 	BugID  string
 	Link   string

--- a/pkg/email/lore/parse.go
+++ b/pkg/email/lore/parse.go
@@ -1,0 +1,96 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package lore
+
+import (
+	"github.com/google/syzkaller/pkg/email"
+)
+
+type Thread struct {
+	Subject   string
+	MessageID string
+	BugIDs    []string
+	Messages  []*email.Email
+}
+
+// Threads extracts individual threads from a list of emails.
+func Threads(emails []*email.Email) []*Thread {
+	ctx := &parseCtx{
+		messages: map[string]*email.Email{},
+	}
+	for _, email := range emails {
+		ctx.record(email)
+	}
+	return ctx.threads()
+}
+
+type parseCtx struct {
+	messages map[string]*email.Email
+}
+
+func (c *parseCtx) record(msg *email.Email) {
+	c.messages[msg.MessageID] = msg
+}
+
+func (c *parseCtx) threads() []*Thread {
+	threads := map[string]*Thread{}
+	threadsList := []*Thread{}
+	// Detect threads, i.e. messages without In-Reply-To.
+	for _, msg := range c.messages {
+		if msg.InReplyTo == "" {
+			thread := &Thread{
+				MessageID: msg.MessageID,
+				Subject:   msg.Subject,
+			}
+			threads[msg.MessageID] = thread
+			threadsList = append(threadsList, thread)
+		}
+	}
+	// Assign messages to threads.
+	for _, msg := range c.messages {
+		base := c.first(msg)
+		if base == nil {
+			continue
+		}
+		thread := threads[base.MessageID]
+		thread.BugIDs = append(thread.BugIDs, msg.BugIDs...)
+		thread.Messages = append(threads[base.MessageID].Messages, msg)
+	}
+	// Deduplicate BugIDs lists.
+	for _, thread := range threads {
+		if len(thread.BugIDs) == 0 {
+			continue
+		}
+		unique := map[string]struct{}{}
+		newList := []string{}
+		for _, id := range thread.BugIDs {
+			if _, ok := unique[id]; !ok {
+				newList = append(newList, id)
+			}
+			unique[id] = struct{}{}
+		}
+		thread.BugIDs = newList
+	}
+	return threadsList
+}
+
+// first finds the firt message of an email thread.
+func (c *parseCtx) first(msg *email.Email) *email.Email {
+	visited := map[*email.Email]struct{}{}
+	for {
+		// There have been a few cases when we'd otherwise get an infinite loop.
+		if _, ok := visited[msg]; ok {
+			return nil
+		}
+		visited[msg] = struct{}{}
+		if msg.InReplyTo == "" {
+			return msg
+		}
+		msg = c.messages[msg.InReplyTo]
+		if msg == nil {
+			// Probably we just didn't load the message.
+			return nil
+		}
+	}
+}

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -1,0 +1,189 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package lore
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/syzkaller/pkg/email"
+)
+
+func TestThreadsCollection(t *testing.T) {
+	messages := []string{
+		// <A-Base> <-- <A-Child-1> <-- <A-Child-1-1>.
+		`Date: Sun, 7 May 2017 19:54:00 -0700
+Subject: Thread A
+Message-ID: <A-Base>
+From: UserA <a@user.com>
+Content-Type: text/plain
+
+
+Some text`,
+		`Date: Sun, 7 May 2017 19:55:00 -0700
+Subject: Re: Thread A
+Message-ID: <A-Child-1>
+From: UserB <b@user.com>
+To: UserA <a@user.com>
+Content-Type: text/plain
+In-Reply-To: <A-Base>
+
+
+Some reply`,
+		`Date: Sun, 7 May 2017 19:56:00 -0700
+Subject: Re: Re: Thread A
+Message-ID: <A-Child-1-1>
+From: UserC <c@user.com>
+To: UserA <a@user.com>, UserB <b@user.com>
+Content-Type: text/plain
+In-Reply-To: <A-Child-1>
+
+
+Some reply (2)`,
+		// <Bug> with two children: <Bug-Reply1>, <Bug-Reply2>.
+		`Date: Sun, 7 May 2017 19:57:00 -0700
+Subject: [syzbot] Some bug
+Message-ID: <Bug>
+From: syzbot <syzbot+4564456@bar.com>
+Content-Type: text/plain
+
+
+Bug report`,
+		`Date: Sun, 7 May 2017 19:58:00 -0700
+Subject: Re: [syzbot] Some bug
+Message-ID: <Bug-Reply1>
+From: UserC <c@user.com>
+To: syzbot <syzbot+4564456@bar.com>
+In-Reply-To: <Bug>
+Content-Type: text/plain
+
+
+Bug report reply`,
+		`Date: Sun, 7 May 2017 19:58:01 -0700
+Subject: Re: [syzbot] Some bug
+Message-ID: <Bug-Reply2>
+From: UserD <d@user.com>
+To: syzbot <syzbot+4564456@bar.com>
+In-Reply-To: <Bug>B
+Content-Type: text/plain
+
+
+Bug report reply 2`,
+		// And one PATCH without replies.
+		`Date: Sun, 7 May 2017 19:58:01 -0700
+Subject: [PATCH] Some bug fixed
+Message-ID: <Patch>
+From: UserE <e@user.com>
+Cc: syzbot <syzbot+12345@bar.com>
+Content-Type: text/plain
+
+
+Patch`,
+	}
+
+	zone := time.FixedZone("", -7*60*60)
+	expected := map[string]*Thread{
+		"<A-Base>": {
+			Subject:   "Thread A",
+			MessageID: "<A-Base>",
+			Messages: []*email.Email{
+				{
+					MessageID: "<A-Base>",
+					Subject:   "Thread A",
+					Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, zone),
+					Author:    "a@user.com",
+					Cc:        []string{"a@user.com"},
+					Command:   email.CmdNone,
+				},
+				{
+					MessageID: "<A-Child-1>",
+					Subject:   "Re: Thread A",
+					Date:      time.Date(2017, time.May, 7, 19, 55, 0, 0, zone),
+					Author:    "b@user.com",
+					Cc:        []string{"a@user.com", "b@user.com"},
+					InReplyTo: "<A-Base>",
+					Command:   email.CmdNone,
+				},
+				{
+					MessageID: "<A-Child-1-1>",
+					Subject:   "Re: Re: Thread A",
+					Date:      time.Date(2017, time.May, 7, 19, 56, 0, 0, zone),
+					Author:    "c@user.com",
+					Cc:        []string{"a@user.com", "b@user.com", "c@user.com"},
+					InReplyTo: "<A-Child-1>",
+					Command:   email.CmdNone,
+				},
+			},
+		},
+		"<Bug>": {
+			Subject:   "[syzbot] Some bug",
+			MessageID: "<Bug>",
+			BugIDs:    []string{"4564456"},
+			Messages: []*email.Email{
+				{
+					MessageID: "<Bug>",
+					BugIDs:    []string{"4564456"},
+					Subject:   "[syzbot] Some bug",
+					Date:      time.Date(2017, time.May, 7, 19, 57, 0, 0, zone),
+					Author:    "syzbot@bar.com",
+					Command:   email.CmdNone,
+				},
+				{
+					MessageID: "<Bug-Reply1>",
+					BugIDs:    []string{"4564456"},
+					Subject:   "Re: [syzbot] Some bug",
+					Date:      time.Date(2017, time.May, 7, 19, 58, 0, 0, zone),
+					Author:    "c@user.com",
+					Cc:        []string{"c@user.com"},
+					InReplyTo: "<Bug>",
+					Command:   email.CmdNone,
+				},
+			},
+		},
+		"<Patch>": {
+			Subject:   "[PATCH] Some bug fixed",
+			MessageID: "<Patch>",
+			BugIDs:    []string{"12345"},
+			Messages: []*email.Email{
+				{
+					MessageID: "<Patch>",
+					BugIDs:    []string{"12345"},
+					Subject:   "[PATCH] Some bug fixed",
+					Date:      time.Date(2017, time.May, 7, 19, 58, 1, 0, zone),
+					Author:    "e@user.com",
+					Cc:        []string{"e@user.com"},
+					Command:   email.CmdNone,
+				},
+			},
+		},
+	}
+
+	emails := []*email.Email{}
+	for _, m := range messages {
+		msg, err := email.Parse(strings.NewReader(m), []string{"syzbot@bar.com"},
+			[]string{}, []string{"bar.com"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.Body = ""
+		emails = append(emails, msg)
+	}
+
+	threads := Threads(emails)
+	for _, d := range threads {
+		sort.Slice(d.Messages, func(i, j int) bool {
+			return d.Messages[i].Date.Before(d.Messages[j].Date)
+		})
+		if diff := cmp.Diff(expected[d.MessageID], d); diff != "" {
+			t.Fatalf("%s: %s", d.MessageID, diff)
+		}
+	}
+
+	if len(threads) != len(expected) {
+		t.Fatalf("Expected %d threads, got %d", len(expected), len(threads))
+	}
+}

--- a/pkg/email/lore/read.go
+++ b/pkg/email/lore/read.go
@@ -1,0 +1,32 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package lore
+
+import (
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/vcs"
+)
+
+type EmailReader struct {
+	Extract func() ([]byte, error)
+}
+
+// ReadArchive queries the parsed messages from a single LKML message archive.
+func ReadArchive(dir string, messages chan<- *EmailReader) error {
+	repo := vcs.NewLKMLRepo(dir)
+	commits, err := repo.ListCommitHashes("HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to get recent commits: %w", err)
+	}
+	for _, iterCommit := range commits {
+		commit := iterCommit
+		messages <- &EmailReader{
+			Extract: func() ([]byte, error) {
+				return repo.Object("m", commit)
+			},
+		}
+	}
+	return nil
+}

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -121,7 +122,10 @@ func TestParse(t *testing.T) {
 	for i, test := range parseTests {
 		body := func(t *testing.T, test ParseTest) {
 			email, err := Parse(strings.NewReader(test.email),
-				[]string{"bot <foo@bar.com>"}, []string{"list@googlegroups.com"})
+				[]string{"bot <foo@bar.com>"},
+				[]string{"list@googlegroups.com"},
+				[]string{"bar.com"},
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -342,6 +346,8 @@ type ParseTest struct {
 	res   Email
 }
 
+var parseTestZone = time.FixedZone("", -7*60*60)
+
 // nolint: lll
 var parseTests = []ParseTest{
 	{`Date: Sun, 7 May 2017 19:54:00 -0700
@@ -362,8 +368,9 @@ To post to this group, send email to syzkaller@googlegroups.com.
 To view this discussion on the web visit https://groups.google.com/d/msgid/syzkaller/abcdef@google.com.
 For more options, visit https://groups.google.com/d/optout.`,
 		Email{
-			BugID:     "4564456",
+			BugIDs:    []string{"4564456"},
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Link:      "https://groups.google.com/d/msgid/syzkaller/abcdef@google.com",
 			Subject:   "test subject",
 			Author:    "bob@example.com",
@@ -394,8 +401,9 @@ Content-Type: text/plain; charset="UTF-8"
 text body
 last line`,
 		Email{
-			BugID:     "4564456",
+			BugIDs:    []string{"4564456"},
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:   "test subject",
 			Author:    "foo@bar.com",
 			Cc:        []string{"bob@example.com"},
@@ -417,6 +425,7 @@ second line
 last line`,
 		Email{
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
@@ -443,6 +452,7 @@ last line
 #syz command`,
 		Email{
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
@@ -483,6 +493,7 @@ IHQpKSB7CiAJCXNwaW5fdW5sb2NrKCZrY292LT5sb2NrKTsKIAkJcmV0dXJuOwo=
 --001a114ce0b01684a6054f0d8b81--`,
 		Email{
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
@@ -571,6 +582,7 @@ or)</div></div></div>
 --f403043eee70018593054f0d9f1f--`,
 		Email{
 			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
@@ -648,6 +660,7 @@ On 2018/06/10 4:57, syzbot wrote:
 d
 `, Email{
 		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2018, time.June, 10, 10, 38, 20, 0, time.FixedZone("", 9*60*60)),
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
@@ -709,8 +722,9 @@ To: syzbot <foo+4564456@bar.com>
 
 nothing to see here`,
 		Email{
-			BugID:       "4564456",
+			BugIDs:      []string{"4564456"},
 			MessageID:   "<123>",
+			Date:        time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:     "#syz test: git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master",
 			Author:      "bob@example.com",
 			Cc:          []string{"bob@example.com"},
@@ -729,6 +743,7 @@ To: syzbot <list@googlegroups.com>
 nothing to see here`,
 		Email{
 			MessageID:   "<123>",
+			Date:        time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:     "Subject",
 			Author:      "user@mail.com",
 			MailingList: "list@googlegroups.com",
@@ -746,6 +761,7 @@ To: <user2@mail.com>
 nothing to see here`,
 		Email{
 			MessageID:   "<123>",
+			Date:        time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:     "Subject",
 			Author:      "user@mail.com",
 			MailingList: "list@googlegroups.com",
@@ -763,6 +779,7 @@ To: <user2@mail.com>
 nothing to see here`,
 		Email{
 			MessageID:   "<123>",
+			Date:        time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 			Subject:     "Subject",
 			Author:      "list@googlegroups.com",
 			MailingList: "list@googlegroups.com",
@@ -776,7 +793,7 @@ Subject: Re: BUG: unable to handle kernel NULL pointer dereference in
 To: syzbot <syzbot+344bb0f46d7719cd9483@syzkaller.appspotmail.com>
 From: bar <bar@foo.com>
 Message-ID: <1250334f-7220-2bff-5d87-b87573758d81@bar.com>
-Date: Sun, 10 Jun 2018 10:38:20 +0900
+Date: Sun, 7 May 2017 19:54:00 -0700
 MIME-Version: 1.0
 Content-Type: text/plain; charset="UTF-8"
 Content-Language: en-US
@@ -787,6 +804,7 @@ test: https://github.com/torvalds/linux.git 7b5bb460defa107dd2e82=
 f950fddb9ea6bdb5e39
 `, Email{
 		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
@@ -796,5 +814,100 @@ test: https://github.com/torvalds/linux.git 7b5bb460defa107dd2e82f950fddb9ea6bdb
 		Command:     CmdTest,
 		CommandStr:  "test:",
 		CommandArgs: "https://github.com/torvalds/linux.git 7b5bb460defa107dd2e82f950fddb9ea6bdb5e39",
+	}},
+	{`Sender: syzkaller-bugs@googlegroups.com
+Subject: [PATCH] Some patch
+To: <someone@foo.com>
+From: bar <bar@foo.com>
+Message-ID: <1250334f-7220-2bff-5d87-b87573758d81@bar.com>
+Date: Sun, 7 May 2017 19:54:00 -0700
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Language: en-US
+Content-Transfer-Encoding: quoted-printable
+
+Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+`, Email{
+		BugIDs:    []string{"223c7461c58c58a4cb10"},
+		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
+		Subject:   "[PATCH] Some patch",
+		Author:    "bar@foo.com",
+		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+`,
+		Command: CmdNone,
+	}},
+	{`Sender: syzkaller-bugs@googlegroups.com
+Subject: [PATCH] Some patch
+To: <someone@foo.com>
+From: bar <bar@foo.com>
+Message-ID: <1250334f-7220-2bff-5d87-b87573758d81@bar.com>
+Date: Sun, 7 May 2017 19:54:00 -0700
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Language: en-US
+
+Link: https://bar.com/bug?extid=223c7461c58c58a4cb10@bar.com
+`, Email{
+		BugIDs:    []string{"223c7461c58c58a4cb10"},
+		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
+		Subject:   "[PATCH] Some patch",
+		Author:    "bar@foo.com",
+		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		Body: `Link: https://bar.com/bug?extid=223c7461c58c58a4cb10@bar.com
+`,
+		Command: CmdNone,
+	}},
+
+	{`Sender: syzkaller-bugs@googlegroups.com
+Subject: [PATCH] Some patch
+To: <someone@foo.com>
+From: bar <bar@foo.com>
+Message-ID: <1250334f-7220-2bff-5d87-b87573758d81@bar.com>
+Date: Sun, 7 May 2017 19:54:00 -0700
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Language: en-US
+Content-Transfer-Encoding: quoted-printable
+
+Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+Reported-by: syzbot <foo+9909090909090909@bar.com>
+`, Email{
+		BugIDs:    []string{"223c7461c58c58a4cb10", "9909090909090909"},
+		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
+		Subject:   "[PATCH] Some patch",
+		Author:    "bar@foo.com",
+		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+Reported-by: syzbot <foo+9909090909090909@bar.com>
+`,
+		Command: CmdNone,
+	}},
+	{`Sender: syzkaller-bugs@googlegroups.com
+Subject: [PATCH] Some patch
+To: <someone@foo.com>, <foo+9909090909090909@bar.com>
+From: bar <bar@foo.com>
+Message-ID: <1250334f-7220-2bff-5d87-b87573758d81@bar.com>
+Date: Sun, 7 May 2017 19:54:00 -0700
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Language: en-US
+Content-Transfer-Encoding: quoted-printable
+
+Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+`, Email{
+		// First come BugIDs from header, then from the body.
+		BugIDs:    []string{"9909090909090909", "223c7461c58c58a4cb10"},
+		MessageID: "<1250334f-7220-2bff-5d87-b87573758d81@bar.com>",
+		Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
+		Subject:   "[PATCH] Some patch",
+		Author:    "bar@foo.com",
+		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
+`,
+		Command: CmdNone,
 	}},
 }

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -95,3 +95,11 @@ func (ctx *fuchsia) ReleaseTag(commit string) (string, error) {
 func (ctx *fuchsia) Contains(commit string) (bool, error) {
 	return false, fmt.Errorf("not implemented for fuchsia")
 }
+
+func (ctx *fuchsia) ListCommitHashes(base string) ([]string, error) {
+	return ctx.repo.ListCommitHashes(base)
+}
+
+func (ctx *fuchsia) Object(name, commit string) ([]byte, error) {
+	return ctx.repo.Object(name, commit)
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -358,6 +358,14 @@ func (git *git) ListRecentCommits(baseCommit string) ([]string, error) {
 	return strings.Split(string(output), "\n"), nil
 }
 
+func (git *git) ListCommitHashes(baseCommit string) ([]string, error) {
+	output, err := git.git("log", "--pretty=format:%h", baseCommit)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(output), "\n"), nil
+}
+
 func (git *git) ExtractFixTagsFromCommits(baseCommit, email string) ([]*Commit, error) {
 	user, domain, err := splitEmail(email)
 	if err != nil {
@@ -575,4 +583,8 @@ func (git *git) IsRelease(commit string) (bool, error) {
 		return false, err
 	}
 	return len(tags1) != len(tags2), nil
+}
+
+func (git *git) Object(name, commit string) ([]byte, error) {
+	return git.git("show", fmt.Sprintf("%s:%s", commit, name))
 }

--- a/pkg/vcs/git_test_util.go
+++ b/pkg/vcs/git_test_util.go
@@ -28,6 +28,7 @@ type TestRepo struct {
 }
 
 func (repo *TestRepo) Git(args ...string) {
+	repo.t.Helper()
 	cmd := osutil.Command("git", args...)
 	cmd.Dir = repo.Dir
 	cmd.Env = filterEnv()

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -61,6 +61,12 @@ type Repo interface {
 	// Remote is not fetched and only commits reachable from the checked out HEAD are searched
 	// (e.g. do CheckoutBranch before).
 	Contains(commit string) (bool, error)
+
+	// ListCommitHashes lists all commit hashes reachable from baseCommit.
+	ListCommitHashes(baseCommit string) ([]string, error)
+
+	// Object returns the contents of a git repository object at the particular moment in history.
+	Object(name, commit string) ([]byte, error)
 }
 
 // Bisecter may be optionally implemented by Repo.
@@ -200,6 +206,10 @@ func NewRepo(os, vmType, dir string, opts ...RepoOpt) (Repo, error) {
 func NewSyzkallerRepo(dir string, opts ...RepoOpt) Repo {
 	git := newGit(dir, nil, append(opts, OptDontSandbox))
 	return git
+}
+
+func NewLKMLRepo(dir string) Repo {
+	return newGit(dir, nil, []RepoOpt{OptDontSandbox})
 }
 
 func Patch(dir string, patch []byte) error {

--- a/tools/syz-lore/query_lkml.go
+++ b/tools/syz-lore/query_lkml.go
@@ -1,0 +1,162 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/email/lore"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/tool"
+	"golang.org/x/sync/errgroup"
+)
+
+// The syz-lore tool can parse Lore archives and extract syzbot-related conversations from there.
+
+var (
+	flagArchives  = flag.String("archives", "", "path to the folder with git archives")
+	flagEmails    = flag.String("emails", "", "comma-separated list of own emails")
+	flagDomains   = flag.String("domains", "", "comma-separated list of own domains")
+	flagDashboard = flag.String("dashboard", "https://syzkaller.appspot.com", "dashboard address")
+	flagAPIClient = flag.String("client", "", "the name of the API client")
+	flagAPIKey    = flag.String("key", "", "api key")
+	flagVerbose   = flag.Bool("v", false, "print more debug info")
+)
+
+func main() {
+	defer tool.Init()()
+	if !osutil.IsDir(*flagArchives) {
+		tool.Failf("the arhives parameter must be a valid directory")
+	}
+	emails := strings.Split(*flagEmails, ",")
+	domains := strings.Split(*flagDomains, ",")
+
+	dash, err := dashapi.New(*flagAPIClient, *flagDashboard, *flagAPIKey)
+	if err != nil {
+		tool.Failf("dashapi failed: %v", err)
+	}
+	threads := processArchives(*flagArchives, emails, domains)
+	for i, thread := range threads {
+		messages := []dashapi.DiscussionMessage{}
+		for _, m := range thread.Messages {
+			messages = append(messages, dashapi.DiscussionMessage{
+				ID:       m.MessageID,
+				External: !emailInList(emails, m.Author),
+				Time:     m.Date,
+			})
+		}
+		discType := dashapi.DiscussionReport
+		if strings.Contains(thread.Subject, "PATCH") {
+			discType = dashapi.DiscussionPatch
+		}
+		log.Printf("saving %d/%d", i+1, len(threads))
+		err := dash.SaveDiscussion(&dashapi.SaveDiscussionReq{
+			Discussion: &dashapi.Discussion{
+				ID:       thread.MessageID,
+				Source:   dashapi.DiscussionLore,
+				Type:     discType,
+				Subject:  thread.Subject,
+				BugIDs:   thread.BugIDs,
+				Messages: messages,
+			},
+		})
+		if err != nil {
+			tool.Failf("dashapi failed: %v", err)
+		}
+	}
+}
+
+func processArchives(dir string, emails, domains []string) []*lore.Thread {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		tool.Failf("failed to read directory: %v", err)
+	}
+	threads := runtime.NumCPU()
+	messages := make(chan *lore.EmailReader, threads*2)
+	wg := sync.WaitGroup{}
+	g, _ := errgroup.WithContext(context.Background())
+
+	// Generate per-email jobs.
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		log.Printf("reading %s", path)
+		wg.Add(1)
+		g.Go(func() error {
+			defer wg.Done()
+			return lore.ReadArchive(path, messages)
+		})
+	}
+
+	// Set up some worker threads.
+	var repoEmails []*email.Email
+	var mu sync.Mutex
+	for i := 0; i < threads; i++ {
+		g.Go(func() error {
+			for rawMsg := range messages {
+				body, err := rawMsg.Extract()
+				if err != nil {
+					continue
+				}
+				msg, err := email.Parse(bytes.NewReader(body), emails, nil, domains)
+				if err != nil {
+					continue
+				}
+				// Keep memory consumption low.
+				msg.Body = ""
+				msg.Patch = ""
+
+				mu.Lock()
+				repoEmails = append(repoEmails, msg)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	// Once all jobs are generated, close the processing channel.
+	wg.Wait()
+	close(messages)
+	if err := g.Wait(); err != nil {
+		tool.Failf("%s", err)
+	}
+
+	list := lore.Threads(repoEmails)
+	log.Printf("collected %d email threads", len(list))
+
+	ret := []*lore.Thread{}
+	for _, d := range list {
+		if d.BugIDs == nil {
+			continue
+		}
+		ret = append(ret, d)
+		if *flagVerbose {
+			log.Printf("discussion ID=%s BugID=%s Subject=%s Messages=%d",
+				d.MessageID, d.BugIDs, d.Subject, len(d.Messages))
+		}
+	}
+	log.Printf("%d threads are related to syzbot", len(ret))
+	return ret
+}
+
+func emailInList(list []string, email string) bool {
+	for _, str := range list {
+		if str == email {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
With the changes from this PR syzbot will be able to collect the latest information about the bug-related discussion on LKML: bug reporting thread and bug fixing patches that include syzbot's `Reported-by` (and therefore Cc syzbot).

The `tools/syz-lkml` tool will need to be run once to extract existing discussions from LKML archives. All new discussions and messages will be picked up automatically.

TODO:
- [x] Integrate the `tools/syz-lkml` tool with the `save_discussion` API.
- [x] Add dashboard tests that cover the new functionality.

Changes that'll be (hopefully) covered in further PRs:
- Instead of ambiguous `Last activity` column show the number of replies in discussions and the number of sent patches.
- Add something like `#syz add discussion` to let users add relevant discussions that did not Cc syzbot.