### PR TITLE
sys/linux/filesystem: Add f2fs errors=remount-ro|continue|panic mount option

### DIFF
--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -759,6 +759,8 @@ f2fs_options [
 	fsync_mode_posix	stringnoz["fsync_mode=posix"]
 	fsync_mode_strict	stringnoz["fsync_mode=strict"]
 	test_dummy_encryption	stringnoz["test_dummy_encryption"]
+	errors_continue		stringnoz["errors=continue"]
+	errors_remount		stringnoz["errors=remount-ro"]
 ] [varlen]
 
 bpf_options [


### PR DESCRIPTION
Handle b62e71be2110 ("f2fs: support errors=remount-ro|continue|panic mountoption")

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
