### PR TITLE
syz-ci: add kernel_src_suffix field to config

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -366,6 +366,9 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Workdir = filepath.Join(dir, "workdir")
 	mgrcfg.KernelSrc = filepath.Join(dir, "kernel")
+	if mgr.mgrcfg.KernelSrcSuffix != "" {
+		mgrcfg.KernelSrc = filepath.Join(dir, "kernel", mgr.mgrcfg.KernelSrcSuffix)
+	}
 	mgrcfg.Syzkaller = filepath.Join(dir, "gopath", "src", "github.com", "google", "syzkaller")
 	os.RemoveAll(mgrcfg.Workdir)
 	defer os.RemoveAll(mgrcfg.Workdir)

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -365,10 +365,7 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	mgrcfg := new(mgrconfig.Config)
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Workdir = filepath.Join(dir, "workdir")
-	mgrcfg.KernelSrc = filepath.Join(dir, "kernel")
-	if mgr.mgrcfg.KernelSrcSuffix != "" {
-		mgrcfg.KernelSrc = filepath.Join(dir, "kernel", mgr.mgrcfg.KernelSrcSuffix)
-	}
+	mgrcfg.KernelSrc = filepath.Join(dir, "kernel", mgr.mgrcfg.KernelSrcSuffix)
 	mgrcfg.Syzkaller = filepath.Join(dir, "gopath", "src", "github.com", "google", "syzkaller")
 	os.RemoveAll(mgrcfg.Workdir)
 	defer os.RemoveAll(mgrcfg.Workdir)

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -143,6 +143,10 @@ func createManager(cfg *Config, mgrcfg *ManagerConfig, stop chan struct{},
 		debug:        debug,
 	}
 
+	if mgrcfg.KernelSrcSuffix != "" {
+		mgr.kernelDir = path.Join(kernelDir, mgrcfg.KernelSrcSuffix)
+	}
+
 	os.RemoveAll(mgr.currentDir)
 	return mgr, nil
 }

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -127,7 +127,7 @@ func createManager(cfg *Config, mgrcfg *ManagerConfig, stop chan struct{},
 	mgr := &Manager{
 		name:         mgrcfg.managercfg.Name,
 		workDir:      filepath.Join(dir, "workdir"),
-		kernelDir:    kernelDir,
+		kernelDir:    path.Join(kernelDir, mgrcfg.KernelSrcSuffix),
 		currentDir:   filepath.Join(dir, "current"),
 		latestDir:    filepath.Join(dir, "latest"),
 		configTag:    hash.String(configData),
@@ -141,10 +141,6 @@ func createManager(cfg *Config, mgrcfg *ManagerConfig, stop chan struct{},
 		debugStorage: !cfg.AssetStorage.IsEmpty() && cfg.AssetStorage.Debug,
 		stop:         stop,
 		debug:        debug,
-	}
-
-	if mgrcfg.KernelSrcSuffix != "" {
-		mgr.kernelDir = path.Join(kernelDir, mgrcfg.KernelSrcSuffix)
 	}
 
 	os.RemoveAll(mgr.currentDir)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -178,6 +178,9 @@ type ManagerConfig struct {
 	Ccache       string `json:"ccache"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
+	// KernelSrcSuffiz adds a suffix to the kernel_src manager config. This is needed for cases where
+	// the kernel source root as reported in the coverage UI is a subdirectory of the VCS root.
+	KernelSrcSuffix string `json:"kernel_src_suffix"`
 	// Build-type-specific parameters.
 	// Parameters for concrete types are in Config type in pkg/build/TYPE.go, e.g. pkg/build/android.go.
 	Build json.RawMessage `json:"build"`

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -178,7 +178,7 @@ type ManagerConfig struct {
 	Ccache       string `json:"ccache"`
 	Userspace    string `json:"userspace"`
 	KernelConfig string `json:"kernel_config"`
-	// KernelSrcSuffiz adds a suffix to the kernel_src manager config. This is needed for cases where
+	// KernelSrcSuffix adds a suffix to the kernel_src manager config. This is needed for cases where
 	// the kernel source root as reported in the coverage UI is a subdirectory of the VCS root.
 	KernelSrcSuffix string `json:"kernel_src_suffix"`
 	// Build-type-specific parameters.


### PR DESCRIPTION
This is used to add a suffix to the kernel_src config field. This is used in Android where kernel source is under .../kernel/aosp/.
