### PR TITLE
dashboard: switch to the f4 instance class

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -4,10 +4,10 @@
 runtime: go120
 app_engine_apis: true
 
-# With the default f1 setting, the app episodically crashes with:
-# Exceeded soft memory limit of 256 MB with 264 MB after servicing 25 requests total.
+# With the f2 setting, the app episodically crashes with:
+# Exceeded soft memory limit of 256 MB with 264 MB after servicing X requests total.
 # See https://cloud.google.com/appengine/docs/standard/go/config/appref#instance_class
-instance_class: f2
+instance_class: f4
 
 inbound_services:
 - mail


### PR DESCRIPTION
We're still seeing "Exceeded soft memory limit" errors. Let's move to a higher instance class, now with the 512M limit.
