### PR TITLE
pkg/bisect: keep KCOV enabled for newer Linux versions

### DIFF
--- a/pkg/vcs/linux_configs.go
+++ b/pkg/vcs/linux_configs.go
@@ -54,7 +54,10 @@ func setLinuxTagConfigs(cf *kconfig.ConfigFile, tags map[string]bool) {
 		// First, we disable coverage in pkg/bisect because it fails machine testing starting from 4.7.
 		// Second, at 6689da155bdcd17abfe4d3a8b1e245d9ed4b5f2c CONFIG_KCOV selects CONFIG_GCC_PLUGIN_SANCOV
 		// (why?), which is build broken for hundreds of revisions.
-		"KCOV": disableAlways,
+		// However, as there's a chance that KCOV might positively affect bug reproduction rate, let's
+		// keep it for newer kernel revisions. Bisection algorithm will try to drop it anyway during
+		// kernel config minimization.
+		"KCOV": "v5.4",
 		// This helps to produce stable binaries in presence of kernel tag changes.
 		"LOCALVERSION_AUTO": disableAlways,
 		// BTF fails lots of builds with:


### PR DESCRIPTION
Let's keep it enabled for newer Linux kernel versions as it keeps the environment closer to the one where the bug happened.

We disable KCOV in baseline configs, so we'll try to drop it at the kernel config bisection stage anyway.

