### PR TITLE
dashboard: prevent infinite reporting of revoked repros

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -276,6 +276,7 @@ var testConfig = &GlobalConfig{
 			},
 			FindBugOriginTrees: true,
 			CacheUIPages:       true,
+			RetestRepros:       true,
 		},
 		"access-public-email": {
 			AccessLevel: AccessPublic,


### PR DESCRIPTION
Fix a bug in the reporting of bugs with revoked reproducers. Add a test that reproduces the problematic situation.

Also, ensure that we don't include the revoked reproducer into the report we send to the next reporting stage.

Cc #4412.
