### PR TITLE
tools/docker/syzbot: add libbpf-dev to Dockerfile

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Google Inc.
  Hidenori Kobayashi
  Florent Revest
  Gabe Kirkpatrick
+ Kevin Krakauer
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -18,7 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	# Needed for building Cuttlefish images.
 	rsync libarchive-tools \
 	# Needed for buiding gVisor.
-	crossbuild-essential-amd64 crossbuild-essential-arm64
+	crossbuild-essential-amd64 crossbuild-essential-arm64 libbpf-dev
 RUN test "$(uname -m)" != x86_64 && exit 0 || \
         DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	  libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-12-dev lib32stdc++-12-dev \


### PR DESCRIPTION
gVisor relies on eBPF since the following 2 commits, so libbpf-dev is required when building:

- https://github.com/google/gvisor/commit/2ae19ffb
- https://github.com/google/gvisor/commit/f6d380ad

Without this change, syzkaller can't build gVisor and gets the following error:

  tools/xdp/cmd/bpf/redirect_host.ebpf.c:15:10: fatal error: 'bpf/bpf_endian.h' file not found
  FAILED: Build did NOT complete successfully