### PR TITLE
dashboard/config: temporarily disable CONFIG_DEBUG_LIST for KMSAN

### DIFF
--- a/dashboard/config/linux/bits/base.yml
+++ b/dashboard/config/linux/bits/base.yml
@@ -86,7 +86,8 @@ config:
  - HARDENED_USERCOPY
  - HARDENED_USERCOPY_FALLBACK: [-v5.15]
  - BUG_ON_DATA_CORRUPTION
- - DEBUG_LIST
+ # TODO: remove when https://github.com/google/syzkaller/issues/4504 is fixed.
+ - DEBUG_LIST: [-kmsan]
  - DEBUG_STACKOVERFLOW: [-v5.0]
 
  # CONFIG_DEBUG_PI_LIST was renamed to CONFIG_DEBUG_PLIST in 8e18faeac3e4.

--- a/dashboard/config/linux/upstream-kmsan-base.config
+++ b/dashboard/config/linux/upstream-kmsan-base.config
@@ -4649,7 +4649,7 @@ CONFIG_STACKTRACE=y
 #
 # Debug kernel data structures
 #
-CONFIG_DEBUG_LIST=y
+# CONFIG_DEBUG_LIST is not set
 CONFIG_DEBUG_PLIST=y
 # CONFIG_DEBUG_SG is not set
 # CONFIG_DEBUG_NOTIFIERS is not set

--- a/dashboard/config/linux/upstream-kmsan.config
+++ b/dashboard/config/linux/upstream-kmsan.config
@@ -8921,7 +8921,7 @@ CONFIG_STACKTRACE=y
 #
 # Debug kernel data structures
 #
-CONFIG_DEBUG_LIST=y
+# CONFIG_DEBUG_LIST is not set
 CONFIG_DEBUG_PLIST=y
 # CONFIG_DEBUG_SG is not set
 # CONFIG_DEBUG_NOTIFIERS is not set


### PR DESCRIPTION
KMSAN is currently reporting boot-time false positives in debugging code called from stackdepot.c (see https://github.com/google/syzkaller/issues/4504)

Disable CONFIG_DEBUG_LIST under KMSAN until the fix lands.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
