### PR TITLE
pkg/vcs: cherry-pick more fixes for Linux

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -58,6 +58,8 @@ type KernelConfig struct {
 	// this minimized one.
 	BaselineConfig []byte
 	Userspace      string
+	// Extra commits to cherry pick to older kernel revisions.
+	Backports []vcs.BackportCommit
 }
 
 type SyzkallerConfig struct {
@@ -566,7 +568,10 @@ func (env *env) build() (*vcs.Commit, string, error) {
 	}
 
 	bisectEnv, err := env.bisecter.EnvForCommit(
-		env.cfg.DefaultCompiler, env.cfg.CompilerType, env.cfg.BinDir, current.Hash, env.kernelConfig)
+		env.cfg.DefaultCompiler, env.cfg.CompilerType,
+		env.cfg.BinDir, current.Hash, env.kernelConfig,
+		env.cfg.Kernel.Backports,
+	)
 	if err != nil {
 		return current, "", err
 	}

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -167,24 +167,10 @@ func (ctx *linux) EnvForCommit(
 		Compiler:     compiler,
 		KernelConfig: cf.Serialize(),
 	}
-
-	// Compiling v4.6..v5.11 with a modern objtool, w/o this patch, results in the
-	// following issue, when compiling with clang:
-	// arch/x86/entry/thunk_64.o: warning: objtool: missing symbol table
-	// We don't bisect that far back with neither clang nor gcc, so this should be fine:
-	fix := "1d489151e9f9d1647110277ff77282fe4d96d09b"
-	fixTitle := "objtool: Don't fail on missing symbol table"
-	searchResult, err := ctx.git.GetCommitByTitle(fixTitle)
+	err = linuxFixBackports(ctx.git)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to cherry pick fixes: %w", err)
 	}
