### PR TITLE
prog: optimize call minimization

### DIFF
--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -67,6 +67,17 @@ func Minimize(p0 *Prog, callIndex0 int, crash bool, pred0 func(*Prog, int) bool)
 }
 
 func removeCalls(p0 *Prog, callIndex0 int, crash bool, pred func(*Prog, int) bool) (*Prog, int) {
+	if callIndex0 >= 0 && callIndex0+2 < len(p0.Calls) {
+		// It's frequently the case that all subsequent calls were not necessary.
+		// Try to drop them all at once.
+		p := p0.Clone()
+		for i := len(p0.Calls) - 1; i > callIndex0; i-- {
+			p.RemoveCall(i)
+		}
+		if pred(p, callIndex0) {
+			p0 = p
+		}
+	}
 	for i := len(p0.Calls) - 1; i >= 0; i-- {
 		if i == callIndex0 {
 			continue


### PR DESCRIPTION
In many cases we can remove all calls that follow the call of interest.

Try this before deleting them one-by-one.

---

I've set up a syz-testbed experiment. Let's see how it goes.
