### PR TITLE
dashboard: differentiate between restarting and invalidating a job

### DIFF
--- a/dashboard/app/admin.go
+++ b/dashboard/app/admin.go
@@ -25,7 +25,7 @@ func handleInvalidateBisection(c context.Context, w http.ResponseWriter, r *http
 		return fmt.Errorf("failed to decode job key %v: %w", encodedKey, err)
 	}
 
-	err = invalidateBisection(c, jobKey)
+	err = invalidateBisection(c, jobKey, r.FormValue("restart") == "1")
 	if err != nil {
 		return fmt.Errorf("failed to invalidate job %v: %w", jobKey, err)
 	}
@@ -182,7 +182,7 @@ func restartFailedBisections(c context.Context, w http.ResponseWriter, r *http.R
 		return nil
 	}
 	for idx, jobKey := range toReset {
-		err = invalidateBisection(c, jobKey)
+		err = invalidateBisection(c, jobKey, true)
 		if err != nil {
 			fmt.Fprintf(w, "job %v update failed: %s", idx, err)
 		}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -711,7 +711,7 @@ func loadAllBackports(c context.Context) ([]*rawBackport, error) {
 		if !job.IsCrossTree() {
 			return nil, fmt.Errorf("job %s: expected to be cross-tree", jobKeys[i])
 		}
-		if len(job.Commits) != 1 {
+		if len(job.Commits) != 1 || job.InvalidatedBy != "" {
 			continue
 		}
 		jobCommit := job.Commits[0]

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -377,6 +377,7 @@ type uiJob struct {
 	*dashapi.JobInfo
 	Crash             *uiCrash
 	InvalidateJobLink string
+	RestartJobLink    string
 	FixCandidate      bool
 }
 
@@ -2225,7 +2226,8 @@ func loadTestPatchJobs(c context.Context, bug *Bug) ([]*uiJob, error) {
 func makeUIJob(c context.Context, job *Job, jobKey *db.Key, bug *Bug, crash *Crash, build *Build) *uiJob {
 	ui := &uiJob{
 		JobInfo:           makeJobInfo(c, job, jobKey, bug, build, crash),
-		InvalidateJobLink: invalidateJobLink(c, job, jobKey),
+		InvalidateJobLink: invalidateJobLink(c, job, jobKey, false),
+		RestartJobLink:    invalidateJobLink(c, job, jobKey, true),
 		FixCandidate:      job.IsCrossTree(),
 	}
 	if crash != nil {
@@ -2234,7 +2236,7 @@ func makeUIJob(c context.Context, job *Job, jobKey *db.Key, bug *Bug, crash *Cra
 	return ui
 }
 
-func invalidateJobLink(c context.Context, job *Job, jobKey *db.Key) string {
+func invalidateJobLink(c context.Context, job *Job, jobKey *db.Key, restart bool) string {
 	if !user.IsAdmin(c) {
 		return ""
 	}
@@ -2247,6 +2249,9 @@ func invalidateJobLink(c context.Context, job *Job, jobKey *db.Key) string {
 	params := url.Values{}
 	params.Add("action", "invalidate_bisection")
 	params.Add("key", jobKey.Encode())
+	if restart {
+		params.Add("restart", "1")
+	}
 	return "/admin?" + params.Encode()
 }
 

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -379,7 +379,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{end}}
 
 	{{if not .Reported}}[report pending]<br>{{end}}
-	{{optlink .InvalidateJobLink "❌ retry this bisection"}}
+	{{optlink .RestartJobLink "🔄 retry this bisection"}}&nbsp;&nbsp;
+	{{optlink .InvalidateJobLink "❌ mark as invalid"}}
 {{end}}
 {{end}}
 
@@ -496,7 +497,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					{{ if $job.InvalidatedBy }}
 						</br>marked invalid by {{$job.InvalidatedBy}}
 					{{end}}
-					{{if and .InvalidateJobLink $.PerBug}}<br/>{{optlink .InvalidateJobLink "❌ retry this bisection"}}{{end}}
+					{{if and $.PerBug (or .InvalidateJobLink .RestartJobLink)}}<br/>{{optlink .RestartJobLink "🔄 retry this bisection"}}&nbsp;&nbsp;{{optlink .InvalidateJobLink "❌ mark as invalid"}}{{end}}
 				</td>
 			</tr>
 		{{end}}


### PR DESCRIPTION
In some cases restarting the failed bisection does not make sense,
because we know that the result will be the same.

Let admins choose between invalidating the job and restarting it.