### PR TITLE
pkg/fuzzer: don't triage saturated calls

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -59,14 +59,7 @@ type Item struct {
 }
 
 func (item Item) StringCall() string {
-	return stringCall(item.Prog, item.Call)
-}
-
-func stringCall(p *prog.Prog, call int) string {
-	if call != -1 {
-		return p.Calls[call].Meta.Name
-	}
-	return ".extra"
+	return item.Prog.CallName(item.Call)
 }
 
 type NewInput struct {
@@ -75,10 +68,6 @@ type NewInput struct {
 	Signal   signal.Signal
 	Cover    []uint32
 	RawCover []uint32
-}
-
-func (item NewInput) StringCall() string {
-	return stringCall(item.Prog, item.Call)
 }
 
 type NewItemEvent struct {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -456,11 +456,12 @@ func (inst *inst) testRepro() ([]byte, error) {
 }
 
 type OptionalFuzzerArgs struct {
-	Slowdown      int
-	RawCover      bool
-	SandboxArg    int
-	PprofPort     int
-	ResetAccState bool
+	Slowdown       int
+	RawCover       bool
+	SandboxArg     int
+	PprofPort      int
+	ResetAccState  bool
+	NetCompression bool
 }
 
 type FuzzerCmdArgs struct {
@@ -504,6 +505,7 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 			{Name: "sandbox_arg", Value: fmt.Sprint(args.Optional.SandboxArg)},
 			{Name: "pprof_port", Value: fmt.Sprint(args.Optional.PprofPort)},
 			{Name: "reset_acc_state", Value: fmt.Sprint(args.Optional.ResetAccState)},
+			{Name: "net_compression", Value: fmt.Sprint(args.Optional.NetCompression)},
 		}
 		optionalArg = " " + tool.OptionalFlags(flags)
 	}

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -14,6 +14,16 @@ type Prog struct {
 	Comments []string
 }
 
+func (p *Prog) CallName(call int) string {
+	if call >= len(p.Calls) || call < -1 {
+		panic(fmt.Sprintf("bad call index %v/%v", call, len(p.Calls)))
+	}
+	if call == -1 {
+		return ".extra"
+	}
+	return p.Calls[call].Meta.Name
+}
+
 // These properties are parsed and serialized according to the tag and the type
 // of the corresponding fields.
 // IMPORTANT: keep the exact values of "key" tag for existing props unchanged,

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -118,16 +118,17 @@ func main() {
 	debug.SetGCPercent(50)
 
 	var (
-		flagName      = flag.String("name", "test", "unique name for manager")
-		flagOS        = flag.String("os", runtime.GOOS, "target OS")
-		flagArch      = flag.String("arch", runtime.GOARCH, "target arch")
-		flagManager   = flag.String("manager", "", "manager rpc address")
-		flagProcs     = flag.Int("procs", 1, "number of parallel test processes")
-		flagOutput    = flag.String("output", "stdout", "write programs to none/stdout/dmesg/file")
-		flagTest      = flag.Bool("test", false, "enable image testing mode")      // used by syz-ci
-		flagRunTest   = flag.Bool("runtest", false, "enable program testing mode") // used by pkg/runtest
-		flagRawCover  = flag.Bool("raw_cover", false, "fetch raw coverage")
-		flagPprofPort = flag.Int("pprof_port", 0, "HTTP port for the pprof endpoint (disabled if 0)")
+		flagName           = flag.String("name", "test", "unique name for manager")
+		flagOS             = flag.String("os", runtime.GOOS, "target OS")
+		flagArch           = flag.String("arch", runtime.GOARCH, "target arch")
+		flagManager        = flag.String("manager", "", "manager rpc address")
+		flagProcs          = flag.Int("procs", 1, "number of parallel test processes")
+		flagOutput         = flag.String("output", "stdout", "write programs to none/stdout/dmesg/file")
+		flagTest           = flag.Bool("test", false, "enable image testing mode")      // used by syz-ci
+		flagRunTest        = flag.Bool("runtest", false, "enable program testing mode") // used by pkg/runtest
+		flagRawCover       = flag.Bool("raw_cover", false, "fetch raw coverage")
+		flagPprofPort      = flag.Int("pprof_port", 0, "HTTP port for the pprof endpoint (disabled if 0)")
+		flagNetCompression = flag.Bool("net_compression", false, "use network compression for RPC calls")
 
 		// Experimental flags.
 		flagResetAccState = flag.Bool("reset_acc_state", false, "restarts executor before most executions")
@@ -179,7 +180,7 @@ func main() {
 	machineInfo, modules := collectMachineInfos(target)
 
 	log.Logf(0, "dialing manager at %v", *flagManager)
-	manager, err := rpctype.NewRPCClient(*flagManager, timeouts.Scale)
+	manager, err := rpctype.NewRPCClient(*flagManager, timeouts.Scale, *flagNetCompression)
 	if err != nil {
 		log.SyzFatalf("failed to create an RPC client: %v ", err)
 	}

--- a/syz-hub/hub.go
+++ b/syz-hub/hub.go
@@ -61,7 +61,7 @@ func main() {
 
 	hub.initHTTP(cfg.HTTP)
 
-	s, err := rpctype.NewRPCServer(cfg.RPC, "Hub", hub)
+	s, err := rpctype.NewRPCServer(cfg.RPC, "Hub", hub, true)
 	if err != nil {
 		log.Fatalf("failed to create rpc server: %v", err)
 	}

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -114,6 +114,10 @@ func (hc *HubConnector) connect(corpus [][]byte) (*rpctype.RPCClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	hub, err := rpctype.NewRPCClient(hc.cfg.HubAddr, 1, true)
+	if err != nil {
+		return nil, err
+	}
 	a := &rpctype.HubConnectArgs{
 		Client:  hc.cfg.HubClient,
 		Key:     key,
@@ -136,12 +140,14 @@ func (hc *HubConnector) connect(corpus [][]byte) (*rpctype.RPCClient, error) {
 	if len(a.Corpus) > max {
 		a.Corpus = a.Corpus[:max]
 	}
+	err = hub.Call("Hub.Connect", a, nil)
 	// Hub.Connect request can be very large, so do it on a transient connection
 	// (rpc connection buffers never shrink).
-	if err := rpctype.RPCCall(hc.cfg.HubAddr, 1, "Hub.Connect", a, nil); err != nil {
+	hub.Close()
+	if err != nil {
 		return nil, err
 	}
-	hub, err := rpctype.NewRPCClient(hc.cfg.HubAddr, 1)
+	hub, err = rpctype.NewRPCClient(hc.cfg.HubAddr, 1, true)
 	if err != nil {
 		return nil, err
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -67,6 +67,7 @@ type Manager struct {
 	vmStop          chan bool
 	checkResult     *rpctype.CheckArgs
 	fresh           bool
+	netCompression  bool
 	expertMode      bool
 	numFuzzing      uint32
 	numReproducing  uint32
@@ -184,6 +185,7 @@ func RunManager(cfg *mgrconfig.Config) {
 		memoryLeakFrames:   make(map[string]bool),
 		dataRaceFrames:     make(map[string]bool),
 		fresh:              true,
+		netCompression:     vm.UseNetCompression(cfg.Type),
 		vmStop:             make(chan bool),
 		externalReproQueue: make(chan *Crash, 10),
 		needMoreRepros:     make(chan chan bool),
@@ -836,11 +838,12 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 		Test:      false,
 		Runtest:   false,
 		Optional: &instance.OptionalFuzzerArgs{
-			Slowdown:      mgr.cfg.Timeouts.Slowdown,
-			RawCover:      mgr.cfg.RawCover,
-			SandboxArg:    mgr.cfg.SandboxArg,
-			PprofPort:     inst.PprofPort(),
-			ResetAccState: mgr.cfg.Experimental.ResetAccState,
+			Slowdown:       mgr.cfg.Timeouts.Slowdown,
+			RawCover:       mgr.cfg.RawCover,
+			SandboxArg:     mgr.cfg.SandboxArg,
+			PprofPort:      inst.PprofPort(),
+			ResetAccState:  mgr.cfg.Experimental.ResetAccState,
+			NetCompression: mgr.netCompression,
 		},
 	}
 	cmd := instance.FuzzerCmd(args)

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1409,10 +1409,10 @@ func (mgr *Manager) machineChecked(a *rpctype.CheckArgs, enabledSyscalls map[*pr
 			}
 			log.Logf(level, msg, args...)
 		},
-		NewInputFilter: func(input *corpus.NewInput) bool {
+		NewInputFilter: func(call string) bool {
 			mgr.mu.Lock()
 			defer mgr.mu.Unlock()
-			return !mgr.saturatedCalls[input.StringCall()]
+			return !mgr.saturatedCalls[call]
 		},
 	}, rnd, mgr.target)
 	mgr.fuzzer.Store(fuzzerObj)

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -74,7 +74,7 @@ func startRPCServer(mgr *Manager) (*RPCServer, error) {
 		cfg:   mgr.cfg,
 		stats: mgr.stats,
 	}
-	s, err := rpctype.NewRPCServer(mgr.cfg.RPC, "Manager", serv)
+	s, err := rpctype.NewRPCServer(mgr.cfg.RPC, "Manager", serv, mgr.netCompression)
 	if err != nil {
 		return nil, err
 	}

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	timeouts := config.Timeouts
-	vrf, err := rpctype.NewRPCClient(*flagAddr, timeouts.Scale)
+	vrf, err := rpctype.NewRPCClient(*flagAddr, timeouts.Scale, true)
 	if err != nil {
 		log.Fatalf("failed to connect to verifier : %v", err)
 	}

--- a/syz-verifier/rpcserver.go
+++ b/syz-verifier/rpcserver.go
@@ -33,7 +33,7 @@ func startRPCServer(vrf *Verifier) (*RPCServer, error) {
 		notChecked: len(vrf.pools),
 	}
 
-	s, err := rpctype.NewRPCServer(vrf.addr, "Verifier", srv)
+	s, err := rpctype.NewRPCServer(vrf.addr, "Verifier", srv, true)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/syz-hubtool/hubtool.go
+++ b/tools/syz-hubtool/hubtool.go
@@ -57,7 +57,7 @@ func main() {
 		return
 	}
 	log.Printf("connecting to hub at %v...", *flagHubAddress)
-	conn, err := rpctype.NewRPCClient(*flagHubAddress, 1)
+	conn, err := rpctype.NewRPCClient(*flagHubAddress, 1, true)
 	if err != nil {
 		log.Fatalf("failed to connect to hub: %v", err)
 	}

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -61,7 +61,7 @@ func main() {
 		reqMap:           make(map[int]*runtest.RunRequest),
 		lastReq:          make(map[string]int),
 	}
-	s, err := rpctype.NewRPCServer(cfg.RPC, "Manager", mgr)
+	s, err := rpctype.NewRPCServer(cfg.RPC, "Manager", mgr, true)
 	if err != nil {
 		log.Fatalf("failed to create rpc server: %v", err)
 	}

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	vmimpl.Register("adb", ctor, false)
+	vmimpl.Register("adb", ctor, false, true)
 }
 
 type Device struct {

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	vmimpl.Register("bhyve", ctor, true)
+	vmimpl.Register("bhyve", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -28,7 +28,7 @@ const (
 )
 
 func init() {
-	vmimpl.Register("cuttlefish", ctor, true)
+	vmimpl.Register("cuttlefish", ctor, true, true)
 }
 
 type Pool struct {

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	vmimpl.Register("gce", ctor, true)
+	vmimpl.Register("gce", ctor, true, true)
 }
 
 type Config struct {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	vmimpl.Register("gvisor", ctor, true)
+	vmimpl.Register("gvisor", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -23,7 +23,7 @@ import (
 const pstoreConsoleFile = "/sys/fs/pstore/console-ramoops-0"
 
 func init() {
-	vmimpl.Register("isolated", ctor, false)
+	vmimpl.Register("isolated", ctor, false, true)
 }
 
 type Config struct {

--- a/vm/kvm/kvm.go
+++ b/vm/kvm/kvm.go
@@ -27,7 +27,7 @@ const (
 )
 
 func init() {
-	vmimpl.Register("kvm", ctor, true)
+	vmimpl.Register("kvm", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/proxyapp/init.go
+++ b/vm/proxyapp/init.go
@@ -32,7 +32,7 @@ func init() {
 		func(env *vmimpl.Env) (vmimpl.Pool, error) {
 			return ctor(makeDefaultParams(), env)
 		},
-		false)
+		false, true)
 }
 
 // Package configuration VARs are mostly needed for tests.

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	var _ vmimpl.Infoer = (*instance)(nil)
-	vmimpl.Register("qemu", ctor, true)
+	vmimpl.Register("qemu", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -22,7 +22,7 @@ import (
 
 func init() {
 	var _ vmimpl.Infoer = (*instance)(nil)
-	vmimpl.Register("starnix", ctor, true)
+	vmimpl.Register("starnix", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -93,6 +93,12 @@ func AllowsOvercommit(typ string) bool {
 	return vmimpl.Types[vmType(typ)].Overcommit
 }
 
+// UseNetCompression says if it's beneficial to use network compression for this VM type.
+// Local VMs (qemu) generally don't benefit from compression, while remote machines may benefit.
+func UseNetCompression(typ string) bool {
+	return vmimpl.Types[vmType(typ)].NetCompression
+}
+
 // Create creates a VM pool that can be used to create individual VMs.
 func Create(cfg *mgrconfig.Config, debug bool) (*Pool, error) {
 	typ, ok := vmimpl.Types[vmType(cfg.Type)]

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -80,7 +80,7 @@ func init() {
 	ctor := func(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return &testPool{}, nil
 	}
-	vmimpl.Register("test", ctor, false)
+	vmimpl.Register("test", ctor, false, false)
 }
 
 type Test struct {

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -129,16 +129,18 @@ func (err InfraError) InfraError() (string, []byte) {
 }
 
 // Register registers a new VM type within the package.
-func Register(typ string, ctor ctorFunc, allowsOvercommit bool) {
+func Register(typ string, ctor ctorFunc, allowsOvercommit, netCompression bool) {
 	Types[typ] = Type{
-		Ctor:       ctor,
-		Overcommit: allowsOvercommit,
+		Ctor:           ctor,
+		Overcommit:     allowsOvercommit,
+		NetCompression: netCompression,
 	}
 }
 
 type Type struct {
-	Ctor       ctorFunc
-	Overcommit bool
+	Ctor           ctorFunc
+	Overcommit     bool
+	NetCompression bool
 }
 
 type ctorFunc func(env *Env) (Pool, error)

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -25,7 +25,7 @@ import (
 var vmctlStatusRegex = regexp.MustCompile(`^\s+([0-9]+)\b.*\brunning`)
 
 func init() {
-	vmimpl.Register("vmm", ctor, true)
+	vmimpl.Register("vmm", ctor, true, false)
 }
 
 type Config struct {

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	vmimpl.Register("vmware", ctor, false)
+	vmimpl.Register("vmware", ctor, false, false)
 }
 
 type Config struct {


### PR DESCRIPTION
Currently we throw away saturated calls only after triage/minimization.
Triage/minimization is unnecessary for saturated calls,
we already know we will throw them away later.
Don't send saturated calls for triage/minimization.
