### PR TITLE
pkg/symbolizer: intern file/func strings

### DIFF
--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -20,6 +20,7 @@ import (
 type Symbolizer struct {
 	target   *targets.Target
 	subprocs map[string]*subprocess
+	interner Interner
 }
 
 type Frame struct {
@@ -51,7 +52,7 @@ func (s *Symbolizer) SymbolizeArray(bin string, pcs []uint64) ([]Frame, error) {
 	if err != nil {
 		return nil, err
 	}
-	return symbolize(sub.input, sub.scanner, pcs)
+	return symbolize(&s.interner, sub.input, sub.scanner, pcs)
 }
 
 func (s *Symbolizer) Close() {
@@ -100,7 +101,7 @@ func (s *Symbolizer) getSubprocess(bin string) (*subprocess, error) {
 	return sub, nil
 }
 
-func symbolize(input *bufio.Writer, scanner *bufio.Scanner, pcs []uint64) ([]Frame, error) {
+func symbolize(interner *Interner, input *bufio.Writer, scanner *bufio.Scanner, pcs []uint64) ([]Frame, error) {
 	var frames []Frame
 	done := make(chan error, 1)
 	go func() {
@@ -116,7 +117,7 @@ func symbolize(input *bufio.Writer, scanner *bufio.Scanner, pcs []uint64) ([]Fra
 		}
 		for range pcs {
 			var frames1 []Frame
-			frames1, err = parse(scanner)
+			frames1, err = parse(interner, scanner)
 			if err != nil {
 				return
 			}
@@ -145,7 +146,7 @@ func symbolize(input *bufio.Writer, scanner *bufio.Scanner, pcs []uint64) ([]Fra
 	return frames, nil
 }
 
-func parse(s *bufio.Scanner) ([]Frame, error) {
+func parse(interner *Interner, s *bufio.Scanner) ([]Frame, error) {
 	pc, err := strconv.ParseUint(s.Text(), 0, 64)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse pc '%v' in addr2line output: %w", s.Text(), err)
@@ -183,8 +184,8 @@ func parse(s *bufio.Scanner) ([]Frame, error) {
 		}
 		frames = append(frames, Frame{
 			PC:     pc,
-			Func:   fn,
-			File:   file,
+			Func:   interner.Do(fn),
+			File:   interner.Do(file),
 			Line:   line,
 			Inline: true,
 		})

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -150,10 +150,11 @@ func TestParse(t *testing.T) {
 	// First, symbolize all PCs one-by-one.
 	input := bufio.NewWriter(inputw)
 	scanner := bufio.NewScanner(outputr)
+	var interner Interner
 	var allPCs []uint64
 	var allFrames []Frame
 	for _, addr := range addresses {
-		frames, err := symbolize(input, scanner, []uint64{addr.pc})
+		frames, err := symbolize(&interner, input, scanner, []uint64{addr.pc})
 		if err != nil {
 			t.Fatalf("got error: %v", err)
 		}
@@ -166,11 +167,11 @@ func TestParse(t *testing.T) {
 
 	// Symbolize PCs in 2 groups.
 	for i := 0; i <= len(addresses); i++ {
-		frames, err := symbolize(input, scanner, allPCs[:i])
+		frames, err := symbolize(&interner, input, scanner, allPCs[:i])
 		if err != nil {
 			t.Fatalf("got error: %v", err)
 		}
-		frames2, err := symbolize(input, scanner, allPCs[i:])
+		frames2, err := symbolize(&interner, input, scanner, allPCs[i:])
 		if err != nil {
 			t.Fatalf("got error: %v", err)
 		}
@@ -185,7 +186,7 @@ func TestParse(t *testing.T) {
 	for i := range lots {
 		lots[i] = addresses[0].pc
 	}
-	frames, err := symbolize(input, scanner, lots)
+	frames, err := symbolize(&interner, input, scanner, lots)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}


### PR DESCRIPTION
Intern/deduplicate file/func strings created during symbolization.
There are lots and lots of duplicates.
In my local run syz-manager heap size jumps from 1.9G to 4.0G
are requesting /cover?jsonl=1 without this change, and from
1.9G to 2.9G with this change.
