### PR TITLE
 pkg/cover: export the frames data as jsonl

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -48,11 +48,12 @@ type ObjectUnit struct {
 }
 
 type Frame struct {
-	Module *Module
-	PC     uint64
-	Name   string
-	Path   string
-	Inline bool
+	Module   *Module
+	PC       uint64
+	Name     string
+	FuncName string
+	Path     string
+	Inline   bool
 	Range
 }
 

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -456,11 +456,12 @@ func symbolizeModule(target *targets.Target, objDir, srcDir, buildDir string, sp
 		for _, frame := range res.frames {
 			name, path := cleanPath(frame.File, objDir, srcDir, buildDir, splitBuildDelimiters)
 			frames = append(frames, Frame{
-				Module: mod,
-				PC:     frame.PC + mod.Addr,
-				Name:   name,
-				Path:   path,
-				Inline: frame.Inline,
+				Module:   mod,
+				PC:       frame.PC + mod.Addr,
+				Name:     name,
+				FuncName: frame.Func,
+				Path:     path,
+				Inline:   frame.Inline,
 				Range: Range{
 					StartLine: frame.Line,
 					StartCol:  0,

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -247,7 +247,7 @@ const (
 	DoRawCoverFiles
 	DoRawCover
 	DoFilterPCs
-	DoCoverJSON
+	DoCoverJSONL
 )
 
 func (mgr *Manager) httpCover(w http.ResponseWriter, r *http.Request) {
@@ -255,8 +255,8 @@ func (mgr *Manager) httpCover(w http.ResponseWriter, r *http.Request) {
 		mgr.httpCoverFallback(w, r)
 		return
 	}
-	if r.FormValue("json") == "1" {
-		mgr.httpCoverCover(w, r, DoCoverJSON)
+	if r.FormValue("jsonl") == "1" {
+		mgr.httpCoverCover(w, r, DoCoverJSONL)
 		return
 	}
 	mgr.httpCoverCover(w, r, DoHTML)
@@ -368,7 +368,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 		DoRawCoverFiles: {rg.DoRawCoverFiles, ctTextPlain},
 		DoRawCover:      {rg.DoRawCover, ctTextPlain},
 		DoFilterPCs:     {rg.DoFilterPCs, ctTextPlain},
-		DoCoverJSON:     {rg.DoCoverJSON, ctApplicationJSON},
+		DoCoverJSONL:    {rg.DoCoverJSONL, ctApplicationJSON},
 	}
 
 	if ct := flagToFunc[funcFlag].contentType; ct != "" {


### PR DESCRIPTION
This data flow generates information only about the visited files.
We need more to calculate coverage numbers. I'll extend this dataflow in the following PRs.
This data is enough to start the data aggregation experiments or detect regressions.