### PR TITLE
Fix compiler warning for kvm_gen

### DIFF
--- a/executor/gen_linux_amd64.go
+++ b/executor/gen_linux_amd64.go
@@ -2,6 +2,6 @@
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 // nolint: lll
-//go:generate bash -c "gcc -DGOARCH_$GOARCH=1 kvm_gen.cc kvm_amd64.S -o kvm_gen && ./kvm_gen > kvm_amd64.S.h && rm ./kvm_gen"
+//go:generate bash -c "gcc -Wa,--noexecstack -DGOARCH_$GOARCH=1 kvm_gen.cc kvm_amd64.S -o kvm_gen && ./kvm_gen > kvm_amd64.S.h && rm ./kvm_gen"
 
 package executor

--- a/executor/kvm_amd64.S
+++ b/executor/kvm_amd64.S
@@ -92,7 +92,7 @@ kvm_asm64_cpl3:
 	movq $SEL_CS64_CPL3, 4(%rsp)
 	movq $ADDR_STACK0, 8(%rsp)
 	movq $SEL_DS64_CPL3, 12(%rsp)
-	lret
+	lretl
 kvm_asm64_cpl3_end:
 	nop
 


### PR DESCRIPTION
This soothes two compiler warnings:
- kvm_gen defaulted to executable stack due to a missing `.note.GNU-stack` elf section.
- kvm_amd64.S contained an at&t instruction with a missing instruction mnemonic suffix.

The kvm_gen bin is used to generate the kvm_amd64.S.h. Neither change affects the final kvm_amd64.S.h