### PR TITLE
pkg/vcs: remove parentheses from email tests

### DIFF
--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -233,24 +233,24 @@ func TestFileLink(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	// nolint: lll
-	test1 := []byte(`Foo (Maintainer) Bar <a@email.com> (maintainer:KERNEL)
-	Foo Bar(Reviewer) <b@email.com> (reviewer:KERNEL)
+	test1 := []byte(`Foo Bar <a@email.com> (maintainer:KERNEL)
+	Foo Bar<b@email.com> (reviewer:KERNEL)
 	<somelist@list.com> (open list:FOO)
 	"Supporter Foo" <c@email.com> (supporter:KERNEL)
 	linux-kernel@vger.kernel.org (open list)`)
 	// nolint: lll
-	test2 := []byte(`Foo (Maintainer) Bar <a@email.com> (maintainer:KERNEL)
-	Foo Bar(Reviewer) <b@email.com> (reviewer:KERNEL)
+	test2 := []byte(`Foo Bar <a@email.com> (maintainer:KERNEL)
+	Foo Bar<b@email.com> (reviewer:KERNEL)
 	"Supporter Foo" <c@email.com> (supporter:KERNEL)
 	linux-kernel@vger.kernel.org (open list)`)
 
-	maintainers1 := Recipients{{mail.Address{Name: "Foo (Maintainer) Bar", Address: "a@email.com"}, To},
-		{mail.Address{Name: "Foo Bar(Reviewer)", Address: "b@email.com"}, Cc},
+	maintainers1 := Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+		{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
 		{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
 		{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, Cc},
 		{mail.Address{Name: "", Address: "somelist@list.com"}, To}}
-	maintainers2 := Recipients{{mail.Address{Name: "Foo (Maintainer) Bar", Address: "a@email.com"}, To},
-		{mail.Address{Name: "Foo Bar(Reviewer)", Address: "b@email.com"}, Cc},
+	maintainers2 := Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+		{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
 		{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
 		{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, To}}
 


### PR DESCRIPTION
There's unfortunately no consistency in how mail.ParseAddress reacts to parentheses in display names.

Versions before 1.22 used to keep them, 1.22+ cut them out.

For syzbot operation the difference is not very significant, but it makes our tests too version dependent. Let's just omit parentheses from the test cases.

