### PR TITLE
dashboard: use short hashes in mail_label_notif.txt

### DIFF
--- a/dashboard/app/mail_label_notif.txt
+++ b/dashboard/app/mail_label_notif.txt
@@ -5,7 +5,7 @@
 syzbot has run the reproducer on other relevant kernel trees and got
 the following results:
 {{range .TreeJobs}}
-{{.KernelAlias}} (commit {{.KernelCommit}}) on {{formatDate .Finished}}:
+{{.KernelAlias}} (commit {{formatTagHash .KernelCommit}}) on {{formatDate .Finished}}:
 {{if eq .CrashTitle "" -}}
 Didn't crash.
 {{- else -}}

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,14 +58,14 @@ func TestTreeOriginDownstream(t *testing.T) {
 syzbot has run the reproducer on other relevant kernel trees and got
 the following results:
 
-downstream (commit 947548860) on 2000/01/11:
+downstream (commit ffffffffffff) on 2000/01/11:
 crash title
 Report: %URL%
 
-lts (commit 947548860) on 2000/01/11:
+lts (commit ffffffffffff) on 2000/01/11:
 Didn't crash.
 
-upstream (commit 947548860) on 2000/01/11:
+upstream (commit ffffffffffff) on 2000/01/11:
 Didn't crash.
 
 More details can be found at:
@@ -757,7 +758,7 @@ func (ctx *treeTestCtx) doJob(resp *dashapi.JobPollResp, day int) {
 	build := testBuild(1)
 	build.KernelRepo = resp.KernelRepo
 	build.KernelBranch = resp.KernelBranch
-	build.KernelCommit = fmt.Sprintf("%d", ctx.now().Unix())
+	build.KernelCommit = strings.Repeat("f", 40)[:40]
 	// Figure out what should the result be.
 	result := treeTestOK
 	for _, item := range found.results {


### PR DESCRIPTION
Full commit ids are not necessary in the notification email.

