### PR TITLE
pkg/csource: annotate syscall() args with their pretty-printed values

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -223,6 +223,24 @@ syscall(SYS_csource6, /*buf=*/0x%xul);
 				target.DataOffset+0x100, target.DataOffset+0x100,
 				target.DataOffset+0x140, target.DataOffset+0x140),
 		},
+		{
+			input: `
+csource7(0x0)
+csource7(0x1)
+csource7(0x2)
+csource7(0x3)
+csource7(0x4)
+csource7(0x5)
+`,
+			output: `
+syscall(SYS_csource7, /*flag=*/0ul);
+syscall(SYS_csource7, /*flag=BIT_0*/1ul);
+syscall(SYS_csource7, /*flag=BIT_1*/2ul);
+syscall(SYS_csource7, /*flag=BIT_0_AND_1*/3ul);
+syscall(SYS_csource7, /*flag=*/4ul);
+syscall(SYS_csource7, /*flag=BIT_0|0x4*/5ul);
+`,
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
@@ -231,6 +249,7 @@ syscall(SYS_csource6, /*buf=*/0x%xul);
 				t.Fatal(err)
 			}
 			ctx := &context{
+				p:         p,
 				target:    target,
 				sysTarget: targets.Get(target.OS, target.Arch),
 			}

--- a/prog/target.go
+++ b/prog/target.go
@@ -26,6 +26,7 @@ type Target struct {
 	Syscalls  []*Syscall
 	Resources []*ResourceDesc
 	Consts    []ConstValue
+	Flags     []FlagDesc
 
 	// MakeDataMmap creates calls that mmaps target data memory range.
 	MakeDataMmap func() []*Call
@@ -63,6 +64,7 @@ type Target struct {
 	// Filled by prog package:
 	SyscallMap map[string]*Syscall
 	ConstMap   map[string]uint64
+	FlagsMap   map[string][]string
 
 	init        sync.Once
 	initArch    func(target *Target)
@@ -165,6 +167,11 @@ func (target *Target) initTarget() {
 	for i, c := range target.Syscalls {
 		c.ID = i
 		target.SyscallMap[c.Name] = c
+	}
+
+	target.FlagsMap = make(map[string][]string)
+	for _, c := range target.Flags {
+		target.FlagsMap[c.Name] = c.Values
 	}
 
 	target.populateResourceCtors()

--- a/prog/target.go
+++ b/prog/target.go
@@ -148,7 +148,6 @@ func (target *Target) lazyInit() {
 		}
 	}
 	// These are used only during lazyInit.
-	target.ConstMap = nil
 	target.types = nil
 }
 
@@ -176,9 +175,6 @@ func (target *Target) initTarget() {
 }
 
 func (target *Target) GetConst(name string) uint64 {
-	if target.ConstMap == nil {
-		panic("GetConst can only be used during target initialization")
-	}
 	v, ok := target.ConstMap[name]
 	if !ok {
 		panic(fmt.Sprintf("const %v is not defined for %v/%v", name, target.OS, target.Arch))

--- a/prog/types.go
+++ b/prog/types.go
@@ -241,6 +241,11 @@ func (t *TypeCommon) Alignment() uint64 {
 	return t.TypeAlign
 }
 
+type FlagDesc struct {
+	Name   string
+	Values []string
+}
+
 type ResourceDesc struct {
 	Name   string
 	Kind   []string

--- a/sys/test/csource.txt
+++ b/sys/test/csource.txt
@@ -5,6 +5,8 @@
 
 resource fd0[int32]
 
+bitmask = BIT_0, BIT_1, BIT_0_AND_1
+
 csource0(num int32) fd0
 csource1(fd fd0)
 csource2(buf ptr[in, array[int8]])
@@ -12,3 +14,4 @@ csource3(buf ptr[in, array[const[0, int8], 10]])
 csource4(buf ptr[in, array[const[0x30, int8], 10]])
 csource5(buf ptr[in, array[const[0x3130, int16], 5]])
 csource6(buf ptr[in, array[const[0x3130, int16be], 6]])
+csource7(flag flags[bitmask])

--- a/sys/test/csource.txt.const
+++ b/sys/test/csource.txt.const
@@ -1,0 +1,4 @@
+arches = 32_fork_shmem, 32_shmem, 64, 64_fork
+BIT_0 = 1
+BIT_1 = 2
+BIT_0_AND_1 = 3


### PR DESCRIPTION
This factorizes const arguments into the shortest flags OR bitmask possible so they are easy to read. E.g:

```
    /*flags=MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE*/ 0x32ul
```

--- 

This follows up on prior discussions at https://github.com/google/syzkaller/pull/3947#pullrequestreview-1472130493

I'm not quite sure what to do of `ParseDescriptions` to be honest... I extracted calls to this function int the `Write` callers so they have more control over the syscall descriptions directory but it's still implemented in `csource.go`. Any guidance on how to make this nicer is very welcome! :) 