### PR TITLE
dashboard: display fix candidate info on the bug page

### DIFF
--- a/dashboard/app/bug.html
+++ b/dashboard/app/bug.html
@@ -35,7 +35,9 @@ Page with details about a single bug.
 		{{end}}
 	{{end}}
 	First crash: {{formatLateness $.Now $.Bug.FirstTime}}, last: {{formatLateness $.Now $.Bug.LastTime}}<br>
-
+	{{if .FixCandidate}}
+		<div class="fix-candidate-block">{{template "bisect_results" .FixCandidate}}</div>
+	{{end}}
 	<div>
 		{{if .BisectCause}}<div class="bug-bisection-info">{{template "bisect_results" .BisectCause}}</div>{{end}}
 		{{if .BisectFix}}<div class="bug-bisection-info">{{template "bisect_results" .BisectFix}}</div>{{end}}

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1539,6 +1539,7 @@ func makeJobInfo(c context.Context, job *Job, jobKey *db.Key, bug *Bug, build *B
 		KernelRepo:       job.KernelRepo,
 		KernelBranch:     job.KernelBranch,
 		KernelAlias:      kernelRepoInfoRaw(c, job.Namespace, job.KernelRepo, job.KernelBranch).Alias,
+		KernelLink:       vcs.CommitLink(job.KernelRepo, job.KernelBranch),
 		KernelCommit:     kernelCommit,
 		KernelCommitLink: vcs.CommitLink(kernelRepo, kernelCommit),
 		PatchLink:        textLink(textPatch, job.Patch),
@@ -1667,6 +1668,24 @@ func (b *bugJobs) bestBisection() *bugJob {
 		}
 		if j.job.MergeBaseRepo != "" {
 			// It was a cross-tree bisection.
+			continue
+		}
+		return j
+	}
+	return nil
+}
+
+// Find the most representative fix candidate bisection result.
+func (b *bugJobs) bestFixCandidate() *bugJob {
+	// Let's take the most recent finished one.
+	for _, j := range b.list {
+		if !j.job.IsFinished() {
+			continue
+		}
+		if j.job.InvalidatedBy != "" {
+			continue
+		}
+		if !j.job.IsCrossTree() {
 			continue
 		}
 		return j

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -240,6 +240,7 @@ type uiBugPage struct {
 	Bug             *uiBug
 	BisectCause     *uiJob
 	BisectFix       *uiJob
+	FixCandidate    *uiJob
 	Sections        []*uiCollapsible
 	SampleReport    template.HTML
 	Crashes         *uiCrashTable
@@ -367,6 +368,7 @@ type uiJob struct {
 	*dashapi.JobInfo
 	Crash             *uiCrash
 	InvalidateJobLink string
+	FixCandidate      bool
 }
 
 type userBugFilter struct {
@@ -838,6 +840,13 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 			return err
 		}
 	}
+	var fixCandidate *uiJob
+	if bug.FixCandidateJob != "" {
+		fixCandidate, err = fixBisections.uiBestFixCandidate(c)
+		if err != nil {
+			return err
+		}
+	}
 	testPatchJobs, err := loadTestPatchJobs(c, bug)
 	if err != nil {
 		return err
@@ -858,6 +867,7 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 		Bug:          uiBug,
 		BisectCause:  bisectCause,
 		BisectFix:    bisectFix,
+		FixCandidate: fixCandidate,
 		Sections:     sections,
 		SampleReport: sampleReport,
 		Crashes:      crashesTable,
@@ -2012,6 +2022,7 @@ func makeUIJob(c context.Context, job *Job, jobKey *db.Key, bug *Bug, crash *Cra
 	ui := &uiJob{
 		JobInfo:           makeJobInfo(c, job, jobKey, bug, build, crash),
 		InvalidateJobLink: invalidateJobLink(c, job, jobKey),
+		FixCandidate:      job.IsCrossTree(),
 	}
 	if crash != nil {
 		ui.Crash = makeUICrash(c, crash, build)
@@ -2136,6 +2147,14 @@ func (b *bugJobs) uiAll(c context.Context) ([]*uiJob, error) {
 
 func (b *bugJobs) uiBestBisection(c context.Context) (*uiJob, error) {
 	j := b.bestBisection()
+	if j == nil {
+		return nil, nil
+	}
+	return j.ui(c)
+}
+
+func (b *bugJobs) uiBestFixCandidate(c context.Context) (*uiJob, error) {
+	j := b.bestFixCandidate()
 	if j == nil {
 		return nil, nil
 	}

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -313,24 +313,32 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{/* Show bisection results */}}
 {{define "bisect_results"}}
 {{if .}}
-	<br>
 	{{$causeJob := 1}}
 	{{$fixJob := 2}}
 	{{if .ErrorLink}}
 		{{if eq .Type $causeJob}}
 			<b>Cause bisection: failed</b>
 		{{else if eq .Type $fixJob}}
-			<b>Fix bisection: failed</b>
+			{{if .FixCandidate}}
+				<b>Fix candidate bisection: failed</b>
+			{{else}}
+			        <b>Fix bisection: failed</b>
+			{{end}}
 		{{end}}
 		<b>({{link .ErrorLink "error log"}}{{if .LogLink}}, {{link .LogLink "bisect log"}}{{end}})</b><br>
 	{{else if .Commit}}
 		{{if eq .Type $causeJob}}
 			<b>Cause bisection: introduced by</b>
 		{{else if eq .Type $fixJob}}
-			<b>Fix bisection: fixed by</b>
+			{{if .FixCandidate}}
+				<b>Fix commit to backport</b>
+			{{else}}
+			        <b>Fix bisection: fixed by</b>
+			{{end}}
 		{{end}}
 		<b>({{link .LogLink "bisect log"}})</b> <span class="bad">{{print .Flags}}</span>:<br>
 		<span class="mono">
+		{{if .FixCandidate}}tree: {{link .KernelLink .KernelAlias}}<br>{{end}}
 		commit {{.Commit.Hash}}<br>
 		Author: {{.Commit.Author}}<br>
 		Date:   {{formatKernelTime .Commit.Date}}<br>
@@ -341,8 +349,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{if eq .Type $causeJob}}
 			<b>Cause bisection: the cause commit could be any of</b>
 		{{else if eq .Type $fixJob}}
-			<b>Fix bisection: the fix commit could be any of</b>
-		{{end}}
+			<b>{{if .FixCandidate}}Fix candidate detection{{else}}Fix bisection{{end}}
+			the fix commit could be any of</b>
+			{{end}}
 		<b>({{link .LogLink "bisect log"}}):</b><br>
 		<span class="mono">
 		{{range $com := .Commits}}
@@ -353,7 +362,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{if eq .Type $causeJob}}
 			<b>Cause bisection: the issue happens on the oldest tested release</b>
 		{{else if eq .Type $fixJob}}
-			<b>Fix bisection: the issue occurs on the latest tested release</b>
+			<b>{{if .FixCandidate}}Fix candidate detection:{{else}}Fix bisection:{{end}}
+			the issue occurs on the latest tested release</b>
 		{{end}}
 		<b>({{link .LogLink "bisect log"}})</b><br>
 	{{end}}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -891,6 +891,7 @@ type JobInfo struct {
 	KernelAlias      string
 	KernelCommit     string
 	KernelCommitLink string
+	KernelLink       string
 	PatchLink        string
 	Attempts         int
 	Started          time.Time

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -364,6 +364,11 @@ aside {
 	width: 20pt;
 }
 
+.fix-candidate-block {
+	background: lightgreen;
+	padding: 5pt;
+}
+
 .bug-bisection-info {
 	float:left;
 	margin-right: 15px;


### PR DESCRIPTION
Display potential fix candidates on the per-bug web pages.