### PR TITLE
dashboard: distinguish cross tree job reports

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1322,6 +1322,7 @@ func bisectFromJob(c context.Context, job *Job) (*dashapi.BisectResult, []string
 		CrashLogLink:    externalLink(c, textCrashLog, job.CrashLog),
 		CrashReportLink: externalLink(c, textCrashReport, job.CrashReport),
 		Fix:             job.Type == JobBisectFix,
+		CrossTree:       job.IsCrossTree(),
 	}
 	for _, com := range job.Commits {
 		bisect.Commits = append(bisect.Commits, &dashapi.Commit{

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -485,6 +485,7 @@ type BisectResult struct {
 	CrashLogLink    string
 	CrashReportLink string
 	Fix             bool
+	CrossTree       bool
 }
 
 type BugListReport struct {


### PR DESCRIPTION
Add a new CrossTree field to dashapi.BisectResult in order to distinguish fix candidate results from normal fix bisections.

This is needed for further changes that will be published as a separate PR: https://github.com/google/syzkaller/commit/37cc32e4a46d218bba40426b091a8bc1f8cc8da8
