### PR TITLE
syz-manager: don't store whole CheckResult

### DIFF
--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -69,11 +69,12 @@ type ConnectArgs struct {
 }
 
 type ConnectRes struct {
-	EnabledCalls      []int
-	GitRevision       string
-	TargetRevision    string
-	AllSandboxes      bool
-	CheckResult       *CheckArgs
+	EnabledCalls   []int
+	GitRevision    string
+	TargetRevision string
+	AllSandboxes   bool
+	// This is forwarded from CheckArgs, if checking was already done.
+	Features          *host.Features
 	MemoryLeakFrames  []string
 	DataRaceFrames    []string
 	CoverFilterBitmap []byte

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -355,8 +355,8 @@ func (mgr *Manager) httpCoverFallback(w http.ResponseWriter, r *http.Request) {
 		calls[id] = append(calls[id], errno)
 	}
 	data := &UIFallbackCoverData{}
-	for _, id := range mgr.checkResult.EnabledCalls[mgr.cfg.Sandbox] {
-		errnos := calls[id]
+	for call := range mgr.targetEnabledSyscalls {
+		errnos := calls[call.ID]
 		sort.Ints(errnos)
 		successful := 0
 		for len(errnos) != 0 && errnos[0] == 0 {
@@ -364,7 +364,7 @@ func (mgr *Manager) httpCoverFallback(w http.ResponseWriter, r *http.Request) {
 			errnos = errnos[1:]
 		}
 		data.Calls = append(data.Calls, UIFallbackCall{
-			Name:       mgr.target.Syscalls[id].Name,
+			Name:       call.Name,
 			Successful: successful,
 			Errnos:     errnos,
 		})

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -44,7 +44,7 @@ func (mgr *Manager) hubSyncLoop(keyGet keyGetter) {
 		target:        mgr.target,
 		domain:        mgr.cfg.TargetOS + "/" + mgr.cfg.HubDomain,
 		enabledCalls:  mgr.targetEnabledSyscalls,
-		leak:          mgr.checkResult.Features[host.FeatureLeak].Enabled,
+		leak:          mgr.checkFeatures[host.FeatureLeak].Enabled,
 		fresh:         mgr.fresh,
 		hubReproQueue: mgr.externalReproQueue,
 		keyGet:        keyGet,


### PR DESCRIPTION
Currently we store whole CheckResult in the manager and send
it back to fuzzers. It is somewhat large for both storing
in memory and sending each time to fuzzers.

We already clear DisabledCalls in CheckResult before storing it
to save space. But we also don't need to store/send EnabledSyscalls.
Currently we use CheckResult.GlobFiles in the fuzzer to update
prog package, but we don't need to do it. That's a leftover from
"fuzzer in the VM" times. We don't generate programs in the fuzzer
anymore.
The only bit we really need it CheckResult.Features, so store/send
just them.
