### PR TITLE
dashboard: emphasise that #syz set overwrites subsystems

### DIFF
--- a/dashboard/app/asset_storage_test.go
+++ b/dashboard/app/asset_storage_test.go
@@ -104,7 +104,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.
 If the bug is already fixed, let syzbot know by replying with:
 #syz fix: exact-commit-title
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -396,7 +396,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.
 If the bug is already fixed, let syzbot know by replying with:
 #syz fix: exact-commit-title
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -244,7 +244,7 @@ If you want syzbot to run the reproducer, reply with:
 #syz test: git://repo/address.git branch-or-commit-hash
 If you attach or paste a git patch, syzbot will apply it before testing.
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -563,7 +563,7 @@ If you want syzbot to run the reproducer, reply with:
 #syz test: git://repo/address.git branch-or-commit-hash
 If you attach or paste a git patch, syzbot will apply it before testing.
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -847,7 +847,7 @@ If you want syzbot to run the reproducer, reply with:
 #syz test: git://repo/address.git branch-or-commit-hash
 If you attach or paste a git patch, syzbot will apply it before testing.
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -76,7 +76,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.
 If the bug is already fixed, let syzbot know by replying with:
 #syz fix: exact-commit-title
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -259,7 +259,7 @@ If you want syzbot to run the reproducer, reply with:
 #syz test: git://repo/address.git branch-or-commit-hash
 If you attach or paste a git patch, syzbot will apply it before testing.
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -703,7 +703,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.
 If the bug is already fixed, let syzbot know by replying with:
 #syz fix: exact-commit-title
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 
@@ -873,7 +873,7 @@ https://goo.gl/tpsmEJ#status for how to communicate with syzbot.
 If the bug is already fixed, let syzbot know by replying with:
 #syz fix: exact-commit-title
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 

--- a/dashboard/app/mail_bug.txt
+++ b/dashboard/app/mail_bug.txt
@@ -66,7 +66,7 @@ If you want syzbot to run the reproducer, reply with:
 If you attach or paste a git patch, syzbot will apply it before testing.
 {{- end}}
 
-If you want to change bug's subsystems, reply with:
+If you want to overwrite bug's subsystems, reply with:
 #syz set subsystems: new-subsystem
 (See the list of subsystem names on the web dashboard)
 


### PR DESCRIPTION
Update the bug cheatsheet to emphasise that "#syz set subsystems" does not add new subsystems, but rather overwrites the whole list.
