### PR TITLE
pkg/bisect: test merge base for cross-tree bisections

### DIFF
--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -673,6 +673,31 @@ var bisectionTests = []BisectionTest{
 		introduced:        "602",
 		noFakeHashTest:    true,
 	},
+	{
+		// There's no fix for the bug because it was introduced
+		// in another tree.
+		name:              "no-fix-cross-tree",
+		fix:               true,
+		startCommit:       852,
+		startCommitBranch: "v8-branch",
+		commitLen:         0,
+		crossTree:         true,
+		introduced:        "851",
+		oldestLatest:      800,
+	},
+	{
+		// We are unable to test the merge base commit.
+		name:              "fix-cross-tree-broken-start",
+		fix:               true,
+		startCommit:       851,
+		startCommitBranch: "v8-branch",
+		commitLen:         0,
+		crossTree:         true,
+		fixCommit:         "903",
+		brokenStart:       800,
+		brokenEnd:         800,
+		oldestLatest:      800,
+	},
 }
 
 func TestBisectionResults(t *testing.T) {


### PR DESCRIPTION
Consider the following situation: we're fix bisecting an lts bug on the mainline tree. Reproducer works on lts HEAD, but does not crash the mainline.

If the bug was not introduced in the mainline, but it's a purely lts bug, bisection would currently end up pointing to the mainline HEAD (in #4123, we assume env.commit to be a commit on the tree we're currently bisecting, otherwise we'd always hit the same merge base commit).

Let's first determine 100% correct bisection range on the mainline tree by testing that both the HEAD does not crash (we already do) and by testing that the new starting commit (=merge base) can be crashed by the reproducer.
