### PR TITLE
docs: remove dupl from syscall descriptions syntax

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -275,11 +275,7 @@ type bool32	int32[0:1]
 type bool64	int64[0:1]
 type boolptr	intptr[0:1]
 
-type fileoff[BASE] BASE
-
 type filename string[filename]
-
-type buffer[DIR] ptr[DIR, array[int8]]
 ```
 
 ## Type Templates


### PR DESCRIPTION
These two templates duplicate next section examples.
They also look confusing because are not yet explained.
