### PR TITLE
pkg/cover, syz-manager: support coverage filtering with modules

### DIFF
--- a/pkg/cover/canonicalizer.go
+++ b/pkg/cover/canonicalizer.go
@@ -117,6 +117,18 @@ func (ci *CanonicalizerInstance) Decanonicalize(cov []uint32, sign signal.Serial
 	ci.decanonicalize.convertPCs(cov, sign)
 }
 
+func (ci *CanonicalizerInstance) DecanonicalizeFilter(bitmap map[uint32]uint32) map[uint32]uint32 {
+	// Skip conversion if modules or filter are not used.
+	if ci.canonical.moduleKeys == nil || len(bitmap) == 0 {
+		return bitmap
+	}
+	instBitmap := make(map[uint32]uint32)
+	for pc, val := range bitmap {
+		instBitmap[ci.decanonicalize.convertPC(pc)] = val
+	}
+	return instBitmap
+}
+
 // Store sorted list of addresses. Used to binary search when converting PCs.
 func setModuleKeys(moduleKeys []uint32, modules []host.KernelModule) {
 	for idx, module := range modules {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -91,7 +91,7 @@ type Manager struct {
 
 	modules            []host.KernelModule
 	coverFilter        map[uint32]uint32
-	coverFilterBitmap  []byte
+	execCoverFilter    map[uint32]uint32
 	modulesInitialized bool
 
 	assetStorage *asset.Storage
@@ -1312,7 +1312,7 @@ func (mgr *Manager) collectSyscallInfoUnlocked() map[string]*CallCov {
 }
 
 func (mgr *Manager) fuzzerConnect(modules []host.KernelModule) (
-	[]rpctype.Input, BugFrames, map[uint32]uint32, []byte, error) {
+	[]rpctype.Input, BugFrames, map[uint32]uint32, map[uint32]uint32, error) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
@@ -1334,16 +1334,13 @@ func (mgr *Manager) fuzzerConnect(modules []host.KernelModule) (
 	if !mgr.modulesInitialized {
 		var err error
 		mgr.modules = modules
-		mgr.coverFilterBitmap, mgr.coverFilter, err = mgr.createCoverageFilter()
+		mgr.execCoverFilter, mgr.coverFilter, err = mgr.createCoverageFilter()
 		if err != nil {
 			log.Fatalf("failed to create coverage filter: %v", err)
 		}
-		if len(modules) > 0 && mgr.coverFilterBitmap != nil {
-			log.Fatalf("coverage filtering is not supported with modules")
-		}
 		mgr.modulesInitialized = true
 	}
-	return corpus, frames, mgr.coverFilter, mgr.coverFilterBitmap, nil
+	return corpus, frames, mgr.coverFilter, mgr.execCoverFilter, nil
 }
 
 func (mgr *Manager) machineChecked(a *rpctype.CheckArgs, enabledSyscalls map[*prog.Syscall]bool) {


### PR DESCRIPTION
Apply module conversion to filter bitmap to support coverage filtering when modules are used.

Coverage bitmap is decanonicalized to match each instance's module PCs.

This was done by decanonicalizing the map of bitmap PCs before bitmap creation to simplify conversion. I could convert the final bitmap or pass in the canonicalization instance to createCoverageFilter() to prevent this change.

The "coverFilter" used by the manager is only used on canonicalized PCs, so it remains unchanged.
