### PR TITLE
syz-ci/manager.go: use dashboard_client from manager config

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -912,7 +912,7 @@ func (mgr *Manager) uploadCoverStat(fuzzingMinutes int) error {
 		pw.Close()
 	}()
 	fileName := fmt.Sprintf("%s/%s-%s-%d-%d.jsonl",
-		mgr.cfg.DashboardClient,
+		mgr.mgrcfg.DashboardClient,
 		mgr.name, curTime.Format(time.DateOnly),
 		curTime.Hour(), curTime.Minute())
 	err = mgr.uploadFile(mgr.cfg.CoverPipelinePath, fileName, pr, false)


### PR DESCRIPTION
It currently uses "dashboard_client" from ci config.