### PR TITLE
.clang-format: remove duplicate attribute

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,11 +5,10 @@ BreakBeforeBraces: Linux
 IndentCaseLabels: false
 DerivePointerAlignment: false
 PointerAlignment: Left
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 ColumnLimit: 0
-AlignTrailingComments: false
 


### PR DESCRIPTION
New versions of clang-format start complaining about the dup attribute.
Remove it.
