### PR TITLE
pkg/instance: don't fail on symbolization error

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -122,7 +122,7 @@ func (inst *ExecProgInstance) runCommand(command string, duration time.Duration)
 		inst.Logf(2, "program did not crash")
 	} else {
 		if err := inst.reporter.Symbolize(result.Report); err != nil {
-			return nil, fmt.Errorf("failed to symbolize report: %v", err)
+			inst.Logf(0, "failed to symbolize report: %v", err)
 		}
 		inst.Logf(2, "program crashed: %v", result.Report.Title)
 	}


### PR DESCRIPTION
The `instance.test()` code is used for reproducer generation and kernel bisections, we don't really need symoblized reports there.

Instead of retuning an error, just print it as a log message.

