### PR TITLE
pkg/corpus: avoid a race in Corpus.Minimize()

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -22,7 +22,7 @@ type Corpus struct {
 	signal  signal.Signal // total signal of all items
 	cover   cover.Cover   // total coverage of all items
 	updates chan<- NewItemEvent
-	ProgramsList
+	*ProgramsList
 }
 
 func NewCorpus(ctx context.Context) *Corpus {
@@ -31,9 +31,10 @@ func NewCorpus(ctx context.Context) *Corpus {
 
 func NewMonitoredCorpus(ctx context.Context, updates chan<- NewItemEvent) *Corpus {
 	return &Corpus{
-		ctx:     ctx,
-		progs:   make(map[string]*Item),
-		updates: updates,
+		ctx:          ctx,
+		progs:        make(map[string]*Item),
+		updates:      updates,
+		ProgramsList: &ProgramsList{},
 	}
 }
 

--- a/pkg/corpus/minimize.go
+++ b/pkg/corpus/minimize.go
@@ -32,7 +32,9 @@ func (corpus *Corpus) Minimize(cover bool) {
 	})
 
 	corpus.progs = make(map[string]*Item)
-	corpus.ProgramsList = ProgramsList{}
+	// ProgramsList has its own mutex, so it'd be unsafe to
+	// overwrite it here, so let's create a new object.
+	corpus.ProgramsList = &ProgramsList{}
 	for _, ctx := range signal.Minimize(inputs) {
 		inp := ctx.(*Item)
 		corpus.progs[inp.Sig] = inp


### PR DESCRIPTION
The following two operations were in conflict:
1) Overwriting of corpus.ProgramsList in Minimize().
2) ProgramsList.ChooseProgram() that used its own mutex.

Instead of overwriting the object, let's create a new one.
