### PR TITLE
dashbord: dispaly fix bisection attempts as a job list

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -49,7 +49,6 @@ Page with details about a single bug.
 		<div class="content">
 			{{if eq $item.Type "bug_list"}}{{template "bug_list" $item.Value}}{{end}}
 			{{if eq $item.Type "job_list"}}{{template "job_list" $item.Value}}{{end}}
-			{{if eq $item.Type "crash_list"}}{{template "crash_list" $item.Value}}{{end}}
 			{{if eq $item.Type "discussion_list"}}{{template "discussion_list" $item.Value}}{{end}}
                 </div>
 	</div>


### PR DESCRIPTION
By displaying it as a table we're missing job logs, which are actually the most significant piece of information there.

Cc @HerrSpace 