### PR TITLE
dashboard: introduce an emergency stop mode

### DIFF
--- a/dashboard/app/admin.html
+++ b/dashboard/app/admin.html
@@ -13,6 +13,12 @@ Main page.
 </head>
 <body>
 	{{template "header" .Header}}
+	{{if $.Stopped}}
+		<div class="emergency-stopped">Syzbot is in the emergency stop state</div>
+	{{else}}
+		<div class="emergency-stop">Syzbot is reporting too many bugs? {{link $.StopLink "Emergency stop"}} [click {{$.MoreStopClicks}} more times]<br />
+		In this mode, syzbot will stop all reporting and won't record any new findings.</div>
+	{{end}}
 
 	<a class="plain" href="#log"><div id="log"><b>Error log:</b></div></a>
 	<textarea id="log_textarea" readonly rows="20" wrap=off>{{printf "%s" .Log}}</textarea>
@@ -21,7 +27,6 @@ Main page.
 		textarea.scrollTop = textarea.scrollHeight;
 	</script>
 	<br><br>
-
 	{{with $.MemcacheStats}}
 	<table class="list_table">
 		<caption><a href="https://pkg.go.dev/google.golang.org/appengine/memcache?tab=doc#Item" target="_blank">Memcache stats:</a></caption>

--- a/dashboard/app/api_test.go
+++ b/dashboard/app/api_test.go
@@ -5,6 +5,9 @@ package main
 
 import (
 	"testing"
+	"time"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
 )
 
 func TestClientSecretOK(t *testing.T) {
@@ -62,4 +65,140 @@ func TestClientNamespaceOK(t *testing.T) {
 	if err != nil || got != "ns1" {
 		t.Errorf("Unexpected error %v %v", got, err)
 	}
+}
+
+func TestEmergentlyStoppedEmail(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+
+	c.advanceTime(time.Hour)
+	_, err := c.AuthGET(AccessAdmin, "/admin?action=emergency_stop")
+	c.expectOK(err)
+
+	// There should be no email.
+	c.advanceTime(time.Hour)
+	c.expectNoEmail()
+}
+
+func TestEmergentlyStoppedReproEmail(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	c.pollEmailBug()
+
+	crash2 := testCrash(build, 1)
+	crash2.ReproOpts = []byte("repro opts")
+	crash2.ReproSyz = []byte("getpid()")
+	client.ReportCrash(crash2)
+
+	c.advanceTime(time.Hour)
+	_, err := c.AuthGET(AccessAdmin, "/admin?action=emergency_stop")
+	c.expectOK(err)
+
+	// There should be no email.
+	c.advanceTime(time.Hour)
+	c.expectNoEmail()
+}
+
+func TestEmergentlyStoppedExternalReport(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.client
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+
+	c.advanceTime(time.Hour)
+	_, err := c.AuthGET(AccessAdmin, "/admin?action=emergency_stop")
+	c.expectOK(err)
+
+	// There should be no email.
+	c.advanceTime(time.Hour)
+	client.pollBugs(0)
+}
+
+func TestEmergentlyStoppedEmailJob(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	crash.ReproOpts = []byte("repro opts")
+	crash.ReproSyz = []byte("getpid()")
+	client.ReportCrash(crash)
+	sender := c.pollEmailBug().Sender
+	c.incomingEmail(sender, "#syz upstream\n")
+	sender = c.pollEmailBug().Sender
+
+	// Send a patch testing request.
+	c.advanceTime(time.Hour)
+	c.incomingEmail(sender, syzTestGitBranchSamplePatch,
+		EmailOptMessageID(1), EmailOptFrom("test@requester.com"),
+		EmailOptCC([]string{"somebody@else.com", "test@syzkaller.com"}))
+	c.expectNoEmail()
+
+	// Emulate a finished job.
+	pollResp := client.pollJobs(build.Manager)
+	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)
+
+	c.advanceTime(time.Hour)
+	jobDoneReq := &dashapi.JobDoneReq{
+		ID:          pollResp.ID,
+		Build:       *build,
+		CrashTitle:  "test crash title",
+		CrashLog:    []byte("test crash log"),
+		CrashReport: []byte("test crash report"),
+	}
+	client.JobDone(jobDoneReq)
+
+	// Now we emergently stop syzbot.
+	c.advanceTime(time.Hour)
+	_, err := c.AuthGET(AccessAdmin, "/admin?action=emergency_stop")
+	c.expectOK(err)
+
+	// There should be no email.
+	c.advanceTime(time.Hour)
+	c.expectNoEmail()
+}
+
+func TestEmergentlyStoppedCrashReport(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	// Now we emergently stop syzbot.
+	c.advanceTime(time.Hour)
+	_, err := c.AuthGET(AccessAdmin, "/admin?action=emergency_stop")
+	c.expectOK(err)
+
+	crash := testCrash(build, 1)
+	crash.ReproOpts = []byte("repro opts")
+	crash.ReproSyz = []byte("getpid()")
+	client.ReportCrash(crash)
+
+	listResp, err := client.BugList()
+	c.expectOK(err)
+	c.expectEQ(len(listResp.List), 0)
 }

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -986,6 +986,13 @@ func (bug *Bug) dashapiStatus() (dashapi.BugStatus, error) {
 	return status, nil
 }
 
