### PR TITLE
ci.yml: run dashboard tests on k8s

### DIFF
--- a/.github/arc_config/runner.yaml
+++ b/.github/arc_config/runner.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: k8s-action-runner
+  namespace: actions-runner-system
+spec:
+  template:
+    spec:
+      repository: google/syzkaller
+      resources:
+        requests:
+          cpu: "31"
+          memory: "26Gi"
+        limits:
+          memory: "28Gi"
+      labels:
+        - k8s-env
+
+---
+
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: k8s-action-runner-autoscaler
+  namespace: actions-runner-system
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: k8s-action-runner
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+      repositoryNames:
+        - google/syzkaller

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make presubmit_aux
   build:
-    runs-on: any-env
+    runs-on: k8s-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
@@ -57,7 +57,7 @@ jobs:
         files: gopath/src/github.com/google/syzkaller/.coverage.txt
         flags: unittests
   dashboard:
-    runs-on: any-env
+    runs-on: k8s-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
@@ -93,7 +93,7 @@ jobs:
       - name: run
         run: gopath/src/github.com/google/syzkaller/.github/workflows/run.sh syz-env make ${{ matrix.target }}
   race:
-    runs-on: any-env
+    runs-on: k8s-env
     steps:
     - name: checkout
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2


### PR DESCRIPTION
We have a GKE cluster with up to 32 cores * 10 nodes.
This PR forwards testing to it and enables autoscaling 3 - 10 nodes.

For every job it downloads syz-env container which takes ~2.5 minutes.
Single PR check time will be the same because "race" job was typically waiting for the build node availability (~3 min). We had 2 nodes (1 used by "build" and 1 by "dashboard").

Potential improvements:
1. Switch to "sysbox".
2. Somehow cache syz-env downloads.
