### PR TITLE
pkg/compiler: relax the resource usage check

### DIFF
--- a/pkg/compiler/testdata/all.txt
+++ b/pkg/compiler/testdata/all.txt
@@ -369,3 +369,11 @@ union$conditional3 [
 ]
 
 conditional(a ptr[in, struct$conditional])
+
+resource r_opt[intptr]
+
+r_opt_inout_struct {
+	f	r_opt[opt]
+}
+
+test$inout_resource(p ptr[inout, r_opt_inout_struct])

--- a/pkg/compiler/testdata/errors2.txt
+++ b/pkg/compiler/testdata/errors2.txt
@@ -508,3 +508,19 @@ conditional_non_packed2 {
 }
 
 foo$conditional3(a ptr[in, conditional_non_packed2])
+
+# If we only have an optional constructor for the resource, it's invalid to
+# use it in the non-optional contexts.
+
+resource r_opt[intptr] ### resource r_opt is used in non-optional contexts, but is created in only optional ones
+
+r_opt_struct {
+	f	r_opt[opt]
+}
+
+r_non_opt_struct {
+	f	r_opt
+}
+
+test$r_opt_out(p ptr[out, r_opt_struct])
+test$r_non_opt_in(p ptr[in, r_non_opt_struct])


### PR DESCRIPTION
If the resource is both generated and used in only optional contexts, it's an acceptable scenario. The change enables the cases when we use a single inout structure that sometimes uses a resource and sometimes creates it.

This PR approaches the same problem as #4580, but from a different side.