### PR TITLE
dashboard: fix a panic during fix candidate job generation

### DIFF
--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -759,6 +759,10 @@ func crossTreeBisection(c context.Context, bug *Bug,
 			return nil
 		}
 		_, successJob := bug.findResult(c, from.repo, wantNewAny{}, runOnHEAD{})
+		if successJob == nil {
+			// The jobs is not done yet.
+			return nil
+		}
 		if successJob.CrashTitle != "" {
 			// The kernel tree is still crashed by the repro.
 			return nil


### PR DESCRIPTION
The existing code fails if it's executed before we have finished the tree origin job for the tree where the fix is supposed to be applied to.

Add a test.