### PR TITLE
fix problem with ip concat with warnning messages

### DIFF
--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -108,7 +109,6 @@ func (inst *instance) clone() error {
 	}
 	return nil
 }
-
 func (inst *instance) boot() error {
 	if inst.debug {
 		log.Logf(0, "starting %v", inst.vmx)
@@ -119,11 +119,21 @@ func (inst *instance) boot() error {
 	if inst.debug {
 		log.Logf(0, "getting IP of %v", inst.vmx)
 	}
-	ip, err := osutil.RunCmd(5*time.Minute, "", "vmrun", "getGuestIPAddress", inst.vmx, "-wait")
+	ipCmd := exec.Command("vmrun", "getGuestIPAddress", inst.vmx, "-wait")
+	ipOutput, err := ipCmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get IP address: %v", err)
 	}
-	inst.ipAddr = strings.TrimSuffix(string(ip), "\n")
+
+	// Extract IP address from the output, ignoring the warning message
+	ipRegex := regexp.MustCompile(`(\d+\.\d+\.\d+\.\d+)`)
+	ipMatches := ipRegex.FindStringSubmatch(string(ipOutput))
+	if len(ipMatches) < 2 {
+		return fmt.Errorf("failed to extract IP address from vmrun output")
+	}
+	ip := strings.TrimSpace(ipMatches[1])
+
+	inst.ipAddr = ip
 	if inst.debug {
 		log.Logf(0, "VM %v has IP: %v", inst.vmx, inst.ipAddr)
 	}


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************

I found following issue when executing syzkaller for vmware machine

```
2024/01/20 18:21:20 starting /home/xxxx/tools/syzkaller/workdir/instance-0/1705771207333434046/syzkaller.vmx
2024/01/20 18:21:20 getting IP of /home/xxxx/tools/syzkaller/workdir/instance-0/1705771207333434046/syzkaller.vmx
2024/01/20 18:22:34 VM /home/xxxx/tools/syzkaller/workdir/instance-0/1705771207333434046/syzkaller.vmx has IP: Warning: program compiled against libxml 210 using older 209
```

Propsed change ensure no warning messages are added to IP address