### PR TITLE
pkg/report: ignore ida_free

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1259,6 +1259,7 @@ var linuxStackParams = &stackParams{
 		"insert_work",
 		"__queue_delayed_work",
 		"queue_delayed_work_on",
+		"ida_free",
 		// arm64 translation exception handling path.
 		"do_(kernel|translation)_fault",
 		"do_mem_abort",

--- a/pkg/report/testdata/linux/report/711
+++ b/pkg/report/testdata/linux/report/711
@@ -1,0 +1,106 @@
+TITLE: WARNING in hci_conn_del
+TYPE: WARNING
+
+[ 1175.642042][T23686] ------------[ cut here ]------------
+[ 1175.648374][T23686] ida_free called for id=8192 which is not allocated.
+[ 1175.656177][T23686] WARNING: CPU: 0 PID: 23686 at lib/idr.c:525 ida_free+0x370/0x420
+[ 1175.664123][T23686] Modules linked in:
+[ 1175.668225][T23686] CPU: 0 PID: 23686 Comm: kworker/u5:0 Not tainted 6.8.0-rc4-syzkaller-00003-g716f4aaa7b48 #0
+[ 1175.679001][T23686] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/25/2024
+[ 1175.689196][T23686] Workqueue: hci2 hci_error_reset
+[ 1175.694257][T23686] RIP: 0010:ida_free+0x370/0x420
+[ 1175.699554][T23686] Code: 10 42 80 3c 28 00 74 05 e8 cd d3 9b f6 48 8b 7c 24 40 4c 89 fe e8 b0 88 17 00 90 48 c7 c7 80 c4 c5 8c 89 de e8 01 c1 fd f5 90 <0f> 0b 90 90 eb 3d e8 35 b6 39 f6 49 bd 00 00 00 00 00 fc ff df 4d
+[ 1175.719363][T23686] RSP: 0018:ffffc90004e379a0 EFLAGS: 00010246
+[ 1175.725527][T23686] RAX: 4250b48c41d0e200 RBX: 0000000000002000 RCX: ffff888021b6d940
+[ 1175.733520][T23686] RDX: 0000000000000000 RSI: 0000000000000001 RDI: 0000000000000000
+[ 1175.741601][T23686] RBP: ffffc90004e37aa0 R08: ffffffff81577992 R09: 1ffff920009c6e88
+[ 1175.750003][T23686] R10: dffffc0000000000 R11: fffff520009c6e89 R12: ffffc90004e379e0
+[ 1175.758224][T23686] R13: dffffc0000000000 R14: ffff8880411880a0 R15: 0000000000000246
+[ 1175.766292][T23686] FS:  0000000000000000(0000) GS:ffff8880b9400000(0000) knlGS:0000000000000000
+[ 1175.775387][T23686] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 1175.782011][T23686] CR2: 00000000200007c0 CR3: 0000000029678000 CR4: 00000000003506f0
+[ 1175.790115][T23686] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[ 1175.798225][T23686] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[ 1175.806327][T23686] Call Trace:
+[ 1175.809643][T23686]  <TASK>
+[ 1175.812614][T23686]  ? __warn+0x162/0x4b0
+[ 1175.816909][T23686]  ? ida_free+0x370/0x420
+[ 1175.821559][T23686]  ? report_bug+0x2b3/0x500
+[ 1175.826172][T23686]  ? ida_free+0x370/0x420
+[ 1175.830540][T23686]  ? handle_bug+0x3e/0x70
+[ 1175.834910][T23686]  ? exc_invalid_op+0x1a/0x50
+[ 1175.839787][T23686]  ? asm_exc_invalid_op+0x1a/0x20
+[ 1175.845106][T23686]  ? __warn_printk+0x292/0x360
+[ 1175.850290][T23686]  ? ida_free+0x370/0x420
+[ 1175.854659][T23686]  ? __pfx_ida_free+0x10/0x10
+[ 1175.859542][T23686]  ? __pfx___mutex_unlock_slowpath+0x10/0x10
+[ 1175.865605][T23686]  ? hci_conn_unlink+0x5a2/0x630
+[ 1175.870592][T23686]  hci_conn_del+0x7c0/0xcb0
+[ 1175.875137][T23686]  hci_conn_hash_flush+0x18e/0x240
+[ 1175.880392][T23686]  hci_dev_close_sync+0x9ab/0xff0
+[ 1175.885603][T23686]  hci_error_reset+0x110/0x270
+[ 1175.890399][T23686]  ? process_scheduled_works+0x825/0x1420
+[ 1175.896248][T23686]  process_scheduled_works+0x913/0x1420
+[ 1175.902111][T23686]  ? __pfx_process_scheduled_works+0x10/0x10
+[ 1175.908199][T23686]  ? assign_work+0x364/0x3d0
+[ 1175.912825][T23686]  worker_thread+0xa5f/0x1000
+[ 1175.917637][T23686]  ? __pfx_worker_thread+0x10/0x10
+[ 1175.922779][T23686]  kthread+0x2ef/0x390
+[ 1175.926954][T23686]  ? __pfx_worker_thread+0x10/0x10
+[ 1175.932109][T23686]  ? __pfx_kthread+0x10/0x10
+[ 1175.936808][T23686]  ret_from_fork+0x4b/0x80
+[ 1175.941250][T23686]  ? __pfx_kthread+0x10/0x10
+[ 1175.945949][T23686]  ret_from_fork_asm+0x1b/0x30
+[ 1175.951057][T23686]  </TASK>
+[ 1175.954100][T23686] Kernel panic - not syncing: kernel: panic_on_warn set ...
+[ 1175.961381][T23686] CPU: 0 PID: 23686 Comm: kworker/u5:0 Not tainted 6.8.0-rc4-syzkaller-00003-g716f4aaa7b48 #0
+[ 1175.971610][T23686] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/25/2024
+[ 1175.981657][T23686] Workqueue: hci2 hci_error_reset
+[ 1175.986685][T23686] Call Trace:
+[ 1175.989956][T23686]  <TASK>
+[ 1175.992879][T23686]  dump_stack_lvl+0x1e7/0x2e0
+[ 1175.997560][T23686]  ? __pfx_dump_stack_lvl+0x10/0x10
+[ 1176.002770][T23686]  ? __pfx__printk+0x10/0x10
+[ 1176.007380][T23686]  ? vscnprintf+0x5d/0x90
+[ 1176.011710][T23686]  panic+0x349/0x860
+[ 1176.015602][T23686]  ? __warn+0x171/0x4b0
+[ 1176.019760][T23686]  ? __pfx_panic+0x10/0x10
+[ 1176.024183][T23686]  ? ret_from_fork_asm+0x1b/0x30
+[ 1176.029123][T23686]  __warn+0x31c/0x4b0
+[ 1176.033097][T23686]  ? ida_free+0x370/0x420
+[ 1176.037419][T23686]  report_bug+0x2b3/0x500
+[ 1176.041735][T23686]  ? ida_free+0x370/0x420
+[ 1176.046058][T23686]  handle_bug+0x3e/0x70
+[ 1176.050208][T23686]  exc_invalid_op+0x1a/0x50
+[ 1176.054711][T23686]  asm_exc_invalid_op+0x1a/0x20
+[ 1176.059564][T23686] RIP: 0010:ida_free+0x370/0x420
+[ 1176.064497][T23686] Code: 10 42 80 3c 28 00 74 05 e8 cd d3 9b f6 48 8b 7c 24 40 4c 89 fe e8 b0 88 17 00 90 48 c7 c7 80 c4 c5 8c 89 de e8 01 c1 fd f5 90 <0f> 0b 90 90 eb 3d e8 35 b6 39 f6 49 bd 00 00 00 00 00 fc ff df 4d
+[ 1176.084093][T23686] RSP: 0018:ffffc90004e379a0 EFLAGS: 00010246
+[ 1176.090152][T23686] RAX: 4250b48c41d0e200 RBX: 0000000000002000 RCX: ffff888021b6d940
+[ 1176.098112][T23686] RDX: 0000000000000000 RSI: 0000000000000001 RDI: 0000000000000000
+[ 1176.106072][T23686] RBP: ffffc90004e37aa0 R08: ffffffff81577992 R09: 1ffff920009c6e88
+[ 1176.114035][T23686] R10: dffffc0000000000 R11: fffff520009c6e89 R12: ffffc90004e379e0
+[ 1176.121996][T23686] R13: dffffc0000000000 R14: ffff8880411880a0 R15: 0000000000000246
+[ 1176.129966][T23686]  ? __warn_printk+0x292/0x360
+[ 1176.134735][T23686]  ? __pfx_ida_free+0x10/0x10
+[ 1176.139409][T23686]  ? __pfx___mutex_unlock_slowpath+0x10/0x10
+[ 1176.145384][T23686]  ? hci_conn_unlink+0x5a2/0x630
+[ 1176.150329][T23686]  hci_conn_del+0x7c0/0xcb0
+[ 1176.154831][T23686]  hci_conn_hash_flush+0x18e/0x240
+[ 1176.159940][T23686]  hci_dev_close_sync+0x9ab/0xff0
+[ 1176.164972][T23686]  hci_error_reset+0x110/0x270
+[ 1176.169728][T23686]  ? process_scheduled_works+0x825/0x1420
+[ 1176.175442][T23686]  process_scheduled_works+0x913/0x1420
+[ 1176.181003][T23686]  ? __pfx_process_scheduled_works+0x10/0x10
+[ 1176.186980][T23686]  ? assign_work+0x364/0x3d0
+[ 1176.191576][T23686]  worker_thread+0xa5f/0x1000
+[ 1176.196263][T23686]  ? __pfx_worker_thread+0x10/0x10
+[ 1176.201367][T23686]  kthread+0x2ef/0x390
+[ 1176.205513][T23686]  ? __pfx_worker_thread+0x10/0x10
+[ 1176.210615][T23686]  ? __pfx_kthread+0x10/0x10
+[ 1176.215198][T23686]  ret_from_fork+0x4b/0x80
+[ 1176.219608][T23686]  ? __pfx_kthread+0x10/0x10
+[ 1176.224189][T23686]  ret_from_fork_asm+0x1b/0x30
+[ 1176.228957][T23686]  </TASK>
+[ 1176.232148][T23686] Kernel Offset: disabled
+[ 1176.236672][T23686] Rebooting in 86400 seconds..


### PR DESCRIPTION
This library method is used in multiple places throughout the kernel.

Sample bug: https://syzkaller.appspot.com/bug?extid=dfab1425afcdae5ac970
