### PR TITLE
WIP: syz-manager: split out the bug reproduction management

### DIFF
--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -594,9 +594,7 @@ func (mgr *Manager) httpFilterPCs(w http.ResponseWriter, r *http.Request) {
 
 func (mgr *Manager) collectCrashes(workdir string) ([]*UICrashType, error) {
 	// Note: mu is not locked here.
-	reproReply := make(chan map[string]bool)
-	mgr.reproRequest <- reproReply
-	repros := <-reproReply
+	repros := mgr.repros.Reproducing()
 
 	crashdir := filepath.Join(workdir, "crashes")
 	dirs, err := osutil.ListDir(crashdir)

--- a/syz-manager/repro.go
+++ b/syz-manager/repro.go
@@ -1,0 +1,202 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/repro"
+	"golang.org/x/sync/semaphore"
+)
+
+type reproManagerInterface interface {
+	runRepro(crash *Crash, vmIndexes []int, putInstances func(...int)) *ReproResult
+	needRepro(crash *Crash) bool
+	saveRepro(res *ReproResult)
+	saveFailedRepro(rep *report.Report, stats *repro.Stats)
+}
+
+type ReproResult struct {
+	instances     []int
+	report0       *report.Report // the original report we started reproducing
+	repro         *repro.Result
+	strace        *repro.StraceResult
+	stats         *repro.Stats
+	err           error
+	fromHub       bool
+	fromDashboard bool
+	originalTitle string // crash title before we started bug reproduction
+}
+
+type reproLoop struct {
+	ctx context.Context
+	mgr reproManagerInterface
+
+	maxVMs int
+
+	// Public fields.
+	NumReproducing atomic.Uint32
+	NumPending     atomic.Uint32
+
+	// We want to limit the number of simultaneous calls to needRepro().
+	triageMu sync.Mutex
+
+	// TODO: can we use just one sem?
+	maxVMSem    *semaphore.Weighted // to ensure we don't take more than maxVMs at the same time
+	reproVMs    *ResourcePool
+	needVMsMu   sync.Mutex
+	needVMs     int
+	reproducing sync.Map
+}
+
+func newReproLoop(ctx context.Context, reproVMs int, mgr reproManagerInterface) *reproLoop {
+	return &reproLoop{
+		ctx:      ctx,
+		mgr:      mgr,
+		maxVMs:   reproVMs,
+		maxVMSem: semaphore.NewWeighted(int64(reproVMs)),
+		reproVMs: EmptyResourcePool(ctx, reproVMs),
+	}
+}
+
+func (rl *reproLoop) Process(crash *Crash, putInstances func(...int)) {
+	if rl.maxVMs == 0 {
+		return
+	}
+	if _, loaded := rl.reproducing.LoadOrStore(crash.Title, true); loaded {
+		return
+	}
+	defer rl.reproducing.Delete(crash.Title)
+
+	rl.NumPending.Add(1)
+	if !rl.needRepro(crash) {
+		log.Logf(1, "repro loop: don't need to reproduce '%v'", crash.Title)
+		rl.NumPending.Add(^uint32(0))
+		return
+	}
+	log.Logf(1, "repro loop: added '%v' to the queue", crash.Title)
+
+	vmIndices := rl.takeVMs(rl.vmsForCrash(crash))
+	if vmIndices == nil {
+		return
+	}
+
+	rl.NumPending.Add(^uint32(0))
+	rl.NumReproducing.Add(1)
+	defer rl.NumReproducing.Add(^uint32(0))
+
+	log.Logf(0, "repro loop: starting repro of '%v' on instances %+v", crash.Title, vmIndices)
+
+	result := rl.mgr.runRepro(crash, vmIndices, func(ids ...int) {
+		// By releasing the semaphore before returning the VM to the
+		// caller we make sure that the following call to TakeInstance()
+		// definitely returns true.
+		rl.maxVMSem.Release(int64(len(ids)))
+		putInstances(ids...)
+	})
+	rl.saveResult(result)
+}
+
+// TakeInstance() records that a new instance has become available.
+// If the instance is to be reserved for reproduction, it returns true.
+func (rl *reproLoop) TakeInstance(idx int) bool {
+	if rl == nil {
+		return false
+	}
+	rl.needVMsMu.Lock()
+	defer rl.needVMsMu.Unlock()
+
+	if rl.needVMs == 0 || !rl.maxVMSem.TryAcquire(1) {
+		return false
+	}
+	log.Logf(0, "took %d", idx)
+	rl.needVMs--
+	rl.reproVMs.Put(idx)
+	return true
+}
+
+func (rl *reproLoop) WantVMs() bool {
+	rl.needVMsMu.Lock()
+	defer rl.needVMsMu.Unlock()
+	if rl.needVMs == 0 {
+		return false
+	}
+	if !rl.maxVMSem.TryAcquire(1) {
+		return false
+	}
+	rl.maxVMSem.Release(1)
+	return true
+}
+
+// Reproducing() returns a snapshot of the currently reproduced bug titles.
+func (rl *reproLoop) Reproducing() map[string]bool {
+	ret := map[string]bool{}
+	rl.reproducing.Range(func(key, _ any) bool {
+		ret[key.(string)] = true
+		return true
+	})
+	return ret
+}
+
+func (rl *reproLoop) takeVMs(needVMs int) []int {
+	rl.needVMsMu.Lock()
+	rl.needVMs += needVMs
+	rl.needVMsMu.Unlock()
+	return rl.reproVMs.Take(needVMs)
+}
+
+func (rl *reproLoop) vmsForCrash(crash *Crash) int {
+	const hubVMs = 2
+	const normalVMs = 3
+
+	ret := normalVMs
+	if crash.fromHub || crash.fromDashboard {
+		// We need fewer VMs for hub reproducers since they are already extracted and minimized.
+		ret = hubVMs
+	}
+	if ret > rl.maxVMs {
+		return rl.maxVMs
+	}
+	return ret
+}
+
+func (rl *reproLoop) needRepro(crash *Crash) bool {
+	// We don't care much about the specific order,
+	// but we do want to call mgr.needRepro() sequentially.
+	rl.triageMu.Lock()
+	defer rl.triageMu.Unlock()
+	return rl.mgr.needRepro(crash)
+}
+
+func (rl *reproLoop) saveResult(res *ReproResult) {
+	crepro := false
+	title := ""
+	if res.repro != nil {
+		crepro = res.repro.CRepro
+		title = res.repro.Report.Title
+	}
+	log.Logf(0, "repro loop: repro on %+v finished '%v', repro=%v crepro=%v desc='%v'"+
+		" hub=%v from_dashboard=%v",
+		res.instances, res.report0.Title, res.repro != nil, crepro, title,
+		res.fromHub, res.fromDashboard,
+	)
+	if res.err != nil {
+		reportReproError(res.err)
+	}
+	if res.repro == nil {
+		if res.fromHub {
+			log.Logf(1, "repro '%v' came from syz-hub, not reporting the failure",
+				res.report0.Title)
+		} else {
+			log.Logf(1, "report repro failure of '%v'", res.report0.Title)
+			rl.mgr.saveFailedRepro(res.report0, res.stats)
+		}
+	} else {
+		rl.mgr.saveRepro(res)
+	}
+}

--- a/syz-manager/repro_test.go
+++ b/syz-manager/repro_test.go
@@ -1,0 +1,231 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/repro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestReproLoopNoRepro(t *testing.T) {
+	mgr := new(loopMgrMock)
+	repros := newReproLoop(context.Background(), 5, mgr)
+
+	// Scenario: dashapi says we don't need the reproducer.
+	mgr.On("needRepro", mock.Anything).Return(false)
+
+	repros.Process(&Crash{Report: &report.Report{Title: "A"}}, func(_ ...int) {})
+
+	assert.Equal(t, uint32(0), repros.NumReproducing.Load())
+	assert.Equal(t, uint32(0), repros.NumPending.Load())
+	mgr.AssertExpectations(t)
+}
+
+func TestReproLoopRepro(t *testing.T) {
+	mgr := new(loopMgrMock)
+	repros := newReproLoop(context.Background(), 3, mgr)
+
+	mgr.On("needRepro", mock.Anything).Return(true).Once()
+	crash := &Crash{Report: &report.Report{Title: "A"}}
+	result := &ReproResult{
+		report0: crash.Report,
+		repro:   &repro.Result{Report: &report.Report{Title: "B"}},
+	}
+	mgr.On("runRepro", crash, []int{0, 1, 2}, mock.Anything).Once().Return(result)
+	mgr.On("saveRepro", result).Once()
+
+	done := make(chan struct{})
+	go func() {
+		repros.Process(crash, func(_ ...int) {})
+		done <- struct{}{}
+	}()
+
+	takeInstanceWait(t, repros, 0)
+	assert.Equal(t, uint32(1), repros.NumPending.Load())
+	assert.True(t, repros.TakeInstance(1))
+	assert.True(t, repros.TakeInstance(2))
+
+	<-done
+	assert.Equal(t, uint32(0), repros.NumPending.Load())
+	mgr.AssertExpectations(t)
+}
+
+func TestReproLoopFailed(t *testing.T) {
+	mgr := new(loopMgrMock)
+	repros := newReproLoop(context.Background(), 3, mgr)
+
+	crash := &Crash{Report: &report.Report{Title: "A"}}
+	mgr.On("needRepro", crash).Return(true).Once()
+	result := &ReproResult{
+		report0: crash.Report,
+		stats:   &repro.Stats{},
+	}
+	mgr.On("runRepro", crash, []int{0, 1, 2}, mock.Anything).Once().Return(result)
+	mgr.On("saveFailedRepro", crash.Report, result.stats).Once()
+
+	done := make(chan struct{})
+	go func() {
+		repros.Process(crash, func(_ ...int) {})
+		done <- struct{}{}
+	}()
+
+	takeInstanceWait(t, repros, 0)
+	assert.True(t, repros.TakeInstance(1))
+	assert.True(t, repros.TakeInstance(2))
+
+	<-done
+	mgr.AssertExpectations(t)
+}
+
+func TestReproLoopHubFailed(t *testing.T) {
+	mgr := new(loopMgrMock)
+	repros := newReproLoop(context.Background(), 3, mgr)
+
+	crash := &Crash{Report: &report.Report{Title: "A"}, fromHub: true}
+	mgr.On("needRepro", crash).Return(true).Once()
+	result := &ReproResult{
+		report0: crash.Report,
+		stats:   &repro.Stats{},
+		fromHub: true,
+	}
+	mgr.On("runRepro", crash, []int{0, 1}, mock.Anything).Once().Return(result)
+
+	done := make(chan struct{})
+	go func() {
+		repros.Process(crash, func(_ ...int) {})
+		done <- struct{}{}
+	}()
+
+	takeInstanceWait(t, repros, 0)
+	assert.True(t, repros.TakeInstance(1))
+	assert.False(t, repros.TakeInstance(2))
+	assert.False(t, repros.WantVMs())
+
+	<-done
+	mgr.AssertExpectations(t)
+}
+
+func TestReproLoopContention(t *testing.T) {
+	mgr := new(loopMgrMock)
+	mgr.On("needRepro", mock.Anything).Return(true).Times(3)
+	repros := newReproLoop(context.Background(), 7, mgr)
+	putInstances := func(idx ...int) {}
+
+	// We don't care about the specific value.
+	result := &ReproResult{report0: &report.Report{Title: "X"}, stats: &repro.Stats{}}
+
+	// First crash.
+	crash1 := &Crash{Report: &report.Report{Title: "A"}}
+	first := make(chan struct{})
+	mgr.On("runRepro", crash1, []int{0, 1, 2}, mock.Anything).Run(func(_ mock.Arguments) {
+		first <- struct{}{}
+		<-first
+	}).Return(result)
+	mgr.On("saveFailedRepro", mock.Anything, mock.Anything).Times(3)
+
+	done := make(chan struct{})
+	go func() {
+		repros.Process(crash1, putInstances)
+		done <- struct{}{}
+	}()
+	takeInstanceWait(t, repros, 0)
+	assert.True(t, repros.TakeInstance(1))
+	assert.True(t, repros.TakeInstance(2))
+	<-first
+	assert.Equal(t, uint32(1), repros.NumReproducing.Load())
+
+	// Second crash.
+	second := make(chan struct{})
+	crash2 := &Crash{Report: &report.Report{Title: "B"}}
+	mgr.On("runRepro", crash2, []int{3, 4, 5}, mock.Anything).Run(func(_ mock.Arguments) {
+		second <- struct{}{}
+		<-second
+	}).Return(result)
+
+	go func() {
+		repros.Process(crash2, putInstances)
+		done <- struct{}{}
+	}()
+	takeInstanceWait(t, repros, 3)
+	assert.True(t, repros.TakeInstance(4))
+	assert.True(t, repros.TakeInstance(5))
+	<-second
+	assert.Equal(t, uint32(2), repros.NumReproducing.Load())
+
+	// Third crash.
+	crash3 := &Crash{Report: &report.Report{Title: "C"}}
+	mgr.On("runRepro", crash3, []int{6, 0, 1}, mock.Anything).Return(result)
+
+	go func() {
+		repros.Process(crash3, putInstances)
+		done <- struct{}{}
+	}()
+
+	// There's capacity and need for one more VM, but not more.
+	takeInstanceWait(t, repros, 6)
+	assert.False(t, repros.TakeInstance(0))
+	assert.False(t, repros.WantVMs())
+	assert.Equal(t, map[string]bool{
+		"A": true,
+		"B": true,
+		"C": true,
+	}, repros.Reproducing())
+
+	// Now let's finish the first reproduction.
+	// It should leave space for the third.
+	first <- struct{}{}
+	<-done
+	takeInstanceWait(t, repros, 0)
+	takeInstanceWait(t, repros, 1)
+
+	second <- struct{}{}
+	<-done
+	<-done
+
+	assert.Equal(t, uint32(0), repros.NumReproducing.Load())
+	assert.Equal(t, map[string]bool{}, repros.Reproducing())
+	mgr.AssertExpectations(t)
+}
+
+// Wait until it is ready to accept the first instance.
+func takeInstanceWait(t *testing.T, repros *reproLoop, idx int) {
+	for i := 0; i <= 100; i++ {
+		time.Sleep(time.Millisecond)
+		if repros.TakeInstance(idx) {
+			break
+		}
+		assert.True(t, i < 100)
+	}
+}
+
+type loopMgrMock struct {
+	mock.Mock
+}
+
+func (lm *loopMgrMock) runRepro(crash *Crash, vmIndices []int, putInstances func(...int)) *ReproResult {
+	args := lm.Called(crash, vmIndices, putInstances)
+	for _, id := range vmIndices {
+		putInstances(id)
+	}
+	return args.Get(0).(*ReproResult)
+}
+
+func (lm *loopMgrMock) needRepro(crash *Crash) bool {
+	args := lm.Called(crash)
+	return args.Bool(0)
+}
+
+func (lm *loopMgrMock) saveRepro(res *ReproResult) {
+	lm.Called(res)
+}
+
+func (lm *loopMgrMock) saveFailedRepro(rep *report.Report, stats *repro.Stats) {
+	lm.Called(rep, stats)
+}


### PR DESCRIPTION
TODO:
- Ensure that it works well when bug reproduction is disabled.
- Test locally.

***

The motivation is as follows:
1) vmLoop() is already too big to understand.
2) We need fewer VMs for reproducers coming from syz-hub, it will let us
   save resources to do more.
3) The syz-manager http interface used to communicate with vmLoop, which
   sometimes caused significant delays in page rendering.

The new code is better isolated, which has made it possible to cover it with tests