### PR TITLE
dashboard: amend configs during tree origin testing

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -254,6 +254,8 @@ type KernelRepo struct {
 	CommitInflow []KernelRepoLink
 	// Enable the missing backport tracking feature for this tree.
 	DetectMissingBackports bool
+	// Append this string to the config file before running reproducers on this tree.
+	AppendConfig string
 }
 
 type KernelRepoLink struct {

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -431,6 +431,7 @@ func (ctx *bugTreeContext) doRunRepro(repo KernelRepo, result expectedResult, ru
 		crash:         ctx.crash,
 		crashKey:      ctx.crashKey,
 		configRef:     ctx.build.KernelConfig,
+		configAppend:  repo.AppendConfig,
 		inTransaction: true,
 		treeOrigin:    true,
 		testReqArgs: testReqArgs{


### PR DESCRIPTION
There are cases when e.g. an LTS kernel does not build if provided with some downstream kernel config.

Introduce a special AppendConfig option to KernelRepo that can help in this case.

