### PR TITLE
syz-manager: prefer non-ANY progs in corpus minimization

### DIFF
--- a/prog/analysis.go
+++ b/prog/analysis.go
@@ -367,3 +367,12 @@ func (p *Prog) ForEachAsset(cb func(name string, typ AssetType, r io.Reader)) {
 		})
 	}
 }
+
+func (p *Prog) ContainsAny() bool {
+	for _, c := range p.Calls {
+		if p.Target.CallContainsAny(c) {
+			return true
+		}
+	}
+	return false
+}

--- a/prog/any.go
+++ b/prog/any.go
@@ -126,7 +126,7 @@ func (target *Target) isAnyRes(name string) bool {
 
 func (target *Target) CallContainsAny(c *Call) (res bool) {
 	ForeachArg(c, func(arg Arg, ctx *ArgCtx) {
-		if target.isAnyPtr(arg.Type()) {
+		if target.isAnyPtr(arg.Type()) || res {
 			res = true
 			ctx.Stop = true
 		}
@@ -136,7 +136,7 @@ func (target *Target) CallContainsAny(c *Call) (res bool) {
 
 func (target *Target) ArgContainsAny(arg0 Arg) (res bool) {
 	ForeachSubArg(arg0, func(arg Arg, ctx *ArgCtx) {
-		if target.isAnyPtr(arg.Type()) {
+		if target.isAnyPtr(arg.Type()) || res {
 			res = true
 			ctx.Stop = true
 		}

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -215,7 +215,7 @@ func (hc *HubConnector) sync(hub *rpctype.RPCClient, corpus [][]byte) error {
 func (hc *HubConnector) processProgs(inputs []rpctype.HubInput) (minimized, smashed, dropped int) {
 	candidates := make([]rpctype.Candidate, 0, len(inputs))
 	for _, inp := range inputs {
-		bad, disabled := checkProgram(hc.target, hc.enabledCalls, inp.Prog)
+		bad, disabled, _ := checkProgram(hc.target, hc.enabledCalls, inp.Prog)
 		if bad != nil || disabled {
 			log.Logf(0, "rejecting program from hub (bad=%v, disabled=%v):\n%s",
 				bad, disabled, inp)
@@ -268,7 +268,7 @@ func splitDomains(domain string) (string, string) {
 func (hc *HubConnector) processRepros(repros [][]byte) int {
 	dropped := 0
 	for _, repro := range repros {
-		bad, disabled := checkProgram(hc.target, hc.enabledCalls, repro)
+		bad, disabled, _ := checkProgram(hc.target, hc.enabledCalls, repro)
 		if bad != nil || disabled {
 			log.Logf(0, "rejecting repro from hub (bad=%v, disabled=%v):\n%s",
 				bad, disabled, repro)


### PR DESCRIPTION
In case of non-squashed programs we can leverage our descriptions in a much better way than just blind mutations of binary blobs.