### PR TITLE
prog: skip optional input resources

### DIFF
--- a/prog/resources.go
+++ b/prog/resources.go
@@ -151,7 +151,7 @@ func (target *Target) getInputResources(c *Syscall) []*ResourceDesc {
 		}
 		switch typ1 := typ.(type) {
 		case *ResourceType:
-			if !typ1.IsOptional && !dedup[typ1.Desc] {
+			if !ctx.Optional && !dedup[typ1.Desc] {
 				dedup[typ1.Desc] = true
 				resources = append(resources, typ1.Desc)
 			}

--- a/prog/resources_test.go
+++ b/prog/resources_test.go
@@ -98,6 +98,32 @@ func TestTransitivelyEnabledCallsLinux(t *testing.T) {
 	}
 }
 
+func TestGetInputResources(t *testing.T) {
+	expectedRequiredResources := map[string]bool{
+		"required_res1": false,
+	}
+
+	t.Parallel()
+	target, err := GetTarget("test", "64")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resources := target.getInputResources(target.SyscallMap["test$optional_res"])
+	for _, resource := range resources {
+		if _, ok := expectedRequiredResources[resource.Name]; ok {
+			expectedRequiredResources[resource.Name] = true
+		} else {
+			t.Fatalf(" unexpected %v", resource.Name)
+		}
+	}
+	for expectedRes, found := range expectedRequiredResources {
+		if !found {
+			t.Fatalf(" missing %v", expectedRes)
+		}
+	}
+}
+
 func TestClockGettime(t *testing.T) {
 	t.Parallel()
 	target, err := GetTarget("linux", "amd64")

--- a/prog/resources_test.go
+++ b/prog/resources_test.go
@@ -153,7 +153,7 @@ func testCreateResource(t *testing.T, target *Target, calls map[*Syscall]bool, r
 			if res, ok := typ.(*ResourceType); ok && ctx.Dir != DirOut {
 				s := newState(target, ct, nil)
 				arg, calls := r.createResource(s, res, DirIn)
-				if arg == nil && !res.Optional() {
+				if arg == nil && !ctx.Optional {
 					t.Fatalf("failed to create resource %v", res.Name())
 				}
 				if arg != nil && len(calls) == 0 {

--- a/prog/resources_test.go
+++ b/prog/resources_test.go
@@ -101,6 +101,7 @@ func TestTransitivelyEnabledCallsLinux(t *testing.T) {
 func TestGetInputResources(t *testing.T) {
 	expectedRequiredResources := map[string]bool{
 		"required_res1": false,
+		"required_res2": false,
 	}
 
 	t.Parallel()

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -872,21 +872,34 @@ syz_r103_r104_s {
 resource optional_res1[int32]
 resource optional_res2[int32]
 resource required_res1[int32]
+resource required_res2[int32]
+
+test_args4 {
+	a	required_res2
+}
+
+test_args3 {
+	a	required_res1
+}
 
 test_args2 {
-	a	array[optional_res2]
+	a	ptr[in, test_args3]
+	b	array[optional_res2]
 }
 
 test_args1 {
+	a0	ptr64[out, test_args4]
 	a1	ptr64[in, array[optional_res1], opt]
 	a2	ptr64[in, test_args2, opt]
-	a3	ptr64[in, required_res1]
+	a3	ptr64[in, test_args3]
+	a4	ptr64[in, test_args4]
 }
 
 test_args0 {
 	a1	optional_res1
 	a2	optional_res2
 	a3	required_res1
+	a4	required_res2
 }
 
 test$output_res(arg ptr[out, test_args0])

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -866,3 +866,28 @@ syz_r103_r104_s {
 	opt0	r103	(out)
 	opt1	r104	(in)
 }
+
+# Optional resources
+
+resource optional_res1[int32]
+resource optional_res2[int32]
+resource required_res1[int32]
+
+test_args2 {
+	a	array[optional_res2]
+}
+
+test_args1 {
+	a1	ptr64[in, array[optional_res1], opt]
+	a2	ptr64[in, test_args2, opt]
+	a3	ptr64[in, required_res1]
+}
+
+test_args0 {
+	a1	optional_res1
+	a2	optional_res2
+	a3	required_res1
+}
+
+test$output_res(arg ptr[out, test_args0])
+test$optional_res(arg ptr[in, test_args1])


### PR DESCRIPTION
First commit updates `getInputResources` to skip input resources that are optional. The third commit fixes a bug that could cause required input resources to be omitted. The second and fourth commits cover the other two in unit tests. See commit descriptions for details. 

Updates: https://github.com/google/syzkaller/issues/2721