### PR TITLE
ci.yml: specify build platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           .github/workflows/run.sh make presubmit_aux
 
   build:
-    runs-on: arc-runner-set
+    runs-on: arc-runner-set, linux
     container: gcr.io/syzkaller/env:latest
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath


### PR DESCRIPTION
Supported values are x64, ARM, or ARM64.
See [docs](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs).
