### PR TITLE
pkg/cover, pkg/mgrconfig: account for PLT when calculating arm64 modu…

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -65,7 +65,7 @@ type Range struct {
 
 const LineEnd = 1 << 30
 
-func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuild bool,
+func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuild, isKernel61OrEarlier bool,
 	moduleObj []string, modules []host.KernelModule) (*Impl, error) {
 	if objDir == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
@@ -83,5 +83,5 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuil
 		// details.
 		delimiters = []string{"/aosp/", "/private/"}
 	}
-	return makeELF(target, objDir, srcDir, buildDir, delimiters, moduleObj, modules)
+	return makeELF(target, objDir, srcDir, buildDir, delimiters, moduleObj, isKernel61OrEarlier, modules)
 }

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -36,7 +36,8 @@ type dwarfParams struct {
 	readTextData          func(*Module) ([]byte, error)
 	readModuleCoverPoints func(*targets.Target, *Module, *symbolInfo) ([2][]uint64, error)
 	readTextRanges        func(*Module) ([]pcRange, []*CompileUnit, error)
-	getModuleOffset       func(string) uint64
+	isKernel61OrEarlier   bool
+	getModuleOffset       func(bool, bool, string) uint64
 	getCompilerVersion    func(string) string
 }
 
@@ -155,7 +156,9 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 	srcDir := params.srcDir
 	buildDir := params.buildDir
 	splitBuildDelimiters := params.splitBuildDelimiters
-	modules, err := discoverModules(target, objDir, params.moduleObj, params.hostModules, params.getModuleOffset)
+	isKernel61OrEarlier := params.isKernel61OrEarlier
+	modules, err := discoverModules(target, objDir, params.moduleObj, params.hostModules,
+		isKernel61OrEarlier, params.getModuleOffset)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cover/backend/elf_test.go
+++ b/pkg/cover/backend/elf_test.go
@@ -4,6 +4,8 @@
 package backend
 
 import (
+	"debug/elf"
+	"fmt"
 	"testing"
 )
 
@@ -31,4 +33,94 @@ func TestGetTraceCallbackType(t *testing.T) {
 			}
 		}
 	}
