### PR TITLE
dashboard: support filtering over multiple labels

### DIFF
--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -94,16 +94,17 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{if .Filter.Any}}
 	<b>Applied filters: </b>
 	{{if .Filter.Manager}}
-		Manager={{.Filter.Manager}} ({{link (call .DropURL "manager") "drop"}})
+		Manager={{.Filter.Manager}} ({{link (call .DropURL "manager" "") "drop"}})
 	{{end}}
 	{{if .Filter.OnlyManager}}
-		Only Manager={{.Filter.OnlyManager}} ({{link (call .DropURL "only_manager") "drop"}})
+		Only Manager={{.Filter.OnlyManager}} ({{link (call .DropURL "only_manager" "") "drop"}})
 	{{end}}
 	{{if .Filter.NoSubsystem}}
-		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem") "drop"}})
+		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem" "") "drop"}})
 	{{end}}
-	{{if .Filter.Label}}
-		Label={{.Filter.Label}} ({{link (call .DropURL "label") "drop"}})
+	{{$drop := .DropURL}}
+	{{range .Filter.Labels}}
+		Label={{.}} ({{link (call $drop "label" .) "drop"}})
 	{{end}}
 	<br>
 {{end}}

--- a/pkg/html/html_test.go
+++ b/pkg/html/html_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package html
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDropParam(t *testing.T) {
+	tests := []struct {
+		in    string
+		key   string
+		value string
+		out   string
+	}{
+		{
+			in:    `/upstream?first=a&second=b`,
+			key:   `first`,
+			value: ``,
+			out:   `/upstream?second=b`,
+		},
+		{
+			in:    `/upstream?first=a&first=b&second=c`,
+			key:   `second`,
+			value: ``,
+			out:   `/upstream?first=a&first=b`,
+		},
+		{
+			in:    `/upstream?first=a&first=b&second=c`,
+			key:   `first`,
+			value: ``,
+			out:   `/upstream?second=c`,
+		},
+		{
+			in:    `/upstream?first=a&first=b&second=c`,
+			key:   `first`,
+			value: `b`,
+			out:   `/upstream?first=a&second=c`,
+		},
+	}
+
+	for _, test := range tests {
+		got := DropParam(test.in, test.key, test.value)
+		assert.Equal(t, test.out, got)
+	}
+}


### PR DESCRIPTION
For each label, allow only one value to be specified. At the same time, allow multiple different labels (subsystem, origin, prio, etc) be specified together.