### PR TITLE
manually update  google.golang.org/api dependency

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"html/template"


### PR DESCRIPTION
Working on last week cloud build error.