### PR TITLE
syz-manager, pkg/cover: normalize signals between VM instances

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1011,9 +1011,12 @@ void write_coverage_signal(cover_t* cov, uint32* signal_count_pos, uint32* cover
 		bool prev_filter = true;
 		for (uint32 i = 0; i < cov->size; i++) {
 			cover_data_t pc = cover_data[i] + cov->pc_offset;
-			uint32 sig = pc;
-			if (use_cover_edges(pc))
-				sig ^= hash(prev_pc);
+			uint32 sig = pc & 0xFFFFF000;
+			if (use_cover_edges(pc)) {
+				// Only hash the lower 12 bits so the hash is
+				// independent of any module offsets.
+				sig |= (pc & 0xFFF) ^ (hash(prev_pc & 0xFFF) & 0xFFF);
+			}
 			bool filter = coverage_filter(pc);
 			// Ignore the edge only if both current and previous PCs are filtered out
 			// to capture all incoming and outcoming edges into the interesting code.

--- a/pkg/cover/canonicalizer_test.go
+++ b/pkg/cover/canonicalizer_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/signal"
 )
 
 type RPCServer struct {
@@ -23,8 +24,10 @@ type RPCServer struct {
 
 type Fuzzer struct {
 	instModules *cover.CanonicalizerInstance
-	testCov     []uint32
-	goalOut     []uint32
+	cov         []uint32
+	goalCov     []uint32
+	sign        signal.Serial
+	goalSign    signal.Serial
 }
 
 type canonicalizeValue int
@@ -39,20 +42,61 @@ func TestNilModules(t *testing.T) {
 	serv := &RPCServer{
 		fuzzers: make(map[string]*Fuzzer),
 	}
-	serv.connect("f1", nil)
-	serv.connect("f2", nil)
+	serv.connect("f1", nil, true)
+	serv.connect("f2", nil, true)
 
-	serv.fuzzers["f1"].testCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
-	serv.fuzzers["f1"].goalOut = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].cov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].goalCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].sign = signal.FromRaw(serv.fuzzers["f1"].cov, 0).Serialize()
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(serv.fuzzers["f1"].goalCov, 0).Serialize()
 
-	serv.fuzzers["f2"].testCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
-	serv.fuzzers["f2"].goalOut = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f2"].cov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f2"].goalCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f2"].sign = signal.FromRaw(serv.fuzzers["f2"].cov, 0).Serialize()
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(serv.fuzzers["f2"].goalCov, 0).Serialize()
+
 	if err := serv.runTest(Canonicalize); err != "" {
 		t.Fatalf("failed in canonicalization: %v", err)
 	}
 
