### PR TITLE
all: determine bug origin trees and missing backports

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -232,7 +232,7 @@ func apiCommitPoll(c context.Context, ns string, r *http.Request, payload []byte
 		ReportEmail: reportEmail(c, ns),
 	}
 	for _, repo := range config.Namespaces[ns].Repos {
-		if repo.Obsolete {
+		if repo.NoPoll {
 			continue
 		}
 		resp.Repos = append(resp.Repos, dashapi.Repo{

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -253,9 +253,10 @@ var testConfig = &GlobalConfig{
 			},
 			Repos: []KernelRepo{
 				{
-					URL:    "git://syzkaller.org/access-public.git",
-					Branch: "access-public",
-					Alias:  "access-public",
+					URL:                    "git://syzkaller.org/access-public.git",
+					Branch:                 "access-public",
+					Alias:                  "access-public",
+					DetectMissingBackports: true,
 				},
 			},
 			Reporting: []Reporting{
@@ -271,6 +272,7 @@ var testConfig = &GlobalConfig{
 					Config:     &TestConfig{Index: 2},
 				},
 			},
+			FindBugOriginTrees: true,
 		},
 		"access-public-email": {
 			AccessLevel: AccessPublic,

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -80,7 +80,7 @@ var testConfig = &GlobalConfig{
 				{
 					URL:    "git://github.com/google/syzkaller",
 					Branch: "master",
-					Alias:  "repo10alias",
+					Alias:  "repo10alias1",
 					CC: CCConfig{
 						Maintainers: []string{"maintainers@repo10.org", "bugs@repo10.org"},
 					},
@@ -88,7 +88,7 @@ var testConfig = &GlobalConfig{
 				{
 					URL:    "git://github.com/google/syzkaller",
 					Branch: "old_master",
-					Alias:  "repo10alias",
+					Alias:  "repo10alias2",
 					NoPoll: true,
 				},
 			},

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -86,10 +86,10 @@ var testConfig = &GlobalConfig{
 					},
 				},
 				{
-					URL:      "git://github.com/google/syzkaller",
-					Branch:   "old_master",
-					Alias:    "repo10alias",
-					Obsolete: true,
+					URL:    "git://github.com/google/syzkaller",
+					Branch: "old_master",
+					Alias:  "repo10alias",
+					NoPoll: true,
 				},
 			},
 			Managers: map[string]ConfigManager{

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -408,7 +408,7 @@ func checkNamespace(ns string, cfg *Config, namespaces, clientNames map[string]b
 	if cfg.Kcidb != nil {
 		checkKcidb(ns, cfg.Kcidb)
 	}
-	checkKernelRepos(ns, cfg)
+	checkKernelRepos(ns, cfg.Repos)
 	checkNamespaceReporting(ns, cfg)
 	checkSubsystems(ns, cfg)
 }
@@ -459,11 +459,12 @@ func checkSubsystems(ns string, cfg *Config) {
 	}
 }
 
-func checkKernelRepos(ns string, cfg *Config) {
-	if len(cfg.Repos) == 0 {
+func checkKernelRepos(ns string, repos []KernelRepo) {
+	if len(repos) == 0 {
 		panic(fmt.Sprintf("no repos in namespace %q", ns))
 	}
-	for _, repo := range cfg.Repos {
+	aliasMap := map[string]bool{}
+	for _, repo := range repos {
 		if !vcs.CheckRepoAddress(repo.URL) {
 			panic(fmt.Sprintf("%v: bad repo URL %q", ns, repo.URL))
 		}
@@ -473,6 +474,10 @@ func checkKernelRepos(ns string, cfg *Config) {
 		if repo.Alias == "" {
 			panic(fmt.Sprintf("%v: empty repo alias for %q", ns, repo.Alias))
 		}
+		if aliasMap[repo.Alias] {
+			panic(fmt.Sprintf("%v: duplicate alias for %q", ns, repo.Alias))
+		}
+		aliasMap[repo.Alias] = true
 		if prio := repo.ReportingPriority; prio < 0 || prio > 9 {
 			panic(fmt.Sprintf("%v: bad kernel repo reporting priority %v for %q", ns, prio, repo.Alias))
 		}

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/pkg/subsystem"
 	"github.com/google/syzkaller/pkg/vcs"
+	"golang.org/x/net/context"
 )
 
 // There are multiple configurable aspects of the app (namespaces, reporting, API clients, etc).
@@ -603,4 +604,17 @@ func (cfg *Config) lastActiveReporting() int {
 		last--
 	}
 	return last
+}
+
+var kernelReposKey = "Custom list of kernel repositories"
+
+func contextWithRepos(c context.Context, list []KernelRepo) context.Context {
+	return context.WithValue(c, &kernelReposKey, list)
+}
+
+func getKernelRepos(c context.Context, ns string) []KernelRepo {
+	if val, ok := c.Value(&kernelReposKey).([]KernelRepo); ok {
+		return val
+	}
+	return config.Namespaces[ns].Repos
 }

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -235,9 +235,8 @@ type KernelRepo struct {
 	ReportingPriority int
 	// CC for all bugs reported on this repo.
 	CC CCConfig
-	// This repository is no longer active and should not be polled for commits.
-	// It will only be used to display kernel aliases for older crashes.
-	Obsolete bool
+	// This repository should not be polled for commits, e.g. because it's no longer active.
+	NoPoll bool
 }
 
 type CCConfig struct {

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1164,7 +1164,7 @@ The specified label value is incorrect.
 Please use one of the supported label values.
 
 The following labels are suported:
-no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
+missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
 The list of subsystems: https://testapp.appspot.com/access-public-email/subsystems?all=true
 
 `)
@@ -1274,7 +1274,7 @@ The specified label "label" is unknown.
 Please use one of the supported labels.
 
 The following labels are suported:
-no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
+missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
 The list of subsystems: https://testapp.appspot.com/access-public-email/subsystems?all=true
 
 `)

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -971,13 +971,13 @@ func removeCrashReference(c context.Context, crashID int64, bugKey *db.Key,
 	return nil
 }
 
-func kernelRepoInfo(build *Build) KernelRepo {
-	return kernelRepoInfoRaw(build.Namespace, build.KernelRepo, build.KernelBranch)
+func kernelRepoInfo(c context.Context, build *Build) KernelRepo {
+	return kernelRepoInfoRaw(c, build.Namespace, build.KernelRepo, build.KernelBranch)
 }
 
-func kernelRepoInfoRaw(ns, url, branch string) KernelRepo {
+func kernelRepoInfoRaw(c context.Context, ns, url, branch string) KernelRepo {
 	var info KernelRepo
-	for _, repo := range config.Namespaces[ns].Repos {
+	for _, repo := range getKernelRepos(c, ns) {
 		if repo.URL == url && repo.Branch == branch {
 			info = repo
 			break

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -521,6 +521,11 @@ type Job struct {
 	IsRunning   bool      // the job might have been started, but never finished
 	LastStarted time.Time `datastore:"Started"`
 	Finished    time.Time // if set, job is finished
+	TreeOrigin  bool      // whether the job is related to tree origin detection
+
+	// If patch test should be done on the merge base between two branches.
+	MergeBaseRepo   string
+	MergeBaseBranch string
 
 	// Result of execution:
 	CrashTitle  string // if empty, we did not hit crash during testing

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -735,7 +735,7 @@ func handleRetestedRepro(c context.Context, now time.Time, job *Job, jobKey *db.
 			crash.ReproIsRevoked = len(req.Commits) > 0
 		}
 	}
-	crash.UpdateReportingPriority(lastBuild, bug)
+	crash.UpdateReportingPriority(c, lastBuild, bug)
 	if _, err := db.Put(c, crashKey, crash); err != nil {
 		return fmt.Errorf("failed to put crash: %v", err)
 	}
@@ -1046,7 +1046,7 @@ func createBugReportForJob(c context.Context, job *Job, jobKey *db.Key, config i
 	if bugReporting == nil {
 		return nil, fmt.Errorf("job bug has no reporting %q", job.Reporting)
 	}
-	kernelRepo := kernelRepoInfo(build)
+	kernelRepo := kernelRepoInfo(c, build)
 	rep := &dashapi.BugReport{
 		Type:            job.Type.toDashapiReportType(),
 		Config:          reportingConfig,

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -367,6 +367,7 @@ type uiJob struct {
 	Commits          []*uiCommit // for inconclusive bisection
 	Crash            *uiCrash
 	Reported         bool
+	TreeOrigin       bool
 }
 
 type userBugFilter struct {
@@ -1942,6 +1943,7 @@ func makeUIJob(c context.Context, job *Job, jobKey *db.Key, bug *Bug, crash *Cra
 		LogLink:          textLink(textLog, job.Log),
 		ErrorLink:        textLink(textError, job.Error),
 		Reported:         job.Reported,
+		TreeOrigin:       job.TreeOrigin,
 	}
 	if !job.Finished.IsZero() {
 		ui.Duration = job.Finished.Sub(job.LastStarted)

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -311,7 +311,7 @@ func createNotification(c context.Context, typ dashapi.BugNotif, public bool, te
 	if err != nil {
 		return nil, err
 	}
-	kernelRepo := kernelRepoInfo(build)
+	kernelRepo := kernelRepoInfo(c, build)
 	notif := &dashapi.BugNotification{
 		Type:      typ,
 		Namespace: bug.Namespace,
@@ -458,7 +458,7 @@ func crashBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key,
 		typ = dashapi.ReportRepro
 	}
 	assetList := createAssetList(build, crash)
-	kernelRepo := kernelRepoInfo(build)
+	kernelRepo := kernelRepoInfo(c, build)
 	rep := &dashapi.BugReport{
 		Type:            typ,
 		Config:          reportingConfig,
@@ -547,7 +547,7 @@ func fillBugReport(c context.Context, rep *dashapi.BugReport, bug *Bug, bugRepor
 	rep.BuildTime = build.Time
 	rep.CompilerID = build.CompilerID
 	rep.KernelRepo = build.KernelRepo
-	rep.KernelRepoAlias = kernelRepoInfo(build).Alias
+	rep.KernelRepoAlias = kernelRepoInfo(c, build).Alias
 	rep.KernelBranch = build.KernelBranch
 	rep.KernelCommit = build.KernelCommit
 	rep.KernelCommitTitle = build.KernelCommitTitle
@@ -610,7 +610,7 @@ func managersToRepos(c context.Context, ns string, managers []string) []string {
 			log.Errorf(c, "failed to get manager %q build: %v", manager, err)
 			continue
 		}
-		repo := kernelRepoInfo(build).Alias
+		repo := kernelRepoInfo(c, build).Alias
 		if dedup[repo] {
 			continue
 		}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -443,7 +443,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				</td>
 				<td>
 					{{if eq $job.Type 0}}
-						{{if $job.User}}{{$job.User}}{{else}}retest repro{{end}}
+						{{if $job.User}}{{$job.User}}
+						{{- else if $job.TreeOrigin}}tree origin
+						{{- else}}retest repro{{end}}
 					{{else if eq $job.Type 1}}
 						bisect
 					{{else if eq $job.Type 2}}

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -1,0 +1,728 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+// Given information on how commits flow from one kernel source tree to another, assign
+// bugs labels of two kinds:
+// a) LabelIntroduced -- reproducer does not work in any other kernel tree, FROM which commits flow.
+// b) LabelReached -- reproducer does not work in any other kernel tree, TO which commits flow.
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
+	"golang.org/x/net/context"
+	db "google.golang.org/appengine/v2/datastore"
+	"google.golang.org/appengine/v2/log"
+)
+
+// generateTreeOriginJobs generates new jobs for bug origin tree determination.
+func generateTreeOriginJobs(c context.Context, bugKey *db.Key,
+	managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, error) {
+	var job *Job
+	var jobKey *db.Key
+	tx := func(c context.Context) error {
+		bug := new(Bug)
+		if err := db.Get(c, bugKey, bug); err != nil {
+			return fmt.Errorf("failed to get bug: %v", err)
+		}
+		ctx := &bugTreeContext{
+			c:      c,
+			bug:    bug,
+			bugKey: bug.key(c),
+		}
+		ret := ctx.pollBugTreeJobs(managers)
+		switch ret.(type) {
+		case pollResultError:
+			return ret.(error)
+		case pollResultWait:
+			newTime, ok := ret.(time.Time)
+			if ok && newTime.After(bug.TreeTests.NextPoll) {
+				bug.TreeTests.NextPoll = newTime
+			}
+		}
+		bug.TreeTests.NeedPoll = false
+		if _, err := db.Put(c, bugKey, bug); err != nil {
+			return fmt.Errorf("failed to put bug: %v", err)
+		}
+		job, jobKey = ctx.job, ctx.jobKey
+		return nil
+	}
+	if err := db.RunInTransaction(c, tx, &db.TransactionOptions{XG: true, Attempts: 10}); err != nil {
+		return nil, nil, err
+	}
+	return job, jobKey, nil
+}
+
+// treeOriginJobDone is supposed to be called when tree origin job is done.
+// It keeps the cached info in Bug up to date and assigns bug tree origin labels.
+func treeOriginJobDone(c context.Context, jobKey *db.Key, job *Job) error {
+	bugKey := jobKey.Parent()
+	tx := func(c context.Context) error {
+		bug := new(Bug)
+		if err := db.Get(c, bugKey, bug); err != nil {
+			return fmt.Errorf("failed to get bug: %v", err)
+		}
+		ctx := &bugTreeContext{
+			c:         c,
+			bug:       bug,
+			bugKey:    bug.key(c),
+			noNewJobs: true,
+		}
+		ret := ctx.pollBugTreeJobs(
+			map[string]dashapi.ManagerJobs{job.Manager: {TestPatches: true}},
+		)
+		switch ret.(type) {
+		case pollResultError:
+			return ret.(error)
+		case pollResultPending:
+			bug.TreeTests.NextPoll = time.Time{}
+			bug.TreeTests.NeedPoll = true
+		}
+		if _, err := db.Put(c, bugKey, bug); err != nil {
+			return fmt.Errorf("failed to put bug: %v", err)
+		}
+		return nil
+	}
+	return db.RunInTransaction(c, tx, &db.TransactionOptions{XG: true, Attempts: 10})
+}
+
+type pollTreeJobResult interface{}
+
+// pollResultPending is returned when we wait some job to finish.
+type pollResultPending struct{}
+
+// pollResultWait is returned when we know the next time the process could be repeated.
+type pollResultWait time.Time
+
+// pollResultSkip means that there are no poll jobs we could run at the moment.
+// It's impossible to say when it changes, so it's better not to repeat polling soon.
+type pollResultSkip struct{}
+
+type pollResultError error
+
+type pollResultDone struct {
+	Crashed  bool
+	Finished time.Time
+}
+
+type bugTreeContext struct {
+	c         context.Context
+	crash     *Crash
+	crashKey  *db.Key
+	bugKey    *db.Key
+	bug       *Bug
+	build     *Build
+	repoNode  *repoNode
+	noNewJobs bool
+
+	// If any jobs were created, here'll be one of them.
+	job    *Job
+	jobKey *db.Key
+}
+
+func (ctx *bugTreeContext) pollBugTreeJobs(managers map[string]dashapi.ManagerJobs) pollTreeJobResult {
+	// Determine the crash we'd stick to.
+	err := ctx.loadCrashInfo()
+	if err != nil {
+		log.Errorf(ctx.c, "bug %q: failed to load crash info: %s", ctx.bug.displayTitle(), err)
+		return pollResultError(err)
+	}
+	if ctx.crash == nil {
+		// There are no crashes we could further work with.
+		// TODO: consider looking at the recent repro retest results.
+		log.Infof(ctx.c, "bug %q: no suitable crash", ctx.bug.displayTitle())
+		return pollResultSkip{}
+	}
+	if ctx.repoNode == nil {
+		// We have no information about the tree on which the bug happened.
+		log.Errorf(ctx.c, "bug %q: no information about the tree", ctx.bug.displayTitle())
+		return pollResultSkip{}
+	}
+	if !managers[ctx.crash.Manager].TestPatches {
+		return pollResultSkip{}
+	}
+	if len(ctx.bug.TreeTests.List) > 0 && ctx.crashKey.IntID() != ctx.bug.TreeTests.List[0].CrashID {
+		// Clean up old job records, they are no longer relevant.
+		ctx.bug.TreeTests.List = nil
+	}
+	for i := range ctx.bug.TreeTests.List {
+		err := ctx.bug.TreeTests.List[i].applyPending(ctx.c)
+		if err != nil {
+			return pollResultError(err)
+		}
+	}
+	return ctx.groupResults([]pollTreeJobResult{
+		ctx.setOriginLabels(),
+		ctx.missingBackports(),
+	})
+}
+
+func (ctx *bugTreeContext) setOriginLabels() pollTreeJobResult {
+	if !ctx.labelsCanBeSet() || ctx.bug.HasUserLabel(OriginLabel) {
+		return pollResultSkip{}
+	}
+	ctx.bug.UnsetLabels(OriginLabel)
+
+	var results []pollTreeJobResult
+	perNode := map[*repoNode]pollTreeJobResult{}
+	for node, merge := range ctx.repoNode.allReachable() {
+		var result pollTreeJobResult
+		if merge {
+			// Merge base gives a much better result quality, so use it whenever possible.
+			result = ctx.runRepro(node.repo, wantFirstAny{}, runOnMergeBase{})
+		} else {
+			result = ctx.runRepro(node.repo, wantFirstAny{}, runOnHEAD{})
+		}
+		perNode[node] = result
+		results = append(results, result)
+	}
+	result := ctx.groupResults(results)
+	if _, ok := result.(pollResultPending); ok {
+		// At least wait until all started jobs have finished (successfully or not).
+		return result
+	}
+	lastDone := ctx.lastDone(results)
+	if lastDone.IsZero() {
+		// Demand that at least one of the finished jobs has finished successfully.
+		return pollResultSkip{}
+	}
+	// Since we have a repro for it, it definitely crashed at some point.
+	perNode[ctx.repoNode] = pollResultDone{Crashed: true}
+	allLabels := append(ctx.selectRepoLabels(true, perNode), ctx.selectRepoLabels(false, perNode)...)
+	for _, label := range allLabels {
+		if label == ctx.repoNode.repo.LabelIntroduced || label == ctx.repoNode.repo.LabelReached {
+			// It looks like our reproducer does not work on other trees.
+			// Just in case verify that it still works on the original one.
+			result := ctx.runRepro(ctx.repoNode.repo, wantNewAny(lastDone), runOnHEAD{})
+			resultDone, ok := result.(pollResultDone)
+			if !ok {
+				return result
+			}
+			if !resultDone.Crashed {
+				// Unfortunately the repro no longer works. Don't assign labels.
+				return pollResultSkip{}
+			}
+		}
+	}
+	var labels []BugLabel
+	for _, label := range allLabels {
+		labels = append(labels, BugLabel{Label: OriginLabel, Value: label})
+	}
+	ctx.bug.SetLabels(makeLabelSet(ctx.c, ctx.bug.Namespace), labels)
+	return pollResultSkip{}
+}
+
+// selectRepoNodes attributes bugs to trees depending on the patch testing results.
+func (ctx *bugTreeContext) selectRepoLabels(in bool, results map[*repoNode]pollTreeJobResult) []string {
+	crashed := map[*repoNode]bool{}
+	for node, result := range results {
+		done, ok := result.(pollResultDone)
+		if ok {
+			crashed[node] = done.Crashed
+		}
+	}
+	for node := range crashed {
+		if !crashed[node] {
+			continue
+		}
+		// (1) The in = true case:
+		// If, for a tree X, there's a tree Y from which commits flow to X and the reproducer crashed
+		// on Y, X cannot be among bug origin trees.
+		// (1) The in = false case:
+		// If, for a tree X, there's a tree Y to which commits flow to X and the reproducer crashed
+		// on Y, X cannot be the last tree to which the bug has spread.
+		for otherNode := range node.reachable(!in) {
+			crashed[otherNode] = false
+		}
+	}
+	ret := []string{}
+	for node, set := range crashed {
+		if !set {
+			continue
+		}
+		if in && node.repo.LabelIntroduced != "" {
+			ret = append(ret, node.repo.LabelIntroduced)
+		} else if !in && node.repo.LabelReached != "" {
+			ret = append(ret, node.repo.LabelReached)
+		}
+	}
+	return ret
+}
+
+// Test if there's any sense in testing other trees.
+// For example, if we hit a bug on a mainline, there's no sense to test linux-next to check
+// if it's a linux-next bug.
+func (ctx *bugTreeContext) labelsCanBeSet() bool {
+	for node := range ctx.repoNode.reachable(true) {
+		if node.repo.LabelIntroduced != "" {
+			return true
+		}
+	}
+	for node := range ctx.repoNode.reachable(false) {
+		if node.repo.LabelReached != "" {
+			return true
+		}
+	}
+	return ctx.repoNode.repo.LabelIntroduced != "" ||
+		ctx.repoNode.repo.LabelReached != ""
+}
+
+func (ctx *bugTreeContext) missingBackports() pollTreeJobResult {
+	if !ctx.repoNode.repo.DetectMissingBackports || ctx.bug.HasUserLabel(MissingBackportLabel) {
+		return pollResultSkip{}
+	}
+	var okDate time.Time
+	results := []pollTreeJobResult{}
+	for node, merge := range ctx.repoNode.reachable(true) {
+		resultOK := ctx.runRepro(node.repo, wantFirstOK{}, runOnHEAD{})
+		doneOK, ok := resultOK.(pollResultDone)
+		if !ok {
+			results = append(results, resultOK)
+			continue
+		}
+		var resultCrash pollTreeJobResult
+		if merge {
+			resultCrash = ctx.runRepro(node.repo, wantFirstAny{}, runOnMergeBase{})
+		} else {
+			// We already know that the reproducer doesn't crash the tree.
+			// There'd be no sense to call runRepro in the hope of getting a crash,
+			// so let's just look into the past tree testing results.
+			resultCrash = ctx.findResult(node.repo, wantFirstCrash{}, runOnAny{})
+		}
+		doneCrash, ok := resultCrash.(pollResultDone)
+		if !ok {
+			results = append(results, resultCrash)
+			continue
+		} else if merge && doneCrash.Crashed || doneOK.Finished.After(doneCrash.Finished) {
+			// That's what we want: earlier it crashed and then stopped.
+			okDate = doneOK.Finished
+			break
+		}
+	}
+	if okDate.IsZero() {
+		return ctx.groupResults(results)
+	}
+	// We are about to assign the "missing backport" label.
+	// To reduce the number of backports, just in case run once more on HEAD.
+	// The bug fix could have already reached the repository.
+	result := ctx.runRepro(ctx.repoNode.repo, wantNewAny(okDate), runOnHEAD{})
+	resultDone, ok := result.(pollResultDone)
+	if !ok {
+		return result
+	}
+	ctx.bug.UnsetLabels(MissingBackportLabel)
+	if resultDone.Crashed {
+		ctx.bug.SetLabels(makeLabelSet(ctx.c, ctx.bug.Namespace), []BugLabel{
+			{Label: MissingBackportLabel},
+		})
+	}
+	return pollResultSkip{}
+}
+
+func (ctx *bugTreeContext) lastDone(results []pollTreeJobResult) time.Time {
+	var maxTime time.Time
+	for _, item := range results {
+		done, ok := item.(pollResultDone)
+		if !ok {
+			continue
+		}
+		if done.Finished.After(maxTime) {
+			maxTime = done.Finished
+		}
+	}
+	return maxTime
+}
+
+func (ctx *bugTreeContext) groupResults(results []pollTreeJobResult) pollTreeJobResult {
+	var minWait time.Time
+	for _, result := range results {
+		switch v := result.(type) {
+		case pollResultPending, pollResultError:
+			// Wait for the job result to continue.
+			return result
+		case pollResultWait:
+			t := time.Time(v)
+			if minWait.IsZero() || minWait.After(t) {
+				minWait = t
+			}
+		}
+	}
+	if !minWait.IsZero() {
+		return pollResultWait(minWait)
+	}
+	return pollResultSkip{}
+}
+
+type expectedResult interface{}
+
+// resultFreshness subtypes.
+type wantFirstOK struct{}
+type wantFirstCrash struct{}
+type wantFirstAny struct{}
+type wantNewAny time.Time
+
+type runReproOn interface{}
+
+// runReproOn subtypes.
+type runOnAny struct{} // attempts to find any result, if unsuccessful, runs on HEAD
+type runOnHEAD struct{}
+type runOnMergeBase struct{}
+
+func (ctx *bugTreeContext) runRepro(repo KernelRepo, result expectedResult, runOn runReproOn) pollTreeJobResult {
+	ret := ctx.doRunRepro(repo, result, runOn)
+	log.Infof(ctx.c, "runRepro on %s, %T, %T: %#v", repo.Alias, result, runOn, ret)
+	return ret
+}
+
+func (ctx *bugTreeContext) doRunRepro(repo KernelRepo, result expectedResult, runOn runReproOn) pollTreeJobResult {
+	existingResult := ctx.findResult(repo, result, runOn)
+	if _, ok := existingResult.(pollResultSkip); !ok {
+		return existingResult
+	}
+	// Okay, nothing suitable was found. We need to set up a new job.
+	if ctx.noNewJobs {
+		return pollResultPending{}
+	}
+	// First check if there's existing BugTreeTest object.
+	if _, ok := runOn.(runOnAny); ok {
+		runOn = runOnHEAD{}
+	}
+	candidates := ctx.bug.matchingTreeTests(ctx.build, repo, runOn)
+	var bugTreeTest *BugTreeTest
+	if len(candidates) > 0 {
+		bugTreeTest = &ctx.bug.TreeTests.List[candidates[0]]
+	} else {
+		item := BugTreeTest{
+			CrashID: ctx.crashKey.IntID(),
+			Repo:    repo.URL,
+			Branch:  repo.Branch,
+		}
+		if _, ok := runOn.(runOnMergeBase); ok {
+			item.MergeBaseRepo = ctx.build.KernelRepo
+			item.MergeBaseBranch = ctx.build.KernelBranch
+		}
+		ctx.bug.TreeTests.List = append(ctx.bug.TreeTests.List, item)
+		bugTreeTest = &ctx.bug.TreeTests.List[len(ctx.bug.TreeTests.List)-1]
+	}
+
+	if bugTreeTest.Error != "" {
+		result := ctx.ensureRepeatPeriod(bugTreeTest.Error)
+		if _, ok := result.(pollResultSkip); !ok {
+			return result
+		}
+		bugTreeTest.Error = ""
+	}
+	if bugTreeTest.Last != "" {
+		result := ctx.ensureRepeatPeriod(bugTreeTest.Last)
+		if _, ok := result.(pollResultSkip); !ok {
+			return result
+		}
+	}
+	var err error
+	ctx.job, ctx.jobKey, err = addTestJob(ctx.c, &testJobArgs{
+		crash:         ctx.crash,
+		crashKey:      ctx.crashKey,
+		configRef:     ctx.build.KernelConfig,
+		inTransaction: true,
+		treeOrigin:    true,
+		testReqArgs: testReqArgs{
+			bug:             ctx.bug,
+			bugKey:          ctx.bugKey,
+			repo:            bugTreeTest.Repo,
+			branch:          bugTreeTest.Branch,
+			mergeBaseRepo:   bugTreeTest.MergeBaseRepo,
+			mergeBaseBranch: bugTreeTest.MergeBaseBranch,
+		},
+	})
+	if err != nil {
+		return pollResultError(err)
+	}
+	bugTreeTest.Pending = ctx.jobKey.Encode()
+	return pollResultPending{}
+}
+
+func (ctx *bugTreeContext) ensureRepeatPeriod(jobKey string) pollTreeJobResult {
+	const retryTime = 24 * time.Hour * 30
+	job, err := fetchJob(ctx.c, jobKey)
+	if err != nil {
+		return pollResultError(err)
+	}
+	timePassed := timeNow(ctx.c).Sub(job.Finished)
+	if timePassed < retryTime {
+		return pollResultWait(job.Finished.Add(retryTime))
+	}
+	return pollResultSkip{}
+}
+
+func (ctx *bugTreeContext) findResult(repo KernelRepo, result expectedResult, runOn runReproOn) pollTreeJobResult {
+	anyPending := false
+	for _, i := range ctx.bug.matchingTreeTests(ctx.build, repo, runOn) {
+		info := &ctx.bug.TreeTests.List[i]
+		anyPending = anyPending || info.Pending != ""
+		key := ""
+		switch result.(type) {
+		case wantFirstOK:
+			key = info.FirstOK
+		case wantFirstCrash:
+			key = info.FirstCrash
+		case wantFirstAny:
+			key = info.First
+		case wantNewAny:
+			key = info.Last
+		default:
+			return pollResultError(fmt.Errorf("unexpected expected result: %T", result))
+		}
+		if key == "" {
+			continue
+		}
+		job, err := fetchJob(ctx.c, key)
+		if err != nil {
+			return pollResultError(err)
+		}
+		if date, ok := result.(wantNewAny); ok {
+			if job.Finished.Before(time.Time(date)) {
+				continue
+			}
+		}
+		return pollResultDone{
+			Crashed:  job.CrashTitle != "",
+			Finished: job.Finished,
+		}
+	}
+	if anyPending {
+		return pollResultPending{}
+	} else {
+		return pollResultSkip{}
+	}
+}
+
+func (bug *Bug) matchingTreeTests(build *Build, repo KernelRepo, runOn runReproOn) []int {
+	ret := []int{}
+	for i, item := range bug.TreeTests.List {
+		if item.Repo != repo.URL {
+			continue
+		}
+		ok := true
+		switch runOn.(type) {
+		case runOnHEAD:
+			ok = item.Branch == repo.Branch
+		case runOnMergeBase:
+			ok = item.Branch == repo.Branch &&
+				item.MergeBaseRepo == build.KernelRepo &&
+				item.MergeBaseBranch == build.KernelBranch
+		}
+		if ok {
+			ret = append(ret, i)
+		}
+	}
+	return ret
+}
+
+func (ctx *bugTreeContext) loadCrashInfo() error {
+	// First look at the crash from previous tests.
+	if len(ctx.bug.TreeTests.List) > 0 {
+		crashID := ctx.bug.TreeTests.List[len(ctx.bug.TreeTests.List)-1].CrashID
+		crashKey := db.NewKey(ctx.c, "Crash", "", crashID, ctx.bugKey)
+		crash := new(Crash)
+		// We need to also tolerate the case when the crash was just deleted.
+		err := db.Get(ctx.c, crashKey, crash)
+		if err != nil && err != db.ErrNoSuchEntity {
+			return fmt.Errorf("failed to get crash: %v", err)
+		} else if err == nil {
+			ok, err := ctx.isCrashRelevant(crash)
+			if err != nil {
+				return err
+			}
+			if ok {
+				ctx.crash = crash
+				ctx.crashKey = crashKey
+			}
+		}
+	}
+	// Query the most relevant crash with repro.
+	if ctx.crash == nil {
+		crash, crashKey, err := findCrashForBug(ctx.c, ctx.bug)
+		if err != nil {
+			return err
+		}
+		ok, err := ctx.isCrashRelevant(crash)
+		if err != nil {
+			return err
+		} else if ok {
+			ctx.crash = crash
+			ctx.crashKey = crashKey
+		}
+	}
+	// Load the rest of the data.
+	if ctx.crash != nil {
+		var err error
+		ns := ctx.bug.Namespace
+		ctx.build, err = loadBuild(ctx.c, ns, ctx.crash.BuildID)
+		if err != nil {
+			return err
+		}
+		repoGraph, err := makeRepoGraph(getKernelRepos(ctx.c, ns))
+		if err != nil {
+			return err
+		}
+		ctx.repoNode = repoGraph.nodeByRepo(ctx.build.KernelRepo, ctx.build.KernelBranch)
+	}
+	return nil
+}
+
+func (ctx *bugTreeContext) isCrashRelevant(crash *Crash) (bool, error) {
+	if crash.ReproIsRevoked {
+		// No sense in running the reproducer.
+		return false, nil
+	} else if crash.ReproC == 0 {
+		// Let's wait for the C repro.
+		return false, nil
+	}
+	newManager, _ := activeManager(crash.Manager, ctx.bug.Namespace)
+	if newManager != crash.Manager {
+		// The manager was deprecated since the crash.
+		// Let's just ignore such bugs for now.
+		return false, nil
+	}
+	build, err := loadBuild(ctx.c, ctx.bug.Namespace, crash.BuildID)
+	if err != nil {
+		return false, err
+	}
+	mgrBuild, err := lastManagerBuild(ctx.c, build.Namespace, newManager)
+	if err != nil {
+		return false, err
+	}
+	// It does happen that we sometimes update the tested tree.
+	// It's not frequent at all, but it will make all results very confusing.
+	return build.KernelRepo == mgrBuild.KernelRepo && build.KernelBranch == mgrBuild.KernelBranch, nil
+}
+
+func (test *BugTreeTest) applyPending(c context.Context) error {
+	if test.Pending == "" {
+		return nil
+	}
+	job, err := fetchJob(c, test.Pending)
+	if err != nil {
+		return err
+	}
+	if job.Finished.IsZero() {
+		// Not yet ready.
+		return nil
+	}
+	pendingKey := test.Pending
+	test.Pending = ""
+	if job.Error != 0 {
+		test.Error = pendingKey
+		return nil
+	}
+	test.Last = pendingKey
+	if test.First == "" {
+		test.First = pendingKey
+	}
+	if test.FirstOK == "" && job.CrashTitle == "" {
+		test.FirstOK = pendingKey
+	} else if test.FirstCrash == "" && job.CrashTitle != "" {
+		test.FirstCrash = pendingKey
+	}
+	return nil
+}
+
+type repoNode struct {
+	repo  KernelRepo
+	edges []repoEdge
+}
+
+type repoEdge struct {
+	in    bool
+	merge bool
+	other *repoNode
+}
+
+type repoGraph struct {
+	nodes map[string]*repoNode
+}
+
+func makeRepoGraph(repos []KernelRepo) (*repoGraph, error) {
+	g := &repoGraph{
+		nodes: map[string]*repoNode{},
+	}
+	for _, repo := range repos {
+		if repo.Alias == "" {
+			return nil, fmt.Errorf("one of the repos has an empty alias")
+		}
+		g.nodes[repo.Alias] = &repoNode{repo: repo}
+	}
+	for _, repo := range repos {
+		for _, link := range repo.CommitInflow {
+			if g.nodes[link.Alias] == nil {
+				return nil, fmt.Errorf("no repo with alias %q", link.Alias)
+			}
+			g.nodes[repo.Alias].addEdge(true, link.Merge, g.nodes[link.Alias])
+			g.nodes[link.Alias].addEdge(false, link.Merge, g.nodes[repo.Alias])
+		}
+	}
+	for alias, node := range g.nodes {
+		reachable := node.reachable(true)
+		if _, ok := reachable[node]; ok {
+			return nil, fmt.Errorf("%q lies on a cycle", alias)
+		}
+	}
+	return g, nil
+}
+
+func (g *repoGraph) nodeByRepo(url, branch string) *repoNode {
+	for _, node := range g.nodes {
+		if node.repo.URL == url && node.repo.Branch == branch {
+			return node
+		}
+	}
+	return nil
+}
+
+func (g *repoGraph) nodeByAlias(alias string) *repoNode {
+	for _, node := range g.nodes {
+		if node.repo.Alias == alias {
+			return node
+		}
+	}
+	return nil
+}
+
+// reachable returns a map *repoNode -> bool (whether commits are merged).
+func (n *repoNode) reachable(in bool) map[*repoNode]bool {
+	ret := map[*repoNode]bool{}
+	var dfs func(*repoNode, bool)
+	dfs = func(node *repoNode, merge bool) {
+		for _, edge := range node.edges {
+			if edge.in != in {
+				continue
+			}
+			if _, ok := ret[edge.other]; ok {
+				continue
+			}
+			ret[edge.other] = merge && edge.merge
+			dfs(edge.other, merge && edge.merge)
+		}
+	}
+	dfs(n, true)
+	return ret
+}
+
+func (n *repoNode) allReachable() map[*repoNode]bool {
+	ret := n.reachable(true)
+	for node, merge := range n.reachable(false) {
+		ret[node] = merge
+	}
+	return ret
+}
+
+func (n *repoNode) addEdge(in, merge bool, other *repoNode) {
+	n.edges = append(n.edges, repoEdge{
+		in:    in,
+		merge: merge,
+		other: other,
+	})
+}

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -694,10 +694,17 @@ func (g *repoGraph) nodeByAlias(alias string) *repoNode {
 // reachable returns a map *repoNode -> bool (whether commits are merged).
 func (n *repoNode) reachable(in bool) map[*repoNode]bool {
 	ret := map[*repoNode]bool{}
+	// First collect nodes only reachable via merge=true links.
+	n.reachableMerged(in, true, ret)
+	n.reachableMerged(in, false, ret)
+	return ret
+}
+
+func (n *repoNode) reachableMerged(in, onlyMerge bool, ret map[*repoNode]bool) {
 	var dfs func(*repoNode, bool)
 	dfs = func(node *repoNode, merge bool) {
 		for _, edge := range node.edges {
-			if edge.in != in {
+			if edge.in != in || onlyMerge && !edge.merge {
 				continue
 			}
 			if _, ok := ret[edge.other]; ok {
@@ -708,7 +715,6 @@ func (n *repoNode) reachable(in bool) map[*repoNode]bool {
 		}
 	}
 	dfs(n, true)
-	return ret
 }
 
 func (n *repoNode) allReachable() map[*repoNode]bool {

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -1,0 +1,796 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/syzkaller/dashboard/dashapi"
+	db "google.golang.org/appengine/v2/datastore"
+)
+
+func TestTreeOriginDownstream(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamRepos)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `downstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:      `lts`,
+			mergeAlias: `downstream`,
+			results:    []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels(`origin:downstream`)
+	// It should habe been enough to run jobs just once.
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+	c.expectEQ(ctx.entries[2].jobsDone, 1)
+}
+
+func TestTreeOriginLts(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamRepos)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `downstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:      `lts`,
+			mergeAlias: `downstream`,
+			results:    []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels(`origin:lts`)
+	c.expectEQ(ctx.entries[0].jobsDone, 0)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+	c.expectEQ(ctx.entries[2].jobsDone, 1)
+}
+
+func TestTreeOriginErrors(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	// Make sure testing works fine despite patch testing errors.
+	ctx := setUpTreeTest(c, downstreamUpstreamRepos)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias:      `lts`,
+			mergeAlias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestError},
+				{fromDay: 31, result: treeTestCrash},
+			},
+		},
+		{
+			alias: `upstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestError},
+				{fromDay: 60, result: treeTestCrash},
+			},
+		},
+	}
+	ctx.jobTestDays = []int{1, 32, 63}
+	ctx.moveToDay(1)
+	ctx.ensureLabels() // Not enough information yet.
+	// The original crash is reproducible again.
+	ctx.moveToDay(32)
+	ctx.ensureLabels(`origin:lts`) // We don't know any better so far.
+	// Upstream is buildable again.
+	ctx.moveToDay(63)
+	ctx.ensureLabels(`origin:upstream`)
+	c.expectEQ(ctx.entries[0].jobsDone, 0)
+	c.expectEQ(ctx.entries[1].jobsDone, 2)
+	c.expectEQ(ctx.entries[2].jobsDone, 3)
+}
+
+var downstreamUpstreamRepos = []KernelRepo{
+	{
+		URL:             `https://downstream.repo/repo`,
+		Branch:          `master`,
+		Alias:           `downstream`,
+		LabelIntroduced: `downstream`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `lts`,
+				Merge: true,
+			},
+			{
+				Alias: `upstream`,
+			},
+		},
+	},
+	{
+		URL:             `https://lts.repo/repo`,
+		Branch:          `lts-master`,
+		Alias:           `lts`,
+		LabelIntroduced: `lts`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `upstream`,
+				Merge: false,
+			},
+		},
+	},
+	{
+		URL:             `https://upstream.repo/repo`,
+		Branch:          `upstream-master`,
+		Alias:           `upstream`,
+		LabelIntroduced: `upstream`,
+	},
+}
+
+func TestOriginTreeNoMergeLts(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, ltsUpstreamRepos)
+	ctx.uploadBug(`https://lts.repo/repo`, `lts-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `lts`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels(`origin:lts-only`)
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+func TestOriginTreeNoMergeNoLabel(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, ltsUpstreamRepos)
+	ctx.uploadBug(`https://lts.repo/repo`, `lts-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `lts`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels()
+	// It should habe been enough to run jobs just once.
+	c.expectEQ(ctx.entries[0].jobsDone, 0)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+func TestTreeOriginRepoChanged(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, ltsUpstreamRepos)
+
+	// First do tests from one repository.
+	ctx.uploadBug(`https://lts.repo/repo`, `lts-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `lts`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10, 20, 25, 30, 62}
+	ctx.moveToDay(10)
+	ctx.ensureLabels(`origin:lts-only`)
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+
+	// Now update the repository.
+	ctx.updateRepos([]KernelRepo{
+		{
+			URL:               `https://new-lts.repo/repo`,
+			Branch:            `lts-master`,
+			Alias:             `lts`,
+			LabelIntroduced:   `lts-only`,
+			ReportingPriority: 9,
+			CommitInflow: []KernelRepoLink{
+				{
+					Alias: `upstream`,
+					Merge: false,
+				},
+			},
+		},
+		{
+			URL:    `https://upstream.repo/repo`,
+			Branch: `upstream-master`,
+			Alias:  `upstream`,
+		},
+	})
+	ctx.entries = []treeTestEntry{
+		{
+			alias: `lts`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 30, result: treeTestError},
+				{fromDay: 60, result: treeTestCrash},
+			},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.moveToDay(20)
+	ctx.ensureLabels(`origin:lts-only`) // No new builds -- nothing we can do.
+
+	// Upload a new manager build.
+	build := ctx.uploadBuild(`https://new-lts.repo/repo`, `lts-master`)
+	ctx.moveToDay(25)
+	ctx.ensureLabels(`origin:lts-only`) // Still nothing we can do, no crashes so far.
+
+	// Now upload a new crash.
+	ctx.uploadBuildCrash(build, dashapi.ReproLevelC)
+	ctx.moveToDay(30)
+	ctx.ensureLabels() // We are no longer sure about tags.
+
+	// After the new tree starts to build again, we can calculate the results again.
+	ctx.moveToDay(62)
+	ctx.ensureLabels(`origin:lts-only`) // We are no longer sure about tags.
+	c.expectEQ(ctx.entries[0].jobsDone, 2)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+var ltsUpstreamRepos = []KernelRepo{
+	{
+		URL:             `https://lts.repo/repo`,
+		Branch:          `lts-master`,
+		Alias:           `lts`,
+		LabelIntroduced: `lts-only`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `upstream`,
+				Merge: false,
+			},
+		},
+	},
+	{
+		URL:    `https://upstream.repo/repo`,
+		Branch: `upstream-master`,
+		Alias:  `upstream`,
+	},
+}
+
+func TestOriginNoNextTree(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, upstreamNextRepos)
+	ctx.uploadBug(`https://upstream.repo/repo`, `upstream-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels()
+}
+
+func TestOriginNoNextFixed(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, upstreamNextRepos)
+	ctx.uploadBug(`https://next.repo/repo`, `next-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `next`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels()
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+func TestOriginNoNext(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, upstreamNextRepos)
+	ctx.uploadBug(`https://next.repo/repo`, `next-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `next`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels()
+	c.expectEQ(ctx.entries[0].jobsDone, 0)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+func TestOriginNext(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, upstreamNextRepos)
+	ctx.uploadBug(`https://next.repo/repo`, `next-master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias:   `next`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestCrash}},
+		},
+		{
+			alias:   `upstream`,
+			results: []treeTestEntryPeriod{{fromDay: 0, result: treeTestOK}},
+		},
+	}
+	ctx.jobTestDays = []int{10}
+	ctx.moveToDay(10)
+	ctx.ensureLabels(`origin:next`)
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+var upstreamNextRepos = []KernelRepo{
+	{
+		URL:    `https://upstream.repo/repo`,
+		Branch: `upstream-master`,
+		Alias:  `upstream`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `next`,
+				Merge: false,
+			},
+		},
+	},
+	{
+		URL:          `https://next.repo/repo`,
+		Branch:       `next-master`,
+		Alias:        `next`,
+		LabelReached: `next`,
+	},
+}
+
+func TestMissingLtsBackport(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamBackports)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias:      `lts`,
+			mergeAlias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias: `lts`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+				{fromDay: 31, result: treeTestOK},
+			},
+		},
+		{
+			alias: `upstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+	}
+	ctx.jobTestDays = []int{0, 35}
+	ctx.moveToDay(35)
+	ctx.ensureLabels(`missing-backport`)
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+}
+
+func TestMissingUpstreamBackport(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamBackports)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias: `lts`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias: `upstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+				{fromDay: 31, result: treeTestOK},
+			},
+		},
+	}
+	ctx.jobTestDays = []int{0, 35}
+	ctx.moveToDay(35)
+	ctx.ensureLabels(`missing-backport`)
+	c.expectEQ(ctx.entries[0].jobsDone, 1)
+	c.expectEQ(ctx.entries[1].jobsDone, 2)
+	c.expectEQ(ctx.entries[1].jobsDone, 2)
+}
+
+func TestNotMissingBackport(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamBackports)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.entries = []treeTestEntry{
+		{
+			alias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+		{
+			alias:      `lts`,
+			mergeAlias: `downstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestOK},
+			},
+		},
+		{
+			alias: `lts`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestOK},
+			},
+		},
+		{
+			alias: `upstream`,
+			results: []treeTestEntryPeriod{
+				{fromDay: 0, result: treeTestCrash},
+			},
+		},
+	}
+	ctx.jobTestDays = []int{0, 35}
+	ctx.moveToDay(35)
+	ctx.ensureLabels()
+	c.expectEQ(ctx.entries[0].jobsDone, 0)
+	c.expectEQ(ctx.entries[1].jobsDone, 1)
+	c.expectEQ(ctx.entries[2].jobsDone, 1)
+	c.expectEQ(ctx.entries[3].jobsDone, 2)
+}
+
+var downstreamUpstreamBackports = []KernelRepo{
+	{
+		URL:    `https://downstream.repo/repo`,
+		Branch: `master`,
+		Alias:  `downstream`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `lts`,
+				Merge: true,
+			},
+			{
+				Alias: `upstream`,
+			},
+		},
+		DetectMissingBackports: true,
+	},
+	{
+		URL:    `https://lts.repo/repo`,
+		Branch: `lts-master`,
+		Alias:  `lts`,
+		CommitInflow: []KernelRepoLink{
+			{
+				Alias: `upstream`,
+				Merge: false,
+			},
+		},
+	},
+	{
+		URL:    `https://upstream.repo/repo`,
+		Branch: `upstream-master`,
+		Alias:  `upstream`,
+	},
+}
+
+func setUpTreeTest(ctx *Ctx, repos []KernelRepo) *treeTestCtx {
+	ret := &treeTestCtx{
+		ctx:     ctx,
+		client:  ctx.makeClient(clientPublic, keyPublic, true),
+		manager: "test-manager",
+	}
+	ret.updateRepos(repos)
+	return ret
+}
+
+type treeTestCtx struct {
+	ctx         *Ctx
+	client      *apiClient
+	bug         *Bug
+	start       time.Time
+	entries     []treeTestEntry
+	perAlias    map[string]KernelRepo
+	jobTestDays []int
+	manager     string
+}
+
+func (ctx *treeTestCtx) now() time.Time {
+	// Yep, that's a bit too much repetition.
+	return timeNow(ctx.ctx.ctx)
+}
+
+func (ctx *treeTestCtx) updateRepos(repos []KernelRepo) {
+	checkKernelRepos("access-public", config.Namespaces["access-public"], repos)
+	ctx.perAlias = map[string]KernelRepo{}
+	for _, repo := range repos {
+		ctx.perAlias[repo.Alias] = repo
+	}
+	ctx.ctx.setKernelRepos(repos)
+}
+
+func (ctx *treeTestCtx) uploadBuild(repo, branch string) *dashapi.Build {
+	build := testBuild(1)
+	build.ID = fmt.Sprintf("%d", ctx.now().Unix())
+	build.Manager = ctx.manager
+	build.KernelRepo = repo
+	build.KernelBranch = branch
+	build.KernelCommit = build.ID
+	ctx.client.UploadBuild(build)
+	return build
+}
+
+func (ctx *treeTestCtx) uploadBuildCrash(build *dashapi.Build, lvl dashapi.ReproLevel) {
+	crash := testCrash(build, 1)
+	if lvl > dashapi.ReproLevelNone {
+		crash.ReproSyz = []byte("getpid()")
+	}
+	if lvl == dashapi.ReproLevelC {
+		crash.ReproC = []byte("getpid()")
+	}
+	ctx.client.ReportCrash(crash)
+	if ctx.bug == nil || ctx.bug.ReproLevel < lvl {
+		rep := ctx.client.pollBug()
+		if ctx.bug == nil {
+			bug, _, err := findBugByReportingID(ctx.ctx.ctx, rep.ID)
+			ctx.ctx.expectOK(err)
+			ctx.bug = bug
+		}
+	}
+}
+
+func (ctx *treeTestCtx) uploadBug(repo, branch string, lvl dashapi.ReproLevel) {
+	build := ctx.uploadBuild(repo, branch)
+	ctx.uploadBuildCrash(build, lvl)
+}
+
+func (ctx *treeTestCtx) moveToDay(tillDay int) {
+	ctx.ctx.t.Helper()
+	if ctx.start.IsZero() {
+		ctx.start = ctx.now()
+	}
+	for _, seqDay := range ctx.jobTestDays {
+		if seqDay > tillDay {
+			break
+		}
+		now := ctx.now()
+		day := ctx.start.Add(time.Hour * 24 * time.Duration(seqDay))
+		if day.Before(now) || ctx.start != ctx.now() && day.Equal(now) {
+			continue
+		}
+		ctx.ctx.advanceTime(day.Sub(now))
+		ctx.ctx.t.Logf("executing jobs on day %d", seqDay)
+		// Execute jobs until they exist.
+		for {
+			pollResp := ctx.client.pollSpecificJobs(ctx.manager, dashapi.ManagerJobs{
+				TestPatches: true,
+			})
+			if pollResp.ID == "" {
+				break
+			}
+			ctx.ctx.advanceTime(time.Minute)
+			ctx.doJob(pollResp, seqDay)
+		}
+	}
+}
+
+func (ctx *treeTestCtx) doJob(resp *dashapi.JobPollResp, day int) {
+	respValues := []string{
+		resp.KernelRepo,
+		resp.KernelBranch,
+		resp.MergeBaseRepo,
+		resp.MergeBaseBranch,
+	}
+	sort.Strings(respValues)
+	var found *treeTestEntry
+	for i, entry := range ctx.entries {
+		entryValues := []string{
+			ctx.perAlias[entry.alias].URL,
+			ctx.perAlias[entry.alias].Branch,
+		}
+		if entry.mergeAlias != "" {
+			entryValues = append(entryValues,
+				ctx.perAlias[entry.mergeAlias].URL,
+				ctx.perAlias[entry.mergeAlias].Branch)
+		} else {
+			entryValues = append(entryValues, "", "")
+		}
+		sort.Strings(entryValues)
+		if reflect.DeepEqual(respValues, entryValues) {
+			found = &ctx.entries[i]
+			break
+		}
+	}
+	if found == nil {
+		ctx.ctx.t.Fatalf("unknown job request: %#v", resp)
+	}
+	build := testBuild(1)
+	build.KernelRepo = resp.KernelRepo
+	build.KernelBranch = resp.KernelBranch
+	build.KernelCommit = fmt.Sprintf("%d", ctx.now().Unix())
+	// Figure out what should the result be.
+	result := treeTestOK
+	for _, item := range found.results {
+		if day >= item.fromDay {
+			result = item.result
+		}
+	}
+	jobDoneReq := &dashapi.JobDoneReq{
+		ID:    resp.ID,
+		Build: *build,
+	}
+	switch result {
+	case treeTestOK:
+	case treeTestCrash:
+		jobDoneReq.CrashTitle = "crash title"
+		jobDoneReq.CrashLog = []byte("test crash log")
+		jobDoneReq.CrashReport = []byte("test crash report")
+	case treeTestError:
+		jobDoneReq.Error = []byte("failed to apply patch")
+	}
+	found.jobsDone++
+	ctx.ctx.expectOK(ctx.client.JobDone(jobDoneReq))
+}
+
+func (ctx *treeTestCtx) ensureLabels(labels ...string) {
+	ctx.ctx.t.Helper()
+	if ctx.bug == nil {
+		ctx.ctx.t.Fatalf("no bug has been created so far")
+	}
+	bug := new(Bug)
+	ctx.ctx.expectOK(db.Get(ctx.ctx.ctx, ctx.bug.key(ctx.ctx.ctx), bug))
+	ctx.bug = bug
+
+	var bugLabels []string
+	for _, item := range bug.Labels {
+		bugLabels = append(bugLabels, item.String())
+	}
+	sort.Strings(bugLabels)
+	sort.Strings(labels)
+	ctx.ctx.expectEQ(labels, bugLabels)
+}
+
+type treeTestEntry struct {
+	alias      string
+	mergeAlias string
+	results    []treeTestEntryPeriod
+	jobsDone   int
+}
+
+type treeTestResult string
+
+const (
+	treeTestCrash treeTestResult = "crash"
+	treeTestOK    treeTestResult = "ok"
+	treeTestError treeTestResult = "error"
+)
+
+type treeTestEntryPeriod struct {
+	fromDay int
+	result  treeTestResult
+}
+
+func TestRepoGraph(t *testing.T) {
+	g, err := makeRepoGraph(downstreamUpstreamRepos)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	downstream := g.nodeByAlias(`downstream`)
+	lts := g.nodeByAlias(`lts`)
+	upstream := g.nodeByAlias(`upstream`)
+
+	// Test the downstream node.
+	if diff := cmp.Diff(map[*repoNode]bool{
+		lts:      true,
+		upstream: false,
+	}, downstream.reachable(true)); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := cmp.Diff(map[*repoNode]bool{}, downstream.reachable(false)); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Test the lts node.
+	if diff := cmp.Diff(map[*repoNode]bool{
+		upstream: false,
+	}, lts.reachable(true)); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := cmp.Diff(map[*repoNode]bool{
+		downstream: true,
+	}, lts.reachable(false)); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Test the upstream node.
+	if diff := cmp.Diff(map[*repoNode]bool{}, upstream.reachable(true)); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := cmp.Diff(map[*repoNode]bool{
+		downstream: false,
+		lts:        false,
+	}, upstream.reachable(false)); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -217,6 +217,12 @@ func (c *Ctx) setSubsystems(ns string, list []*subsystem.Subsystem, rev int) {
 	}
 }
 
+func (c *Ctx) setKernelRepos(list []KernelRepo) {
+	c.transformContext = func(c context.Context) context.Context {
+		return contextWithRepos(c, list)
+	}
+}
+
 // GET sends admin-authorized HTTP GET request to the app.
 func (c *Ctx) GET(url string) ([]byte, error) {
 	return c.AuthGET(AccessAdmin, url)

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -176,6 +176,8 @@ type JobPollResp struct {
 	Manager           string
 	KernelRepo        string
 	KernelBranch      string
+	MergeBaseRepo     string
+	MergeBaseBranch   string
 	KernelCommit      string
 	KernelCommitTitle string
 	KernelCommitDate  time.Time

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -103,3 +103,7 @@ func (ctx *fuchsia) ListCommitHashes(base string) ([]string, error) {
 func (ctx *fuchsia) Object(name, commit string) ([]byte, error) {
 	return ctx.repo.Object(name, commit)
 }
+
+func (ctx *fuchsia) MergeBases(firstCommit, secondCommit string) ([]*Commit, error) {
+	return ctx.repo.MergeBases(firstCommit, secondCommit)
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -588,3 +588,19 @@ func (git *git) IsRelease(commit string) (bool, error) {
 func (git *git) Object(name, commit string) ([]byte, error) {
 	return git.git("show", fmt.Sprintf("%s:%s", commit, name))
 }
+
+func (git *git) MergeBases(firstCommit, secondCommit string) ([]*Commit, error) {
+	output, err := git.git("merge-base", firstCommit, secondCommit)
+	if err != nil {
+		return nil, err
+	}
+	ret := []*Commit{}
+	for _, hash := range strings.Fields(string(output)) {
+		commit, err := git.getCommit(hash)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, commit)
+	}
+	return ret, nil
+}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -67,6 +67,9 @@ type Repo interface {
 
 	// Object returns the contents of a git repository object at the particular moment in history.
 	Object(name, commit string) ([]byte, error)
+
+	// MergeBases returns good common ancestors of the two commits.
+	MergeBases(firstCommit, secondCommit string) ([]*Commit, error)
 }
 
 // Bisecter may be optionally implemented by Repo.

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -591,47 +591,9 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create kernel repo: %v", err)
 	}
-	var kernelCommit *vcs.Commit
-	if req.MergeBaseRepo != "" {
-		jp.Logf(1, "checking out the base kernel...")
-		firstCommit, err := checkoutKernelOrCommit(repo, req.KernelRepo, req.KernelBranch)
-		if err != nil {
-			return fmt.Errorf("failed to checkout first kernel repo %v on %v: %v",
-				req.KernelRepo, req.KernelBranch, err)
-		}
-		secondCommit, err := checkoutKernelOrCommit(repo, req.MergeBaseRepo, req.MergeBaseBranch)
-		if err != nil {
-			return fmt.Errorf("failed to checkout second kernel repo %v on %v: %v",
-				req.MergeBaseRepo, req.MergeBaseBranch, err)
-		}
-		bases, err := repo.MergeBases(firstCommit.Hash, secondCommit.Hash)
-		if err != nil {
-			return fmt.Errorf("failed to calculate merge bases between %v and %v: %v",
-				firstCommit.Hash, secondCommit.Hash, err)
-		}
-		if len(bases) != 1 {
-			return fmt.Errorf("expected one merge base between %v and %v, got %d",
-				firstCommit.Hash, secondCommit.Hash, len(bases))
-		}
-		kernelCommit, err = repo.CheckoutCommit(req.KernelRepo, bases[0].Hash)
-		if err != nil {
-			return fmt.Errorf("failed to checkout kernel repo %v on merge base commit %v: %v",
-				req.KernelRepo, bases[0].Hash, err)
-		}
-		resp.Build.KernelBranch = ""
-	} else if vcs.CheckCommitHash(req.KernelBranch) {
-		kernelCommit, err = repo.CheckoutCommit(req.KernelRepo, req.KernelBranch)
-		if err != nil {
-			return fmt.Errorf("failed to checkout kernel repo %v on commit %v: %v",
-				req.KernelRepo, req.KernelBranch, err)
-		}
-		resp.Build.KernelBranch = ""
-	} else {
-		kernelCommit, err = repo.CheckoutBranch(req.KernelRepo, req.KernelBranch)
-		if err != nil {
-			return fmt.Errorf("failed to checkout kernel repo %v/%v: %v",
-				req.KernelRepo, req.KernelBranch, err)
-		}
+	kernelCommit, err := jp.checkoutJobCommit(job, repo)
+	if err != nil {
+		return err
 	}
 	resp.Build.KernelCommit = kernelCommit.Hash
 	resp.Build.KernelCommitTitle = kernelCommit.Title
@@ -694,6 +656,55 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	}
 	resp.CrashLog = ret.rawOutput
 	return nil
+}
+
+func (jp *JobProcessor) checkoutJobCommit(job *Job, repo vcs.Repo) (*vcs.Commit, error) {
+	req, resp := job.req, job.resp
+	var kernelCommit *vcs.Commit
+	if req.MergeBaseRepo != "" {
+		jp.Logf(1, "checking out the base kernel...")
+		firstCommit, err := checkoutKernelOrCommit(repo, req.KernelRepo, req.KernelBranch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout first kernel repo %v on %v: %v",
+				req.KernelRepo, req.KernelBranch, err)
+		}
+		secondCommit, err := checkoutKernelOrCommit(repo, req.MergeBaseRepo, req.MergeBaseBranch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout second kernel repo %v on %v: %v",
+				req.MergeBaseRepo, req.MergeBaseBranch, err)
+		}
+		bases, err := repo.MergeBases(firstCommit.Hash, secondCommit.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate merge bases between %v and %v: %v",
+				firstCommit.Hash, secondCommit.Hash, err)
+		}
+		if len(bases) != 1 {
+			return nil, fmt.Errorf("expected one merge base between %v and %v, got %d",
+				firstCommit.Hash, secondCommit.Hash, len(bases))
+		}
+		kernelCommit, err = repo.CheckoutCommit(req.KernelRepo, bases[0].Hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout kernel repo %v on merge base %v: %v",
+				req.KernelRepo, bases[0].Hash, err)
+		}
+		resp.Build.KernelBranch = ""
+	} else if vcs.CheckCommitHash(req.KernelBranch) {
+		var err error
+		kernelCommit, err = repo.CheckoutCommit(req.KernelRepo, req.KernelBranch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout kernel repo %v on commit %v: %v",
+				req.KernelRepo, req.KernelBranch, err)
+		}
+		resp.Build.KernelBranch = ""
+	} else {
+		var err error
+		kernelCommit, err = repo.CheckoutBranch(req.KernelRepo, req.KernelBranch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout kernel repo %v/%v: %v",
+				req.KernelRepo, req.KernelBranch, err)
+		}
+	}
+	return kernelCommit, nil
 }
 
 func checkoutKernelOrCommit(repo vcs.Repo, url, branch string) (*vcs.Commit, error) {


### PR DESCRIPTION
Run reproducers on other trees in order to determine:
1) The tree where the bug originated.
2) The tree to which the bug has already spread.
3) Missing backports for bugs.

Extend the KernelRepo structure to contain the information about commit
flow and about the exact labels that need to be assigned for (1) and
(2).

Fore better understanding look at the tests in tree_test.go.

TODO (before merging):
- [x] Display at least the minimal information in the UI: show the labels and a collapsed list of bug tree origin related jobs.
- [x] https://github.com/google/syzkaller/pull/3813 will contain changes to how bug labels are stored. Rebase after it's merged.
- [x] Deploy on a dev syzbot instance and see how it work in practice.
- [x] We need to rename the `Obsolete` label in `KernelRepo`.