### PR TITLE
dashboard: unset labels also by value

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1200,6 +1200,11 @@ func TestEmailSetSubsystems(t *testing.T) {
 	c.incomingEmail(sender, "#syz set subsystems: subsystemA, subsystemB\n",
 		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
 	expectLabels(t, client, extBugID, "subsystems:subsystemA", "subsystems:subsystemB")
+
+	// Unset one subsystem by value.
+	c.incomingEmail(sender, "#syz unset: subsystemB\n",
+		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
+	expectLabels(t, client, extBugID, "subsystems:subsystemA")
 }
 
 func TestEmailBugLabels(t *testing.T) {

--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -227,6 +227,25 @@ func (bug *Bug) UnsetLabels(labels ...BugLabelType) map[BugLabelType]struct{} {
 	return notFound
 }
 
+func (bug *Bug) UnsetLabelValues(values ...string) map[string]struct{} {
+	toDelete := map[string]struct{}{}
+	notFound := map[string]struct{}{}
+	for _, val := range values {
+		toDelete[val] = struct{}{}
+		notFound[val] = struct{}{}
+	}
+	var newList []BugLabel
+	for _, item := range bug.Labels {
+		if _, ok := toDelete[item.Value]; ok && item.Value != "" {
+			delete(notFound, item.Value)
+			continue
+		}
+		newList = append(newList, item)
+	}
+	bug.Labels = newList
+	return notFound
+}
+
 func (bug *Bug) HasUserLabel(label BugLabelType) bool {
 	for _, item := range bug.Labels {
 		if item.Label == label && item.SetBy != "" {


### PR DESCRIPTION
It looks to be more intuitive for users to use `#syz unset` than `#syz set subsystems: <new list>`.

Adjust syzbot's command handling mechanism to support label unsetting by values.
