### PR TITLE
dashboard: retest missing backports

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -567,7 +567,8 @@ var testConfig = &GlobalConfig{
 					},
 				},
 			},
-			FindBugOriginTrees: true,
+			FindBugOriginTrees:     true,
+			RetestMissingBackports: true,
 		},
 	},
 }

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -94,6 +94,9 @@ type Config struct {
 	FixBisectionAutoClose bool
 	// If set, dashboard will periodically request repros and revoke no longer working ones.
 	RetestRepros bool
+	// If set, dashboard will periodically verify the presence of the missing backports in the
+	// tested kernel trees.
+	RetestMissingBackports bool
 	// If set, dashboard will create patch testing jobs to determine bug origin trees.
 	FindBugOriginTrees bool
 	// Managers contains some special additional info about syz-manager instances.

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -292,6 +292,16 @@ type Commit struct {
 	Date       time.Time
 }
 
+func (com Commit) toDashapi() *dashapi.Commit {
+	return &dashapi.Commit{
+		Hash:       com.Hash,
+		Title:      com.Title,
+		Author:     com.Author,
+		AuthorName: com.AuthorName,
+		Date:       com.Date,
+	}
+}
+
 type BugDiscussionInfo struct {
 	Source  string
 	Summary DiscussionSummary
@@ -588,8 +598,9 @@ type Job struct {
 	Error       int64 // reference to Error text entity, if set job failed
 	Flags       dashapi.JobDoneFlags
 
-	Reported      bool   // have we reported result back to user?
-	InvalidatedBy string // user who marked this bug as invalid, empty by default
+	Reported         bool   // have we reported result back to user?
+	InvalidatedBy    string // user who marked this bug as invalid, empty by default
+	BackportedCommit Commit
 }
 
 func (job *Job) IsBisection() bool {

--- a/dashboard/app/mail_fix_candidate.txt
+++ b/dashboard/app/mail_fix_candidate.txt
@@ -1,4 +1,22 @@
-{{$bisect := .BisectFix}}syzbot suspects this issue could be fixed by backporting the following commit:
+{{$bisect := .BisectFix -}}
+
+{{- if $bisect.Backported -}}
+The commit that was suspected to fix the issue was backported to the fuzzed
+kernel trees.
+
+commit {{$bisect.Backported.Hash}}
+Author: {{$bisect.Backported.AuthorName}} <{{$bisect.Backported.Author}}>
+Date:   {{formatKernelTime $bisect.Backported.Date}}
+
+    {{$bisect.Commit.Title}}
+
+If you believe this is correct, please reply with
+#syz fix: {{$bisect.Backported.Title}}
+
+The commit was initially detected here:
+{{- else -}}
+syzbot suspects this issue could be fixed by backporting the following commit:
+{{- end}}
 
 commit {{$bisect.Commit.Hash}}
 git tree: {{.KernelRepoAlias}}
@@ -17,6 +35,9 @@ bisection log:  {{$bisect.LogLink}}
 {{end}}{{if .ReproCLink}}C reproducer:   {{.ReproCLink}}
 {{end}}
 
+{{- if not $bisect.Backported}}
+
 Please keep in mind that other backports might be required as well.
 
 For information about bisection process see: https://goo.gl/tpsmEJ#bisection
+{{end -}}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -500,6 +500,8 @@ type BisectResult struct {
 	CrashReportLink string
 	Fix             bool
 	CrossTree       bool
+	// In case a missing backport was backported.
+	Backported *Commit
 }
 
 type BugListReport struct {


### PR DESCRIPTION
Poll missing backport commits and, once a missing backport is found to
be present in the fuzzed trees, don't display it on the web dashboard
and send an email with the suggestion to close the bug.

Closes https://github.com/google/syzkaller/issues/4425.