### PR TITLE
syz-manager: differentiate between repros from hub and from dashboard

### DIFF
--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -283,8 +283,8 @@ func (hc *HubConnector) processRepros(repros [][]byte) int {
 			typ = crash.MemoryLeak
 		}
 		hc.hubReproQueue <- &Crash{
-			vmIndex:  -1,
-			external: true,
+			vmIndex: -1,
+			fromHub: true,
 			Report: &report.Report{
 				Title:  "external repro",
 				Type:   typ,


### PR DESCRIPTION
From dashboard we receive logs, from syz-hub - ready reproducers. They must be treated differently.

If we failed to find a repro from the log, report a failure back to the dashboard. If we succeeded, prepend the options.