### PR TITLE
syz-executor: don't fail on netlink errors during fuzzing

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -258,6 +258,13 @@ static void find_vf_interface(void)
 static int netlink_send_ext(struct nlmsg* nlmsg, int sock,
 			    uint16 reply_type, int* reply_len, bool dofail)
 {
+#if SYZ_EXECUTOR
+	if (in_execute_one && dofail) {
+		// We can expect different sorts of breakages during fuzzing,
+		// we should not kill the whole process because of them.
+		failmsg("invalid netlink_send_ext arguments", "dofail is true during syscall execution");
+	}
+#endif
 	if (nlmsg->pos > nlmsg->buf + sizeof(nlmsg->buf) || nlmsg->nesting)
 		fail("nlmsg overflow/bad nesting");
 	struct nlmsghdr* hdr = (struct nlmsghdr*)nlmsg->buf;

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -188,6 +188,10 @@ static uint64 syscall_timeout_ms;
 static uint64 program_timeout_ms;
 static uint64 slowdown_scale;
 
+// Can be used to disginguish whether we're at the initialization stage
+// or we already execute programs.
+static bool in_execute_one = false;
+
 #define SYZ_EXECUTOR 1
 #include "common.h"
 
@@ -748,6 +752,7 @@ void realloc_output_data()
 // execute_one executes program stored in input_data.
 void execute_one()
 {
+	in_execute_one = true;
 #if SYZ_EXECUTOR_USES_SHMEM
 	realloc_output_data();
 	output_pos = output_data;

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -2909,6 +2909,11 @@ static void find_vf_interface(void)
 static int netlink_send_ext(struct nlmsg* nlmsg, int sock,
 			    uint16 reply_type, int* reply_len, bool dofail)
 {
+#if SYZ_EXECUTOR
+	if (in_execute_one && dofail) {
+		failmsg("invalid netlink_send_ext arguments", "dofail is true during syscall execution");
+	}
+#endif
 	if (nlmsg->pos > nlmsg->buf + sizeof(nlmsg->buf) || nlmsg->nesting)
 		fail("nlmsg overflow/bad nesting");
 	struct nlmsghdr* hdr = (struct nlmsghdr*)nlmsg->buf;


### PR DESCRIPTION
During fuzzing, it's expected that certain operations might return errors. Don't abort the whole syz-executor process in this case, this is too expensive.