### PR TITLE
dashboard: only count last stage bugs in monthly reports

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -481,11 +481,12 @@ var testConfig = &GlobalConfig{
 			},
 			Reporting: []Reporting{
 				{
-					AccessLevel: AccessUser,
-					Name:        "non-public",
+					// Let's emulate public moderation.
+					AccessLevel: AccessPublic,
+					Name:        "moderation",
 					DailyLimit:  1000,
 					Filter: func(bug *Bug) FilterResult {
-						if strings.Contains(bug.Title, "keep private") {
+						if strings.Contains(bug.Title, "keep in moderation") {
 							return FilterReport
 						}
 						return FilterSkip

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -243,17 +243,12 @@ func findSubsystemReportByID(c context.Context, ID string) (*Subsystem,
 func querySubsystemReport(c context.Context, subsystem *Subsystem, reporting *Reporting,
 	config *BugListReportingConfig) (*SubsystemReport, error) {
 	rawOpenBugs, fixedBugs, err := queryMatchingBugs(c, subsystem.Namespace,
-		subsystem.Name, reporting.AccessLevel)
+		subsystem.Name, reporting)
 	if err != nil {
 		return nil, err
 	}
 	withRepro, noRepro := []*Bug{}, []*Bug{}
 	for _, bug := range rawOpenBugs {
-		currReporting, _, _, _, _ := currentReporting(c, bug)
-		if reporting.Name != currReporting.Name {
-			// The big is not at the expected reporting stage.
-			continue
-		}
 		const possiblyFixedTimespan = 24 * time.Hour * 14
 		if bug.LastTime.Before(timeNow(c).Add(-possiblyFixedTimespan)) {
 			// The bug didn't happen recently, possibly it was already fixed.
@@ -352,7 +347,7 @@ func makeSubsystemReportStats(c context.Context, open, fixed []*Bug, days int) S
 	return ret
 }
 
-func queryMatchingBugs(c context.Context, ns, name string, accessLevel AccessLevel) ([]*Bug, []*Bug, error) {
+func queryMatchingBugs(c context.Context, ns, name string, reporting *Reporting) ([]*Bug, []*Bug, error) {
 	allOpenBugs, _, err := loadAllBugs(c, func(query *db.Query) *db.Query {
 		return query.Filter("Namespace=", ns).
 			Filter("Status=", BugStatusOpen).
@@ -382,7 +377,11 @@ func queryMatchingBugs(c context.Context, ns, name string, accessLevel AccessLev
 		if err != nil {
 			continue
 		}
-		if currReporting.AccessLevel > accessLevel {
+		if reporting.Name != currReporting.Name {
+			// The bug is not at the expected reporting stage.
+			continue
+		}
+		if currReporting.AccessLevel > reporting.AccessLevel {
 			continue
 		}
 		open = append(open, bug)

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -345,7 +345,7 @@ func TestPeriodicSubsystemReminders(t *testing.T) {
 
 	// Make sure we don't report crashes at other reporting stages.
 	crash := testCrash(build, 1)
-	crash.Title = `WARNING: a third, keep private` // see the config in app_test.go
+	crash.Title = `WARNING: a third, keep in moderation` // see the config in app_test.go
 	crash.GuiltyFiles = []string{"a.c"}
 	client.ReportCrash(crash)
 	client.pollBug()


### PR DESCRIPTION
Currently we count all publicly visible bugs, which can get confusing now that we keep KCSAN bugs in public moderation. Only consider the reporting stage at which we generate the report.

This is tested in TestPeriodicSubsystemReminders().
