### PR TITLE
syz-ci: accept the global per-syz-ci backport list

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -503,7 +503,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 			Config:         req.KernelConfig,
 			BaselineConfig: baseline,
 			Userspace:      mgr.mgrcfg.Userspace,
-			Backports:      mgr.mgrcfg.BisectBackports,
+			Backports:      mgr.backportCommits(),
 		},
 		Syzkaller: bisect.SyzkallerConfig{
 			Repo:   jp.cfg.SyzkallerRepo,

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -686,6 +686,13 @@ func (mgr *Manager) pollCommits(buildCommit string) ([]string, []dashapi.Commit,
 	return present, fixCommits, nil
 }
 
+func (mgr *Manager) backportCommits() []vcs.BackportCommit {
+	return append(
+		append([]vcs.BackportCommit{}, mgr.cfg.BisectBackports...),
+		mgr.mgrcfg.BisectBackports...,
+	)
+}
+
 func (mgr *Manager) uploadBuildAssets(buildInfo *dashapi.Build, assetFolder string) ([]dashapi.NewAsset, error) {
 	if mgr.storage == nil {
 		// No reason to continue anyway.

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -117,8 +117,11 @@ type Config struct {
 	// in bisection results.
 	// Values of the map are ignored and can e.g. serve as comments.
 	BisectIgnore map[string]string `json:"bisect_ignore"`
-	Ccache       string            `json:"ccache"`
-	Managers     []*ManagerConfig  `json:"managers"`
+	// Extra commits to cherry-pick to older kernel revisions.
+	// The list is concatenated with the similar parameter from ManagerConfig.
+	BisectBackports []vcs.BackportCommit `json:"bisect_backports"`
+	Ccache          string               `json:"ccache"`
+	Managers        []*ManagerConfig     `json:"managers"`
 	// Poll period for jobs in seconds (optional, defaults to 10 seconds)
 	JobPollPeriod int `json:"job_poll_period"`
 	// Set up a second (parallel) job processor to speed up processing.


### PR DESCRIPTION
Now that we also support checking whether the guilty commit is present, we can afford to share the custom backport list among all syz-ci managers in a number of cases.
