### PR TITLE
tools/docker: update to bookworm images

### DIFF
--- a/pkg/report/testdata/linux/decompile/amd64/4.out
+++ b/pkg/report/testdata/linux/decompile/amd64/4.out
@@ -63,13 +63,13 @@ Code disassembly (best guess):
   11:	80 3c 02 00          	cmpb   $0x0,(%rdx,%rax,1)
   15:	74 08                	je     0x1f
   17:	4c 89 e7             	mov    %r12,%rdi
-  1a:	e8 f0 8e 14 fe       	callq  0xfe148f0f
+  1a:	e8 f0 8e 14 fe       	call   0xfe148f0f
   1f:	48 8b 83 18 02 00 00 	mov    0x218(%rbx),%rax
   26:	89 ed                	mov    %ebp,%ebp
   28:	31 d2                	xor    %edx,%edx
 * 2a:	48 f7 f5             	div    %rbp <-- trapping instruction
   2d:	48 89 83 18 02 00 00 	mov    %rax,0x218(%rbx)
   34:	45 31 ed             	xor    %r13d,%r13d
-  37:	e8 7f b5 f2 fd       	callq  0xfdf2b5bb
+  37:	e8 7f b5 f2 fd       	call   0xfdf2b5bb
   3c:	44 89 e8             	mov    %r13d,%eax
   3f:	5b                   	pop    %rbx

--- a/pkg/report/testdata/linux/decompile/arm/0.out
+++ b/pkg/report/testdata/linux/decompile/arm/0.out
@@ -112,4 +112,4 @@ Code disassembly (best guess):
    4:	e2853020 	add	r3, r5, #32
    8:	e1a02000 	mov	r2, r0
    c:	e2422008 	sub	r2, r2, #8
