### PR TITLE
syz-manager/covfilter: return nil bitmap if filtering is not used

### DIFF
--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -135,6 +135,10 @@ func covFilterAddRawPCs(pcs map[uint32]uint32, rawPCsFiles []string) error {
 }
 
 func createCoverageBitmap(target *targets.Target, pcs map[uint32]uint32) []byte {
+	// Return nil if filtering is not used.
+	if len(pcs) == 0 {
+		return nil
+	}
 	start, size := coverageFilterRegion(pcs)
 	log.Logf(0, "coverage filter from 0x%x to 0x%x, size 0x%x, pcs %v", start, start+size, size, len(pcs))
 	// The file starts with two uint32: covFilterStart and covFilterSize,

--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -50,4 +50,7 @@ func TestCreateBitmap(t *testing.T) {
 		0x81000102: 1,
 	}
 	createCoverageBitmap(target, pcs)
+	// Test nil bitmap.
+	pcs = nil
+	createCoverageBitmap(target, pcs)
 }


### PR DESCRIPTION
PR https://github.com/google/syzkaller/pull/3953 caused the error 'SYZFAIL: coverage filter was enabled but bitmap initialization failed' when filter was not instantiated.

The previous PR ran createCoverageBitmap() regardless of whether or not the coverage filtering was used, instantiating a bitmap with an empty size.