### PR TITLE
syz-fuzzer: add logging RPC call

### DIFF
--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -200,3 +200,9 @@ type RunTestDoneArgs struct {
 	Info   []*ipc.ProgInfo
 	Error  string
 }
+
+type LogMessageReq struct {
+	Level   int
+	Name    string
+	Message string
+}

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -625,6 +625,21 @@ func (fuzzer *Fuzzer) checkNewCallSignal(p *prog.Prog, info *ipc.CallInfo, call 
 	return true
 }
 
+// nolint: unused
+// It's only needed for debugging.
+func (fuzzer *Fuzzer) Logf(level int, msg string, args ...interface{}) {
+	go func() {
+		a := &rpctype.LogMessageReq{
+			Level:   level,
+			Name:    fuzzer.name,
+			Message: fmt.Sprintf(msg, args...),
+		}
+		if err := fuzzer.manager.Call("Manager.LogMessage", a, nil); err != nil {
+			log.SyzFatalf("Manager.LogMessage call failed: %v", err)
+		}
+	}()
+}
+
 func setupPprofHandler(port int) {
 	// Necessary for pprof handlers.
 	go func() {

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -396,3 +396,8 @@ func (serv *RPCServer) shutdownInstance(name string) []byte {
 	delete(serv.fuzzers, name)
 	return fuzzer.machineInfo
 }
+
+func (serv *RPCServer) LogMessage(m *rpctype.LogMessageReq, r *int) error {
+	log.Logf(m.Level, "%s: %s", m.Name, m.Message)
+	return nil
+}


### PR DESCRIPTION
Add an RPC call to post a log message to syz-manager directly from syz-fuzzer.

It's very convenient during the debugging and profiling of the actual fuzzing code.