-* 10:	e5034020 	str	r4, [r3, #-32]	; 0xffffffe0 <-- trapping instruction
+* 10:	e5034020 	str	r4, [r3, #-32]	@ 0xffffffe0 <-- trapping instruction

--- a/tools/docker/big-env/Dockerfile
+++ b/tools/docker/big-env/Dockerfile
@@ -34,10 +34,7 @@ RUN dpkg --add-architecture i386 && \
 	apt-get update --allow-releaseinfo-change && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	# required to build root images.
-	debootstrap ssh-tools qemu-user-static \
-	# required for gcloud sdk.
-	python2 \
-	&& \
+	debootstrap ssh-tools qemu-user-static && \
 	apt-get -y autoremove && \
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -47,13 +44,22 @@ RUN curl https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz | tar -C /usr/loca
 
 RUN curl https://storage.googleapis.com/syzkaller/fuchsia-toolchain.tar.gz | tar -C /syzkaller -xz
 RUN curl https://storage.googleapis.com/syzkaller/netbsd-toolchain.tar.gz | tar -C /syzkaller -xz
-RUN curl https://storage.googleapis.com/syzkaller/akaros-toolchain.tar.gz | tar -C /syzkaller -xz
 ENV SOURCEDIR_FUCHSIA /syzkaller/fuchsia
 ENV SOURCEDIR_NETBSD /syzkaller/netbsd
-ENV SOURCEDIR_AKAROS /syzkaller/akaros
+
+# Build Python 2.7 from source.
+RUN apt-get install -y -q libsqlite3-dev
+RUN wget -O /tmp/Python-2.7.18.tgz 'https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz'
+RUN cd /tmp/ && tar -zxf Python-2.7.18.tgz
+RUN cd /tmp/Python-2.7.18 && ./configure
+RUN cd /tmp/Python-2.7.18 && make -j2 && make altinstall
+RUN ln -s /usr/local/bin/python2.7 /usr/bin/python2
 
 # Install gcloud sdk for dashboard/app tests.
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-360.0.0-linux-x86_64.tar.gz | tar -C /usr/local -xz
+# The newest version (as of 07/10/23) is 437, however, it seems to expect to be run with python3
+# (but still requires python2). But Go's aetest package still runs dev_appserver.py with python2.7.
+# So let's use an older, but working sdk.
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-400.0.0-linux-x86_64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/google-cloud-sdk/bin:$PATH
 RUN gcloud components install --quiet app-engine-python app-engine-go app-engine-python-extras cloud-datastore-emulator
 RUN chmod 0777 /usr/local/google-cloud-sdk

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -3,16 +3,17 @@
 
 # See /tools/docker/README.md for details.
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 LABEL homepage="https://github.com/google/syzkaller"
 
 RUN apt-get update --allow-releaseinfo-change
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
-	sudo make python nano unzip curl ca-certificates binutils g++ \
+	sudo make nano unzip curl ca-certificates binutils g++ \
 	g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu \
-	libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-10-dev lib32stdc++-10-dev \
+	libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-12-dev lib32stdc++-12-dev \
+	python3 python-is-python3 \
 	# These are needed to build Linux kernel:
 	flex bison bc libelf-dev libssl-dev \
 	# qemu-user is required to run alien arch binaries in pkg/cover tests.
@@ -34,12 +35,10 @@ RUN mkdir -p /syzkaller/gopath/src/github.com/google/syzkaller && \
 	mkdir -p /syzkaller/.cache && \
 	chmod -R 0777 /syzkaller
 
-# The default clang-11 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main"
 RUN apt-get update --allow-releaseinfo-change
-RUN apt-get remove -y -q clang-11
 RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15
 RUN apt autoremove -y -q
 RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -3,7 +3,7 @@
 
 # See /tools/docker/README.md for details.
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update --allow-releaseinfo-change
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
@@ -23,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	crossbuild-essential-amd64 crossbuild-essential-arm64
 RUN test "$(uname -m)" != x86_64 && exit 0 || \
         DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
-	  libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-10-dev lib32stdc++-10-dev \
+	  libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-12-dev lib32stdc++-12-dev \
 	  # These are required to run foreign arch kernels:
 	  qemu-utils qemu-system-misc qemu-system-x86 qemu-system-arm qemu-system-aarch64  \
 	  qemu-system-s390x qemu-system-mips qemu-system-ppc \
@@ -34,12 +34,11 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 RUN curl https://dl.google.com/go/go1.20.1.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
-# The default clang-11 is too old, install the latest one.
+# The default clang-14 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
+RUN add-apt-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main"
 RUN apt-get update --allow-releaseinfo-change
-RUN apt-get remove -y -q clang-11
 RUN apt-get install -y -q --no-install-recommends clang-15 clang-format-15 clang-tidy-15 lld-15
 RUN apt autoremove -y -q
 RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
@@ -54,13 +53,6 @@ RUN mkdir -p /usr/grte/v5/bin && ln -s /usr/bin/python3 /usr/grte/v5/bin/python2
 # Install bazel
 # Download the official bazel binary. The APT repository isn't used because there is not packages for arm64.
 RUN sh -c 'curl -o /usr/local/bin/bazel https://releases.bazel.build/6.2.0/release/bazel-6.2.0-linux-$(uname -m | sed s/aarch64/arm64/) && chmod ugo+x /usr/local/bin/bazel'
-
-# Update pahole from 1.20 to 1.22 to avoid this build error seen on 5.10 based kernels:
-# [43990] INT DW_ATE_unsigned_24 Error emitting BTF type
-# The default git is too old, install a newer one.
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
-RUN apt update
-RUN apt install -y -q dwarves/bullseye-backports git/bullseye-backports
 
 # pkg/osutil uses syzkaller user for sandboxing.
 RUN useradd --create-home syzkaller


### PR DESCRIPTION
We ultimately want to merge all these 3 docker images to 1, but let's update them all to bookworm first, it was already quite challenging per se. During merging there will likely be another set of problems.

---

Closes #3973.

As Python 2.7 is no longer present in the packages, build it directly in Dockerfile. It's rather small and doesn't take much time.
