### PR TITLE
prog: assorted fixes for conditional fields

### DIFF
--- a/prog/clone.go
+++ b/prog/clone.go
@@ -39,6 +39,10 @@ func cloneCall(c *Call, newargs map[*ResultArg]*ResultArg) *Call {
 	return c1
 }
 
+func CloneArg(arg Arg) Arg {
+	return clone(arg, nil)
+}
+
 func clone(arg Arg, newargs map[*ResultArg]*ResultArg) Arg {
 	var arg1 Arg
 	switch a := arg.(type) {

--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -257,9 +257,13 @@ func (target *Target) Deserialize(data []byte, mode DeserializeMode) (*Prog, err
 	// This validation is done even in non-debug mode because deserialization
 	// procedure does not catch all bugs (e.g. mismatched types).
 	// And we can receive bad programs from corpus and hub.
-	if err := prog.validate(); err != nil {
+	if err := prog.validateWithOpts(validationOptions{
+		// Don't validate auto-set conditional fields. We'll patch them later.
+		ignoreTransient: true,
+	}); err != nil {
 		return nil, err
 	}
+	p.fixupConditionals(prog)
 	if p.autos != nil {
 		p.fixupAutos(prog)
 	}
@@ -1151,6 +1155,13 @@ func (p *parser) fixupAutos(prog *Prog) {
 	}
 	if len(p.autos) != 0 {
 		panic(fmt.Sprintf("leftoever autos: %+v", p.autos))
+	}
+}
+
+func (p *parser) fixupConditionals(prog *Prog) {
+	for _, c := range prog.Calls {
+		// Only overwrite transient union fields.
+		c.setDefaultConditions(p.target, true)
 	}
 }
 

--- a/prog/expr.go
+++ b/prog/expr.go
@@ -174,7 +174,7 @@ func matchingUnionArgs(typ *UnionType, finder ArgFinder) []int {
 
 func (p *Prog) checkConditions() error {
 	for _, c := range p.Calls {
-		err := c.checkConditions(p.Target)
+		err := c.checkConditions(p.Target, false)
 		if err != nil {
 			return err
 		}
@@ -184,12 +184,15 @@ func (p *Prog) checkConditions() error {
 
 var ErrViolatedConditions = errors.New("conditional fields rules violation")
 
-func (c *Call) checkConditions(target *Target) error {
+func (c *Call) checkConditions(target *Target, ignoreTransient bool) error {
 	var ret error
 
 	makeArgFinder := argFinderConstructor(target, c)
 	forEachStaleUnion(target, c, makeArgFinder,
 		func(a *UnionArg, t *UnionType, okIndices []int) {
+			if ignoreTransient && a.transient {
+				return
+			}
 			ret = fmt.Errorf("%w union %s field is #%d(%s), but %v satisfy conditions",
 				ErrViolatedConditions, t.Name(), a.Index, t.Fields[a.Index].Name,
 				okIndices)
@@ -197,7 +200,7 @@ func (c *Call) checkConditions(target *Target) error {
 	return ret
 }
 
-func (c *Call) setDefaultConditions(target *Target) bool {
+func (c *Call) setDefaultConditions(target *Target, transientOnly bool) bool {
 	var anyReplaced bool
 	// Replace stale conditions with the default values of their correct types.
 	for {
@@ -205,6 +208,9 @@ func (c *Call) setDefaultConditions(target *Target) bool {
 		makeArgFinder := argFinderConstructor(target, c)
 		forEachStaleUnion(target, c, makeArgFinder,
 			func(unionArg *UnionArg, unionType *UnionType, okIndices []int) {
+				if transientOnly && !unionArg.transient {
+					return
+				}
 				// If several union options match, take the first one.
 				idx := okIndices[0]
 				field := unionType.Fields[idx]

--- a/prog/expr_test.go
+++ b/prog/expr_test.go
@@ -42,6 +42,23 @@ func TestGenerateConditionalFields(t *testing.T) {
 	}
 }
 
+func TestConditionalResources(t *testing.T) {
+	// Let's stress test the code and rely on various internal checks.
+	target, rs, _ := initRandomTargetTest(t, "test", "64")
+	ct := target.BuildChoiceTable(nil, map[*Syscall]bool{
+		target.SyscallMap["test$create_cond_resource"]: true,
+		target.SyscallMap["test$use_cond_resource"]:    true,
+	})
+	iters := 500
+	if testing.Short() {
+		iters /= 10
+	}
+	for i := 0; i < iters; i++ {
+		p := target.Generate(rs, 10, ct)
+		p.Mutate(rs, 10, ct, nil, nil)
+	}
+}
+
 func TestMutateConditionalFields(t *testing.T) {
 	target, rs, _ := initRandomTargetTest(t, "test", "64")
 	ct := target.DefaultChoiceTable()

--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -281,7 +281,7 @@ func minimizeInt(ctx *minimizeArgsCtx, arg Arg, path string) bool {
 
 	// By mutating an integer, we risk violating conditional fields.
 	// If the fields are patched, the minimization process must be restarted.
-	patched := ctx.call.setDefaultConditions(ctx.p.Target)
+	patched := ctx.call.setDefaultConditions(ctx.p.Target, false)
 	if ctx.pred(ctx.p, ctx.callIndex0) {
 		*ctx.p0 = ctx.p
 		ctx.triedPaths[path] = true

--- a/prog/mutation.go
+++ b/prog/mutation.go
@@ -505,7 +505,6 @@ func (t *UnionType) mutate(r *randGen, s *state, arg Arg, ctx ArgCtx) (calls []*
 		index++
 	}
 	optType, optDir := t.Fields[index].Type, t.Fields[index].Dir(a.Dir())
-	removeArg(a.Option)
 	var newOpt Arg
 	newOpt, calls = r.generateArg(s, optType, optDir)
 	replaceArg(arg, MakeUnionArg(t, a.Dir(), newOpt, index))

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -354,6 +354,9 @@ func (p *Prog) insertBefore(c *Call, calls []*Call) {
 
 // replaceArg replaces arg with arg1 in a program.
 func replaceArg(arg, arg1 Arg) {
+	if arg == arg1 {
+		panic("replacing an argument with itself")
+	}
 	switch a := arg.(type) {
 	case *ConstArg:
 		*a = *arg1.(*ConstArg)

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -362,6 +362,9 @@ func replaceArg(arg, arg1 Arg) {
 	case *PointerArg:
 		*a = *arg1.(*PointerArg)
 	case *UnionArg:
+		if a.Option != nil {
+			removeArg(a.Option)
+		}
 		*a = *arg1.(*UnionArg)
 	case *DataArg:
 		*a = *arg1.(*DataArg)

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -886,7 +886,7 @@ func (a *UnionType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*C
 	if a.isConditional() {
 		// Conditions may reference other fields that may not have already
 		// been generated. We'll fill them in later.
-		return a.DefaultTransientArg(dir), nil
+		return a.DefaultArg(dir), nil
 	}
 	index := r.Intn(len(a.Fields))
 	optType, optDir := a.Fields[index].Type, a.Fields[index].Dir(dir)

--- a/prog/test/fuzz_test.go
+++ b/prog/test/fuzz_test.go
@@ -30,6 +30,9 @@ test$res2()
 test$res2()
 test$res2()
 `,
+		`r=test$res0()
+test$recur2(&(293324893027559)={r})
+`,
 	} {
 		t.Logf("test #%v: %q", i, data)
 		inp := []byte(data)[:len(data):len(data)]

--- a/prog/types.go
+++ b/prog/types.go
@@ -735,13 +735,9 @@ func (t *UnionType) String() string {
 func (t *UnionType) DefaultArg(dir Dir) Arg {
 	idx := t.defaultField()
 	f := t.Fields[idx]
-	return MakeUnionArg(t, dir, f.DefaultArg(f.Dir(dir)), idx)
-}
-
-func (t *UnionType) DefaultTransientArg(dir Dir) Arg {
-	unionArg := t.DefaultArg(dir).(*UnionArg)
-	unionArg.transient = true
-	return unionArg
+	arg := MakeUnionArg(t, dir, f.DefaultArg(f.Dir(dir)), idx)
+	arg.transient = t.isConditional()
+	return arg
 }
 
 func (t *UnionType) defaultField() int {

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -21,15 +21,25 @@ func (p *Prog) debugValidate() {
 	}
 }
 
+func (p *Prog) validate() error {
+	return p.validateWithOpts(validationOptions{})
+}
+
 type validCtx struct {
 	target *Target
+	opts   validationOptions
 	args   map[Arg]bool
 	uses   map[Arg]Arg
 }
 
-func (p *Prog) validate() error {
+type validationOptions struct {
+	ignoreTransient bool
+}
+
+func (p *Prog) validateWithOpts(opts validationOptions) error {
 	ctx := &validCtx{
 		target: p.Target,
+		opts:   opts,
 		args:   make(map[Arg]bool),
 		uses:   make(map[Arg]Arg),
 	}
@@ -65,7 +75,7 @@ func (ctx *validCtx) validateCall(c *Call) error {
 			return err
 		}
 	}
-	if err := c.checkConditions(ctx.target); err != nil {
+	if err := c.checkConditions(ctx.target, ctx.opts.ignoreTransient); err != nil {
 		return err
 	}
 	return ctx.validateRet(c)

--- a/sys/linux/init_iptables.go
+++ b/sys/linux/init_iptables.go
@@ -31,7 +31,7 @@ func (arch *arch) generateNetfilterTable(g *prog.Gen, typ prog.Type, dir prog.Di
 	} else {
 		// TODO(dvyukov): try to restore original hook order after mutation
 		// instead of assigning brand new offsets.
-		arg = old
+		arg = prog.CloneArg(old)
 		calls = g.MutateArg(arg)
 	}
 	var tableArg *prog.GroupArg
@@ -113,7 +113,7 @@ func (arch *arch) generateEbtables(g *prog.Gen, typ prog.Type, dir prog.Dir, old
 	} else {
 		// TODO(dvyukov): try to restore original hook order after mutation
 		// instead of assigning brand new offsets.
-		arg = old
+		arg = prog.CloneArg(old)
 		calls = g.MutateArg(arg)
 	}
 	if g.Target().ArgContainsAny(arg) {

--- a/sys/linux/init_vusb.go
+++ b/sys/linux/init_vusb.go
@@ -55,7 +55,7 @@ func (arch *arch) generateUsbDeviceDescriptor(g *prog.Gen, typ0 prog.Type, dir p
 	if old == nil {
 		arg = g.GenerateSpecialArg(typ0, dir, &calls)
 	} else {
-		arg = old
+		arg = prog.CloneArg(old)
 		calls = g.MutateArg(arg)
 	}
 	if g.Target().ArgContainsAny(arg) {
@@ -144,7 +144,7 @@ func (arch *arch) generateUsbHidDeviceDescriptor(g *prog.Gen, typ0 prog.Type, di
 	if old == nil {
 		arg = g.GenerateSpecialArg(typ0, dir, &calls)
 	} else {
-		arg = old
+		arg = prog.CloneArg(old)
 		calls = g.MutateArg(arg)
 	}
 	if g.Target().ArgContainsAny(arg) {

--- a/sys/test/expressions.txt
+++ b/sys/test/expressions.txt
@@ -68,3 +68,14 @@ conditional_union_parent {
 }
 
 test$conditional_union(a ptr[in, conditional_union_parent])
+
+resource cond_res[int32]
+
+test$create_cond_resource() cond_res
+
+conditional_resouce_struct {
+	f0	int8
+	f1	cond_res	(if[value[f0] == 1])
+}
+
+test$use_cond_resource(a ptr[in, conditional_resouce_struct])


### PR DESCRIPTION
The previous attempt: #4556

We got the following panics on syzbot:

```
panic: replaceArg: group fields don't match: 2/0

goroutine 11 [running]:
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d17e0?}, {0xe56770?, 0xc0005d1ac0?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:377 +0x425
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d17a0?}, {0xe56770?, 0xc0005d1a80?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d1780?}, {0xe56770?, 0xc0005d1a60?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d1760?}, {0xe56770?, 0xc0005d1a40?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d1740?}, {0xe56770?, 0xc0005d1a20?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d1720?}, {0xe56770?, 0xc0005d1a00?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d1700?}, {0xe56770?, 0xc0005d19e0?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.replaceArg({0xe56770?, 0xc0005d16e0?}, {0xe56770?, 0xc0005d19c0?})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/prog.go:382 +0x345
github.com/google/syzkaller/prog.(*StructType).mutate(0x16d44a0, 0xc0005d18e0, 0xc000b14b40, {0xe56770, 0xc0005d16c0?}, {0xc000b14a08, {0x1db72e0, 0x4, 0x4}, 0xc000ad5f80, ...})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/mutation.go:490 +0x185
github.com/google/syzkaller/prog.(*Target).mutateArg(0x0?, 0x0?, 0x10084fdc8?, {0xe56770, 0xc0005d16c0}, {0xc000b14a08, {0x1db72e0, 0x4, 0x4}, 0xc000ad5f80, ...}, ...)
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/mutation.go:245 +0xe2
github.com/google/syzkaller/prog.(*mutator).mutateArg(0xc000b79e48)
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/mutation.go:196 +0x245
github.com/google/syzkaller/prog.(*Prog).Mutate(0xc000b7fe40, {0xe52aa8?, 0xc000aca0c0}, 0x1e, 0xc001358000, 0xc00007ae40, {0xc000d34000, 0x421, 0x500})
	/syzkaller/gopath/src/github.com/google/syzkaller/prog/mutation.go:51 +0x2ba
main.(*Proc).loop(0xc000e6ef40)
	/syzkaller/gopath/src/github.com/google/syzkaller/syz-fuzzer/proc.go:95 +0x365
created by main.main in goroutine 1
	/syzkaller/gopath/src/github.com/google/syzkaller/syz-fuzzer/fuzzer.go:336 +0x1665



```