### PR TITLE
syz-manager: truncate repro logs before reporting

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -742,6 +742,27 @@ func replace(where []byte, start, end int, what []byte) []byte {
 	return where
 }
 
+// Truncate leaves up to `begin` bytes at the beginning of log and
+// up to `end` bytes at the end of the log.
+func Truncate(log []byte, begin, end int) []byte {
+	if begin+end >= len(log) {
+		return log
+	}
+	var b bytes.Buffer
+	b.Write(log[:begin])
+	if begin > 0 {
+		b.WriteString("\n\n")
+	}
+	fmt.Fprintf(&b, "<<cut %d bytes out>>",
+		len(log)-begin-end,
+	)
+	if end > 0 {
+		b.WriteString("\n\n")
+	}
+	b.Write(log[len(log)-end:])
+	return b.Bytes()
+}
+
 var (
 	filenameRe    = regexp.MustCompile(`([a-zA-Z0-9_\-\./]*[a-zA-Z0-9_\-]+\.(c|h)):[0-9]+`)
 	reportFrameRe = regexp.MustCompile(`.* in ([a-zA-Z0-9_]+)`)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/assert"
 )
 
 var flagUpdate = flag.Bool("update", false, "update test files accordingly to current results")
@@ -429,4 +430,18 @@ func TestFuzz(t *testing.T) {
 	} {
 		Fuzz([]byte(data)[:len(data):len(data)])
 	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, []byte(`01234
+
+<<cut 11 bytes out>>`), Truncate([]byte(`0123456789ABCDEF`), 5, 0))
+	assert.Equal(t, []byte(`<<cut 11 bytes out>>
+
+BCDEF`), Truncate([]byte(`0123456789ABCDEF`), 0, 5))
+	assert.Equal(t, []byte(`0123
+
+<<cut 9 bytes out>>
+
+DEF`), Truncate([]byte(`0123456789ABCDEF`), 4, 3))
 }


### PR DESCRIPTION
Until we have figured out a way to solve #4495, let's just truncate repro logs before sending them over the dashboard API.
