### PR TITLE
tools: misc create-image.sh, create-gce-image.sh updates

### DIFF
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -61,7 +61,7 @@ case "$IMG_ARCH" in
 		PARTDEV=$DISKDEV"p1"
 		;;
 	ppc64le)
-		echo -en "g\nn\n1\n2048\n16383\nt\n7\nn\n2\n\n\nw\n" | sudo fdisk $DISKDEV
+		echo -en "o\nn\np\n1\n2048\n16383\na\nt\n41\nn\np\n2\n\n\nw\n" | sudo fdisk $DISKDEV
 		PARTDEV=$DISKDEV"p2"
 		;;
 esac
@@ -143,9 +143,9 @@ terminal_output console
 set timeout=0
 menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod gzio
-	insmod part_gpt
+	insmod part_msdos
 	insmod ext2
-	set root='(ieee1275/disk,gpt2)'
+	set root='(ieee1275/disk,msdos2)'
 	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF

--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -146,7 +146,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_msdos
 	insmod ext2
 	search -f --set /vmlinuz
-	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
+	linux /vmlinuz root=/dev/sda2 rootwait console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=60 net.ifnames=0 $CMDLINE
 }
 EOF
 	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"

--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -145,7 +145,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod gzio
 	insmod part_msdos
 	insmod ext2
-	set root='(ieee1275/disk,msdos2)'
+	search -f --set /vmlinuz
 	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -195,7 +195,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod gzio
 	insmod part_msdos
 	insmod ext2
-	set root='(ieee1275/disk,msdos2)'
+	search -f --set /vmlinuz
 	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -99,7 +99,7 @@ case "$IMG_ARCH" in
 		;;
 	ppc64le)
 		# Create a small PowerPC PReP boot partition, and a Linux partition for the rest
-		echo -en "g\nn\n1\n2048\n16383\nt\n7\nn\n2\n\n\nw\n" | sudo fdisk $DISKDEV
+		echo -en "o\nn\np\n1\n2048\n16383\na\nt\n41\nn\np\n2\n\n\nw\n" | sudo fdisk $DISKDEV
 		PARTDEV=$DISKDEV"p2"
 		;;
 esac
@@ -193,9 +193,9 @@ set timeout=0
 # debug is not set as it produces too much output
 menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod gzio
-	insmod part_gpt
+	insmod part_msdos
 	insmod ext2
-	set root='(ieee1275/disk,gpt2)'
+	set root='(ieee1275/disk,msdos2)'
 	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
 }
 EOF

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -196,7 +196,7 @@ menuentry 'linux' --class gnu-linux --class gnu --class os {
 	insmod part_msdos
 	insmod ext2
 	search -f --set /vmlinuz
-	linux /vmlinuz root=/dev/sda2 console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=86400 net.ifnames=0 $CMDLINE
+	linux /vmlinuz root=/dev/sda2 rootwait console=ttyS0 earlyprintk=serial oops=panic panic_on_warn=1 nmi_watchdog=panic panic=60 net.ifnames=0 $CMDLINE
 }
 EOF
 	sudo grub-install --target=powerpc-ieee1275 --boot-directory=disk.mnt/boot $DISKDEV"p1"

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -144,7 +144,7 @@ fi
 if [ $DEBARCH == "riscv64" ]; then
     DEBOOTSTRAP_PARAMS="--keyring /usr/share/keyrings/debian-ports-archive-keyring.gpg --exclude firmware-atheros $DEBOOTSTRAP_PARAMS http://deb.debian.org/debian-ports"
 fi
-sudo debootstrap $DEBOOTSTRAP_PARAMS
+sudo --preserve-env=http_proxy,https_proxy,ftp_proxy,no_proxy debootstrap $DEBOOTSTRAP_PARAMS
 
 # 2. debootstrap stage: only necessary if target != host architecture
 

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -134,7 +134,7 @@ sudo chmod 0755 $DIR
 
 # 1. debootstrap stage
 
-DEBOOTSTRAP_PARAMS="--arch=$DEBARCH --include=$PREINSTALL_PKGS --components=main,contrib,non-free $RELEASE $DIR"
+DEBOOTSTRAP_PARAMS="--arch=$DEBARCH --include=$PREINSTALL_PKGS --components=main,contrib,non-free,non-free-firmware $RELEASE $DIR"
 if [ $FOREIGN = "true" ]; then
     DEBOOTSTRAP_PARAMS="--foreign $DEBOOTSTRAP_PARAMS"
 fi


### PR DESCRIPTION
- Workarounds for some ppc64le platform quirks
- Add the `non-free-firmware` Debian archive component so that we can install `firmware-atheros` on new Debian releases
- Preserve proxy variables when invoking debootstrap via sudo in `create-image.sh` for environments where you have a proxy set