### PR TITLE
.github/workflows/ci.yml: require min 31 core per test job

### DIFF
--- a/.github/arc_config/values.yaml
+++ b/.github/arc_config/values.yaml
@@ -195,6 +195,9 @@ template:
     - name: runner
       image: ghcr.io/actions/actions-runner:latest
       command: ["/home/runner/run.sh"]
+      resources:
+        requests:
+          cpu: 31
 
 ## Optional controller service account that needs to have required Role and RoleBinding
 ## to operate this gha-runner-scale-set installation.


### PR DESCRIPTION
We use machines with 32 CPU and 32 RAM.
Adding this options we prevent 2 runner PODs scheduling to the same node.
