### PR TITLE
dashboard: update HeadReproLevel separately

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -796,6 +796,8 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 		}
 		if bug.ReproLevel < reproLevel {
 			bug.ReproLevel = reproLevel
+		}
+		if bug.HeadReproLevel < reproLevel {
 			bug.HeadReproLevel = reproLevel
 		}
 		if len(req.Report) != 0 {


### PR DESCRIPTION
There are cases when we have revoked a reproducer, but quickly found a newer one. In that case we should update HeadReproLevel.
