### PR TITLE
dashboard/app: tidy UI

### DIFF
--- a/dashboard/app/subsystems.html
+++ b/dashboard/app/subsystems.html
@@ -14,12 +14,7 @@ The list of polled trees.
 <body>
 	{{template "header" .Header}}
 	<h2>The list of subsystems</h2><br>
-	<i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br><br>
-	{{if .SomeHidden}}
-		Empty subsystems have been hidden from the list. {{link .ShowAllURL "Show all"}}. <br>
-	{{end}}
 	<table class="list_table">
-		<caption>Subsystems list</caption>
 		<thead>
 			<tr>
 				<th><a onclick="return sortTable(this, 'Name', textSort)" href="#">Name</a></th>
@@ -47,5 +42,9 @@ The list of polled trees.
 		</tr>
 		</tfoot>
 	</table>
+	<i>(*) Note that the numbers below do not represent the latest data. They are updated once an hour.</i><br><br>
+	{{if .SomeHidden}}
+		Empty subsystems have been hidden from the list. {{link .ShowAllURL "Show all"}}. <br>
+	{{end}}
 </body>
 </html>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -359,7 +359,6 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	<caption>{{.Caption}}:</caption>
 		<thead>
 		<tr>
-			<th><a onclick="return sortTable(this, 'Manager', textSort)" href="#">Manager</a></th>
 			<th><a onclick="return sortTable(this, 'Time', textSort, true)" href="#">Time</a></th>
 			<th><a onclick="return sortTable(this, 'Kernel', textSort)" href="#">Kernel</a></th>
 			<th><a onclick="return sortTable(this, 'Commit', textSort)" href="#">Commit</a></th>
@@ -371,13 +370,13 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<th><a onclick="return sortTable(this, 'C repro', textSort)" href="#">C repro</a></th>
 			<th><a onclick="return sortTable(this, 'VM info', textSort)" href="#">VM info</a></th>
 			<th><a onclick="return sortTable(this, 'Assets', textSort)" href="#">Assets</a></th>
+			<th><a onclick="return sortTable(this, 'Manager', textSort)" href="#">Manager</a></th>
 			<th><a onclick="return sortTable(this, 'Title', textSort)" href="#">Title</a></th>
 		</tr>
 		</thead>
 		<tbody>
 		{{range $b := .Crashes}}
 		<tr>
-			<td class="manager">{{$b.Manager}}</td>
 			<td class="time">{{formatTime $b.Time}}</td>
 			<td class="kernel" title="{{$b.KernelAlias}}">{{$b.KernelAlias}}</td>
 			<td class="tag" title="{{$b.KernelCommit}}
@@ -392,6 +391,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="assets">{{range $i, $asset := .Assets}}
 				<span class="no-break">[<a href="{{$asset.DownloadURL}}">{{$asset.Title}}</a>]</span>
 			{{end}}</td>
+			<td class="manager">{{$b.Manager}}</td>
 			<td class="manager">{{$b.Title}}</td>
 		</tr>
 		{{end}}

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -191,8 +191,7 @@ table td, table th {
 }
 
 .list_table .assets {
-	max-width: 120pt;
-	white-space: normal;
+	white-space: nowrap;
 }
 
 .list_table .assets .no-break {

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -23,7 +23,7 @@ h1, h2, h3, h4 {
 
 .navigation_tab_selected {
 	font-weight: bold;
-	border: 2px solid black;
+	border: 3px solid black;
 	padding: 4px;
 	margin: 4px;
 }


### PR DESCRIPTION
- dashboard/app: remove repetition on subsystems page
- dashboard/app: move aux notes to the bottom of the page
- dashboard/app: move manager to the end of crashes table
- dashboard/app: don't wrap assets column in crashes table
