### PR TITLE
dashboard: consider more bugs for fix candidate jobs

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -454,7 +454,7 @@ func jobFromBugSample(c context.Context, managers map[string]dashapi.ManagerJobs
 func createTreeBisectionJobs(c context.Context, bugs []*Bug, bugKeys []*db.Key,
 	managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, error) {
 	log.Infof(c, "createTreeBisectionJobs is called for %d bugs", len(bugs))
-	const maxProcess = 2
+	const maxProcess = 5
 	processed := 0
 	for _, bug := range bugs {
 		if bug.FixCandidateJob != "" {
@@ -477,7 +477,7 @@ func createTreeBisectionJobs(c context.Context, bugs []*Bug, bugKeys []*db.Key,
 		}
 		if expensive {
 			// Only count expensive lookups.
-			// It we didn't have to query anything from the DB, it's not a problem to
+			// If we didn't have to query anything from the DB, it's not a problem to
 			// examine more bugs.
 			processed++
 		}

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -738,6 +738,7 @@ func crossTreeBisection(c context.Context, bug *Bug,
 		if !info.BisectFixes {
 			return nil
 		}
+		expensive = true
 		log.Infof(c, "%s: considering cross-tree bisection %s/%s",
 			bug.displayTitle(), from.repo.Alias, to.repo.Alias)
 		_, crashJob := bug.findResult(c, to.repo, wantNewAny{}, runOnHEAD{})
@@ -749,7 +750,6 @@ func crossTreeBisection(c context.Context, bug *Bug,
 			// The bug is already fixed on the target tree.
 			return nil
 		}
-		expensive = true
 		crashBuild, err := loadBuild(c, bug.Namespace, crashJob.BuildID)
 		if err != nil {
 			return err


### PR DESCRIPTION
Determine "expensive" lookups correctly, previously a few db lookups were overlooked.

Increase the limit, as 2 definitely discriminates such jobs.
