### PR TITLE
compiler: Unified const/flags definitions

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -27,8 +27,10 @@ rest of the type-options are type-specific:
 "const": integer constant, type-options:
 	value, underlying type (one of "intN", "intptr")
 "intN"/"intptr": an integer without a particular meaning, type-options:
-	optional range of values (e.g. "5:10", or "100:200"),
-	optionally followed by an alignment parameter
+	either an optional range of values (e.g. "5:10", or "100:200")
+	or a reference to flags description (see below),
+	or a single value
+	optionally followed by an alignment parameter if using a range
 "flags": a set of values, type-options:
 	reference to flags description (see below), underlying int type (e.g. "int32")
 "array": a variable/fixed-length array, type-options:
@@ -110,6 +112,9 @@ By appending `be` suffix (e.g. `int16be`) integers become big-endian.
 
 It's possible to specify a range of values for an integer in the format of `int32[0:100]` or `int32[0:4096, 512]` for a 512-aligned int.
 
+Integers can also take a reference to flags description or a value as its first type-option.
+In that case, the alignment parameter is not supported.
+
 To denote a bitfield of size N use `int64:N`.
 
 It's possible to use these various kinds of ints as base types for `const`, `flags`, `len` and `proc`.
@@ -121,6 +126,8 @@ example_struct {
 	f2	int32[0:100]		# random 4-byte integer with values from 0 to 100 inclusive
 	f3	int32[1:10, 2]		# random 4-byte integer with values {1, 3, 5, 7, 9}
 	f4	int64:20		# random 20-bit bitfield
+	f5	int8[10]		# const 1-byte integer with value 10
+	f6	int32[flagname]		# random 4-byte integer from the set of values referenced by flagname
 }
 ```
 
@@ -393,6 +400,7 @@ foo(a const[10], b const[-10])
 foo(a const[0xabcd])
 foo(a int8['a':'z'])
 foo(a const[PATH_MAX])
+foo(a int32[PATH_MAX])
 foo(a ptr[in, array[int8, MY_PATH_MAX]])
 define MY_PATH_MAX	PATH_MAX + 2
 ```

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -25,7 +25,7 @@ func (comp *compiler) typecheck() {
 	comp.checkTypes()
 }
 
