### PR TITLE
pkg/repro: assorted improvements

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -183,3 +183,7 @@ func (inst *ExecProgInstance) RunSyzProg(syzProg []byte, duration time.Duration,
 	defer os.Remove(progFile)
 	return inst.RunSyzProgFile(progFile, duration, opts)
 }
+
+func (inst *ExecProgInstance) Close() {
+	inst.VMInstance.Close()
+}

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -5,6 +5,7 @@ package repro
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -59,6 +60,8 @@ type context struct {
 	timeouts     targets.Timeouts
 }
 
+var ErrNoPrograms = errors.New("crash log does not contain any programs")
+
 func Run(crashLog []byte, cfg *mgrconfig.Config, features *host.Features, reporter *report.Reporter,
 	vmPool *vm.Pool, vmIndexes []int) (*Result, *Stats, error) {
 	if len(vmIndexes) == 0 {
@@ -66,7 +69,7 @@ func Run(crashLog []byte, cfg *mgrconfig.Config, features *host.Features, report
 	}
 	entries := cfg.Target.ParseLog(crashLog)
 	if len(entries) == 0 {
-		return nil, nil, fmt.Errorf("crash log does not contain any programs")
+		return nil, nil, ErrNoPrograms
 	}
 	crashStart := len(crashLog)
 	crashTitle, crashType := "", report.Unknown

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -73,7 +73,7 @@ var ErrNoPrograms = errors.New("crash log does not contain any programs")
 
 func Run(crashLog []byte, cfg *mgrconfig.Config, features *host.Features, reporter *report.Reporter,
 	vmPool *vm.Pool, vmIndexes []int) (*Result, *Stats, error) {
-	ctx, err := prepareCtx(crashLog, cfg, features, reporter, vmIndexes)
+	ctx, err := prepareCtx(crashLog, cfg, features, reporter, len(vmIndexes))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,8 +82,8 @@ func Run(crashLog []byte, cfg *mgrconfig.Config, features *host.Features, report
 }
 
 func prepareCtx(crashLog []byte, cfg *mgrconfig.Config, features *host.Features, reporter *report.Reporter,
-	vmIndexes []int) (*context, error) {
-	if len(vmIndexes) == 0 {
+	VMs int) (*context, error) {
+	if VMs == 0 {
 		return nil, fmt.Errorf("no VMs provided")
 	}
 	entries := cfg.Target.ParseLog(crashLog)
@@ -123,14 +123,14 @@ func prepareCtx(crashLog []byte, cfg *mgrconfig.Config, features *host.Features,
 		crashType:    crashType,
 		crashStart:   crashStart,
 		entries:      entries,
-		instances:    make(chan *reproInstance, len(vmIndexes)),
-		bootRequests: make(chan int, len(vmIndexes)),
+		instances:    make(chan *reproInstance, VMs),
+		bootRequests: make(chan int, VMs),
 		testTimeouts: testTimeouts,
 		startOpts:    createStartOptions(cfg, features, crashType),
 		stats:        new(Stats),
 		timeouts:     cfg.Timeouts,
 	}
-	ctx.reproLogf(0, "%v programs, %v VMs, timeouts %v", len(entries), len(vmIndexes), testTimeouts)
+	ctx.reproLogf(0, "%v programs, %v VMs, timeouts %v", len(entries), VMs, testTimeouts)
 	return ctx, nil
 }
 

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -119,7 +119,6 @@ func generateTestInstances(ctx *context, count int, execInterface execInterface)
 		}
 	}()
 	wg.Wait()
-	close(ctx.instances)
 }
 
 type testExecInterface struct {

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -5,9 +5,16 @@ package repro
 
 import (
 	"math/rand"
+	"regexp"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
@@ -97,4 +104,108 @@ func TestSimplifies(t *testing.T) {
 		}
 	}
 	check(opts, 0)
+}
+
+func generateTestInstances(ctx *context, count int, execInterface execInterface) {
+	for i := 0; i < count; i++ {
+		ctx.bootRequests <- i
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for vmIndex := range ctx.bootRequests {
+			ctx.instances <- &reproInstance{execProg: execInterface, index: vmIndex}
+		}
+	}()
+	wg.Wait()
+	close(ctx.instances)
+}
+
+type testExecInterface struct {
+	t *testing.T
+	// For now only do the simplest imitation.
+	run func([]byte) (*instance.RunResult, error)
+}
+
+func (tei *testExecInterface) Close() {}
+
+func (tei *testExecInterface) RunCProg(p *prog.Prog, duration time.Duration,
+	opts csource.Options) (*instance.RunResult, error) {
+	return tei.RunSyzProg(p.Serialize(), duration, opts)
+}
+
+func (tei *testExecInterface) RunSyzProg(syzProg []byte, duration time.Duration,
+	opts csource.Options) (*instance.RunResult, error) {
+	return tei.run(syzProg)
+}
+
+func prepareTestCtx(t *testing.T, log string) *context {
+	mgrConfig := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetVMArch: targets.AMD64,
+		},
+		Sandbox: "namespace",
+	}
+	var err error
+	mgrConfig.Target, err = prog.GetTarget(targets.Linux, targets.AMD64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reporter, err := report.NewReporter(mgrConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, err := prepareCtx([]byte(log), mgrConfig, nil, reporter, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
+const testReproLog = `
+2015/12/21 12:18:05 executing program 1:
+getpid()
+pause()
+2015/12/21 12:18:10 executing program 2:
+getpid()
+getuid()
+2015/12/21 12:18:15 executing program 1:
+alarm(0x5)
+pause()
+2015/12/21 12:18:20 executing program 3:
+alarm(0xa)
+getpid()
+`
+
+// Just a pkg/repro smoke test: check that we can extract a two-call reproducer.
+// No focus on error handling and minor corner cases.
+func TestPlainRepro(t *testing.T) {
+	ctx := prepareTestCtx(t, testReproLog)
+	// Only crash if `pause()` is followed by `alarm(0xa)`.
+	var match = regexp.MustCompile(`(?s)pause\(\).*alarm\(0xa\)`)
+	go generateTestInstances(ctx, 3, &testExecInterface{
+		t: t,
+		run: func(log []byte) (*instance.RunResult, error) {
+			crash := match.Match(log)
+			if crash {
+				ret := &instance.RunResult{}
+				ret.Report = &report.Report{
+					Title: `some crash`,
+				}
+				return ret, nil
+			}
+			return &instance.RunResult{}, nil
+		},
+	})
+	result, _, err := ctx.run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(`pause()
+alarm(0xa)
+`, string(result.Prog.Serialize())); diff != "" {
+		t.Fatal(diff)
+	}
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -328,7 +328,7 @@ type ReproResult struct {
 func (mgr *Manager) vmLoop() {
 	log.Logf(0, "booting test machines...")
 	log.Logf(0, "wait for the connection from test machine...")
-	instancesPerRepro := 4
+	instancesPerRepro := 3
 	vmCount := mgr.vmPool.Count()
 	maxReproVMs := vmCount - mgr.cfg.FuzzingVMs
 	if instancesPerRepro > maxReproVMs && maxReproVMs > 0 {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -437,7 +437,7 @@ func (mgr *Manager) vmLoop() {
 			log.Logf(1, "loop: repro on %+v finished '%v', repro=%v crepro=%v desc='%v'",
 				res.instances, res.report0.Title, res.repro != nil, crepro, title)
 			if res.err != nil {
-				log.Errorf("repro failed: %v", res.err)
+				reportReproError(res.err)
 			}
 			delete(reproducing, res.report0.Title)
 			if res.repro == nil {
@@ -465,6 +465,17 @@ func (mgr *Manager) vmLoop() {
 			reply <- repros
 			goto wait
 		}
+	}
+}
+
+func reportReproError(err error) {
+	switch err {
+	case repro.ErrNoPrograms:
+		// This is not extraordinary as programs are collected via SSH.
+		log.Logf(0, "repro failed: %v", err)
+	default:
+		// Report everything else as errors.
+		log.Errorf("repro failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/google/syzkaller/issues/3903

1. Refactor `pkg/repro` to facilitate testing and add a smoke test.
2. Repeat executions one more time in case of errors (we're getting a lot of `failed to copy prog to VM` that seem transient).
3. Wait for all `pkg/repro` routines to finish before returning.
4. Decrease the default number of VMs dedicated for bug reproduction from 4 to 3.

See individual commit messages.