### PR TITLE
make bisection more robust in case of config minimization failures

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -126,3 +126,5 @@ Marius Fleischer
 Piotr Siminski
 Purdue University
  Sungwoo Kim
+Krzysztof Pawlaczyk
+Simone Weiß

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -416,7 +416,11 @@ func (env *env) minimizeConfig() (*testResult, error) {
 	minConfig, err := env.minimizer.Minimize(env.cfg.Manager.SysTarget, env.cfg.Kernel.Config,
 		env.cfg.Kernel.BaselineConfig, env.reportTypes, env.cfg.Trace, predMinimize)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, vcs.ErrBadKconfig) {
+			env.log("config minimization failed due to bad Kconfig %v\nproceeding with the original config", err)
+		} else {
+			return nil, err
+		}
 	}
 	env.kernelConfig = minConfig
 	return testResults[hash.Hash(minConfig)], nil

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -5,6 +5,7 @@ package vcs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/mail"
 	"path/filepath"
@@ -274,6 +275,8 @@ func ParseMaintainersLinux(text []byte) Recipients {
 	return mtrs
 }
 
+var ErrBadKconfig = errors.New("failed to parse Kconfig")
+
 const configBisectTag = "# Minimized by syzkaller"
 
 // Minimize() attempts to drop Linux kernel configs that are unnecessary(*) for bug reproduction.
@@ -289,7 +292,7 @@ func (ctx *linux) Minimize(target *targets.Target, original, baseline []byte, ty
 	}
 	kconf, err := kconfig.Parse(target, filepath.Join(ctx.git.dir, "Kconfig"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Kconfig: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrBadKconfig, err)
 	}
 	config, err := kconfig.ParseConfigData(original, "original")
 	if err != nil {
@@ -324,8 +327,10 @@ func (ctx *linux) Minimize(target *targets.Target, original, baseline []byte, ty
 	}
 	if len(baseline) > 0 {
 		baselineConfig, err := kconfig.ParseConfigData(baseline, "baseline")
+		// If we fail to parse the baseline config proceed with original one as baseline config
+		// is an optional parameter.
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", ErrBadKconfig, err)
 		}
 		err = minimizeCtx.minimizeAgainst(baselineConfig)
 		if err != nil {


### PR DESCRIPTION
When using the bisect script, we noticed that some bisection just failed as the config minimization internally failed and the bisect script then just gave up. However, we can actually continue bisection with the original config and still find reasonable bisection results. The needed change for that behavior is small and simple.
