### PR TITLE
pkg/vcs/vcs.go: nolint goconst because it improves readability

### DIFF
--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -368,6 +368,7 @@ func FileLink(url, hash, file string, line int) string {
 	return link(url, hash, file, line, 3)
 }
 
+// nolint: goconst
 func link(url, hash, file string, line, typ int) string {
 	if url == "" || hash == "" {
 		return ""


### PR DESCRIPTION
To unblock #4285.
