### PR TITLE
tools: build a new ext4 image for arm32

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -130,6 +130,7 @@ EOF
 		cat >>.config <<EOF
 BR2_cortex_a57=y
 # BR2_LINUX_KERNEL is not set
+BR2_TARGET_ROOTFS_EXT2_4=y
 EOF
 ;;
 	s390x)


### PR DESCRIPTION
The newly built image resolves the following problem:

debug1: Sending subsystem: sftp
debug1: pledge: fork
subsystem request failed on channel 0

Also, ext2->ext4 transition allows to fuzz swap on arm32.

----

It didn't work earlier, but this time it for some reason worked locally. I've deployed the new image to syzbot, let's see how it goes.
