### PR TITLE
prog: speed up TestDeterminism() 

### DIFF
--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -385,17 +385,13 @@ func (job *hintsJob) run(fuzzer *Fuzzer) {
 	// Then mutate the initial program for every match between
 	// a syscall argument and a comparison operand.
 	// Execute each of such mutants to check if it gives new coverage.
-	var stop bool
 	p.MutateWithHints(job.call, result.Info.Calls[job.call].Comps,
-		func(p *prog.Prog) {
-			if stop {
-				return
-			}
+		func(p *prog.Prog) bool {
 			result := fuzzer.exec(job, &Request{
 				Prog:       p,
 				NeedSignal: true,
 				stat:       statHint,
 			})
-			stop = stop || result.Stop
+			return !result.Stop
 		})
 }

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -63,9 +63,13 @@ func generateProg(t *testing.T, target *Target, rs rand.Source, ct *ChoiceTable,
 			comps.AddComp(v, v+1)
 			comps.AddComp(v, v+10)
 		}
+		// If unbounded, this code may take O(N^2) time to complete.
+		// Since large programs are not uncommon, let's limit the number of hint iterations.
+		limit := 100
 		p.MutateWithHints(i, comps, func(p1 *Prog) bool {
 			p = p1.Clone()
-			return true
+			limit--
+			return limit > 0
 		})
 	}
 	for _, crash := range []bool{false, true} {

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -63,8 +63,9 @@ func generateProg(t *testing.T, target *Target, rs rand.Source, ct *ChoiceTable,
 			comps.AddComp(v, v+1)
 			comps.AddComp(v, v+10)
 		}
-		p.MutateWithHints(i, comps, func(p1 *Prog) {
+		p.MutateWithHints(i, comps, func(p1 *Prog) bool {
 			p = p1.Clone()
+			return true
 		})
 	}
 	for _, crash := range []bool{false, true} {

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -251,11 +251,12 @@ func (ctx *Context) printHints(p *prog.Prog, info *ipc.ProgInfo) {
 				fmt.Printf("\n")
 			}
 		}
-		p.MutateWithHints(i, comps, func(p *prog.Prog) {
+		p.MutateWithHints(i, comps, func(p *prog.Prog) bool {
 			ncandidates++
 			if *flagOutput {
 				log.Logf(1, "PROGRAM:\n%s", p.Serialize())
 			}
+			return true
 		})
 	}
 	log.Logf(0, "ncomps=%v ncandidates=%v", ncomps, ncandidates)

--- a/tools/syz-mutate/mutate.go
+++ b/tools/syz-mutate/mutate.go
@@ -89,8 +89,9 @@ func main() {
 		if *flagHintCall != -1 {
 			comps := make(prog.CompMap)
 			comps.AddComp(*flagHintSrc, *flagHintCmp)
-			p.MutateWithHints(*flagHintCall, comps, func(p *prog.Prog) {
+			p.MutateWithHints(*flagHintCall, comps, func(p *prog.Prog) bool {
 				fmt.Printf("%s\n\n", p.Serialize())
+				return true
 			})
 			return
 		} else {


### PR DESCRIPTION
We don't need to try out all possible mutations. It can be very slow for
large programs, so let's limit the number of hint mutations to 100.