### PR TITLE
executor: set a separate stack for SIGSEGV and SIGBUS signal handlers

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1240,6 +1240,9 @@ void* worker_thread(void* arg)
 {
 	thread_t* th = (thread_t*)arg;
 	current_thread = th;
+
+	setaltstack();
+
 	if (cover_collection_required())
 		cover_enable(&th->cov, flag_comparisons, false);
 	for (;;) {

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -71,6 +71,7 @@ static unsigned long long procid;
 #include <setjmp.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/mman.h>
 
 #if GOOS_linux
 #include <sys/syscall.h>
@@ -118,8 +119,22 @@ static void segv_handler(int sig, siginfo_t* info, void* ctx)
 	doexit(sig);
 }
 
+static void setaltstack(void)
+{
+	stack_t ss = {};
+	ss.ss_size = SIGSTKSZ;
+	ss.ss_sp = mmap(NULL, SIGSTKSZ, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE | MAP_ANON, -1, 0);
+	if (ss.ss_sp == MAP_FAILED)
+		fail("mmap failed");
+	if (sigaltstack(&ss, NULL) == -1)
+		fail("sigaltstack failed");
+}
+
 static void install_segv_handler(void)
 {
+	setaltstack();
+
 	struct sigaction sa;
 #if GOOS_linux
 	memset(&sa, 0, sizeof(sa));
@@ -129,7 +144,7 @@ static void install_segv_handler(void)
 #endif
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_sigaction = segv_handler;
-	sa.sa_flags = SA_NODEFER | SA_SIGINFO;
+	sa.sa_flags = SA_NODEFER | SA_SIGINFO | SA_ONSTACK;
 	sigaction(SIGSEGV, &sa, NULL);
 	sigaction(SIGBUS, &sa, NULL);
 }
@@ -12385,6 +12400,10 @@ static int running;
 static void* thr(void* arg)
 {
 	struct thread_t* th = (struct thread_t*)arg;
+
+#if SYZ_EXECUTOR || SYZ_HANDLE_SEGV
+	setaltstack();
+#endif
 	for (;;) {
 		event_wait(&th->ready);
 		event_reset(&th->ready);


### PR DESCRIPTION
The rt_sigreturn syscall can chage a stack pointer and it can trigger a fault. In such cases, a signal handler can corrupt the current stack.

It is an attempt to fix
https://syzkaller.appspot.com/bug?extid=ec17ddba0a4bd12dfebb.

