### PR TITLE
syz-fuzzer: avoid recognizing unsupported syscalls as kernel oops

### DIFF
--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -301,7 +301,9 @@ func buildCallList(target *prog.Target, enabledCalls []int, sandbox string) (
 	}
 	for c := range calls {
 		if reason, ok := unsupported[c]; ok {
-			log.Logf(1, "unsupported syscall: %v: %v", c.Name, reason)
+			// Note: if we print call name followed by ':', it may be detected
+			// as a kernel crash if the call ends with "BUG" or "INFO".
+			log.Logf(1, "unsupported syscall: %v(): %v", c.Name, reason)
 			disabled = append(disabled, rpctype.SyscallReason{
 				ID:     c.ID,
 				Reason: reason,
@@ -312,7 +314,7 @@ func buildCallList(target *prog.Target, enabledCalls []int, sandbox string) (
 	_, unsupported = target.TransitivelyEnabledCalls(calls)
 	for c := range calls {
 		if reason, ok := unsupported[c]; ok {
-			log.Logf(1, "transitively unsupported: %v: %v", c.Name, reason)
+			log.Logf(1, "transitively unsupported: %v(): %v", c.Name, reason)
 			disabled = append(disabled, rpctype.SyscallReason{
 				ID:     c.ID,
 				Reason: reason,


### PR DESCRIPTION
Just got this pearl:

2023/04/28 06:46:56 unsupported syscall: quotactl_fd$Q_GETINFO: sys_quotactl_fd is not
	enabled in the kernel (not present in /proc/kallsyms)
...
2023/04/28 06:47:26 vm-0: crash: INFO: sys_quotactl_fd is not
	enabled in the kernel (not present in /proc/kallsyms)
