### PR TITLE
pkg/bisect: estimate confidence in the result

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -541,6 +541,10 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		if res.IsRelease {
 			resp.Flags |= dashapi.BisectResultRelease
 		}
+		const confidenceCutOff = 0.5
+		if res.Confidence < confidenceCutOff {
+			resp.Flags |= dashapi.BisectResultIgnore
+		}
 		ignoredCommits := []string{
 			// Commit "usb: gadget: add raw-gadget interface" adds a kernel interface for
 			// triggering USB bugs, which ends up being the guilty commit during bisection


### PR DESCRIPTION
Estimate reproducer's flakiness more carefully, as it can help us get better results.

During config minimization, do not let reproducibility drop too low.

For each `test()` run, estimate our confidence in the result. For now, only consider the false negative case: if we got no crashes, it's likely that the bug is there, but the reproducer was not lucky enough. Given an estimate of reproduction likelihood, we can easily calculate the chance of an invalid result: `(1-probability)^runs`.

Combine all individual `test()` confidences into `Result.Confidence`. If the resulting Confidence is too low, ignore the bisection result.
