### PR TITLE
pkg/vcs: ensure config transformation in predicates

### DIFF
--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -372,7 +372,7 @@ func (ctx *minimizeLinuxCtx) minimizeAgainst(base *kconfig.ConfigFile) error {
 	// Bisection is not getting much faster with smaller configs, only more reliable,
 	// so there's a trade-off. Try to do best in 5 iterations, that's about 1.5 hours.
 	const minimizeRuns = 5
-	minConfig, err := ctx.kconf.Minimize(base, ctx.config, ctx.pred, minimizeRuns, ctx)
+	minConfig, err := ctx.kconf.Minimize(base, ctx.config, ctx.runPred, minimizeRuns, ctx)
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func (ctx *minimizeLinuxCtx) dropInstrumentation(types []crash.Type) error {
 		return nil
 	}
 	ctx.SaveFile("no-instrumentation.config", newConfig.Serialize())
-	ok, err := ctx.pred(newConfig)
+	ok, err := ctx.runPred(newConfig)
 	if err != nil {
 		return err
 	}
@@ -404,6 +404,12 @@ func (ctx *minimizeLinuxCtx) dropInstrumentation(types []crash.Type) error {
 		ctx.config = newConfig
 	}
 	return nil
+}
+
+func (ctx *minimizeLinuxCtx) runPred(cfg *kconfig.ConfigFile) (bool, error) {
+	cfg = cfg.Clone()
+	ctx.transform(cfg)
+	return ctx.pred(cfg)
 }
 
 func (ctx *minimizeLinuxCtx) getConfig() []byte {


### PR DESCRIPTION
The transform() call is assumed to be idempotent, so let's also run it before all predicate runs. It will ensure that we return exactly the same config from getConfig() as the one that was actually tested.

Context: there've been some mysteriously incorrect bisection results lately. See e.g. https://syzkaller.appspot.com/x/bisect.txt?x=122e2c31a80000

The exact reason is still unclear, but let's submit this change as it can only improve things anyway.
