### PR TITLE
dashboard: use a down-pointing triangle in collapsible blocks

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -43,7 +43,7 @@ Page with details about a single bug.
 	<div class="collapsible {{if $item.Show}}collapsible-show{{else}}collapsible-hide{{end}}">
 		<div class="head">
 			<span class="show-icon">&#9654;</span>
-			<span class="hide-icon">&#9650;</span>
+			<span class="hide-icon">&#9660;</span>
 			<span>{{$item.Title}}</span>
 		</div>
 		<div class="content">


### PR DESCRIPTION
It's more intuitive for users to see a down-facing triangle for collapsed blocks.

