### PR TITLE
syz-ci: use the right default RPC port value

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -424,7 +424,7 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 		managercfg.HTTP = fmt.Sprintf(":%v", cfg.ManagerPort)
 		cfg.ManagerPort++
 	}
-	if managercfg.RPC == "" {
+	if managercfg.RPC == ":0" {
 		managercfg.RPC = fmt.Sprintf(":%v", cfg.RPCPort)
 		cfg.RPCPort++
 	}


### PR DESCRIPTION
The "syz-ci: assign RPC ports to instances" commit implied that it was "", but in reality it's set to ":0" by LoadPartialData().

