### PR TITLE
pkg/bisect: support bisections on other trees

### DIFF
--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -62,8 +62,9 @@ type Config struct {
 	// Sysctl/cmdline files used to build the image which was used to crash the kernel, e.g. see:
 	// dashboard/config/upstream.sysctl
 	// dashboard/config/upstream-selinux.cmdline
-	Sysctl  string `json:"sysctl"`
-	Cmdline string `json:"cmdline"`
+	Sysctl    string `json:"sysctl"`
+	Cmdline   string `json:"cmdline"`
+	CrossTree bool   `json:"cross_tree"`
 
 	KernelConfig         string `json:"kernel_config"`
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
@@ -104,6 +105,7 @@ func main() {
 		Linker:          mycfg.Linker,
 		BinDir:          mycfg.BinDir,
 		Ccache:          mycfg.Ccache,
+		CrossTree:       mycfg.CrossTree,
 		Kernel: bisect.KernelConfig{
 			Repo:        mycfg.KernelRepo,
 			Branch:      mycfg.KernelBranch,


### PR DESCRIPTION
Last rewritten piece of https://github.com/google/syzkaller/pull/3952

----

The current code only supports fix/cause bisections when the known bad commit is reachable from Kernel.Repo/Kernel.Branch.

Add a CrossTree parameter to pkg/bisect. If it's set to true and we're doing a fix bisection, the bisection algorithm first operates with the original commit message (i.e. checks that it indeed crashes the kernel and performs config minimization), but the actual bisection starts from the merge base of Commit and Branch.

We could have calculated the merge base outside of pkg/bisect and just started the algorithm from that merge base, but there's a problem: there's no guarantee that the kernel will build/boot with a syzbot config at the merge base. So we take the commit known to work well and then assume that the bug is also present on the merge base commit. If it were not present, we wouldn't have found a fix commit from Branch anyway.
