### PR TITLE
vm/cuttlefish: increase cuttlefish memory

### DIFF
--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -79,7 +79,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	// Start a Cuttlefish device on the GCE instance.
 	if err := inst.runOnHost(10*time.Minute,
 		fmt.Sprintf("./bin/launch_cvd -daemon -kernel_path=./bzImage -initramfs_path=./initramfs.img"+
-			" --noenable_sandbox -report_anonymous_usage_stats=n")); err != nil {
+			" --noenable_sandbox -report_anonymous_usage_stats=n --memory_mb=8192")); err != nil {
 		return nil, fmt.Errorf("failed to start cuttlefish: %s", err)
 	}
 


### PR DESCRIPTION
Cuttlefish instances are running out of memory;
increased size to allow for a margin on
running processes.
