### PR TITLE
docs: add GREBE reference

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -1,6 +1,7 @@
 # Research work based on syzkaller
 
 _newer first_
+* [GREBE: Unveiling Exploitation Potential for Linux Kernel Bugs](https://zplin.me/papers/GREBE.pdf)
 * [Precise Detection of Kernel Data Races with Probabilistic Lockset Analysis](https://www.cs.columbia.edu/~gabe/files/oakland2023_pla.pdf)
 * [Linux Kernel Enriched Corpus](https://github.com/cmu-pasta/linux-kernel-enriched-corpus) : [corpus.db](https://github.com/cmu-pasta/linux-kernel-enriched-corpus/raw/main/corpus.db)
 * [HotBPF - An On-demand and On-the-fly Memory Protection](https://www.youtube.com/watch?v=1KSLTsgxaSU)


### PR DESCRIPTION
tl;dr they try to identify the data structure involved in a crash, e.g. by parsing the WARN_ON condition. they modify the compiler instrumentation to overwrite some of the upper bits in the program counters, for program counters that modify the data structure. then they guide coverage by these magic PCs. they do this to find other failure modes of buggy code found by syzkaller.