### PR TITLE
pkg/fuzzer: use a MAB to decide on exec fuzz vs exec gen

### DIFF
--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -85,6 +85,8 @@ func TestFuzz(t *testing.T) {
 		t.Logf("%s", p.Serialize())
 	}
 
+	t.Logf("stats: %+v", fuzzer.Stats().Named)
+
 	assert.Equal(t, len(tf.expectedCrashes), len(tf.crashes),
 		"not all expected crashes were found")
 }

--- a/pkg/fuzzer/stats.go
+++ b/pkg/fuzzer/stats.go
@@ -42,5 +42,7 @@ func (fuzzer *Fuzzer) Stats() Stats {
 	for k, v := range fuzzer.stats {
 		ret.Named[k] = v
 	}
+	ret.Named["exec gen, sig/sec*1000"] = uint64(fuzzer.genSignalSpeed.Load() * 1000)
+	ret.Named["exec fuzz, sig/sec*1000"] = uint64(fuzzer.fuzzSignalSpeed.Load() * 1000)
 	return ret
 }

--- a/pkg/learning/mab.go
+++ b/pkg/learning/mab.go
@@ -1,0 +1,77 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package learning
+
+import (
+	"math/rand"
+	"sync"
+)
+
+type Action[T comparable] struct {
+	Arm   T
+	index int
+}
+
+func (a Action[T]) Empty() bool {
+	return a == Action[T]{}
+}
+
+type countedValue struct {
+	value float64
+	count int64
+}
+
+func (cv *countedValue) update(value, minStep float64) {
+	// Using larger steps at the beginning allows us to
+	// converge faster to the actual value.
+	// The minStep limit ensures that we can still track
+	// non-stationary problems.
+	cv.count++
+	step := 1.0 / float64(cv.count)
+	if step < minStep {
+		step = minStep
+	}
+	cv.value += (value - cv.value) * step
+}
+
+// PlainMAB is a very simple epsylon-greedy MAB implementation.
+type PlainMAB[T comparable] struct {
+	MinLearningRate float64
+	ExplorationRate float64
+
+	mu      sync.RWMutex
+	arms    []T
+	weights []countedValue
+}
+
+func (p *PlainMAB[T]) AddArms(arms ...T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, arm := range arms {
+		p.arms = append(p.arms, arm)
+		p.weights = append(p.weights, countedValue{0, 0})
+	}
+}
+
+func (p *PlainMAB[T]) Action(r *rand.Rand) Action[T] {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var pos int
+	if r.Float64() < p.ExplorationRate {
+		pos = r.Intn(len(p.arms))
+	} else {
+		for i := 1; i < len(p.arms); i++ {
+			if p.weights[i].value > p.weights[pos].value {
+				pos = i
+			}
+		}
+	}
+	return Action[T]{Arm: p.arms[pos], index: pos}
+}
+
+func (p *PlainMAB[T]) SaveReward(action Action[T], reward float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.weights[action.index].update(reward, p.MinLearningRate)
+}

--- a/pkg/learning/mab_test.go
+++ b/pkg/learning/mab_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package learning
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMABSmallDiff(t *testing.T) {
+	r := rand.New(testutil.RandSource(t))
+	bandit := &PlainMAB[int]{
+		MinLearningRate: 0.0001,
+		ExplorationRate: 0.1,
+	}
+	arms := []float64{0.65, 0.7}
+	for i := range arms {
+		bandit.AddArms(i)
+	}
+	const steps = 40000
+	counts := runMAB(r, bandit, arms, steps)
+	t.Logf("counts: %v", counts)
+	assert.Greater(t, counts[1], steps/4*3)
+}
+
+func TestNonStationaryMAB(t *testing.T) {
+	r := rand.New(testutil.RandSource(t))
+	bandit := &PlainMAB[int]{
+		MinLearningRate: 0.02,
+		ExplorationRate: 0.04,
+	}
+
+	arms := []float64{0.2, 0.7, 0.5, 0.1}
+	for i := range arms {
+		bandit.AddArms(i)
+	}
+
+	const steps = 25000
+	counts := runMAB(r, bandit, arms, steps)
+	t.Logf("initially: %v", counts)
+
+	// Ensure that we've found the best arm.
+	assert.Greater(t, counts[1], steps/2)
+
+	// Now change the best arm's avg reward.
+	arms[3] = 0.9
+	counts = runMAB(r, bandit, arms, steps)
+	t.Logf("after reward change: %v", counts)
+	assert.Greater(t, counts[3], steps/2)
+}
+
+func runMAB(r *rand.Rand, bandit *PlainMAB[int], arms []float64, steps int) []int {
+	counts := make([]int, len(arms))
+	for i := 0; i < steps; i++ {
+		action := bandit.Action(r)
+		// TODO: use normal distribution?
+		reward := r.Float64() * arms[action.Arm]
+		counts[action.Arm]++
+		bandit.SaveReward(action, reward)
+	}
+	return counts
+}

