### PR TITLE
executor: don't fail in syz_socket_connect_nvme_tcp()

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2479,8 +2479,11 @@ static long syz_init_net_socket(volatile long domain, volatile long type, volati
 		return -1;
 	int sock = syscall(__NR_socket, domain, type, proto);
 	int err = errno;
-	if (setns(netns, 0))
-		fail("setns(netns) failed");
+	if (setns(netns, 0)) {
+		// The operation may fail if the fd is closed by
+		// a syscall from another thread.
+		exitf("setns(netns) failed");
+	}
 	close(netns);
 	errno = err;
 	return sock;
@@ -2514,8 +2517,11 @@ static long syz_socket_connect_nvme_tcp()
 		return -1;
 	int sock = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0x0);
 	int err = errno;
-	if (setns(netns, 0))
-		fail("setns(netns) failed");
+	if (setns(netns, 0)) {
+		// The operation may fail if the fd is closed by
+		// a syscall from another thread.
+		exitf("setns(netns) failed");
+	}
 	close(netns);
 	errno = err;
 	// We only connect to an NVMe-oF/TCP server on 127.0.0.1:4420

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -6289,8 +6289,9 @@ static long syz_init_net_socket(volatile long domain, volatile long type, volati
 		return -1;
 	int sock = syscall(__NR_socket, domain, type, proto);
 	int err = errno;
-	if (setns(netns, 0))
-		fail("setns(netns) failed");
+	if (setns(netns, 0)) {
+		exitf("setns(netns) failed");
+	}
 	close(netns);
 	errno = err;
 	return sock;
@@ -6324,8 +6325,9 @@ static long syz_socket_connect_nvme_tcp()
 		return -1;
 	int sock = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0x0);
 	int err = errno;
-	if (setns(netns, 0))
-		fail("setns(netns) failed");
+	if (setns(netns, 0)) {
+		exitf("setns(netns) failed");
+	}
 	close(netns);
 	errno = err;
 	nvme_local_address.sin_family = AF_INET;


### PR DESCRIPTION
```
The fd may be closed by an async close() call, it's not a reason to report a failure.

Reported-by: Andrei Vagin <avagin@google.com>
```
Cc @avagin 
