### PR TITLE
tools/create-openbsd: substitute ubsan_minimal for fuzzer_test

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -40,6 +40,10 @@ echo 'permit keepenv nopass syzkaller as root' > /etc/doas.conf
 
 mkdir /syzkaller
 echo '/dev/sd1a /syzkaller ffs rw,noauto 1 0' >> /etc/fstab
+
+mkdir -p /usr/lib/clang/16/lib/openbsd
+ln -s /usr/lib/clang/16/lib/libclang_rt.ubsan_minimal.a /usr/lib/clang/16/lib/openbsd/libclang_rt.ubsan_standalone-x86_64.a
+touch /usr/lib/clang/16/lib/openbsd/libclang_rt.ubsan_standalone_cxx-x86_64.a
 EOF
 
 cat >etc/installurl <<EOF


### PR DESCRIPTION
Reliance on -fsanitize-coverage=trace-pc makes clang look for full ubsan libraries. The only one currently available on OpenBSD is ubsan_minimal. We temporarily use it in place of ubsan_standalone. The ubsan_standalone_cxx library seems currently not necessary and so an empty file works in its stead.

This is a temporary measure until I figure out the best course of action for making fsanitize-coverage=trace-pc work out of the box on OpenBSD.

This should help with one of the issues we just discovered having replaced the base OS image we use to run syzkaller on OpenBSD.
