### PR TITLE
pkg/cover: print a warning and discard coverage if module is invalid

### DIFF
--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -79,8 +79,9 @@ func (s Signal) Serialize() Serial {
 	return res
 }
 
-func (ser Serial) UpdateElem(idx int, newElem uint32) {
-	ser.Elems[idx] = elemType(newElem)
+func (ser *Serial) AddElem(elem uint32, prio prioType) {
+	ser.Elems = append(ser.Elems, elemType(elem))
+	ser.Prios = append(ser.Prios, prio)
 }
 
 func (ser Serial) Deserialize() Signal {

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -269,7 +269,7 @@ func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 
 	f := serv.fuzzers[a.Name]
 	if f != nil {
-		f.instModules.Canonicalize(a.Cover, a.Signal)
+		a.Cover, a.Signal = f.instModules.Canonicalize(a.Cover, a.Signal)
 	}
 	// Note: f may be nil if we called shutdownInstance,
 	// but this request is already in-flight.
@@ -378,7 +378,7 @@ func (serv *RPCServer) Poll(a *rpctype.PollArgs, r *rpctype.PollRes) error {
 		}
 	}
 	for _, inp := range r.NewInputs {
-		f.instModules.Decanonicalize(inp.Cover, inp.Signal)
+		inp.Cover, inp.Signal = f.instModules.Decanonicalize(inp.Cover, inp.Signal)
 	}
 	log.Logf(4, "poll from %v: candidates=%v inputs=%v maxsignal=%v",
 		a.Name, len(r.Candidates), len(r.NewInputs), len(r.MaxSignal.Elems))


### PR DESCRIPTION
Addresses https://github.com/google/syzkaller/issues/4078

Does not fix canonicalization when modules change over time, but does unblock fuzzing by avoiding a kernel panic when modules change.
