### PR TITLE
dashboard: let admins retry jobs from job lists

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -2039,11 +2039,12 @@ func invalidateJobLink(c context.Context, job *Job, jobKey *db.Key) string {
 	if !user.IsAdmin(c) {
 		return ""
 	}
-
+	if job.InvalidatedBy != "" || job.Finished.IsZero() {
+		return ""
+	}
 	if job.Type != JobBisectCause && job.Type != JobBisectFix {
 		return ""
 	}
-
 	params := url.Values{}
 	params.Add("action", "invalidate_bisection")
 	params.Add("key", jobKey.Encode())

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -492,6 +492,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					{{ if $job.InvalidatedBy }}
 						</br>marked invalid by {{$job.InvalidatedBy}}
 					{{end}}
+					{{if and .InvalidateJobLink $.PerBug}}<br/>{{optlink .InvalidateJobLink "❌ retry this bisection"}}{{end}}
 				</td>
 			</tr>
 		{{end}}


### PR DESCRIPTION
Currently we only display the link for latest fix/cause bisections on the bug page.

Also display it inside the collapsible job lists.
