### PR TITLE
ci.yml: run on any-env not self-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_aux
   build:
-    runs-on: self-hosted
+    runs-on: any-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
@@ -57,7 +57,7 @@ jobs:
         files: gopath/src/github.com/google/syzkaller/.coverage.txt
         flags: unittests
   dashboard:
-    runs-on: self-hosted
+    runs-on: any-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
@@ -93,7 +93,7 @@ jobs:
       - name: run
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make ${{ matrix.target }}
   race:
-    runs-on: self-hosted
+    runs-on: any-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2


### PR DESCRIPTION
"self-hosted" is the automatically assigned label.
k8s cluster runners are also "self-hosted".
To distinguish k8s and gce instances additional label is needed.
"any-env" will be temporarily used until full migration to k8s.