### PR TITLE
syz-ci: make auto-restart optional

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -79,6 +79,8 @@ var (
 	flagAutoUpdate = flag.Bool("autoupdate", true, "auto-update the binary (for testing)")
 	flagManagers   = flag.Bool("managers", true, "start managers (for testing)")
 	flagDebug      = flag.Bool("debug", false, "debug mode (for testing)")
+	// nolint: lll
+	flagExitOnUpgrade = flag.Bool("exit-on-upgrade", false, "exit after a syz-ci upgrade is applied; otherwise syz-ci restarts")
 )
 
 type Config struct {

--- a/syz-ci/updater.go
+++ b/syz-ci/updater.go
@@ -194,6 +194,10 @@ func (upd *SyzUpdater) UpdateAndRestart() {
 	if err := osutil.CopyFile(latestBin, upd.exe); err != nil {
 		log.Fatal(err)
 	}
+	if *flagExitOnUpgrade {
+		log.Logf(0, "exiting, please restart syz-ci to run the new version")
+		os.Exit(0)
+	}
 	if err := syscall.Exec(upd.exe, os.Args, os.Environ()); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
By letting syz-ci just exit on update, we make it possible to also automatically pull the latest Docker container before starting the new version.

Fixes #2985
