### PR TITLE
dashboard: don't close bugs on cross-tree fix findings

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -512,8 +512,9 @@ var testConfig = &GlobalConfig{
 			},
 		},
 		"tree-tests": {
-			AccessLevel: AccessPublic,
-			Key:         "treeteststreeteststreeteststreeteststreeteststreetests",
+			AccessLevel:           AccessPublic,
+			FixBisectionAutoClose: true,
+			Key:                   "treeteststreeteststreeteststreeteststreeteststreetests",
 			Clients: map[string]string{
 				clientTreeTests: keyTreeTests,
 			},

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -1219,5 +1219,12 @@ func addBisectFixJob(c *Ctx, build *dashapi.Build) (*dashapi.JobPollResp, *dasha
 	c.expectOK(c.client2.JobDone(done))
 	msg := c.client2.pollEmailBug()
 	c.expectTrue(strings.Contains(msg.Body, "syzbot suspects this issue was fixed by commit:"))
+
+	// Ensure we do not automatically close the bug.
+	c.expectTrue(!config.Namespaces["test2"].FixBisectionAutoClose)
+	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
+	c.expectOK(err)
+	dbBug, _, _ := c.loadBug(extBugID)
+	c.expectTrue(len(dbBug.Commits) == 0)
 	return resp, done, jobID
 }

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1355,6 +1355,7 @@ func jobReported(c context.Context, jobID string) error {
 		// if the setting is enabled for the namespace.
 		if job.Type == JobBisectFix &&
 			config.Namespaces[job.Namespace].FixBisectionAutoClose &&
+			!job.IsCrossTree() &&
 			len(job.Commits) == 1 {
 			bug := new(Bug)
 			bugKey := jobKey.Parent()

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -287,6 +287,10 @@ For information about bisection process see: %URL%#bisection
 	commit := fix.BisectFix.Commit
 	assert.Equal(t, "deadf00d", commit.Hash)
 	assert.Equal(t, "kernel: fix a bug", commit.Title)
+
+	// Ensure the bug is not automatically closed.
+	bug := ctx.loadBug()
+	assert.Len(t, bug.Commits, 0)
 }
 
 func TestTreeOriginErrors(t *testing.T) {


### PR DESCRIPTION
Accept only normal fix bisections as a reason to auto-close a bug if FixBisectionAutoClose is set to true.
