### PR TITLE
pkg/build: return KernelBuildSrc in ImageDetails and use it in SyzCI

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -123,7 +123,7 @@ func (a android) build(params Params) (ImageDetails, error) {
 		return details, fmt.Errorf("failed to generate signature: %w", err)
 	}
 
-	details.BuildSrcPath = buildCfg.BuildSrcPath
+	details.BuildSrcPath = filepath.Join(params.KernelDir, buildCfg.BuildSrcPath)
 
 	return details, nil
 }

--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -23,6 +23,7 @@ type BuildParams struct {
 	BuildTarget       string `json:"build_target"`
 	BuildScript       string `json:"build_script"`
 	VendorBootImage   string `json:"vendor_boot_image"`
+	BuildSrcPath      string `json:"build_src_path"`
 }
 
 var ccCompilerRegexp = regexp.MustCompile(`#define\s+CONFIG_CC_VERSION_TEXT\s+"(.*)"`)
@@ -121,6 +122,8 @@ func (a android) build(params Params) (ImageDetails, error) {
 	if err != nil {
 		return details, fmt.Errorf("failed to generate signature: %w", err)
 	}
+
+	details.BuildSrcPath = buildCfg.BuildSrcPath
 
 	return details, nil
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -42,8 +42,9 @@ type Params struct {
 
 // Information that is returned from the Image function.
 type ImageDetails struct {
-	Signature  string
-	CompilerID string
+	Signature    string
+	CompilerID   string
+	BuildSrcPath string
 }
 
 // Image creates a disk image for the specified OS/ARCH/VM.

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -366,6 +366,7 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Workdir = filepath.Join(dir, "workdir")
 	mgrcfg.KernelSrc = filepath.Join(dir, "kernel")
+	mgrcfg.KernelBuildSrc = mgr.kernelBuildSrc
 	mgrcfg.Syzkaller = filepath.Join(dir, "gopath", "src", "github.com", "google", "syzkaller")
 	os.RemoveAll(mgrcfg.Workdir)
 	defer os.RemoveAll(mgrcfg.Workdir)


### PR DESCRIPTION
This is useful for cases like Android, where the KernelBuildSrc parameter in the manager config is different from the kernel root. When running a local Syzkaller instance this can be specified by the config already, but we want to fuzz using SyzCI as well.
