### PR TITLE
dashboard/app: increase the repro retesting start period

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -180,7 +180,7 @@ type ObsoletingConfig struct {
 	ReproRetestPeriod time.Duration
 	// Reproducer retesting begins after there have been no crashes during
 	// the ReproRetestStart period.
-	// By default, it's 7 days.
+	// By default, it's 14 days.
 	ReproRetestStart time.Duration
 }
 
@@ -405,7 +405,7 @@ func checkObsoleting(o *ObsoletingConfig) {
 		panic("obsoleting: NonFinalMinPeriod without MinPeriod")
 	}
 	if o.ReproRetestStart == 0 {
-		o.ReproRetestStart = time.Hour * 24 * 7
+		o.ReproRetestStart = time.Hour * 24 * 14
 	}
 }
 


### PR DESCRIPTION
7 days was a too low figure that has caused too many unnecessary reproducer retests. Increase it to 14.