### PR TITLE
executor: introduce syz_pidfd_open()

### DIFF
--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -11823,6 +11823,18 @@ static void setup_swap()
 
 #endif
 
+#if SYZ_EXECUTOR || __NR_syz_pidfd_open
+#include <sys/syscall.h>
+static long syz_pidfd_open(volatile long pid, volatile long flags)
+{
+	if (pid == 1) {
+		pid = 0;
+	}
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+#endif
+
 #elif GOOS_test
 
 #include <stdlib.h>

--- a/pkg/host/syscalls_linux.go
+++ b/pkg/host/syscalls_linux.go
@@ -327,6 +327,7 @@ var syzkallSupport = map[string]func(*prog.Syscall, *prog.Target, string) (bool,
 	"syz_clone3":                  alwaysSupported,
 	"syz_pkey_set":                isSyzPkeySetSupported,
 	"syz_socket_connect_nvme_tcp": isSyzSocketConnectNvmeTCPSupported,
+	"syz_pidfd_open":              alwaysSupported,
 }
 
 func isSupportedSyzkall(c *prog.Syscall, target *prog.Target, sandbox string) (bool, string) {

--- a/sys/linux/sys.txt
+++ b/sys/linux/sys.txt
@@ -653,7 +653,10 @@ resource fd_pidfd[fd]
 openat$pidfd(fd const[AT_FDCWD], file ptr[in, string["/proc/self"]], flags flags[open_flags], mode const[0]) fd_pidfd
 openat$thread_pidfd(fd const[AT_FDCWD], file ptr[in, string["/proc/thread-self"]], flags flags[open_flags], mode const[0]) fd_pidfd
 pidfd_send_signal(fd fd_pidfd, sig signalno, info ptr[in, siginfo], flags const[0])
-pidfd_open(pid pid, flags const[0]) fd_pidfd
+
+# pidfd_open is dangerous, so we use syz_pidfd_open instead.
+pidfd_open(pid pid, flags const[0]) fd_pidfd (disabled)
+syz_pidfd_open(pid pid, flags const[0]) fd_pidfd
 pidfd_getfd(pidfd fd_pidfd, fd fd, flags const[0]) fd
 
 close_range(fd fd, max_fd fd, flags flags[close_range_flags])

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -490,6 +490,7 @@ var oses = map[string]osCommon{
 			"syz_io_uring_setup":  {"io_uring_setup"},
 			"syz_clone3":          {"clone3", "exit"},
 			"syz_clone":           {"clone", "exit"},
+			"syz_pidfd_open":      {"pidfd_open"},
 		},
 		cflags: []string{"-static-pie"},
 	},


### PR DESCRIPTION
This kernel interface provides access to fds of other processes, which is readily abused by the fuzzer to mangle parent syz-executor fds.

Pid=1 is the parent syz-executor process when PID namespace is created. Sanitize it in the new syz_pidfd_open() pseudo-syscall.

We could not patch the argument in `sys/linux/init.go` because the first argument is a resource.