-	serv.fuzzers["f1"].goalOut = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
-	serv.fuzzers["f2"].goalOut = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].goalCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(serv.fuzzers["f1"].goalCov, 0).Serialize()
+	serv.fuzzers["f2"].goalCov = []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(serv.fuzzers["f2"].goalCov, 0).Serialize()
+	if err := serv.runTest(Decanonicalize); err != "" {
+		t.Fatalf("failed in decanonicalization: %v", err)
+	}
+}
+
+// Confirms there is no change to signals if coverage is disabled and fallback signals are used.
+func TestDisabledSignals(t *testing.T) {
+	serv := &RPCServer{
+		fuzzers: make(map[string]*Fuzzer),
+	}
+	// Create modules at the specified address offsets.
+	f1ModuleAddresses := []uint64{0x00015000, 0x00020000, 0x00030000, 0x00040000, 0x00045000}
+	f1ModuleSizes := []uint64{0x5000, 0x5000, 0x10000, 0x5000, 0x10000}
+	f1Modules := initModules(f1ModuleAddresses, f1ModuleSizes)
+	serv.connect("f1", f1Modules, false)
+
+	f2ModuleAddresses := []uint64{0x00015000, 0x00040000, 0x00045000, 0x00020000, 0x00030000}
+	f2ModuleSizes := []uint64{0x5000, 0x5000, 0x10000, 0x5000, 0x10000}
+	f2Modules := initModules(f2ModuleAddresses, f2ModuleSizes)
+	serv.connect("f2", f2Modules, false)
+
+	pcs := []uint32{0x00010000, 0x00020000, 0x00030000, 0x00040000}
+	serv.fuzzers["f1"].sign = signal.FromRaw(pcs, 0).Serialize()
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(pcs, 0).Serialize()
+
+	serv.fuzzers["f2"].sign = signal.FromRaw(pcs, 0).Serialize()
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(pcs, 0).Serialize()
+
+	if err := serv.runTest(Canonicalize); err != "" {
+		t.Fatalf("failed in canonicalization: %v", err)
+	}
+
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(pcs, 0).Serialize()
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(pcs, 0).Serialize()
 	if err := serv.runTest(Decanonicalize); err != "" {
 		t.Fatalf("failed in decanonicalization: %v", err)
 	}
@@ -68,34 +112,41 @@ func TestModules(t *testing.T) {
 	f1ModuleAddresses := []uint64{0x00015000, 0x00020000, 0x00030000, 0x00040000, 0x00045000}
 	f1ModuleSizes := []uint64{0x5000, 0x5000, 0x10000, 0x5000, 0x10000}
 	f1Modules := initModules(f1ModuleAddresses, f1ModuleSizes)
-	serv.connect("f1", f1Modules)
+	serv.connect("f1", f1Modules, true)
 
 	f2ModuleAddresses := []uint64{0x00015000, 0x00040000, 0x00045000, 0x00020000, 0x00030000}
 	f2ModuleSizes := []uint64{0x5000, 0x5000, 0x10000, 0x5000, 0x10000}
 	f2Modules := initModules(f2ModuleAddresses, f2ModuleSizes)
-	serv.connect("f2", f2Modules)
+	serv.connect("f2", f2Modules, true)
 
 	// f1 is the "canonical" fuzzer as it is first one instantiated.
 	// This means that all coverage output should be the same as the inputs.
-	serv.fuzzers["f1"].testCov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
+	serv.fuzzers["f1"].cov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
 		0x00035000, 0x00040000, 0x00045000, 0x00050000, 0x00055000}
-	serv.fuzzers["f1"].goalOut = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
+	serv.fuzzers["f1"].goalCov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
 		0x00035000, 0x00040000, 0x00045000, 0x00050000, 0x00055000}
+	serv.fuzzers["f1"].sign = signal.FromRaw(serv.fuzzers["f1"].cov, 0).Serialize()
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(serv.fuzzers["f1"].goalCov, 0).Serialize()
 
 	// The modules addresss are inverted between: (2 and 4), (3 and 5),
 	// affecting the output canonical coverage values in these ranges.
-	serv.fuzzers["f2"].testCov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
+	serv.fuzzers["f2"].cov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
 		0x00035000, 0x00040000, 0x00045000, 0x00050000, 0x00055000}
-	serv.fuzzers["f2"].goalOut = []uint32{0x00010000, 0x00015000, 0x00040000, 0x00025000, 0x00045000,
+	serv.fuzzers["f2"].goalCov = []uint32{0x00010000, 0x00015000, 0x00040000, 0x00025000, 0x00045000,
 		0x0004a000, 0x00020000, 0x00030000, 0x0003b000, 0x00055000}
+	serv.fuzzers["f2"].sign = signal.FromRaw(serv.fuzzers["f2"].cov, 0).Serialize()
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(serv.fuzzers["f2"].goalCov, 0).Serialize()
+
 	if err := serv.runTest(Canonicalize); err != "" {
 		t.Fatalf("failed in canonicalization: %v", err)
 	}
 
-	serv.fuzzers["f1"].goalOut = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
+	serv.fuzzers["f1"].goalCov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
 		0x00035000, 0x00040000, 0x00045000, 0x00050000, 0x00055000}
-	serv.fuzzers["f2"].goalOut = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
+	serv.fuzzers["f1"].goalSign = signal.FromRaw(serv.fuzzers["f1"].goalCov, 0).Serialize()
+	serv.fuzzers["f2"].goalCov = []uint32{0x00010000, 0x00015000, 0x00020000, 0x00025000, 0x00030000,
 		0x00035000, 0x00040000, 0x00045000, 0x00050000, 0x00055000}
