### PR TITLE
pkg/vcs: lengthen command timeout

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -443,7 +443,7 @@ func (git *git) git(args ...string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	return osutil.Run(time.Hour, cmd)
+	return osutil.Run(3*time.Hour, cmd)
 }
 
 func splitEmail(email string) (user, domain string, err error) {


### PR DESCRIPTION
The Pixel repository from partner-android takes ~2 hours to initialize, so increased the git command timeout to 3 hours.