### PR TITLE
dashboard: drop #syz unset from bug's template

### DIFF
--- a/dashboard/app/asset_storage_test.go
+++ b/dashboard/app/asset_storage_test.go
@@ -108,9 +108,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 
@@ -402,9 +399,6 @@ If the bug is already fixed, let syzbot know by replying with:
 If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
-
-If you want to unassign a label, reply with:
-#syz unset some-label
 
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -246,9 +246,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 
@@ -568,9 +565,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 
@@ -851,9 +845,6 @@ If you attach or paste a git patch, syzbot will apply it before testing.
 If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
-
-If you want to unassign a label, reply with:
-#syz unset some-label
 
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -80,9 +80,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 
@@ -260,9 +257,6 @@ If you attach or paste a git patch, syzbot will apply it before testing.
 If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
-
-If you want to unassign a label, reply with:
-#syz unset some-label
 
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
@@ -703,9 +697,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 
@@ -875,9 +866,6 @@ If the bug is already fixed, let syzbot know by replying with:
 If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
-
-If you want to unassign a label, reply with:
-#syz unset some-label
 
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report

--- a/dashboard/app/mail_bug.txt
+++ b/dashboard/app/mail_bug.txt
@@ -65,9 +65,6 @@ If you want to change bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
-If you want to unassign a label, reply with:
-#syz unset some-label
-
 If the bug is a duplicate of another bug, reply with:
 #syz dup: exact-subject-of-another-report
 


### PR DESCRIPTION
We don't mention the whole list of #syz set labels there, so it will only confuse people.
