### PR TITLE
tools/syz-lore: save discussions as JSON files

### DIFF
--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -639,6 +639,7 @@ type DiscussionMessage struct {
 	ID       string
 	External bool // true if the message is not from the bot itself
 	Time     time.Time
+	Email    string // not saved to the DB
 }
 
 type SaveDiscussionReq struct {


### PR DESCRIPTION
Make the tool more flexible by supporting two modes of operation:
1) The already existing mode -- upload the results to dashboard.
2) The local mode -- save parsed LKML discussions as JSON files.