### PR TITLE
syz-ci: don't wait for semaphore to query a job

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -162,11 +162,6 @@ loop:
 		}
 		select {
 		case <-jp.jobTicker:
-			if buildSem.Available() == 0 {
-				// If normal kernel build is in progress (usually on start), don't query jobs.
-				// Otherwise we claim a job, but can't start it for a while.
-				continue loop
-			}
 			jp.pollJobs()
 		case <-jp.commitTicker:
 			jp.pollCommits()


### PR DESCRIPTION
Now that almost all upstream kernel builds are broken, we're experiencing problems with job execution -- attempts to rebuild a kernel on each syz-ci restart keep global locks taken almost all the time.

----

This condition is no longer really important -- build and test are anyway controlled by semaphores, so if we don't take the job, nobody else will be able to finish it sooner.

Also, we reset job statuses on syz-ci restart, so it won't be a problem to take a job again.
