### PR TITLE
dashboard: auto-guess repo and branch for email-sent `#syz test`

### DIFF
--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -698,9 +698,13 @@ var emailCmdToStatus = map[email.Command]dashapi.BugStatus{
 
 func handleTestCommand(c context.Context, info *bugInfoResult,
 	msg *email.Email, command *email.SingleCommand) string {
-	args := strings.Split(command.Args, " ")
-	if len(args) != 2 {
-		return fmt.Sprintf("want 2 args (repo, branch), got %v", len(args))
+	args := strings.Fields(command.Args)
+	if len(args) != 0 && len(args) != 2 {
+		return fmt.Sprintf("want either no args or 2 args (repo, branch), got %v", len(args))
+	}
+	repo, branch := "", ""
+	if len(args) == 2 {
+		repo, branch = args[0], args[1]
 	}
 	if info.bug.sanitizeAccess(AccessPublic) != AccessPublic {
 		log.Warningf(c, "%v: bug is not AccessPublic, patch testing request is denied", info.bug.Title)
@@ -710,7 +714,7 @@ func handleTestCommand(c context.Context, info *bugInfoResult,
 	err := handleTestRequest(c, &testReqArgs{
 		bug: info.bug, bugKey: info.bugKey, bugReporting: info.bugReporting,
 		user: msg.Author, extID: msg.MessageID, link: msg.Link,
-		patch: []byte(msg.Patch), repo: args[0], branch: args[1], jobCC: msg.Cc})
+		patch: []byte(msg.Patch), repo: repo, branch: branch, jobCC: msg.Cc})
 	if err != nil {
 		var testDenied *TestRequestDeniedError
 		var badTest *BadTestRequestError

--- a/docs/syzbot.md
+++ b/docs/syzbot.md
@@ -83,6 +83,14 @@ or alternatively, to test on exact commit reply with:
 #syz test: git://repo/address.git commit-hash
 ```
 
+You can also completely omit these parameters:
+```
+#syz test
+```
+
+In this case, syzbot will check out the latest commit from the branch where the
+issue was detected.
+
 If you also provide a patch with the email, `syzbot` will apply it on top of the
 tree before testing. The patch can be provided inline in email text or as
 a text attachment (which is more reliable if your email client messes with

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -217,7 +217,8 @@ git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git locking/core
 		cmd: &SingleCommand{
 			Command: CmdTest,
 			Str:     "test",
-			Args:    "git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git locking/core",
+			// We only look for arguments if there's ":" after "#syz test".
+			Args: "",
 		},
 	},
 	{
@@ -247,6 +248,16 @@ locking/core
 			Command: CmdTest,
 			Str:     "test:",
 			Args:    "repo commit",
+		},
+	},
+	{
+		body: `#syz test
+patch-begins
+`,
+		cmd: &SingleCommand{
+			Command: CmdTest,
+			Str:     "test",
+			Args:    "",
 		},
 	},
 	{
@@ -696,7 +707,7 @@ index 3d85747bd86e..a257b872a53d 100644
 				{
 					Command: CmdTest,
 					Str:     "test",
-					Args:    "commit 59372bbf3abd5b24a7f6f676a3968685c280f955",
+					Args:    "",
 				},
 			},
 		}},


### PR DESCRIPTION
We used to support this only for external reportings, but let's auto-guess repo and branch parameters for all incoming patch testing commands.