### PR TITLE
pkg/cover: add full symbolization for /cover?jsonl=1

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Impl struct {
-	Units       []*CompileUnit
-	Symbols     []*Symbol
-	Frames      []Frame
-	Symbolize   func(pcs map[*Module][]uint64) ([]Frame, error)
-	RestorePC   func(pc uint32) uint64
-	CoverPoints map[uint64]bool
+	Units                  []*CompileUnit
+	Symbols                []*Symbol
+	Frames                 []Frame
+	Symbolize              func(pcs map[*Module][]uint64) ([]Frame, error)
+	RestorePC              func(pc uint32) uint64
+	CallbackPoints         map[uint64]bool
+	CoverageCallbackPoints []uint64
 }
 
 type Module struct {

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -261,8 +261,9 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 		Symbolize: func(pcs map[*Module][]uint64) ([]Frame, error) {
 			return symbolize(target, objDir, srcDir, buildDir, splitBuildDelimiters, pcs)
 		},
-		RestorePC:   makeRestorePC(params, pcBase),
-		CoverPoints: allCoverPointsMap,
+		RestorePC:              makeRestorePC(params, pcBase),
+		CallbackPoints:         allCoverPointsMap,
+		CoverageCallbackPoints: allCoverPoints[0],
 	}
 	return impl, nil
 }

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -226,8 +226,10 @@ type coverageInfo struct {
 
 // DoCoverJSONL is a handler for "/cover?jsonl=1".
 func (rg *ReportGenerator) DoCoverJSONL(w io.Writer, params CoverHandlerParams) error {
-	if err := rg.symbolizePCs(rg.CoverageCallbackPoints); err != nil {
-		return fmt.Errorf("failed to rg.fullSymbolize(): %w", err)
+	if rg.CoverageCallbackPoints != nil {
+		if err := rg.symbolizePCs(rg.CoverageCallbackPoints); err != nil {
+			return fmt.Errorf("failed to symbolize PCs(): %w", err)
+		}
 	}
 	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
 	fm, err := rg.prepareFileMap(progs, params.Debug)

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -186,7 +186,7 @@ func fileLineContents(file *file, lines [][]byte) lineCoverExport {
 
 func (rg *ReportGenerator) DoRawCoverFiles(w io.Writer, params CoverHandlerParams) error {
 	progs := fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
-	if err := rg.lazySymbolize(progs); err != nil {
+	if err := rg.symbolizePCs(uniquePCs(progs)); err != nil {
 		return err
 	}
 
@@ -226,6 +226,9 @@ type coverageInfo struct {
 
 // DoCoverJSONL is a handler for "/cover?jsonl=1".
 func (rg *ReportGenerator) DoCoverJSONL(w io.Writer, params CoverHandlerParams) error {
+	if err := rg.symbolizePCs(rg.CoverageCallbackPoints); err != nil {
+		return fmt.Errorf("failed to rg.fullSymbolize(): %w", err)
+	}
 	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
 	fm, err := rg.prepareFileMap(progs, params.Debug)
 	if err != nil {


### PR DESCRIPTION
First request with lazy symbolization - 19s.
Time to get updated numbers (after 5 seconds) - 17s.
Lazy symbolized data - 361k lines, 61M.

First request with full symbolization - 49s.
Time to get fresh data (after 5 seconds)  - 5.5s.
Fully symbolized data - 3491k lines, 611M.

/cover uses 40G RAM every time it is called.
/cover?jsonl=1 uses 40G RAM only the first time. /cover takes 3 seconds and consumes 0 RAM if called after.
