### PR TITLE
.gcloudignore: enable blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ sys/*/gen/*.go
 executor/defs.h
 executor/syscalls.h
 
-# produced by gcloud command
-dashboard/app/.gcloudignore
-
 # jetbrains goland
 .idea
 

--- a/dashboard/app/.gcloudignore
+++ b/dashboard/app/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
gcloud beta app deploy in GOMOD uploads 1.7G of data.
There is a way to see what files were recently uploaded. Let's get working solution first and review how can we reduce 1.7G to the current 30M.

To see what files were uploaded:
$ version=$(gcloud app --project=syzkaller versions list --sort-by '~version'
  --format='value(version.id)' --hide-no-traffic --limit=1)
$ gcloud app --project=syzkaller versions describe --service=default "$version"

Origin: https://www.googlecloudcommunity.com/gc/Developer-Tools/Viewing-code-currently-deployed-in-App-Engine/m-p/605823