### PR TITLE
sys/linux: fix vlang double tag const

### DIFF
--- a/sys/linux/vnet.txt
+++ b/sys/linux/vnet.txt
@@ -73,7 +73,7 @@ type mac_addr_mask array[flags[mac_addr_mask_vals, int8], 6]
 mac_addr_mask_vals = 0, 0xff
 
 vlan_tag_ad {
-	tpid	const[ETH_P_QINQ1, int16be]
+	tpid	const[ETH_P_8021AD, int16be]
 	pcp	int16:3
 	dei	int16:1
 	vid	int16:12[0:4]


### PR DESCRIPTION
Double tagging is used in 802.1ad, which is identified by TPID=0x88a8. We were using an incorrect const.