+}
+
+func makeSection(name string, flags elf.SectionFlag, size, addralign uint64) *elf.Section {
+	s := elf.SectionHeader{
+		Name:      name,
+		Flags:     flags,
+		Size:      size,
+		Addralign: addralign,
+	}
+	return &elf.Section{
+		SectionHeader: s,
+	}
+}
+
+type ElfModuleLoadParams struct {
+	isArm64             bool
+	isKernel61OrEarlier bool
+	text                *elf.Section
+	sections            *[]*elf.Section
+}
+
+func elfModuleLoadHelper(t *testing.T, p ElfModuleLoadParams, expect uint64) {
+	result := elfSimulateModuleLoad(p.text, *p.sections, p.isArm64, p.isKernel61OrEarlier)
+	if result != expect {
+		sect := ""
+		for _, s := range *p.sections {
+			sect += fmt.Sprintf("%v\n", s)
+		}
+		t.Fatalf("elfSimulateModuleLoad() returned 0x%x instead of 0x%x\nSections:\n%v", result, expect, sect)
+	}
+}
+
+func TestElfSimulateModuleLoad(t *testing.T) {
+	var sect []*elf.Section
+	text := makeSection(".text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1000, 0x1)
+
+	// Test the non-ARM64 path.
+	params := ElfModuleLoadParams{
+		isArm64:             false,
+		isKernel61OrEarlier: false,
+		text:                text,
+		sections:            &sect,
+	}
+	// Trivial case: .text section is loaded at 0x0.
+	sect = append(sect, text)
+	elfModuleLoadHelper(t, params, 0x0)
+
+	// .init and .exit sections are ignored, as well as sections with non-text flags.
+	sect = nil
+	sect = append(sect, makeSection(".init.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1000, 0x1))
+	sect = append(sect, makeSection(".data", elf.SHF_ALLOC|elf.SHF_WRITE, 0x1000, 0x1000))
+	sect = append(sect, text)
+	sect = append(sect, makeSection(".exit.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1000, 0x1))
+	elfModuleLoadHelper(t, params, 0x0)
+
+	// .text section is loaded after another code section. Alignment of that section doesn't matter.
+	sect = nil
+	sect = append(sect, makeSection(".foobar.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x4, 0x10))
+	sect = append(sect, text)
+	elfModuleLoadHelper(t, params, 0x4)
+
+	// .text section is loaded after two sections. Alignment of the second section matters.
+	sect = nil
+	sect = append(sect, makeSection(".foobar.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x4, 0x10))
+	sect = append(sect, makeSection(".foobaz.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x4, 0x10))
+	sect = append(sect, text)
+	elfModuleLoadHelper(t, params, 0x14)
+
+	// Same rules apply to non-default sections on ARM64.
+	params.isArm64 = true
+	elfModuleLoadHelper(t, params, 0x14)
+
+	// module_frob_arch_sections() overrides size/alignment of .plt and .text.ftrace_trampoline.
+	sect = nil
+	sect = append(sect, makeSection(".plt", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1, 0x16))
+	sect = append(sect, makeSection(".text.ftrace_trampoline", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1, 0x1))
+	sect = append(sect, text)
+	elfModuleLoadHelper(t, params, 0x18)
+
+	// Older kernels add 12 extra bytes to .text.ftrace_trampoline.
+	params.isKernel61OrEarlier = true
+	elfModuleLoadHelper(t, params, 0x24)
+
+	// Nothing matters in the presence of a section with sufficiently big alignment.
+	sect = nil
+	sect = append(sect, makeSection(".plt", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1, 0x16))
+	sect = append(sect, makeSection(".text.ftrace_trampoline", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x1, 0x1))
+	sect = append(sect, makeSection(".hyp.text", elf.SHF_ALLOC|elf.SHF_EXECINSTR, 0x0, 0x1000))
+	sect = append(sect, text)
+	elfModuleLoadHelper(t, params, 0x1000)
 }

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -33,7 +33,7 @@ var RestorePC = backend.RestorePC
 func MakeReportGenerator(cfg *mgrconfig.Config, subsystem []mgrconfig.Subsystem,
 	modules []host.KernelModule, rawCover bool) (*ReportGenerator, error) {
 	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelObj,
-		cfg.KernelSrc, cfg.KernelBuildSrc, cfg.AndroidSplitBuild, cfg.ModuleObj, modules)
+		cfg.KernelSrc, cfg.KernelBuildSrc, cfg.AndroidSplitBuild, cfg.IsKernel61OrEarlier, cfg.ModuleObj, modules)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	KernelBuildSrc string `json:"kernel_build_src,omitempty"`
 	// Is the kernel built separately from the modules? (Specific to Android builds)
 	AndroidSplitBuild bool `json:"android_split_build"`
+	// Starting from 6.2, Linux kernels calculate module offsets in a slightly different way.
+	IsKernel61OrEarlier bool `json:"is_kernel_6_1_or_earlier"`
 	// Kernel subsystem with paths to each subsystem
 	//	"kernel_subsystem": [
 	//		{ "name": "sound", "path": ["sound", "techpack/audio"]},


### PR DESCRIPTION
…le offset

On ARM64 Linux kernel performs extra trickery when calculating the offset of the .text section. In particular, it overrides sizes and alignments of the .plt and .text.ftrace_trampoline sections, ignoring what is written in the ELF headers.

This patch factors out the module loading code into elfSimulateModuleLoad(), makes the necessary adjustments to account for the changed section attributes, and adds tests for elfSimulateModuleLoad().

Because the size of .text.ftrace_trampoline depends on the kernel version, we also introduce the `is_kernel_6_1_or_earlier` config parameter that is used to calculate the correct size.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
