### PR TITLE
Updates to starnix VM startup process

### DIFF
--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -57,7 +57,7 @@ type instance struct {
 	diagnose         chan bool
 }
 
-const targetDir = "/data"
+const targetDir = "/tmp"
 
 func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	cfg := &Config{}


### PR DESCRIPTION
2 updates necessitated by recent starnix changes:
- push the syz-executor binary to /tmp rather than /data
- mark the syz-executor binary as executable after pushing to the VM