### PR TITLE
pkg/csource: compile pseudo syscalls individually

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -66,9 +66,9 @@ NORETURN void doexit_thread(int status)
 #endif
 #endif
 
-#if SYZ_EXECUTOR || SYZ_MULTI_PROC || SYZ_REPEAT && SYZ_CGROUPS ||         \
-    SYZ_NET_DEVICES || __NR_syz_mount_image || __NR_syz_read_part_table || \
-    __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k ||                  \
+#if SYZ_EXECUTOR || SYZ_MULTI_PROC || SYZ_REPEAT && SYZ_CGROUPS ||                      \
+    SYZ_NET_DEVICES || __NR_syz_mount_image || __NR_syz_read_part_table ||              \
+    __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k || __NR_syz_usbip_server_init || \
     (GOOS_freebsd || GOOS_darwin || GOOS_openbsd || GOOS_netbsd) && SYZ_NET_INJECTION
 static unsigned long long procid;
 #endif
@@ -192,7 +192,9 @@ static void kill_and_wait(int pid, int* status)
 
 #if !GOOS_windows
 #if SYZ_EXECUTOR || SYZ_THREADED || SYZ_REPEAT && SYZ_EXECUTOR_USES_FORK_SERVER || \
-    __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k || __NR_syz_sleep_ms
+    __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k || __NR_syz_sleep_ms ||     \
+    __NR_syz_usb_control_io || __NR_syz_usb_ep_read || __NR_syz_usb_ep_write ||    \
+    __NR_syz_usb_disconnect
 static void sleep_ms(uint64 ms)
 {
 	usleep(ms * 1000);

--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -13,7 +13,7 @@
 
 #if GOOS_netbsd
 
-#if SYZ_EXECUTOR || __NR_syz_usb_connect
+#if SYZ_EXECUTOR || __NR_syz_usb_connect || __NR_syz_usb_disconnect
 #include "common_usb_netbsd.h"
 #endif
 #if SYZ_EXECUTOR || SYZ_USB

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -111,6 +111,7 @@ static bool write_file(const char* file, const char* what, ...)
 #if SYZ_EXECUTOR || SYZ_NET_DEVICES || SYZ_NET_INJECTION || SYZ_DEVLINK_PCI || SYZ_WIFI || SYZ_802154 || \
     __NR_syz_genetlink_get_family_id || __NR_syz_80211_inject_frame || __NR_syz_80211_join_ibss || SYZ_NIC_VF
 #include <arpa/inet.h>
+#include <errno.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <stdbool.h>
@@ -2364,7 +2365,9 @@ static long syz_extract_tcp_res(volatile long a0, volatile long a1, volatile lon
 #define MAX_FDS 30
 #endif
 
-#if SYZ_EXECUTOR || __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k
+#if SYZ_EXECUTOR || __NR_syz_usb_connect || __NR_syz_usb_connect_ath9k ||       \
+    __NR_syz_usb_ep_write || __NR_syz_usb_ep_read || __NR_syz_usb_control_io || \
+    __NR_syz_usb_disconnect
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/usb/ch9.h>
@@ -2889,6 +2892,7 @@ static long syz_genetlink_get_family_id(volatile long name, volatile long sock_a
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/loop.h>
+#include <stdbool.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -5314,6 +5318,7 @@ static volatile long syz_fuse_handle_req(volatile long a0, // /dev/fuse fd.
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_80211_inject_frame
+#include <errno.h>
 #include <linux/genetlink.h>
 #include <linux/if_ether.h>
 #include <linux/nl80211.h>

--- a/executor/common_usb_netbsd.h
+++ b/executor/common_usb_netbsd.h
@@ -149,6 +149,7 @@ struct usb_qualifier_descriptor {
 #define USB_REQ_GET_VDM 23
 #define USB_REQ_SEND_VDM 24
 
+#if SYZ_EXECUTOR || __NR_syz_usb_connect
 #include "common_usb.h"
 
 static int vhci_open(void)
@@ -307,7 +308,6 @@ static volatile long syz_usb_connect_impl(int fd, uint64 speed, uint64 dev_len,
 	return fd;
 }
 
-#if SYZ_EXECUTOR || __NR_syz_usb_connect
 static volatile long syz_usb_connect(volatile long a0, volatile long a1,
 				     volatile long a2, volatile long a3)
 {

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -53,6 +53,23 @@ func TestGenerate(t *testing.T) {
 			checked[target.OS] = true
 			t.Parallel()
 			testTarget(t, target, full)
+			testPseudoSyscalls(t, target)
+		})
+	}
+}
+
+func testPseudoSyscalls(t *testing.T, target *prog.Target) {
+	// Use options that are as minimal as possible.
+	// We want to ensure that the code can always be compiled.
+	opts := Options{
+		Slowdown: 1,
+	}
+	rs := testutil.RandSource(t)
+	for _, meta := range target.PseudoSyscalls() {
+		p := target.GenSampleProg(meta, rs)
+		t.Run(fmt.Sprintf("single_%s", meta.CallName), func(t *testing.T) {
+			t.Parallel()
+			testOne(t, p, opts)
 		})
 	}
 }


### PR DESCRIPTION
There seem to be a lot of unclear dependencies between pseudo syscall
code and global methods. By testing them only together we have little
chance to detect these problems because implementations can indiretly
help one another.

In addition to existing tests, also compile all pseudo syscalls
independently.