### PR TITLE
prog: preserve resource arg direction during squashing 

### DIFF
--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -1110,8 +1110,8 @@ ANYUNION [
 ] [varlen]
 
 ANYPTRS [
-	ANYPTR		ptr[in, array[ANYUNION]]
-	ANYPTR64	ptr64[in, array[ANYUNION]]
+	ANYPTR		ptr[inout, array[ANYUNION]]
+	ANYPTR64	ptr64[inout, array[ANYUNION]]
 ]
 
 resource ANYRES8[int8]: -1, 0

--- a/prog/any.go
+++ b/prog/any.go
@@ -250,7 +250,6 @@ func (target *Target) squashResult(arg *ResultArg, elems *[]Arg) {
 		panic("bad")
 	}
 	arg.ref = typ.ref()
-	arg.dir = DirIn
 	*elems = append(*elems, MakeUnionArg(target.any.union, DirIn, arg, index))
 }
 

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -45,7 +45,7 @@ type Arg interface {
 	Dir() Dir
 	Size() uint64
 
-	validate(ctx *validCtx) error
+	validate(ctx *validCtx, dir Dir) error
 	serialize(ctx *serializer)
 }
 

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -94,7 +94,12 @@ func (ctx *validCtx) validateArg(arg Arg, typ Type, dir Dir) error {
 	if _, ok := typ.(*PtrType); ok {
 		dir = DirIn // pointers are always in
 	}
-	if arg.Dir() != dir {
+	// We used to demand that Arg has exactly the same dir as Type, however,
+	// it leads to problems when dealing with ANYRES* types.
+	// If the resource was DirIn before squashing, we should not demand that
+	// it be DirInOut - it would only lead to mutations that make little sense.
+	// Let's only deny truly conflicting directions, e.g. DirIn vs DirOut.
+	if arg.Dir() != dir && dir != DirInOut {
 		return fmt.Errorf("arg %#v type %v has wrong dir %v, expect %v", arg, arg.Type(), arg.Dir(), dir)
 	}
 	if !ctx.target.isAnyPtr(arg.Type()) && arg.Type() != typ {


### PR DESCRIPTION
Currently, we override it to `DirIn`. At the same time, if other calls continue using the resource, it should actually be `DirInOut`.

`Reported-by: John Miller <jm3228520@gmail.com>`