### PR TITLE
all: perform cross-tree fix bisections

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -263,6 +263,8 @@ type KernelRepoLink struct {
 	Alias string
 	// Whether commits from the other repository merged or cherry-picked.
 	Merge bool
+	// Whether syzbot should try to fix bisect the bug in the Alias tree.
+	BisectFixes bool
 }
 
 type CCConfig struct {

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -822,7 +822,6 @@ func createJobResp(c context.Context, job *Job, jobKey *db.Key) (*dashapi.JobPol
 		MergeBaseBranch:   job.MergeBaseBranch,
 		KernelCommit:      build.KernelCommit,
 		KernelCommitTitle: build.KernelCommitTitle,
-		KernelCommitDate:  build.KernelCommitDate,
 		KernelConfig:      kernelConfig,
 		SyzkallerCommit:   build.SyzkallerCommit,
 		Patch:             patch,

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -1358,6 +1358,13 @@ func loadFullBugInfo(c context.Context, bug *Bug, bugKey *db.Key,
 			return nil, err
 		}
 	}
+	// Query the fix candidate.
+	if bug.FixCandidateJob != "" {
+		ret.FixCandidate, err = prepareFixCandidateReport(c, bug, reporting)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// Query similar bugs.
 	similar, err := loadSimilarBugs(c, bug)
 	if err != nil {
@@ -1398,6 +1405,18 @@ func loadFullBugInfo(c context.Context, bug *Bug, bugKey *db.Key,
 	ret.TreeJobs, err = treeTestJobs(c, bug)
 	if err != nil {
 		return nil, err
+	}
+	return ret, nil
+}
+
+func prepareFixCandidateReport(c context.Context, bug *Bug, reporting *Reporting) (*dashapi.BugReport, error) {
+	job, jobKey, err := fetchJob(c, bug.FixCandidateJob)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := createBugReportForJob(c, job, jobKey, reporting.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the job bug report: %w", err)
 	}
 	return ret, nil
 }

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -171,6 +171,10 @@ type ManagerJobs struct {
 	BisectFix   bool
 }
 
+func (m ManagerJobs) Any() bool {
+	return m.TestPatches || m.BisectCause || m.BisectFix
+}
+
 type JobPollResp struct {
 	ID                string
 	Type              JobType

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -176,13 +176,16 @@ func (m ManagerJobs) Any() bool {
 }
 
 type JobPollResp struct {
-	ID                string
-	Type              JobType
-	Manager           string
-	KernelRepo        string
-	KernelBranch      string
-	MergeBaseRepo     string
-	MergeBaseBranch   string
+	ID         string
+	Type       JobType
+	Manager    string
+	KernelRepo string
+	// KernelBranch is used for patch testing and serves as the current HEAD
+	// for bisections.
+	KernelBranch    string
+	MergeBaseRepo   string
+	MergeBaseBranch string
+	// Bisection starts from KernelCommit.
 	KernelCommit      string
 	KernelCommitTitle string
 	KernelConfig      []byte
@@ -785,11 +788,12 @@ type LoadFullBugReq struct {
 }
 
 type FullBugInfo struct {
-	SimilarBugs []*SimilarBugInfo
-	BisectCause *BugReport
-	BisectFix   *BugReport
-	Crashes     []*BugReport
-	TreeJobs    []*JobInfo
+	SimilarBugs  []*SimilarBugInfo
+	BisectCause  *BugReport
+	BisectFix    *BugReport
+	Crashes      []*BugReport
+	TreeJobs     []*JobInfo
+	FixCandidate *BugReport
 }
 
 type SimilarBugInfo struct {

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -185,7 +185,6 @@ type JobPollResp struct {
 	MergeBaseBranch   string
 	KernelCommit      string
 	KernelCommitTitle string
-	KernelCommitDate  time.Time
 	KernelConfig      []byte
 	SyzkallerCommit   string
 	Patch             []byte

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -382,20 +382,15 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 		},
 	}
 	job.resp = resp
+	resp.Build.KernelRepo = req.KernelRepo
+	resp.Build.KernelBranch = req.KernelBranch
+	resp.Build.KernelCommit = "[unknown]"
+	resp.Build.KernelConfig = req.KernelConfig
 	switch req.Type {
 	case dashapi.JobTestPatch:
 		mgrcfg.Name += "-test" + jp.instanceSuffix
-		resp.Build.KernelRepo = req.KernelRepo
-		resp.Build.KernelBranch = req.KernelBranch
-		resp.Build.KernelCommit = "[unknown]"
 	case dashapi.JobBisectCause, dashapi.JobBisectFix:
 		mgrcfg.Name += "-bisect" + jp.instanceSuffix
-		resp.Build.KernelRepo = mgr.mgrcfg.Repo
-		resp.Build.KernelBranch = mgr.mgrcfg.Branch
-		resp.Build.KernelCommit = req.KernelCommit
-		resp.Build.KernelCommitTitle = req.KernelCommitTitle
-		resp.Build.KernelCommitDate = req.KernelCommitDate
-		resp.Build.KernelConfig = req.KernelConfig
 	default:
 		err := fmt.Errorf("bad job type %v", req.Type)
 		job.resp.Error = []byte(err.Error())

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -297,7 +297,7 @@ func (jp *JobProcessor) pollJobs() {
 			BisectCause: jobs.BisectCause,
 			BisectFix:   jobs.BisectFix,
 		}
-		if apiJobs.TestPatches || apiJobs.BisectCause || apiJobs.BisectFix {
+		if apiJobs.Any() {
 			poll.Managers[mgr.name] = apiJobs
 		}
 	}


### PR DESCRIPTION
If tree origin assessment code has identified that the bug is not reproducible in a tree from which we merge/cherry-pick commits, use fix bisection to identify that commit. This can e.g. be used to find fixing commits that were not backported from Linux kernel mainline into LTS branches.

This PR does not (yet?) include the code to share/display such findings.

See individual commits.