### PR TITLE
syz-manager: pause log reporting for successful repros

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1118,18 +1118,19 @@ func (mgr *Manager) saveRepro(res *ReproResult) {
 		}
 
 		dc := &dashapi.Crash{
-			BuildID:       mgr.cfg.Tag,
-			Title:         report.Title,
-			AltTitles:     report.AltTitles,
-			Suppressed:    report.Suppressed,
-			Recipients:    report.Recipients.ToDash(),
-			Log:           output,
-			Flags:         crashFlags,
-			Report:        report.Report,
-			ReproOpts:     repro.Opts.Serialize(),
-			ReproSyz:      progText,
-			ReproC:        cprogText,
-			ReproLog:      fullReproLog(res.stats),
+			BuildID:    mgr.cfg.Tag,
+			Title:      report.Title,
+			AltTitles:  report.AltTitles,
+			Suppressed: report.Suppressed,
+			Recipients: report.Recipients.ToDash(),
+			Log:        output,
+			Flags:      crashFlags,
+			Report:     report.Report,
+			ReproOpts:  repro.Opts.Serialize(),
+			ReproSyz:   progText,
+			ReproC:     cprogText,
+			// Paused because of #4495.
+			// ReproLog:      fullReproLog(res.stats),
 			Assets:        mgr.uploadReproAssets(repro),
 			OriginalTitle: res.originalTitle,
 		}


### PR DESCRIPTION
The log is apparently too big, which results in numerous code 413 errors.

Let's not include the repro log for some time before #4495 is fixed.