### PR TITLE
syz-ci: stream coverage from manager to gcs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,7 @@ linters-settings:
     min-len: 3
     min-occurrences: 3
     ignore-tests: true # re-enable once goconst 1.7.0+ merged into golangci-lint
-    ignore-strings: "[syzbot] | (2)|Re: " # will be enabled by goconst 1.7.0
+    ignore-strings: '.html'
   nestif:
     # TODO: consider reducing this value.
     min-complexity: 12

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -211,8 +211,7 @@ func (rg *ReportGenerator) DoRawCoverFiles(w io.Writer, params CoverHandlerParam
 	return nil
 }
 
-type coverageInfo struct {
-	Version   int    `json:"version"`
+type CoverageInfo struct {
 	FilePath  string `json:"file_path"`
 	FuncName  string `json:"func_name"`
 	StartLine int    `json:"sl"`
@@ -245,8 +244,7 @@ func (rg *ReportGenerator) DoCoverJSONL(w io.Writer, params CoverHandlerParams) 
 		}
 		pcProgCount := FileByFrame(fm, &frame).lines[frame.StartLine].pcProgCount
 		hitCount := pcProgCount[frame.PC]
-		covInfo := &coverageInfo{
-			Version:   1,
+		covInfo := &CoverageInfo{
 			FilePath:  frame.Name,
 			FuncName:  frame.FuncName,
 			StartLine: frame.Range.StartLine,

--- a/pkg/cover/manager_to_ci.go
+++ b/pkg/cover/manager_to_ci.go
@@ -1,0 +1,51 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package cover
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// CIDetails fields will be added to every CSV line.
+type CIDetails struct {
+	Version        int    `json:"version"`
+	Timestamp      string `json:"timestamp"`
+	FuzzingMinutes int    `json:"fuzzing_minutes"`
+	Arch           string `json:"arch"`
+	BuildID        string `json:"build_id"`
+	Manager        string `json:"manager"`
+	KernelRepo     string `json:"kernel_repo"`
+	KernelBranch   string `json:"kernel_branch"`
+	KernelCommit   string `json:"kernel_commit"`
+}
+
+type dbCoverageRecord struct {
+	CIDetails
+	CoverageInfo
+}
+
+func writeJSLine(w io.Writer, covInfo dbCoverageRecord) error {
+	bs, err := json.Marshal(covInfo)
+	if err != nil {
+		return fmt.Errorf("failed to marshal covInfo: %w", err)
+	}
+	bs = append(bs, '\n')
+	if _, err = w.Write(bs); err != nil {
+		return fmt.Errorf("failed to write js data: %w", err)
+	}
+	return nil
+}
+
+func WriteCIJSONLine(w io.Writer, managerCover CoverageInfo, ciDetails CIDetails) error {
+	dbLine := dbCoverageRecord{
+		CIDetails:    ciDetails,
+		CoverageInfo: managerCover,
+	}
+	if err := writeJSLine(w, dbLine); err != nil {
+		return fmt.Errorf("failed to serialize func line: %w", err)
+	}
+	return nil
+}

--- a/pkg/cover/manager_to_ci_test.go
+++ b/pkg/cover/manager_to_ci_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package cover
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteCIJSONLine(t *testing.T) {
+	expectedJSON :=
+		`{"version":1,` +
+			`"timestamp":"2014-04-14 00:00:00.000",` +
+			`"fuzzing_minutes":360,` +
+			`"arch":"x86",` +
+			`"build_id":"sample_buildid",` +
+			`"manager":"sample_manager",` +
+			`"kernel_repo":"sample_repo_path",` +
+			`"kernel_branch":"",` +
+			`"kernel_commit":"",` +
+			`"file_path":"main.c",` +
+			`"func_name":"main",` +
+			`"sl":1,"sc":0,"el":1,"ec":-1,` +
+			`"hit_count":1,` +
+			`"inline":false,` +
+			`"pc":12345}
+`
+
+	covInfo := CoverageInfo{}
+	assert.NoError(t, json.Unmarshal(sampleCoverJSON, &covInfo))
+
+	buf := new(bytes.Buffer)
+	assert.NoError(t, WriteCIJSONLine(buf, covInfo, CIDetails{
+		Version:        1,
+		Timestamp:      "2014-04-14 00:00:00.000",
+		FuzzingMinutes: 360,
+		Arch:           "x86",
+		BuildID:        "sample_buildid",
+		Manager:        "sample_manager",
+		KernelRepo:     "sample_repo_path",
+	}))
+	assert.Equal(t, expectedJSON, buf.String())
+}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -429,13 +429,13 @@ func checkCSVReport(t *testing.T, CSVReport []byte) {
 	}
 }
 
+var sampleCoverJSON = []byte(`{"file_path":"main.c","func_name":"main",` +
+	`"sl":1,"sc":0,"el":1,"ec":-1,"hit_count":1,"inline":false,"pc":12345}`)
+
 // nolint:lll
 func checkJSONLReport(t *testing.T, r []byte) {
-	expected := []byte(`{"version":1,"file_path":"main.c","func_name":"main",` +
-		`"sl":1,"sc":0,"el":1,"ec":-1,"hit_count":1,"inline":false,"pc":12345}`)
-
 	compacted := new(bytes.Buffer)
-	if err := json.Compact(compacted, expected); err != nil {
+	if err := json.Compact(compacted, sampleCoverJSON); err != nil {
 		t.Errorf("failed to prepare compacted json: %v", err)
 	}
 	compacted.Write([]byte("\n"))

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -941,7 +941,8 @@ func (mgr *Manager) uploadFile(dstPath, name string, file io.Reader, allowPublis
 	URL.Path = path.Join(URL.Path, name)
 	URLStr := URL.String()
 	log.Logf(0, "uploading %v to %v", name, URLStr)
-	if strings.HasPrefix(URLStr, "http") {
+	if strings.HasPrefix(URLStr, "http://") ||
+		strings.HasPrefix(URLStr, "https://") {
 		return uploadFileHTTPPut(URLStr, file)
 	}
 	return uploadFileGCS(URLStr, file, allowPublishing && mgr.cfg.PublishGCS)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -106,7 +106,6 @@ type Config struct {
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).
 	CoverUploadPath string `json:"cover_upload_path"`
 	// Path to upload json coverage reports from managers (optional).
-	// Supported protocol: GCS (gs://)
 	CoverPipelinePath string `json:"cover_pipeline_path"`
 	// Path to upload corpus.db from managers (optional).
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -105,6 +105,9 @@ type Config struct {
 	// Path to upload coverage reports from managers (optional).
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).
 	CoverUploadPath string `json:"cover_upload_path"`
+	// Path to upload json coverage reports from managers (optional).
+	// Supported protocol: GCS (gs://)
+	CoverPipelinePath string `json:"cover_pipeline_path"`
 	// Path to upload corpus.db from managers (optional).
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).
 	CorpusUploadPath string `json:"corpus_upload_path"`


### PR DESCRIPTION
The goal is to put coverage details into DB.
Available options:
1. To put them directly. It will require the DB usage code.
2. To use GCP template pipelines. GCS based or Pub/Sub based pipeline.

GCS based pipeline looks the easiest because we already have GCS integration code.
