### PR TITLE
vm/adb: a more reliable way to delete broken symlinks

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -160,8 +160,11 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	// Remove temp files from previous runs.
 	// rm chokes on bad symlinks so we must remove them first
 	if _, err := inst.adb("shell", "ls /data/syzkaller*"); err == nil {
-		if _, err := inst.adb("shell", "find /data/syzkaller* -type l -exec unlink {} \\;"+
-			" && rm -Rf /data/syzkaller*"); err != nil {
+		if _, err := inst.adb("shell", "find /data/syzkaller* 2>&1 | grep 'No such file' "+
+			"| sed 's/.*\\/data/\\/data/;s/:.*//' | xargs -r unlink"); err != nil {
+			return nil, err
+		}
+		if _, err := inst.adb("shell", "rm -Rf /data/syzkaller*"); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
When fuzzing Android, the executor sometimes leaves broken symlinks that
point to non-existent directories. The command that adb.go was using to
delete the leftover symlinks:
  `find /data/syzkaller* -type l -exec unlink {} \;`
actually choked on such files and led to syzkaller rebooting the device
indefinitely.
Parse the output of `find /data/syzkaller*` to obtain the list of broken
symlinks and pass them to `unlink` one by one.

Fixes #2831.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
