### PR TITLE
executor: Include missing linux/falloc.h

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -5580,6 +5580,7 @@ static long syz_pkey_set(volatile long pkey, volatile long val)
 
 #if SYZ_EXECUTOR || SYZ_SWAP
 #include <fcntl.h>
+#include <linux/falloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -11767,6 +11767,7 @@ static long syz_pkey_set(volatile long pkey, volatile long val)
 
 #if SYZ_EXECUTOR || SYZ_SWAP
 #include <fcntl.h>
+#include <linux/falloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Its needed for FALLOC_FL_ZERO_RANGE which needs this header, it works with glibc because fcntl.h includes this header indirectly, however the failure comes to fore with musl C library where this header is not included indirectly by other system headers, therefore include it as required.

Fixes
In file included from executor/common.h:505:
executor/common_linux.h:5604:16: error: use of undeclared identifier 'FALLOC_FL_ZERO_RANGE'
        fallocate(fd, FALLOC_FL_ZERO_RANGE, 0, SWAP_FILE_SIZE);
                      ^

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
