### PR TITLE
vm/isolated: allow the use of system-wide SSH config

### DIFF
--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -250,7 +250,7 @@ func (inst *instance) Boot() error {
 	}
 
 	if err := vmimpl.WaitForSSH(inst.debug, 10*time.Minute, inst.sshhost,
-		inst.sshkey, inst.sshuser, inst.os, 22, nil); err != nil {
+		inst.sshkey, inst.sshuser, inst.os, 22, nil, false); err != nil {
 		bootOutputStop <- true
 		<-bootOutputStop
 		return vmimpl.MakeBootError(err, bootOutput)
@@ -285,7 +285,7 @@ func (inst *instance) Forward(port int) (string, error) {
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	vmDst := filepath.Join("/root", filepath.Base(hostSrc))
-	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, 22),
+	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, 22, false),
 		hostSrc, inst.sshuser+"@"+inst.sshhost+":"+vmDst)
 	if inst.debug {
 		log.Logf(0, "running command: scp %#v", args)
@@ -305,7 +305,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	}
 	inst.merger.Add("ssh", rpipe)
 
-	args := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, 22),
+	args := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, 22, false),
 		inst.sshuser+"@"+inst.sshhost, command)
 	if inst.debug {
 		log.Logf(0, "running command: ssh %#v", args)

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -104,7 +104,7 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 }
 
 func (inst *instance) sshArgs(command string) []string {
-	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.sshKey, 22), inst.sshUser+"@"+inst.name)
+	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.sshKey, 22, false), inst.sshUser+"@"+inst.name)
 	if inst.sshUser != "root" {
 		return append(sshArgs, "sudo", "bash", "-c", "'"+command+"'")
 	}

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -550,7 +550,7 @@ func (inst *instance) boot() error {
 		}
 	}()
 	if err := vmimpl.WaitForSSH(inst.debug, 10*time.Minute*inst.timeouts.Scale, "localhost",
-		inst.sshkey, inst.sshuser, inst.os, inst.port, inst.merger.Err); err != nil {
+		inst.sshkey, inst.sshuser, inst.os, inst.port, inst.merger.Err, false); err != nil {
 		bootOutputStop <- true
 		<-bootOutputStop
 		return vmimpl.MakeBootError(err, bootOutput)
@@ -632,7 +632,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		inst.files[vmDst] = hostSrc
 	}
 
-	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, inst.port),
+	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, inst.port, false),
 		hostSrc, inst.sshuser+"@localhost:"+vmDst)
 	if inst.debug {
 		log.Logf(0, "running command: scp %#v", args)
@@ -652,7 +652,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	}
 	inst.merger.Add("ssh", rpipe)
 
-	sshArgs := vmimpl.SSHArgsForward(inst.debug, inst.sshkey, inst.port, inst.forwardPort)
+	sshArgs := vmimpl.SSHArgsForward(inst.debug, inst.sshkey, inst.port, inst.forwardPort, false)
 	args := strings.Split(command, " ")
 	if bin := filepath.Base(args[0]); inst.target.HostFuzzer &&
 		(bin == "syz-fuzzer" || bin == "syz-execprog") {
@@ -751,7 +751,7 @@ func (inst *instance) ssh(args ...string) ([]byte, error) {
 }
 
 func (inst *instance) sshArgs(args ...string) []string {
-	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, inst.port), inst.sshuser+"@localhost")
+	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, inst.port, false), inst.sshuser+"@localhost")
 	return append(sshArgs, args...)
 }
 

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -187,7 +187,7 @@ func (inst *instance) Boot() error {
 	}
 
 	if err := vmimpl.WaitForSSH(inst.debug, 20*time.Minute, inst.sshhost,
-		inst.sshkey, inst.sshuser, inst.os, inst.sshport, nil); err != nil {
+		inst.sshkey, inst.sshuser, inst.os, inst.sshport, nil, false); err != nil {
 		out := <-inst.merger.Output
 		return vmimpl.BootError{Title: err.Error(), Output: out}
 	}
@@ -239,7 +239,7 @@ func (inst *instance) Forward(port int) (string, error) {
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	vmDst := filepath.Join("/root", filepath.Base(hostSrc))
-	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, inst.sshport),
+	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, inst.sshport, false),
 		hostSrc, inst.sshuser+"@"+inst.sshhost+":"+vmDst)
 	if inst.debug {
 		log.Logf(0, "running command: scp %#v", args)
@@ -259,7 +259,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	}
 	inst.merger.Add("ssh", rpipe)
 
-	args := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, inst.sshport),
+	args := append(vmimpl.SSHArgs(inst.debug, inst.sshkey, inst.sshport, false),
 		inst.sshuser+"@"+inst.sshhost, command)
 	if inst.debug {
 		log.Logf(0, "running command: ssh %#v", args)

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -157,7 +157,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	base := filepath.Base(hostSrc)
 	vmDst := filepath.Join("/", base)
 
-	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, 22),
+	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, 22, false),
 		hostSrc, fmt.Sprintf("%v@%v:%v", inst.sshuser, inst.ipAddr, vmDst))
 
 	if inst.debug {
@@ -186,7 +186,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 		return nil, nil, err
 	}
 
-	args := vmimpl.SSHArgs(inst.debug, inst.sshkey, 22)
+	args := vmimpl.SSHArgs(inst.debug, inst.sshkey, 22, false)
 	// Forward target port as part of the ssh connection (reverse proxy)
 	if inst.forwardPort != 0 {
 		proxy := fmt.Sprintf("%v:127.0.0.1:%v", inst.forwardPort, inst.forwardPort)


### PR DESCRIPTION
Most of the VM types tightly manage the target they SSH into and can safely assume that system wide SSH configuration would mess with the SSH flags provided by syzkaller. However, in the "isolate" VM type, one can connect to a host that is not at all managed by syzkaller. In this case, it can be useful to leverage system wide SSH config, maybe provided by a corporate environment.

This adds an option to the isolated config to skip some of the SSH and SCP flags that would drop system wide config.
