### PR TITLE
all: move fuzzer to the host

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/hash"
-	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/prog"
 )
@@ -63,15 +62,6 @@ func (item Item) StringCall() string {
 	return stringCall(item.Prog, item.Call)
 }
 
-// RPCInputShort() does not include coverage.
-func (item Item) RPCInputShort() rpctype.Input {
-	return rpctype.Input{
-		Call:   item.Call,
-		Prog:   item.ProgData,
-		Signal: item.Signal.Serialize(),
-	}
-}
-
 func stringCall(p *prog.Prog, call int) string {
 	if call != -1 {
 		return p.Calls[call].Meta.Name
@@ -89,16 +79,6 @@ type NewInput struct {
 
 func (item NewInput) StringCall() string {
 	return stringCall(item.Prog, item.Call)
-}
-
-func (item NewInput) RPCInput() rpctype.Input {
-	return rpctype.Input{
-		Call:     item.Call,
-		Prog:     item.Prog.Serialize(),
-		Signal:   item.Signal.Serialize(),
-		Cover:    item.Cover,
-		RawCover: item.RawCover,
-	}
 }
 
 type NewItemEvent struct {

--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -149,13 +149,6 @@ func (corpus *Corpus) Save(inp NewInput) {
 		}
 	}
 }
-
-func (corpus *Corpus) DiffSignal(s signal.Signal) signal.Signal {
-	corpus.mu.RLock()
-	defer corpus.mu.RUnlock()
-	return corpus.signal.Diff(s)
-}
-
 func (corpus *Corpus) Signal() signal.Signal {
 	corpus.mu.RLock()
 	defer corpus.mu.RUnlock()

--- a/pkg/fuzzer/cover.go
+++ b/pkg/fuzzer/cover.go
@@ -35,6 +35,12 @@ func (cover *Cover) addRawMaxSignal(signal []uint32, prio uint8) signal.Signal {
 	return diff
 }
 
+func (cover *Cover) CopyMaxSignal() signal.Signal {
+	cover.mu.RLock()
+	defer cover.mu.RUnlock()
+	return cover.maxSignal.Copy()
+}
+
 func (cover *Cover) GrabNewSignal() signal.Signal {
 	cover.mu.Lock()
 	defer cover.mu.Unlock()

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -81,7 +81,6 @@ type Config struct {
 	Collide        bool
 	EnabledCalls   map[*prog.Syscall]bool
 	NoMutateCalls  map[int]bool
-	LeakChecking   bool
 	FetchRawCover  bool
 	// If the number of queued candidates is less than MinCandidates,
 	// NeedCandidates is triggered.

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -323,3 +323,15 @@ func (fuzzer *Fuzzer) logCurrentStats() {
 		fuzzer.Logf(0, "%s", str)
 	}
 }
+
+func (fuzzer *Fuzzer) RotateMaxSignal(items int) {
+	corpusSignal := fuzzer.Config.Corpus.Signal()
+	pureMaxSignal := fuzzer.Cover.pureMaxSignal(corpusSignal)
+	if pureMaxSignal.Len() < items {
+		items = pureMaxSignal.Len()
+	}
+	fuzzer.Logf(1, "rotate %d max signal elements", items)
+
+	delta := pureMaxSignal.RandomSubset(fuzzer.rand(), items)
+	fuzzer.Cover.subtract(delta)
+}

--- a/pkg/fuzzer/prio_queue.go
+++ b/pkg/fuzzer/prio_queue.go
@@ -19,6 +19,14 @@ func (p priority) greaterThan(other priority) bool {
 			return false
 		}
 	}
+	for i := len(p); i < len(other); i++ {
+		if other[i] < 0 {
+			return true
+		}
+		if other[i] > 0 {
+			return false
+		}
+	}
 	return false
 }
 

--- a/pkg/fuzzer/prio_queue_test.go
+++ b/pkg/fuzzer/prio_queue_test.go
@@ -14,6 +14,8 @@ func TestPriority(t *testing.T) {
 	assert.True(t, priority{1, 2}.greaterThan(priority{1, 1}))
 	assert.True(t, priority{3, 2}.greaterThan(priority{2, 3}))
 	assert.True(t, priority{1, -5}.greaterThan(priority{1, -10}))
+	assert.True(t, priority{1}.greaterThan(priority{1, -1}))
+	assert.False(t, priority{1}.greaterThan(priority{1, 1}))
 }
 
 func TestPrioQueueOrder(t *testing.T) {

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -49,8 +49,9 @@ type ExchangeInfoRequest struct {
 
 // ExchangeInfoReply is a reply to ExchangeInfoRequest.
 type ExchangeInfoReply struct {
-	Requests     []ExecutionRequest
-	NewMaxSignal []uint32
+	Requests      []ExecutionRequest
+	NewMaxSignal  []uint32
+	DropMaxSignal []uint32
 }
 
 // TODO: merge ExecutionRequest and ExecTask.

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -4,6 +4,8 @@
 // Package signal provides types for working with feedback signal.
 package signal
 
+import "math/rand"
+
 type (
 	elemType uint32
 	prioType int8
@@ -117,6 +119,35 @@ func (s *Signal) Merge(s1 Signal) {
 			s0[e] = p1
 		}
 	}
+}
+
+func (s *Signal) Subtract(s1 Signal) {
+	s0 := *s
+	if s0 == nil {
+		return
+	}
+	for e, p1 := range s1 {
+		if p, ok := s0[e]; ok && p == p1 {
+			delete(s0, e)
+		}
+	}
+}
+
+func (s Signal) RandomSubset(r *rand.Rand, size int) Signal {
+	if size > len(s) {
+		size = len(s)
+	}
+	keys := make([]elemType, 0, len(s))
+	for e := range s {
+		keys = append(keys, e)
+	}
+	r.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+
+	ret := make(Signal, size)
+	for _, e := range keys[:size] {
+		ret[e] = s[e]
+	}
+	return ret
 }
 
 // FilterRaw returns a subset of original raw elements that coincides with the one in Signal.

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -33,8 +33,10 @@ func (s Signal) Copy() Signal {
 }
 
 func (s *Signal) Split(n int) Signal {
-	if s.Empty() {
-		return nil
+	if n >= s.Len() {
+		ret := *s
+		*s = nil
+		return ret
 	}
 	c := make(Signal, n)
 	for e, p := range *s {

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package signal
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomSubset(t *testing.T) {
+	r := rand.New(testutil.RandSource(t))
+	base := FromRaw([]uint32{0, 1, 2, 3, 4}, 0)
+	var s Signal
+	for i := 0; i < 1000 && s.Len() < base.Len(); i++ {
+		delta := base.RandomSubset(r, 1)
+		assert.Equal(t, 1, delta.Len())
+		s.Merge(delta)
+	}
+	assert.Equal(t, base.Len(), s.Len())
+}
+
+func TestSubtract(t *testing.T) {
+	base := FromRaw([]uint32{0, 1, 2, 3, 4}, 0)
+	assert.Equal(t, 5, base.Len())
+	base.Subtract(FromRaw([]uint32{0}, 0))
+	assert.Equal(t, 4, base.Len())
+	base.Subtract(FromRaw([]uint32{1}, 0))
+	assert.Equal(t, 3, base.Len())
+}

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -348,7 +348,7 @@ func (tool *FuzzerTool) exchangeDataCall(needProgs int, results []executionResul
 	if err := tool.manager.Call("Manager.ExchangeInfo", a, r); err != nil {
 		log.SyzFatalf("Manager.ExchangeInfo call failed: %v", err)
 	}
-	tool.addMaxSignal(r.NewMaxSignal)
+	tool.updateMaxSignal(r.NewMaxSignal, r.DropMaxSignal)
 	for _, req := range r.Requests {
 		p := tool.deserializeInput(req.ProgData)
 		if p == nil {
@@ -442,10 +442,11 @@ func (tool *FuzzerTool) diffMaxSignal(info *ipc.ProgInfo) {
 	diffProgInfo(info, tool.maxSignal)
 }
 
-func (tool *FuzzerTool) addMaxSignal(diff []uint32) {
+func (tool *FuzzerTool) updateMaxSignal(add, drop []uint32) {
 	tool.signalMu.Lock()
 	defer tool.signalMu.Unlock()
-	tool.maxSignal.Merge(signal.FromRaw(diff, 0))
+	tool.maxSignal.Subtract(signal.FromRaw(drop, 0))
+	tool.maxSignal.Merge(signal.FromRaw(add, 0))
 }
 
 func setupPprofHandler(port int) {

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -237,7 +237,6 @@ func main() {
 		Collide:        execOpts.Flags&ipc.FlagThreaded > 0,
 		EnabledCalls:   calls,
 		NoMutateCalls:  r.NoMutateCalls,
-		LeakChecking:   r.CheckResult.Features[host.FeatureLeak].Enabled,
 		FetchRawCover:  *flagRawCover,
 		MinCandidates:  uint(*flagProcs * 2),
 		NewInputs:      make(chan corpus.NewInput),

--- a/syz-fuzzer/fuzzer_test.go
+++ b/syz-fuzzer/fuzzer_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/pkg/signal"
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint: dupl
+func TestFilterProgInfo(t *testing.T) {
+	mask := signal.FromRaw([]uint32{2, 4, 6, 8}, 0)
+	info := ipc.ProgInfo{
+		Calls: []ipc.CallInfo{
+			{
+				Signal: []uint32{1, 2, 3},
+				Cover:  []uint32{1, 2, 3},
+			},
+			{
+				Signal: []uint32{2, 3, 4},
+				Cover:  []uint32{2, 3, 4},
+			},
+		},
+		Extra: ipc.CallInfo{
+			Signal: []uint32{3, 4, 5},
+			Cover:  []uint32{3, 4, 5},
+		},
+	}
+	filterProgInfo(&info, mask)
+	assert.Equal(t, ipc.ProgInfo{
+		Calls: []ipc.CallInfo{
+			{
+				Signal: []uint32{2},
+				Cover:  []uint32{1, 2, 3},
+			},
+			{
+				Signal: []uint32{2, 4},
+				Cover:  []uint32{2, 3, 4},
+			},
+		},
+		Extra: ipc.CallInfo{
+			Signal: []uint32{4},
+			Cover:  []uint32{3, 4, 5},
+		},
+	}, info)
+}
+
+// nolint: dupl
+func TestDiffProgInfo(t *testing.T) {
+	base := signal.FromRaw([]uint32{0, 1, 2}, 0)
+	info := ipc.ProgInfo{
+		Calls: []ipc.CallInfo{
+			{
+				Signal: []uint32{0, 1, 2},
+				Cover:  []uint32{0, 1, 2},
+			},
+			{
+				Signal: []uint32{1, 2, 3},
+				Cover:  []uint32{1, 2, 3},
+			},
+		},
+		Extra: ipc.CallInfo{
+			Signal: []uint32{2, 3, 4},
+			Cover:  []uint32{2, 3, 4},
+		},
+	}
+	diffProgInfo(&info, base)
+	assert.Equal(t, ipc.ProgInfo{
+		Calls: []ipc.CallInfo{
+			{
+				Signal: nil,
+				Cover:  []uint32{0, 1, 2},
+			},
+			{
+				Signal: []uint32{3},
+				Cover:  []uint32{1, 2, 3},
+			},
+		},
+		Extra: ipc.CallInfo{
+			Signal: []uint32{3, 4},
+			Cover:  []uint32{2, 3, 4},
+		},
+	}, info)
+}

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -131,9 +131,10 @@ func (mgr *Manager) collectStats() []UIStat {
 		{Name: "uptime", Value: fmt.Sprint(time.Since(mgr.startTime) / 1e9 * 1e9)},
 		{Name: "fuzzing", Value: fmt.Sprint(mgr.fuzzingTime / 60e9 * 60e9)},
 		{Name: "corpus", Value: fmt.Sprint(mgr.corpus.Stats().Progs), Link: "/corpus"},
-		{Name: "triage queue", Value: fmt.Sprint(len(mgr.candidates))},
+		{Name: "triage queue", Value: fmt.Sprint(mgr.stats.triageQueueLen.get())},
 		{Name: "signal", Value: fmt.Sprint(rawStats["signal"])},
 		{Name: "coverage", Value: fmt.Sprint(rawStats["coverage"]), Link: "/cover"},
+		{Name: "fuzzer jobs", Value: fmt.Sprint(mgr.stats.fuzzerJobs.get())},
 	}
 	if mgr.coverFilter != nil {
 		stats = append(stats, UIStat{
@@ -147,6 +148,7 @@ func (mgr *Manager) collectStats() []UIStat {
 	delete(rawStats, "signal")
 	delete(rawStats, "coverage")
 	delete(rawStats, "filtered coverage")
+	delete(rawStats, "fuzzer jobs")
 	if mgr.checkResult != nil {
 		stats = append(stats, UIStat{
 			Name:  "syscalls",

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1479,7 +1479,6 @@ func (mgr *Manager) fuzzerLoop() {
 		if fuzzerStats.Candidates == 0 {
 			mgr.mu.Lock()
 			if mgr.phase == phaseLoadedCorpus {
-				mgr.fuzzer.EnableOutOfQueue()
 				if mgr.cfg.HubClient != "" {
 					mgr.phase = phaseTriagedCorpus
 					go mgr.hubSyncLoop(pickGetter(mgr.cfg.HubKey))

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1425,12 +1425,6 @@ func (mgr *Manager) hubIsUnreachable() {
 	}
 }
 
-func (mgr *Manager) rotateCorpus() bool {
-	mgr.mu.Lock()
-	defer mgr.mu.Unlock()
-	return mgr.phase == phaseTriagedHub
-}
-
 func (mgr *Manager) collectUsedFiles() {
 	if mgr.vmPool == nil {
 		return

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -19,7 +19,6 @@ type Stats struct {
 	crashSuppressed     Stat
 	vmRestarts          Stat
 	newInputs           Stat
-	rotatedInputs       Stat
 	execTotal           Stat
 	rpcTraffic          Stat
 	hubSendProgAdd      Stat
@@ -68,7 +67,6 @@ func (stats *Stats) all() map[string]uint64 {
 		"suppressed":        stats.crashSuppressed.get(),
 		"vm restarts":       stats.vmRestarts.get(),
 		"new inputs":        stats.newInputs.get(),
-		"rotated inputs":    stats.rotatedInputs.get(),
 		"exec total":        stats.execTotal.get(),
 		"coverage":          stats.corpusCover.get(),
 		"filtered coverage": stats.corpusCoverFiltered.get(),

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -32,6 +32,8 @@ type Stats struct {
 	corpusCoverFiltered Stat
 	corpusSignal        Stat
 	maxSignal           Stat
+	triageQueueLen      Stat
+	fuzzerJobs          Stat
 
 	mu         sync.Mutex
 	namedStats map[string]uint64
@@ -73,6 +75,7 @@ func (stats *Stats) all() map[string]uint64 {
 		"signal":            stats.corpusSignal.get(),
 		"max signal":        stats.maxSignal.get(),
 		"rpc traffic (MB)":  stats.rpcTraffic.get() / 1e6,
+		"fuzzer jobs":       stats.fuzzerJobs.get(),
 	}
 	if stats.haveHub {
 		m["hub: send prog add"] = stats.hubSendProgAdd.get()
@@ -104,6 +107,17 @@ func (stats *Stats) mergeNamed(named map[string]uint64) {
 		default:
 			stats.namedStats[k] += v
 		}
+	}
+}
+
+func (stats *Stats) setNamed(named map[string]uint64) {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+	if stats.namedStats == nil {
+		stats.namedStats = make(map[string]uint64)
+	}
+	for k, v := range named {
+		stats.namedStats[k] = v
 	}
 }
 


### PR DESCRIPTION
The version seems to be working locally, but there are still a lot of experiments and improvements to be done.

While it's still under development, I don't see sense in splitting it into smaller commits. I will later probably split out some of the changes that don't break their dependencies in an incompatible way.

Parent issue: #1541

***

Instead of doing fuzzing in parallel in running VM, make all decisions in the host syz-manager process.

Instantiate and keep a fuzzer.Fuzzer object in syz-manager and update the RPC between syz-manager and syz-fuzzer to exchange exact programs to execute and their resulting signal and coverage.

To optimize the networking traffic, exchange mostly only the difference between the known max signal and the detected signal.