### PR TITLE
all: support pprof in syz-fuzzer

### DIFF
--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -28,6 +30,7 @@ import (
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/sys"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/google/syzkaller/vm/vmimpl"
 )
 
 type Fuzzer struct {
@@ -182,6 +185,14 @@ func main() {
 		<-shutdown
 		log.Logf(0, "SYZ-FUZZER: PREEMPTED")
 		os.Exit(1)
+	}()
+
+	// Necessary for pprof handlers.
+	go func() {
+		err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%v", vmimpl.PprofPort), nil)
+		if err != nil {
+			log.SyzFatalf("failed to setup a server: %v", err)
+		}
 	}()
 
 	checkArgs := &checkArgs{

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -425,6 +425,7 @@ func (inst *instance) Close() {
 func (inst *instance) boot() error {
 	inst.port = vmimpl.UnusedTCPPort()
 	inst.monport = vmimpl.UnusedTCPPort()
+	instanceName := fmt.Sprintf("VM-%v", inst.index)
 	args := []string{
 		"-m", strconv.Itoa(inst.cfg.Mem),
 		"-smp", strconv.Itoa(inst.cfg.CPU),
@@ -433,16 +434,22 @@ func (inst *instance) boot() error {
 		"-display", "none",
 		"-serial", "stdio",
 		"-no-reboot",
-		"-name", fmt.Sprintf("VM-%v", inst.index),
+		"-name", instanceName,
 	}
 	if inst.archConfig.RngDev != "" {
 		args = append(args, "-device", inst.archConfig.RngDev)
 	}
 	templateDir := filepath.Join(inst.workdir, "template")
 	args = append(args, splitArgs(inst.cfg.QemuArgs, templateDir, inst.index)...)
+
+	forwardedPort := vmimpl.UnusedTCPPort()
+	pprofExt := fmt.Sprintf(",hostfwd=tcp::%v-:%v", forwardedPort, vmimpl.PprofPort)
+	log.Logf(3, "instance %s's pprof is available at 127.0.0.1:%v", instanceName, forwardedPort)
+
 	args = append(args,
 		"-device", inst.cfg.NetDev+",netdev=net0",
-		"-netdev", fmt.Sprintf("user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:%v-:22", inst.port))
+		"-netdev", fmt.Sprintf("user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:%v-:22%s", inst.port, pprofExt),
+	)
 	if inst.image == "9p" {
 		args = append(args,
 			"-fsdev", "local,id=fsdev0,path=/,security_model=none,readonly",

--- a/vm/vmimpl/console.go
+++ b/vm/vmimpl/console.go
@@ -1,5 +1,6 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+//go:build !windows
 
 package vmimpl
 

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -186,6 +186,9 @@ func Multiplex(cmd *exec.Cmd, merger *OutputMerger, console io.Closer, timeout t
 	return merger.Output, errc, nil
 }
 
+// On VMs, pprof will be listening to this port.
+const PprofPort = 6060
+
 func RandomPort() int {
 	n, err := rand.Int(rand.Reader, big.NewInt(64<<10-1<<10))
 	if err != nil {


### PR DESCRIPTION
* Expose a pprof endpoint from syz-fuzzer.
* Optionally forward the pprof port for qemu instances.