### PR TITLE
dashboard: display cross tree bisection results

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -35,7 +35,9 @@ Page with details about a single bug.
 		{{end}}
 	{{end}}
 	First crash: {{formatLateness $.Now $.Bug.FirstTime}}, last: {{formatLateness $.Now $.Bug.LastTime}}<br>
-
+	{{if .FixCandidate}}
+		<div class="fix-candidate-block">{{template "bisect_results" .FixCandidate}}</div>
+	{{end}}
 	<div>
 		{{if .BisectCause}}<div class="bug-bisection-info">{{template "bisect_results" .BisectCause}}</div>{{end}}
 		{{if .BisectFix}}<div class="bug-bisection-info">{{template "bisect_results" .BisectFix}}</div>{{end}}

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -595,16 +595,19 @@ const (
 	JobBisectFix
 )
 
-func (typ JobType) toDashapiReportType() dashapi.ReportType {
-	switch typ {
+func (job *Job) dashapiReportType() dashapi.ReportType {
+	switch job.Type {
 	case JobTestPatch:
 		return dashapi.ReportTestPatch
 	case JobBisectCause:
 		return dashapi.ReportBisectCause
 	case JobBisectFix:
+		if job.IsCrossTree() {
+			return dashapi.ReportFixCandidate
+		}
 		return dashapi.ReportBisectFix
 	default:
-		panic(fmt.Sprintf("unknown job type %v", typ))
+		panic(fmt.Sprintf("unknown job type %v", job.Type))
 	}
 }
 

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1665,13 +1665,25 @@ func (b *bugJobs) bestBisection() *bugJob {
 		if j.job.InvalidatedBy != "" {
 			continue
 		}
-		if j.job.MergeBaseRepo != "" {
+		if j.job.IsCrossTree() {
 			// It was a cross-tree bisection.
 			continue
 		}
 		return j
 	}
 	return nil
+}
+
+func (b *bugJobs) crossTreeJobs() *bugJobs {
+	var ret []*bugJob
+	for _, j := range b.list {
+		if j.job.IsCrossTree() {
+			ret = append(ret, j)
+		}
+	}
+	return &bugJobs{
+		list: ret,
+	}
 }
 
 func (b *bugJobs) all() []*bugJob {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -240,6 +240,7 @@ type uiBugPage struct {
 	Bug             *uiBug
 	BisectCause     *uiJob
 	BisectFix       *uiJob
+	FixCandidate    *uiJob
 	Sections        []*uiCollapsible
 	SampleReport    template.HTML
 	Crashes         *uiCrashTable
@@ -838,6 +839,13 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 			return err
 		}
 	}
+	var fixCandidate *uiJob
+	if bug.FixCandidateJob != "" {
+		fixCandidate, err = fixBisections.uiBestFixCandidate(c)
+		if err != nil {
+			return err
+		}
+	}
 	testPatchJobs, err := loadTestPatchJobs(c, bug)
 	if err != nil {
 		return err
@@ -858,6 +866,7 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 		Bug:          uiBug,
 		BisectCause:  bisectCause,
 		BisectFix:    bisectFix,
+		FixCandidate: fixCandidate,
 		Sections:     sections,
 		SampleReport: sampleReport,
 		Crashes:      crashesTable,
@@ -2147,6 +2156,14 @@ func (b *bugJobs) uiAll(c context.Context) ([]*uiJob, error) {
 
 func (b *bugJobs) uiBestBisection(c context.Context) (*uiJob, error) {
 	j := b.bestBisection()
+	if j == nil {
+		return nil, nil
+	}
+	return j.ui(c)
+}
+
+func (b *bugJobs) uiBestFixCandidate(c context.Context) (*uiJob, error) {
+	j := b.bestFixCandidate()
 	if j == nil {
 		return nil, nil
 	}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -893,6 +893,17 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 				"Cause bisection attempts", uiList))
 		}
 	}
+	crossTreeJobs := fixBisections.crossTreeJobs()
+	if len(crossTreeJobs.all()) > 0 {
+		uiList, err := crossTreeJobs.uiAll(c)
+		if err != nil {
+			return err
+		}
+		if len(uiList) != 0 {
+			data.Sections = append(data.Sections, makeCollapsibleBugJobs(
+				"Cross-tree fix bisection attempts", uiList))
+		}
+	}
 	if isJSONRequested(r) {
 		w.Header().Set("Content-Type", "application/json")
 		return writeJSONVersionOf(w, data)

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -316,11 +316,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	<br>
 	{{$causeJob := 1}}
 	{{$fixJob := 2}}
+	{{$fixCandidate := 3}}
 	{{if .ErrorLink}}
 		{{if eq .Type $causeJob}}
 			<b>Cause bisection: failed</b>
 		{{else if eq .Type $fixJob}}
 			<b>Fix bisection: failed</b>
+		{{else if eq .Type $fixCandidate}}
+			<b>Fix candidate bisection: failed</b>
 		{{end}}
 		<b>({{link .ErrorLink "error log"}}{{if .LogLink}}, {{link .LogLink "bisect log"}}{{end}})</b><br>
 	{{else if .Commit}}
@@ -328,9 +331,12 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<b>Cause bisection: introduced by</b>
 		{{else if eq .Type $fixJob}}
 			<b>Fix bisection: fixed by</b>
+		{{else if eq .Type $fixCandidate}}
+			<b>Fix commit to backport</b>
 		{{end}}
 		<b>({{link .LogLink "bisect log"}})</b> <span class="bad">{{print .Flags}}</span>:<br>
 		<span class="mono">
+		{{if eq .Type $fixCandidate}}tree: {{link .KernelCommitLink .KernelAlias}}<br>{{end}}
 		commit {{.Commit.Hash}}<br>
 		Author: {{.Commit.Author}}<br>
 		Date:   {{formatKernelTime .Commit.Date}}<br>
@@ -342,6 +348,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<b>Cause bisection: the cause commit could be any of</b>
 		{{else if eq .Type $fixJob}}
 			<b>Fix bisection: the fix commit could be any of</b>
+		{{else if eq .Type $fixCandidate}}
+			<b>Fix candidate detection: the fix commit could be any of</b>
 		{{end}}
 		<b>({{link .LogLink "bisect log"}}):</b><br>
 		<span class="mono">
@@ -354,6 +362,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<b>Cause bisection: the issue happens on the oldest tested release</b>
 		{{else if eq .Type $fixJob}}
 			<b>Fix bisection: the issue occurs on the latest tested release</b>
+		{{else if eq .Type $fixCandidate}}
+			<b>Fix candidate bisection: the issue occurs on the latest tested release</b>
 		{{end}}
 		<b>({{link .LogLink "bisect log"}})</b><br>
 	{{end}}
@@ -453,7 +463,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 						{{- else}}retest repro{{end}}
 					{{else if eq $job.Type 1}}
 						bisect
-					{{else if eq $job.Type 2}}
+					{{else if or (eq $job.Type 2) (eq $job.Type 3)}}
 						bisect fix
 					{{end}}
 				</td>

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -257,9 +257,9 @@ func TestTreeOriginLtsBisection(t *testing.T) {
 	assert.NotNil(t, info.FixCandidate)
 	fix := info.FixCandidate
 	assert.Equal(t, "upstream", fix.KernelRepoAlias)
-	assert.NotNil(t, fix.BisectFix)
-	assert.NotNil(t, fix.BisectFix.Commit)
-	commit := fix.BisectFix.Commit
+	assert.NotNil(t, fix.FixCandidate)
+	assert.NotNil(t, fix.FixCandidate.Commit)
+	commit := fix.FixCandidate.Commit
 	assert.Equal(t, "deadf00d", commit.Hash)
 	assert.Equal(t, "kernel: fix a bug", commit.Title)
 }

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -443,6 +443,7 @@ type BugReport struct {
 	PatchLink      string
 	BisectCause    *BisectResult
 	BisectFix      *BisectResult
+	FixCandidate   *BisectResult
 	Assets         []Asset
 	Subsystems     []BugSubsystem
 	ReportElements *ReportElements
@@ -871,6 +872,7 @@ const (
 	ReportTestPatch                     // Patch testing result.
 	ReportBisectCause                   // Cause bisection result for an already reported bug.
 	ReportBisectFix                     // Fix bisection result for an already reported bug.
+	ReportFixCandidate
 )
 
 type JobInfo struct {

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -364,6 +364,10 @@ aside {
 	width: 20pt;
 }
 
+.fix-candidate-block {
+	background: lightgreen;
+}
+
 .bug-bisection-info {
 	float:left;
 	margin-right: 15px;


### PR DESCRIPTION
Display potential fix candidates on the per-bug web pages.