### PR TITLE
pkg/csource/generated.go: fix uninitialized variable when generating kvm poc

### DIFF
--- a/executor/common_kvm_amd64.h
+++ b/executor/common_kvm_amd64.h
@@ -322,6 +322,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* gdt = (uint64*)(host_mem + sregs.gdt.base);
 
 	struct kvm_segment seg_ldt;
+	memset(&seg_ldt, 0, sizeof(seg_ldt));
 	seg_ldt.selector = SEL_LDT;
 	seg_ldt.type = 2;
 	seg_ldt.base = guest_mem + ADDR_LDT;
@@ -336,6 +337,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* ldt = (uint64*)(host_mem + sregs.ldt.base);
 
 	struct kvm_segment seg_cs16;
+	memset(&seg_cs16, 0, sizeof(seg_cs16));
 	seg_cs16.selector = SEL_CS16;
 	seg_cs16.type = 11;
 	seg_cs16.base = 0;
@@ -391,6 +393,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_ds64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_tss32;
+	memset(&seg_tss32, 0, sizeof(seg_tss32));
 	seg_tss32.selector = SEL_TSS32;
 	seg_tss32.type = 9;
 	seg_tss32.base = ADDR_VAR_TSS32;
@@ -441,6 +444,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_tss64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_cgate16;
+	memset(&seg_cgate16, 0, sizeof(seg_cgate16));
 	seg_cgate16.selector = SEL_CGATE16;
 	seg_cgate16.type = 4;
 	seg_cgate16.base = SEL_CS16 | (2 << 16); // selector + param count

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -7677,6 +7677,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* gdt = (uint64*)(host_mem + sregs.gdt.base);
 
 	struct kvm_segment seg_ldt;
+	memset(&seg_ldt, 0, sizeof(seg_ldt));
 	seg_ldt.selector = SEL_LDT;
 	seg_ldt.type = 2;
 	seg_ldt.base = guest_mem + ADDR_LDT;
@@ -7691,6 +7692,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	uint64* ldt = (uint64*)(host_mem + sregs.ldt.base);
 
 	struct kvm_segment seg_cs16;
+	memset(&seg_cs16, 0, sizeof(seg_cs16));
 	seg_cs16.selector = SEL_CS16;
 	seg_cs16.type = 11;
 	seg_cs16.base = 0;
@@ -7746,6 +7748,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_ds64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_tss32;
+	memset(&seg_tss32, 0, sizeof(seg_tss32));
 	seg_tss32.selector = SEL_TSS32;
 	seg_tss32.type = 9;
 	seg_tss32.base = ADDR_VAR_TSS32;
@@ -7796,6 +7799,7 @@ static volatile long syz_kvm_setup_cpu(volatile long a0, volatile long a1, volat
 	seg_tss64_cpl3.dpl = 3;
 
 	struct kvm_segment seg_cgate16;
+	memset(&seg_cgate16, 0, sizeof(seg_cgate16));
 	seg_cgate16.selector = SEL_CGATE16;
 	seg_cgate16.type = 4;
 	seg_cgate16.base = SEL_CS16 | (2 << 16);


### PR DESCRIPTION
pkg/csource/generated.go: fix uninitialized variable when generating kvm poc

The "avl" fields (variable type is u8) of the kvm_segment structure variables such as seg_cs16 and seg_ldt are not initialized to zero. During creation, there is a chance that they are set to values other than 0 or 1, which can cause the "avl" fields to overwrite other fields when executing the fill_segment_descriptor function, leading to erroneous results.