### PR TITLE
syz-manager: add more logging for repro reporting 

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -427,7 +427,7 @@ func (mgr *Manager) restartManager() {
 	}
 	bin := filepath.FromSlash("syzkaller/current/bin/syz-manager")
 	logFile := filepath.Join(mgr.currentDir, "manager.log")
-	args := []string{"-config", cfgFile}
+	args := []string{"-config", cfgFile, "-vv", "1"}
 	if mgr.debug {
 		args = append(args, "-debug")
 	}


### PR DESCRIPTION
Currently it's hard to understand individual syz-manager decisions during repro processing.