### PR TITLE
pkg/vcs: properly disable lockdep

### DIFF
--- a/pkg/vcs/linux_configs.go
+++ b/pkg/vcs/linux_configs.go
@@ -111,11 +111,14 @@ func setLinuxSanitizerConfigs(cf *kconfig.ConfigFile, types []crash.Type, dt deb
 					val[:pos]+" rcupdate.rcu_cpu_stall_suppress=1"+val[pos:])
 			}
 		},
-		crash.MemoryLeak:  func() { cf.Unset("DEBUG_KMEMLEAK") },
-		crash.UBSAN:       func() { cf.Unset("UBSAN") },
-		crash.Bug:         func() { cf.Unset("BUG") },
-		crash.KASAN:       func() { cf.Unset("KASAN") },
-		crash.LockdepBug:  func() { cf.Unset("LOCKDEP") },
+		crash.MemoryLeak: func() { cf.Unset("DEBUG_KMEMLEAK") },
+		crash.UBSAN:      func() { cf.Unset("UBSAN") },
+		crash.Bug:        func() { cf.Unset("BUG") },
+		crash.KASAN:      func() { cf.Unset("KASAN") },
+		crash.LockdepBug: func() {
+			cf.Unset("LOCKDEP")
+			cf.Unset("PROVE_LOCKING") // it selects LOCKDEP
+		},
 		crash.AtomicSleep: func() { cf.Unset("DEBUG_ATOMIC_SLEEP") },
 	}
 	need := map[crash.Type]bool{}

--- a/pkg/vcs/linux_configs_test.go
+++ b/pkg/vcs/linux_configs_test.go
@@ -47,7 +47,7 @@ func TestDropLinuxSanitizerConfigs(t *testing.T) {
 			name:  "lockdep",
 			types: []crash.Type{crash.LockdepBug},
 			test: func(t *testing.T, cf *kconfig.ConfigFile) {
-				assertConfigs(t, cf, "LOCKDEP")
+				assertConfigs(t, cf, "LOCKDEP", "PROVE_LOCKING")
 			},
 		},
 		{
@@ -68,6 +68,7 @@ CONFIG_LOCKDEP=y
 CONFIG_RCU_STALL_COMMON=y
 CONFIG_UBSAN=y
 CONFIG_DEBUG_ATOMIC_SLEEP=y
+CONFIG_PROVE_LOCKING=y
 `
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
We also need to disable CONFIG_PROVE_LOCKING, which forces CONFIG_LOCKDEP to be enabled.
