### PR TITLE
compiler: increase test coverage

### DIFF
--- a/pkg/compiler/attrs.go
+++ b/pkg/compiler/attrs.go
@@ -14,7 +14,9 @@ type attrDesc struct {
 	Name string
 	// For now we assume attributes can have only 1 argument and it's an integer,
 	// enough to cover existing cases.
-	HasArg      bool
+	HasArg bool
+	// This function is not invoked for per-field attributes, only for whole
+	// structs/unions.
 	CheckConsts func(comp *compiler, parent ast.Node, attr *ast.Type)
 }
 

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -326,10 +326,6 @@ func (comp *compiler) checkAttributeValues() {
 			for _, f := range st.Fields {
 				isOut := hasOutOverlay
 				for _, attr := range f.Attrs {
-					desc := structFieldAttrs[attr.Ident]
-					if desc.CheckConsts != nil {
-						desc.CheckConsts(comp, f, attr)
-					}
 					switch attr.Ident {
 					case attrOutOverlay.Name:
 						hasOutOverlay = true

--- a/pkg/compiler/testdata/errors.txt
+++ b/pkg/compiler/testdata/errors.txt
@@ -139,6 +139,7 @@ foo$70() ("foo")		### unexpected string "foo", expect attribute
 foo$71() (42)			### unexpected int 42, expect attribute
 foo$72() (disabled, disabled)	### duplicate syscall foo$72 attribute disabled
 foo$73(a int32[int_flags, 2])	### align argument of int32 is not supported unless first argument is a range
+foo$74() (int8:1)		### unexpected ':'
 
 opt {				### struct uses reserved name opt
 	f1	int32
@@ -167,6 +168,7 @@ s3 {
 	f7	int32:33	### bitfield of size 33 is too large for base type of size 32
 	f8	const[0, int32:C1]	### literal const bitfield sizes are not supported
 	f9	const[0]	### wrong number of arguments for type const, expect value, base type
+	f10	int8:1:1	### unexpected ':'
 } [packed, align[4]]
 
 s5 {
@@ -200,6 +202,10 @@ s12 {
 s13 {
 	f1	int8
 } [size[0[0]]]			### size attribute has colon or args
+
+s14 {
+	f1	int8
+} [size[1, 2]]			### size attribute is expected to have 1 argument
 
 u3 [
 	f1	int8

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -157,14 +157,23 @@ slen1 {
 	f7 len[syscall:b, int32]	### len target b does not exist
 	f8 offsetof[parent, int32]	### offsetof must refer to fields
 	f9 offsetof[slen1, int32]	### offsetof must refer to fields
+	f10 len[f0:syscall:b, int32]	### syscall can't be in the middle of path expressions
+	f11 len[slen3:a, int32]		### len path slen3 does not refer to a struct
 	slen2 ptr[in, array[slen2]]
 	slen21 slen2
+	slen3 slen3
 	slen22 array[slen2]
 }
 
 slen2 {
-	f int32
+	f	int32
+	f1	slen3
 }
+
+slen3 [
+	a int32
+	b int32
+]
 
 # Resource ctor tests.
 


### PR DESCRIPTION
This pull request adds a couple small test cases to cover error cases that I noticed weren't covered in `pkg/compiler/{check,compiler}.go`, according to Codecov. I then verified with the latest version of this pull request that all targeted cases are now covered.