+	serv.fuzzers["f2"].goalSign = signal.FromRaw(serv.fuzzers["f2"].goalCov, 0).Serialize()
 	if err := serv.runTest(Decanonicalize); err != "" {
 		t.Fatalf("failed in decanonicalization: %v", err)
 	}
@@ -104,21 +155,25 @@ func TestModules(t *testing.T) {
 func (serv *RPCServer) runTest(val canonicalizeValue) string {
 	for name, fuzzer := range serv.fuzzers {
 		if val == Canonicalize {
-			fuzzer.instModules.Canonicalize(fuzzer.testCov)
+			fuzzer.instModules.Canonicalize(fuzzer.cov, fuzzer.sign)
 		} else {
-			fuzzer.instModules.Decanonicalize(fuzzer.testCov)
+			fuzzer.instModules.Decanonicalize(fuzzer.cov, fuzzer.sign)
 		}
-		if !reflect.DeepEqual(fuzzer.testCov, fuzzer.goalOut) {
-			return fmt.Sprintf("fuzzer %v.\nExpected: 0x%x.\nReturned: 0x%x",
-				name, fuzzer.goalOut, fuzzer.testCov)
+		if !reflect.DeepEqual(fuzzer.cov, fuzzer.goalCov) {
+			return fmt.Sprintf("failed in coverage conversion. Fuzzer %v.\nExpected: 0x%x.\nReturned: 0x%x",
+				name, fuzzer.goalCov, fuzzer.cov)
+		}
+		if !reflect.DeepEqual(fuzzer.sign.Deserialize(), fuzzer.goalSign.Deserialize()) {
+			return fmt.Sprintf("failed in signal conversion. Fuzzer %v.\nExpected: 0x%x.\nReturned: 0x%x",
+				name, fuzzer.goalSign, fuzzer.sign)
 		}
 	}
 	return ""
 }
 
-func (serv *RPCServer) connect(name string, modules []host.KernelModule) {
+func (serv *RPCServer) connect(name string, modules []host.KernelModule, flagSignal bool) {
 	if !serv.modulesInitialized {
-		serv.canonicalModules = cover.NewCanonicalizer(modules)
+		serv.canonicalModules = cover.NewCanonicalizer(modules, flagSignal)
 		serv.modulesInitialized = true
 	}
 

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -79,6 +79,10 @@ func (s Signal) Serialize() Serial {
 	return res
 }
 
+func (ser Serial) UpdateElem(idx int, newElem uint32) {
+	ser.Elems[idx] = elemType(newElem)
+}
+
 func (ser Serial) Deserialize() Signal {
 	if len(ser.Elems) != len(ser.Prios) {
 		panic("corrupted Serial")

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -100,7 +100,7 @@ func (serv *RPCServer) Connect(a *rpctype.ConnectArgs, r *rpctype.ConnectRes) er
 	serv.modules = a.Modules
 
 	if serv.canonicalModules == nil {
-		serv.canonicalModules = cover.NewCanonicalizer(a.Modules)
+		serv.canonicalModules = cover.NewCanonicalizer(a.Modules, serv.cfg.Cover)
 	}
 
 	serv.mu.Lock()
@@ -268,7 +268,7 @@ func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 
 	f := serv.fuzzers[a.Name]
 	if f != nil {
-		f.instModules.Canonicalize(a.Cover)
+		f.instModules.Canonicalize(a.Cover, a.Signal)
 	}
 	// Note: f may be nil if we called shutdownInstance,
 	// but this request is already in-flight.
@@ -377,7 +377,7 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 		}
 	}
 	for _, inp := range r.NewInputs {
-		f.instModules.Decanonicalize(inp.Cover)
+		f.instModules.Decanonicalize(inp.Cover, inp.Signal)
 	}
 	log.Logf(4, "poll from %v: candidates=%v inputs=%v maxsignal=%v",
 		a.Name, len(r.Candidates), len(r.NewInputs), len(r.MaxSignal.Elems))


### PR DESCRIPTION
Adjust signal creation in syz-executor so hash
is independent of module offsets. This allows
for canonicalization of the signal between VMs.

Added signals to canonicalization/decanonicalization between instances.

Coverts serialized Signal values as they have already been serialized in rpc.go. Added a function in signal.go to update serial signal elements.
