### PR TITLE
dashboard: show coverage reports in per manager pages

### DIFF
--- a/dashboard/app/asset_storage.go
+++ b/dashboard/app/asset_storage.go
@@ -496,7 +496,7 @@ func queryLatestManagerAssets(c context.Context, ns string, assetType dashapi.As
 	return ret, nil
 }
 
-func createAssetList(build *Build, crash *Crash) []dashapi.Asset {
+func createAssetList(build *Build, crash *Crash, forReport bool) []dashapi.Asset {
 	var crashAssets []Asset
 	if crash != nil {
 		crashAssets = crash.Assets
@@ -504,7 +504,7 @@ func createAssetList(build *Build, crash *Crash) []dashapi.Asset {
 	assetList := []dashapi.Asset{}
 	for _, reportAsset := range append(build.Assets, crashAssets...) {
 		typeDescr := asset.GetTypeDescription(reportAsset.Type)
-		if typeDescr == nil || typeDescr.NoReporting {
+		if typeDescr == nil || forReport && typeDescr.NoReporting {
 			continue
 		}
 		assetList = append(assetList, dashapi.Asset{

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -548,7 +548,7 @@ func crashBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key,
 	if !bugReporting.Reported.IsZero() {
 		typ = dashapi.ReportRepro
 	}
-	assetList := createAssetList(build, crash)
+	assetList := createAssetList(build, crash, true)
 	kernelRepo := kernelRepoInfo(c, build)
 	rep := &dashapi.BugReport{
 		Type:            typ,


### PR DESCRIPTION
There's no sense to restrict the list of build assets there.
