### PR TITLE
dashboard: support subsystem redirects

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -309,6 +309,9 @@ var testConfig = &GlobalConfig{
 			RetestRepros: true,
 			Subsystems: SubsystemsConfig{
 				Service: subsystem.MustMakeService(testSubsystems),
+				Redirect: map[string]string{
+					"oldSubsystem": "subsystemA",
+				},
 			},
 		},
 		// The second namespace reporting to the same mailing list.

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -131,6 +131,8 @@ type SubsystemsConfig struct {
 	Revision int
 	// Periodic per-subsystem reminders about open bugs.
 	Reminder *BugListReportingConfig
+	// Maps old subsystem names to new ones.
+	Redirect map[string]string
 }
 
 // BugListReportingConfig describes how aggregated reminders about open bugs should be processed.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -511,7 +511,12 @@ func handleSubsystemPage(c context.Context, w http.ResponseWriter, r *http.Reque
 	}
 	var subsystem *subsystem.Subsystem
 	if pos := strings.Index(r.URL.Path, "/s/"); pos != -1 {
-		subsystem = service.ByName(r.URL.Path[pos+3:])
+		name := r.URL.Path[pos+3:]
+		if newName := config.Namespaces[hdr.Namespace].Subsystems.Redirect[name]; newName != "" {
+			http.Redirect(w, r, r.URL.Path[:pos+3]+newName, http.StatusMovedPermanently)
+			return nil
+		}
+		subsystem = service.ByName(name)
 	}
 	if subsystem == nil {
 		return fmt.Errorf("%w: the subsystem is not found in the path %v", ErrClientBadRequest, r.URL.Path)


### PR DESCRIPTION
There are cases when subsystem names change over time. As we share /namespace/s/name links in our reminder emails, we have to make sure they remain valid.

Introduce an old => new name map into the dashboard configuration.