### PR TITLE
sys/linux: mark drm_msm_gem_new 'handle' as out

### DIFF
--- a/sys/linux/dev_msm.txt
+++ b/sys/linux/dev_msm.txt
@@ -7,11 +7,6 @@ include <drm/msm_drm.h>
 
 resource fd_msm[fd]
 
-# This either comes from a MSM_GEM_SUBMIT ioctl described below or from a kms
-# ioctl creating an OUT_FENCE_PTR (see drivers/gpu/drm/drm_atomic_uapi.c and
-# https://www.kernel.org/doc/html/latest/gpu/drm-kms.html for more details)
-# Once fences are described this should be updated to an fd_drm_fence.
-
 openat$msm(fd const[AT_FDCWD], file ptr[in, string["/dev/msm"]], flags flags[open_flags], mode const[0]) fd_msm
 
 ioctl$DRM_IOCTL_MSM_GET_PARAM(fd fd_msm, cmd const[DRM_IOCTL_MSM_GET_PARAM], arg ptr[inout, drm_msm_param])

--- a/sys/linux/dev_msm.txt
+++ b/sys/linux/dev_msm.txt
@@ -32,7 +32,7 @@ _ = __NR_mmap2
 drm_msm_gem_new {
 	size	int64
 	flags	flags[msm_gem_new_flags, int32]
-	handle	drm_gem_handle
+	handle	drm_gem_handle	(out)
 }
 
 drm_msm_gem_info {


### PR DESCRIPTION
The handle is an output value, used for other gem handle inputs. Mark it as such to clarify where gem handles come from.
