### PR TITLE
syz-manager: retry listen on EADDRINUSE

### DIFF
--- a/pkg/rpctype/rpc.go
+++ b/pkg/rpctype/rpc.go
@@ -5,11 +5,13 @@ package rpctype
 
 import (
 	"compress/flate"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/rpc"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/google/syzkaller/pkg/log"
@@ -159,4 +161,12 @@ func (fc *flateConn) Close() error {
 		err0 = err
 	}
 	return err0
+}
+
+func IsAddrInUse(err error) bool {
+	var syscallErr *os.SyscallError
+	if !errors.As(err, &syscallErr) {
+		return false
+	}
+	return syscallErr.Err == syscall.EADDRINUSE
 }


### PR DESCRIPTION
There happen to be EADDRINUSE errors for both HTTP and RPC endpoints, which are very likely just due to ephemeral ports assigned by the OS. They won't stay busy for a long time.

Retry listen() 3 times with a 30 seconds delay and only then fail with an error.
