### PR TITLE
dashboard: display backport lists

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -293,6 +293,12 @@ var testConfig = &GlobalConfig{
 					Branch: "access-public-email",
 					Alias:  "access-public-email",
 				},
+				{
+					// Needed for TestTreeOriginLtsBisection().
+					URL:    "https://upstream.repo/repo",
+					Branch: "upstream-master",
+					Alias:  "upstream-master",
+				},
 			},
 			Reporting: []Reporting{
 				{
@@ -531,7 +537,7 @@ var testConfig = &GlobalConfig{
 			},
 			Reporting: []Reporting{
 				{
-					AccessLevel: AccessUser,
+					AccessLevel: AccessAdmin,
 					Name:        "non-public",
 					DailyLimit:  1000,
 					Filter: func(bug *Bug) FilterResult {
@@ -540,8 +546,8 @@ var testConfig = &GlobalConfig{
 					Config: &TestConfig{Index: 1},
 				},
 				{
-					AccessLevel: AccessPublic,
-					Name:        "public",
+					AccessLevel: AccessUser,
+					Name:        "user",
 					DailyLimit:  1000,
 					Config: &EmailConfig{
 						Email:         "bugs@syzkaller.com",

--- a/dashboard/app/backports.html
+++ b/dashboard/app/backports.html
@@ -1,0 +1,45 @@
+{{/*
+Copyright 2023 syzkaller project authors. All rights reserved.
+Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+*/}}
+
+<!doctype html>
+<html>
+<head>
+	{{template "head" .Header}}
+	<title>syzbot</title>
+</head>
+<body>
+	{{template "header" .Header}}
+	{{$getName := .DisplayNamespace}}
+	{{range $group := .Groups}}
+        <b>{{$group.From.URL}} {{$group.From.Branch}} → {{$group.To.URL}} {{$group.To.Branch}}</b><br />
+        
+	<table class="list_table">
+		<tr>
+			<th>Commit</th>
+			{{range $ns := .Namespaces}}
+			<th>{{call $getName $ns}}</th>
+			{{end}}
+		</tr>
+		{{range $backport := $group.List}}
+		<tr>
+			<td class="commit_list">
+			{{link $backport.Commit.Link (formatShortHash $backport.Commit.Hash)}}
+			{{$backport.Commit.Title}}
+			</td>
+			{{range $ns := $group.Namespaces}}
+			<td>
+			{{$bugs := index $backport.Bugs $ns}}
+				{{range $i, $bug := $bugs}}
+					{{if gt $i 0}}<br/>{{end}}
+					{{link $bug.Link $bug.Title}}
+				{{end}}
+			</td>
+                        {{end}}
+		</tr>
+		{{end}}
+	</table>
+	{{end}}
+</body>
+</html>

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -130,6 +130,7 @@ type uiHeader struct {
 	Namespace           string
 	ContactEmail        string
 	BugCounts           *CachedBugStats
+	MissingBackports    int
 	Namespaces          []uiNamespace
 	ShowSubsystems      bool
 }
@@ -215,6 +216,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 			return nil, err
 		}
 		h.BugCounts = &cached.Total
+		h.MissingBackports = cached.MissingBackports
 	}
 	return h, nil
 }

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -119,6 +119,11 @@ indexes:
   - name: Labels.Value
   - name: Status
 
+- kind: Bug
+  properties:
+  - name: Status
+  - name: FixCandidateJob
+
 - kind: Build
   properties:
   - name: Namespace

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -70,6 +70,10 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 						<span style="color:ForestGreen;">🐞</span> Fixed [{{$.BugCounts.Fixed}}]</a>
 					<a class="navigation_tab{{if eq .URLPath (printf "/%v/invalid" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/invalid'>
 						<span style="color:RoyalBlue;">🐞</span> Invalid [{{$.BugCounts.Invalid}}]</a>
+					{{if gt .MissingBackports 0}}
+                                        <a class="navigation_tab{{if eq .URLPath (printf "/%v/backports" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/backports'>
+						<span style="color:ForestGreen;">⬇</span> Missing Backports [{{$.MissingBackports}}]</a>
+					{{end}}
 					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/bugs" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/graph/bugs'>
 						<span style="color:DarkOrange;">📈</span> Kernel Health</a>
 					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/graph/lifetimes'>


### PR DESCRIPTION
Add a per-namespace page that contains:
1) The list of commits to backport from the trees fuzzed in that
   namespace.
2) The list of commits to backport into the namespace.

