### PR TITLE
pkg/bisect: ignore transient crashes

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -839,6 +839,9 @@ int main(void)
 #if SYZ_802154
 	setup_802154();
 #endif
+#if SYZ_SWAP
+	setup_swap();
+#endif
 #if SYZ_HANDLE_SEGV
 	install_segv_handler();
 #endif

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1153,6 +1153,18 @@ static void initialize_wifi_devices(void)
 }
 #endif
 
+#if SYZ_EXECUTOR || (SYZ_NET_DEVICES && SYZ_NIC_VF) || SYZ_SWAP
+static int runcmdline(char* cmdline)
+{
+	debug("%s\n", cmdline);
+	int ret = system(cmdline);
+	if (ret) {
+		debug("FAIL: %s\n", cmdline);
+	}
+	return ret;
+}
+#endif
+
 #if SYZ_EXECUTOR || SYZ_NET_DEVICES
 #include <arpa/inet.h>
 #include <errno.h>
@@ -1428,15 +1440,6 @@ error:
 }
 
 #if SYZ_EXECUTOR || SYZ_NIC_VF
-static int runcmdline(char* cmdline)
-{
-	debug("%s\n", cmdline);
-	int ret = system(cmdline);
-	if (ret) {
-		debug("FAIL: %s\n", cmdline);
-	}
-	return ret;
-}
 
 static void netlink_nicvf_setup(void)
 {
@@ -5573,4 +5576,42 @@ static long syz_pkey_set(volatile long pkey, volatile long val)
 #endif
 	return 0;
 }
+#endif
+
+#if SYZ_EXECUTOR || SYZ_SWAP
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/swap.h>
+#include <sys/types.h>
+
+#define SWAP_FILE "/swap-file"
+#define SWAP_FILE_SIZE (128 * 1000 * 1000) // 128 MB.
+
+static void setup_swap()
+{
+	// The call must be idempotent, so first disable swap and remove the swap file.
+	swapoff(SWAP_FILE);
+	unlink(SWAP_FILE);
+	// Zero-fill the file.
+	int fd = open(SWAP_FILE, O_CREAT | O_WRONLY | O_CLOEXEC, 0600);
+	if (fd == -1) {
+		debug("open(%s) failed: %d\n", SWAP_FILE, errno);
+		return;
+	}
+	// We cannot do ftruncate -- swapon complains about this. Do fallocate instead.
+	fallocate(fd, FALLOC_FL_ZERO_RANGE, 0, SWAP_FILE_SIZE);
+	close(fd);
+	// Set up the swap file.
+	char cmdline[64];
+	sprintf(cmdline, "mkswap %s", SWAP_FILE);
+	if (runcmdline(cmdline))
+		return;
+	if (swapon(SWAP_FILE, SWAP_FLAG_PREFER) == 1) {
+		debug("swapon(%s) failed: %d\n", SWAP_FILE, errno);
+		return;
+	}
+}
+
 #endif

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -250,4 +250,5 @@ static feature_t features[] = {
     {"kcsan", setup_kcsan},
     {"usb", setup_usb},
     {"802154", setup_802154},
+    {"swap", setup_swap},
 };

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -127,6 +127,7 @@ func commonDefines(p *prog.Prog, opts Options) map[string]bool {
 		"SYZ_WIFI":                      opts.Wifi,
 		"SYZ_802154":                    opts.IEEE802154,
 		"SYZ_SYSCTL":                    opts.Sysctl,
+		"SYZ_SWAP":                      opts.Swap,
 		"SYZ_EXECUTOR_USES_SHMEM":       sysTarget.ExecutorUsesShmem,
 		"SYZ_EXECUTOR_USES_FORK_SERVER": sysTarget.ExecutorUsesForkServer,
 	}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -3767,6 +3767,18 @@ static void initialize_wifi_devices(void)
 }
 #endif
 
+#if SYZ_EXECUTOR || (SYZ_NET_DEVICES && SYZ_NIC_VF) || SYZ_SWAP
+static int runcmdline(char* cmdline)
+{
+	debug("%s\n", cmdline);
+	int ret = system(cmdline);
+	if (ret) {
+		debug("FAIL: %s\n", cmdline);
+	}
+	return ret;
+}
+#endif
+
 #if SYZ_EXECUTOR || SYZ_NET_DEVICES
 #include <arpa/inet.h>
 #include <errno.h>
@@ -4028,15 +4040,6 @@ error:
 }
 
 #if SYZ_EXECUTOR || SYZ_NIC_VF
