### PR TITLE
pkg/subsystem: fix nilfs syscalls

### DIFF
--- a/pkg/subsystem/linux/rules.go
+++ b/pkg/subsystem/linux/rules.go
@@ -43,7 +43,7 @@ var (
 			"jfs":      {"syz_mount_image$jfs"},
 			"kvm":      {"syz_kvm_setup_cpu"},
 			"minix":    {"syz_mount_image$minix"},
-			"nilfs2":   {"syz_mount_image$nilfs2"},
+			"nilfs":    {"syz_mount_image$nilfs2"},
 			"ntfs":     {"syz_mount_image$ntfs"},
 			"ntfs3":    {"syz_mount_image$ntfs3"},
 			"ocfs2":    {"syz_mount_image$ocfs2"},

--- a/pkg/subsystem/lists/linux.go
+++ b/pkg/subsystem/lists/linux.go
@@ -3203,6 +3203,7 @@ func subsystems_linux() []*Subsystem {
 
 	nilfs = Subsystem{
 		Name:        "nilfs",
+		Syscalls:    []string{"syz_mount_image$nilfs2"},
 		Lists:       []string{"linux-nilfs@vger.kernel.org"},
 		Maintainers: []string{"konishi.ryusuke@gmail.com"},
 		Parents:     []*Subsystem{&fs},


### PR DESCRIPTION
Adjust the rules so that syz_mount_image$nilfs2 begins to point to nilfs.