### PR TITLE
dashboard: update subsystems for all bugs

### DIFF
--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -115,6 +115,11 @@ indexes:
 - kind: Bug
   properties:
   - name: Namespace
+  - name: SubsystemsRev
+
+- kind: Bug
+  properties:
+  - name: Namespace
   - name: Labels.Label
   - name: Labels.Value
   - name: Status

--- a/dashboard/app/subsystem.go
+++ b/dashboard/app/subsystem.go
@@ -66,10 +66,14 @@ func bugsToUpdateSubsystems(c context.Context, ns string, count int) ([]*Bug, []
 			Filter("Namespace=", ns).
 			Filter("Status=", BugStatusOpen).
 			Filter("SubsystemsTime<", now.Add(-openBugsUpdateTime)),
-		// And, finally, let's consider the update of closed bugs.
+		// Then let's consider the update of closed bugs.
 		db.NewQuery("Bug").
 			Filter("Namespace=", ns).
 			Filter("Status=", BugStatusFixed).
+			Filter("SubsystemsRev<", rev),
+		// And, at the end, everything else.
+		db.NewQuery("Bug").
+			Filter("Namespace=", ns).
 			Filter("SubsystemsRev<", rev),
 	}
 	var bugs []*Bug


### PR DESCRIPTION
Although we currently do not highlight the number of per-subsystem invalid and dup bugs, we still lack consistency in the Bug table, which complicates statistics collection for us.

Let's recalculate subsystems for invalidated and duped bugs as well. Do it after everything else is updated.
