### PR TITLE
datastore: refactor patch retesting functionality

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1556,19 +1556,6 @@ func checkClient(conf *GlobalConfig, name0, secretPassword, oauthSubject string)
 	return "", ErrAccess
 }
 
-func handleRetestRepros(w http.ResponseWriter, r *http.Request) {
-	c := appengine.NewContext(r)
-	for ns, cfg := range config.Namespaces {
-		if !cfg.RetestRepros {
-			continue
-		}
-		err := updateRetestReproJobs(c, ns)
-		if err != nil {
-			log.Errorf(c, "failed to update retest repro jobs for %s: %v", ns, err)
-		}
-	}
-}
-
 func handleRefreshSubsystems(w http.ResponseWriter, r *http.Request) {
 	c := appengine.NewContext(r)
 	const updateBugsCount = 25

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -190,7 +190,6 @@ var testConfig = &GlobalConfig{
 					},
 				},
 			},
-			RetestRepros: true,
 		},
 		// Namespaces for access level testing.
 		"access-admin": {
@@ -304,6 +303,7 @@ var testConfig = &GlobalConfig{
 					},
 				},
 			},
+			RetestRepros: true,
 			Subsystems: SubsystemsConfig{
 				Service: subsystem.MustMakeService(testSubsystems),
 			},

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -91,6 +91,7 @@ func TestBisectCause(t *testing.T) {
 
 	// BisectCause #2
 	pollResp2 := pollResp
+	c.advanceTime(time.Minute)
 	pollResp = c.client2.pollJobs(build.Manager)
 	c.expectNE(pollResp.ID, pollResp2.ID)
 	c.expectEQ(pollResp.ReproOpts, []byte("repro opts 2"))
@@ -248,6 +249,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 		"bugs2@syzkaller.com",
 		"default2@maintainers.com",
 	})
+	c.advanceTime(time.Minute)
 	pollResp = c.client2.pollJobs(build.Manager)
 
 	// Bisection succeeded.
@@ -307,6 +309,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 	}
 
 	// BisectFix #2
+	c.advanceTime(time.Minute)
 	pollResp = c.client2.pollJobs(build.Manager)
 	c.expectNE(pollResp.ID, "")
 	c.expectEQ(pollResp.Type, dashapi.JobBisectFix)
@@ -320,6 +323,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 	c.expectOK(c.client2.JobDone(done))
 
 	// BisectFix #3
+	c.advanceTime(time.Minute)
 	pollResp = c.client2.pollJobs(build.Manager)
 	c.expectNE(pollResp.ID, "")
 	c.expectEQ(pollResp.Type, dashapi.JobBisectFix)
@@ -332,6 +336,7 @@ https://goo.gl/tpsmEJ#testing-patches`,
 	c.expectOK(c.client2.JobDone(done))
 
 	// BisectFix #4
+	c.advanceTime(time.Minute)
 	pollResp = c.client2.pollJobs(build.Manager)
 	c.expectNE(pollResp.ID, "")
 	c.expectEQ(pollResp.Type, dashapi.JobBisectFix)

--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -10,8 +10,6 @@ cron:
   schedule: every 1 hours
 - url: /cron/kcidb_poll
   schedule: every 5 minutes
-- url: /cron/retest_repros
-  schedule: every 1 hours
 - url: /cron/refresh_subsystems
   schedule: every 5 minutes
 - url: /cron/subsystem_reports

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -34,6 +34,7 @@ type Manager struct {
 	FailedSyzBuildBug string
 	LastAlive         time.Time
 	CurrentUpTime     time.Duration
+	LastGeneratedJob  time.Time
 }
 
 // ManagerStats holds per-day manager runtime stats.

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -41,9 +41,9 @@ indexes:
 
 - kind: Bug
   properties:
-  - name: Namespace
   - name: Status
-  - name: LastTime
+  - name: HappenedOn
+  - name: HeadReproLevel
 
 - kind: Bug
   properties:

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -66,7 +66,6 @@ func initHTTPHandlers() {
 	}
 	http.HandleFunc("/cron/cache_update", cacheUpdate)
 	http.HandleFunc("/cron/deprecate_assets", handleDeprecateAssets)
-	http.HandleFunc("/cron/retest_repros", handleRetestRepros)
 	http.HandleFunc("/cron/refresh_subsystems", handleRefreshSubsystems)
 	http.HandleFunc("/cron/subsystem_reports", handleSubsystemReports)
 }

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -386,11 +386,6 @@ func (c *Ctx) expectNoEmail() {
 	}
 }
 
-func (c *Ctx) updRetestReproJobs() {
-	_, err := c.GET("/cron/retest_repros")
-	c.expectOK(err)
-}
-
 type apiClient struct {
 	*Ctx
 	*dashapi.Dashboard


### PR DESCRIPTION
Refactor patch testing functionality.

Instead of creating patch testing jobs per cron, create them on demand
during pollJob(). This allows to only create jobs for managers that do
support jobs and also simplifies further changes that are related to
patch testing.

As there are too many bugs and poll period is quite small, don't query
all the database each time. Consider a random subset of bugs each time,
this should be enough given high poll rate.