### PR TITLE
pkg/compiler, prog: avoid copyout of fmt'ed resources

### DIFF
--- a/pkg/compiler/attrs.go
+++ b/pkg/compiler/attrs.go
@@ -31,6 +31,7 @@ var (
 	structAttrs      = makeAttrs(attrPacked, attrSize, attrAlign)
 	unionAttrs       = makeAttrs(attrVarlen, attrSize)
 	structFieldAttrs = makeAttrs(attrIn, attrOut, attrInOut, attrOutOverlay)
+	unionFieldAttrs  = makeAttrs(attrIn) // Let's still support attrIn, it's safe.
 	callAttrs        = make(map[string]*attrDesc)
 )
 

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -185,7 +185,7 @@ func (comp *compiler) checkStructFields(n *ast.Struct, typ, name string) {
 	hasDirections, hasOutOverlay := false, false
 	for fieldIdx, f := range n.Fields {
 		if n.IsUnion {
-			comp.parseAttrs(nil, f, f.Attrs)
+			comp.parseAttrs(unionFieldAttrs, f, f.Attrs)
 			continue
 		}
 		attrs := comp.parseAttrs(structFieldAttrs, f, f.Attrs)

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -419,8 +419,9 @@ union$overlay0 [
 ]
 
 union$directions [
-	f1	int32	(in)	### unknown arg/field f1 attribute in
+	f1	int32	(in)
 	f2	int32	(out)	### unknown arg/field f2 attribute out
+	f3	int32	(inout)	### unknown arg/field f3 attribute inout
 ]
 
 

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -421,3 +421,7 @@ foo$non_generatable(a compressed_image) (no_minimize)	### call foo$non_generatab
 foo$non_minimizable(a compressed_image) (no_generate)	### call foo$non_minimizable refers to type compressed_image and so must be marked no_minimize
 foo$non_generatable_via_struct(a ptr[in, struct_non_generatable])	(no_minimize)	### call foo$non_generatable_via_struct refers to type compressed_image and so must be marked no_generate
 foo$non_minimizable_via_union(a ptr[in, union_non_minimizable])	(no_generate)	### call foo$non_minimizable_via_union refers to type compressed_image and so must be marked no_minimize
+
+resource for_fmt[int32]
+foo$fmt_copyin(a ptr[in, fmt[dec, for_fmt]])
+foo$fmt_copyout(a ptr[out, fmt[dec, for_fmt]])	### resource for_fmt cannot be created in fmt

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -1104,9 +1104,9 @@ ANYUNION [
 	ANYRES16	ANYRES16
 	ANYRES32	ANYRES32
 	ANYRES64	ANYRES64
-	ANYRESDEC	fmt[dec, ANYRES64]
-	ANYRESHEX	fmt[hex, ANYRES64]
-	ANYRESOCT	fmt[oct, ANYRES64]
+	ANYRESDEC	fmt[dec, ANYRES64] (in)
+	ANYRESHEX	fmt[hex, ANYRES64] (in)
+	ANYRESOCT	fmt[oct, ANYRES64] (in)
 ] [varlen]
 
 ANYPTRS [
@@ -1120,7 +1120,7 @@ resource ANYRES32[int32]: -1, 0
 resource ANYRES64[int64]: -1, 0
 
 syz_builtin0(a ptr[in, ANYPTRS]) (disabled)
-syz_builtin1(a ptr[out, ANYUNION]) (disabled)
+syz_builtin1(a ptr[inout, ANYUNION]) (disabled)
 syz_builtin2() ANYRES8 (disabled)
 syz_builtin3() ANYRES16 (disabled)
 syz_builtin4() ANYRES32 (disabled)

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -20,6 +20,7 @@ type typeDesc struct {
 	CanBeTypedef      bool            // can be type alias target?
 	CantBeOpt         bool            // can't be marked as opt?
 	CantBeOut         bool            // can't be used as an explicitly output argument?
+	CantHaveOut       bool            // everything inside can only be in
 	NeedBase          bool            // needs base type when used as field?
 	MaxColon          int             // max number of colons (int8:2) on fields
 	OptArgs           int             // number of optional arguments in Args array
@@ -764,6 +765,7 @@ var typeFmt = &typeDesc{
 	CanBeTypedef: true,
 	CantBeOpt:    true,
 	CantBeOut:    true,
+	CantHaveOut:  true,
 	Args: []namedArg{
 		{Name: "format", Type: typeFmtFormat},
 		{Name: "value", Type: typeArgType, IsArg: true},

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -169,6 +169,9 @@ func (arg *ResultArg) validate(ctx *validCtx, dir Dir) error {
 	if arg.Dir() == DirIn && len(arg.uses) > 0 {
 		return fmt.Errorf("result arg '%v' is DirIn, but is used %d times", typ.Name(), len(arg.uses))
 	}
+	if len(arg.uses) > 0 && arg.Size() > 8 {
+		return fmt.Errorf("result arg '%v' is to be copied out, yet it's bigger than int64 (%d > 8)", typ.Name(), arg.Size())
+	}
 	return nil
 }
 


### PR DESCRIPTION
We had a problem -- ANYUNION being `(inout)` leads to syzkaller generating copyout instructions for fmt[X, resource] types. We get executor crashes and `pkg/csource` compilation errors.

Add a validation rule to detect such copyouts in syzkaller tests. Adjust `pkg/compiler` to fail on `fmt[X, resource]` not being `DirIn`.

Fix the problem with ANY types by supporting `(in)` for union fields. Previously, all union field direction attributes were banned as they were making things more complicated. But the (in) attribute is definitely safe and only allows for more flexibility.