### PR TITLE
prog: optimize resourceCentric()

### DIFF
--- a/prog/clone.go
+++ b/prog/clone.go
@@ -8,7 +8,10 @@ import (
 )
 
 func (p *Prog) Clone() *Prog {
-	newargs := make(map[*ResultArg]*ResultArg)
+	return p.cloneWithMap(make(map[*ResultArg]*ResultArg))
+}
+
+func (p *Prog) cloneWithMap(newargs map[*ResultArg]*ResultArg) *Prog {
 	p1 := &Prog{
 		Target: p.Target,
 		Calls:  cloneCalls(p.Calls, newargs),

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -943,12 +943,15 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 	var p *Prog
 	var resource *ResultArg
 	for _, idx := range r.Perm(len(s.corpus)) {
-		p = s.corpus[idx].Clone()
-		resources := getCompatibleResources(p, t.TypeName, r)
-		if len(resources) > 0 {
-			resource = resources[r.Intn(len(resources))]
-			break
+		corpusProg := s.corpus[idx]
+		resources := getCompatibleResources(corpusProg, t.TypeName, r)
+		if len(resources) == 0 {
+			continue
 		}
+		argMap := make(map[*ResultArg]*ResultArg)
+		p = corpusProg.cloneWithMap(argMap)
+		resource = argMap[resources[r.Intn(len(resources))]]
+		break
 	}
 
 	// No compatible resource was found.


### PR DESCRIPTION
In practice, we need to try out many different corpus programs before we may find a matching resource. It's very inefficient to Clone() each of them.

This change gives a +76% speed improvement in the BenchmarkMutate() test.

```
          │ upstream      │              optimized                  │
          │    sec/op     │    sec/op     vs base                   │
Mutate-36     443.1µ ± 8%   103.1µ ± 31%  -76.73% (p=0.000 n=15+25)

          │ upstream      │              optimized                  │
          │    B/op       │    B/op     vs base                     │
Mutate-36    836.0Ki ± 1%   188.8Ki ± 0%  -77.42% (p=0.000 n=15+25)

          │ upstream      │              optimized                  │
          │  allocs/op    │      allocs/op     vs base              │
Mutate-36     2.643k ± 1%       1.778k ± 0%     -32.73% (n=15+25)
```