### PR TITLE
vm/gvisor: set the fs.nr_open limit

### DIFF
--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -421,29 +421,32 @@ const configTempl = `
 		"readonly": true
 	},
 	"linux": {
-	  "cgroupsPath": "%[3]v",
-	  "resources": {
-		  "cpu": {
-			"shares": 1024
-		  },
-		  "memory": {
-			"limit": %[4]d,
-			"reservation": %[4]d,
-			"disableOOMKiller": false
-		  }
-	  }
+		"cgroupsPath": "%[3]v",
+		"resources": {
+			"cpu": {
+				"shares": 1024
+			},
+			"memory": {
+				"limit": %[4]d,
+				"reservation": %[4]d,
+				"disableOOMKiller": false
+			}
+		},
+		"sysctl": {
+			"fs.nr_open": "1048576"
+		}
 	},
 	"process":{
-                "args": ["/init"],
-                "cwd": "/tmp",
-                "env": ["SYZ_GVISOR_PROXY=1"],
-                "capabilities": {
-                	"bounding": [%[2]v],
-                	"effective": [%[2]v],
-                	"inheritable": [%[2]v],
-                	"permitted": [%[2]v],
-                	"ambient": [%[2]v]
-                }
+		"args": ["/init"],
+		"cwd": "/tmp",
+		"env": ["SYZ_GVISOR_PROXY=1"],
+		"capabilities": {
+			"bounding": [%[2]v],
+			"effective": [%[2]v],
+			"inheritable": [%[2]v],
+			"permitted": [%[2]v],
+			"ambient": [%[2]v]
+		}
 	}
 }
 `


### PR DESCRIPTION
By default, gVisor is set fs.nr_open to the maximum. In this case, large allocations can be triggered in the Sentry and it can cause OOM-s on the test node.
