### PR TITLE
syz-ci: limit fuzzing of old kernel images

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -199,9 +199,13 @@ type ManagerConfig struct {
 	Jobs         ManagerJobs `json:"jobs"`
 	// Extra commits to cherry pick to older kernel revisions.
 	BisectBackports []vcs.BackportCommit `json:"bisect_backports"`
-
+	// Base syz-manager config for the instance.
 	ManagerConfig json.RawMessage `json:"manager_config"`
-	managercfg    *mgrconfig.Config
+	// If the kernel's commit is older than MaxKernelLagDays days,
+	// fuzzing won't be started on this instance.
+	// By default it's 30 days.
+	MaxKernelLagDays int
+	managercfg       *mgrconfig.Config
 }
 
 type ManagerJobs struct {
@@ -443,6 +447,9 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 	mgr.KernelSysctl = osutil.Abs(mgr.KernelSysctl)
 	if mgr.KernelConfig != "" && mgr.KernelBaselineConfig == "" {
 		mgr.KernelBaselineConfig = inferBaselineConfig(mgr.KernelConfig)
+	}
+	if mgr.MaxKernelLagDays == 0 {
+		mgr.MaxKernelLagDays = 30
 	}
 	if err := mgr.validate(cfg); err != nil {
 		return err


### PR DESCRIPTION
Introduce a new manager config -- the maximum allowed (non-)freshness of the kernel image that we fuzz. Once the kernel image is old enough and we're unable to build a newer version, don't start the instance.