### PR TITLE
executor: fix loop condition in lookup_endpoint

### DIFF
--- a/executor/common_usb_linux.h
+++ b/executor/common_usb_linux.h
@@ -187,7 +187,7 @@ static int lookup_endpoint(int fd, uint8 bEndpointAddress)
 	if (index->iface_cur < 0)
 		return -1;
 
-	for (int ep = 0; index->ifaces[index->iface_cur].eps_num; ep++)
+	for (int ep = 0; ep < index->ifaces[index->iface_cur].eps_num; ep++)
 		if (index->ifaces[index->iface_cur].eps[ep].desc.bEndpointAddress == bEndpointAddress)
 			return index->ifaces[index->iface_cur].eps[ep].handle;
 	return -1;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -5784,7 +5784,7 @@ static int lookup_endpoint(int fd, uint8 bEndpointAddress)
 	if (index->iface_cur < 0)
 		return -1;
 
-	for (int ep = 0; index->ifaces[index->iface_cur].eps_num; ep++)
+	for (int ep = 0; ep < index->ifaces[index->iface_cur].eps_num; ep++)
 		if (index->ifaces[index->iface_cur].eps[ep].desc.bEndpointAddress == bEndpointAddress)
 			return index->ifaces[index->iface_cur].eps[ep].handle;
 	return -1;


### PR DESCRIPTION
The loop in lookup_endpoint incorrectly iterates over endpoints.

Fixes #4038.

Reported-by: @cyruscyliu
