### PR TITLE
pkg/ipc: copy signal and coverage

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -493,13 +493,17 @@ func readUint32Array(outp *[]byte, size uint32) ([]uint32, bool) {
 	if int(size)*4 > len(out) {
 		return nil, false
 	}
+	// "Convert" the data to uint32.
 	var res []uint32
 	hdr := (*reflect.SliceHeader)((unsafe.Pointer(&res)))
 	hdr.Data = uintptr(unsafe.Pointer(&out[0]))
 	hdr.Len = int(size)
 	hdr.Cap = int(size)
 	*outp = out[size*4:]
-	return res, true
+	// Now duplicate the resulting array.
+	dupRes := make([]uint32, size)
+	copy(dupRes, res)
+	return dupRes, true
 }
 
 type command struct {


### PR DESCRIPTION
This change was taken out of https://github.com/google/syzkaller/pull/4509
***

We used to optimize the memory usage by making the slices of individual CallInfo structs point to the shared memory buffer between syz-fuzzer and executor.

However, this puts very strict expectations on all pkg/ipc users and complicates the decoupling of the fuzzing logic from individual proc loops.

Let's try to live without this optimization. When compared with the cost of a single syz-executor execution, the cost of array copying is very very small anyway.