### PR TITLE
syz-cover improvements

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -30,9 +30,10 @@ type Prog struct {
 
 var RestorePC = backend.RestorePC
 
-func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir string, subsystem []mgrconfig.Subsystem,
-	moduleObj []string, modules []host.KernelModule, rawCover bool) (*ReportGenerator, error) {
-	impl, err := backend.Make(target, vm, objDir, srcDir, buildDir, moduleObj, modules)
+func MakeReportGenerator(cfg *mgrconfig.Config, subsystem []mgrconfig.Subsystem,
+	modules []host.KernelModule, rawCover bool) (*ReportGenerator, error) {
+	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelObj,
+		cfg.KernelSrc, cfg.KernelBuildSrc, cfg.ModuleObj, modules)
 	if err != nil {
 		return nil, err
 	}
@@ -41,9 +42,9 @@ func MakeReportGenerator(target *targets.Target, vm, objDir, srcDir, buildDir st
 		Paths: []string{""},
 	})
 	rg := &ReportGenerator{
-		target:          target,
-		srcDir:          srcDir,
-		buildDir:        buildDir,
+		target:          cfg.SysTarget,
+		srcDir:          cfg.KernelSrc,
+		buildDir:        cfg.KernelBuildSrc,
 		subsystem:       subsystem,
 		rawCoverEnabled: rawCover,
 		Impl:            impl,

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -260,6 +260,15 @@ func buildTestBinary(t *testing.T, target *targets.Target, test Test, dir string
 func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []byte, error) {
 	dir := t.TempDir()
 	bin := buildTestBinary(t, target, test, dir)
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			SysTarget: target,
+		},
+		KernelObj:      dir,
+		KernelSrc:      dir,
+		KernelBuildSrc: dir,
+		Type:           "",
+	}
 	subsystem := []mgrconfig.Subsystem{
 		{
 			Name: "sound",
@@ -277,7 +286,7 @@ func generateReport(t *testing.T, target *targets.Target, test Test) ([]byte, []
 		progs = append(progs, Prog{Sig: p.Sig, Data: p.Data, PCs: append([]uint64{}, p.PCs...)})
 	}
 
-	rg, err := MakeReportGenerator(target, "", dir, dir, dir, subsystem, nil, nil, false)
+	rg, err := MakeReportGenerator(cfg, subsystem, nil, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -45,9 +45,17 @@ func CollectGlobsInfo(globs map[string]bool) (map[string][]string, error) {
 	return machineGlobsInfo(globs)
 }
 
+func ParseModulesText(modulesText []byte) ([]KernelModule, error) {
+	if machineParseModules == nil {
+		return nil, nil
+	}
+	return machineParseModules(modulesText)
+}
+
 var machineInfoFuncs []machineInfoFunc
 var machineModulesInfo func() ([]KernelModule, error)
 var machineGlobsInfo func(map[string]bool) (map[string][]string, error)
+var machineParseModules func([]byte) ([]KernelModule, error)
 
 type machineInfoFunc struct {
 	name string

--- a/pkg/host/machine_info_linux.go
+++ b/pkg/host/machine_info_linux.go
@@ -21,6 +21,7 @@ func init() {
 	}
 	machineModulesInfo = getModulesInfo
 	machineGlobsInfo = getGlobsInfo
+	machineParseModules = parseModules
 }
 
 func readCPUInfo(buffer *bytes.Buffer) error {
@@ -125,8 +126,12 @@ func readKVMInfo(buffer *bytes.Buffer) error {
 }
 
 func getModulesInfo() ([]KernelModule, error) {
-	var modules []KernelModule
 	modulesText, _ := os.ReadFile("/proc/modules")
+	return parseModules(modulesText)
+}
+
+func parseModules(modulesText []byte) ([]KernelModule, error) {
+	var modules []KernelModule
 	re := regexp.MustCompile(`(\w+) ([0-9]+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
 	for _, m := range re.FindAllSubmatch(modulesText, -1) {
 		addr, err := strconv.ParseUint(string(m[3]), 0, 64)

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -20,8 +20,7 @@ var getReportGenerator = func() func(cfg *mgrconfig.Config,
 	return func(cfg *mgrconfig.Config, modules []host.KernelModule) (*cover.ReportGenerator, error) {
 		once.Do(func() {
 			log.Logf(0, "initializing coverage information...")
-			rg, err = cover.MakeReportGenerator(cfg.SysTarget, cfg.Type, cfg.KernelObj, cfg.KernelSrc,
-				cfg.KernelBuildSrc, cfg.KernelSubsystem, cfg.ModuleObj, modules, cfg.RawCover)
+			rg, err = cover.MakeReportGenerator(cfg, cfg.KernelSubsystem, modules, cfg.RawCover)
 		})
 		return rg, err
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -39,8 +39,9 @@ import (
 
 func main() {
 	var (
-		flagConfig         = flag.String("config", "", "configuration file")
-		flagModules        = flag.String("modules", "", "modules info obtained from /modules (optional)")
+		flagConfig  = flag.String("config", "", "configuration file")
+		flagModules = flag.String("modules", "",
+			"modules info obtained from /modules or file from /proc/modules (optional)")
 		flagExportCSV      = flag.String("csv", "", "export coverage data in csv format (optional)")
 		flagExportLineJSON = flag.String("json", "", "export coverage data with source line info in json format (optional)")
 		flagExportHTML     = flag.String("html", "", "save coverage HTML report to file (optional)")
@@ -145,7 +146,7 @@ func loadModules(fname string) ([]host.KernelModule, error) {
 	}
 	var modules []host.KernelModule
 	if err := json.Unmarshal(data, &modules); err != nil {
-		return nil, err
+		return host.ParseModulesText(data)
 	}
 	return modules, nil
 }

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -65,8 +65,7 @@ func main() {
 		}
 		modules = m
 	}
-	rg, err := cover.MakeReportGenerator(cfg.SysTarget, cfg.Type, cfg.KernelObj,
-		cfg.KernelSrc, cfg.KernelBuildSrc, nil, nil, modules, false)
+	rg, err := cover.MakeReportGenerator(cfg, cfg.KernelSubsystem, modules, false)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
Improve syz-cover to
1. read params from cfg file
2. pass cfg to MakeReportGenerator
3. use all pcs from rg.Symbols if flag.Args() == 0
4. parse modules info from file dumped from /proc/modules

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
