### PR TITLE
syz-manager: don't set up pprof endpoints for host fuzzing

### DIFF
--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -347,6 +347,7 @@ func testMonitorExecution(t *testing.T, test *Test) {
 				Slowdown: 1,
 				NoOutput: 5 * time.Second,
 			},
+			SysTarget: targets.Get(targets.Linux, targets.AMD64),
 		},
 		Workdir: dir,
 		Type:    "test",


### PR DESCRIPTION
In this mode, all syz-fuzzers will be on the same network and will start competing with each other for binding to the same port.

For now, we don't have the need to use pprof in the host fuzzer mode, so let's just disable it.