+// If an entity of type EmergencyStop exists, syzbot's operation is paused until
+// a support engineer deletes it from the DB.
+type EmergencyStop struct {
+	Time time.Time
+	User string
+}
+
 func addCrashReference(c context.Context, crashID int64, bugKey *db.Key, ref CrashReference) error {
 	crash := new(Crash)
 	crashKey := db.NewKey(c, "Crash", "", crashID, bugKey)

--- a/dashboard/app/reporting_external.go
+++ b/dashboard/app/reporting_external.go
@@ -19,6 +19,9 @@ import (
 // and report back bug status updates with apiReportingUpdate.
 
 func apiReportingPollBugs(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
+	if stop, err := emergentlyStopped(c); err != nil || stop {
+		return &dashapi.PollBugsResponse{}, err
+	}
 	req := new(dashapi.PollBugsRequest)
 	if err := json.Unmarshal(payload, req); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request: %w", err)
@@ -36,6 +39,9 @@ func apiReportingPollBugs(c context.Context, r *http.Request, payload []byte) (i
 }
 
 func apiReportingPollNotifications(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
+	if stop, err := emergentlyStopped(c); err != nil || stop {
+		return &dashapi.PollNotificationsResponse{}, err
+	}
 	req := new(dashapi.PollNotificationsRequest)
 	if err := json.Unmarshal(payload, req); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request: %w", err)
@@ -48,6 +54,9 @@ func apiReportingPollNotifications(c context.Context, r *http.Request, payload [
 }
 
 func apiReportingPollClosed(c context.Context, r *http.Request, payload []byte) (interface{}, error) {
+	if stop, err := emergentlyStopped(c); err != nil || stop {
+		return &dashapi.PollClosedResponse{}, err
+	}
 	req := new(dashapi.PollClosedRequest)
 	if err := json.Unmarshal(payload, req); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request: %w", err)

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -409,3 +409,15 @@ aside {
 .collapsible-show .show-icon {
 	display: none;
 }
+
+.emergency-stop {
+	background-color: yellow;
+	padding: 5pt;
+	margin-bottom: 5pt;
+}
+
+.emergency-stopped {
+	background-color: coral;
+	padding: 5pt;
+	margin-bottom: 5pt;
+}


### PR DESCRIPTION
Add an emergency stop button that can be used by any admin. After it's clicked two times, syzbot stops all reporting and recoding of new bugs.

It's assumed that the stop mode is revoked by manually deleting an entry from the database.

Cc #4412