--- a/pkg/learning/window.go
+++ b/pkg/learning/window.go
@@ -1,0 +1,67 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package learning
+
+import "sync"
+
+type Number interface {
+	int | int64 | float64
+}
+
+type RunningAverage[T Number] struct {
+	window []T
+	mu     sync.RWMutex
+	pos    int
+	total  T
+}
+
+func NewRunningAverage[T Number](size int) *RunningAverage[T] {
+	return &RunningAverage[T]{
+		window: make([]T, size),
+	}
+}
+
+func (ra *RunningAverage[T]) SaveInt(val int) {
+	ra.Save(T(val))
+}
+
+func (ra *RunningAverage[T]) Save(val T) {
+	ra.mu.Lock()
+	defer ra.mu.Unlock()
+	prev := ra.window[ra.pos]
+	ra.window[ra.pos] = val
+	ra.total += val - prev
+	ra.pos = (ra.pos + 1) % len(ra.window)
+}
+
+func (ra *RunningAverage[T]) Load() T {
+	ra.mu.RLock()
+	defer ra.mu.RUnlock()
+	return ra.total
+}
+
+type RunningRatioAverage[T Number] struct {
+	values   *RunningAverage[T]
+	divideBy *RunningAverage[T]
+}
+
+func NewRunningRatioAverage[T Number](size int) *RunningRatioAverage[T] {
+	return &RunningRatioAverage[T]{
+		values:   NewRunningAverage[T](size),
+		divideBy: NewRunningAverage[T](size),
+	}
+}
+
+func (rra *RunningRatioAverage[T]) Save(nomDelta, denomDelta T) {
+	rra.values.Save(nomDelta)
+	rra.divideBy.Save(denomDelta)
+}
+
+func (rra *RunningRatioAverage[T]) Load() float64 {
+	denom := rra.divideBy.Load()
+	if denom == 0 {
+		return 0
+	}
+	return float64(rra.values.Load()) / float64(denom)
+}

--- a/pkg/learning/window_test.go
+++ b/pkg/learning/window_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package learning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunningRatioAverage(t *testing.T) {
+	ra := NewRunningRatioAverage[float64](3)
+	for i := 0; i < 4; i++ {
+		ra.Save(2.0, 1.0)
+	}
+	assert.InDelta(t, 2.0, ra.Load(), 0.1)
+	for i := 0; i < 4; i++ {
+		ra.Save(3.0, 2.0)
+	}
+	assert.InDelta(t, 1.5, ra.Load(), 0.1)
+}
+
+func TestRunningAverage(t *testing.T) {
+	ra := NewRunningAverage[int](3)
+	assert.Equal(t, 0, ra.Load())
+	ra.Save(1)
+	assert.Equal(t, 1, ra.Load())
+	ra.Save(2)
+	assert.Equal(t, 3, ra.Load())
+	for i := 4; i <= 10; i++ {
+		ra.SaveInt(i)
+	}
+	assert.Equal(t, 8+9+10, ra.Load())
+}

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -176,7 +176,7 @@ func (mgr *Manager) collectStats() []UIStat {
 		for k, v := range rawStats {
 			val := ""
 			switch {
-			case k == "fuzzer jobs" || strings.HasPrefix(k, "rpc exchange"):
+			case k == "fuzzer jobs" || strings.HasPrefix(k, "rpc exchange") || strings.Contains(k, "/sec"):
 				val = fmt.Sprint(v)
 			default:
 				val = rateStat(v, secs)

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -325,7 +325,9 @@ func (runner *Runner) doneRequest(resp rpctype.ExecutionResult, fuzzerObj *fuzze
 	}
 	info.Extra.Cover = runner.instModules.Canonicalize(info.Extra.Cover)
 	info.Extra.Signal = runner.instModules.Canonicalize(info.Extra.Signal)
-	fuzzerObj.Done(req, &fuzzer.Result{Info: info})
+	fuzzerObj.Done(req, &fuzzer.Result{
+		Info: info,
+	})
 }
 
 func (runner *Runner) newRequest(req *fuzzer.Request) rpctype.ExecutionRequest {


### PR DESCRIPTION
I'm currently running experiments to see whether it brings any fuzzing performance improvements.

***
Cc #1950

Let's try to use a plain delta-epsylon MAB for this purpose.

To better track its effect, also calculate moving averages of the "new max signal" / "execution time" ratios for exec fuzz and exec gen.