### PR TITLE
dashboard: generate more cross tree bisections

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -452,7 +452,7 @@ func jobFromBugSample(c context.Context, managers map[string]dashapi.ManagerJobs
 func createTreeBisectionJobs(c context.Context, bugs []*Bug, bugKeys []*db.Key,
 	managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, error) {
 	log.Infof(c, "createTreeBisectionJobs is called for %d bugs", len(bugs))
-	const maxProcess = 3
+	const maxProcess = 2
 	processed := 0
 	for _, bug := range bugs {
 		if bug.FixCandidateJob != "" {
@@ -469,10 +469,15 @@ func createTreeBisectionJobs(c context.Context, bugs []*Bug, bugKeys []*db.Key,
 		if !any {
 			continue
 		}
-		processed++
-		job, key, err := crossTreeBisection(c, bug, managers)
+		job, key, expensive, err := crossTreeBisection(c, bug, managers)
 		if job != nil || err != nil {
 			return job, key, err
+		}
+		if expensive {
+			// Only count expensive lookups.
+			// It we didn't have to query anything from the DB, it's not a problem to
+			// examine more bugs.
+			processed++
 		}
 	}
 	return nil, nil, nil


### PR DESCRIPTION
Currently these jobs are heavily underrepresented -- we rarely get to generate them and, when we do, we only look up 3 random bugs.

At the same time, for the majority of issues, the check is rather cheap, we don't even have to query anything from the DB.

Split the job generation results into expensive (= extra DB queries needed) and non-expensive (= it was enough to examine *Bug) one. Limit only the amount of the former ones.