### PR TITLE
tools/docker/env: use Go 1.20

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -80,8 +80,6 @@ RUN dpkg --add-architecture i386 && \
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN rm -rf /usr/local/go
-RUN curl https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 RUN curl https://storage.googleapis.com/syzkaller/fuchsia-toolchain.tar.gz | tar -C /syzkaller -xz
 RUN curl https://storage.googleapis.com/syzkaller/netbsd-toolchain.tar.gz | tar -C /syzkaller -xz


### PR DESCRIPTION
By mistake, we're installing Go twice in this Dockerfile. Remove the 1.19 installation and only leave the 1.20 one.
