### PR TITLE
pkg/cover/backend: check absolute path when cleaning path

### DIFF
--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -457,14 +457,15 @@ func readCoverPoints(target *targets.Target, info *symbolInfo, data []byte) ([2]
 
 func cleanPath(path, objDir, srcDir, buildDir string) (string, string) {
 	filename := ""
+	absPath := osutil.Abs(path)
 	switch {
-	case strings.HasPrefix(path, objDir):
+	case strings.HasPrefix(absPath, objDir):
 		// Assume the file was built there.
-		path = strings.TrimPrefix(path, objDir)
+		path = strings.TrimPrefix(absPath, objDir)
 		filename = filepath.Join(objDir, path)
-	case strings.HasPrefix(path, buildDir):
+	case strings.HasPrefix(absPath, buildDir):
 		// Assume the file was moved from buildDir to srcDir.
-		path = strings.TrimPrefix(path, buildDir)
+		path = strings.TrimPrefix(absPath, buildDir)
 		filename = filepath.Join(srcDir, path)
 	default:
 		// Assume this is relative path.


### PR DESCRIPTION
The arguments `objDir`and `srcDir` of cleanPath() are absolute paths, see osutil.Abs() calls in:
* syz-cover: tools/syz-cover/syz-cover.go
* syz-manager: pkg/mgrconfig/load.go

However, when the `path` argument is not absolute, the first two checks of cleanPath (when file is built in path or when file was moved from builDir to srcDir) always evaluate to false.

Instead use absolute path for those checks.
