### PR TITLE
dashboard: speed up apiReportingPollClosed

### DIFF
--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -227,3 +227,11 @@ indexes:
   - name: Type
   - name: Finished
     direction: desc
+
+- kind: Bug
+  properties:
+  - name: Reporting.Closed
+  - name: DupOf
+  - name: Namespace
+  - name: Reporting.ID
+  - name: Status

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -702,7 +702,9 @@ func reportingPollClosed(c context.Context, ids []string) ([]string, error) {
 		idMap[id] = true
 	}
 	var closed []string
-	err := foreachBug(c, nil, func(bug *Bug, _ *db.Key) error {
+	err := foreachBug(c, func(query *db.Query) *db.Query {
+		return query.Project("Reporting.ID", "Status", "Reporting.Closed", "Namespace", "DupOf")
+	}, func(bug *Bug, _ *db.Key) error {
 		for i := range bug.Reporting {
 			bugReporting := &bug.Reporting[i]
 			if !idMap[bugReporting.ID] {


### PR DESCRIPTION
Only query the necessary fields from the database. It reduces query time from 55s to 10s.
