### PR TITLE
dashboard: allow repo aliases in patch testing requests

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -220,6 +220,13 @@ func patchTestJobArgs(c context.Context, args *testJobArgs) error {
 		args.branch = build.KernelBranch
 		args.repo = build.KernelRepo
 	}
+	// Let trees be also identified by their alias names.
+	for _, repo := range getNsConfig(c, args.bug.Namespace).Repos {
+		if repo.Alias != "" && repo.Alias == args.repo {
+			args.repo = repo.URL
+			break
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
In our reports, we sometimes supply short alias names for the repositories. It was confusing for our users why they could not use that same short name in patch testing requests.

Closes #2265.
