### PR TITLE
dashboard: capture cover and PCs after corpus triage

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1142,6 +1142,12 @@ func apiManagerStats(c context.Context, ns string, r *http.Request, payload []by
 		stats.TotalCrashes += int64(req.Crashes)
 		stats.SuppressedCrashes += int64(req.SuppressedCrashes)
 		stats.TotalExecs += int64(req.Execs)
+		if cur := int64(req.TriagedCoverage); cur > stats.TriagedCoverage {
+			stats.TriagedCoverage = cur
+		}
+		if cur := int64(req.TriagedPCs); cur > stats.TriagedPCs {
+			stats.TriagedPCs = cur
+		}
 		return nil
 	})
 	return nil, err

--- a/dashboard/app/entities.go
+++ b/dashboard/app/entities.go
@@ -50,6 +50,9 @@ type ManagerStats struct {
 	CrashTypes        int64 // unique crash types
 	SuppressedCrashes int64
 	TotalExecs        int64
+	// These are only recorded once right after corpus is triaged.
+	TriagedCoverage int64
+	TriagedPCs      int64
 }
 
 type Asset struct {

--- a/dashboard/app/graph_fuzzing.html
+++ b/dashboard/app/graph_fuzzing.html
@@ -24,7 +24,7 @@ Manager statistics graphs.
 			{{- end}}
 			data.addRows([ {{range $.Graph.Columns}}
 					[ "{{.Hint}}", {{range .Vals}}
-						{{if .Val}}{{.Val}}{{end}}, '{{.Hint}}',
+						{{if .IsNull}}null{{else if .Val}}{{.Val}}{{end}}, '{{.Hint}}',
 					{{- end}}
 					],
 				{{- end}}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -725,6 +725,10 @@ type ManagerStatsReq struct {
 	Crashes           uint64
 	SuppressedCrashes uint64
 	Execs             uint64
+
+	// Non-zero only when set.
+	TriagedCoverage uint64
+	TriagedPCs      uint64
 }
 
 func (dash *Dashboard) UploadManagerStats(req *ManagerStatsReq) error {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -90,10 +90,11 @@ type Manager struct {
 	// Maps file name to modification time.
 	usedFiles map[string]time.Time
 
-	modules            []host.KernelModule
-	coverFilter        map[uint32]uint32
-	execCoverFilter    map[uint32]uint32
-	modulesInitialized bool
+	modules             []host.KernelModule
+	coverFilter         map[uint32]uint32
+	execCoverFilter     map[uint32]uint32
+	modulesInitialized  bool
+	afterTriageStatSent bool
 
 	assetStorage *asset.Storage
 }
@@ -1520,6 +1521,11 @@ func (mgr *Manager) dashboardReporter() {
 			Crashes:           crashes - lastCrashes,
 			SuppressedCrashes: suppressedCrashes - lastSuppressedCrashes,
 			Execs:             execs - lastExecs,
+		}
+		if mgr.phase >= phaseTriagedCorpus && !mgr.afterTriageStatSent {
+			mgr.afterTriageStatSent = true
+			req.TriagedCoverage = mgr.stats.corpusSignal.get()
+			req.TriagedPCs = mgr.stats.corpusCover.get()
 		}
 		mgr.mu.Unlock()
 


### PR DESCRIPTION
This statistics allows us to better estimate the amount of coverage that is lost after every syzbot instance is restarted.
