### PR TITLE
syz-build: don't require kernel config file

### DIFF
--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -35,9 +35,13 @@ func main() {
 		fmt.Printf("not running under root, image build may fail\n")
 	}
 	os.Setenv("SYZ_DISABLE_SANDBOXING", "yes")
-	kernelConfig, err := os.ReadFile(*flagKernelConfig)
-	if err != nil {
-		tool.Fail(err)
+	var kernelConfig []byte
+	if *flagKernelConfig != "" {
+		var err error
+		kernelConfig, err = os.ReadFile(*flagKernelConfig)
+		if err != nil {
+			tool.Fail(err)
+		}
 	}
 	params := build.Params{
 		TargetOS:     *flagOS,

--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -43,12 +43,16 @@ func main() {
 			tool.Fail(err)
 		}
 	}
+	wd, err := os.Getwd()
+	if err != nil {
+		tool.Fail(err)
+	}
 	params := build.Params{
 		TargetOS:     *flagOS,
 		TargetArch:   *flagArch,
 		VMType:       *flagVM,
 		KernelDir:    *flagKernelSrc,
-		OutputDir:    ".",
+		OutputDir:    wd,
 		Compiler:     *flagCompiler,
 		Linker:       *flagLinker,
 		Ccache:       "",


### PR DESCRIPTION
syz-build implicitly requires a kernel config file to be present. Make it optional as it's not required by all syzkaller-supported OSes.
