### PR TITLE
executor: add missing header for syz_mount_image

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2991,6 +2991,7 @@ error_clear_loop:
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_mount_image
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 #include <sys/mount.h>

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7085,6 +7085,7 @@ error_clear_loop:
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_mount_image
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 #include <sys/mount.h>


### PR DESCRIPTION
The pseudosyscall is using booleans without importing them first.
