### PR TITLE
pkg/vcs: use gcc 10.1 for linux v5.8..v5.16

### DIFF
--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -203,9 +203,11 @@ func linuxClangPath(tags map[string]bool, binDir, defaultCompiler string) string
 func linuxGCCPath(tags map[string]bool, binDir, defaultCompiler string) string {
 	version := ""
 	switch {
-	case tags["v5.9"]:
-		// Verified to work with 10.1.0.
+	case tags["v5.16"]:
+		// Verified to work with 15.0.7.
 		return defaultCompiler
+	case tags["v5.9"]:
+		version = "10.1.0"
 	case tags["v4.12"]:
 		version = "8.1.0"
 	case tags["v4.11"]:

--- a/pkg/vcs/linux_test.go
+++ b/pkg/vcs/linux_test.go
@@ -43,7 +43,7 @@ func TestGCCVersion(t *testing.T) {
 	assert.Equal(t, actual, expected, "unexpected gcc path")
 
 	// Recent tag case.
-	tags["v5.9"] = true
+	tags["v5.16"] = true
 	actual = linuxGCCPath(tags, binDir, defaultCompiler)
 	expected = defaultCompiler
 	assert.Equal(t, actual, expected, "unexpected gcc path")


### PR DESCRIPTION
This was already the case before #3420. Using the default compiler so far back was overly optimistic, as pointed out in #3814.
