### PR TITLE
syz-fuzzer: assorted optimizations

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -561,7 +561,7 @@ func makeCommand(pid int, bin []string, config *Config, inFile, outFile *os.File
 		// Executor has an internal timeout and protects against most hangs when fork server is enabled,
 		// so we use quite large timeout. Executor can be slow due to global locks in namespaces
 		// and other things, so let's better wait than report false misleading crashes.
-		timeout *= 10
+		timeout *= 5
 	}
 
 	c := &command{


### PR DESCRIPTION
Minor optimizations that significantly speed up the corpus triage stage and kernel fuzzing overall. More details are in commit descriptions.

* On a local qemu-based instance, the corpus triage speed is ~66% higher than it was.
* Fuzzing on GCE is ~27% faster than it was. Looks like there are also other bottlenecks there that still need to be found.