### PR TITLE
pkg/report/freebsd.go: nolint goconst for freebsdOopses

### DIFF
--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -34,6 +34,7 @@ func (ctx *freebsd) Symbolize(rep *Report) error {
 
 var freebsdStackParams = &stackParams{}
 
+// nolint: goconst
 var freebsdOopses = append([]*oops{
 	{
 		[]byte("Fatal trap"),


### PR DESCRIPTION
To unblock #4285.
