### PR TITLE
pkg/cover: fix jsonl hit count calculation

### DIFF
--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -120,7 +120,7 @@ func (rg *ReportGenerator) prepareFileMap(progs []Prog, debug bool) (fileMap, er
 	}
 	matchedPC := false
 	for _, frame := range rg.Frames {
-		f := FileByFrame(files, &frame)
+		f := fileByFrame(files, &frame)
 		ln := f.lines[frame.StartLine]
 		coveredBy := progPCs[frame.PC]
 		if len(coveredBy) == 0 {
@@ -219,7 +219,7 @@ func (rg *ReportGenerator) symbolizePCs(PCs []uint64) error {
 	return nil
 }
 
-func FileByFrame(files map[string]*file, frame *backend.Frame) *file {
+func fileByFrame(files map[string]*file, frame *backend.Frame) *file {
 	f := files[frame.Name]
 	if f == nil {
 		f = &file{


### PR DESCRIPTION
prepareFileMap does more work than we need and leads to incorrect hit counts.
prepareFileMap produces hit counts per source line (for source reports),
but jsonl exports data based on coverage callbacks, not source lines.
So if we have 2 callbacks on the same line, we will double count them
(both will have hit count 2). If we calculate total percent later
based on that data, it will be wrong.

Use simpler calculation based on PCs.
