### PR TITLE
dashboard: optionally disable monthly reports

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -524,6 +524,13 @@ var testSubsystems = []*subsystem.Subsystem{
 		Lists:       []string{"subsystemB@list.com"},
 		Maintainers: []string{"subsystemB@person.com"},
 	},
+	{
+		Name:        "subsystemC",
+		PathRules:   []subsystem.PathRule{{IncludeRegexp: `c\.c`}},
+		Lists:       []string{"subsystemC@list.com"},
+		Maintainers: []string{"subsystemC@person.com"},
+		NoReminders: true,
+	},
 }
 
 const (

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -48,6 +48,9 @@ func reportingPollBugLists(c context.Context, typ string) []*dashapi.BugListRepo
 			return rawSubsystems[i].Name < rawSubsystems[j].Name
 		})
 		for _, entry := range rawSubsystems {
+			if entry.NoReminders {
+				continue
+			}
 			for _, dbReport := range registry.get(ns, entry.Name) {
 				if stateEntry.Sent >= reporting.DailyLimit {
 					break
@@ -86,6 +89,9 @@ func handleSubsystemReports(w http.ResponseWriter, r *http.Request) {
 		reporting := nsConfig.ReportingByName(rConfig.SourceReporting)
 		var subsystems []*Subsystem
 		for _, entry := range nsConfig.Subsystems.Service.List() {
+			if entry.NoReminders {
+				continue
+			}
 			subsystems = append(subsystems, registry.get(ns, entry.Name))
 		}
 		// Poll subsystems in a round-robin manner.

--- a/pkg/subsystem/entities.go
+++ b/pkg/subsystem/entities.go
@@ -10,6 +10,8 @@ type Subsystem struct {
 	Lists       []string
 	Maintainers []string
 	Parents     []*Subsystem
+	// If NoReminders is set to true, there should be no monthly reports for the subsystem.
+	NoReminders bool
 }
 
 // ReachableParents returns the set of subsystems reachable from the current one.

--- a/pkg/subsystem/linux/rules.go
+++ b/pkg/subsystem/linux/rules.go
@@ -12,6 +12,8 @@ type customRules struct {
 	// These subsystems need to be extracted even without mailing lists.
 	// Key is the subsystem name, value is the list of raw names in MAINTAINERS.
 	extraSubsystems map[string][]string
+	// For these subsystems we do not generate monthly reminders.
+	noReminders map[string]struct{}
 }
 
 var (
@@ -87,6 +89,11 @@ var (
 			"isofs":  {"ISOFS FILESYSTEM"},
 			"kernfs": {"KERNFS"},
 			"udf":    {"UDF FILESYSTEM"},
+		},
+		noReminders: map[string]struct{}{
+			// Many misclassified bugs end up in `kernel`, so there's no sense
+			// in generating monthly reports for it.
+			"kernel": {},
 		},
 	}
 )

--- a/pkg/subsystem/linux/subsystems.go
+++ b/pkg/subsystem/linux/subsystems.go
@@ -130,6 +130,7 @@ func (ctx *linuxCtx) applyExtraRules(list []*subsystem.Subsystem) {
 	}
 	for _, entry := range list {
 		entry.Syscalls = ctx.extraRules.subsystemCalls[entry.Name]
+		_, entry.NoReminders = ctx.extraRules.noReminders[entry.Name]
 	}
 }
 

--- a/pkg/subsystem/lists/linux.go
+++ b/pkg/subsystem/lists/linux.go
@@ -2149,6 +2149,7 @@ func subsystems_linux() []*Subsystem {
 			{IncludeRegexp: "^net/vmw_vsock/vmci_transport[^/]*$"},
 			{IncludeRegexp: "axp[128]"},
 		},
+		NoReminders: true,
 	}
 
 	kernfs = Subsystem{

--- a/tools/syz-query-subsystems/generator.go
+++ b/tools/syz-query-subsystems/generator.go
@@ -45,10 +45,11 @@ func generateSubsystemsFile(name string, list []*subsystem.Subsystem, commitInfo
 		}
 		sort.Strings(parents)
 		subsystem := &templateSubsystem{
-			VarName:   varName,
-			Name:      serializer.WriteString(entry.Name),
-			PathRules: serializer.WriteString(entry.PathRules),
-			Parents:   parents,
+			VarName:     varName,
+			Name:        serializer.WriteString(entry.Name),
+			PathRules:   serializer.WriteString(entry.PathRules),
+			Parents:     parents,
+			NoReminders: entry.NoReminders,
 		}
 		// Some of the records are mostly empty.
 		if len(entry.Maintainers) > 0 {
@@ -118,6 +119,7 @@ type templateSubsystem struct {
 	Lists       string
 	Maintainers string
 	Parents     []string
+	NoReminders bool
 }
 
 type templateVars struct {
@@ -167,6 +169,9 @@ var {{range $i, $item := .List}}
  Parents: []*Subsystem{ {{range .Parents}} &{{.}}, {{end}} },
 {{- end}}
  PathRules: {{.PathRules}},
+{{- if .NoReminders}}
+ NoReminders: true,
+{{- end}}
 }
 {{end}}
 


### PR DESCRIPTION
For some subsystems (e.g. `kernel`) such reports just don't make much sense, since there are too many incorrectly classified bugs in there. Make it possible to exclude such subsystems from periodic reminders.

