### PR TITLE
prog: prefer precise constructors

### DIFF
--- a/prog/resources_test.go
+++ b/prog/resources_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResourceCtors(t *testing.T) {
@@ -189,4 +190,24 @@ func testCreateResource(t *testing.T, target *Target, calls map[*Syscall]bool, r
 			}
 		})
 	}
+}
+
+func TestPreferPreciseResources(t *testing.T) {
+	target, rs, _ := initRandomTargetTest(t, "test", "64")
+	r := newRand(target, rs)
+	counts := map[string]int{}
+	for i := 0; i < 1500; i++ {
+		s := newState(target, target.DefaultChoiceTable(), nil)
+		calls := r.generateParticularCall(s,
+			target.SyscallMap["test$consume_subtype_of_common"])
+		for _, call := range calls {
+			if call.Meta.Name == "test$consume_subtype_of_common" {
+				continue
+			}
+			counts[call.Meta.Name]++
+		}
+	}
+	assert.Greater(t, counts["test$produce_common"], 15)
+	assert.Greater(t, counts["test$also_produce_common"], 15)
+	assert.Greater(t, counts["test$produce_subtype_of_common"], 100)
 }

--- a/prog/target.go
+++ b/prog/target.go
@@ -69,7 +69,7 @@ type Target struct {
 	types       []Type
 	resourceMap map[string]*ResourceDesc
 	// Maps resource name to a list of calls that can create the resource.
-	resourceCtors map[string][]*Syscall
+	resourceCtors map[string][]ResourceCtor
 	any           anyTypes
 
 	// The default ChoiceTable is used only by tests and utilities, so we initialize it lazily.
@@ -169,7 +169,7 @@ func (target *Target) initTarget() {
 	}
 
 	target.populateResourceCtors()
-	target.resourceCtors = make(map[string][]*Syscall)
+	target.resourceCtors = make(map[string][]ResourceCtor)
 	for _, res := range target.Resources {
 		target.resourceCtors[res.Name] = target.calcResourceCtors(res, false)
 	}

--- a/prog/types.go
+++ b/prog/types.go
@@ -249,7 +249,7 @@ type ResourceDesc struct {
 }
 
 type ResourceCtor struct {
-	Call    int // index in Target.Syscalls
+	Call    *Syscall
 	Precise bool
 }
 

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -927,3 +927,13 @@ test_args0 {
 
 test$output_res(arg ptr[out, test_args0])
 test$optional_res(arg ptr[in, test_args1])
+
+resource common[int32]
+resource subtype_of_common[common]
+
+test$produce_common() common
+test$also_produce_common() common
+test$produce_subtype_of_common() subtype_of_common
+
+test$consume_common(val common)
+test$consume_subtype_of_common(val subtype_of_common)


### PR DESCRIPTION
During resource argument generation, we used to randomly select one of the matching resources. With so many descendants of fd, this becomes quite inefficient and most of the time syzkaller fails to build correct programs.

Give precise resource contructions priority. Experiment with other resource types only in 1/3 of cases.