### PR TITLE
syz-env: don't invoke docker with --user in rootless mode

### DIFF
--- a/tools/syz-env
+++ b/tools/syz-env
@@ -54,13 +54,21 @@ elif [ "$(basename -- "$0")" == "syz-old-env" ]; then
         IMAGE="old-env"
 fi
 
+# If we're running rootless docker, files owned by the host user appear within the
+# container as being owned by root.
+#
+# If we're running regular rootful docker, we need to specify --user, as otherwise
+# processes within the container will create files with the wrong ownership.
+if [ ! "$(docker info -f "{{println .SecurityOptions}}" | grep rootless)" ]; then
+	DOCKERARGS+=" --user $(id -u ${USER}):$(id -g ${USER})"
+fi
+
 # Update docker image
 docker pull -q gcr.io/syzkaller/${IMAGE}
 
 # Run everything as the host user, this is important for created/modified files.
 docker run \
 	--rm \
-	--user $(id -u ${USER}):$(id -g ${USER}) \
 	--volume "$SCRIPT_DIR/..:/syzkaller/gopath/src/github.com/google/syzkaller:z" \
 	--volume "$HOME/.cache:/syzkaller/.cache:z" \
 	--volume "/var/run/docker.sock":"/var/run/docker.sock" \


### PR DESCRIPTION
Docker now supports rootless mode, which allows you to run your dockerd as a non-root user. This is helpful for security, as traditional rootful Docker can trivially be used to obtain root privileges outside of a container.

Rootless Docker is implemented using RootlessKit (a fancy version of fakeroot that uses user namespaces) to create a new user namespace that maps the uid of the user running dockerd to 0. Files in mounted volumes that are owned by that user will appear in the container as belonging to root.

Currently, syz-env invokes "docker run" with --user to set the uid inside the container to match the user's uid outside the container, to ensure that file ownership and permissions behave as expected. This breaks under rootless mode, as the files will appear to be owned by root while the user has a non-root uid.

Only add the --user flag if the Docker daemon is not running in rootless mode. If running in rootless mode, run without --user so that the user appears to be root inside the container.

Closes: #3765 ("syz-env: uid/permissions issues when running with rootless Docker")

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
