### PR TITLE
pkg/vcs: make git fetch calls more specific

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -134,17 +134,21 @@ func (git *git) CheckoutCommit(repo, commit string) (*Commit, error) {
 	if err := git.repair(); err != nil {
 		return nil, err
 	}
-	if err := git.fetchRemote(repo); err != nil {
+	if err := git.fetchRemote(repo, commit); err != nil {
 		return nil, err
 	}
 	return git.SwitchCommit(commit)
 }
 
-func (git *git) fetchRemote(repo string) error {
+func (git *git) fetchRemote(repo, commit string) error {
 	repoHash := hash.String([]byte(repo))
 	// Ignore error as we can double add the same remote and that will fail.
 	git.git("remote", "add", repoHash, repo)
-	_, err := git.git("fetch", "--force", "--tags", repoHash)
+	fetchArgs := []string{"fetch", "--force", "--tags", repoHash}
+	if commit != "" {
+		fetchArgs = append(fetchArgs, commit)
+	}
+	_, err := git.git(fetchArgs...)
 	if err != nil {
 		var verbose *osutil.VerboseError
 		if errors.As(err, &verbose) &&

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -195,7 +195,7 @@ func (ctx *linux) PrepareBisect() error {
 	if ctx.vmType != "gvisor" {
 		// Some linux repos we fuzz don't import the upstream release git tags. We need tags
 		// to decide which compiler versions to use. Let's fetch upstream for its tags.
-		err := ctx.git.fetchRemote("https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git")
+		err := ctx.git.fetchRemote("https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git", "")
 		if err != nil {
 			return fmt.Errorf("fetching upstream linux failed: %w", err)
 		}


### PR DESCRIPTION
This should make syzkaller only fetch the commits relevant for further processing. Also, specifying the exact commit/branch name to fetch allows us to access commits from custom refs.

Test the new behaviour and double-check that remote tags fetch was not broken.