-static int runcmdline(char* cmdline)
-{
-	debug("%s\n", cmdline);
-	int ret = system(cmdline);
-	if (ret) {
-		debug("FAIL: %s\n", cmdline);
-	}
-	return ret;
-}
 
 static void netlink_nicvf_setup(void)
 {
@@ -11762,6 +11765,40 @@ static long syz_pkey_set(volatile long pkey, volatile long val)
 }
 #endif
 
+#if SYZ_EXECUTOR || SYZ_SWAP
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/swap.h>
+#include <sys/types.h>
+
+#define SWAP_FILE "/swap-file"
+#define SWAP_FILE_SIZE (128 * 1000 * 1000)
+
+static void setup_swap()
+{
+	swapoff(SWAP_FILE);
+	unlink(SWAP_FILE);
+	int fd = open(SWAP_FILE, O_CREAT | O_WRONLY | O_CLOEXEC, 0600);
+	if (fd == -1) {
+		debug("open(%s) failed: %d\n", SWAP_FILE, errno);
+		return;
+	}
+	fallocate(fd, FALLOC_FL_ZERO_RANGE, 0, SWAP_FILE_SIZE);
+	close(fd);
+	char cmdline[64];
+	sprintf(cmdline, "mkswap %s", SWAP_FILE);
+	if (runcmdline(cmdline))
+		return;
+	if (swapon(SWAP_FILE, SWAP_FLAG_PREFER) == 1) {
+		debug("swapon(%s) failed: %d\n", SWAP_FILE, errno);
+		return;
+	}
+}
+
+#endif
+
 #elif GOOS_test
 
 #include <stdlib.h>
@@ -12644,6 +12681,9 @@ int main(void)
 #endif
 #if SYZ_802154
 	setup_802154();
+#endif
+#if SYZ_SWAP
+	setup_swap();
 #endif
 #if SYZ_HANDLE_SEGV
 	install_segv_handler();

--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	Wifi          bool `json:"wifi,omitempty"`
 	IEEE802154    bool `json:"ieee802154,omitempty"`
 	Sysctl        bool `json:"sysctl,omitempty"`
+	Swap          bool `json:"swap,omitempty"`
 
 	UseTmpDir  bool `json:"tmpdir,omitempty"`
 	HandleSegv bool `json:"segv,omitempty"`
