### PR TITLE
sys/linux: fix infiniband syzlang description

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -121,3 +121,4 @@ Arm Ltd
  Andrew Turner
 h0wdy
 Dylan Yudaken
+Marius Fleischer

--- a/sys/linux/dev_infiniband_rdma.txt
+++ b/sys/linux/dev_infiniband_rdma.txt
@@ -1418,8 +1418,8 @@ write$DESTROY_AH(fd fd_rdma, buf ptr[inout, destroy_ah_cmd], len len[buf])
 
 # mr
 write$REG_MR(fd fd_rdma, buf ptr[inout, reg_mr_cmd], len len[buf])
-write$DEREG_MR(fd fd_rdma, buf ptr[inout, rereg_mr_cmd], len len[buf])
-write$REREG_MR(fd fd_rdma, buf ptr[inout, dereg_mr_cmd], len len[buf])
+write$REREG_MR(fd fd_rdma, buf ptr[inout, rereg_mr_cmd], len len[buf])
+write$DEREG_MR(fd fd_rdma, buf ptr[inout, dereg_mr_cmd], len len[buf])
 
 # mw
 write$ALLOC_MW(fd fd_rdma, buf ptr[inout, alloc_mw_cmd], len len[buf])


### PR DESCRIPTION
Currently, the descriptions for  `write$REREG_MR` and `write$DEREG_MR` use the wrong structs as arguments.
