### PR TITLE
dashboard: display bug origin tree testing results

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -53,7 +53,8 @@ Page with details about a single bug.
 			{{if eq $item.Type "bug_list"}}{{template "bug_list" $item.Value}}{{end}}
 			{{if eq $item.Type "job_list"}}{{template "job_list" $item.Value}}{{end}}
 			{{if eq $item.Type "discussion_list"}}{{template "discussion_list" $item.Value}}{{end}}
-                </div>
+			{{if eq $item.Type "test_results"}}{{template "test_results" $item.Value}}{{end}}
+		</div>
 	</div>
 	{{end}}
 

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1380,16 +1380,16 @@ func jobID2Key(c context.Context, id string) (*db.Key, error) {
 	return jobKey, nil
 }
 
-func fetchJob(c context.Context, key string) (*Job, error) {
+func fetchJob(c context.Context, key string) (*Job, *db.Key, error) {
 	jobKey, err := db.DecodeKey(key)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	job := new(Job)
 	if err := db.Get(c, jobKey, job); err != nil {
-		return nil, fmt.Errorf("failed to get job: %v", err)
+		return nil, nil, fmt.Errorf("failed to get job: %v", err)
 	}
-	return job, nil
+	return job, jobKey, nil
 }
 
 func makeJobInfo(c context.Context, job *Job, jobKey *db.Key, bug *Bug, build *Build,
@@ -1423,6 +1423,7 @@ func makeJobInfo(c context.Context, job *Job, jobKey *db.Key, bug *Bug, build *B
 		ErrorLink:        textLink(textError, job.Error),
 		Reported:         job.Reported,
 		TreeOrigin:       job.TreeOrigin,
+		OnMergeBase:      job.MergeBaseRepo != "",
 	}
 	if !job.Finished.IsZero() {
 		info.Duration = job.Finished.Sub(job.LastStarted)

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -254,6 +254,7 @@ const (
 	sectionBugList        = "bug_list"
 	sectionJobList        = "job_list"
 	sectionDiscussionList = "discussion_list"
+	sectionTestResults    = "test_results"
 )
 
 type uiCollapsible struct {
@@ -746,6 +747,18 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 			Value: discussions,
 		})
 	}
+	treeTestJobs, err := treeTestJobs(c, bug)
+	if err != nil {
+		return err
+	}
+	if len(treeTestJobs) > 0 {
+		sections = append(sections, &uiCollapsible{
+			Title: fmt.Sprintf("Bug presence on other trees (%d)", len(treeTestJobs)),
+			Show:  true,
+			Type:  sectionTestResults,
+			Value: treeTestJobs,
+		})
+	}
 	similar, err := loadSimilarBugsUI(c, r, bug, state)
 	if err != nil {
 		return err
@@ -758,7 +771,6 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 			Value: similar,
 		})
 	}
