### PR TITLE
introduce the split_build flag

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -65,7 +65,7 @@ type Range struct {
 
 const LineEnd = 1 << 30
 
-func Make(target *targets.Target, vm, objDir, srcDir, buildDir string,
+func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuild bool,
 	moduleObj []string, modules []host.KernelModule) (*Impl, error) {
 	if objDir == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
@@ -76,5 +76,12 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string,
 	if vm == "gvisor" {
 		return makeGvisor(target, objDir, srcDir, buildDir, modules)
 	}
-	return makeELF(target, objDir, srcDir, buildDir, moduleObj, modules)
+	var delimiters []string
+	if splitBuild {
+		// Path prefixes used by Android Pixel kernels. See
+		// https://source.android.com/docs/setup/build/building-pixel-kernels for more
+		// details.
+		delimiters = []string{"/aosp/", "/private/"}
+	}
+	return makeELF(target, objDir, srcDir, buildDir, delimiters, moduleObj, modules)
 }

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -15,13 +15,14 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func makeELF(target *targets.Target, objDir, srcDir, buildDir string,
-	moduleObj []string, hostModules []host.KernelModule) (*Impl, error) {
+func makeELF(target *targets.Target, objDir, srcDir, buildDir string, splitBuildDelimiters, moduleObj []string,
+	hostModules []host.KernelModule) (*Impl, error) {
 	return makeDWARF(&dwarfParams{
 		target:                target,
 		objDir:                objDir,
 		srcDir:                srcDir,
 		buildDir:              buildDir,
+		splitBuildDelimiters:  splitBuildDelimiters,
 		moduleObj:             moduleObj,
 		hostModules:           hostModules,
 		readSymbols:           elfReadSymbols,

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -33,7 +33,7 @@ var RestorePC = backend.RestorePC
 func MakeReportGenerator(cfg *mgrconfig.Config, subsystem []mgrconfig.Subsystem,
 	modules []host.KernelModule, rawCover bool) (*ReportGenerator, error) {
 	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelObj,
-		cfg.KernelSrc, cfg.KernelBuildSrc, cfg.ModuleObj, modules)
+		cfg.KernelSrc, cfg.KernelBuildSrc, cfg.AndroidSplitBuild, cfg.ModuleObj, modules)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	KernelSrc string `json:"kernel_src,omitempty"`
 	// Location of the driectory where the kernel was built (if not set defaults to KernelSrc)
 	KernelBuildSrc string `json:"kernel_build_src,omitempty"`
+	// Is the kernel built separately from the modules? (Specific to Android builds)
+	AndroidSplitBuild bool `json:"android_split_build"`
 	// Kernel subsystem with paths to each subsystem
 	//	"kernel_subsystem": [
 	//		{ "name": "sound", "path": ["sound", "techpack/audio"]},


### PR DESCRIPTION
Source files for Pixel devices are split between the common AOSP kernel
(path/to/kernel/aosp) and the device-specific drivers residing in a
separate dir (path/to/kernel/private/google-modules for Android 14
and path/to/kernel/gs/google-modules for older Android versions).
See https://source.android.com/docs/setup/build/building-pixel-kernels
for details.

Android build system may reference these dirs in various ways, for which
syzkaller cannot always understand where it should look for the source.

The newly introduced split_build flags handles the problem by adding a
list of "delimiters" used when normalizing the kernel source paths.
If the path contains any of such delimiters ("/aosp/", "/gs/" or
"/private/"), then everything preceding the last delimiter in the path
is replaced with the contents of "kernel_src" from the manager config.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
