### PR TITLE
syz-ci: set bisection job build to start commit

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -384,12 +384,14 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	job.resp = resp
 	resp.Build.KernelRepo = req.KernelRepo
 	resp.Build.KernelBranch = req.KernelBranch
-	resp.Build.KernelCommit = "[unknown]"
 	resp.Build.KernelConfig = req.KernelConfig
 	switch req.Type {
 	case dashapi.JobTestPatch:
+		resp.Build.KernelCommit = "[unknown]"
 		mgrcfg.Name += "-test" + jp.instanceSuffix
 	case dashapi.JobBisectCause, dashapi.JobBisectFix:
+		resp.Build.KernelCommit = req.KernelCommit
+		resp.Build.KernelCommitTitle = req.KernelCommitTitle
 		mgrcfg.Name += "-bisect" + jp.instanceSuffix
 	default:
 		err := fmt.Errorf("bad job type %v", req.Type)


### PR DESCRIPTION
Given that mail_bisect_template.txt refers to that data as "start commit", let's directly use the information about the starting commit that we already have.

Otherwise we get `start commit:   [unknown]` in our reports.