@@ -150,6 +151,7 @@ func (opts Options) checkLinuxOnly(OS string) error {
 		"Fault":         &opts.Fault,
 		"Leak":          &opts.Leak,
 		"Sysctl":        &opts.Sysctl,
+		"Swap":          &opts.Swap,
 	} {
 		if *opt {
 			return fmt.Errorf("option %v is not supported on %v", name, OS)
@@ -183,6 +185,7 @@ func DefaultOpts(cfg *mgrconfig.Config) Options {
 		opts.Wifi = true
 		opts.IEEE802154 = true
 		opts.Sysctl = true
+		opts.Swap = true
 	}
 	if cfg.Sandbox == "" || cfg.Sandbox == "setuid" {
 		opts.NetReset = false
@@ -316,6 +319,7 @@ func defaultFeatures(value bool) Features {
 		"wifi":        {"setup and use mac80211_hwsim for wifi emulation", value},
 		"ieee802154":  {"setup and use mac802154_hwsim for emulation", value},
 		"sysctl":      {"setup sysctl's for fuzzing", value},
+		"swap":        {"setup and use a swap file", value},
 	}
 }
 

--- a/pkg/csource/options_test.go
+++ b/pkg/csource/options_test.go
@@ -314,6 +314,7 @@ func TestParseFeaturesFlags(t *testing.T) {
 			"wifi":        true,
 			"ieee802154":  true,
 			"sysctl":      true,
+			"swap":        true,
 		}},
 		{"none", "none", false, map[string]bool{}},
 		{"all", "none", true, map[string]bool{
@@ -330,6 +331,7 @@ func TestParseFeaturesFlags(t *testing.T) {
 			"wifi":        true,
 			"ieee802154":  true,
 			"sysctl":      true,
+			"swap":        true,
 		}},
 		{"", "none", true, map[string]bool{}},
 		{"none", "all", true, map[string]bool{}},
@@ -347,6 +349,7 @@ func TestParseFeaturesFlags(t *testing.T) {
 			"wifi":        true,
 			"ieee802154":  true,
 			"sysctl":      true,
+			"swap":        true,
 		}},
 		{"tun,net_dev", "none", true, map[string]bool{
 			"tun":     true,
@@ -364,9 +367,13 @@ func TestParseFeaturesFlags(t *testing.T) {
 			"wifi":        true,
 			"ieee802154":  true,
 			"sysctl":      true,
+			"swap":        true,
 		}},
 		{"close_fds", "none", true, map[string]bool{
 			"close_fds": true,
+		}},
+		{"swap", "none", true, map[string]bool{
+			"swap": true,
 		}},
 	}
 	for i, test := range tests {

--- a/pkg/host/features.go
+++ b/pkg/host/features.go
@@ -34,6 +34,7 @@ const (
 	FeatureVhciInjection
 	FeatureWifiEmulation
 	Feature802154Emulation
+	FeatureSwap
 	numFeatures
 )
 
@@ -77,6 +78,7 @@ func Check(target *prog.Target) (*Features, error) {
 		FeatureVhciInjection:    {Name: "hci packet injection", Reason: unsupported},
 		FeatureWifiEmulation:    {Name: "wifi device emulation", Reason: unsupported},
 		Feature802154Emulation:  {Name: "802.15.4 emulation", Reason: unsupported},
+		FeatureSwap:             {Name: "swap file", Reason: unsupported},
 	}
 	if noHostChecks(target) {
 		return res, nil
@@ -124,6 +126,9 @@ func Setup(target *prog.Target, features *Features, featureFlags csource.Feature
 	}
 	if featureFlags["ieee802154"].Enabled && features[Feature802154Emulation].Enabled {
 		args = append(args, "802154")
+	}
+	if features[FeatureSwap].Enabled {
+		args = append(args, "swap")
 	}
 	output, err := osutil.RunCmd(5*time.Minute, "", executor, args...)
 	log.Logf(1, "executor %v\n%s", args, output)

--- a/pkg/host/features_linux.go
+++ b/pkg/host/features_linux.go
@@ -5,6 +5,7 @@ package host
 
 import (
 	"fmt"
+	"os/exec"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -37,6 +38,7 @@ func init() {
 	checkFeature[FeatureVhciInjection] = checkVhciInjection
 	checkFeature[FeatureWifiEmulation] = checkWifiEmulation
 	checkFeature[Feature802154Emulation] = check802154Emulation
+	checkFeature[FeatureSwap] = checkSwap
 }
 
 func checkCoverage() string {
@@ -283,6 +285,16 @@ func checkWifiEmulation() string {
 func check802154Emulation() string {
 	if err := osutil.IsAccessible("/sys/bus/platform/devices/mac802154_hwsim"); err != nil {
 		return err.Error()
+	}
+	return ""
+}
+
+func checkSwap() string {
+	if err := osutil.IsAccessible("/proc/swaps"); err != nil {
+		return err.Error()
+	}
+	if _, err := exec.LookPath("mkswap"); err != nil {
+		return "mkswap is not available"
 	}
 	return ""
 }

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -201,6 +201,9 @@ func createStartOptions(cfg *mgrconfig.Config, features *host.Features, crashTyp
 		if !features[host.Feature802154Emulation].Enabled {
 			opts.IEEE802154 = false
 		}
+		if !features[host.FeatureSwap].Enabled {
+			opts.Swap = false
+		}
 	}
 	return opts
 }
@@ -817,6 +820,7 @@ var cSimplifies = append(progSimplifies, []Simplify{
 		opts.USB = false
 		opts.VhciInjection = false
 		opts.Wifi = false
+		opts.Swap = false
 		return true
 	},
 	func(opts *csource.Options) bool {
@@ -924,6 +928,13 @@ var cSimplifies = append(progSimplifies, []Simplify{
 			return false
 		}
 		opts.Sysctl = false
+		return true
+	},
+	func(opts *csource.Options) bool {
+		if !opts.Swap {
+			return false
+		}
+		opts.Swap = false
 		return true
 	},
 }...)

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -467,6 +467,7 @@ func (ctx *Context) createCTest(p *prog.Prog, sandbox string, threaded bool, tim
 		HandleSegv:  true,
 		Cgroups:     p.Target.OS == targets.Linux && sandbox != "",
 		Trace:       true,
+		Swap:        ctx.Features[host.FeatureSwap].Enabled,
 	}
 	if sandbox != "" {
 		if ctx.Features[host.FeatureNetInjection].Enabled {


### PR DESCRIPTION
This was one of https://github.com/google/syzkaller/pull/3952  commits.

----

There are cases when a crash, even though it didn't occur during boot and image testing phases, still should not be counted during bisection. Otherwise we risk diverting the whole process in the wrong direction.

One of such problem classes is getting SYZFATAL errors when we are not bisecting a SYZFATAL crash.
