### PR TITLE
executor/common_zlib: fix an mmap leak

### DIFF
--- a/executor/common_zlib.h
+++ b/executor/common_zlib.h
@@ -494,5 +494,5 @@ static int puff_zlib_to_file(const unsigned char* source, unsigned long sourcele
 		return -1;
 	}
 	// Unmap memory-mapped region
-	return munmap(dest, destlen);
+	return munmap(dest, max_destlen);
 }

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7023,7 +7023,7 @@ static int puff_zlib_to_file(const unsigned char* source, unsigned long sourcele
 		munmap(dest, max_destlen);
 		return -1;
 	}
-	return munmap(dest, destlen);
+	return munmap(dest, max_destlen);
 }
 
 #include <errno.h>
@@ -12213,7 +12213,7 @@ static int puff_zlib_to_file(const unsigned char* source, unsigned long sourcele
 		munmap(dest, max_destlen);
 		return -1;
 	}
-	return munmap(dest, destlen);
+	return munmap(dest, max_destlen);
 }
 
 #include <errno.h>


### PR DESCRIPTION
The `mmap` size is `max_destlen`, but `munmap` size is `destlen`, which causes a memory leak.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
