### PR TITLE
dashboard: report fix candidate commits per email

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1198,11 +1198,6 @@ func pollCompletedJobs(c context.Context, typ string) ([]*dashapi.BugReport, err
 		if job.Type == JobBisectFix && len(job.Commits) != 1 {
 			continue
 		}
-		// Don't report cross-tree bisection results for now as we need to first understand
-		// how reliable their results are.
-		if job.IsCrossTree() {
-			continue
-		}
 		// If the bug is already known to be fixed, invalid or duplicate, do not report the bisection results.
 		if job.Type == JobBisectCause || job.Type == JobBisectFix {
 			bug := new(Bug)

--- a/dashboard/app/mail_fix_candidate.txt
+++ b/dashboard/app/mail_fix_candidate.txt
@@ -1,0 +1,22 @@
+{{$bisect := .BisectFix}}syzbot suspects this issue could be fixed by backporting the following commit:
+
+commit {{$bisect.Commit.Hash}}
+git tree: {{.KernelRepoAlias}}
+Author: {{$bisect.Commit.AuthorName}} <{{$bisect.Commit.Author}}>
+Date:   {{formatKernelTime $bisect.Commit.Date}}
+
+    {{$bisect.Commit.Title}}
+
+bisection log:  {{$bisect.LogLink}}
+{{if $bisect.CrashReportLink}}final oops:     {{$bisect.CrashReportLink}}
+{{end}}{{if $bisect.CrashLogLink}}console output: {{$bisect.CrashLogLink}}
+{{end}}{{if .KernelConfigLink}}kernel config:  {{.KernelConfigLink}}
+{{end}}dashboard link: {{.Link}}
+{{if .UserSpaceArch}}userspace arch: {{.UserSpaceArch}}
+{{end}}{{if .ReproSyzLink}}syz repro:      {{.ReproSyzLink}}
+{{end}}{{if .ReproCLink}}C reproducer:   {{.ReproCLink}}
+{{end}}
+
+Please keep in mind that other backports might be required as well.
+
+For information about bisection process see: https://goo.gl/tpsmEJ#bisection

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -343,8 +343,17 @@ func emailReport(c context.Context, rep *dashapi.BugReport) error {
 	case dashapi.ReportTestPatch:
 		templ = "mail_test_result.txt"
 		cfg.MailMaintainers = false
-	case dashapi.ReportBisectCause, dashapi.ReportBisectFix:
+	case dashapi.ReportBisectCause:
 		templ = "mail_bisect_result.txt"
+	case dashapi.ReportBisectFix:
+		if rep.BisectFix.CrossTree {
+			templ = "mail_fix_candidate.txt"
+			if rep.BisectFix.Commit == nil {
+				return fmt.Errorf("reporting failed fix candidate bisection for %s", rep.ID)
+			}
+		} else {
+			templ = "mail_bisect_result.txt"
+		}
 	default:
 		return fmt.Errorf("unknown report type %v", rep.Type)
 	}


### PR DESCRIPTION
Enable reporting of the results of cross-tree bisections.

Adjust email reporting to differentiate between normal fix bisections and fix candidate reporting.
