### PR TITLE
dashboard: display discussion info on the main page

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -108,6 +108,8 @@ type Config struct {
 	Kcidb *KcidbConfig
 	// Subsystems config.
 	Subsystems SubsystemsConfig
+	// Instead of Last acitivity, display Discussions on the main page.
+	DisplayDiscussions bool
 }
 
 // DiscussionEmailConfig defines the correspondence between an email and a DiscussionSource.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -275,6 +275,7 @@ type uiBugGroup struct {
 	ShowIndex     int
 	Bugs          []*uiBug
 	DispLastAct   bool
+	DispDiscuss   bool
 }
 
 type uiJobList struct {
@@ -306,6 +307,7 @@ type uiBug struct {
 	NumManagers    int
 	LastActivity   time.Time
 	Subsystems     []*uiBugSubsystem
+	Discussions    DiscussionSummary
 }
 
 type uiBugSubsystem struct {
@@ -443,7 +445,11 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 		return err
 	}
 	for _, group := range groups {
-		group.DispLastAct = true
+		if config.Namespaces[hdr.Namespace].DisplayDiscussions {
+			group.DispDiscuss = true
+		} else {
+			group.DispLastAct = true
+		}
 	}
 	data := &uiMainPage{
 		Header:         hdr,
@@ -1462,6 +1468,7 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 		CreditEmail:    creditEmail,
 		NumManagers:    len(managers),
 		LastActivity:   bug.LastActivity,
+		Discussions:    bug.discussionSummary(),
 	}
 	for _, entry := range bug.Tags.Subsystems {
 		uiBug.Subsystems = append(uiBug.Subsystems, makeBugSubsystemUI(c, bug, entry))

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -139,6 +139,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{if $.DispLastAct}}
 		<th><a onclick="return sortTable(this, 'Last activity', timeSort, desc=true)" href="#">Last activity</a></th>
 		{{end}}
+		{{if $.DispDiscuss}}
+		<th><a onclick="return sortTable(this, 'Discussions', timeSort, desc=true)" href="#">Discussions</a></th>
+		{{end}}
 		{{if $.ShowPatched}}
 			<th><a onclick="return sortTable(this, 'Patched', patchedSort)" href="#">Patched</a></th>
 		{{end}}
@@ -174,7 +177,17 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				{{end}}
 			</td>
 			{{if $.DispLastAct}}
-			<td class="stat">{{formatLateness $.Now $b.LastActivity}}</td>
+				<td class="stat">{{formatLateness $.Now $b.LastActivity}}</td>
+			{{end}}
+			{{if $.DispDiscuss}}
+			{{$d := $b.Discussions}}
+			<td class="discussions" sort-value="{{formatLateness $.Now $d.LastMessage}}">
+			{{- if $d.LastPatchMessage.IsZero -}}
+				<span class="icon">&#128172;</span> {{$d.ExternalMessages}} [{{formatLateness $.Now $d.LastMessage}}]
+			{{else}}
+				<b>PATCH</b> [{{formatLateness $.Now $d.LastPatchMessage}}]
+			{{- end -}}
+			</td>
 			{{end}}
 			{{if $.ShowPatched}}
 				<td class="patched" {{if $b.Commits}}title="{{with $com := index $b.Commits 0}}{{$com.Title}}{{end}}"{{end}}>{{len $b.PatchedOn}}/{{$b.NumManagers}}</td>

--- a/pkg/html/pages/common.js
+++ b/pkg/html/pages/common.js
@@ -6,8 +6,13 @@ function sortTable(item, colName, conv, desc = false) {
 	rows = table.rows;
 	col = findColumnByName(rows[0].getElementsByTagName("th"), colName);
 	values = [];
-	for (i = 1; i < rows.length; i++)
-		values.push([conv(rows[i].getElementsByTagName("td")[col].textContent), rows[i]]);
+	for (i = 1; i < rows.length; i++) {
+		const td = rows[i].getElementsByTagName("td")[col]
+		let value = td.textContent
+		if (td.getAttribute("sort-value") != null)
+			value = td.getAttribute("sort-value")
+		values.push([conv(value), rows[i]]);
+	}
 	if (desc)
 		desc = !isSorted(values.slice().reverse())
 	else

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -160,6 +160,11 @@ table td, table th {
 	text-align: right;
 }
 
+.list_table .discussions {
+	font-family: monospace;
+	text-align: left;
+}
+
 .list_table .bisect_status {
 	width: 75pt;
 	max-width: 75pt;
@@ -196,6 +201,10 @@ table td, table th {
 
 .list_table .assets .no-break {
 	display: inline-block;
+}
+
+.list_table .icon {
+	font-size: 75%;
 }
 
 .subsystem {


### PR DESCRIPTION
This should help users clearly distinguish silently ignored bug reports, bug reports with discussions and bugs for which patches have already been sent.