### PR TITLE
syz-ci: increase bisection confidence cut-off to 0.66

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -549,7 +549,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		if res.IsRelease {
 			resp.Flags |= dashapi.BisectResultRelease
 		}
-		const confidenceCutOff = 0.5
+		const confidenceCutOff = 0.66
 		if res.Confidence < confidenceCutOff {
 			resp.Flags |= dashapi.BisectResultIgnore
 		}


### PR DESCRIPTION
Judging from the bisection logs, the confidence level statistic indeed correlates with the chance of the result being true positive.

Let's use a stricter threshold to publish fewer false positives.