-	if searchResult == nil {
-		_, err := ctx.git.git("cherry-pick", "--no-commit", fix)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return env, nil
 }
 

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -139,6 +139,7 @@ func gitReleaseTagToInt(tag string, includeRC bool) uint64 {
 
 func (ctx *linux) EnvForCommit(
 	defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte,
+	backports []BackportCommit,
 ) (*BisectEnv, error) {
 	tagList, err := ctx.previousReleaseTags(commit, true, false, false)
 	if err != nil {
@@ -167,7 +168,7 @@ func (ctx *linux) EnvForCommit(
 		Compiler:     compiler,
 		KernelConfig: cf.Serialize(),
 	}
-	err = linuxFixBackports(ctx.git)
+	err = linuxFixBackports(ctx.git, backports...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cherry pick fixes: %w", err)
 	}

--- a/pkg/vcs/linux_patches.go
+++ b/pkg/vcs/linux_patches.go
@@ -1,0 +1,72 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vcs
+
+// BackportCommit describes a fix commit that must be cherry-picked to an older
+// kernel revision in order to enable kernel build / boot.
+type BackportCommit struct {
+	// If non-empty, it will be first ensured that this commit is reachable.
+	GuiltyTitle string `json:"guilty_title"`
+	// The hash of the commit to cherry-pick.
+	FixHash string `json:"fix_hash"`
+	// The title of the commit to cherry-pick.
+	// It's used to determine whether the fix is already in place.
+	FixTitle string `json:"fix_title"`
+}
+
+// linuxFixBackports() cherry-picks the commits necessary to compile/run older Linux kernel releases.
+func linuxFixBackports(repo *git, extraCommits ...BackportCommit) error {
+	list := append([]BackportCommit{}, pickLinuxCommits...)
+	for _, info := range append(list, extraCommits...) {
+		if info.GuiltyTitle != "" {
+			guiltyCommit, err := repo.GetCommitByTitle(info.GuiltyTitle)
+			if err != nil {
+				return err
+			}
+			if guiltyCommit == nil {
+				// The problem is not yet introduced.
+				continue
+			}
+		}
+		fixCommit, err := repo.GetCommitByTitle(info.FixTitle)
+		if err != nil {
+			return err
+		}
+		if fixCommit != nil {
+			// The fix is already present.
+			continue
+		}
+		_, err = repo.git("cherry-pick", "--no-commit", info.FixHash)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var pickLinuxCommits = []BackportCommit{
+	{
+		// Compiling v4.6..v5.11 with a modern objtool, w/o this patch, results in the
+		// following issue, when compiling with clang:
+		// arch/x86/entry/thunk_64.o: warning: objtool: missing symbol table
+		// We don't bisect that far back with neither clang nor gcc, so this should be fine:
+		FixHash:  `1d489151e9f9d1647110277ff77282fe4d96d09b`,
+		FixTitle: `objtool: Don't fail on missing symbol table`,
+	},
+	{
+		// In newer compiler versions, kernel compilation fails with:
+		// subcmd-util.h:56:23: error: pointer may be used after ‘realloc’ [-Werror=use-after-free]
+		// 56 |                 ret = realloc(ptr, size);
+		GuiltyTitle: `perf tools: Finalize subcmd independence`,
+		FixHash:     `52a9dab6d892763b2a8334a568bd4e2c1a6fde66`,
+		FixTitle:    `libsubcmd: Fix use-after-free for realloc(..., 0)`,
+	},
+	{
+		// A number of old releases fail with KASAN: use-after-free in task_active_pid_ns.
+		// The problem was actually present so long ago that we do not need to check whether
+		// the guilty commit is present. We don't bisect that back (v2.*) anyway.
+		FixHash:  `0711f0d7050b9e07c44bc159bbc64ac0a1022c7f`,
+		FixTitle: "pid: take a reference when initializing `cad_pid`",
+	},
+}

--- a/pkg/vcs/testos.go
+++ b/pkg/vcs/testos.go
@@ -29,6 +29,7 @@ func (ctx *testos) PreviousReleaseTags(commit, compilerType string) ([]string, e
 
 func (ctx *testos) EnvForCommit(
 	defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte,
+	backports []BackportCommit,
 ) (*BisectEnv, error) {
 	return &BisectEnv{KernelConfig: kernelConfig}, nil
 }

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -93,7 +93,8 @@ type Bisecter interface {
 
 	IsRelease(commit string) (bool, error)
 
-	EnvForCommit(defaultCompiler, compilerType, binDir, commit string, kernelConfig []byte) (*BisectEnv, error)
+	EnvForCommit(defaultCompiler, compilerType, binDir, commit string,
+		kernelConfig []byte, backports []BackportCommit) (*BisectEnv, error)
 }
 
 type ConfigMinimizer interface {

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -498,6 +498,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 			Config:         req.KernelConfig,
 			BaselineConfig: baseline,
 			Userspace:      mgr.mgrcfg.Userspace,
+			Backports:      mgr.mgrcfg.BisectBackports,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   jp.cfg.SyzkallerRepo,

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -71,6 +71,7 @@ import (
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 var (
@@ -182,6 +183,8 @@ type ManagerConfig struct {
 	// File with sysctl values (e.g. output of sysctl -a, optional).
 	KernelSysctl string      `json:"kernel_sysctl"`
 	Jobs         ManagerJobs `json:"jobs"`
+	// Extra commits to cherry pick to older kernel revisions.
+	BisectBackports []vcs.BackportCommit `json:"bisect_backports"`
 
 	ManagerConfig json.RawMessage `json:"manager_config"`
 	managercfg    *mgrconfig.Config

--- a/tools/syz-bisect/bisect.go
+++ b/tools/syz-bisect/bisect.go
@@ -62,9 +62,10 @@ type Config struct {
 	// Sysctl/cmdline files used to build the image which was used to crash the kernel, e.g. see:
 	// dashboard/config/upstream.sysctl
 	// dashboard/config/upstream-selinux.cmdline
-	Sysctl    string `json:"sysctl"`
-	Cmdline   string `json:"cmdline"`
-	CrossTree bool   `json:"cross_tree"`
+	Sysctl    string               `json:"sysctl"`
+	Cmdline   string               `json:"cmdline"`
+	CrossTree bool                 `json:"cross_tree"`
+	Backports []vcs.BackportCommit `json:"backports"`
 
 	KernelConfig         string `json:"kernel_config"`
 	KernelBaselineConfig string `json:"kernel_baseline_config"`
@@ -114,6 +115,7 @@ func main() {
 			Userspace:   mycfg.Userspace,
 			Sysctl:      mycfg.Sysctl,
 			Cmdline:     mycfg.Cmdline,
+			Backports:   mycfg.Backports,
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   mycfg.SyzkallerRepo,

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -125,7 +125,7 @@ func main() {
 
 func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instance.Env, com *vcs.Commit) {
 	compiler, compilerType, linker, ccache := "gcc", "gcc", "ld", ""
-	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin, com.Hash, kernelConfig)
+	bisectEnv, err := bisecter.EnvForCommit(compiler, compilerType, *flagBisectBin, com.Hash, kernelConfig, nil)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
* Refactor cherry picking for older kernel revisions in `pkg/vcs`.
* Add more Linux-specific cherry-picks.
* Let users specify custom cherry-picks in the `syz-ci` config.