### PR TITLE
pkg/bisect: support linux gcc builds back to v4.19+ again

### DIFF
--- a/docs/syzbot.md
+++ b/docs/syzbot.md
@@ -187,7 +187,7 @@ using `#syz fix: commit-title` commands.
 can reproduce the bug and then goes back release-by-release to find the first
 release where kernel does not crash. Once such release is found, `syzbot` starts
 bisection on that range. `syzbot` has limitation of how far back in time it can
-go (currently `v4.1`), going back in time is [very hard](/pkg/vcs/linux.go)
+go (currently `v4.19`), going back in time is [very hard](/pkg/vcs/linux.go)
 because of incompatible compiler/linker/asm/perl/make/libc/etc, kernel
 build/boot breakages and large amounts of bugs.
 

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -64,12 +64,16 @@ func (ctx *linux) PreviousReleaseTags(commit, compilerType string) ([]string, er
 		//
 		// We used to use 4.1 as the oldest tested release (it works in general).
 		// However, there is correlation between how far back we go and probability
-		// of getting correct result (see #1532). So we now stop at 4.6.
+		// of getting correct result (see #1532). So we then stopped at 4.6.
 		// 4.6 is somewhat arbitrary, we've seen lots of wrong results in 4.5..4.6 range,
 		// but there is definitive reason for 4.6. Most likely later we want to bump it
 		// even more (as new releases are produced). Next good candidate may be 4.11
 		// because then we won't need gcc 5.5.
-		cutoff = "v4.5"
+		//
+		// TODO: The buildroot images deployed after #2820 can only boot v4.19+ kernels.
+		// This has caused lots of bad bisection results, see #3224. We either need a new
+		// universal image or a kernel version dependant image selection.
+		cutoff = "v4.18"
 	} else if compilerType == "clang" {
 		// v5.3 was the first release with solid clang support, however I was able to
 		// compile v5.1..v5.3 using a newer defconfig + make oldconfig. Everything older

--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -58,7 +58,7 @@ BR2_PACKAGE_OPENSSH=y
 
 BR2_TARGET_ROOTFS_EXT2_SIZE="1G"
 # Slightly more interesting and realistic options.
-BR2_TARGET_ROOTFS_EXT2_MKFS_OPTIONS="-O 64bit,ext_attr,encrypt,verity,extents,huge_file,flex_bg,dir_nlink,sparse_super,resize_inode,has_journal"
+BR2_TARGET_ROOTFS_EXT2_MKFS_OPTIONS="-O 64bit,ext_attr,encrypt,extents,huge_file,flex_bg,dir_nlink,sparse_super,resize_inode,has_journal"
 
 # Install firmware for USB devices we can connect during fuzzing.
 BR2_PACKAGE_LINUX_FIRMWARE=y


### PR DESCRIPTION
The buildroot based rootfs we have been using for a while has resulted in a lot of bad and inconclusive bisections. Reasons are:
- It enabled the ext4 feature verity, which makes the image not (rw) mountable at v5.3 and below.
- Kernels at v4.18 and below simply refuse to boot with this rootfs.

Hence in this PR I propose disabling ext4 verity and not trying to bisect beyond v4.19. See commit messages for more details.

After this I'll be working on:
- [This PR to not markt this kind of issue as "inconclusive" ](https://github.com/google/syzkaller/pull/3663)
- [Bisection fixes specific to clang](https://github.com/google/syzkaller/issues/3814)

In the future we should probably teach the bisect code to pick different rootfs images based on kernel version, however I'm not planing to do this work right now.