### PR TITLE
pkg/bisect: ignore transient crashes

### DIFF
--- a/pkg/report/crash/types.go
+++ b/pkg/report/crash/types.go
@@ -18,6 +18,7 @@ const (
 	LockdepBug       = Type("LOCKDEP")
 	AtomicSleep      = Type("ATOMIC_SLEEP")
 	KMSAN            = Type("KMSAN")
+	SyzFailure       = Type("SYZ_FAILURE")
 )
 
 func (t Type) String() string {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -763,7 +763,7 @@ var commonOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
+		crash.SyzFailure,
 	},
 	{
 		// Errors produced by log.Fatal functions.
@@ -777,7 +777,7 @@ var commonOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
+		crash.SyzFailure,
 	},
 	{
 		[]byte("panic:"),

--- a/pkg/report/testdata/all/report/5
+++ b/pkg/report/testdata/all/report/5
@@ -1,4 +1,5 @@
 TITLE: SYZFATAL: executor NUM failed NUM times: call NUM/NUM/NUM: signal overflow: ADDR/ADDR
 ALT: SYZFATAL
+TYPE: SYZ_FAILURE
 
 2022/04/21 07:35:27 SYZFATAL: executor 0 failed 11 times: call 15/15/3356: signal overflow: 808464432/16776764

--- a/pkg/report/testdata/linux/report/601
+++ b/pkg/report/testdata/linux/report/601
@@ -1,4 +1,5 @@
 TITLE: SYZFAIL: negative running
+TYPE: SYZ_FAILURE
 
 2021/02/21 12:37:19 executor 5 failed 11 times:
 executor 5: exit status 67

--- a/pkg/report/testdata/linux/report/660
+++ b/pkg/report/testdata/linux/report/660
@@ -1,5 +1,6 @@
 TITLE: SYZFATAL: executor NUM failed NUM times: failed to create temp dir: mkdir ./syzkaller-testdirNUM: read-only file system
 ALT: SYZFATAL
+TYPE: SYZ_FAILURE
 
 2022/10/02 11:34:15 SYZFATAL: executor 4 failed 11 times: failed to create temp dir: mkdir ./syzkaller-testdir264563108: read-only file system
 


### PR DESCRIPTION
This is a rewritten part of https://github.com/google/syzkaller/pull/3952

----
There are cases when a crash, even though it didn't occur during boot
and image testing phases, still should not be counted during bisection.
Otherwise we risk diverting the whole process in the wrong direction.

One of such problem classes is getting SYZFATAL errors when we are not
bisecting a SYZFATAL crash.