-
 	var bisectCause *uiJob
 	if bug.BisectCause > BisectPending {
 		bisectCause, err = getUIJob(c, bug, JobBisectCause)

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -544,3 +544,44 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 </table>
 {{end}}
 {{end}}
+
+{{/* List of test results, invoked with []*dashapi.JobInfo */}}
+{{define "test_results"}}
+{{if .}}
+<table class="list_table">
+	<thead>
+	<tr>
+		<th>Date</th>
+		<th>Name</th>
+		<th>Commit</th>
+		<th>Repro</th>
+		<th>Result</th>
+	</tr>
+	</thead>
+	<tbody>
+	{{range $item := .}}
+		<tr>
+			<td>{{formatDate $item.Finished}}</td>
+			<td>{{$item.KernelAlias}} {{if $item.OnMergeBase}}(merge base){{else}}(ToT){{end}}</td>
+			<td class="stat">{{link $item.KernelCommitLink (formatTagHash $item.KernelCommit)}}</td>
+			<td>
+				{{if $item.ReproCLink}}<a href="{{$item.ReproCLink}}">C</a>
+				{{else if $item.ReproSyzLink}}<a href="{{$item.ReproSyzLink}}">C</a>{{end}}
+			</td>
+			{{if ne $item.CrashTitle ""}}
+			<td class="status-crashed">
+				{{link $item.CrashReportLink "[report]"}} <i>{{$item.CrashTitle}}</i>
+			</td>
+			{{else if ne $item.ErrorLink ""}}
+			<td class="status-error">
+				Failed due to {{link $item.ErrorLink "an error"}}; will retry later
+			</td>
+			{{else}}
+			<td class="status-ok">Didn't crash</td>
+                        {{end}}
+		</tr>
+	{{end}}
+	</tbody>
+</table>
+{{end}}
+{{end}}

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -43,6 +43,9 @@ func TestTreeOriginDownstream(t *testing.T) {
 	c.expectEQ(ctx.entries[0].jobsDone, 1)
 	c.expectEQ(ctx.entries[1].jobsDone, 1)
 	c.expectEQ(ctx.entries[2].jobsDone, 1)
+	// Test that we can render the bug page.
+	_, err := c.GET(ctx.bugLink())
+	c.expectEQ(err, nil)
 }
 
 func TestTreeOriginLts(t *testing.T) {
@@ -728,6 +731,10 @@ func (ctx *treeTestCtx) ensureLabels(labels ...string) {
 	sort.Strings(bugLabels)
 	sort.Strings(labels)
 	ctx.ctx.expectEQ(labels, bugLabels)
+}
+
+func (ctx *treeTestCtx) bugLink() string {
+	return fmt.Sprintf("/bug?id=%v", ctx.bug.key(ctx.ctx.ctx).StringID())
 }
 
 type treeTestEntry struct {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -865,6 +865,7 @@ type JobInfo struct {
 	Commits          []*Commit // for inconclusive bisection
 	Reported         bool
 	TreeOrigin       bool
+	OnMergeBase      bool
 }
 
 func (dash *Dashboard) Query(method string, req, reply interface{}) error {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -113,6 +113,7 @@ type Commit struct {
 	Recipients Recipients
 	BugIDs     []string // ID's extracted from Reported-by tags
 	Date       time.Time
+	Link       string // set if the commit is a part of a reply
 }
 
 func (dash *Dashboard) UploadBuild(build *Build) error {
@@ -832,6 +833,39 @@ const (
 	ReportBisectCause                   // Cause bisection result for an already reported bug.
 	ReportBisectFix                     // Fix bisection result for an already reported bug.
 )
+
+type JobInfo struct {
+	Type             JobType
+	Flags            JobDoneFlags
+	Created          time.Time
+	BugLink          string
+	ExternalLink     string
+	User             string
+	Reporting        string
+	Namespace        string
+	Manager          string
+	BugTitle         string
+	BugID            string
+	KernelAlias      string
+	KernelCommit     string
+	KernelCommitLink string
+	PatchLink        string
+	Attempts         int
+	Started          time.Time
+	Finished         time.Time
+	Duration         time.Duration
+	CrashTitle       string
+	CrashLogLink     string
+	CrashReportLink  string
+	LogLink          string
+	ErrorLink        string
+	ReproCLink       string
+	ReproSyzLink     string
+	Commit           *Commit   // for conclusive bisection
+	Commits          []*Commit // for inconclusive bisection
+	Reported         bool
+	TreeOrigin       bool
+}
 
 func (dash *Dashboard) Query(method string, req, reply interface{}) error {
 	if dash.logger != nil {

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -207,6 +207,18 @@ table td, table th {
 	font-size: 75%;
 }
 
+.list_table .status-crashed {
+  background-color: #FF8674;
+}
+
+.list_table .status-ok {
+  background-color: lightgreen;
+}
+
+.list_table .status-error {
+  background-color: lightgray;
+}
+
 .bug-label {
 	background: white;
 	border: 1pt solid black;


### PR DESCRIPTION
Display them as a collapsible block on the bug info page. 