### PR TITLE
vm/qemu.go: fix nil-ptr-deref in ctor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -124,3 +124,5 @@ h0wdy
 Dylan Yudaken
 Marius Fleischer
 Piotr Siminski
+Purdue University
+ Sungwoo Kim

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -376,7 +376,7 @@ func (pool *Pool) ctor(workdir, sshkey, sshuser string, index int) (vmimpl.Insta
 		sshuser:    sshuser,
 		diagnose:   make(chan bool, 1),
 	}
-	if st, err := os.Stat(inst.image); err != nil && st.Size() == 0 {
+	if st, err := os.Stat(inst.image); err == nil && st.Size() == 0 {
 		// Some kernels may not need an image, however caller may still
 		// want to pass us a fake empty image because the rest of syzkaller
 		// assumes that an image is mandatory. So if the image is empty, we ignore it.


### PR DESCRIPTION
`os.Stat()` may return `(nil, err)` if it fails to open a file.

So, the code below wrongly validates `st` as it will be always `nil` if `err != nil`, causing nil pointer dereference in `st.Size()`.
```go
if st, err := os.Stat(inst.image); err != nil && st.Size() == 0 {
```

To fix this, this patch allows st.Size() only if `err == nil`.