### PR TITLE
dashboard: use the original KernelRepo

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1524,7 +1524,7 @@ func makeJobInfo(c context.Context, job *Job, jobKey *db.Key, bug *Bug, build *B
 	crash *Crash) *dashapi.JobInfo {
 	kernelRepo, kernelCommit := job.KernelRepo, job.KernelBranch
 	if build != nil {
-		kernelRepo, kernelCommit = build.KernelRepo, build.KernelCommit
+		kernelCommit = build.KernelCommit
 	}
 	info := &dashapi.JobInfo{
 		JobKey:           jobKey.Encode(),


### PR DESCRIPTION
We always set it for jobs and it's always relevant for the result.

The problem is that, for cross-tree bisections, the original crash points to a potentially different tree. As a result, we provide wrong links to the bisected commits.
