### PR TITLE
pkg/vcs: search cherry-picks by title

### DIFF
--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -172,11 +172,12 @@ func (ctx *linux) EnvForCommit(
 	// arch/x86/entry/thunk_64.o: warning: objtool: missing symbol table
 	// We don't bisect that far back with neither clang nor gcc, so this should be fine:
 	fix := "1d489151e9f9d1647110277ff77282fe4d96d09b"
-	contained, err := ctx.git.Contains(fix)
+	fixTitle := "objtool: Don't fail on missing symbol table"
+	searchResult, err := ctx.git.GetCommitByTitle(fixTitle)
 	if err != nil {
 		return nil, err
 	}
-	if !contained {
+	if searchResult == nil {
 		_, err := ctx.git.git("cherry-pick", "--no-commit", fix)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We sometimes cherry-pick fixes to a bisected branch, for issues that make large parts of history untestable. Previously we cherry-picked if the fix commit hash isn't already present.

This is incorrect, as forks / lts trees may already cherry-picked the fix. In this case the fix would be present, but not have the expected hash. Unfortunately git doesn't have Change-Ids like gerrit, so there is no great way to check if a fix is already present.

Instead we now just check whether any commit with the expected title is present.