### PR TITLE
vm/vm_test.go: allow duplicates

### DIFF
--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -92,6 +92,7 @@ type Test struct {
 	Report         *report.Report
 }
 
+// nolint: goconst // "DIAGNOSE\n", "BUG: bad\n" and "other output\n"
 var tests = []*Test{
 	{
 		Name: "program-exits-normally",


### PR DESCRIPTION
These duplicates improve test code readability.
It contributes to #4317 unblocking.
