### PR TITLE
RFC: pkg/bisect: support cross-tree bisections and improve bisection result quality

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -646,14 +646,16 @@ func (env *env) test() (*testResult, error) {
 			env.log("reproducer seems to be flaky")
 			env.flaky = true
 		}
-	} else if good != 0 {
+	} else if 2*good > len(results) {
+		// Require at least 50% of successful runs to say it's a good commit.
+		// Otherwise we just have too little data to come to any conclusion.
 		res.verdict = vcs.BisectGood
 	} else {
 		res.rep = &report.Report{
 			Title: fmt.Sprintf("failed testing reproducer on %v", current.Hash),
 		}
 	}
-	// If all runs failed with a boot/test error, we just end up with BisectSkip.
+	// If most runs failed with a boot/test error, we end up with BisectSkip.
 	// TODO: when we start supporting boot/test error bisection, we need to make
 	// processResults treat that verdit as "good".
 	return res, nil

--- a/pkg/kconfig/config.go
+++ b/pkg/kconfig/config.go
@@ -123,7 +123,7 @@ func ParseConfigData(data []byte, file string) (*ConfigFile, error) {
 	return cf, nil
 }
 
-func (cf *ConfigFile) clone() *ConfigFile {
+func (cf *ConfigFile) Clone() *ConfigFile {
 	cf1 := &ConfigFile{
 		Map:      make(map[string]*Config),
 		comments: cf.comments,

--- a/pkg/kconfig/minimize.go
+++ b/pkg/kconfig/minimize.go
@@ -27,7 +27,7 @@ func (kconf *KConfig) Minimize(base, full *ConfigFile, pred func(*ConfigFile) (b
 		return base, nil
 	}
 	// Since base does not crash, full config is our best bet for now.
-	current := full.clone()
+	current := full.Clone()
 	var suspects []string
 	// Take half of the diff between base and full, apply to base and test.
 	// If this candidate config crashes, we commit it as new full and repeat the process.
@@ -47,7 +47,7 @@ top:
 		for _, part := range [][]string{diff[:half], diff[half:]} {
 			dt.Log("trying half: %v", part)
 			closure := kconf.addDependencies(base, full, part)
-			candidate := base.clone()
+			candidate := base.Clone()
 			// Always move all non-tristate configs from full to base as we don't minimize them.
 			for _, cfg := range other {
 				candidate.Set(cfg.Name, cfg.Value)

--- a/pkg/kconfig/reduce.go
+++ b/pkg/kconfig/reduce.go
@@ -20,7 +20,7 @@ func (kconf *KConfig) Reduce(base, full *ConfigFile, pred func(*ConfigFile) (boo
 	dt.Log("kconfig reduce: base=%v full=%v diff=%v", len(base.Configs), len(full.Configs), len(diff))
 
 	take := 0.75 // at first, aim at taking 3/4 of diffs
-	current := full.clone()
+	current := full.Clone()
 	// TODO: prioritize the deletion of leaf configs (i.e. those that don't affect anything else)?
 	// Presumably they should have the least effect, yet there's a lot of them.
 	for step := 1; step <= steps; step++ {
@@ -47,7 +47,7 @@ func (kconf *KConfig) Reduce(base, full *ConfigFile, pred func(*ConfigFile) (boo
 				break
 			}
 		}
-		candidate := base.clone()
+		candidate := base.Clone()
 		for _, cfg := range other {
 			candidate.Set(cfg.Name, cfg.Value)
 		}

--- a/pkg/kconfig/reduce.go
+++ b/pkg/kconfig/reduce.go
@@ -1,0 +1,95 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package kconfig
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/google/syzkaller/pkg/debugtracer"
+)
+
+// Reduce finds an equivalent smaller config with respect to the `pred` predicate.
+// Unlike Minize, Reduce does not aim at finding the least config, but rather tries to do
+// its best in no more than `steps`.
+func (kconf *KConfig) Reduce(base, full *ConfigFile, pred func(*ConfigFile) (bool, error),
+	steps int, r *rand.Rand, dt debugtracer.DebugTracer) (*ConfigFile, error) {
+	// Let's only consider leaf configs -- those that are not automatically enabled by anyone else.
+	diff, other := kconf.missingLeafConfigs(base, full)
+	dt.Log("kconfig reduce: base=%v full=%v diff=%v", len(base.Configs), len(full.Configs), len(diff))
+
+	take := 0.75 // at first, aim at taking 3/4 of diffs
+	current := full.clone()
+	// TODO: prioritize the deletion of leaf configs (i.e. those that don't affect anything else)?
+	// Presumably they should have the least effect, yet there's a lot of them.
+	for step := 1; step <= steps; step++ {
+		totalClosure := kconf.addDependencies(base, full, diff)
+		dt.Log("step %d: diff=%v closure=%d take=%.2f", step, len(diff), len(totalClosure), take)
+		r.Shuffle(len(diff), func(i, j int) {
+			diff[i], diff[j] = diff[j], diff[i]
+		})
+		// We can't just take e.g. diff[:len(diff)*take], because after
+		// addDependencies there'll be many more resulting diffs.
+		// So pick one by one until we have reached the target.
+		var yes, tookDiff []string
+		// TODO: consider using binary search here.
+		for i := 1; i <= len(diff); i++ {
+			closure := kconf.addDependencies(base, full, diff[:i])
+			if len(closure) == len(totalClosure) {
+				// We've enabled everything. That's not a split.
+				break
+			}
+			tookDiff = diff[:i]
+			yes = closure
+			if float64(len(closure)) >= take*float64(len(totalClosure)) {
+				// Already enough.
+				break
+			}
+		}
+		candidate := base.clone()
+		for _, cfg := range other {
+			candidate.Set(cfg.Name, cfg.Value)
+		}
+		for _, cfg := range yes {
+			candidate.Set(cfg, Yes)
+		}
+		dt.SaveFile(fmt.Sprintf("step_%d.config", step), candidate.Serialize())
+		res, err := pred(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if res {
+			diff = tookDiff
+			current = candidate
+		} else if len(tookDiff) == 0 {
+			dt.Log("empty diff didn't crash, stopping")
+			break
+		} else {
+			// There's a chance that there are simply too many necessary kernel
+			// configs. Slowly increase the share we take each step.
+			take = take + (1.0-take)/4
+		}
+	}
+	return current, nil
+}
+
+// missingLeafConfigs returns the set of configs no other config depends on.
+func (kconf *KConfig) missingLeafConfigs(base, full *ConfigFile) ([]string, []*Config) {
+	diff, other := kconf.missingConfigs(base, full)
+	needed := map[string]bool{}
+	for _, config := range diff {
+		for _, needs := range kconf.addDependencies(base, full, []string{config}) {
+			if needs != config {
+				needed[needs] = true
+			}
+		}
+	}
+	var leaves []string
+	for _, key := range diff {
+		if !needed[key] {
+			leaves = append(leaves, key)
+		}
+	}
+	return leaves, other
+}

--- a/pkg/kconfig/reduce_test.go
+++ b/pkg/kconfig/reduce_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package kconfig
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/testutil"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func TestReduce(t *testing.T) {
+	const (
+		kconfig = `
+mainmenu "test"
+config A
+config B
+config C
+	depends on B
+
+config NET
+
+menuconfig HAMRADIO
+	depends on NET && !S390
+	bool "Amateur Radio support"
+
+config AX25
+	tristate "Amateur Radio AX.25 Level 2 protocol"
+	depends on HAMRADIO
+
+config ROSE
+	tristate "Amateur Radio X.25 PLP (Rose)"
+	depends on AX25
+`
+		baseConfig = `
+CONFIG_A=y
+`
+		fullConfig = `
+CONFIG_A=y
+CONFIG_B=y
+CONFIG_C=y
+CONFIG_S="foo"
+CONFIG_NET=y
+CONFIG_HAMRADIO=y
+CONFIG_AX25=y
+CONFIG_ROSE=y
+`
+	)
+	type Test struct {
+		pred   func(*ConfigFile) (bool, error)
+		result string
+	}
+	tests := []Test{
+		{
+			pred: func(cf *ConfigFile) (bool, error) {
+				return true, nil
+			},
+			result: `
+CONFIG_A=y
+CONFIG_S="foo"
+`,
+		},
+		{
+			pred: func(cf *ConfigFile) (bool, error) {
+				return false, nil
+			},
+			result: fullConfig,
+		},
+		{
+			pred: func(cf *ConfigFile) (bool, error) {
+				return cf.Value("C") != No, nil
+			},
+			result: `
+CONFIG_A=y
+CONFIG_S="foo"
+CONFIG_B=y
+CONFIG_C=y
+`,
+		},
+	}
+	kconf, err := ParseData(targets.Get("linux", "amd64"), []byte(kconfig), "kconf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := ParseConfigData([]byte(baseConfig), "base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	full, err := ParseConfigData([]byte(fullConfig), "full")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := rand.New(testutil.RandSource(t))
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			res, err := kconf.Reduce(base, full, test.pred, 10, r, &debugtracer.TestTracer{T: t})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := string(res.Serialize())
+			if result != test.result {
+				t.Fatalf("got:\n%v\n\nwant:\n%s", result, test.result)
+			}
+		})
+	}
+}

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -107,3 +107,7 @@ func (ctx *fuchsia) Object(name, commit string) ([]byte, error) {
 func (ctx *fuchsia) MergeBases(firstCommit, secondCommit string) ([]*Commit, error) {
 	return ctx.repo.MergeBases(firstCommit, secondCommit)
 }
+
+func (ctx *fuchsia) FetchRemote(repo string) error {
+	return ctx.repo.FetchRemote(repo)
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -127,13 +127,13 @@ func (git *git) CheckoutCommit(repo, commit string) (*Commit, error) {
 	if err := git.repair(); err != nil {
 		return nil, err
 	}
-	if err := git.fetchRemote(repo); err != nil {
+	if err := git.FetchRemote(repo); err != nil {
 		return nil, err
 	}
 	return git.SwitchCommit(commit)
 }
 
-func (git *git) fetchRemote(repo string) error {
+func (git *git) FetchRemote(repo string) error {
 	repoHash := hash.String([]byte(repo))
 	// Ignore error as we can double add the same remote and that will fail.
 	git.git("remote", "add", repoHash, repo)

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -6,6 +6,7 @@ package vcs
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"net/mail"
 	"path/filepath"
 	"regexp"
@@ -406,7 +407,8 @@ func (ctx *linux) Minimize(target *targets.Target, original, baseline []byte,
 		res, err := pred(serialize(candidate))
 		return res == BisectBad, err
 	}
-	minConfig, err := kconf.Minimize(baselineConfig, originalConfig, kconfPred, dt)
+	r := rand.New(rand.New(rand.NewSource(time.Now().UnixNano())))
+	minConfig, err := kconf.Reduce(baselineConfig, originalConfig, kconfPred, 5, r, dt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -301,7 +301,7 @@ func (ctx *linux) PrepareBisect() error {
 	if ctx.vmType != "gvisor" {
 		// Some linux repos we fuzz don't import the upstream release git tags. We need tags
 		// to decide which compiler versions to use. Let's fetch upstream for its tags.
-		err := ctx.git.fetchRemote("https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git")
+		err := ctx.git.FetchRemote("https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git")
 		if err != nil {
 			return fmt.Errorf("fetching upstream linux failed: %w", err)
 		}

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -257,10 +257,12 @@ func linuxAlterConfigs(cf *kconfig.ConfigFile, tags map[string]bool, dt debugtra
 		// UBSAN is broken in multiple ways before v5.3, see:
 		// https://github.com/google/syzkaller/issues/1523#issuecomment-696514105
 		"UBSAN": "v5.3",
-		// First, we disable coverage in pkg/bisect because it fails machine testing starting from 4.7.
+		// First, we want to disable coverage in pkg/bisect because it fails machine testing starting from 4.7.
 		// Second, at 6689da155bdcd17abfe4d3a8b1e245d9ed4b5f2c CONFIG_KCOV selects CONFIG_GCC_PLUGIN_SANCOV
 		// (why?), which is build broken for hundreds of revisions.
-		"KCOV": disableAlways,
+		// Still, let's keep it enabled for newer Linux versions -- it keeps the kernel as close to the one
+		// where we triggered the crash and thus makes crashes that depends on timings less flaky.
+		"KCOV": "v5.0",
 		// This helps to produce stable binaries in presence of kernel tag changes.
 		"LOCALVERSION_AUTO": disableAlways,
 		// BTF fails lots of builds with:

--- a/pkg/vcs/linux_sanitizers.go
+++ b/pkg/vcs/linux_sanitizers.go
@@ -1,0 +1,101 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"regexp"
+
+	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/kconfig"
+)
+
+type linuxSanitizer struct {
+	name      string
+	titleRe   *regexp.Regexp
+	disable   func(cf *kconfig.ConfigFile)
+	dependsOn []*linuxSanitizer
+}
+
+var linuxSanitizers = []*linuxSanitizer{
+	warnings,
+	{
+		name:    "ubsan",
+		titleRe: regexp.MustCompile(`UBSAN`),
+		disable: disableUBSAN,
+	},
+	{
+		name:    "kasan",
+		titleRe: regexp.MustCompile(`KASAN`),
+		disable: disableKASAN,
+	},
+	{
+		name:    "lockdep",
+		titleRe: regexp.MustCompile(`possible deadlock in`),
+		disable: disableLockdep,
+	},
+	{
+		name:    "rcu stalls",
+		titleRe: regexp.MustCompile(`INFO: rcu detected stall in`),
+		disable: disableRcuStalls,
+		// TODO: verify whether it actually depends.
+		dependsOn: []*linuxSanitizer{warnings},
+	},
+}
+
+var warnings = &linuxSanitizer{
+	name:    "warnings/bugs",
+	titleRe: regexp.MustCompile(`WARNING in|kernel BUG in|BUG: `),
+	disable: disableWarnings,
+}
+
+// It's assumed that the config _already_ has all the needed sanitizers enabled
+// and, additionally, some that are not really needed.
+func adjustLinuxSanitizers(cf *kconfig.ConfigFile, crashTitle string, dt debugtracer.DebugTracer) {
+	matched := map[*linuxSanitizer]bool{}
+	for _, item := range linuxSanitizers {
+		if !item.titleRe.MatchString(crashTitle) {
+			continue
+		}
+		// Assume there are no cycles.
+		queue := []*linuxSanitizer{item}
+		for len(queue) > 0 {
+			item := queue[len(queue)-1]
+			matched[item] = true
+			queue = append(queue[:len(queue)-1], item.dependsOn...)
+		}
+	}
+	if len(matched) == 0 {
+		// We didn't recognize any sanitizer, so let's not risk disabling all of them.
+		return
+	}
+	var disabledNames []string
+	for _, item := range linuxSanitizers {
+		if matched[item] {
+			continue
+		}
+		disabledNames = append(disabledNames, item.name)
+		item.disable(cf)
+	}
+	dt.Log("disabled %v in config as it was not needed", disabledNames)
+}
+
+func disableWarnings(cf *kconfig.ConfigFile) {
+	cf.Unset("BUG")
+}
+
+func disableUBSAN(cf *kconfig.ConfigFile) {
+	cf.Unset("UBSAN")
+}
+
+func disableKASAN(cf *kconfig.ConfigFile) {
+	cf.Unset("KASAN")
+}
+
+func disableLockdep(cf *kconfig.ConfigFile) {
+	cf.Unset("LOCKDEP")
+}
+
+func disableRcuStalls(cf *kconfig.ConfigFile) {
+	cf.Unset("RCU_STALL_COMMON")
+}

--- a/pkg/vcs/linux_sanitizers_test.go
+++ b/pkg/vcs/linux_sanitizers_test.go
@@ -1,0 +1,98 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/kconfig"
+)
+
+func TestLinuxSanitizers(t *testing.T) {
+	tests := []struct {
+		name  string
+		crash string
+		test  func(cf *kconfig.ConfigFile) bool
+	}{
+		{
+			name:  "warning",
+			crash: "WARNING in abcd",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "BUG")
+			},
+		},
+		{
+			name:  "kasan bug",
+			crash: "KASAN: slab-use-after-free Read in abcd",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "KASAN")
+			},
+		},
+		{
+			name:  "lockdep",
+			crash: "possible deadlock in abcd",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "LOCKDEP")
+			},
+		},
+		{
+			name:  "rcu stall",
+			crash: "INFO: rcu detected stall in abcd",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "BUG", "RCU_STALL_COMMON")
+			},
+		},
+		{
+			name:  "unknown title",
+			crash: "general protection fault in abcd",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "BUG", "KASAN", "LOCKDEP", "RCU_STALL_COMMON", "UBSAN")
+			},
+		},
+		{
+			name:  "no title",
+			crash: "",
+			test: func(cf *kconfig.ConfigFile) bool {
+				return onlySet(cf, "BUG", "KASAN", "LOCKDEP", "RCU_STALL_COMMON", "UBSAN")
+			},
+		},
+	}
+
+	const base = `
+CONFIG_BUG=y
+CONFIG_KASAN=y
+CONFIG_LOCKDEP=y
+CONFIG_RCU_STALL_COMMON=y
+CONFIG_UBSAN=y
+`
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := kconfig.ParseConfigData([]byte(base), "base")
+			if err != nil {
+				t.Fatal(err)
+			}
+			adjustLinuxSanitizers(conf, test.crash, &debugtracer.NullTracer{})
+			if !test.test(conf) {
+				t.Fatal("invalid results")
+			}
+		})
+	}
+}
+
+func onlySet(cf *kconfig.ConfigFile, names ...string) bool {
+	for _, name := range names {
+		if cf.Value(name) != kconfig.Yes {
+			return false
+		}
+	}
+	total := 0
+	for _, param := range cf.Configs {
+		if cf.Value(param.Name) == kconfig.Yes {
+			total++
+		}
+	}
+	return total == len(names)
+}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -68,8 +68,11 @@ type Repo interface {
 	// Object returns the contents of a git repository object at the particular moment in history.
 	Object(name, commit string) ([]byte, error)
 
-	// MergeBases returns good common ancestors of the two commits.
+	// MergeBases returns best common ancestors of the two commits.
 	MergeBases(firstCommit, secondCommit string) ([]*Commit, error)
+
+	// FetchRemote fetches all commits/branches from a remote repository.
+	FetchRemote(repo string) error
 }
 
 // Bisecter may be optionally implemented by Repo.

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -95,12 +95,23 @@ type Bisecter interface {
 
 	IsRelease(commit string) (bool, error)
 
-	EnvForCommit(defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
+	EnvForCommit(defaultCompiler, compilerType, binDir, commit string,
+		kernelConfig []byte, dt debugtracer.DebugTracer) (*BisectEnv, error)
+}
+
+type DropSanitizers struct {
+	CrashTitle string
+}
+
+type AgainstBaseline struct {
+	Baseline []byte
 }
 
 type ConfigMinimizer interface {
-	Minimize(target *targets.Target, original, baseline []byte, dt debugtracer.DebugTracer,
-		pred func(test []byte) (BisectResult, error)) ([]byte, error)
+	Minimize(target *targets.Target, original []byte, dt debugtracer.DebugTracer,
+		pred func(test []byte) (BisectResult, error),
+		how ...interface{},
+	) ([]byte, error)
 }
 
 type Commit struct {

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -50,11 +50,12 @@ type Config struct {
 	// BinDir must point to a dir that contains compilers required to build
 	// older versions of the kernel. For linux, it needs to include several
 	// compiler versions.
-	BinDir        string `json:"bin_dir"`
-	Ccache        string `json:"ccache"`
-	KernelRepo    string `json:"kernel_repo"`
-	KernelBranch  string `json:"kernel_branch"`
-	SyzkallerRepo string `json:"syzkaller_repo"`
+	BinDir           string `json:"bin_dir"`
+	Ccache           string `json:"ccache"`
+	KernelRepo       string `json:"kernel_repo"`
+	KernelBranch     string `json:"kernel_branch"`
+	KernelCommitRepo string `json:"kernel_commit_repo"`
+	SyzkallerRepo    string `json:"syzkaller_repo"`
 	// Directory with user-space system for building kernel images
 	// (for linux that's the input to tools/create-gce-image.sh).
 	Userspace string `json:"userspace"`
@@ -66,6 +67,8 @@ type Config struct {
 
 	KernelConfig         string `json:"kernel_config"`
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
+
+	FromMergeBase bool `json:"from_merge_base"`
 
 	// Manager config that was used to obtain the crash.
 	Manager json.RawMessage `json:"manager"`
@@ -103,13 +106,15 @@ func main() {
 		BinDir:          mycfg.BinDir,
 		Ccache:          mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
-			Repo:        mycfg.KernelRepo,
-			Branch:      mycfg.KernelBranch,
-			Commit:      *flagKernelCommit,
-			CommitTitle: *flagKernelCommitTitle,
-			Userspace:   mycfg.Userspace,
-			Sysctl:      mycfg.Sysctl,
-			Cmdline:     mycfg.Cmdline,
+			Repo:          mycfg.KernelRepo,
+			Branch:        mycfg.KernelBranch,
+			Commit:        *flagKernelCommit,
+			CommitTitle:   *flagKernelCommitTitle,
+			CommitRepo:    mycfg.KernelCommitRepo,
+			FromMergeBase: mycfg.FromMergeBase,
+			Userspace:     mycfg.Userspace,
+			Sysctl:        mycfg.Sysctl,
+			Cmdline:       mycfg.Cmdline,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   mycfg.SyzkallerRepo,

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -68,6 +68,7 @@ type Config struct {
 
 	KernelConfig         string `json:"kernel_config"`
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
+	DropSanitizers       bool   `json:"drop_sanitizers"`
 
 	FromMergeBase bool `json:"from_merge_base"`
 
@@ -108,15 +109,16 @@ func main() {
 		BinDir:          mycfg.BinDir,
 		Ccache:          mycfg.Ccache,
 		Kernel: bisect.KernelConfig{
-			Repo:          mycfg.KernelRepo,
-			Branch:        mycfg.KernelBranch,
-			Commit:        *flagKernelCommit,
-			CommitTitle:   *flagKernelCommitTitle,
-			CommitRepo:    mycfg.KernelCommitRepo,
-			FromMergeBase: mycfg.FromMergeBase,
-			Userspace:     mycfg.Userspace,
-			Sysctl:        mycfg.Sysctl,
-			Cmdline:       mycfg.Cmdline,
+			Repo:           mycfg.KernelRepo,
+			Branch:         mycfg.KernelBranch,
+			Commit:         *flagKernelCommit,
+			CommitTitle:    *flagKernelCommitTitle,
+			CommitRepo:     mycfg.KernelCommitRepo,
+			FromMergeBase:  mycfg.FromMergeBase,
+			Userspace:      mycfg.Userspace,
+			Sysctl:         mycfg.Sysctl,
+			Cmdline:        mycfg.Cmdline,
+			DropSanitizers: mycfg.DropSanitizers,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   mycfg.SyzkallerRepo,

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -50,6 +50,7 @@ type Config struct {
 	// BinDir must point to a dir that contains compilers required to build
 	// older versions of the kernel. For linux, it needs to include several
 	// compiler versions.
+	Linker           string `json:"linker"`
 	BinDir           string `json:"bin_dir"`
 	Ccache           string `json:"ccache"`
 	KernelRepo       string `json:"kernel_repo"`
@@ -103,6 +104,7 @@ func main() {
 		Fix:             *flagFix,
 		DefaultCompiler: mycfg.Compiler,
 		CompilerType:    mycfg.CompilerType,
+		Linker:          mycfg.Linker,
 		BinDir:          mycfg.BinDir,
 		Ccache:          mycfg.Ccache,
 		Kernel: bisect.KernelConfig{

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 
 	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
@@ -125,7 +126,8 @@ func main() {
 
 func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.Env, com *vcs.Commit) {
 	compiler, compilerType, linker, ccache := "gcc", "gcc", "ld", ""
-	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin, com.Hash, kernelConfig)
+	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin,
+		com.Hash, kernelConfig, &debugtracer.NullTracer{})
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
(More comments are in commit descriptions)

The main purpose of the PR is to adjust `pkg/bisect` to enable bisections for the case when the known-to-us failing commit is not reachable from `HEAD`. This will e.g. be useful for finding fixes in `torvalds/master` for lts bugs. In that case, the code will do all preparations on the lts commit and start the bisection from the merge base between the commit and `torvalds/master`.

I also locally ran bisections for a few randomly chosen bugs, analyzed reasons of bisection failures and implemented a number of improvements that made those bisections work well. Hopefully it should also improve the process in general.

Some of the changes may sound controversial, but why not? :) Bisection quality is currently quite bad on big revision ranges anyway, so we can afford taking risks here.

What is included in the PR:
* Revive config minimization. Moreover, I think it's better, instead of doing a full and long minimization, to just try to swipe out some random subset of the unneeded configs in a limited number of steps.
  * In the end, the purpose here is not to find the single faulty config (there may be several -- which makes the normal bisection crazy), but to make builds and boots less flaky by cutting off irrelevant parts of the kernel.
* Disable unnecessary sanitizers. It should lead to fewer irrelevant crashes that derail the bisection process.
* Make the conditions for `bisect good` and `bisect bad` stricter. E.g. if almost all runs failed with a boot error and only a few ran fine, it's better to skip the commit than to declare it good.

If it turns out to be needed, I'll split out the most controversial changes to separate PRs.