### PR TITLE
Apply memory limit to gVisor instances.

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -29,8 +29,9 @@ func init() {
 }
 
 type Config struct {
-	Count     int    `json:"count"` // number of VMs to use
-	RunscArgs string `json:"runsc_args"`
+	Count            int    `json:"count"` // number of VMs to use
+	RunscArgs        string `json:"runsc_args"`
+	MemoryTotalBytes uint64 `json:"memory_total_bytes"`
 }
 
 type Pool struct {
@@ -59,6 +60,12 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	}
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
+	}
+	hostTotalMemory := osutil.SystemMemorySize()
+	minMemory := uint64(cfg.Count) * 10_000_000
+	if cfg.MemoryTotalBytes != 0 && (cfg.MemoryTotalBytes < minMemory || cfg.MemoryTotalBytes > hostTotalMemory) {
+		return nil, fmt.Errorf("invalid config param memory_total_bytes: %v, want [%d,%d]",
+			minMemory, cfg.MemoryTotalBytes, hostTotalMemory)
 	}
 	if env.Debug && cfg.Count > 1 {
 		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
@@ -94,7 +101,11 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		caps += "\"" + c + "\""
 	}
 	name := fmt.Sprintf("%v-%v", pool.env.Name, index)
-	vmConfig := fmt.Sprintf(configTempl, imageDir, caps, name)
+	memoryLimit := int64(pool.cfg.MemoryTotalBytes / uint64(pool.Count()))
+	if pool.cfg.MemoryTotalBytes == 0 {
+		memoryLimit = -1
+	}
+	vmConfig := fmt.Sprintf(configTempl, imageDir, caps, name, memoryLimit)
 	if err := osutil.WriteFile(filepath.Join(bundleDir, "config.json"), []byte(vmConfig)); err != nil {
 		return nil, err
 	}
@@ -414,6 +425,11 @@ const configTempl = `
 	  "resources": {
 		  "cpu": {
 			"shares": 1024
+		  },
+		  "memory": {
+			"limit": %[4]d,
+			"reservation": %[4]d,
+			"disableOOMKiller": false
 		  }
 	  }
 	},


### PR DESCRIPTION
There have been cases where gvisor ARM instances become inaccessible due to global OOMs, and it's possible that bounding memory usage per instance may help. 