### PR TITLE
dashboard: let users see decommissioned namespaces

### DIFF
--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -177,11 +177,11 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 			}
 			continue
 		}
-		if cfg.Decommissioned {
-			continue
-		}
 		if ns1 == ns {
 			found = true
+		}
+		if cfg.Decommissioned {
+			continue
 		}
 		h.Namespaces = append(h.Namespaces, uiNamespace{
 			Name:    ns1,


### PR DESCRIPTION
Still don't show them in the header, but at least serve all direct links to the bugs of a decommissioned namespace.
