### PR TITLE
syz-ci, dashboard: limit fuzzing of stale kernels

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -99,6 +99,9 @@ var testConfig = &GlobalConfig{
 					ObsoletingMinPeriod: 10 * 24 * time.Hour,
 					ObsoletingMaxPeriod: 20 * 24 * time.Hour,
 				},
+				"next-fuzzing": {
+					StaleFuzzingLimit: 3 * 24 * time.Hour,
+				},
 			},
 			Reporting: []Reporting{
 				{
@@ -672,6 +675,12 @@ func testBuild(id int) *dashapi.Build {
 	}
 }
 
+func testManagerBuild(id int, mgr string) *dashapi.Build {
+	ret := testBuild(id)
+	ret.Manager = mgr
+	return ret
+}
+
 var buildCommitDate = time.Date(1, 2, 3, 4, 5, 6, 0, time.UTC)
 
 func testCrash(build *dashapi.Build, id int) *dashapi.Crash {
@@ -993,12 +1002,13 @@ func TestManagerFailedBuild(t *testing.T) {
 	failedBuild.KernelCommit = "kern2"
 	failedBuild.KernelCommitTitle = "failed build 1"
 	failedBuild.SyzkallerCommit = "syz2"
-	c.expectOK(c.client.ReportBuildError(&dashapi.BuildErrorReq{
+	_, err := c.client.ReportBuildError(&dashapi.BuildErrorReq{
 		Build: *failedBuild,
 		Crash: dashapi.Crash{
 			Title: "failed build 1",
 		},
-	}))
+	})
+	c.expectOK(err)
 	checkManagerBuild(c, build, failedBuild, nil)
 
 	// Now the old good build again, nothing should change.
@@ -1016,12 +1026,13 @@ func TestManagerFailedBuild(t *testing.T) {
 	failedBuild.KernelCommit = "kern4"
 	failedBuild.KernelCommitTitle = "failed build 4"
 	failedBuild.SyzkallerCommit = "syz4"
-	c.expectOK(c.client.ReportBuildError(&dashapi.BuildErrorReq{
+	_, err = c.client.ReportBuildError(&dashapi.BuildErrorReq{
 		Build: *failedBuild,
 		Crash: dashapi.Crash{
 			Title: "failed build 4",
 		},
-	}))
+	})
+	c.expectOK(err)
 	checkManagerBuild(c, build, failedBuild, nil)
 
 	failedBuild2 := new(dashapi.Build)
@@ -1030,12 +1041,13 @@ func TestManagerFailedBuild(t *testing.T) {
 	failedBuild2.KernelCommit = ""
 	failedBuild2.KernelCommitTitle = "failed build 5"
 	failedBuild2.SyzkallerCommit = "syz5"
-	c.expectOK(c.client.ReportBuildError(&dashapi.BuildErrorReq{
+	_, err = c.client.ReportBuildError(&dashapi.BuildErrorReq{
 		Build: *failedBuild2,
 		Crash: dashapi.Crash{
 			Title: "failed build 5",
 		},
-	}))
+	})
+	c.expectOK(err)
 	checkManagerBuild(c, build, failedBuild, failedBuild2)
 
 	build.ID = "id6"

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -208,6 +208,10 @@ type ConfigManager struct {
 	// Other parameters being equal, Priority helps to order bug's crashes.
 	// Priority is an integer in the range [-3;3].
 	Priority int
+	// For how long an old-built kernel image may continue to be fuzzed.
+	// Only taken into account once we fail to build a new kernel image.
+	// By default, the latest working kernel is fuzzed forever until it can be replaced.
+	StaleFuzzingLimit time.Duration
 }
 
 const (

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -660,7 +660,8 @@ func TestEmailFailedBuild(t *testing.T) {
 			Maintainers: []string{"maintainer@crash"},
 		},
 	}
-	c.expectOK(c.client2.ReportBuildError(buildErrorReq))
+	_, err := c.client2.ReportBuildError(buildErrorReq)
+	c.expectOK(err)
 
 	msg := c.pollEmailBug()
 	sender, extBugID, err := email.RemoveAddrContext(msg.Sender)
@@ -784,7 +785,8 @@ func TestEmailManagerCC(t *testing.T) {
 			Log:    []byte("log\n"),
 		},
 	}
-	c.expectOK(c.client2.ReportBuildError(buildErrorReq))
+	_, err := c.client2.ReportBuildError(buildErrorReq)
+	c.expectOK(err)
 	msg = c.pollEmailBug()
 	c.expectEQ(msg.To, []string{
 		"always@manager.org",

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -275,8 +275,14 @@ type BuildErrorReq struct {
 	Crash Crash
 }
 
-func (dash *Dashboard) ReportBuildError(req *BuildErrorReq) error {
-	return dash.Query("report_build_error", req, nil)
+type BuildErrorResp struct {
+	ContinueFuzzing bool
+}
+
+func (dash *Dashboard) ReportBuildError(req *BuildErrorReq) (*BuildErrorResp, error) {
+	resp := new(BuildErrorResp)
+	err := dash.Query("report_build_error", req, resp)
+	return resp, err
 }
 
 type CommitPollResp struct {

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -335,7 +335,7 @@ func (upd *SyzUpdater) uploadBuildError(commit *vcs.Commit, buildErr error) {
 				Log:   output,
 			},
 		}
-		if err := dash.ReportBuildError(req); err != nil {
+		if _, err := dash.ReportBuildError(req); err != nil {
 			// TODO: log ReportBuildError error to dashboard.
 			log.Logf(0, "failed to report build error for %v: %v", mgrcfg.Name, err)
 		}


### PR DESCRIPTION
**Please review changes in syz-ci with extra care. The code is tricky and not covered by tests.**


In some (or, actually, in many) cases it does not make very much sense to continue fuzzing and reporting bugs in a stale kernel.

For example, faulty patch series may appear and disappear in linux-next in a matter of just a few days. We should not keep on finding and reporting bugs in the code that may already be long obsolete.

Let syz-ci ask dashboard whether it should continue fuzzing when it uploads a faulty kernel build.