### PR TITLE
pkg/report: drop "ALT: KMSAN origin" titles for uninit reports

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1374,7 +1374,6 @@ var linuxOopses = append([]*oops{
 				fmt:    "KMSAN: %[1]v in %[3]v",
 				alt: []string{
 					"bad-access in %[3]v",
-					"KMSAN origin in %[4]v",
 				},
 				stack: &stackFmt{
 					parts: []*regexp.Regexp{

--- a/pkg/report/testdata/linux/report/626
+++ b/pkg/report/testdata/linux/report/626
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in prepare_task_switch
-ALT: KMSAN origin in step_into
 ALT: bad-access in prepare_task_switch
 
 [  567.476354][    T1] =====================================================

--- a/pkg/report/testdata/linux/report/632
+++ b/pkg/report/testdata/linux/report/632
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in __perf_event_task_sched_in
-ALT: KMSAN origin in corrupted
 ALT: bad-access in __perf_event_task_sched_in
 CORRUPTED: Y
 

--- a/pkg/report/testdata/linux/report/633
+++ b/pkg/report/testdata/linux/report/633
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in prepend_path
-ALT: KMSAN origin in corrupted
 ALT: bad-access in prepend_path
 CORRUPTED: Y
 

--- a/pkg/report/testdata/linux/report/634
+++ b/pkg/report/testdata/linux/report/634
@@ -1,5 +1,4 @@
 TITLE: KMSAN: kernel-infoleak in urandom_read_nowarn
-ALT: KMSAN origin in crng_reseed
 ALT: bad-access in urandom_read_nowarn
 
 [  600.161674][ T9046] =====================================================

--- a/pkg/report/testdata/linux/report/635
+++ b/pkg/report/testdata/linux/report/635
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in sctp_epaddr_lookup_transport
-ALT: KMSAN origin in sctp_rcv
 ALT: bad-access in sctp_epaddr_lookup_transport
 
 [  701.063465][    C1] =====================================================

--- a/pkg/report/testdata/linux/report/636
+++ b/pkg/report/testdata/linux/report/636
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in ppp_send_frame
-ALT: KMSAN origin in ppp_write
 ALT: bad-access in ppp_send_frame
 
 [   87.733076][ T3479] =====================================================

--- a/pkg/report/testdata/linux/report/670
+++ b/pkg/report/testdata/linux/report/670
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in native_apic_mem_write
-ALT: KMSAN origin in inet_reqsk_alloc
 ALT: bad-access in native_apic_mem_write
 
 [  663.629383][    C1] =====================================================

--- a/pkg/report/testdata/linux/report/671
+++ b/pkg/report/testdata/linux/report/671
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in flush_to_ldisc
-ALT: KMSAN origin in __pskb_copy_fclone
 ALT: bad-access in flush_to_ldisc
 
 [ 1725.922949][   T52] =====================================================

--- a/pkg/report/testdata/linux/report/672
+++ b/pkg/report/testdata/linux/report/672
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in ext4_evict_inode
-ALT: KMSAN origin in ext4_alloc_inode
 ALT: bad-access in ext4_evict_inode
 
 [  345.516988][ T3516] =====================================================

--- a/pkg/report/testdata/linux/report/673
+++ b/pkg/report/testdata/linux/report/673
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in nilfs_bmap_lookup_at_level
-ALT: KMSAN origin in nilfs_alloc_inode
 ALT: bad-access in nilfs_bmap_lookup_at_level
 
 [  231.715107][ T3795] =====================================================

--- a/pkg/report/testdata/linux/report/674
+++ b/pkg/report/testdata/linux/report/674
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in ntfs_iget5
-ALT: KMSAN origin in ntfs_alloc_inode
 ALT: bad-access in ntfs_iget5
 
 [  493.519926][ T7865] =====================================================

--- a/pkg/report/testdata/linux/report/681
+++ b/pkg/report/testdata/linux/report/681
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in net_tx_action
-ALT: KMSAN origin in rtnetlink_rcv
 ALT: bad-access in net_tx_action
 
 [  142.141483][    C0] =====================================================

--- a/pkg/report/testdata/linux/report/682
+++ b/pkg/report/testdata/linux/report/682
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in ieee80211_rx_list
-ALT: KMSAN origin in nfnetlink_rcv
 ALT: bad-access in ieee80211_rx_list
 
 [  338.587187][    C0] BUG: KMSAN: uninit-value in ieee80211_rx_list+0x1839/0x5860

--- a/pkg/report/testdata/linux/report/689
+++ b/pkg/report/testdata/linux/report/689
@@ -1,5 +1,4 @@
 TITLE: KMSAN: kernel-infoleak in kernfs_fop_read_iter
-ALT: KMSAN origin in dev_set_name
 ALT: bad-access in kernfs_fop_read_iter
 
 [  160.663319][ T5029] =====================================================

--- a/pkg/report/testdata/linux/report/690
+++ b/pkg/report/testdata/linux/report/690
@@ -1,5 +1,4 @@
 TITLE: KMSAN: kernel-infoleak in __skb_datagram_iter
-ALT: KMSAN origin in pfkey_add
 ALT: bad-access in __skb_datagram_iter
 
 [ 2104.495854][ T4311] =====================================================

--- a/pkg/report/testdata/linux/report/699
+++ b/pkg/report/testdata/linux/report/699
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in aes_encrypt
-ALT: KMSAN origin in ext4_write_begin
 ALT: bad-access in aes_encrypt
 
 [  311.903743][ T5388] =====================================================

--- a/pkg/report/testdata/linux/report/700
+++ b/pkg/report/testdata/linux/report/700
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in virtqueue_add
-ALT: KMSAN origin in ext4_da_write_begin
 ALT: bad-access in virtqueue_add
 
 [  897.203644][ T1083] =====================================================

--- a/pkg/report/testdata/linux/report/701
+++ b/pkg/report/testdata/linux/report/701
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in btrfs_bin_search
-ALT: KMSAN origin in alloc_extent_buffer
 ALT: bad-access in btrfs_bin_search
 
 [  343.493742][ T5647] =====================================================

--- a/pkg/report/testdata/linux/report/702
+++ b/pkg/report/testdata/linux/report/702
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in post_read_mst_fixup
-ALT: KMSAN origin in map_mft_record
 ALT: bad-access in post_read_mst_fixup
 
 [  355.605345][ T5697] =====================================================

--- a/pkg/report/testdata/linux/report/703
+++ b/pkg/report/testdata/linux/report/703
@@ -1,5 +1,4 @@
 TITLE: KMSAN: uninit-value in nilfs_add_checksums_on_logs
-ALT: KMSAN origin in block_write_begin
 ALT: bad-access in nilfs_add_checksums_on_logs
 
 [  417.716144][ T7542] =====================================================


### PR DESCRIPTION
It was initially proposed in
https://github.com/google/syzkaller/issues/1575 that KMSAN reports with the same origin should be clustered together using an alt title.

This however turns out to be too aggressive: certain KMSAN reports have their uninitialized values originating from common functions - this leads to too many KMSAN reports being glued together. Because KMSAN reports can be also clustered with KASAN reports or other kernel panics, ultimately seemingly unrelated crashes are considered similar just because they share their top frames with two KMSAN reports that, in turn, share the same origin.

The resulting issues on the dashboard look confusing to the users, they are hard to find and require manual untangling, which probably outweighs the benefits of having KMSAN issues with exactly the same origin clustered together.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
