### PR TITLE
pkg/host: get module .text address from /sys/module

### DIFF
--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -50,10 +50,9 @@ func discoverModulesLinux(dirs []string, hostModules []host.KernelModule,
 			continue
 		}
 		log.Logf(0, "module %v -> %v", mod.Name, path)
-		offset := getModuleOffset(path)
 		modules = append(modules, &Module{
 			Name: mod.Name,
-			Addr: mod.Addr + offset,
+			Addr: mod.Addr,
 			Path: path,
 		})
 	}

--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -45,17 +45,9 @@ func CollectGlobsInfo(globs map[string]bool) (map[string][]string, error) {
 	return machineGlobsInfo(globs)
 }
 
-func ParseModulesText(modulesText []byte) ([]KernelModule, error) {
-	if machineParseModules == nil {
-		return nil, nil
-	}
-	return machineParseModules(modulesText)
-}
-
 var machineInfoFuncs []machineInfoFunc
 var machineModulesInfo func() ([]KernelModule, error)
 var machineGlobsInfo func(map[string]bool) (map[string][]string, error)
-var machineParseModules func([]byte) ([]KernelModule, error)
 
 type machineInfoFunc struct {
 	name string

--- a/pkg/host/machine_info_linux.go
+++ b/pkg/host/machine_info_linux.go
@@ -21,7 +21,6 @@ func init() {
 	}
 	machineModulesInfo = getModulesInfo
 	machineGlobsInfo = getGlobsInfo
-	machineParseModules = parseModules
 }
 
 func readCPUInfo(buffer *bytes.Buffer) error {
@@ -140,26 +139,9 @@ func getModuleTextAddr(moduleName string) (uint64, error) {
 }
 
 func getModulesInfo() ([]KernelModule, error) {
-	modulesText, _ := os.ReadFile("/proc/modules")
-	modules, err := parseModules(modulesText)
-	if err != nil {
-		return modules, err
-	}
-	// Fix up module addresses to use .text addresses where available.
-	for i, module := range modules {
-		addr, err := getModuleTextAddr(module.Name)
-		if err == nil {
-			offset := addr - modules[i].Addr
-			modules[i].Addr += offset
-			modules[i].Size -= offset
-		}
-	}
-	return modules, nil
-}
-
-func parseModules(modulesText []byte) ([]KernelModule, error) {
 	var modules []KernelModule
 	re := regexp.MustCompile(`(\w+) ([0-9]+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
+	modulesText, _ := os.ReadFile("/proc/modules")
 	for _, m := range re.FindAllSubmatch(modulesText, -1) {
 		name := string(m[1])
 		modAddr, err := strconv.ParseUint(string(m[3]), 0, 64)

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -41,7 +41,7 @@ func main() {
 	var (
 		flagConfig  = flag.String("config", "", "configuration file")
 		flagModules = flag.String("modules", "",
-			"modules info obtained from /modules or file from /proc/modules (optional)")
+			"modules JSON info obtained from /modules (optional)")
 		flagExportCSV      = flag.String("csv", "", "export coverage data in csv format (optional)")
 		flagExportLineJSON = flag.String("json", "", "export coverage data with source line info in json format (optional)")
 		flagExportHTML     = flag.String("html", "", "save coverage HTML report to file (optional)")
@@ -150,8 +150,9 @@ func loadModules(fname string) ([]host.KernelModule, error) {
 		return nil, err
 	}
 	var modules []host.KernelModule
-	if err := json.Unmarshal(data, &modules); err != nil {
-		return host.ParseModulesText(data)
+	err = json.Unmarshal(data, &modules)
+	if err != nil {
+		return nil, err
 	}
 	return modules, nil
 }


### PR DESCRIPTION
The address from /proc/modules is not necessarily the address of .text, e.g., can be the address of .plt.

If available, fix up the module address using the address from /sys/module/<module-name>/sections/.text

This patch was originally uploaded to
https://github.com/google/syzkaller/pull/4025.
Since then, it was reworked to store the addresses obtained from /proc/modules (aka `ProcAddr`) and /sys/module (aka `Addr`) independently.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
