### PR TITLE
prog: validate call properties

### DIFF
--- a/prog/validation.go
+++ b/prog/validation.go
@@ -53,6 +53,9 @@ func (ctx *validCtx) validateCall(c *Call) error {
 	if c.Meta.Attrs.Disabled {
 		return fmt.Errorf("use of a disabled call")
 	}
+	if c.Props.Rerun > 0 && c.Props.FailNth > 0 {
+		return fmt.Errorf("rerun > 0 && fail_nth > 0")
+	}
 	if len(c.Args) != len(c.Meta.Args) {
 		return fmt.Errorf("wrong number of arguments, want %v, got %v",
 			len(c.Meta.Args), len(c.Args))


### PR DESCRIPTION
Syz-executor fails if rerun > 0 && fail_nth > 0, but we don't do this check during prog validation.

It works fine when syzkaller runs as a standalone app (because it never generates such programs), but it can be a problem when receiving progs from other instances via syz-hub.