-func (comp *compiler) check() {
+func (comp *compiler) check(consts map[string]uint64) {
 	comp.checkTypeValues()
 	comp.checkAttributeValues()
 	comp.checkUnused()
@@ -34,6 +34,7 @@ func (comp *compiler) check() {
 	comp.checkConstructors()
 	comp.checkVarlens()
 	comp.checkDupConsts()
+	comp.checkConstsFlags(consts)
 }
 
 func (comp *compiler) checkComments() {
@@ -657,6 +658,15 @@ func (comp *compiler) checkUnused() {
 	for _, n := range comp.collectUnused() {
 		pos, typ, name := n.Info()
 		comp.error(pos, fmt.Sprintf("unused %v %v", typ, name))
+	}
+}
+
+func (comp *compiler) checkConstsFlags(consts map[string]uint64) {
+	for name := range consts {
+		if flags, isFlag := comp.intFlags[name]; isFlag {
+			pos, _, _ := flags.Info()
+			comp.error(pos, "const %v is already a flag", name)
+		}
 	}
 }
 

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -634,7 +634,8 @@ func (comp *compiler) collectUsedType(structs, flags, strflags map[string]bool, 
 		}
 		return
 	}
-	if desc == typeFlags {
+	if desc == typeFlags ||
+		(desc == typeInt && len(t.Args) > 0 && t.Args[0].Ident != "") {
 		flags[t.Args[0].Ident] = true
 		return
 	}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -93,7 +93,7 @@ func Compile(desc *ast.Description, consts map[string]uint64, target *targets.Ta
 		comp.assignSyscallNumbers(consts)
 	}
 	comp.patchConsts(consts)
-	comp.check()
+	comp.check(consts)
 	if comp.errors != 0 {
 		return nil
 	}

--- a/pkg/compiler/consts.go
+++ b/pkg/compiler/consts.go
@@ -105,7 +105,7 @@ func (comp *compiler) extractConsts() map[string]*ConstInfo {
 func (comp *compiler) extractTypeConsts(infos map[string]*constInfo, n ast.Node) {
 	comp.foreachType(n, func(t *ast.Type, desc *typeDesc, args []*ast.Type, _ prog.IntTypeCommon) {
 		for i, arg := range args {
-			if desc.Args[i].Type.Kind == kindInt {
+			if desc.Args[i].Type.Kind&kindInt != 0 {
 				if arg.Ident != "" {
 					comp.addConst(infos, arg.Pos, arg.Ident)
 				}
@@ -228,7 +228,7 @@ func (comp *compiler) patchConsts(consts0 map[string]uint64) {
 			comp.foreachType(decl, func(_ *ast.Type, desc *typeDesc,
 				args []*ast.Type, _ prog.IntTypeCommon) {
 				for i, arg := range args {
-					if desc.Args[i].Type.Kind == kindInt {
+					if desc.Args[i].Type.Kind&kindInt != 0 {
 						comp.patchTypeConst(arg, consts, &missing)
 					}
 				}

--- a/pkg/compiler/testdata/all.txt
+++ b/pkg/compiler/testdata/all.txt
@@ -21,6 +21,8 @@ foo_13() (disabled)
 foo_14() r0 (timeout[100])
 foo_15() r0 (disabled, timeout[C1], prog_timeout[C2])
 foo_16(a int32[int_flags])
+foo_17(a int8[C1])
+foo_18(a int64[100])
 
 resource r0[intptr]
 
@@ -182,6 +184,7 @@ bitfield0 {
 	f4	int16:8[0:255]
 	f5	int64:64[-1:1]
 	f6	int32:4[int_flags]
+	f7	int8:3[C1]
 }
 
 foo_bitfield0(a ptr[in, bitfield0])

--- a/pkg/compiler/testdata/all.txt
+++ b/pkg/compiler/testdata/all.txt
@@ -20,6 +20,7 @@ foo_12(a int64[0:-1, 0x1000])
 foo_13() (disabled)
 foo_14() r0 (timeout[100])
 foo_15() r0 (disabled, timeout[C1], prog_timeout[C2])
+foo_16(a int32[int_flags])
 
 resource r0[intptr]
 
@@ -180,6 +181,7 @@ bitfield0 {
 	f3	int16:8[-127:0]
 	f4	int16:8[0:255]
 	f5	int64:64[-1:1]
+	f6	int32:4[int_flags]
 }
 
 foo_bitfield0(a ptr[in, bitfield0])

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -88,7 +88,7 @@ foo$11(a buffer["in"])		### unexpected string "in" for direction argument of ptr
 foo$12(a buffer[10])		### unexpected int 10 for direction argument of ptr type, expect [in out inout]
 foo$13(a int32[2:3])
 foo$14(a int32[2:2])
-foo$16(a int32[3])		### first argument of int32 needs to be a range
+foo$16(a int32[3])		### first argument of int32 needs to be a range or flag
 foo$17(a ptr[in, int32])
 foo$18(a ptr[in, int32[2:3]])
 foo$19(a ptr[in, int32[opt]])
@@ -104,7 +104,7 @@ foo$30(a ptr[in, string[no]])	### unknown string flags no
 foo$31(a int8, b ptr[in, csum[a, inet]])		### wrong number of arguments for type csum, expect csum target, kind, [proto], base type
 foo$32(a int8, b ptr[in, csum[a, inet, 1, int32]])	### only pseudo csum can have proto
 foo$33(a int8, b ptr[in, csum[a, pseudo, 1, int32]])
-foo$34(a int32["foo"])		### unexpected string "foo" for range argument of int32 type, expect int
+foo$34(a int32["foo"])		### unexpected string "foo" for value argument of int32 type, expect identifier or int
 foo$35(a ptr[in, s3[opt]])	### s3 can't be marked as opt
 foo$36(a const[1:2])		### unexpected ':'
 foo$39(a fileoff:1)		### type alias fileoff with ':'
@@ -129,16 +129,17 @@ foo$59(a s1)			### s1 can't be syscall argument
 foo$60() s1			### s1 can't be syscall return
 foo$61(a u6)			### u6 can't be syscall argument
 foo$62() u6			### u6 can't be syscall return
-foo$63(a int32[1[2]])		### range argument has subargs
+foo$63(a int32[1[2]])		### value argument has subargs
 foo$64(a ptr[in, flags[f1[int32], int32]])	### flags argument has subargs
 foo$65(a int32, b len[1])	### unexpected int 1 for len target argument of len type, expect identifier
 foo$66(a int32, b len[a:1])	### unexpected int 1 after colon, expect identifier
 foo$67(x int32[1:2:3, opt])	### unexpected ':'
-foo$68(a int32[15, 2])		### first argument of int32 needs to be a range
+foo$68(a int32[15, 2])		### first argument of int32 needs to be a range or flag
 foo$69() (foo)			### unknown syscall foo$69 attribute foo
 foo$70() ("foo")		### unexpected string "foo", expect attribute
 foo$71() (42)			### unexpected int 42, expect attribute
 foo$72() (disabled, disabled)	### duplicate syscall foo$72 attribute disabled
+foo$73(a int32[int_flags, 2])	### align argument of int32 is not supported unless first argument is a range
 
 opt {				### struct uses reserved name opt
 	f1	int32
@@ -146,6 +147,7 @@ opt {				### struct uses reserved name opt
 
 in = 1, 2			### flags uses reserved name in
 out = "1", "2"			### string flags uses reserved name out
+int_flags = 0, 1, 0xabc, 'x', -11
 
 out [				### union uses reserved name out
 	f1	int32

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -110,7 +110,7 @@ foo$36(a const[1:2])		### unexpected ':'
 foo$39(a fileoff:1)		### type alias fileoff with ':'
 foo$40(a len["a"])		### unexpected string "a" for len target argument of len type, expect identifier
 foo$41(a vma[C1:C2])
-foo$43(a ptr[in, string[1]])	### unexpected int 1, string arg must be a string literal or string flags
+foo$43(a ptr[in, string[1]])	### unexpected int 1 for literal or flags argument of string type, expect string or identifier
 foo$44(a int32) len[a]		### len can't be syscall return
 foo$45(a int32) len[b]		### len can't be syscall return
 foo$46(a ptr[in, in])		### unknown type in
@@ -369,7 +369,7 @@ type TT3[A] {
 
 foo$213(a ptr[in, TT1[int8]])
 
-foo$glob001(a ptr[in, glob[1]])			### unexpected int 1, string arg must be a string literal or string flags
+foo$glob001(a ptr[in, glob[1]])			### unexpected int 1 for literal or flags argument of glob type, expect string or identifier
 foo$glob002(a ptr[in, glob])			### glob only accepts 1 arg, provided 0
 foo$glob003(a ptr[in, glob["/sys", 5]])		### glob only accepts 1 arg, provided 2
 foo$glob004(a ptr[in, glob["/sys", 5, 2]])	### wrong number of arguments for type glob, expect [literal or flags], [size], [opt]

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -88,7 +88,6 @@ foo$11(a buffer["in"])		### unexpected string "in" for direction argument of ptr
 foo$12(a buffer[10])		### unexpected int 10 for direction argument of ptr type, expect [in out inout]
 foo$13(a int32[2:3])
 foo$14(a int32[2:2])
-foo$16(a int32[3])		### first argument of int32 needs to be a range or flag
 foo$17(a ptr[in, int32])
 foo$18(a ptr[in, int32[2:3]])
 foo$19(a ptr[in, int32[opt]])
@@ -134,7 +133,7 @@ foo$64(a ptr[in, flags[f1[int32], int32]])	### flags argument has subargs
 foo$65(a int32, b len[1])	### unexpected int 1 for len target argument of len type, expect identifier
 foo$66(a int32, b len[a:1])	### unexpected int 1 after colon, expect identifier
 foo$67(x int32[1:2:3, opt])	### unexpected ':'
-foo$68(a int32[15, 2])		### first argument of int32 needs to be a range or flag
+foo$68(a int32[15, 2])		### align argument of int32 is not supported unless first argument is a range
 foo$69() (foo)			### unknown syscall foo$69 attribute foo
 foo$70() ("foo")		### unexpected string "foo", expect attribute
 foo$71() (42)			### unexpected int 42, expect attribute

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -383,6 +383,9 @@ type type500 proc[C1, 8, int8]	### values starting from 1 with step 8 overflow b
 type type501 int8		### unused type type501
 type type502[C] const[C, int8]	### unused type type502
 
+C2 = 0, 1, 2			### const C2 is already a flag
+use_flags(a flags[C2])
+
 s405 {
 	f1	int16:8[-256:0]		### int range [18446744073709551360:0] is too large for base type of size 8
 	f2	int16:8[0:256]		### int range [0:256] is too large for base type of size 8

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -369,6 +369,7 @@ foo$531(a ptr[in, const[0xffffffffffffffab, int8]])
 foo$532(a ptr[in, const[0x7234567812345678, int64]])
 foo$533(a ptr[in, const[0x12, int8:4]])	### const val 0x12 does not fit into 4 bits
 foo$534(a ptr[in, flags[large_flags, int8]])	### large_flags U16_MAX=0xffff doesn't fit into 8 bits
+foo$535(a int64[no])			### unknown flags no
 
 large_flags = U8_MAX, U16_MAX
 

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -60,8 +60,8 @@ type namedArg struct {
 }
 
 const (
-	kindAny = iota
-	kindInt
+	kindAny = 0
+	kindInt = 1 << iota
 	kindIdent
 	kindString
 )
@@ -748,11 +748,8 @@ func (comp *compiler) stringSize(t *ast.Type, args []*ast.Type) uint64 {
 }
 
 var typeArgStringFlags = &typeArg{
+	Kind: kindIdent | kindString,
 	Check: func(comp *compiler, t *ast.Type) {
-		if !t.HasString && t.Ident == "" {
-			comp.error(t.Pos, "unexpected int %v, string arg must be a string literal or string flags", t.Value)
-			return
-		}
 		if t.Ident != "" && comp.strFlags[t.Ident] == nil {
 			comp.error(t.Pos, "unknown string flags %v", t.Ident)
 			return

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -273,8 +273,8 @@ func TestDeserialize(t *testing.T) {
 			Err: `wrong type *prog.IntType for AUTO`,
 		},
 		{
-			In:  `test$bf2(&AUTO={AUTO, 0x10, 0x0})`,
-			Out: `test$bf2(&(0x7f0000000040)={0x8, 0x10, 0x0})`,
+			In:  `test$bf2(&AUTO={AUTO, 0x10, 0x0, AUTO})`,
+			Out: `test$bf2(&(0x7f0000000040)={0x8, 0x10, 0x0, 0x18})`,
 		},
 		{
 			In:  `test$str0(&AUTO="303100090a0d7022273a")`,

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -273,6 +273,10 @@ func TestDeserialize(t *testing.T) {
 			Err: `wrong type *prog.IntType for AUTO`,
 		},
 		{
+			In:  `test$bf2(&AUTO={AUTO, 0x10, 0x0})`,
+			Out: `test$bf2(&(0x7f0000000040)={0x8, 0x10, 0x0})`,
+		},
+		{
 			In:  `test$str0(&AUTO="303100090a0d7022273a")`,
 			Out: `test$str0(&(0x7f0000000040)='01\x00\t\n\rp\"\':')`,
 		},

--- a/sys/linux/bpf.txt
+++ b/sys/linux/bpf.txt
@@ -436,18 +436,18 @@ bpf_insn_generic {
 	imm	int32
 }
 
-type bpf_insn_ldst_t[CLASS_TYPE, CLASS, SZ_TYPE, SZ, MODE_TYPE, MODE, DST, SRC, OFF, IMM] {
-	code_class	CLASS_TYPE[CLASS, int8:3]
-	code_size	SZ_TYPE[SZ, int8:2]
-	code_mode	MODE_TYPE[MODE, int8:3]
+type bpf_insn_ldst_t[CLASS, SZ, MODE, DST, SRC, OFF, IMM] {
+	code_class	int8:3[CLASS]
+	code_size	int8:2[SZ]
+	code_mode	int8:3[MODE]
 	dst		DST
 	src		SRC
 	off		OFF
 	imm		IMM
 }
 
-type bpf_insn_ldst bpf_insn_ldst_t[flags, bpf_ldst_insn, flags, bpf_ldst_size, flags, bpf_ldst_mode, flags[bpf_reg, int8:4], flags[bpf_reg, int8:4], flags[bpf_insn_offsets, int16], flags[bpf_insn_immediates, int32]]
-type bpf_insn_st64_reg[SRC, DST, OFF] bpf_insn_ldst_t[const, BPF_STX, const, BPF_DW0, const, BPF_MEM0, const[DST, int8:4], const[SRC, int8:4], const[OFF, int16], const[0, int32]]
+type bpf_insn_ldst bpf_insn_ldst_t[bpf_ldst_insn, bpf_ldst_size, bpf_ldst_mode, flags[bpf_reg, int8:4], flags[bpf_reg, int8:4], flags[bpf_insn_offsets, int16], flags[bpf_insn_immediates, int32]]
+type bpf_insn_st64_reg[SRC, DST, OFF] bpf_insn_ldst_t[BPF_STX, BPF_DW0, BPF_MEM0, const[DST, int8:4], const[SRC, int8:4], const[OFF, int16], const[0, int32]]
 
 bpf_ldst_insn = BPF_LD, BPF_LDX, BPF_ST, BPF_STX
 bpf_ldst_size = BPF_W0, BPF_H0, BPF_B0, BPF_DW0
@@ -465,22 +465,22 @@ define BPF_MEM0	BPF_MEM >> 5
 define BPF_XADD0	BPF_XADD >> 5
 define BPF_MEMSX0	BPF_MEMSX >> 5
 
-type bpf_insn_alu_t[CLASS_TYPE, CLASS, SOURCE_TYPE, SOURCE, OP_TYPE, OP, DST, SRC, OFF, IMM] {
-	code_class	CLASS_TYPE[CLASS, int8:3]
-	code_s		SOURCE_TYPE[SOURCE, int8:1]
-	code_op		OP_TYPE[OP, int8:4]
+type bpf_insn_alu_t[CLASS, SOURCE, OP, DST, SRC, OFF, IMM] {
+	code_class	int8:3[CLASS]
+	code_s		int8:1[SOURCE]
+	code_op		int8:4[OP]
 	dst		DST
 	src		SRC
 	off		OFF
 	imm		IMM
 }
 
-type bpf_insn_alu bpf_insn_alu_t[flags, bpf_alu_insn, flags, bpf_alu_source, flags, bpf_alu_op, flags[bpf_reg, int8:4], flags[bpf_reg, int8:4], flags[bpf_insn_offsets, int16], flags[bpf_insn_immediates, int32]]
-type bpf_insn_mov_imm[DST, IMM] bpf_insn_alu_t[const, BPF_ALU64, const, BPF_K0, const, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], const[IMM, int32]]
-type bpf_insn_mov_imm_any[DST] bpf_insn_alu_t[const, BPF_ALU64, const, BPF_K0, const, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], int32]
-type bpf_insn_mov_imm_flag[DST, FLAG] bpf_insn_alu_t[const, BPF_ALU64, const, BPF_K0, const, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], flags[FLAG, int32]]
-type bpf_insn_mov_reg[SRC, DST] bpf_insn_alu_t[const, BPF_ALU64, const, BPF_X0, const, BPF_MOV0, const[DST, int8:4], const[SRC, int8:4], const[0, int16], const[0, int32]]
-type bpf_insn_op_imm[DST, OP, IMM] bpf_insn_alu_t[const, BPF_ALU64, const, BPF_K0, const, OP, const[DST, int8:4], const[0, int8:4], const[0, int16], const[IMM, int32]]
+type bpf_insn_alu bpf_insn_alu_t[bpf_alu_insn, bpf_alu_source, bpf_alu_op, flags[bpf_reg, int8:4], flags[bpf_reg, int8:4], flags[bpf_insn_offsets, int16], flags[bpf_insn_immediates, int32]]
+type bpf_insn_mov_imm[DST, IMM] bpf_insn_alu_t[BPF_ALU64, BPF_K0, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], const[IMM, int32]]
+type bpf_insn_mov_imm_any[DST] bpf_insn_alu_t[BPF_ALU64, BPF_K0, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], int32]
+type bpf_insn_mov_imm_flag[DST, FLAG] bpf_insn_alu_t[BPF_ALU64, BPF_K0, BPF_MOV0, const[DST, int8:4], const[0, int8:4], const[0, int16], flags[FLAG, int32]]
+type bpf_insn_mov_reg[SRC, DST] bpf_insn_alu_t[BPF_ALU64, BPF_X0, BPF_MOV0, const[DST, int8:4], const[SRC, int8:4], const[0, int16], const[0, int32]]
+type bpf_insn_op_imm[DST, OP, IMM] bpf_insn_alu_t[BPF_ALU64, BPF_K0, OP, const[DST, int8:4], const[0, int8:4], const[0, int16], const[IMM, int32]]
 
 bpf_alu_source = BPF_K0, BPF_X0
 bpf_alu_insn = BPF_ALU, BPF_ALU64

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -589,8 +589,15 @@ syz_bf_struct3 {
 	f4	int64be:16
 }
 
+syz_bf_struct26 {
+	f0	bytesize[parent, int32]
+	f1	int32:16[bitmask_flags2]
+	f2	int32:16
+}
+
 test$bf0(a0 ptr[in, syz_bf_struct0])
 test$bf1(a0 ptr[in, syz_bf_struct1])
+test$bf2(a0 ptr[in, syz_bf_struct26])
 
 # Checksums
 

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -592,7 +592,8 @@ syz_bf_struct3 {
 syz_bf_struct26 {
 	f0	bytesize[parent, int32]
 	f1	int32:16[bitmask_flags2]
-	f2	int32:16
+	f2	int32:8
+	f3	int32:8[0x18]
 }
 
 test$bf0(a0 ptr[in, syz_bf_struct0])


### PR DESCRIPTION
This pull request adds support for the following syntaxes:

    int_flags = 1, 5, 8, 9
    int32[int_flags]
    int8[constant]

which is equivalent to:

    int_flags = 1, 5, 8, 9
    flags[int_flags, int32]
    const[constant, int8]

The first two commits implement a bit of refactoring. The third and fourth add this support in the compiler. The fifth updates the documentation. The last commit uses this syntax in the BPF descriptions.

Fixes: https://github.com/google/syzkaller/issues/4269.