### PR TITLE
.github/workflows/ci.yml: workaround codecov limitation to detect environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
       TERM: dumb
+      GITHUB_ACTIONS: true
     steps:
     - name: checkout
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -75,6 +76,7 @@ jobs:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
       TERM: dumb
+      GITHUB_ACTIONS: true
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
codecov [uploader believes](https://github.com/codecov/uploader/blob/8ebf576d1180832f5b66fc66f3271b3df998b157/src/ci_providers/provider_githubactions.ts#L11) GITHUB_ACTIONS env signal about github actions environment.
At least for the kubernetes mode actions runner controller this assumption is not correct.
Let's help codecov to understand who is who.