### PR TITLE
prog: optimize foreachArgImpl()

### DIFF
--- a/prog/analysis.go
+++ b/prog/analysis.go
@@ -155,11 +155,13 @@ func foreachArgImpl(arg Arg, ctx *ArgCtx, f func(Arg, *ArgCtx)) {
 				totalSize = ctx.Offset - ctx0.Offset
 			}
 		}
-		claimedSize := a.Size()
-		varlen := a.Type().Varlen()
-		if varlen && totalSize > claimedSize || !varlen && totalSize != claimedSize {
-			panic(fmt.Sprintf("bad group arg size %v, should be <= %v for %#v type %#v",
-				totalSize, claimedSize, a, a.Type().Name()))
+		if debug {
+			claimedSize := a.Size()
+			varlen := a.Type().Varlen()
+			if varlen && totalSize > claimedSize || !varlen && totalSize != claimedSize {
+				panic(fmt.Sprintf("bad group arg size %v, should be <= %v for %#v type %#v",
+					totalSize, claimedSize, a, a.Type().Name()))
+			}
 		}
 	case *PointerArg:
 		if a.Res != nil {


### PR DESCRIPTION
Per profiling, (*GroupArg).Size() calls from this function were one of the hottest paths during the BenchmarkMutate() benchmark.

Some of those calls are made only to issue a runtime panic, which we arguably don't need unless we're testing the code.

After the changes:
```
          │ /tmp/original │              /tmp/new               │
          │    sec/op     │   sec/op     vs base                │
Mutate-36     221.8µ ± 4%   179.0µ ± 3%  -19.31% (p=0.000 n=15)
```