### PR TITLE
dashboard: enable CONFIG_PVH from v5.0

### DIFF
--- a/dashboard/config/linux/bits/x86_64.yml
+++ b/dashboard/config/linux/bits/x86_64.yml
@@ -58,4 +58,4 @@ config:
  - PM_TRACE_RTC: [optional]
 
  # Allows to boot kernel via qemu directly from a vmlinux file.
- - PVH
+ - PVH: [v5.0]


### PR DESCRIPTION
It's not present in earlier versions.