### PR TITLE
dashboard: forward incoming commands emails

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -374,14 +374,9 @@ unknown command "bad-command"
 	}
 
 	// Now mark the bug as fixed.
-	c.incomingEmail(sender1, "#syz fix: some: commit title", EmailOptCC(nil))
-	reply := c.pollEmailBug().Body
-	// nolint: lll
-	c.expectEQ(reply, `> #syz fix: some: commit title
-
-Your commands are accepted, but please keep bugs@syzkaller.com mailing list in CC next time. It serves as a history of what happened with each bug report. Thank you.
-
-`)
+	c.incomingEmail(sender1, "#syz fix: some: commit title",
+		EmailOptCC([]string{"bugs@syzkaller.com", "default@maintainers.com"}),
+		EmailOptSubject("fix bug title"))
 
 	// Check that the commit is now passed to builders.
 	builderPollResp, _ := c.client2.BuilderPoll(build.Manager)
@@ -502,15 +497,16 @@ func TestEmailDup2(t *testing.T) {
 			msg2 = c.pollEmailBug()
 			c.expectEQ(msg2.Subject, "[syzbot] KASAN: another bad thing")
 
+			cc := EmailOptCC([]string{"bugs@syzkaller.com", "default@maintainers.com"})
 			switch i {
 			case 0:
-				c.incomingEmail(msg2.Sender, "#syz dup: BUG: something bad")
+				c.incomingEmail(msg2.Sender, "#syz dup: BUG: something bad", cc)
 			case 1:
-				c.incomingEmail(msg2.Sender, "#syz dup: [syzbot] BUG: something bad")
+				c.incomingEmail(msg2.Sender, "#syz dup: [syzbot] BUG: something bad", cc)
 			case 2:
-				c.incomingEmail(msg2.Sender, "#syz dup: [syzbot] [subsystemA?] BUG: something bad")
+				c.incomingEmail(msg2.Sender, "#syz dup: [syzbot] [subsystemA?] BUG: something bad", cc)
 			default:
-				c.incomingEmail(msg2.Sender, "#syz dup: syzbot: BUG: something bad")
+				c.incomingEmail(msg2.Sender, "#syz dup: syzbot: BUG: something bad", cc)
 				reply := c.pollEmailBug()
 				c.expectTrue(strings.Contains(reply.Body, "can't find the dup bug"))
 			}
@@ -579,8 +575,10 @@ func TestEmailCrossReportingDup(t *testing.T) {
 		crash1.Title = fmt.Sprintf("bug_%v", i)
 		c.client2.ReportCrash(crash1)
 		bugSender := c.pollEmailBug().Sender
+		cc := EmailOptCC([]string{"default@maintainers.com", "test@syzkaller.com",
+			"bugs@syzkaller.com", "default2@maintainers.com", "bugs2@syzkaller.com"})
 		for j := 0; j < test.bug; j++ {
-			c.incomingEmail(bugSender, "#syz upstream")
+			c.incomingEmail(bugSender, "#syz upstream", cc)
 			bugSender = c.pollEmailBug().Sender
 		}
 
@@ -589,11 +587,11 @@ func TestEmailCrossReportingDup(t *testing.T) {
 		c.client2.ReportCrash(crash2)
 		dupSender := c.pollEmailBug().Sender
 		for j := 0; j < test.dup; j++ {
-			c.incomingEmail(dupSender, "#syz upstream")
+			c.incomingEmail(dupSender, "#syz upstream", cc)
 			dupSender = c.pollEmailBug().Sender
 		}
 
-		c.incomingEmail(bugSender, "#syz dup: "+crash2.Title)
+		c.incomingEmail(bugSender, "#syz dup: "+crash2.Title, cc)
 		if test.result {
 			c.expectNoEmail()
 		} else {
@@ -1320,4 +1318,90 @@ func expectLabels(t *testing.T, client *apiClient, extID string, labels ...strin
 		names = append(names, item.String())
 	}
 	assert.ElementsMatch(t, names, labels)
+}
+
+var forwardEmailConfig = EmailConfig{
+	Email:              "test@syzkaller.com",
+	HandleListEmails:   true,
+	SubjectPrefix:      "[syzbot]",
+	MailMaintainers:    true,
+	DefaultMaintainers: []string{"some@list.com"},
+}
+
+func TestSingleListForward(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublicEmail, keyPublicEmail, true)
+	c.updateReporting("access-public-email", "access-public-email-reporting1",
+		func(r Reporting) Reporting {
+			r.Config = &forwardEmailConfig
+			return r
+		})
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+
+	sender := c.pollEmailBug().Sender
+
+	c.incomingEmail(sender, "#syz fix: some: commit title",
+		EmailOptCC([]string{"some@list.com"}), EmailOptSubject("fix bug title"))
+
+	forwarded := c.pollEmailBug()
+	c.expectEQ(forwarded.Subject, "[syzbot] fix bug title")
+	c.expectEQ(forwarded.Sender, sender)
+	c.expectEQ(forwarded.To, []string{"test@syzkaller.com"})
+	c.expectEQ(len(forwarded.Cc), 0)
+	c.expectEQ(forwarded.Body, `For archival purposes, forwarding an incoming command email to
+test@syzkaller.com.
+
+***
+
+Subject: fix bug title
+Author: default@sender.com
+
+#syz fix: some: commit title
+`)
+}
+
+func TestTwoListsForward(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublicEmail, keyPublicEmail, true)
+	c.updateReporting("access-public-email", "access-public-email-reporting1",
+		func(r Reporting) Reporting {
+			r.Config = &forwardEmailConfig
+			return r
+		})
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+
+	sender := c.pollEmailBug().Sender
+
+	c.incomingEmail(sender, "#syz fix: some: commit title",
+		EmailOptCC(nil), EmailOptSubject("fix bug title"))
+
+	forwarded := c.pollEmailBug()
+	c.expectEQ(forwarded.Subject, "[syzbot] fix bug title")
+	c.expectEQ(forwarded.Sender, sender)
+	c.expectEQ(forwarded.To, []string{"some@list.com", "test@syzkaller.com"})
+	c.expectEQ(len(forwarded.Cc), 0)
+	c.expectEQ(forwarded.Body, `For archival purposes, forwarding an incoming command email to
+some@list.com, test@syzkaller.com.
+
+***
+
+Subject: fix bug title
+Author: default@sender.com
+
+#syz fix: some: commit title
+`)
 }

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -292,13 +292,12 @@ func TestBootErrorPatch(t *testing.T) {
 	crash.Title = "riscv/fixes boot error: can't ssh into the instance"
 	c.client2.ReportCrash(crash)
 
-	sender := c.pollEmailBug().Sender
-	c.incomingEmail(sender, "#syz upstream\n")
-	sender = c.pollEmailBug().Sender
-	mailingList := c.config().Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
+	report := c.pollEmailBug()
+	c.incomingEmail(report.Sender, "#syz upstream\n", EmailOptCC(report.To))
+	report = c.pollEmailBug()
 
-	c.incomingEmail(sender, syzTestGitBranchSamplePatch,
-		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
+	c.incomingEmail(report.Sender, syzTestGitBranchSamplePatch,
+		EmailOptFrom("test@requester.com"), EmailOptCC(report.To))
 	c.expectNoEmail()
 	pollResp := c.client2.pollJobs(build.Manager)
 	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)
@@ -319,11 +318,10 @@ func TestTestErrorPatch(t *testing.T) {
 
 	sender := c.pollEmailBug().Sender
 	c.incomingEmail(sender, "#syz upstream\n")
-	sender = c.pollEmailBug().Sender
-	mailingList := c.config().Namespaces["test2"].Reporting[1].Config.(*EmailConfig).Email
+	report := c.pollEmailBug()
 
-	c.incomingEmail(sender, syzTestGitBranchSamplePatch,
-		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
+	c.incomingEmail(report.Sender, syzTestGitBranchSamplePatch,
+		EmailOptFrom("test@requester.com"), EmailOptCC(report.To))
 	c.expectNoEmail()
 	pollResp := c.client2.pollJobs(build.Manager)
 	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)

--- a/dashboard/app/notifications_test.go
+++ b/dashboard/app/notifications_test.go
@@ -257,16 +257,18 @@ func TestEmailNotifObsoleted(t *testing.T) {
 	if !strings.Contains(notif.Body, "Auto-closing this bug as obsolete") {
 		t.Fatalf("bad notification text: %q", notif.Body)
 	}
-	c.expectEQ(notif.To, []string{"bugs@syzkaller.com", "default@sender.com", "somebody@else.com"})
+	c.expectEQ(notif.To, []string{"bugs@syzkaller.com", "default@maintainers.com",
+		"default@sender.com", "somebody@else.com"})
 
 	// New crash must create new bug.
 	c.client2.ReportCrash(crash)
 	report = c.pollEmailBug()
 	c.expectEQ(report.Subject, "title1 (2)")
 	// Now the same, but for the last reporting (must have smaller CC list).
-	c.incomingEmail(report.Sender, "#syz upstream")
+	c.incomingEmail(report.Sender, "#syz upstream", EmailOptCC([]string{"test@syzkaller.com"}))
 	report = c.pollEmailBug()
-	c.incomingEmail(report.Sender, "#syz upstream")
+	c.incomingEmail(report.Sender, "#syz upstream",
+		EmailOptCC([]string{"bugs@syzkaller.com", "default@maintainers.com"}))
 	report = c.pollEmailBug()
 	_ = report
 

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -1005,7 +1005,7 @@ func TestRemindersPriority(t *testing.T) {
 	defer c.Close()
 
 	client := c.makeClient(clientSubsystemRemind, keySubsystemRemind, true)
-	mailingList := c.config().Namespaces["subsystem-reminders"].Reporting[1].Config.(*EmailConfig).Email
+	cc := EmailOptCC([]string{"bugs@syzkaller.com", "default@maintainers.com"})
 	build := testBuild(1)
 	client.UploadBuild(build)
 
@@ -1018,7 +1018,7 @@ func TestRemindersPriority(t *testing.T) {
 	client.ReportCrash(aFirst)
 	sender, firstExtID := client.pollEmailAndExtID()
 	c.incomingEmail(sender, "#syz set prio: low\n",
-		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
+		EmailOptFrom("test@requester.com"), cc)
 	c.advanceTime(time.Hour)
 
 	// WARNING: a second, normal prio
@@ -1036,7 +1036,7 @@ func TestRemindersPriority(t *testing.T) {
 	client.ReportCrash(aThird)
 	sender, thirdExtID := client.pollEmailAndExtID()
 	c.incomingEmail(sender, "#syz set prio: high\n",
-		EmailOptFrom("test@requester.com"), EmailOptCC([]string{mailingList}))
+		EmailOptFrom("test@requester.com"), cc)
 	c.advanceTime(time.Hour)
 
 	// Report bugs once more to pretend they're still valid.

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -246,6 +246,12 @@ func (c *Ctx) setNoObsoletions() {
 	}
 }
 
+func (c *Ctx) updateReporting(ns, name string, f func(Reporting) Reporting) {
+	c.transformContext = func(c context.Context) context.Context {
+		return contextWithConfig(c, replaceReporting(c, ns, name, f))
+	}
+}
+
 func (c *Ctx) decommissionManager(ns, oldManager, newManager string) {
 	c.transformContext = func(c context.Context) context.Context {
 		newConfig := replaceManagerConfig(c, ns, oldManager, func(cfg ConfigManager) ConfigManager {
@@ -726,6 +732,21 @@ func replaceManagerConfig(c context.Context, ns, mgr string, f func(ConfigManage
 			newMgrMap[name] = mgrCfg
 		}
 		ret.Managers = newMgrMap
+		return &ret
+	})
+}
+
+func replaceReporting(c context.Context, ns, name string, f func(Reporting) Reporting) *GlobalConfig {
+	return replaceNamespaceConfig(c, ns, func(cfg *Config) *Config {
+		ret := *cfg
+		var newReporting []Reporting
+		for _, cfg := range ret.Reporting {
+			if cfg.Name == name {
+				cfg = f(cfg)
+			}
+			newReporting = append(newReporting, cfg)
+		}
+		ret.Reporting = newReporting
 		return &ret
 	})
 }


### PR DESCRIPTION
Instead of reminding users to mention our mailing lists, forward their emails there automatically.

Closes #4260.
