### PR TITLE
dashboard: fix a nil pointer dereference

### DIFF
--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -737,6 +737,10 @@ func crossTreeBisection(c context.Context, bug *Bug,
 		log.Infof(c, "%s: considering cross-tree bisection %s/%s",
 			bug.displayTitle(), from.repo.Alias, to.repo.Alias)
 		_, crashJob := bug.findResult(c, to.repo, wantNewAny{}, runOnHEAD{})
+		if crashJob == nil {
+			// No patch testing was performed yet.
+			return nil
+		}
 		if crashJob.CrashTitle == "" {
 			// The bug is already fixed on the target tree.
 			return nil

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -293,6 +293,19 @@ For information about bisection process see: %URL%#bisection
 	assert.Len(t, bug.Commits, 0)
 }
 
+func TestTreeBisectionBeforeOrigin(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	ctx := setUpTreeTest(c, downstreamUpstreamRepos)
+	ctx.uploadBug(`https://downstream.repo/repo`, `master`, dashapi.ReproLevelC)
+	ctx.reportToEmail()
+	// Ensure the job is no longer created.
+	ctx.ctx.advanceTime(time.Hour)
+	job := ctx.client.pollSpecificJobs(ctx.manager, dashapi.ManagerJobs{BisectFix: true})
+	assert.Equal(t, "", job.ID)
+}
+
 func TestTreeOriginErrors(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()


### PR DESCRIPTION
If bug's origin has not yet been determined, the dashboard app might crash with "panic: runtime error: invalid memory address or nil pointer dereference" at dashboard/app/tree.go:740.

Fix this and add a test.
