### PR TITLE
syz-manager: resend inputs from non-crashed VMs

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -757,7 +757,7 @@ func (mgr *Manager) runInstance(index int) (*Crash, error) {
 
 	rep, vmInfo, err := mgr.runInstanceInner(index, instanceName)
 
-	machineInfo := mgr.serv.shutdownInstance(instanceName)
+	machineInfo := mgr.serv.shutdownInstance(instanceName, rep != nil)
 	if len(vmInfo) != 0 {
 		machineInfo = append(append(vmInfo, '\n'), machineInfo...)
 	}


### PR DESCRIPTION
If a VM was e.g. intentionally restarted, there's no need to discard all pending requests.

Remember them and then redistribute to other VMs.
