### PR TITLE
Fix uninitialized variable when generating kvm poc

### DIFF
--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7677,6 +7677,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* gdt = (uint64*)(host_mem + sregs.gdt.base);
 
 	struct kvm_segment seg_ldt;
+	memset(&seg_ldt, 0, sizeof(seg_ldt));
 	seg_ldt.selector = SEL_LDT;
 	seg_ldt.type = 2;
 	seg_ldt.base = guest_mem + ADDR_LDT;
@@ -7691,6 +7692,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* ldt = (uint64*)(host_mem + sregs.ldt.base);
 
 	struct kvm_segment seg_cs16;
+	memset(&seg_cs16, 0, sizeof(seg_cs16));
 	seg_cs16.selector = SEL_CS16;
 	seg_cs16.type = 11;
 	seg_cs16.base = 0;
@@ -7746,6 +7748,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_ds64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_tss32;
+	memset(&seg_tss32, 0, sizeof(seg_tss32));
 	seg_tss32.selector = SEL_TSS32;
 	seg_tss32.type = 9;
 	seg_tss32.base = ADDR_VAR_TSS32;
@@ -7796,6 +7799,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_tss64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_cgate16;
+	memset(&seg_cgate16, 0, sizeof(seg_cgate16));
 	seg_cgate16.selector = SEL_CGATE16;
 	seg_cgate16.type = 4;
 	seg_cgate16.base = SEL_CS16 | (2 << 16);


### PR DESCRIPTION
The original `commonHeader` in `generated.go` did not initialize the `avl` field of the segment register, and the `avl` field is of type `u8` in `kvm.h`. When executing the `fill_segment_descriptor` function, the `avl` field could randomly produce results that might overwrite and affect other fields in the segment register.