### PR TITLE
pkg/build: don't coverage-instrument gVisor sync package in race builds

### DIFF
--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -51,6 +51,7 @@ func (gvisor gvisor) build(params Params) (ImageDetails, error) {
 			// sync/atomic.AddInt32), which will not work.
 			exclusions = append(exclusions, []string{
 				"//pkg/sleep:sleep",
+				"//pkg/sync:sync",
 				"//pkg/syncevent:syncevent",
 			}...)
 		}


### PR DESCRIPTION
sync.gateCommit() is also a go:norace function called during runtime.gopark().