### PR TITLE
pkg/cover: make tests build for non-Linux targets

### DIFF
--- a/pkg/cover/manager_to_ci_test.go
+++ b/pkg/cover/manager_to_ci_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var sampleCoverJSON = []byte(`{"file_path":"main.c","func_name":"main",` +
+	`"sl":1,"sc":0,"el":1,"ec":-1,"hit_count":1,"inline":false,"pc":12345}`)
+
 func TestWriteCIJSONLine(t *testing.T) {
 	expectedJSON :=
 		`{"version":1,` +

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -429,9 +429,6 @@ func checkCSVReport(t *testing.T, CSVReport []byte) {
 	}
 }
 
-var sampleCoverJSON = []byte(`{"file_path":"main.c","func_name":"main",` +
-	`"sl":1,"sc":0,"el":1,"ec":-1,"hit_count":1,"inline":false,"pc":12345}`)
-
 // nolint:lll
 func checkJSONLReport(t *testing.T, r []byte) {
 	compacted := new(bytes.Buffer)


### PR DESCRIPTION
The sampleCoverJSON was defined in a Linux-only test file.

Cc @blackgnezdo 