### PR TITLE
dashboard: retry bisections on infrastructure errors

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -93,27 +93,28 @@ type Bug struct {
 	NumRepro     int64
 	// ReproLevel is the best ever found repro level for this bug.
 	// HeadReproLevel is best known repro level that still works on the HEAD commit.
-	ReproLevel     dashapi.ReproLevel
-	HeadReproLevel dashapi.ReproLevel `datastore:"HeadReproLevel"`
-	BisectCause    BisectStatus
-	BisectFix      BisectStatus
-	HasReport      bool
-	NeedCommitInfo bool
-	FirstTime      time.Time
-	LastTime       time.Time
-	LastSavedCrash time.Time
-	LastReproTime  time.Time
-	FixTime        time.Time // when we become aware of the fixing commit
-	LastActivity   time.Time // last time we observed any activity related to the bug
-	Closed         time.Time
-	SubsystemsTime time.Time // when we have updated subsystems last time
-	SubsystemsRev  int
-	Reporting      []BugReporting
-	Commits        []string // titles of fixing commmits
-	CommitInfo     []Commit // additional info for commits (for historical reasons parallel array to Commits)
-	HappenedOn     []string // list of managers
-	PatchedOn      []string `datastore:",noindex"` // list of managers
-	UNCC           []string // don't CC these emails on this bug
+	ReproLevel      dashapi.ReproLevel
+	HeadReproLevel  dashapi.ReproLevel `datastore:"HeadReproLevel"`
+	BisectCause     BisectStatus
+	BisectFix       BisectStatus
+	HasReport       bool
+	NeedCommitInfo  bool
+	FirstTime       time.Time
+	LastTime        time.Time
+	LastSavedCrash  time.Time
+	LastReproTime   time.Time
+	LastCauseBisect time.Time
+	FixTime         time.Time // when we become aware of the fixing commit
+	LastActivity    time.Time // last time we observed any activity related to the bug
+	Closed          time.Time
+	SubsystemsTime  time.Time // when we have updated subsystems last time
+	SubsystemsRev   int
+	Reporting       []BugReporting
+	Commits         []string // titles of fixing commmits
+	CommitInfo      []Commit // additional info for commits (for historical reasons parallel array to Commits)
+	HappenedOn      []string // list of managers
+	PatchedOn       []string `datastore:",noindex"` // list of managers
+	UNCC            []string // don't CC these emails on this bug
 	// Kcidb publishing status bitmask:
 	// bit 0 - the bug is published
 	// bit 1 - don't want to publish it (syzkaller build/test errors)

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -219,10 +219,11 @@ const (
 type JobDoneFlags int64
 
 const (
-	BisectResultMerge   JobDoneFlags = 1 << iota // bisected to a merge commit
-	BisectResultNoop                             // commit does not affect resulting kernel binary
-	BisectResultRelease                          // commit is a kernel release
-	BisectResultIgnore                           // this particular commit should be ignored, see syz-ci/jobs.go
+	BisectResultMerge      JobDoneFlags = 1 << iota // bisected to a merge commit
+	BisectResultNoop                                // commit does not affect resulting kernel binary
+	BisectResultRelease                             // commit is a kernel release
+	BisectResultIgnore                              // this particular commit should be ignored, see syz-ci/jobs.go
+	BisectResultInfraError                          // the bisect failed due to an infrastructure problem
 )
 
 func (dash *Dashboard) JobPoll(req *JobPollReq) (*JobPollResp, error) {

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -135,7 +135,7 @@ func Run(cfg *Config) (*Result, error) {
 		return nil, err
 	}
 	if _, err = repo.CheckoutBranch(cfg.Kernel.Repo, cfg.Kernel.Branch); err != nil {
-		return nil, err
+		return nil, &InfraError{Title: fmt.Sprintf("%v", err)}
 	}
 	return runImpl(cfg, repo, inst)
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -216,6 +216,7 @@ func OverrideVMCount(cfg *mgrconfig.Config, n int) error {
 
 type TestError struct {
 	Boot   bool // says if the error happened during booting or during instance testing
+	Infra  bool // whether the problem is related to some infrastructure problems
 	Title  string
 	Output []byte
 	Report *report.Report
@@ -323,6 +324,12 @@ func (inst *inst) test() EnvTestResult {
 			}
 			testErr.Report = rep
 			testErr.Title = rep.Title
+		} else {
+			testErr.Infra = true
+			if infraErr, ok := err.(vm.InfraErrorer); ok {
+				// In case there's more info available.
+				testErr.Title, testErr.Output = infraErr.InfraError()
+			}
 		}
 		return ret
 	}

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -521,6 +521,9 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 	res, err := bisect.Run(cfg)
 	resp.Log = trace.Bytes()
 	if err != nil {
+		if _, ok := err.(*bisect.InfraError); ok {
+			resp.Flags |= dashapi.BisectResultInfraError
+		}
 		return err
 	}
 	for _, com := range res.Commits {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -57,13 +57,18 @@ type Instance struct {
 }
 
 var (
-	Shutdown               = vmimpl.Shutdown
-	ErrTimeout             = vmimpl.ErrTimeout
-	_          BootErrorer = vmimpl.BootError{}
+	Shutdown                = vmimpl.Shutdown
+	ErrTimeout              = vmimpl.ErrTimeout
+	_          BootErrorer  = vmimpl.BootError{}
+	_          InfraErrorer = vmimpl.InfraError{}
 )
 
 type BootErrorer interface {
 	BootError() (string, []byte)
+}
+
+type InfraErrorer interface {
+	InfraError() (string, []byte)
 }
 
 // vmType splits the VM type from any suffix (separated by ":"). This is mostly

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -85,6 +85,8 @@ type Env struct {
 }
 
 // BootError is returned by Pool.Create when VM does not boot.
+// It should not be used for VMM intfrastructure errors, i.e. for problems not related
+// to the tested kernel itself.
 type BootError struct {
 	Title  string
 	Output []byte
@@ -104,6 +106,21 @@ func (err BootError) Error() string {
 }
 
 func (err BootError) BootError() (string, []byte) {
+	return err.Title, err.Output
+}
+
+// By default, all Pool.Create() errors are related to infrastructure problems.
+// InfraError is to be used when we want to also attach output to the title.
+type InfraError struct {
+	Title  string
+	Output []byte
+}
+
+func (err InfraError) Error() string {
+	return fmt.Sprintf("%v\n%s", err.Title, err.Output)
+}
+
+func (err InfraError) InfraError() (string, []byte) {
 	return err.Title, err.Output
 }
 

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -201,11 +201,17 @@ func (inst *instance) lookupSSHAddress() (string, error) {
 	}
 	lines := strings.Split(out, "\n")
 	if len(lines) < 2 {
-		return "", vmimpl.BootError{Title: "Unexpected vmctl status output", Output: []byte(out)}
+		return "", vmimpl.InfraError{
+			Title:  "unexpected vmctl status output",
+			Output: []byte(out),
+		}
 	}
 	matches := vmctlStatusRegex.FindStringSubmatch(lines[1])
 	if len(matches) < 2 {
-		return "", vmimpl.BootError{Title: "Unexpected vmctl status output", Output: []byte(out)}
+		return "", vmimpl.InfraError{
+			Title:  "unexpected vmctl status output",
+			Output: []byte(out),
+		}
 	}
 	return fmt.Sprintf("100.64.%s.3", matches[1]), nil
 }


### PR DESCRIPTION
Closes https://github.com/google/syzkaller/issues/3854

See descriptions of individual commits.

TL;DR:
* Separate boot/test errors and infrastructure errors.
* If more than 50% of runs failed due to infra problems, abort a bisection.
* Restart cause and fix bisections if they were aborted due to infrastructure problems. 