### PR TITLE
dashboard: fix the Config.Decommissioned race

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -677,3 +677,22 @@ func getKernelRepos(c context.Context, ns string) []KernelRepo {
 	}
 	return config.Namespaces[ns].Repos
 }
+
+var decommKey = "Custom decommissioned status"
+
+func contextWithDecommission(c context.Context, ns string, value bool) context.Context {
+	mm, _ := c.Value(&decommKey).(map[string]bool)
+	if mm == nil {
+		mm = map[string]bool{}
+	}
+	mm[ns] = value
+	return context.WithValue(c, &decommKey, mm)
+}
+
+func isDecommissioned(c context.Context, ns string) bool {
+	mm, _ := c.Value(&decommKey).(map[string]bool)
+	if val, set := mm[ns]; set {
+		return val
+	}
+	return config.Namespaces[ns].Decommissioned
+}

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -180,7 +180,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 		if ns1 == ns {
 			found = true
 		}
-		if cfg.Decommissioned {
+		if isDecommissioned(c, ns1) {
 			continue
 		}
 		h.Namespaces = append(h.Namespaces, uiNamespace{

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -406,7 +406,7 @@ func createPatchTestingJobs(c context.Context, managers map[string]dashapi.Manag
 				// for which we were already given fixing commits.
 				return false
 			}
-			if config.Namespaces[bug.Namespace].Decommissioned {
+			if isDecommissioned(c, bug.Namespace) {
 				return false
 			}
 			return true
@@ -648,7 +648,7 @@ func shouldBisectBug(c context.Context, bug *Bug, managers map[string]bool, jobT
 		return false
 	}
 
-	if config.Namespaces[bug.Namespace].Decommissioned {
+	if isDecommissioned(c, bug.Namespace) {
 		return false
 	}
 

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -465,7 +465,7 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 	}
 	data := &uiMainPage{
 		Header:         hdr,
-		Decommissioned: config.Namespaces[hdr.Namespace].Decommissioned,
+		Decommissioned: isDecommissioned(c, hdr.Namespace),
 		Now:            timeNow(c),
 		Groups:         groups,
 		Managers:       makeManagerList(managers, hdr.Namespace),

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -166,7 +166,7 @@ func reportingPollNotifications(c context.Context, typ string) []*dashapi.BugNot
 	log.Infof(c, "fetched %v bugs", len(bugs))
 	var notifs []*dashapi.BugNotification
 	for _, bug := range bugs {
-		if config.Namespaces[bug.Namespace].Decommissioned {
+		if isDecommissioned(c, bug.Namespace) {
 			continue
 		}
 		notif, err := handleReportNotif(c, typ, bug)
@@ -800,7 +800,7 @@ func reportingPollClosed(c context.Context, ids []string) ([]string, error) {
 				break
 			}
 			if bug.Status >= BugStatusFixed || !bugReporting.Closed.IsZero() ||
-				config.Namespaces[bug.Namespace].Decommissioned {
+				isDecommissioned(c, bug.Namespace) {
 				closed = append(closed, bugReporting.ID)
 			}
 			break

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1099,8 +1099,7 @@ func TestReportDecommissionedBugs(t *testing.T) {
 	c.expectEQ(len(closed), 0)
 
 	// And now let's decommission the namespace.
-	config.Namespaces[rep.Namespace].Decommissioned = true
-	defer func() { config.Namespaces[rep.Namespace].Decommissioned = false }()
+	c.decommission(rep.Namespace)
 
 	closed, _ = client.ReportingPollClosed([]string{rep.ID})
 	c.expectEQ(len(closed), 1)

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -230,6 +230,12 @@ func (c *Ctx) setNoObsoletions() {
 	}
 }
 
+func (c *Ctx) decommission(ns string) {
+	c.transformContext = func(c context.Context) context.Context {
+		return contextWithDecommission(c, ns, true)
+	}
+}
+
 // GET sends admin-authorized HTTP GET request to the app.
 func (c *Ctx) GET(url string) ([]byte, error) {
 	return c.AuthGET(AccessAdmin, url)


### PR DESCRIPTION
Race detector reports a race between
dashboard/app/reporting_test.go:1102
and
dashboard/app/handler.go:183

Fix this by storing decommission updates in the context rather than by directly modifying the global config variable.