### PR TITLE
sys/netbsd: neutralize compat_50_mknod

### DIFF
--- a/sys/netbsd/init_test.go
+++ b/sys/netbsd/init_test.go
@@ -1,0 +1,21 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package netbsd_test
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/prog"
+	_ "github.com/google/syzkaller/sys/netbsd/gen"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func TestNetBSDNeutralize(t *testing.T) {
+	prog.TestDeserializeHelper(t, targets.NetBSD, targets.AMD64, nil, []prog.DeserializeTest{
+		{
+			In:  `compat_50_mknod(&(0x7f0000000000)='./file0\x00', 0x2001, 0x400)`,
+			Out: `compat_50_mknod(&(0x7f0000000000)='./file0\x00', 0x8001, 0x400)`,
+		},
+	})
+}

--- a/sys/targets/common.go
+++ b/sys/targets/common.go
@@ -91,7 +91,7 @@ func (arch *UnixNeutralizer) Neutralize(c *prog.Call, fixStructure bool) error {
 		}
 		// Add MAP_FIXED flag, otherwise it produces non-deterministic results.
 		c.Args[3].(*prog.ConstArg).Val |= arch.MAP_FIXED
-	case "mknod", "mknodat":
+	case "mknod", "mknodat", "compat_50_mknod":
 		pos := 1
 		if c.Meta.CallName == "mknodat" {
 			pos = 2


### PR DESCRIPTION
Otherwise we may end up corrupting device memory.

See https://groups.google.com/g/syzkaller-netbsd-bugs/c/Iy8-NZ_M9Ug/m/5jKKfncsAQAJ
