### PR TITLE
dashboard: show per-bisect type job lists for admins

### DIFF
--- a/dashboard/app/admin.html
+++ b/dashboard/app/admin.html
@@ -47,8 +47,13 @@ Main page.
 	{{end}}
 
 	{{template "manager_list" $.Managers}}
+	&nbsp;&nbsp;
+	{{if $.FixBisectionsLink}}<a href="{{$.FixBisectionsLink}}">[Fix Bisections]</a>{{end}}
+	{{if $.CauseBisectionsLink}}<a href="{{$.CauseBisectionsLink}}">[Cause Bisections]</a>{{end}}
+	{{if $.JobOverviewLink}}<a href="{{$.JobOverviewLink}}">[Jobs Overview]</a>{{end}}
 	{{template "job_list" $.RunningJobs}}
 	{{template "job_list" $.PendingJobs}}
 	{{template "job_list" $.RecentJobs}}
+	{{template "job_list" $.TypeJobs}}
 </body>
 </html>

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -227,3 +227,9 @@ indexes:
   - name: Type
   - name: Finished
     direction: desc
+
+- kind: Job
+  properties:
+  - name: Type
+  - name: Finished
+    direction: desc

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -423,7 +423,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 {{/* List of jobs, invoked with *uiJobList */}}
 {{define "job_list"}}
-{{if $.Jobs}}
+{{if and $ $.Jobs}}
 	<table class="list_table">
 		<caption id="jobs"><a class="plain" href="#jobs">{{$.Title}}</a></caption>
 		<thead>

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -463,7 +463,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				<td class="result">
 					{{if $job.ErrorLink}}
 						{{link $job.ErrorLink "error"}}
-					{{else if $job.LogLink}}
+					{{end}}
+					{{if $job.LogLink}}
 						{{link $job.LogLink "job log"}}
 						({{if $job.Commit}}1{{else}}{{len $job.Commits}}{{end}})
 					{{else if $job.CrashTitle}}


### PR DESCRIPTION
Currently we only show running/pending/recent jobs. Let admins also see the list of the latest cause/fix bisections.
