### PR TITLE
pkg/report: make "mand mount option" regexps more robust

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1874,7 +1874,7 @@ var linuxOopses = append([]*oops{
 		[]*regexp.Regexp{
 			compile("WARNING: /etc/ssh/moduli does not exist, using fixed modulus"), // printed by sshd
 			compile("WARNING: workqueue cpumask: online intersect > possible intersect"),
-			compile("WARNING: [Tt]he mand mount option (is being|has been) deprecated"),
+			compile("WARNING: [Tt]he mand mount option"),
 			compile("WARNING: Unsupported flag value\\(s\\) of 0x%x in DT_FLAGS_1"), // printed when glibc is dumped
 			compile("WARNING: Unprivileged eBPF is enabled with eIBRS"),
 			compile(`WARNING: fbcon: Driver '(.*)' missed to adjust virtual screen size (\((?:\d+)x(?:\d+) vs\. (?:\d+)x(?:\d+)\))`),

--- a/pkg/report/testdata/linux/report/712
+++ b/pkg/report/testdata/linux/report/712
@@ -1,0 +1,4 @@
+TITLE: 
+
+[   33.603917][ T3329] ======================================================
+[   33.603917][ T3329] WARNING: the mand mount option is being deprecat


### PR DESCRIPTION
In some cases, we may only collect a part of the kernel output. There are no other "mand mount option" warnings in the kernel, so let's match by a shorter regexp.
