### PR TITLE
Selectively disable executor unit tests for hardware with SVM virtualization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ Lee Jones
 Junquan Zhou
 Arm Ltd
 Tudor Ambarus
+Elektrobit Automotive GmbH

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -123,3 +123,4 @@ Arm Ltd
 h0wdy
 Dylan Yudaken
 Marius Fleischer
+Piotr Siminski

--- a/executor/test_linux.h
+++ b/executor/test_linux.h
@@ -101,7 +101,7 @@ static int test_one(int text_type, const char* text, int text_size, int flags, u
 
 static int test_kvm()
 {
-	int res;
+	int res = 0;
 
 	unsigned ver = host_kernel_version();
 	printf("host kernel version %u\n", ver);


### PR DESCRIPTION
As discussed on the mailing list (see Link), the executor unit tests fail on some newer hardware, probably due to SVM virtualization not supporting older VMX virtualization features. So, we disable the tests for that. Before touching the file, we made the style checker happy. And afterwards, we add Piotr as contributor and Elektrobit as copyright holder.

Link: https://groups.google.com/g/syzkaller/c/jmb8Pt8qdQg