### PR TITLE
pkg/cover: delete getModuleOffset()

### DIFF
--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -36,7 +36,6 @@ type dwarfParams struct {
 	readTextData          func(*Module) ([]byte, error)
 	readModuleCoverPoints func(*targets.Target, *Module, *symbolInfo) ([2][]uint64, error)
 	readTextRanges        func(*Module) ([]pcRange, []*CompileUnit, error)
-	getModuleOffset       func(string) uint64
 	getCompilerVersion    func(string) string
 }
 
@@ -165,7 +164,7 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 	srcDir := params.srcDir
 	buildDir := params.buildDir
 	splitBuildDelimiters := params.splitBuildDelimiters
-	modules, err := discoverModules(target, objDir, params.moduleObj, params.hostModules, params.getModuleOffset)
+	modules, err := discoverModules(target, objDir, params.moduleObj, params.hostModules)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -29,7 +29,6 @@ func makeELF(target *targets.Target, objDir, srcDir, buildDir string, splitBuild
 		readTextData:          elfReadTextData,
 		readModuleCoverPoints: elfReadModuleCoverPoints,
 		readTextRanges:        elfReadTextRanges,
-		getModuleOffset:       elfGetModuleOffset,
 		getCompilerVersion:    elfGetCompilerVersion,
 	})
 }
@@ -203,40 +202,6 @@ func elfReadModuleCoverPoints(target *targets.Target, module *Module, info *symb
 	return pcs, nil
 }
 
-// Calculate the offset of the module .text section in the kernel memory.
-// /proc/modules only contains the base address, which corresponds to the
-// beginning of the first code section, but that section does not have to
-// be .text (e.g. on Android it may be .plt).
-// The offset is calculated by summing up the aligned sizes of sections
-// that:
-//   - precede .text;
-//   - are not .init/.exit sections;
-//   - have the SHF_ALLOC and SHF_EXECINSTR flags.
-func elfGetModuleOffset(path string) uint64 {
-	file, err := elf.Open(path)
-	if err != nil {
-		return 0
-	}
-	defer file.Close()
-	ts := file.Section(".text")
-	if ts == nil {
-		return 0
-	}
-	off := uint64(0)
-	const textFlagsMask = elf.SHF_ALLOC | elf.SHF_EXECINSTR
-	for _, s := range file.Sections {
-		if (s.Flags&textFlagsMask == textFlagsMask) && !strings.HasPrefix(s.SectionHeader.Name, ".init") &&
-			!strings.HasPrefix(s.SectionHeader.Name, ".exit") {
-			off = alignUp(off, s.SectionHeader.Addralign)
-			if s == ts {
-				return off
-			}
-			off += s.SectionHeader.Size
-		}
-	}
-	return 0
-}
-
 func elfGetCompilerVersion(path string) string {
 	file, err := elf.Open(path)
 	if err != nil {
@@ -252,11 +217,4 @@ func elfGetCompilerVersion(path string) string {
 		return ""
 	}
 	return string(data[:])
-}
-
-func alignUp(addr, align uint64) uint64 {
-	if align == 0 {
-		return addr
-	}
-	return (addr + align - 1) & ^(align - 1)
 }

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -17,7 +17,7 @@ import (
 )
 
 func discoverModules(target *targets.Target, objDir string, moduleObj []string,
-	hostModules []host.KernelModule, getModuleOffset func(string) uint64) (
+	hostModules []host.KernelModule) (
 	[]*Module, error) {
 	modules := []*Module{
 		// A dummy module representing the kernel itself.
@@ -25,7 +25,7 @@ func discoverModules(target *targets.Target, objDir string, moduleObj []string,
 	}
 	if target.OS == targets.Linux {
 		modules1, err := discoverModulesLinux(append([]string{objDir}, moduleObj...),
-			hostModules, getModuleOffset)
+			hostModules)
 		if err != nil {
 			return nil, err
 		}
@@ -37,7 +37,7 @@ func discoverModules(target *targets.Target, objDir string, moduleObj []string,
 }
 
 func discoverModulesLinux(dirs []string, hostModules []host.KernelModule,
-	getModuleOffset func(string) uint64) ([]*Module, error) {
+) ([]*Module, error) {
 	paths, err := locateModules(dirs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since commit 971a0f14c5cf6 ("pkg/host: get module .text address from /sys/module") getModuleOffset() is not used by anyone, so it should be safe to delete it.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
