### PR TITLE
vm/gce: only enable DisplayDevice for amd64

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -79,9 +79,10 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 		return nil, fmt.Errorf("config param name is empty (required for GCE)")
 	}
 	cfg := &Config{
-		Count:         1,
-		Preemptible:   true,
-		DisplayDevice: true,
+		Count:       1,
+		Preemptible: true,
+		// Display device is not supported on other platforms.
+		DisplayDevice: env.Arch == targets.AMD64,
 	}
 	if err := config.LoadData(env.Config, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse gce vm config: %w", err)


### PR DESCRIPTION
GCE has begun to fail on arm64 instance creation with: Arm based instances do not support display device.

Enable the feature for amd64 only.