### PR TITLE
ci.yml: let's dumb the TERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     steps:
       # Checks out syzkaller repo at the path.
       - name: checkout
@@ -40,6 +41,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     steps:
     - name: checkout
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -72,6 +74,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -93,6 +96,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     strategy:
       matrix:
         target: [ presubmit_arch_linux, presubmit_arch_freebsd, presubmit_arch_netbsd, presubmit_arch_openbsd, presubmit_arch_darwin, presubmit_arch_windows, presubmit_arch_executor ]
@@ -113,6 +117,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -141,6 +146,7 @@ jobs:
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
+      TERM: dumb
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
It is to avoid "tput: No value for $TERM and no -T specified" in logs.
