### PR TITLE
dashboard: access config through context

### DIFF
--- a/dashboard/app/admin.go
+++ b/dashboard/app/admin.go
@@ -213,7 +213,7 @@ func updateBugReporting(c context.Context, w http.ResponseWriter, r *http.Reques
 		return err
 	}
 	log.Warningf(c, "fetched %v bugs for namespce %v", len(bugs), ns)
-	cfg := getConfig(c).Namespaces[ns]
+	cfg := getNsConfig(c, ns)
 	var update []*db.Key
 	for i, bug := range bugs {
 		if len(bug.Reporting) >= len(cfg.Reporting) {

--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -807,7 +807,7 @@ func reportCrash(c context.Context, build *Build, req *dashapi.Crash) (*Bug, err
 			bug.HasReport = true
 		}
 		if calculateSubsystems {
-			bug.SetAutoSubsystems(c, newSubsystems, now, getSubsystemRevision(c, ns))
+			bug.SetAutoSubsystems(c, newSubsystems, now, getNsConfig(c, ns).Subsystems.Revision)
 		}
 		bug.increaseCrashStats(now)
 		bug.HappenedOn = mergeString(bug.HappenedOn, build.Manager)

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -34,6 +34,7 @@ func init() {
 	isBrokenAuthDomainInTest = true
 	obsoleteWhatWontBeFixBisected = true
 	notifyAboutUnsuccessfulBisections = true
+	ensureConfigImmutability = true
 	initMocks()
 	installConfig(testConfig)
 }

--- a/dashboard/app/asset_storage.go
+++ b/dashboard/app/asset_storage.go
@@ -136,7 +136,7 @@ func neededCrashURLs(c context.Context) ([]string, error) {
 
 func handleDeprecateAssets(w http.ResponseWriter, r *http.Request) {
 	c := appengine.NewContext(r)
-	for ns := range config.Namespaces {
+	for ns := range getConfig(c).Namespaces {
 		err := deprecateNamespaceAssets(c, ns)
 		if err != nil {
 			log.Errorf(c, "deprecateNamespaceAssets failed for ns=%v: %v", ns, err)

--- a/dashboard/app/asset_storage_test.go
+++ b/dashboard/app/asset_storage_test.go
@@ -66,7 +66,7 @@ func TestBuildAssetLifetime(t *testing.T) {
 	crashLogLink := externalLink(c.ctx, textCrashLog, dbCrash.Log)
 	kernelConfigLink := externalLink(c.ctx, textKernelConfig, dbBuild.KernelConfig)
 	c.expectEQ(sender, fromAddr(c.ctx))
-	to := config.Namespaces["test2"].Reporting[0].Config.(*EmailConfig).Email
+	to := c.config().Namespaces["test2"].Reporting[0].Config.(*EmailConfig).Email
 	c.expectEQ(msg.To, []string{to})
 	c.expectEQ(msg.Subject, crash.Title)
 	c.expectEQ(len(msg.Attachments), 0)
@@ -358,7 +358,7 @@ func TestCrashAssetLifetime(t *testing.T) {
 	crashLogLink := externalLink(c.ctx, textCrashLog, dbCrash.Log)
 	kernelConfigLink := externalLink(c.ctx, textKernelConfig, dbBuild.KernelConfig)
 	c.expectEQ(sender, fromAddr(c.ctx))
-	to := config.Namespaces["test2"].Reporting[0].Config.(*EmailConfig).Email
+	to := c.config().Namespaces["test2"].Reporting[0].Config.(*EmailConfig).Email
 	c.expectEQ(msg.To, []string{to})
 	c.expectEQ(msg.Subject, crash.Title)
 	c.expectEQ(len(msg.Attachments), 0)

--- a/dashboard/app/bisect_test.go
+++ b/dashboard/app/bisect_test.go
@@ -170,9 +170,9 @@ For information about bisection process see: https://goo.gl/tpsmEJ#bisection
 `, extBugID, bisectLogLink, bisectCrashReportLink, bisectCrashLogLink, kernelConfigLink, reproSyzLink, reproCLink))
 
 		syzRepro := []byte(fmt.Sprintf("# https://testapp.appspot.com/bug?id=%v\n%s#%s\n%s",
-			dbBug.keyHash(), syzReproPrefix, crash2.ReproOpts, crash2.ReproSyz))
+			dbBug.keyHash(c.ctx), syzReproPrefix, crash2.ReproOpts, crash2.ReproSyz))
 		cRepro := []byte(fmt.Sprintf("// https://testapp.appspot.com/bug?id=%v\n%s",
-			dbBug.keyHash(), crash2.ReproC))
+			dbBug.keyHash(c.ctx), crash2.ReproC))
 		c.checkURLContents(bisectLogLink, []byte("bisect log 2"))
 		c.checkURLContents(bisectCrashReportLink, []byte("bisect crash report"))
 		c.checkURLContents(bisectCrashLogLink, []byte("bisect crash log"))
@@ -428,7 +428,7 @@ For information about bisection process see: https://goo.gl/tpsmEJ#bisection
 `, extBugID, bisectLogLink, bisectCrashReportLink, bisectCrashLogLink, kernelConfigLink, reproSyzLink, reproCLink))
 
 		syzRepro := []byte(fmt.Sprintf("# https://testapp.appspot.com/bug?id=%v\n%s#%s\n%s",
-			dbBug.keyHash(), syzReproPrefix, crash4.ReproOpts, crash4.ReproSyz))
+			dbBug.keyHash(c.ctx), syzReproPrefix, crash4.ReproOpts, crash4.ReproSyz))
 		c.checkURLContents(bisectLogLink, []byte("bisectfix log 4"))
 		c.checkURLContents(bisectCrashReportLink, []byte("bisectfix crash report 4"))
 		c.checkURLContents(bisectCrashLogLink, []byte("bisectfix crash log 4"))
@@ -1231,7 +1231,7 @@ func addBisectFixJob(c *Ctx, build *dashapi.Build) (*dashapi.JobPollResp, *dasha
 	c.expectTrue(strings.Contains(msg.Body, "syzbot suspects this issue was fixed by commit:"))
 
 	// Ensure we do not automatically close the bug.
-	c.expectTrue(!config.Namespaces["test2"].FixBisectionAutoClose)
+	c.expectTrue(!c.config().Namespaces["test2"].FixBisectionAutoClose)
 	_, extBugID, err := email.RemoveAddrContext(msg.Sender)
 	c.expectOK(err)
 	dbBug, _, _ := c.loadBug(extBugID)

--- a/dashboard/app/cache.go
+++ b/dashboard/app/cache.go
@@ -57,7 +57,7 @@ func cacheUpdate(w http.ResponseWriter, r *http.Request) {
 		log.Errorf(c, "failed load backports: %v", err)
 		return
 	}
-	for ns := range config.Namespaces {
+	for ns := range getConfig(c).Namespaces {
 		bugs, _, err := loadNamespaceBugs(c, ns)
 		if err != nil {
 			log.Errorf(c, "failed load ns=%v bugs: %v", ns, err)
@@ -79,7 +79,7 @@ func buildAndStoreCached(c context.Context, bugs []*Bug, backports []*rawBackpor
 		Subsystems: make(map[string]CachedBugStats),
 	}
 	for _, bug := range bugs {
-		if bug.Status == BugStatusOpen && accessLevel < bug.sanitizeAccess(accessLevel) {
+		if bug.Status == BugStatusOpen && accessLevel < bug.sanitizeAccess(c, accessLevel) {
 			continue
 		}
 		v.Total.Record(bug)
@@ -96,7 +96,7 @@ func buildAndStoreCached(c context.Context, bugs []*Bug, backports []*rawBackpor
 	for _, backport := range backports {
 		outgoing := stringInList(backport.FromNs, ns)
 		for _, bug := range backport.Bugs {
-			if accessLevel < bug.sanitizeAccess(accessLevel) {
+			if accessLevel < bug.sanitizeAccess(c, accessLevel) {
 				continue
 			}
 			if bug.Namespace == ns || outgoing {

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -370,6 +370,10 @@ func getConfig(c context.Context) *GlobalConfig {
 	return configDontUse // The base config was not overwriten.
 }
 
+func getNsConfig(c context.Context, ns string) *Config {
+	return getConfig(c).Namespaces[ns]
+}
+
 func checkConfig(cfg *GlobalConfig) {
 	if cfg == nil {
 		panic("installing nil config")

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -708,7 +708,3 @@ func (cfg *Config) lastActiveReporting() int {
 	}
 	return last
 }
-
-func isDecommissioned(c context.Context, ns string) bool {
-	return getConfig(c).Namespaces[ns].Decommissioned
-}

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -775,7 +775,7 @@ func loadAllManagers(c context.Context, ns string) ([]*Manager, []*db.Key, error
 	var result []*Manager
 	var resultKeys []*db.Key
 	for i, mgr := range managers {
-		if getConfig(c).Namespaces[mgr.Namespace].Managers[mgr.Name].Decommissioned {
+		if getNsConfig(c, mgr.Namespace).Managers[mgr.Name].Decommissioned {
 			continue
 		}
 		result = append(result, mgr)
@@ -864,11 +864,11 @@ func (bug *Bug) keyHash(c context.Context) string {
 }
 
 func bugKeyHash(c context.Context, ns, title string, seq int64) string {
-	return hash.String([]byte(fmt.Sprintf("%v-%v-%v-%v", getConfig(c).Namespaces[ns].Key, ns, title, seq)))
+	return hash.String([]byte(fmt.Sprintf("%v-%v-%v-%v", getNsConfig(c, ns).Key, ns, title, seq)))
 }
 
 func loadSimilarBugs(c context.Context, bug *Bug) ([]*Bug, error) {
-	domain := getConfig(c).Namespaces[bug.Namespace].SimilarityDomain
+	domain := getNsConfig(c, bug.Namespace).SimilarityDomain
 	dedup := make(map[string]bool)
 	dedup[bug.keyHash(c)] = true
 
@@ -882,7 +882,7 @@ func loadSimilarBugs(c context.Context, bug *Bug) ([]*Bug, error) {
 			return nil, err
 		}
 		for _, bug := range similar {
-			if getConfig(c).Namespaces[bug.Namespace].SimilarityDomain != domain ||
+			if getNsConfig(c, bug.Namespace).SimilarityDomain != domain ||
 				dedup[bug.keyHash(c)] {
 				continue
 			}
@@ -1001,7 +1001,7 @@ func kernelRepoInfo(c context.Context, build *Build) KernelRepo {
 
 func kernelRepoInfoRaw(c context.Context, ns, url, branch string) KernelRepo {
 	var info KernelRepo
-	for _, repo := range getConfig(c).Namespaces[ns].Repos {
+	for _, repo := range getNsConfig(c, ns).Repos {
 		if repo.URL == url && repo.Branch == branch {
 			info = repo
 			break

--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -166,7 +166,7 @@ func loadGraphBugs(c context.Context, ns string) ([]*Bug, error) {
 	}
 	n := 0
 	fixes := make(map[string]bool)
-	lastReporting := getConfig(c).Namespaces[ns].lastActiveReporting()
+	lastReporting := getNsConfig(c, ns).lastActiveReporting()
 	for _, bug := range bugs {
 		if bug.Reporting[lastReporting].Reported.IsZero() {
 			if bug.Status == BugStatusOpen {

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -196,7 +196,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 	cookie := decodeCookie(r)
 	if !found {
 		ns = getConfig(c).DefaultNamespace
-		if cfg := getConfig(c).Namespaces[cookie.Namespace]; cfg != nil && cfg.AccessLevel <= accessLevel {
+		if cfg := getNsConfig(c, cookie.Namespace); cfg != nil && cfg.AccessLevel <= accessLevel {
 			ns = cookie.Namespace
 		}
 		if accessLevel == AccessAdmin {

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -182,7 +182,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 		if ns1 == ns {
 			found = true
 		}
-		if isDecommissioned(c, ns1) {
+		if getNsConfig(c, ns1).Decommissioned {
 			continue
 		}
 		h.Namespaces = append(h.Namespaces, uiNamespace{
@@ -208,7 +208,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 	}
 	if ns != adminPage {
 		h.Namespace = ns
-		h.ShowSubsystems = getSubsystemService(c, ns) != nil
+		h.ShowSubsystems = getNsConfig(c, ns).Subsystems.Service != nil
 		cookie.Namespace = ns
 		encodeCookie(w, cookie)
 		cached, err := CacheGet(c, r, ns)

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -434,7 +434,7 @@ func jobFromBugSample(c context.Context, managers map[string]dashapi.ManagerJobs
 				// for which we were already given fixing commits.
 				return false
 			}
-			if isDecommissioned(c, bug.Namespace) {
+			if getNsConfig(c, bug.Namespace).Decommissioned {
 				return false
 			}
 			return true
@@ -712,7 +712,7 @@ func shouldBisectBug(c context.Context, bug *Bug, managers map[string]bool, jobT
 		return false
 	}
 
-	if isDecommissioned(c, bug.Namespace) {
+	if getNsConfig(c, bug.Namespace).Decommissioned {
 		return false
 	}
 

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -41,7 +41,7 @@ func TestJob(t *testing.T) {
 	sender = c.pollEmailBug().Sender
 	_, extBugID, err := email.RemoveAddrContext(sender)
 	c.expectOK(err)
-	mailingList := config.Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
 	c.incomingEmail(sender, "bla-bla-bla", EmailOptFrom("maintainer@kernel.org"),
 		EmailOptCC([]string{mailingList, "kernel@mailing.list"}))
 
@@ -293,7 +293,7 @@ func TestBootErrorPatch(t *testing.T) {
 	sender := c.pollEmailBug().Sender
 	c.incomingEmail(sender, "#syz upstream\n")
 	sender = c.pollEmailBug().Sender
-	mailingList := config.Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
 
 	c.incomingEmail(sender, "#syz test: git://git.git/git.git kernel-branch\n"+sampleGitPatch,
 		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
@@ -318,7 +318,7 @@ func TestTestErrorPatch(t *testing.T) {
 	sender := c.pollEmailBug().Sender
 	c.incomingEmail(sender, "#syz upstream\n")
 	sender = c.pollEmailBug().Sender
-	mailingList := config.Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
 
 	c.incomingEmail(sender, "#syz test: git://git.git/git.git kernel-branch\n"+sampleGitPatch,
 		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
@@ -431,7 +431,7 @@ func TestReproRetestJob(t *testing.T) {
 	c.expectEQ(bug.ReproLevel, ReproLevelC)
 
 	// Let's say that the C repro testing has failed.
-	c.advanceTime(config.Obsoleting.ReproRetestStart + time.Hour)
+	c.advanceTime(c.config().Obsoleting.ReproRetestStart + time.Hour)
 	for i := 0; i < 2; i++ {
 		resp := client.pollSpecificJobs(build.Manager, dashapi.ManagerJobs{TestPatches: true})
 		c.expectEQ(resp.Type, dashapi.JobTestPatch)
@@ -461,7 +461,7 @@ func TestReproRetestJob(t *testing.T) {
 	bug, _, _ = c.loadBug(extBugID)
 	c.expectEQ(bug.HeadReproLevel, ReproLevelSyz)
 	// Let's also deprecate the syz repro.
-	c.advanceTime(config.Obsoleting.ReproRetestPeriod + time.Hour)
+	c.advanceTime(c.config().Obsoleting.ReproRetestPeriod + time.Hour)
 
 	resp := client.pollSpecificJobs(build.Manager, dashapi.ManagerJobs{TestPatches: true})
 	c.expectEQ(resp.Type, dashapi.JobTestPatch)
@@ -510,10 +510,7 @@ func TestDelegatedManagerReproRetest(t *testing.T) {
 	c.expectOK(err)
 
 	// Deprecate the oldManager.
-	mgrConfig := config.Namespaces["test-mgr-decommission"].Managers[oldManager]
-	mgrConfig.Decommissioned = true
-	mgrConfig.DelegatedTo = newManager
-	config.Namespaces["test-mgr-decommission"].Managers[oldManager] = mgrConfig
+	c.decommissionManager("test-mgr-decommission", oldManager, newManager)
 
 	// Upload a build for the new manager.
 	c.advanceTime(time.Minute)
@@ -531,7 +528,7 @@ func TestDelegatedManagerReproRetest(t *testing.T) {
 	c.pollEmailBug()
 
 	// Let's say that the C repro testing has failed.
-	c.advanceTime(config.Obsoleting.ReproRetestPeriod + time.Hour)
+	c.advanceTime(c.config().Obsoleting.ReproRetestPeriod + time.Hour)
 
 	resp := client.pollSpecificJobs(build.Manager, dashapi.ManagerJobs{TestPatches: true})
 	c.expectEQ(resp.Type, dashapi.JobTestPatch)
@@ -1252,7 +1249,7 @@ func TestEmailTestCommandNoArgs(t *testing.T) {
 	client.ReportCrash(crash)
 
 	sender := c.pollEmailBug().Sender
-	mailingList := config.Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
 
 	c.incomingEmail(sender, "#syz test\n"+sampleGitPatch,
 		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))

--- a/dashboard/app/kcidb.go
+++ b/dashboard/app/kcidb.go
@@ -21,7 +21,7 @@ func initKcidb() {
 
 func handleKcidbPoll(w http.ResponseWriter, r *http.Request) {
 	c := appengine.NewContext(r)
-	for ns, cfg := range config.Namespaces {
+	for ns, cfg := range getConfig(c).Namespaces {
 		if cfg.Kcidb == nil {
 			continue
 		}
@@ -60,7 +60,7 @@ func handleKcidbNamespce(c context.Context, ns string, cfg *KcidbConfig) error {
 
 func publishKcidbBug(c context.Context, client *kcidb.Client, bug *Bug, bugKey *db.Key) (bool, error) {
 	if bug.KcidbStatus != 0 ||
-		bug.sanitizeAccess(AccessPublic) > AccessPublic ||
+		bug.sanitizeAccess(c, AccessPublic) > AccessPublic ||
 		bug.Reporting[len(bug.Reporting)-1].Reported.IsZero() ||
 		bug.Status != BugStatusOpen && timeSince(c, bug.LastTime) > 7*24*time.Hour {
 		return false, nil

--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -42,7 +42,7 @@ func makeLabelSet(c context.Context, ns string) *labelSet {
 		NoRemindersLabel:     trueFalse{},
 		MissingBackportLabel: trueFalse{},
 	}
-	service := getSubsystemService(c, ns)
+	service := getNsConfig(c, ns).Subsystems.Service
 	if service != nil {
 		names := []string{}
 		for _, item := range service.List() {

--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -52,7 +52,7 @@ func makeLabelSet(c context.Context, ns string) *labelSet {
 	}
 
 	originLabels := []string{}
-	for _, repo := range getKernelRepos(c, ns) {
+	for _, repo := range getConfig(c).Namespaces[ns].Repos {
 		if repo.LabelIntroduced != "" {
 			originLabels = append(originLabels, repo.LabelIntroduced)
 		}

--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -52,7 +52,7 @@ func makeLabelSet(c context.Context, ns string) *labelSet {
 	}
 
 	originLabels := []string{}
-	for _, repo := range getConfig(c).Namespaces[ns].Repos {
+	for _, repo := range getNsConfig(c, ns).Repos {
 		if repo.LabelIntroduced != "" {
 			originLabels = append(originLabels, repo.LabelIntroduced)
 		}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -508,7 +508,7 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 	}
 	data := &uiMainPage{
 		Header:         hdr,
-		Decommissioned: isDecommissioned(c, hdr.Namespace),
+		Decommissioned: getNsConfig(c, hdr.Namespace).Decommissioned,
 		Now:            timeNow(c),
 		Groups:         groups,
 		Managers:       makeManagerList(managers, hdr.Namespace),
@@ -546,7 +546,7 @@ func handleSubsystemPage(c context.Context, w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return err
 	}
-	service := getSubsystemService(c, hdr.Namespace)
+	service := getNsConfig(c, hdr.Namespace).Subsystems.Service
 	if service == nil {
 		return fmt.Errorf("%w: the namespace does not have subsystems", ErrClientBadRequest)
 	}
@@ -1191,7 +1191,7 @@ func getLabelGroups(c context.Context, bug *Bug) []*uiBugLabelGroup {
 }
 
 func debugBugSubsystems(c context.Context, w http.ResponseWriter, bug *Bug) error {
-	service := getSubsystemService(c, bug.Namespace)
+	service := getNsConfig(c, bug.Namespace).Subsystems.Service
 	if service == nil {
 		w.Write([]byte("Subsystem service was not found."))
 		return nil
@@ -1331,7 +1331,7 @@ func handleSubsystemsList(c context.Context, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return err
 	}
-	service := getSubsystemService(c, hdr.Namespace)
+	service := getNsConfig(c, hdr.Namespace).Subsystems.Service
 	if service == nil {
 		return fmt.Errorf("%w: the namespace does not have subsystems", ErrClientBadRequest)
 	}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -500,7 +500,7 @@ func handleMain(c context.Context, w http.ResponseWriter, r *http.Request) error
 		return err
 	}
 	for _, group := range groups {
-		if getConfig(c).Namespaces[hdr.Namespace].DisplayDiscussions {
+		if getNsConfig(c, hdr.Namespace).DisplayDiscussions {
 			group.DispDiscuss = true
 		} else {
 			group.DispLastAct = true
@@ -553,7 +553,7 @@ func handleSubsystemPage(c context.Context, w http.ResponseWriter, r *http.Reque
 	var subsystem *subsystem.Subsystem
 	if pos := strings.Index(r.URL.Path, "/s/"); pos != -1 {
 		name := r.URL.Path[pos+3:]
-		if newName := getConfig(c).Namespaces[hdr.Namespace].Subsystems.Redirect[name]; newName != "" {
+		if newName := getNsConfig(c, hdr.Namespace).Subsystems.Redirect[name]; newName != "" {
 			http.Redirect(w, r, r.URL.Path[:pos+3]+newName, http.StatusMovedPermanently)
 			return nil
 		}
@@ -575,7 +575,7 @@ func handleSubsystemPage(c context.Context, w http.ResponseWriter, r *http.Reque
 		return err
 	}
 	for _, group := range groups {
-		group.DispDiscuss = getConfig(c).Namespaces[hdr.Namespace].DisplayDiscussions
+		group.DispDiscuss = getNsConfig(c, hdr.Namespace).DisplayDiscussions
 	}
 	cached, err := CacheGet(c, r, hdr.Namespace)
 	if err != nil {
@@ -680,7 +680,7 @@ func handleBackports(c context.Context, w http.ResponseWriter, r *http.Request) 
 		Header: hdr,
 		Groups: groups,
 		DisplayNamespace: func(ns string) string {
-			return getConfig(c).Namespaces[ns].DisplayTitle
+			return getNsConfig(c, ns).DisplayTitle
 		},
 	})
 }
@@ -1030,7 +1030,7 @@ func handleBug(c context.Context, w http.ResponseWriter, r *http.Request) error 
 	if len(similar.Bugs) > 0 {
 		sections = append(sections, &uiCollapsible{
 			Title: fmt.Sprintf("Similar bugs (%d)", len(similar.Bugs)),
-			Show:  getConfig(c).Namespaces[hdr.Namespace].AccessLevel != AccessPublic,
+			Show:  getNsConfig(c, hdr.Namespace).AccessLevel != AccessPublic,
 			Type:  sectionBugList,
 			Value: similar,
 		})
@@ -1415,7 +1415,7 @@ func handleTextImpl(c context.Context, w http.ResponseWriter, r *http.Request, t
 		}
 		return err
 	}
-	if err := checkAccessLevel(c, r, getConfig(c).Namespaces[ns].AccessLevel); err != nil {
+	if err := checkAccessLevel(c, r, getNsConfig(c, ns).AccessLevel); err != nil {
 		return err
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1545,7 +1545,7 @@ func fetchNamespaceBugs(c context.Context, accessLevel AccessLevel, ns string,
 		}
 		mergeUIBug(c, bug, dup)
 	}
-	cfg := getConfig(c).Namespaces[ns]
+	cfg := getNsConfig(c, ns)
 	var uiGroups []*uiBugGroup
 	for index, bugs := range groups {
 		sort.Slice(bugs, func(i, j int) bool {
@@ -1834,7 +1834,7 @@ func createUIBug(c context.Context, bug *Bug, state *ReportingState, managers []
 	updateBugBadness(c, uiBug)
 	if len(bug.Commits) != 0 {
 		for i, com := range bug.Commits {
-			cfg := getConfig(c).Namespaces[bug.Namespace]
+			cfg := getNsConfig(c, bug.Namespace)
 			info := bug.getCommitInfo(i)
 			uiBug.Commits = append(uiBug.Commits, &uiCommit{
 				Hash:   info.Hash,
@@ -2128,7 +2128,7 @@ func loadManagerList(c context.Context, accessLevel AccessLevel, ns string,
 	var filtered []*Manager
 	var filteredKeys []*db.Key
 	for i, mgr := range managers {
-		cfg := getConfig(c).Namespaces[mgr.Namespace]
+		cfg := getNsConfig(c, mgr.Namespace)
 		if accessLevel < cfg.AccessLevel {
 			continue
 		}

--- a/dashboard/app/main_test.go
+++ b/dashboard/app/main_test.go
@@ -256,7 +256,7 @@ func TestMultiLabelFilter(t *testing.T) {
 	defer c.Close()
 
 	client := c.makeClient(clientPublicEmail, keyPublicEmail, true)
-	mailingList := config.Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
 
 	build1 := testBuild(1)
 	build1.Manager = "manager-name-123"

--- a/dashboard/app/notifications_test.go
+++ b/dashboard/app/notifications_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/email"
+	"golang.org/x/net/context"
 )
 
 func TestEmailNotifUpstreamEmbargo(t *testing.T) {
@@ -214,9 +215,10 @@ func TestBugObsoleting(t *testing.T) {
 			period: 80 * day,
 		},
 	}
+	c := context.Background()
 	for i, test := range tests {
 		test.bug.Namespace = "test1"
-		got := test.bug.obsoletePeriod()
+		got := test.bug.obsoletePeriod(c)
 		if got != test.period {
 			t.Errorf("test #%v: got: %.2f, want %.2f",
 				i, float64(got/time.Hour)/24, float64(test.period/time.Hour)/24)

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -167,7 +167,7 @@ func reportingPollNotifications(c context.Context, typ string) []*dashapi.BugNot
 	log.Infof(c, "fetched %v bugs", len(bugs))
 	var notifs []*dashapi.BugNotification
 	for _, bug := range bugs {
-		if isDecommissioned(c, bug.Namespace) {
+		if getNsConfig(c, bug.Namespace).Decommissioned {
 			continue
 		}
 		notif, err := handleReportNotif(c, typ, bug)
@@ -813,7 +813,7 @@ func reportingPollClosed(c context.Context, ids []string) ([]string, error) {
 				break
 			}
 			if bug.Status >= BugStatusFixed || !bugReporting.Closed.IsZero() ||
-				isDecommissioned(c, bug.Namespace) {
+				getNsConfig(c, bug.Namespace).Decommissioned {
 				closed = append(closed, bugReporting.ID)
 			}
 			break

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -272,7 +272,7 @@ func emailSendBugNotif(c context.Context, notif *dashapi.BugNotification) error 
 func buildBadCommitMessage(c context.Context, notif *dashapi.BugNotification) (string, error) {
 	var sb strings.Builder
 	days := int(notifyAboutBadCommitPeriod / time.Hour / 24)
-	nsConfig := getConfig(c).Namespaces[notif.Namespace]
+	nsConfig := getNsConfig(c, notif.Namespace)
 	fmt.Fprintf(&sb, `This bug is marked as fixed by commit:
 %v
 
@@ -954,7 +954,7 @@ func identifyEmail(c context.Context, msg *email.Email) (*bugInfoResult, *bugLis
 			log.Errorf(c, "no bug list with the %v ID found", bugID)
 			return nil, nil, nil
 		}
-		reminderConfig := getConfig(c).Namespaces[subsystem.Namespace].Subsystems.Reminder
+		reminderConfig := getNsConfig(c, subsystem.Namespace).Subsystems.Reminder
 		if reminderConfig == nil {
 			log.Errorf(c, "reminder configuration is empty")
 			return nil, nil, nil
@@ -1047,7 +1047,7 @@ func loadBugInfo(c context.Context, msg *email.Email) *bugInfoResult {
 		}
 		return nil
 	}
-	reporting := getConfig(c).Namespaces[bug.Namespace].ReportingByName(bugReporting.Name)
+	reporting := getNsConfig(c, bug.Namespace).ReportingByName(bugReporting.Name)
 	if reporting == nil {
 		log.Errorf(c, "can't find reporting for this bug: namespace=%q reporting=%q",
 			bug.Namespace, bugReporting.Name)

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -443,7 +443,7 @@ func reportingBugListReport(c context.Context, subsystemReport *SubsystemReport,
 			Moderation:  stage.Moderation,
 			TotalStats:  subsystemReport.TotalStats.toDashapi(),
 			PeriodStats: subsystemReport.PeriodStats.toDashapi(),
-			PeriodDays:  getConfig(c).Namespaces[ns].Subsystems.Reminder.PeriodDays,
+			PeriodDays:  getNsConfig(c, ns).Subsystems.Reminder.PeriodDays,
 		}
 		bugKeys, err := subsystemReport.getBugKeys()
 		if err != nil {
@@ -456,7 +456,7 @@ func reportingBugListReport(c context.Context, subsystemReport *SubsystemReport,
 		}
 		for _, bug := range bugs {
 			bugReporting := bugReportingByName(bug,
-				getConfig(c).Namespaces[ns].Subsystems.Reminder.SourceReporting)
+				getNsConfig(c, ns).Subsystems.Reminder.SourceReporting)
 			ret.Bugs = append(ret.Bugs, dashapi.BugListItem{
 				Title:      bug.displayTitle(),
 				Link:       fmt.Sprintf("%v/bug?extid=%v", appURL(c), bugReporting.ID),
@@ -470,7 +470,7 @@ func reportingBugListReport(c context.Context, subsystemReport *SubsystemReport,
 }
 
 func bugListReportingConfig(c context.Context, ns string, stage *SubsystemReportStage) ReportingType {
-	cfg := getConfig(c).Namespaces[ns].Subsystems.Reminder
+	cfg := getNsConfig(c, ns).Subsystems.Reminder
 	if stage.Moderation {
 		return cfg.ModerationConfig
 	}

--- a/dashboard/app/subsystem.go
+++ b/dashboard/app/subsystem.go
@@ -191,11 +191,11 @@ func subsystemMaintainers(c context.Context, ns, subsystemName string) []string 
 }
 
 func getSubsystemService(c context.Context, ns string) *subsystem.Service {
-	return getConfig(c).Namespaces[ns].Subsystems.Service
+	return getNsConfig(c, ns).Subsystems.Service
 }
 
 func getSubsystemRevision(c context.Context, ns string) int {
-	return getConfig(c).Namespaces[ns].Subsystems.Revision
+	return getNsConfig(c, ns).Subsystems.Revision
 }
 
 func subsystemListURL(c context.Context, ns string) string {

--- a/dashboard/app/subsystem.go
+++ b/dashboard/app/subsystem.go
@@ -19,7 +19,7 @@ import (
 // reassignBugSubsystems is expected to be periodically called to refresh old automatic
 // subsystem assignments.
 func reassignBugSubsystems(c context.Context, ns string, count int) error {
-	service := getSubsystemService(c, ns)
+	service := getNsConfig(c, ns).Subsystems.Service
 	if service == nil {
 		return nil
 	}
@@ -28,7 +28,7 @@ func reassignBugSubsystems(c context.Context, ns string, count int) error {
 		return err
 	}
 	log.Infof(c, "updating subsystems for %d bugs in %#v", len(keys), ns)
-	rev := getSubsystemRevision(c, ns)
+	rev := getNsConfig(c, ns).Subsystems.Revision
 	for i, bugKey := range keys {
 		if bugs[i].hasUserSubsystems() {
 			// It might be that the user-set subsystem no longer exists.
@@ -179,7 +179,7 @@ func inferSubsystems(c context.Context, bug *Bug, bugKey *db.Key,
 
 // subsystemMaintainers queries the list of emails to send the bug to.
 func subsystemMaintainers(c context.Context, ns, subsystemName string) []string {
-	service := getSubsystemService(c, ns)
+	service := getNsConfig(c, ns).Subsystems.Service
 	if service == nil {
 		return nil
 	}
@@ -199,7 +199,7 @@ func getSubsystemRevision(c context.Context, ns string) int {
 }
 
 func subsystemListURL(c context.Context, ns string) string {
-	if getSubsystemService(c, ns) == nil {
+	if getNsConfig(c, ns).Subsystems.Service == nil {
 		return ""
 	}
 	return fmt.Sprintf("%v/%v/subsystems?all=true", appURL(c), ns)

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -1005,7 +1005,7 @@ func TestRemindersPriority(t *testing.T) {
 	defer c.Close()
 
 	client := c.makeClient(clientSubsystemRemind, keySubsystemRemind, true)
-	mailingList := config.Namespaces["subsystem-reminders"].Reporting[1].Config.(*EmailConfig).Email
+	mailingList := c.config().Namespaces["subsystem-reminders"].Reporting[1].Config.(*EmailConfig).Email
 	build := testBuild(1)
 	client.UploadBuild(build)
 

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -585,7 +585,7 @@ func (ctx *bugTreeContext) loadCrashInfo() error {
 	if ctx.crash != nil {
 		var err error
 		ns := ctx.bug.Namespace
-		repoGraph, err := makeRepoGraph(getKernelRepos(ctx.c, ns))
+		repoGraph, err := makeRepoGraph(getConfig(ctx.c).Namespaces[ns].Repos)
 		if err != nil {
 			return err
 		}
@@ -602,7 +602,7 @@ func (ctx *bugTreeContext) isCrashRelevant(crash *Crash) (bool, *Build, error) {
 		// Let's wait for the repro.
 		return false, nil, nil
 	}
-	newManager, _ := activeManager(crash.Manager, ctx.bug.Namespace)
+	newManager, _ := activeManager(ctx.cGlobal, crash.Manager, ctx.bug.Namespace)
 	if newManager != crash.Manager {
 		// The manager was deprecated since the crash.
 		// Let's just ignore such bugs for now.
@@ -719,7 +719,7 @@ func treeTestJobs(c context.Context, bug *Bug) ([]*dashapi.JobInfo, error) {
 // b) Whether the lookup was expensive (it can help optimize crossTreeBisection calls).
 func crossTreeBisection(c context.Context, bug *Bug,
 	managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, bool, error) {
-	repoGraph, err := makeRepoGraph(getKernelRepos(c, bug.Namespace))
+	repoGraph, err := makeRepoGraph(getConfig(c).Namespaces[bug.Namespace].Repos)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -754,7 +754,7 @@ func crossTreeBisection(c context.Context, bug *Bug,
 		if err != nil {
 			return err
 		}
-		manager, _ := activeManager(crashJob.Manager, crashJob.Namespace)
+		manager, _ := activeManager(c, crashJob.Manager, crashJob.Namespace)
 		if !managers[manager].BisectFix {
 			return nil
 		}

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -585,7 +585,7 @@ func (ctx *bugTreeContext) loadCrashInfo() error {
 	if ctx.crash != nil {
 		var err error
 		ns := ctx.bug.Namespace
-		repoGraph, err := makeRepoGraph(getConfig(ctx.c).Namespaces[ns].Repos)
+		repoGraph, err := makeRepoGraph(getNsConfig(ctx.c, ns).Repos)
 		if err != nil {
 			return err
 		}
@@ -719,7 +719,7 @@ func treeTestJobs(c context.Context, bug *Bug) ([]*dashapi.JobInfo, error) {
 // b) Whether the lookup was expensive (it can help optimize crossTreeBisection calls).
 func crossTreeBisection(c context.Context, bug *Bug,
 	managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, bool, error) {
-	repoGraph, err := makeRepoGraph(getConfig(c).Namespaces[bug.Namespace].Repos)
+	repoGraph, err := makeRepoGraph(getNsConfig(c, bug.Namespace).Repos)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/dashboard/app/tree_test.go
+++ b/dashboard/app/tree_test.go
@@ -967,12 +967,12 @@ func (ctx *treeTestCtx) now() time.Time {
 }
 
 func (ctx *treeTestCtx) updateRepos(repos []KernelRepo) {
-	checkKernelRepos("tree-tests", config.Namespaces["tree-tests"], repos)
+	checkKernelRepos("tree-tests", ctx.ctx.config().Namespaces["tree-tests"], repos)
 	ctx.perAlias = map[string]KernelRepo{}
 	for _, repo := range repos {
 		ctx.perAlias[repo.Alias] = repo
 	}
-	ctx.ctx.setKernelRepos(repos)
+	ctx.ctx.setKernelRepos("tree-tests", repos)
 }
 
 func (ctx *treeTestCtx) uploadBuild(repo, branch string) *dashapi.Build {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -82,7 +82,6 @@ func NewCtx(t *testing.T) *Ctx {
 	c.client2 = c.makeClient(client2, password2, true)
 	c.publicClient = c.makeClient(clientPublicEmail, keyPublicEmail, true)
 	c.ctx = registerRequest(r, c).Context()
-
 	return c
 }
 
@@ -207,6 +206,7 @@ func (c *Ctx) Close() {
 		}
 	}
 	unregisterContext(c)
+	validateGlobalConfig()
 }
 
 func (c *Ctx) advanceTime(d time.Duration) {


### PR DESCRIPTION
We used to have a single global `config` variable and access it
throughout the whole dashboard application.

However, this approach has been more and more complicated test writing
-- sometimes we want the config to be only slightly different, so that
it's not worth it adding new namespaces, sometimes we have to test how
dashboard handles config changes over time.

This has already led to a number of hacky contextWithXXX methods that
mocked various parts of the global variable. The rest of the code had to
sometimes still use `config` directly and sometimes invoke getXXX(c)
methods. This is very inconsistent and prone to errors.

With more and more situations where we need to patch the config
appearing (see https://github.com/google/syzkaller/issues/4118), let's refactor the application to always access
config via the getConfig(c) method. This allows us to uniformly patch
the config and be sure that the non-patched copy is not accessible from
anywhere else.

Closes #4118