### PR TITLE
pkg/cover, pkg/mgrconfig: introduce the ignore_mismatching_coverage flag

### DIFF
--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -27,11 +27,12 @@ type CoverHandlerParams struct {
 	Progs       []Prog
 	CoverFilter map[uint32]uint32
 	Debug       bool
+	Force       bool
 }
 
 func (rg *ReportGenerator) DoHTML(w io.Writer, params CoverHandlerParams) error {
 	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
-	files, err := rg.prepareFileMap(progs, params.Debug)
+	files, err := rg.prepareFileMap(progs, params.Force, params.Debug)
 	if err != nil {
 		return err
 	}
@@ -134,7 +135,7 @@ type lineCoverExport struct {
 
 func (rg *ReportGenerator) DoLineJSON(w io.Writer, params CoverHandlerParams) error {
 	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
-	files, err := rg.prepareFileMap(progs, params.Debug)
+	files, err := rg.prepareFileMap(progs, params.Force, params.Debug)
 	if err != nil {
 		return err
 	}
@@ -348,7 +349,7 @@ var csvFilesHeader = []string{
 }
 
 func (rg *ReportGenerator) convertToStats(progs []Prog) ([]fileStats, error) {
-	files, err := rg.prepareFileMap(progs, false)
+	files, err := rg.prepareFileMap(progs, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +597,7 @@ var csvHeader = []string{
 
 func (rg *ReportGenerator) DoCSV(w io.Writer, params CoverHandlerParams) error {
 	var progs = fixUpPCs(rg.target.Arch, params.Progs, params.CoverFilter)
-	files, err := rg.prepareFileMap(progs, params.Debug)
+	files, err := rg.prepareFileMap(progs, params.Force, params.Debug)
 	if err != nil {
 		return err
 	}

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -78,7 +78,7 @@ type line struct {
 
 type fileMap map[string]*file
 
-func (rg *ReportGenerator) prepareFileMap(progs []Prog, debug bool) (fileMap, error) {
+func (rg *ReportGenerator) prepareFileMap(progs []Prog, force, debug bool) (fileMap, error) {
 	if err := rg.symbolizePCs(uniquePCs(progs)); err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (rg *ReportGenerator) prepareFileMap(progs []Prog, debug bool) (fileMap, er
 	}
 	// If the backend provided coverage callback locations for the binaries, use them to
 	// verify data returned by kcov.
-	if len(unmatchedProgPCs) > 0 {
+	if len(unmatchedProgPCs) > 0 && !force {
 		return nil, coverageCallbackMismatch(debug, len(progPCs), unmatchedProgPCs)
 	}
 	for _, unit := range rg.Units {
@@ -181,7 +181,8 @@ func coverageCallbackMismatch(debug bool, numPCs int, unmatchedProgPCs map[uint6
 		}
 	}
 	return fmt.Errorf("%d out of %d PCs returned by kcov do not have matching coverage callbacks."+
-		" Check the discoverModules() code.%s", len(unmatchedProgPCs), numPCs, debugStr)
+		" Check the discoverModules() code. Use ?force=1 to disable this message.%s",
+		len(unmatchedProgPCs), numPCs, debugStr)
 }
 
 func uniquePCs(progs []Prog) []uint64 {

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -324,6 +324,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 		Progs:       progs,
 		CoverFilter: coverFilter,
 		Debug:       r.FormValue("debug") != "",
+		Force:       r.FormValue("force") != "",
 	}
 
 	type handlerFuncType func(w io.Writer, params cover.CoverHandlerParams) error

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -82,6 +82,7 @@ func main() {
 		Progs:       progs,
 		CoverFilter: nil,
 		Debug:       false,
+		Force:       false,
 	}
 	if *flagExportCSV != "" {
 		if err := rg.DoCSV(buf, params); err != nil {


### PR DESCRIPTION
When coverage points returned by kcov do not have corresponding coverage callbacks, this may indicate a problem with irrelevant signal being used for fuzzing. Therefore, by default syz-manager reports errors and does not show the coverage report in this case.

However, these errors can be annoying when onboarding new platforms, so the new `ignore_mismatching_coverage` flag is introduced to disable them. We still do not recommend to use it widely (e.g. on syzkaller.appspot.com)

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
