### PR TITLE
sys/linux: describe submit queue id as a resource in msm

### DIFF
--- a/sys/linux/dev_msm.txt
+++ b/sys/linux/dev_msm.txt
@@ -6,6 +6,7 @@
 include <drm/msm_drm.h>
 
 resource fd_msm[fd]
+resource msm_submitqueue_id[int32]
 
 openat$msm(fd const[AT_FDCWD], file ptr[in, string["/dev/msm"]], flags flags[open_flags], mode const[0]) fd_msm
 
@@ -18,7 +19,7 @@ ioctl$DRM_IOCTL_MSM_GEM_SUBMIT(fd fd_msm, cmd const[DRM_IOCTL_MSM_GEM_SUBMIT], a
 ioctl$DRM_IOCTL_MSM_WAIT_FENCE(fd fd_msm, cmd const[DRM_IOCTL_MSM_WAIT_FENCE], arg ptr[in, drm_msm_wait_fence])
 ioctl$DRM_IOCTL_MSM_GEM_MADVISE(fd fd_msm, cmd const[DRM_IOCTL_MSM_GEM_MADVISE], arg ptr[inout, drm_msm_gem_madvise])
 ioctl$DRM_IOCTL_MSM_SUBMITQUEUE_NEW(fd fd_msm, cmd const[DRM_IOCTL_MSM_SUBMITQUEUE_NEW], arg ptr[inout, drm_msm_submitqueue])
-ioctl$DRM_IOCTL_MSM_SUBMITQUEUE_CLOSE(fd fd_msm, cmd const[DRM_IOCTL_MSM_SUBMITQUEUE_CLOSE], arg ptr[in, int32])
+ioctl$DRM_IOCTL_MSM_SUBMITQUEUE_CLOSE(fd fd_msm, cmd const[DRM_IOCTL_MSM_SUBMITQUEUE_CLOSE], arg ptr[in, msm_submitqueue_id])
 ioctl$DRM_IOCTL_MSM_SUBMITQUEUE_QUERY(fd fd_msm, cmd const[DRM_IOCTL_MSM_SUBMITQUEUE_QUERY], arg ptr[inout, drm_msm_submitqueue_query])
 
 mmap$DRM_MSM(addr vma, len len[addr], prot flags[mmap_prot], flags flags[mmap_flags], fd fd_msm, offset fileoff)
@@ -97,7 +98,7 @@ drm_msm_gem_submit {
 	bos		ptr64[in, array[drm_msm_gem_submit_bo]]
 	cmds		ptr64[in, array[drm_msm_gem_submit_cmd]]
 	fence_fd	fd_sync_file[opt]
-	queueid		int32
+	queueid		msm_submitqueue_id
 	in_syncobjs	ptr64[in, array[drm_msm_gem_submit_syncobj]]
 	out_syncobjs	ptr64[in, array[drm_msm_gem_submit_syncobj]]
 	nr_in_syncobjs	len[in_syncobjs, int32]
@@ -110,7 +111,7 @@ drm_msm_wait_fence {
 	fence	int32
 	pad	const[0, int32]
 	timeout	drm_msm_timespec	(in)
-	queueid	int32
+	queueid	msm_submitqueue_id
 }
 
 drm_msm_gem_madvise {
@@ -122,12 +123,12 @@ drm_msm_gem_madvise {
 drm_msm_submitqueue {
 	flags	flags[msm_submitqueue_flags, int32]
 	prio	int32
-	id	int32
+	id	msm_submitqueue_id	(out)
 }
 
 drm_msm_submitqueue_query {
 	data	int64
-	id	int32
+	id	msm_submitqueue_id
 	param	flags[msm_submitqueue_query_flags, int32]
 	len	int32
 	pad	const[0, int32]


### PR DESCRIPTION
The msm gpu driver has a submit queue and some associated ioctls for it. The driver uses an 'id' to identify an element in the queue. Make a resource for this id and update the descriptions to use the resource so we can provide better hints about what sorts of numbers to try here.

@zsm-oss @robclark
