### PR TITLE
vm/adb: unlink directory contents before directories

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -160,7 +160,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	// Remove temp files from previous runs.
 	// rm chokes on bad symlinks so we must remove them first
 	if _, err := inst.adb("shell", "ls /data/syzkaller*"); err == nil {
-		if _, err := inst.adb("shell", "find /data/syzkaller* -type l -exec unlink {} \\;"+
+		if _, err := inst.adb("shell", "find /data/syzkaller* -type l -depth -exec unlink {} \\;"+
 			" && rm -Rf /data/syzkaller*"); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
There have been reports of the find command failing with: find: /data/XXX/syzkaller.YYY/ZZZ/cgroup: No such file or directory

It's not really clear how this comes about, but let's try to improve find's arguments first. It anyway makes more sense to unlink directory's content before unlinking the parent, even though find should not be following symlinks in the first place..

Cc #4162