### PR TITLE
tools: update Fuchsia SDK

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -615,10 +615,9 @@ func fuchsiaCFlags(arch, clangArch string) []string {
 	return []string{
 		"-Wno-deprecated",
 		"-target", clangArch + "-fuchsia",
-		"-ldriver",
 		"-lfdio",
 		"-lzircon",
-		"--sysroot", out + "/zircon_toolchain/obj/zircon/public/sysroot/sysroot",
+		"--sysroot", out + "/sysroot",
 		"-I", sourceDirVar + "/sdk/lib/fdio/include",
 		"-I", sourceDirVar + "/zircon/system/ulib/fidl/include",
 		"-I", sourceDirVar + "/src/lib/ddk/include",

--- a/tools/build_fuchsia_sdk.sh
+++ b/tools/build_fuchsia_sdk.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright 2023 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+# First follow the tutorial at https://fuchsia.dev/fuchsia-src/get-started/build_fuchsia
+# Set the following env variables before executing this script:
+# SYZKALLER -- path to the syzkaller checkout.
+# FUCHSIA -- path to the fuchsia checkout.
+# SDK -- where the generated sdk should be stored.
+
+
+if [ -z "${SYZKALLER}" ]; then
+  echo "The SYZKALLER environment variable is not set."
+  exit 1
+fi
+
+if [ -z "${FUCHSIA}" ]; then
+  echo "The FUCHSIA environment variable is not set."
+  exit 1
+fi
+
+if [ -z "${SDK}" ]; then
+  echo "The SDK environment variable is not set."
+  exit 1
+fi
+
+# Copy generic SDK files.
+
+function copy_dir() {
+    FROM=${1}
+    TO=${2}
+    FLAGS=${3}
+    if [ -z "$FLAGS" ]
+    then
+      FLAGS="-rL"
+    fi
+    mkdir -p ${TO}
+    echo "Copying ${FLAGS} ${FROM}/. to ${TO}"
+    cp ${FLAGS} ${FROM}/. ${TO}
+}
+
+mkdir -p $SDK
+
+# Build and copy arm64 files.
+
+cd ${FUCHSIA}
+
+SYZKALLER_ARG=\"${SYZKALLER}\"
+fx --dir "out/arm64" set core.arm64 \
+  --with-base "//bundles/tools" \
+  --with-base "//src/testing/fuzzing/syzkaller" \
+  --args=syzkaller_dir="${SYZKALLER_ARG}" \
+  --variant=kasan
+
+fx build
+
+for folder in out/arm64/fidling/gen out/arm64/arm64-shared; do
+  copy_dir ${FUCHSIA}/${folder} ${SDK}/${folder}
+done
+copy_dir ${FUCHSIA}/out/arm64/sdk/exported/zircon_sysroot/arch/arm64/sysroot ${SDK}/out/arm64/sysroot
+
+# Build and copy x64 files.
+
+fx --dir "out/x64" set core.x64 \
+  --with-base "//bundles/tools" \
+  --with-base "//src/testing/fuzzing/syzkaller" \
+  --args=syzkaller_dir="${SYZKALLER_ARG}" \
+  --variant=kasan
+
+fx build
+
+for folder in out/x64/fidling/gen out/x64/x64-shared; do
+  copy_dir ${FUCHSIA}/${folder} ${SDK}/${folder}
+done
+copy_dir ${FUCHSIA}/out/x64/sdk/exported/zircon_sysroot/arch/x64/sysroot ${SDK}/out/x64/sysroot
+
+# Copy common files.
+
+for folder in sdk/lib src/lib zircon; do
+  copy_dir ${FUCHSIA}/${folder} ${SDK}/${folder}
+done
+copy_dir ${FUCHSIA}/prebuilt/third_party/clang ${SDK}/prebuilt/third_party/clang "-r --preserve=links"

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -48,14 +48,8 @@ RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/b
 
 # Install OS toolchains from pre-built archives.
 # These archives were created with:
-# tar -cz --owner=0 --group=0 --mode=go=u -f akaros-toolchain.tar.gz akaros/toolchain
 # tar -cz --owner=0 --group=0 --mode=go=u -f netbsd-toolchain.tar.gz netbsd/tools netbsd/dest
-# tar -cz --owner=0 --group=0 --mode=go=u -f fuchsia-toolchain.tar.gz fuchsia/prebuilt/third_party/clang \
-#	fuchsia/zircon/system/ulib fuchsia/src/lib/ddk fuchsia/out/x64/fidling/gen \
-#	fuchsia/out/x64/zircon_toolchain/obj/zircon/public/sysroot/sysroot \
-#	fuchsia/out/x64/x64-shared/*.so fuchsia/out/arm64/fidling/gen \
-#	fuchsia/out/arm64/zircon_toolchain/obj/zircon/public/sysroot/sysroot \
-#	fuchsia/out/arm64/arm64-shared/*.so
+# tar -cz --owner=0 --group=0 --mode=go=u -f fuchsia-toolchain.tar.gz fuchsia
 #
 # And then uploaded to GCS with:
 # gsutil mv gs://syzkaller/GOOS-toolchain.tar.gz gs://syzkaller/GOOS-toolchain.old.tar.gz
@@ -81,7 +75,7 @@ RUN dpkg --add-architecture i386 && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 
-RUN curl https://storage.googleapis.com/syzkaller/fuchsia-toolchain.tar.gz | tar -C /syzkaller -xz
+RUN curl https://storage.googleapis.com/syzkaller/fuchsia-toolchain-20230905.tar.gz | tar -C /syzkaller -xzv 
 RUN curl https://storage.googleapis.com/syzkaller/netbsd-toolchain.tar.gz | tar -C /syzkaller -xz
 ENV SOURCEDIR_FUCHSIA /syzkaller/fuchsia
 ENV SOURCEDIR_NETBSD /syzkaller/netbsd


### PR DESCRIPTION
We've been getting a lot of TestGenerate failures for Fuchsia tests lately. Fix this by using a newer SDK in our Docker images.

@mvanotti Could you please take a look at this PR?
The resulting SDK definitely increased in size compared to our existing SDK archive, but at least now compile tests seem to work fine.

P.S. Tests won't pass until the image is pushed to the server.