### PR TITLE
pkg/symbolizer: add Cache type

### DIFF
--- a/pkg/symbolizer/cache.go
+++ b/pkg/symbolizer/cache.go
@@ -1,0 +1,42 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package symbolizer
+
+import (
+	"sync"
+)
+
+// Cache caches symbolization results from Symbolizer in a thread-safe way.
+type Cache struct {
+	mu    sync.RWMutex
+	cache map[cacheKey]cacheVal
+}
+
+type cacheKey struct {
+	bin string
+	pc  uint64
+}
+
+type cacheVal struct {
+	frames []Frame
+	err    error
+}
+
+func (c *Cache) Symbolize(inner func(string, uint64) ([]Frame, error), bin string, pc uint64) ([]Frame, error) {
+	key := cacheKey{bin, pc}
+	c.mu.RLock()
+	val, ok := c.cache[key]
+	c.mu.RUnlock()
+	if ok {
+		return val.frames, val.err
+	}
+	frames, err := inner(bin, pc)
+	c.mu.Lock()
+	if c.cache == nil {
+		c.cache = make(map[cacheKey]cacheVal)
+	}
+	c.cache[key] = cacheVal{frames, err}
+	c.mu.Unlock()
+	return frames, err
+}

--- a/pkg/symbolizer/cache_test.go
+++ b/pkg/symbolizer/cache_test.go
@@ -1,0 +1,38 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package symbolizer
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCache(t *testing.T) {
+	called := make(map[cacheKey]bool)
+	inner := func(bin string, pc uint64) ([]Frame, error) {
+		key := cacheKey{bin, pc}
+		assert.False(t, called[key])
+		called[key] = true
+		if bin == "error" {
+			return nil, fmt.Errorf("error %v", pc)
+		}
+		return []Frame{{PC: pc, Func: bin + "_func"}}, nil
+	}
+	var cache Cache
+	check := func(bin string, pc uint64, frames []Frame, err error) {
+		gotFrames, gotErr := cache.Symbolize(inner, bin, pc)
+		assert.Equal(t, gotFrames, frames)
+		assert.Equal(t, gotErr, err)
+	}
+	check("foo", 1, []Frame{{PC: 1, Func: "foo_func"}}, nil)
+	check("foo", 1, []Frame{{PC: 1, Func: "foo_func"}}, nil)
+	check("foo", 2, []Frame{{PC: 2, Func: "foo_func"}}, nil)
+	check("foo", 1, []Frame{{PC: 1, Func: "foo_func"}}, nil)
+	check("error", 10, nil, errors.New("error 10"))
+	check("error", 10, nil, errors.New("error 10"))
+	check("error", 11, nil, errors.New("error 11"))
+}


### PR DESCRIPTION
When the same crash happens all over again,
we repeatedly symbolize the same PCs.
This is slow and blocks VM loop in the manager.
Cache PCs we already symbolize, we are likely
to symbolize them again.
