### PR TITLE
RFC: syz-fuzzer: prefer less covered areas for mutation

### DIFF
--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -91,7 +91,7 @@ func (proc *Proc) loop() {
 			proc.executeAndCollide(proc.execOpts, p, ProgNormal, StatGenerate)
 		} else {
 			// Mutate an existing prog.
-			p := fuzzerSnapshot.chooseProgram(proc.rnd).Clone()
+			p := proc.fuzzer.selector.chooseProgram(proc.rnd).Clone()
 			p.Mutate(proc.rnd, prog.RecommendedCalls, ct, proc.fuzzer.noMutate, fuzzerSnapshot.corpus)
 			log.Logf(1, "#%v: mutated", proc.pid)
 			proc.executeAndCollide(proc.execOpts, p, ProgNormal, StatFuzz)

--- a/syz-fuzzer/selector.go
+++ b/syz-fuzzer/selector.go
@@ -1,0 +1,88 @@
+// Copyright 2023 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/google/syzkaller/pkg/signal"
+	"github.com/google/syzkaller/prog"
+)
+
+type progSelector struct {
+	perHashProgs map[uint32][]*prog.Prog
+	allHashes    []uint32
+	noHashes     []*prog.Prog
+	mu           sync.RWMutex
+}
+
+func (ps *progSelector) addInput(p *prog.Prog, hashes signal.Signal) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if hashes.Empty() {
+		// We cannot do any better than just store such inputs separately.
+		ps.noHashes = append(ps.noHashes, p)
+		return
+	}
+	if ps.perHashProgs == nil {
+		// Let's do lazy init to simplify object construction.
+		ps.perHashProgs = map[uint32][]*prog.Prog{}
+	}
+	// Update each hash from the signal.
+	for hashRaw := range hashes.Serialize().Elems {
+		hash := uint32(hashRaw)
+		old, ok := ps.perHashProgs[hash]
+		if !ok {
+			ps.allHashes = append(ps.allHashes, hash)
+			// Let's reduce load on the allocator/garbage collector.
+			const startCapacity = 4
+			ps.perHashProgs[hash] = make([]*prog.Prog, 0, startCapacity)
+		}
+		// If a hash is covered by many progs already, it does not matter
+		// anymore by how many exactly.
+		const perHashLimit = 32
+		if len(old) >= perHashLimit {
+			continue
+		}
+		ps.perHashProgs[hash] = append(old, p)
+	}
+}
+
+func (ps *progSelector) chooseProgram(r *rand.Rand) *prog.Prog {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	total := len(ps.allHashes)
+	if total == 0 {
+		// Select one of the inputs without signal then.
+		if len(ps.noHashes) > 0 {
+			return ps.noHashes[r.Intn(len(ps.noHashes))]
+		}
+		return nil
+	}
+	// In general, we want to distribute weights inversely proportional to
+	// the number of progs that cover a specific hash.
+	// It's much easier in practice to approximate it by randomly selecting
+	// several hashes and picking the least covered one.
+
+	// For Linux, ~25% of PCs are covered by just one program, so let's
+	// randomize the number of selections to give all counts a chance.
+	attempts := 1 + r.Intn(4)
+
+	var smallestProgs []*prog.Prog
+	for i := 0; i < attempts; i++ {
+		hash := ps.allHashes[r.Intn(total)]
+		progs := ps.perHashProgs[hash]
+		if len(smallestProgs) == 0 || len(smallestProgs) > len(progs) {
+			smallestProgs = progs
+		}
+	}
+	if len(smallestProgs) == 0 {
+		// This should never happen.
+		panic("smallestProgs is empty")
+	}
+	return smallestProgs[r.Intn(len(smallestProgs))]
+}


### PR DESCRIPTION
Currently, when selecting a corpus prog for "exec fuzz", syzkaller gives preference to progs with larger signal. It makes sense - the bigger the coverage is, the more there are chances to derail execution and explore some new paths.

However, it seems to become less and less efficient as fuzzing goes on for longer periods of time. As only the total coverage is considered (ignoring parts shared by many inputs), it creates a bias towards more and more computationally intensive programs. I think it's exactly the behavior that leads to the gradual slowdown of execution speed over time (#2996).

Refactor the code to use another approach:
1. For every signal hash, store programs that cover it.
2. When selecting a prog for mutation, give preference to progs that cover less often covered parts of the kernel.

Approximate this behavior by looking at several random hashes and picking the one that's covered by the least number of corpus programs. This will give preference to less covered parts yet leaving chances for the rest of the kernel too.

Preliminary benchmarking results show a <s>~60% speedup</s> (likely smaller) in the number of executions per second (but not from the very beginning). There's no radical drop of the speed with time. Syzkaller reaches much more coverage in the same uptime.

But the number of crashes triggered during fuzzing did not increase comparably. I think it can be explained by syzkaller putting less attention to bulky code that had a higher concentration of bugs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
