### PR TITLE
dashboard: wait for repro only when it makes sense

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -223,11 +223,15 @@ func patchTestJobArgs(c context.Context, args *testJobArgs) error {
 	return nil
 }
 
+func crashNeedsRepro(title string) bool {
+	return !strings.Contains(title, "boot error:") &&
+		!strings.Contains(title, "test error:") &&
+		!strings.Contains(title, "build error")
+}
+
 func checkTestJob(args *testJobArgs) string {
 	crash, bug := args.crash, args.bug
-	needRepro := !strings.Contains(crash.Title, "boot error:") &&
-		!strings.Contains(crash.Title, "test error:") &&
-		!strings.Contains(crash.Title, "build error")
+	needRepro := crashNeedsRepro(crash.Title)
 	switch {
 	case needRepro && crash.ReproC == 0 && crash.ReproSyz == 0:
 		return "This crash does not have a reproducer. I cannot test it."

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -120,7 +120,8 @@ func needReport(c context.Context, typ string, state *ReportingState, bug *Bug) 
 		reporting, bugReporting = nil, nil
 		return
 	}
-	if bug.ReproLevel < ReproLevelC && timeSince(c, bug.FirstTime) < cfg.WaitForRepro {
+	if crashNeedsRepro(bug.Title) && bug.ReproLevel < ReproLevelC &&
+		timeSince(c, bug.FirstTime) < cfg.WaitForRepro {
 		status = fmt.Sprintf("%v: waiting for C repro", reporting.DisplayTitle)
 		reporting, bugReporting = nil, nil
 		return

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -274,6 +274,17 @@ func (c *Ctx) decommission(ns string) {
 	}
 }
 
+func (c *Ctx) setWaitForRepro(ns string, d time.Duration) {
+	c.transformContext = func(c context.Context) context.Context {
+		newConfig := replaceNamespaceConfig(c, ns, func(cfg *Config) *Config {
+			ret := *cfg
+			ret.WaitForRepro = d
+			return &ret
+		})
+		return contextWithConfig(c, newConfig)
+	}
+}
+
 // GET sends admin-authorized HTTP GET request to the app.
 func (c *Ctx) GET(url string) ([]byte, error) {
 	return c.AuthGET(AccessAdmin, url)


### PR DESCRIPTION
In case or build/boot/test errors there will never be a reproducer. It's better to report them right away, without waiting.
