### PR TITLE
.golangci.yml: disable nilness check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,8 @@ linters:
     - wsl
 
 linters-settings:
+  staticcheck:
+    checks: [ all, -nilness ]
   revive:
     rules:
     - name: package-comments


### PR DESCRIPTION
It seems to be a golangci-lint v1.55.2 specific problem.
The fix alternatives are rollback to older version or this fix.
Picked from here -> https://github.com/signalfx/splunk-otel-collector/pull/4027
