### PR TITLE
syz-manager/covfilter_test: test nil coverage bitmap

### DIFF
--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -50,7 +50,13 @@ func TestCreateBitmap(t *testing.T) {
 		0x81000102: 1,
 	}
 	createCoverageBitmap(target, pcs)
-	// Test nil bitmap.
-	pcs = nil
-	createCoverageBitmap(target, pcs)
+}
+
+func TestNilCoverageBitmap(t *testing.T) {
+	pcs := map[uint32]uint32(nil)
+	target := targets.Get("test", "64")
+	bitmap := createCoverageBitmap(target, pcs)
+	if bitmap != nil {
+		t.Errorf("created a bitmap on nil pcs")
+	}
 }


### PR DESCRIPTION
Error when creating a coverage bitmap without
input pcs.

