### PR TITLE
dashboard: don't create jobs for decommissioned namespaces

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -348,6 +348,9 @@ func createPatchTestingJobs(c context.Context, managers map[string]dashapi.Manag
 				// for which we were already given fixing commits.
 				return false
 			}
+			if config.Namespaces[bug.Namespace].Decommissioned {
+				return false
+			}
 			return true
 		})
 		r.Shuffle(len(bugs), func(i, j int) {
@@ -581,6 +584,9 @@ func findBugsForBisection(c context.Context, managers map[string]bool,
 
 func shouldBisectBug(bug *Bug, managers map[string]bool) bool {
 	if len(bug.Commits) != 0 {
+		return false
+	}
+	if config.Namespaces[bug.Namespace].Decommissioned {
 		return false
 	}
 	for _, mgr := range bug.HappenedOn {

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -683,6 +683,18 @@ func foreachBug(c context.Context, filter func(*db.Query) *db.Query, fn func(bug
 	}
 }
 
+func filterBugs(bugs []*Bug, keys []*db.Key, filter func(*Bug) bool) ([]*Bug, []*db.Key) {
+	var retBugs []*Bug
+	var retKeys []*db.Key
+	for i, bug := range bugs {
+		if filter(bug) {
+			retBugs = append(retBugs, bugs[i])
+			retKeys = append(retKeys, keys[i])
+		}
+	}
+	return retBugs, retKeys
+}
+
 // reportingPollClosed is called by backends to get list of closed bugs.
 func reportingPollClosed(c context.Context, ids []string) ([]string, error) {
 	idMap := make(map[string]bool, len(ids))


### PR DESCRIPTION
There's a chance jobs will be created at the time between a namespace is decommissioned and syz-ci's are stopped.