### PR TITLE
dashboard: prefer bug?extid= links over bug?id=

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1025,7 +1025,7 @@ func updateBugBisection(c context.Context, job *Job, jobKey *db.Key, req *dashap
 	if _, err := db.Put(c, bugKey, bug); err != nil {
 		return fmt.Errorf("failed to put bug: %v", err)
 	}
-	_, bugReporting, _, _, _ := currentReporting(c, bug)
+	_, bugReporting, _, _, _ := currentReporting(bug)
 	// The bug is either already closed or not yet reported in the current reporting,
 	// either way we don't need to report it. If it wasn't reported, it will be reported
 	// with the bisection results.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1551,7 +1551,6 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 			log.Errorf(c, "failed to generate credit email: %v", err)
 		}
 	}
-	id := bug.keyHash()
 	uiBug := &uiBug{
 		Namespace:      bug.Namespace,
 		Title:          bug.displayTitle(),
@@ -1565,7 +1564,7 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 		ReproLevel:     bug.ReproLevel,
 		ReportingIndex: reportingIdx,
 		Status:         status,
-		Link:           bugLink(id),
+		Link:           bugExtLink(bug),
 		ExternalLink:   link,
 		CreditEmail:    creditEmail,
 		NumManagers:    len(managers),
@@ -2126,6 +2125,17 @@ func fetchErrorLogs(c context.Context) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// bugExtLink should be preferred to bugLink since it provides a URL that's more consistent with
+// links from email addresses.
+func bugExtLink(bug *Bug) string {
+	_, bugReporting, _, _, _ := currentReporting(bug)
+	if bugReporting == nil || bugReporting.ID == "" {
+		return bugLink(bug.keyHash())
+	}
+	return "/bug?extid=" + bugReporting.ID
+}
+
+// bugLink should only be used when it's too inconvenient to actually load the bug from the DB.
 func bugLink(id string) string {
 	if id == "" {
 		return ""

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -95,7 +95,7 @@ func handleReportBug(c context.Context, typ string, state *ReportingState, bug *
 func needReport(c context.Context, typ string, state *ReportingState, bug *Bug) (
 	reporting *Reporting, bugReporting *BugReporting, reportingIdx int,
 	status, link string, err error) {
-	reporting, bugReporting, reportingIdx, status, err = currentReporting(c, bug)
+	reporting, bugReporting, reportingIdx, status, err = currentReporting(bug)
 	if err != nil || reporting == nil {
 		return
 	}
@@ -186,7 +186,7 @@ func reportingPollNotifications(c context.Context, typ string) []*dashapi.BugNot
 }
 
 func handleReportNotif(c context.Context, typ string, bug *Bug) (*dashapi.BugNotification, error) {
-	reporting, bugReporting, _, _, err := currentReporting(c, bug)
+	reporting, bugReporting, _, _, err := currentReporting(bug)
 	if err != nil || reporting == nil {
 		return nil, nil
 	}
@@ -339,7 +339,7 @@ func createNotification(c context.Context, typ dashapi.BugNotif, public bool, te
 	return notif, nil
 }
 
-func currentReporting(c context.Context, bug *Bug) (*Reporting, *BugReporting, int, string, error) {
+func currentReporting(bug *Bug) (*Reporting, *BugReporting, int, string, error) {
 	if bug.NumCrashes == 0 {
 		// This is possible during the short window when we already created a bug,
 		// but did not attach the first crash to it yet. We need to avoid reporting this bug yet
@@ -1331,7 +1331,7 @@ func loadFullBugInfo(c context.Context, bug *Bug, bugKey *db.Key,
 		return nil, err
 	}
 	for _, similarBug := range similar {
-		_, bugReporting, _, _, _ := currentReporting(c, similarBug)
+		_, bugReporting, _, _, _ := currentReporting(similarBug)
 		if bugReporting == nil {
 			continue
 		}

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -1090,7 +1090,7 @@ func matchBugFromList(c context.Context, sender, subject string) (*bugInfoResult
 			log.Infof(c, "access denied")
 			continue
 		}
-		reporting, bugReporting, _, _, err := currentReporting(c, bug)
+		reporting, bugReporting, _, _, err := currentReporting(bug)
 		if err != nil || reporting == nil {
 			log.Infof(c, "could not query reporting: %s", err)
 			continue

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -249,7 +249,7 @@ func querySubsystemReport(c context.Context, subsystem *Subsystem, reporting *Re
 	}
 	withRepro, noRepro := []*Bug{}, []*Bug{}
 	for _, bug := range rawOpenBugs {
-		currReporting, _, _, _, _ := currentReporting(c, bug)
+		currReporting, _, _, _, _ := currentReporting(bug)
 		if reporting.Name != currReporting.Name {
 			// The big is not at the expected reporting stage.
 			continue
@@ -366,7 +366,7 @@ func queryMatchingBugs(c context.Context, ns, name string, accessLevel AccessLev
 			fixed = append(fixed, bug)
 			continue
 		}
-		currReporting, _, _, _, err := currentReporting(c, bug)
+		currReporting, _, _, _, err := currentReporting(bug)
 		if err != nil {
 			continue
 		}

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -524,7 +524,7 @@ func TestMachineInfo(t *testing.T) {
 	// and the content is correct.
 	indexPage, err := c.AuthGET(AccessAdmin, "/test1")
 	c.expectOK(err)
-	bugLinkRegex := regexp.MustCompile(`<a href="(/bug\?id=[^"]+)">title1</a>`)
+	bugLinkRegex := regexp.MustCompile(`<a href="(/bug\?extid=[^"]+)">title1</a>`)
 	bugLinkSubmatch := bugLinkRegex.FindSubmatch(indexPage)
 	c.expectEQ(len(bugLinkSubmatch), 2)
 	bugURL := html.UnescapeString(string(bugLinkSubmatch[1]))


### PR DESCRIPTION
Context: https://lore.kernel.org/lkml/ZFi5FfjVpxLEk48A@mit.edu/

The former one is consistent with the dashboard URL from our bug reports.

This PR fixes URLs for open/closed/fixed/subsystem bug lists, but still leaves a few exceptions:
* Links to bugs about kernel/syzkaller build problems from the manager table.
* Links from /admin page.
* Bugs that were never reported.

In the first two cases we'd have to do extra loads the Bug entity from the database. For now it doesn't seem to be worth it, as nobody except syzbot maintainers usually follows those links. In the third case there's no extid.