### PR TITLE
pkg/cover: fix missing frames and export Inline by /rawcoverfiles

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -51,6 +51,7 @@ type Frame struct {
 	PC     uint64
 	Name   string
 	Path   string
+	Inline bool
 	Range
 }
 

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -387,6 +387,7 @@ func symbolizeModule(target *targets.Target, objDir, srcDir, buildDir string,
 				PC:     frame.PC + mod.Addr,
 				Name:   name,
 				Path:   path,
+				Inline: frame.Inline,
 				Range: Range{
 					StartLine: frame.Line,
 					StartCol:  0,

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -181,15 +181,6 @@ func (rg *ReportGenerator) lazySymbolize(progs []Prog) error {
 		return err
 	}
 	rg.Frames = append(rg.Frames, frames...)
-	uniqueFrames := make(map[uint64]bool)
-	var finalFrames []backend.Frame
-	for _, frame := range rg.Frames {
-		if !uniqueFrames[frame.PC] {
-			uniqueFrames[frame.PC] = true
-			finalFrames = append(finalFrames, frame)
-		}
-	}
-	rg.Frames = finalFrames
 	for sym := range symbolize {
 		sym.Symbolized = true
 	}


### PR DESCRIPTION
Some regression happened in Jun 2021. This PR fixes that regression and return additional frames to our coverage.
Briefly - if some addr has 10 associated frames, we take first for the visualization and drop others.

rawcoverfiles shows all the frames now and additionally explains Inlining context.