### PR TITLE
pkg/vcs: support fetches by a short git hash

### DIFF
--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -426,3 +426,22 @@ func TestGitRemoteTags(t *testing.T) {
 	sort.Strings(tags)
 	assert.Equal(t, []string{"v1.0", "v2.0"}, tags)
 }
+
+func TestGitFetchShortHash(t *testing.T) {
+	remoteRepoDir := t.TempDir()
+	remote := MakeTestRepo(t, remoteRepoDir)
+	remote.Git("commit", "--no-edit", "--allow-empty", "-m", "base commit")
+	remote.Git("checkout", "-b", "base_branch")
+	remote.Git("tag", "base_tag")
+	remote.Git("checkout", "-b", "temp_branch")
+	remote.Git("commit", "--no-edit", "--allow-empty", "-m", "detached commit")
+	refCommit, _ := remote.repo.HeadCommit()
+
+	// Create a local repo.
+	localRepoDir := t.TempDir()
+	local := newGit(localRepoDir, nil, nil)
+
+	// Fetch the commit from the custom ref.
+	_, err := local.CheckoutCommit(remoteRepoDir, refCommit.Hash[:12])
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
The approach we used works perfectly for all commits, but they must be referenced by the full 40 character hash. In almost all cases, users would prefer to use the shorter one.

If the commit hash is not 40 characters long, fetch the whole git tree.

The only unsupported scenario is fetching a commit that is referenced by custom refs/* by its short hash. It's unlikely there's anything we can do here.
