### PR TITLE
dashboard: don't overwrite user-set subsystems

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -770,9 +770,12 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 	}
 
 	newSubsystems := []*subsystem.Subsystem{}
-	// Recalculate subsystems on the first saved crash and on the first saved repro.
-	calculateSubsystems := save && (bug.NumCrashes == 0 ||
-		bug.ReproLevel == ReproLevelNone && reproLevel != ReproLevelNone)
+	// Recalculate subsystems on the first saved crash and on the first saved repro,
+	// unless a user has already manually specified them.
+	calculateSubsystems := save &&
+		!bug.hasUserSubsystems() &&
+		(bug.NumCrashes == 0 ||
+			bug.ReproLevel == ReproLevelNone && reproLevel != ReproLevelNone)
 	if calculateSubsystems {
 		newSubsystems, err = inferSubsystems(c, bug, bugKey, &debugtracer.NullTracer{})
 		if err != nil {


### PR DESCRIPTION
Don't recalculate subsystems when a user has already specified them. Add a test to verify this behavior.
