### PR TITLE
pkg/cover/backend: support veneers on ARM64

### DIFF
--- a/pkg/cover/backend/elf_test.go
+++ b/pkg/cover/backend/elf_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"testing"
+)
+
+func TestGetTraceCallbackType(t *testing.T) {
+	inputData := map[int][]string{
+		TraceCbNone: {
+			"foobar",
+			"___sanitizer_cov_trace_pc",
+		},
+		TraceCbPc: {
+			"__sanitizer_cov_trace_pc",
+			"____sanitizer_cov_trace_pc_veneer",
+		},
+		TraceCbCmp: {
+			"__sanitizer_cov_trace_cmp1",
+			"__sanitizer_cov_trace_const_cmp4",
+			"____sanitizer_cov_trace_const_cmp4_veneer",
+		},
+	}
+	for expected, names := range inputData {
+		for _, name := range names {
+			result := getTraceCallbackType(name)
+			if result != expected {
+				t.Fatalf("getTraceCallbackType(`%v`) unexpectedly returned %v", name, result)
+			}
+		}
+	}
+}

--- a/pkg/cover/backend/mach-o.go
+++ b/pkg/cover/backend/mach-o.go
@@ -75,7 +75,7 @@ func machoReadSymbols(module *Module, info *symbolInfo) ([]*Symbol, error) {
 			if symb.Name == "___sanitizer_cov_trace_pc_guard" {
 				info.tracePCIdx[i] = true
 				if text {
-					info.tracePC = symb.Value
+					info.tracePC[symb.Value] = true
 				}
 			} else {
 				info.traceCmpIdx[i] = true


### PR DESCRIPTION
Certain ARM64 builds continued reporting errors about coverage points not matching __sanitizer_cov_trace_pc calls. It turned out such coverage originated from calls to ____sanitizer_cov_trace_pc_veneer functions that are inserted by the linker to extend the range of BL instructions (limited by +/-128M).

Add support for __funcname_veneer functions to ELF to make sure this coverage is correctly attributed.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
