### PR TITLE
syz-manager: improve prog validation errors logging

### DIFF
--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -216,7 +216,7 @@ func (hc *HubConnector) processProgs(inputs []rpctype.HubInput) (minimized, smas
 	candidates := make([]rpctype.Candidate, 0, len(inputs))
 	for _, inp := range inputs {
 		bad, disabled := checkProgram(hc.target, hc.enabledCalls, inp.Prog)
-		if bad || disabled {
+		if bad != nil || disabled {
 			log.Logf(0, "rejecting program from hub (bad=%v, disabled=%v):\n%s",
 				bad, disabled, inp)
 			dropped++
@@ -269,7 +269,7 @@ func (hc *HubConnector) processRepros(repros [][]byte) int {
 	dropped := 0
 	for _, repro := range repros {
 		bad, disabled := checkProgram(hc.target, hc.enabledCalls, repro)
-		if bad || disabled {
+		if bad != nil || disabled {
 			log.Logf(0, "rejecting repro from hub (bad=%v, disabled=%v):\n%s",
 				bad, disabled, repro)
 			dropped++

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -257,8 +257,8 @@ func (serv *RPCServer) Check(a *rpctype.CheckArgs, r *int) error {
 
 func (serv *RPCServer) NewInput(a *rpctype.NewInputArgs, r *int) error {
 	bad, disabled := checkProgram(serv.cfg.Target, serv.targetEnabledSyscalls, a.Input.Prog)
-	if bad || disabled {
-		log.Logf(0, "rejecting program from fuzzer (bad=%v, disabled=%v):\n%s", bad, disabled, a.Input.Prog)
+	if bad != nil || disabled {
+		log.Errorf("rejecting program from fuzzer (bad=%v, disabled=%v):\n%s", bad, disabled, a.Input.Prog)
 		return nil
 	}
 	serv.mu.Lock()


### PR DESCRIPTION
If we received an invalid program from the fuzzer, log it as an error. It should never be happening under normal conditions.

Include the exact error text in log messages.
