### PR TITLE
tools: simplify openbsd startup script

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -66,8 +66,9 @@ EOF2
     cd /syzkaller
     set -eux
     ulimit -d 8000000
-    export GOCACHE=/syzkaller/go-cache
-    mkdir -p \$GOCACHE
+    mkdir -p /syzkaller/go-cache
+    GOCACHE=/syzkaller/go-cache
+    export GOCACHE
     test -x syz-ci || (
          go get github.com/google/syzkaller/syz-ci &&
          go build github.com/google/syzkaller/syz-ci)


### PR DESCRIPTION
It's not worth the trouble to figure out how to quote things to save a single copy for a short literal.

