### PR TITLE
dashboard: fix subsystem page filtering

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -136,7 +136,7 @@ type BugLabel struct {
 	Link string
 }
 
-func (label *BugLabel) String() string {
+func (label BugLabel) String() string {
 	if label.Value == "" {
 		return string(label.Label)
 	}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -372,7 +372,6 @@ type uiJob struct {
 type userBugFilter struct {
 	Manager     string // show bugs that happened on the manager
 	OnlyManager string // show bugs that happened ONLY on the manager
-	Subsystem   string // only show bugs belonging to the subsystem
 	Label       string // TODO: support multiple.
 	NoSubsystem bool
 }
@@ -503,7 +502,10 @@ func handleSubsystemPage(c context.Context, w http.ResponseWriter, r *http.Reque
 	}
 	groups, err := fetchNamespaceBugs(c, accessLevel(c, r),
 		hdr.Namespace, &userBugFilter{
-			Subsystem: subsystem.Name,
+			Label: BugLabel{
+				Label: SubsystemLabel,
+				Value: subsystem.Name,
+			}.String(),
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
It got broken during recent label-related changes.
