### PR TITLE
syz-ci: make the TestManagerPollCommits() test not flaky

### DIFF
--- a/syz-ci/manager_test.go
+++ b/syz-ci/manager_test.go
@@ -84,7 +84,7 @@ Reported-by: foo+abcd000@bar.com`,
 
 	foundCommits := map[string]bool{}
 	// Call it several more times to catch all commits.
-	for i := 0; i < 15; i++ {
+	for i := 0; i < 100; i++ {
 		for _, name := range matches {
 			foundCommits[name] = true
 		}


### PR DESCRIPTION
It uses randomization, so let's make more iterations.
