### PR TITLE
dashboard: change low-priority bugs reporting

### DIFF
--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -512,12 +512,14 @@ func (r *SubsystemReport) findStage(id string) *SubsystemReportStage {
 
 type SubsystemReportStats struct {
 	Reported int
+	LowPrio  int
 	Fixed    int
 }
 
 func (s *SubsystemReportStats) toDashapi() dashapi.BugListReportStats {
 	return dashapi.BugListReportStats{
 		Reported: s.Reported,
+		LowPrio:  s.LowPrio,
 		Fixed:    s.Fixed,
 	}
 }

--- a/dashboard/app/mail_subsystem.txt
+++ b/dashboard/app/mail_subsystem.txt
@@ -7,6 +7,12 @@ All related reports/information can be found at:
 During the period, {{.PeriodStats.Reported}} new issues were detected and {{.PeriodStats.Fixed}} were fixed.
 In total, {{.TotalStats.Reported}} issues are still open
 {{- if .TotalStats.Fixed}} and {{.TotalStats.Fixed}} ha{{if eq .TotalStats.Fixed 1}}s{{else}}ve{{end}} been fixed so far{{end}}.
+{{- if eq .TotalStats.LowPrio 1}}
+There is also 1 low-priority issue.
+{{- end}}
+{{- if gt .TotalStats.LowPrio 1}}
+There are also {{.TotalStats.LowPrio}} low-priority issues.
+{{- end}}
 
 Some of the still happening issues:
 

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -264,6 +264,11 @@ func querySubsystemReport(c context.Context, subsystem *Subsystem, reporting *Re
 			// Don't take bugs which are too new -- they're still fresh in memory.
 			continue
 		}
+		if bug.prio() == LowPrioBug {
+			// Don't include low priority bugs in reports because the community
+			// actually perceives them as non-actionable.
+			continue
+		}
 		discussions := bug.discussionSummary()
 		if discussions.ExternalMessages > 0 &&
 			discussions.LastMessage.After(timeNow(c).Add(-config.UserReplyFrist)) {

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -1056,8 +1056,9 @@ This is a 30-day syzbot report for the subsystemA subsystem.
 All related reports/information can be found at:
 https://testapp.appspot.com/subsystem-reminders/s/subsystemA
 
-During the period, 3 new issues were detected and 0 were fixed.
-In total, 3 issues are still open.
+During the period, 2 new issues were detected and 0 were fixed.
+In total, 2 issues are still open.
+There is also 1 low-priority issue.
 
 Some of the still happening issues:
 

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -1066,8 +1066,6 @@ Ref Crashes Repro Title
                   https://testapp.appspot.com/bug?extid=%[1]v
 <2> 2       No    WARNING: a second
                   https://testapp.appspot.com/bug?extid=%[2]v
-<3> 2       Yes   WARNING: a first
-                  https://testapp.appspot.com/bug?extid=%[3]v
 
 The report will be sent to: [subsystemA@list.com subsystemA@person.com].
 

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -505,6 +505,7 @@ type BugListReport struct {
 
 type BugListReportStats struct {
 	Reported int
+	LowPrio  int
 	Fixed    int
 }
 


### PR DESCRIPTION
* Don't display low priority issues in monthly reports at all.
* Display the count of low priority bugs separately.