### PR TITLE
pkg/cover: do not bail out from prepareFileMap() if callbacks mismatch

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -130,13 +131,9 @@ func (rg *ReportGenerator) prepareFileMap(progs []Prog) (map[string]*file, error
 		return nil, fmt.Errorf("coverage doesn't match any coverage callbacks")
 	}
 	if len(allProgPCs) != len(matchedProgPCs) {
-		for mismatch := range allProgPCs {
-			if !matchedProgPCs[mismatch] {
-				return nil, fmt.Errorf("%d out of %d PCs returned by kcov do not have matching "+
-					"coverage callbacks. Check the discoverModules() code, %v",
-					len(allProgPCs)-len(matchedProgPCs), len(allProgPCs), mismatch)
-			}
-		}
+		log.Logf(0, "%d out of %d PCs returned by kcov do not have matching "+
+			"coverage callbacks. Check the discoverModules() code.",
+			len(allProgPCs)-len(matchedProgPCs), len(allProgPCs))
 	}
 	for _, unit := range rg.Units {
 		f := files[unit.Name]


### PR DESCRIPTION
Turns out some coverage data on syzbot does not have matching callbacks, which prevents syzkaller from generating coverage reports on x86. While we are investigating that, replace the error with a log.Logf

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
