### PR TITLE
compiler: support using int flags in field conditions

### DIFF
--- a/pkg/ast/testdata/all.txt
+++ b/pkg/ast/testdata/all.txt
@@ -16,8 +16,11 @@ expressions {
 	f3	int8	(if[X & (A == B) & Z != C])
 }
 
+intflags = 1, 2, 3, 4
+
 condFields {
 	mask	int8
+	flags	flags[intflags, int8]
 # Simple expressions work.
 	f0	int16	(if[val[mask] == SOME_CONST])
 # Conditions and other attributes work together.
@@ -25,5 +28,5 @@ condFields {
 # Test some more complex expressions.
 	f2	int16	(out, if[val[mask] & SOME_CONST == OTHER_CONST])
 	f3	int16	(out, if[val[mask] & SOME_CONST & OTHER_CONST == val[mask] & CONST_X])
-	f4	int16	(out, if[val[mask] & SOME_CONST])
+	f4	int16	(out, if[val[flags] & SOME_CONST])
 }

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -650,8 +650,8 @@ func (comp *compiler) checkPathField(target, t *ast.Type, field *ast.Field) bool
 
 func (comp *compiler) checkExprLastField(target *ast.Type, field *ast.Field) {
 	_, desc := comp.derefPointers(field.Type)
-	if desc != typeInt {
-		comp.error(target.Pos, "%v does not refer to an integer", field.Name.Name)
+	if desc != typeInt && desc != typeFlags {
+		comp.error(target.Pos, "%v does not refer to an integer or a flag", field.Name.Name)
 	}
 }
 

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -470,11 +470,11 @@ conditional_fields {
 	f3	some_nested_flags
 	f4	int32	(if[value[f3:f1] != 0])
 	f5	int32	(if[value[f3:f2:f4] != 0]) ### value path f2 does not refer to a struct
-	f6	int32	(if[value[f3:f4] != 0]) ### f4 does not refer to an integer
+	f6	int32	(if[value[f3:f4] != 0]) ### f4 does not refer to an integer or a flag
 	f7	int32	(if[value[f3:some_field] != 0]) ### value target some_field does not exist in some_nested_flags
 	f8	int32	(if[value[f3:f5] != 0]) ### f5 has conditions, so value path cannot reference it
 	f9	int32	(if[value[parent:a] != 0]) ### value target a does not exist in conditional_fields
-	f10	int32	(if[value[f3:f6] != 0]) ### f6 does not refer to an integer
+	f10	int32	(if[value[f3:f6] != 0]) ### f6 does not refer to an integer or a flag
 	f11	len[f2, int32] ### f2 has conditions, so len path cannot reference it
 	f12	union_cond_fields
 	f13	int32:8 (if[1]) ### bitfields may not have conditions


### PR DESCRIPTION
Commit ed571339c6ff ("pkg/compiler: support if[expr] attributes") added support for conditional fields in structs and unions. Conditions however cannot refer to flags, as in the following example:

    struct {
      f0 flags[some_flags, int32]
      f1 int32                     (if[value[f0] & FLAG1])
    } [packed]

It will fail to compile with:

    flags does not refer to an integer

This commit adds support for that syntax.