### PR TITLE
RFC: syz-manager: facilitate automated log analysis

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -153,6 +153,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
+	log.SetName(cfg.Name)
 	RunManager(cfg)
 }
 


### PR DESCRIPTION
1. Update the default syzkaller log format to facilitate automated log analysis.
2. Set the type of some syz-manager log messages to `Error`.