### PR TITLE
dashboard/app/reporting_external.go: rephrase error message

### DIFF
--- a/dashboard/app/reporting_external.go
+++ b/dashboard/app/reporting_external.go
@@ -29,7 +29,7 @@ func apiReportingPollBugs(c context.Context, r *http.Request, payload []byte) (i
 	}
 	jobs, err := pollCompletedJobs(c, req.Type)
 	if err != nil {
-		log.Errorf(c, "failed to poll jobs: %v", err)
+		log.Errorf(c, "failed to poll jobs(bugs): %v", err)
 	}
 	resp.Reports = append(resp.Reports, jobs...)
 	return resp, nil


### PR DESCRIPTION
Currently 2 lines emit the same error message.
Lets add more details to distinguish them.

