### PR TITLE
dashboard: do asset deprecation less frequently

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -9,7 +9,7 @@ cron:
 - url: /cron/minute_cache_update
   schedule: every 1 minutes
 - url: /cron/deprecate_assets
-  schedule: every 1 hours
+  schedule: every 3 hours
 - url: /cron/kcidb_poll
   schedule: every 5 minutes
 - url: /cron/refresh_subsystems


### PR DESCRIPTION
It looks like the action is requiring more DB operations that we expected.

Do it less frequently until we've done profiling and optimized the code.