### PR TITLE
dashboard: export more stat data

### DIFF
--- a/dashboard/app/stats.go
+++ b/dashboard/app/stats.go
@@ -154,19 +154,24 @@ func getBugSummaries(c context.Context, ns, stage string) ([]*syzbotstats.BugSta
 			continue
 		}
 		targetStage := bugReportingByName(bug, stage)
-		if targetStage == nil || targetStage.Closed.IsZero() {
+		if targetStage == nil || targetStage.Reported.IsZero() {
 			continue
 		}
 		obj := &syzbotstats.BugStatSummary{
 			Title:        bug.Title,
-			ReleasedTime: targetStage.Closed,
+			FirstTime:    bug.FirstTime,
+			ReleasedTime: targetStage.Reported,
 			ResolvedTime: bug.Closed,
+			HappenedOn:   bug.HappenedOn,
 			Strace:       dashapi.CrashFlags(crash.Flags)&dashapi.CrashUnderStrace > 0,
 		}
 		for _, stage := range bug.Reporting {
 			if stage.ID != "" {
 				obj.IDs = append(obj.IDs, stage.ID)
 			}
+		}
+		for _, commit := range bug.CommitInfo {
+			obj.FixHashes = append(obj.FixHashes, commit.Hash)
 		}
 		if crash.ReproSyz > 0 {
 			obj.ReproTime = crash.Time

--- a/pkg/stats/syzbotstats/bug.go
+++ b/pkg/stats/syzbotstats/bug.go
@@ -8,14 +8,17 @@ import "time"
 type BugStatSummary struct {
 	Title           string
 	IDs             []string  // IDs used by syzbot for this bug.
+	FirstTime       time.Time // When the bug was first hit.
 	ReleasedTime    time.Time // When the bug was published.
 	ReproTime       time.Time // When we found the reproducer.
 	CauseBisectTime time.Time // When we found cause bisection.
 	ResolvedTime    time.Time // When the bug was resolved.
 	Status          BugStatus
 	Subsystems      []string
-	Strace          bool    // Whether we managed to reproduce under strace.
-	HitsPerDay      float64 // Average number of bug hits per day.
+	Strace          bool     // Whether we managed to reproduce under strace.
+	HitsPerDay      float64  // Average number of bug hits per day.
+	FixHashes       []string // Hashes of fix commits.
+	HappenedOn      []string // Managers on which the crash happened.
 }
 
 type BugStatus string


### PR DESCRIPTION
Export first crash time and fix commit hashes.
Calculate reporting time more precisely.