### PR TITLE
dashboard: restructure repro retesting configuration

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -520,8 +520,9 @@ func createPatchRetestingJobs(c context.Context, bugs []*Bug, bugKeys []*db.Key,
 			// Repro retesting is disabled for the namespace.
 			continue
 		}
-		if timeNow(c).Sub(bug.LastTime) < config.Obsoleting.ReproRetestPeriod {
-			// Also don't retest reproducers if crashes are still happening.
+		if config.Obsoleting.ReproRetestPeriod == 0 ||
+			timeNow(c).Sub(bug.LastTime) < config.Obsoleting.ReproRetestStart {
+			// Don't retest reproducers if crashes are still happening.
 			continue
 		}
 		takeBugs--

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -431,7 +431,7 @@ func TestReproRetestJob(t *testing.T) {
 	c.expectEQ(bug.ReproLevel, ReproLevelC)
 
 	// Let's say that the C repro testing has failed.
-	c.advanceTime(config.Obsoleting.ReproRetestPeriod + time.Hour)
+	c.advanceTime(config.Obsoleting.ReproRetestStart + time.Hour)
 	for i := 0; i < 2; i++ {
 		resp := client.pollSpecificJobs(build.Manager, dashapi.ManagerJobs{TestPatches: true})
 		c.expectEQ(resp.Type, dashapi.JobTestPatch)


### PR DESCRIPTION
Currently we wait ReproRetestPeriod both to start retesting and to retest every reproducer that's still working. That's not very convenient.

In some cases (e.g. for linux-next), it's often the case that bugs are quickly introduced and quickly resolved. Let's adapt to this and retest the reproducer once shortly after crashes stopped coming and then once in a potentially long ReproRetestPeriod.

Depending on the results, later we'll use this to also close such bugs earlier.
