### PR TITLE
dashboard/app/README.md: update gcloud howto

### DIFF
--- a/dashboard/app/README.md
+++ b/dashboard/app/README.md
@@ -22,11 +22,12 @@ production use.
 The app also needs one or more [syz-ci](/syz-ci/syz-ci.go) instances running elsewhere. The `syz-ci` instances
 do the actual fuzzing, bisection, patch testing, etc.
 
-The app can be deployed with `GO111MODULE=off gcloud beta app deploy ./dashboard/app/app.yaml` command:
-1. GO111MODULE=off is needed to deploy the package, not module.
-2. "beta app" instead of "app" is needed to support the "app_engine_apis: true" flag in yaml file.
-3. [optional flag] "--no-promote" let you to test the app firs and migrate the traffic to it later.
-4. [optional flag] "--verbosity=info" let you to see what files are going to be deployed.
+The app can be deployed by `gcloud app deploy ./dashboard/app/app.yaml`.
+
+Next optional flags are available:
+
+1. "--no-promote" to test the app firs and migrate the traffic to it later.
+2. "--verbosity=info" to see what files are going to be deployed.
 
 The app tests can be run with:
 ```


### PR DESCRIPTION
1. We use modules now.
2. gcloud app deploy supports app_engine_apis flag.
3. "gcloud beta app deploy" believes project root is syzkaller/ and doesn't work.
