### PR TITLE
all: refactor pprof endpoint configuration

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -459,6 +459,7 @@ type OptionalFuzzerArgs struct {
 	Slowdown   int
 	RawCover   bool
 	SandboxArg int
+	PprofPort  int
 }
 
 type FuzzerCmdArgs struct {
@@ -500,6 +501,7 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 			{Name: "slowdown", Value: fmt.Sprint(args.Optional.Slowdown)},
 			{Name: "raw_cover", Value: fmt.Sprint(args.Optional.RawCover)},
 			{Name: "sandbox_arg", Value: fmt.Sprint(args.Optional.SandboxArg)},
+			{Name: "pprof_port", Value: fmt.Sprint(args.Optional.PprofPort)},
 		}
 		optionalArg = " " + tool.OptionalFlags(flags)
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -827,6 +827,7 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 			Slowdown:   mgr.cfg.Timeouts.Slowdown,
 			RawCover:   mgr.cfg.RawCover,
 			SandboxArg: mgr.cfg.SandboxArg,
+			PprofPort:  inst.PprofPort(),
 		},
 	}
 	cmd := instance.FuzzerCmd(args)

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -243,6 +243,14 @@ func (inst *instance) Info() ([]byte, error) {
 	return []byte(info), nil
 }
 
+func (inst *instance) PprofPort() int {
+	// Some of the gVisor instances use the host's network namespace, which
+	// results in conflicting bind operations on the same HTTP port.
+	// Until there's an actual need to debug gVisor VMs with pprof, let's
+	// just disable it.
+	return 0
+}
+
 func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	cmd := osutil.Command(inst.image, append(inst.args(), add...)...)
 	cmd.Env = []string{

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -187,6 +187,13 @@ func (inst *Instance) Info() ([]byte, error) {
 	return nil, nil
 }
 
+func (inst *Instance) PprofPort() int {
+	if ii, ok := inst.impl.(vmimpl.PprofPortProvider); ok {
+		return ii.PprofPort()
+	}
+	return vmimpl.PprofPort
+}
+
 func (inst *Instance) diagnose(rep *report.Report) ([]byte, bool) {
 	if rep == nil {
 		panic("rep is nil")

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -67,6 +67,11 @@ type Infoer interface {
 	Info() ([]byte, error)
 }
 
+// PprofPortProvider is used when the instance wants to define a custom pprof port.
+type PprofPortProvider interface {
+	PprofPort() int
+}
+
 // Env contains global constant parameters for a pool of VMs.
 type Env struct {
 	// Unique name


### PR DESCRIPTION
In some cases (e.g. gVisor instances using host's network namespace) attempts to bind() all syz-fuzzer processes to the same port result in conflicts and fuzzing breakages.

Refactor the code to enable custom pprof configuration depending on the vm type.

For now, just disable pprof endpoints for gVisor VMs. Once we actually need the feature there, we can generate custom ports for every gVisor VM.

Cc @avagin 