### PR TITLE
pkg/subsystem: remove gfs2 from name exceptions

### DIFF
--- a/pkg/subsystem/linux/names.go
+++ b/pkg/subsystem/linux/names.go
@@ -110,7 +110,6 @@ var (
 		"rust-for-linux@vger.kernel.org":            "rust",
 		"industrypack-devel@lists.sourceforge.net":  "ipack",
 		"v9fs-developer@lists.sourceforge.net":      "9p",
-		"cluster-devel@redhat.com":                  "gfs2",
 		"kernel-tls-handshake@lists.linux.dev":      "tls",
 		"bcm-kernel-feedback-list@broadcom.com":     "broadcom",
 		"linux@ew.tq-group.com":                     "tq-systems",


### PR DESCRIPTION
The new mailing list can be parsed by the generic algorithm.
