### PR TITLE
pkg/bisect: differentiate between revisions with a fixed and with a not-yet-introduced bug

### DIFF
--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -540,11 +540,11 @@ var bisectionTests = []BisectionTest{
 	{
 		name:        "fix-inconclusive",
 		fix:         true,
-		startCommit: 400,
-		brokenStart: 500,
-		brokenEnd:   600,
-		commitLen:   8,
-		fixCommit:   "501",
+		startCommit: 500,
+		brokenStart: 600,
+		brokenEnd:   700,
+		commitLen:   9,
+		fixCommit:   "601",
 	},
 	{
 		name:            "cause-same-binary",


### PR DESCRIPTION
_It might be easier to review the PR per-commit rather than as a whole._

If there's a merge from a branch that was based on a much older
revision, it's likely that it does not YET contain the bug. If we don't
consider this possibility, we're likely to get invalid fix bisection
results for bugs that existed only for a short period of time.

For every fix bisection step, determine first whether the guilty
revision is reachable from it. Cache resuls to speed up processing.

Closes https://github.com/google/syzkaller/issues/4117.