### PR TITLE
pkg/fuzzer: deflake against new signal

### DIFF
--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -186,11 +186,12 @@ func (job *triageJob) deflake(exec func(job, *Request) *Result, stat *stats.Val,
 	)
 	signals := make([]signal.Signal, needRuns)
 	for i := 0; i < maxRuns; i++ {
-		if signals[needRuns-1].Len() > 0 {
-			// We've already got signal common to needRuns.
+		if job.newSignal.IntersectsWith(signals[needRuns-1]) {
+			// We already have the right deflaked signal.
 			break
 		}
-		if left := maxRuns - i; left < needRuns && signals[needRuns-left-1].Len() == 0 {
+		if left := maxRuns - i; left < needRuns &&
+			!job.newSignal.IntersectsWith(signals[needRuns-left-1]) {
 			// There's no chance to get coverage common to needRuns.
 			break
 		}

--- a/pkg/fuzzer/job_test.go
+++ b/pkg/fuzzer/job_test.go
@@ -24,7 +24,7 @@ func TestDeflakeFail(t *testing.T) {
 	testJob := &triageJob{
 		p:         prog,
 		info:      ipc.CallInfo{},
-		newSignal: signal.FromRaw([]uint32{0, 1, 2}, 0),
+		newSignal: signal.FromRaw([]uint32{0, 1, 2, 3, 4}, 0),
 	}
 
 	run := 0

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -92,6 +92,15 @@ func (s Signal) DiffRaw(raw []uint32, prio uint8) Signal {
 	return res
 }
 
+func (s Signal) IntersectsWith(other Signal) bool {
+	for e, p := range s {
+		if p1, ok := other[e]; ok && p1 >= p {
+			return true
+		}
+	}
+	return false
+}
+
 func (s Signal) Intersection(s1 Signal) Signal {
 	if s1.Empty() {
 		return nil

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -31,3 +31,11 @@ func TestSubtract(t *testing.T) {
 	base.Subtract(FromRaw([]uint32{1}, 0))
 	assert.Equal(t, 3, base.Len())
 }
+
+func TestIntersectsWith(t *testing.T) {
+	base := FromRaw([]uint32{0, 1, 2, 3, 4}, 1)
+	assert.True(t, base.IntersectsWith(FromRaw([]uint32{0, 5, 10}, 1)))
+	assert.False(t, base.IntersectsWith(FromRaw([]uint32{5, 10, 15}, 1)))
+	// The other signal has a lower priority.
+	assert.False(t, base.IntersectsWith(FromRaw([]uint32{0, 1, 2}, 0)))
+}


### PR DESCRIPTION
We don't want to reach just any stable signal, we know the specific new signal that we target. The previous approach might have reduced the efficiency of the new deflake() approach.
