### PR TITLE
run dashboard race tests independently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,23 @@ jobs:
           cd gopath/src/github.com/google/syzkaller
           .github/workflows/run.sh make presubmit_race
 
+  race_dashboard:
+    runs-on: arc-runner-set
+    container: gcr.io/syzkaller/env:latest
+    env:
+      GOPATH: /__w/syzkaller/syzkaller/gopath
+      CI: true
+      TERM: dumb
+    steps:
+      - name: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          path: gopath/src/github.com/google/syzkaller
+      - name: run
+        run: |
+          cd gopath/src/github.com/google/syzkaller
+          .github/workflows/run.sh make presubmit_race_dashboard
+
   old:
     runs-on: ubuntu-latest
     container: gcr.io/syzkaller/old-env:latest

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ presubmit_build: descriptions
 	# This does not check build of test files, but running go test takes too long (even for building).
 	$(GO) build ./...
 	$(MAKE) lint
-	SYZ_SKIP_DASHBOARD=1 $(MAKE) test
+	SYZ_SKIP_DEV_APPSERVER_TESTS=1 $(MAKE) test
 
 presubmit_arch_linux: descriptions
 	env HOSTOS=linux HOSTARCH=amd64 $(MAKE) host
@@ -375,7 +375,7 @@ presubmit_dashboard: descriptions
 presubmit_race: descriptions
 	# -race requires cgo
 	env CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
-	env CGO_ENABLED=1 SYZ_SKIP_DASHBOARD=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
+	env CGO_ENABLED=1 SYZ_SKIP_DEV_APPSERVER_TESTS=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
 	fi
 
 presubmit_race_dashboard: descriptions

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ endif
 	check_copyright check_language check_whitespace check_links check_diff check_commits check_shebang \
 	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd \
 	presubmit_arch_netbsd presubmit_arch_openbsd presubmit_arch_darwin presubmit_arch_windows \
-	presubmit_arch_executor presubmit_dashboard presubmit_race presubmit_old
+	presubmit_arch_executor presubmit_dashboard presubmit_race presubmit_race_dashboard presubmit_old
 
 all: host target
 host: manager runtest repro mutate prog2c db upgrade
@@ -310,6 +310,7 @@ presubmit:
 	$(MAKE) presubmit_arch_windows
 	$(MAKE) presubmit_arch_executor
 	$(MAKE) presubmit_race
+	$(MAKE) presubmit_race_dashboard
 
 presubmit_aux:
 	$(MAKE) generate
@@ -374,7 +375,13 @@ presubmit_dashboard: descriptions
 presubmit_race: descriptions
 	# -race requires cgo
 	env CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
-	env CGO_ENABLED=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
+	env CGO_ENABLED=1 SYZ_SKIP_DASHBOARD=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
+	fi
+
+presubmit_race_dashboard: descriptions
+	# -race requires cgo
+	env CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
+	env CGO_ENABLED=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./dashboard/app/... ;\
 	fi
 
 presubmit_old: descriptions

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -51,7 +51,7 @@ var skipDevAppserverTests = func() bool {
 	_, err := exec.LookPath("dev_appserver.py")
 	// Don't silently skip tests on CI, we should have gcloud sdk installed there.
 	return err != nil && os.Getenv("SYZ_ENV") == "" ||
-		os.Getenv("SYZ_SKIP_DASHBOARD") != ""
+		os.Getenv("SYZ_SKIP_DEV_APPSERVER_TESTS") != ""
 }()
 
 func NewCtx(t *testing.T) *Ctx {


### PR DESCRIPTION
There are 2 reasons:
1. They take 82/346 seconds. TOP2 candidate takes 38 seconds.
2. They pollute output adding 14k log lines.

$ cat race_logs.txt | grep github.com/google/syzkaller | grep -v files | grep ok | awk '{print $3, $4}' |  rev | cut -c2- | rev | awk '{print $2, $1}' | sort -rn
82.796 github.com/google/syzkaller/dashboard/app
38.479 github.com/google/syzkaller/pkg/host
28.317 github.com/google/syzkaller/pkg/runtest
17.904 github.com/google/syzkaller/prog
16.030 github.com/google/syzkaller/pkg/db
15.192 github.com/google/syzkaller/pkg/ipc
11.147 github.com/google/syzkaller/pkg/compiler
9.869 github.com/google/syzkaller/vm
8.882 github.com/google/syzkaller/pkg/cover/backend
7.515 github.com/google/syzkaller/pkg/ast
6.898 github.com/google/syzkaller/pkg/cover
6.778 github.com/google/syzkaller/pkg/bisect
6.684 github.com/google/syzkaller/pkg/ifuzz
6.227 github.com/google/syzkaller/executor
5.693 github.com/google/syzkaller/pkg/image
5.381 github.com/google/syzkaller/prog/test
4.809 github.com/google/syzkaller/vm/proxyapp
3.533 github.com/google/syzkaller/syz-fuzzer
3.432 github.com/google/syzkaller/pkg/vcs
3.357 github.com/google/syzkaller/tools/syz-linter
3.094 github.com/google/syzkaller/syz-ci
2.714 github.com/google/syzkaller/pkg/subsystem/lists
2.650 github.com/google/syzkaller/pkg/report
2.603 github.com/google/syzkaller/pkg/repro
2.576 github.com/google/syzkaller/pkg/build
2.335 github.com/google/syzkaller/pkg/mgrconfig
2.166 github.com/google/syzkaller/pkg/bisect/minimize
2.108 github.com/google/syzkaller/pkg/instance
2.071 github.com/google/syzkaller/syz-manager
1.881 github.com/google/syzkaller/syz-verifier
1.849 github.com/google/syzkaller/vm/vmimpl
1.835 github.com/google/syzkaller/tools/syz-trace2syz/proggen
1.830 github.com/google/syzkaller/vm/isolated
1.525 github.com/google/syzkaller/sys/linux
1.275 github.com/google/syzkaller/pkg/kconfig
1.263 github.com/google/syzkaller/pkg/asset
1.222 github.com/google/syzkaller/pkg/osutil
1.141 github.com/google/syzkaller/syz-hub/state
1.132 github.com/google/syzkaller/pkg/email
1.115 github.com/google/syzkaller/pkg/symbolizer
1.112 github.com/google/syzkaller/pkg/subsystem/linux
1.075 github.com/google/syzkaller/syz-hub
1.075 github.com/google/syzkaller/pkg/html
1.072 github.com/google/syzkaller/sys/openbsd
1.071 github.com/google/syzkaller/pkg/email/lore
1.069 github.com/google/syzkaller/sys/netbsd
1.055 github.com/google/syzkaller/tools/syz-kconf
1.055 github.com/google/syzkaller/pkg/auth
1.054 github.com/google/syzkaller/tools/syz-trace2syz/parser
1.051 github.com/google/syzkaller/pkg/subsystem
1.051 github.com/google/syzkaller/pkg/csource
1.045 github.com/google/syzkaller/pkg/config
1.042 github.com/google/syzkaller/pkg/tool
1.042 github.com/google/syzkaller/pkg/gce
1.040 github.com/google/syzkaller/pkg/serializer
1.037 github.com/google/syzkaller/pkg/stats
1.030 github.com/google/syzkaller/pkg/log
1.030 github.com/google/syzkaller/pkg/kd