### PR TITLE
all: experiment with an option to reset accumulated state

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -456,10 +456,11 @@ func (inst *inst) testRepro() ([]byte, error) {
 }
 
 type OptionalFuzzerArgs struct {
-	Slowdown   int
-	RawCover   bool
-	SandboxArg int
-	PprofPort  int
+	Slowdown      int
+	RawCover      bool
+	SandboxArg    int
+	PprofPort     int
+	ResetAccState bool
 }
 
 type FuzzerCmdArgs struct {
@@ -502,6 +503,7 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 			{Name: "raw_cover", Value: fmt.Sprint(args.Optional.RawCover)},
 			{Name: "sandbox_arg", Value: fmt.Sprint(args.Optional.SandboxArg)},
 			{Name: "pprof_port", Value: fmt.Sprint(args.Optional.PprofPort)},
+			{Name: "reset_acc_state", Value: fmt.Sprint(args.Optional.ResetAccState)},
 		}
 		optionalArg = " " + tool.OptionalFlags(flags)
 	}

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -293,6 +293,13 @@ func (env *Env) Exec(opts *ExecOpts, p *prog.Prog) (output []byte, info *ProgInf
 	return
 }
 
+func (env *Env) ForceRestart() {
+	if env.cmd != nil {
+		env.cmd.close()
+		env.cmd = nil
+	}
+}
+
 // This smethod brings up an executor process if it was stopped.
 func (env *Env) RestartIfNeeded(target *prog.Target) error {
 	if env.cmd == nil {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -202,8 +202,19 @@ type Config struct {
 	// More details can be found in pkg/asset/config.go.
 	AssetStorage *asset.Config `json:"asset_storage"`
 
+	// Experimental options.
+	Experimental Experimental
+
 	// Implementation details beyond this point. Filled after parsing.
 	Derived `json:"-"`
+}
+
+// These options are not guaranteed to be backward/forward compatible and
+// can be dropped at any moment.
+type Experimental struct {
+	// Don't let the VM state accumulate too much by restarting
+	// syz-executor before most prog executions.
+	ResetAccState bool `json:"reset_acc_state"`
 }
 
 type Subsystem struct {

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -71,6 +71,9 @@ type Fuzzer struct {
 
 	// Let's limit the number of concurrent NewInput requests.
 	parallelNewInputs chan struct{}
+
+	// Experimental flags.
+	resetAccState bool
 }
 
 type FuzzerSnapshot struct {
@@ -169,6 +172,9 @@ func main() {
 		flagRunTest   = flag.Bool("runtest", false, "enable program testing mode") // used by pkg/runtest
 		flagRawCover  = flag.Bool("raw_cover", false, "fetch raw coverage")
 		flagPprofPort = flag.Int("pprof_port", 0, "HTTP port for the pprof endpoint (disabled if 0)")
+
+		// Experimental flags.
+		flagResetAccState = flag.Bool("reset_acc_state", false, "restarts executor before most executions")
 	)
 	defer tool.Init()()
 	outputType := parseOutputType(*flagOutput)
@@ -299,6 +305,7 @@ func main() {
 		stats:                    make([]uint64, StatCount),
 		// Queue no more than ~3 new inputs / proc.
 		parallelNewInputs: make(chan struct{}, int64(3**flagProcs)),
+		resetAccState:     *flagResetAccState,
 	}
 	gateCallback := fuzzer.useBugFrames(r, *flagProcs)
 	fuzzer.gate = ipc.NewGate(gateSize, gateCallback)


### PR DESCRIPTION
In the cases where we do not / cannot sandbox individual prog executions well enough, some share of progs end up being dependent on the previously accumulated state of the whole VM.

As the result,
* We lose 5-10% of coverage/signal on every instance restart.
* A share of our corpus programs do not actually trigger the coverage they were thought to reliably trigger.

This significantly affects fuzzing efficiency and prevents syzkaller from accumulating bigger and better corpus over multiple runs.

Let's see if the situation becomes better if we restart syz-executor before most of prog executions.
