### PR TITLE
pkg/cover, syz-manager: introduce the /cover?debug=1 parameter

### DIFF
--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -24,9 +24,15 @@ import (
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
-func (rg *ReportGenerator) DoHTML(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
-	files, err := rg.prepareFileMap(progs)
+type CoverHandlerParams struct {
+	Progs       []Prog
+	CoverFilter map[uint32]uint32
+	Debug       bool
+}
+
+func (rg *ReportGenerator) DoHTML(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
+	files, err := rg.prepareFileMap(progs, params.Debug)
 	if err != nil {
 		return err
 	}
@@ -127,9 +133,9 @@ type lineCoverExport struct {
 	Both      []int `json:",omitempty"`
 }
 
-func (rg *ReportGenerator) DoLineJSON(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
-	files, err := rg.prepareFileMap(progs)
+func (rg *ReportGenerator) DoLineJSON(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
+	files, err := rg.prepareFileMap(progs, params.Debug)
 	if err != nil {
 		return err
 	}
@@ -291,7 +297,7 @@ var csvFilesHeader = []string{
 }
 
 func (rg *ReportGenerator) convertToStats(progs []Prog) ([]fileStats, error) {
-	files, err := rg.prepareFileMap(progs)
+	files, err := rg.prepareFileMap(progs, false)
 	if err != nil {
 		return nil, err
 	}
@@ -341,8 +347,8 @@ func (rg *ReportGenerator) convertToStats(progs []Prog) ([]fileStats, error) {
 	return data, nil
 }
 
-func (rg *ReportGenerator) DoCSVFiles(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
+func (rg *ReportGenerator) DoCSVFiles(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
 	data, err := rg.convertToStats(progs)
 	if err != nil {
 		return err
@@ -441,8 +447,8 @@ func groupCoverByFilePrefixes(datas []fileStats, subsystems []mgrconfig.Subsyste
 	return d
 }
 
-func (rg *ReportGenerator) DoHTMLTable(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
+func (rg *ReportGenerator) DoHTMLTable(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
 	data, err := rg.convertToStats(progs)
 	if err != nil {
 		return err
@@ -517,8 +523,8 @@ func groupCoverByModule(datas []fileStats) map[string]map[string]string {
 	return d
 }
 
-func (rg *ReportGenerator) DoModuleCover(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
+func (rg *ReportGenerator) DoModuleCover(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
 	data, err := rg.convertToStats(progs)
 	if err != nil {
 		return err
@@ -537,9 +543,9 @@ var csvHeader = []string{
 	"Total PCs",
 }
 
-func (rg *ReportGenerator) DoCSV(w io.Writer, progs []Prog, coverFilter map[uint32]uint32) error {
-	progs = fixUpPCs(rg.target.Arch, progs, coverFilter)
-	files, err := rg.prepareFileMap(progs)
+func (rg *ReportGenerator) DoCSV(w io.Writer, params CoverHandlerParams) error {
+	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
+	files, err := rg.prepareFileMap(progs, params.Debug)
 	if err != nil {
 		return err
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -365,20 +365,23 @@ func generateReport(t *testing.T, target *targets.Target, test *Test) ([]byte, [
 		progs = append(progs, Prog{Data: "main", PCs: pcs})
 	}
 	html := new(bytes.Buffer)
-	if err := rg.DoHTML(html, progs, nil); err != nil {
+	params := CoverHandlerParams{
+		Progs: progs,
+	}
+	if err := rg.DoHTML(html, params); err != nil {
 		return nil, nil, err
 	}
 	htmlTable := new(bytes.Buffer)
-	if err := rg.DoHTMLTable(htmlTable, progs, nil); err != nil {
+	if err := rg.DoHTMLTable(htmlTable, params); err != nil {
 		return nil, nil, err
 	}
 	_ = htmlTable
 	csv := new(bytes.Buffer)
-	if err := rg.DoCSV(csv, progs, nil); err != nil {
+	if err := rg.DoCSV(csv, params); err != nil {
 		return nil, nil, err
 	}
 	csvFiles := new(bytes.Buffer)
-	if err := rg.DoCSVFiles(csvFiles, progs, nil); err != nil {
+	if err := rg.DoCSVFiles(csvFiles, params); err != nil {
 		return nil, nil, err
 	}
 	_ = csvFiles

--- a/syz-manager/html.go
+++ b/syz-manager/html.go
@@ -349,6 +349,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 	}
 
 	do := rg.DoHTML
+
 	if funcFlag == DoHTMLTable {
 		do = rg.DoHTMLTable
 	} else if funcFlag == DoModuleCover {
@@ -359,7 +360,15 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 		do = rg.DoCSVFiles
 	}
 
-	if err := do(w, progs, coverFilter); err != nil {
+	debug := r.FormValue("debug") != ""
+
+	params := cover.CoverHandlerParams{
+		Progs:       progs,
+		CoverFilter: coverFilter,
+		Debug:       debug,
+	}
+
+	if err := do(w, params); err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate coverage profile: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -77,8 +77,13 @@ func main() {
 	}
 	progs := []cover.Prog{{PCs: pcs}}
 	buf := new(bytes.Buffer)
+	params := cover.CoverHandlerParams{
+		Progs:       progs,
+		CoverFilter: nil,
+		Debug:       false,
+	}
 	if *flagExportCSV != "" {
-		if err := rg.DoCSV(buf, progs, nil); err != nil {
+		if err := rg.DoCSV(buf, params); err != nil {
 			tool.Fail(err)
 		}
 		if err := osutil.WriteFile(*flagExportCSV, buf.Bytes()); err != nil {
@@ -87,7 +92,7 @@ func main() {
 		return
 	}
 	if *flagExportLineJSON != "" {
-		if err := rg.DoLineJSON(buf, progs, nil); err != nil {
+		if err := rg.DoLineJSON(buf, params); err != nil {
 			tool.Fail(err)
 		}
 		if err := osutil.WriteFile(*flagExportLineJSON, buf.Bytes()); err != nil {
@@ -95,7 +100,7 @@ func main() {
 		}
 		return
 	}
-	if err := rg.DoHTML(buf, progs, nil); err != nil {
+	if err := rg.DoHTML(buf, params); err != nil {
 		tool.Fail(err)
 	}
 	if *flagExportHTML != "" {


### PR DESCRIPTION
Debugging coverage point validation warnings may require looking at specific addresses, which are not printed anywhere. Add a URL parameter that can be passed to prepareFileMap() to print a more meaningful error message.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
