### PR TITLE
syz-ci: auto-guess baseline kernel configs

### DIFF
--- a/syz-ci/config_test.go
+++ b/syz-ci/config_test.go
@@ -4,11 +4,31 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadConfig(t *testing.T) {
 	if _, err := loadConfig("testdata/example.cfg"); err != nil {
 		t.Fatalf("failed to load: %v", err)
 	}
+}
+
+func TestBaselineCanInference(t *testing.T) {
+	dir := t.TempDir()
+	kernelConfig := filepath.Join(dir, "kernel.config")
+	kernelBaseConfig := filepath.Join(dir, "kernel-base.config")
+	osutil.WriteFile(kernelConfig, nil)
+	osutil.WriteFile(kernelBaseConfig, nil)
+	assert.Equal(t, kernelBaseConfig, inferBaselineConfig(kernelConfig))
+}
+
+func TestBaselineCannotInference(t *testing.T) {
+	dir := t.TempDir()
+	kernelConfig := filepath.Join(dir, "kernel.config")
+	osutil.WriteFile(kernelConfig, nil)
+	assert.Equal(t, "", inferBaselineConfig(kernelConfig))
 }


### PR DESCRIPTION
If a kernel config is specified, infer it's `-base.config` counterpart. If such a file is present, use it as a default value for KernelBaselineConfig.

