### PR TITLE
dashboard: improve crash priority calculation

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -855,9 +855,11 @@ func (crash *Crash) UpdateReportingPriority(c context.Context, build *Build, bug
 	if crash.Title == bug.Title {
 		prio += 1e8 // prefer reporting crash that matches bug title
 	}
+	managerPrio := 0
 	if _, mgrConfig := activeManager(crash.Manager, bug.Namespace); mgrConfig != nil {
-		prio += int64((mgrConfig.Priority - MinManagerPriority) * 1e5)
+		managerPrio = mgrConfig.Priority
 	}
+	prio += int64((managerPrio - MinManagerPriority) * 1e5)
 	if build.Arch == targets.AMD64 {
 		prio += 1e3
 	}


### PR DESCRIPTION
If there's no config record for the manager, activeManager would return a nil pointer to ConfigManager. Assume the priority to be 0 in this case.

Update the admin.go function that recalculates priorities.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
