### PR TITLE
pkg/email/lore: better classify emails

### DIFF
--- a/pkg/email/lore/parse.go
+++ b/pkg/email/lore/parse.go
@@ -39,7 +39,7 @@ func DiscussionType(msg *email.Email) dashapi.DiscussionType {
 		discType = dashapi.DiscussionReport
 	}
 	// This is very crude, but should work for now.
-	if strings.Contains(msg.Subject, "PATCH") {
+	if strings.Contains(strings.ToLower(msg.Subject), "[patch") {
 		discType = dashapi.DiscussionPatch
 	} else if strings.Contains(msg.Subject, "Monthly") {
 		discType = dashapi.DiscussionReminder

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -263,6 +263,12 @@ func TestDiscussionType(t *testing.T) {
 		},
 		{
 			msg: &email.Email{
+				Subject: "[patch v3] Bla-bla",
+			},
+			ret: dashapi.DiscussionPatch,
+		},
+		{
+			msg: &email.Email{
 				Subject:  "[syzbot] Monthly ext4 report",
 				OwnEmail: true,
 			},


### PR DESCRIPTION
Patches are not always spelled upper case. Also, looking for just PATCH may lead to false positives, so first put the subject to lower case and then look for the "[patch" substring.
