### PR TITLE
go: update to 1.21.4 everywhere and 1.20.11 in old-env

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -1,7 +1,7 @@
 # Copyright 2017 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-runtime: go120
+runtime: go121
 app_engine_apis: true
 
 # With the f2 setting, the app episodically crashes with:

--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -27,13 +27,13 @@ If you encounter any troubles, check the [troubleshooting](/docs/troubleshooting
 
 ### Go and syzkaller
 
-`syzkaller` is written in [Go](https://golang.org), and `Go 1.19+` toolchain is required for build.
+`syzkaller` is written in [Go](https://golang.org), and `Go 1.20+` toolchain is required for build.
 Generally we aim at supporting 2 latest releases of Go.
 The toolchain can be installed with:
 
 ```
-wget https://dl.google.com/go/go1.20.1.linux-amd64.tar.gz
-tar -xf go1.20.1.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.21.4.linux-amd64.tar.gz
+tar -xf go1.21.4.linux-amd64.tar.gz
 export GOROOT=`pwd`/go
 export PATH=$GOROOT/bin:$PATH
 ```

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -23,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN curl https://dl.google.com/go/go1.20.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl https://dl.google.com/go/go1.21.4.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath
 

--- a/tools/docker/old-env/Dockerfile
+++ b/tools/docker/old-env/Dockerfile
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN curl https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl https://dl.google.com/go/go1.20.11.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath
 

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -26,7 +26,7 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 	  g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	  g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu
 
-RUN curl https://dl.google.com/go/go1.20.1.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz | tar -C /usr/local -xz
+RUN curl https://dl.google.com/go/go1.21.4.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 # The default clang-14 is too old, install the latest one.


### PR DESCRIPTION

https://tip.golang.org/doc/go1.21 will be the default one.