### PR TITLE
sys/targets: avoid building TestOS on OpenBSD

### DIFF
--- a/executor/common_ext_test.go
+++ b/executor/common_ext_test.go
@@ -14,12 +14,17 @@ import (
 	"github.com/google/syzkaller/pkg/ipc/ipcconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 func TestCommonExt(t *testing.T) {
 	target, err := prog.GetTarget("test", "64_fork")
 	if err != nil {
 		t.Fatal(err)
+	}
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken cross-compiler: %v", sysTarget.BrokenCompiler)
 	}
 	bin, err := csource.BuildFile(target, "executor.cc", "-DSYZ_TEST_COMMON_EXT_EXAMPLE=1")
 	if err != nil {

--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -38,6 +38,10 @@ func TestFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken cross-compiler: %v", sysTarget.BrokenCompiler)
+	}
 	executor := buildExecutor(t, target)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -196,6 +196,10 @@ func TestZlib(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken cross-compiler: %v", sysTarget.BrokenCompiler)
+	}
 	cfg, opts, err := ipcconfig.Default(target)
 	if err != nil {
 		t.Fatal(err)

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -693,6 +693,9 @@ func init() {
 				target.CFlags[i] = strings.Replace(target.CFlags[i], "-m32", "-m31", -1)
 			}
 		}
+		if runtime.GOOS == OpenBSD {
+			target.BrokenCompiler = "can't build TestOS on OpenBSD due to missing syscall function."
+		}
 		target.BuildOS = goos
 	}
 }


### PR DESCRIPTION
OpenBSD's missing syscall function yet TestOS requires it.