### PR TITLE
syz-manager: resend inputs from crashed VMs

### DIFF
--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -93,9 +93,14 @@ type Request struct {
 	NeedHints    bool
 	SignalFilter signal.Signal // If specified, the resulting signal MAY be a subset of it.
 	// Fields that are only relevant within pkg/fuzzer.
-	flags   ProgTypes
-	stat    *stats.Val
-	resultC chan *Result
+	notImportant bool
+	flags        ProgTypes
+	stat         *stats.Val
+	resultC      chan *Result
+}
+
+func (r *Request) Important() bool {
+	return !r.notImportant
 }
 
 type Result struct {

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -70,9 +70,10 @@ func genProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *Request {
 		prog.RecommendedCalls,
 		fuzzer.ChoiceTable())
 	return &Request{
-		Prog:       p,
-		NeedSignal: rpctype.NewSignal,
-		stat:       fuzzer.statExecGenerate,
+		Prog:         p,
+		NeedSignal:   rpctype.NewSignal,
+		stat:         fuzzer.statExecGenerate,
+		notImportant: true,
 	}
 }
 
@@ -89,9 +90,10 @@ func mutateProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *Request {
 		fuzzer.Config.Corpus.Programs(),
 	)
 	return &Request{
-		Prog:       newP,
-		NeedSignal: rpctype.NewSignal,
-		stat:       fuzzer.statExecFuzz,
+		Prog:         newP,
+		NeedSignal:   rpctype.NewSignal,
+		stat:         fuzzer.statExecFuzz,
+		notImportant: true,
 	}
 }
 

--- a/pkg/stats/avg.go
+++ b/pkg/stats/avg.go
@@ -1,0 +1,32 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package stats
+
+import (
+	"sync"
+	"time"
+)
+
+type AverageParameter interface {
+	time.Duration
+}
+
+type AverageValue[T AverageParameter] struct {
+	mu    sync.Mutex
+	total int64
+	avg   T
+}
+
+func (av *AverageValue[T]) Value() T {
+	av.mu.Lock()
+	defer av.mu.Unlock()
+	return av.avg
+}
+
+func (av *AverageValue[T]) Save(val T) {
+	av.mu.Lock()
+	defer av.mu.Unlock()
+	av.total++
+	av.avg += (val - av.avg) / T(av.total)
+}

--- a/syz-manager/rpc_test.go
+++ b/syz-manager/rpc_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	var called []bool
+	expectCalled := func(val int) func(*int) {
+		pos := len(called)
+		called = append(called, false)
+		return func(usedVal *int) {
+			called[pos] = val == *usedVal
+		}
+	}
+	expectNoCall := func(_ *int) {
+		t.Fatal("unexpected revoke")
+	}
+	intToPtr := func(v int) *int {
+		return &v
+	}
+
+	q := newQueue[int](3)
+
+	// First test simple operation -- we push and then fetch right away.
+	for i := 0; i < 10; i++ {
+		q.Add(intToPtr(10), expectNoCall)
+		assert.Equal(t, 10, *q.Fetch())
+	}
+
+	// Let's overflow the queue.
+	for i := 0; i <= 10; i++ {
+		expect := expectNoCall
+		if i >= 3 {
+			expect = expectCalled(i - 3)
+		}
+		ii := i
+		q.Add(&ii, expect)
+	}
+
+	// Ensure the queue works fine after overflow.
+	assert.Equal(t, 8, *q.Fetch())
+	q.Add(intToPtr(11), expectNoCall)
+	assert.Equal(t, 9, *q.Fetch())
+	q.Add(intToPtr(12), expectNoCall)
+	assert.Equal(t, 10, *q.Fetch())
+	assert.Equal(t, 11, *q.Fetch())
+	assert.Equal(t, 12, *q.Fetch())
+	assert.Nil(t, q.Fetch())
+
+	for _, v := range called {
+		assert.True(t, v)
+	}
+}

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -20,6 +20,7 @@ type Stats struct {
 	statSuppressed     *stats.Val
 	statUptime         *stats.Val
 	statFuzzingTime    *stats.Val
+	statAvgBootTime    *stats.Val
 }
 
 func (mgr *Manager) initStats() {
@@ -46,6 +47,14 @@ func (mgr *Manager) initStats() {
 			}
 			return int(time.Now().Unix() - firstConnect)
 		}, func(v int, period time.Duration) string {
+			return fmt.Sprintf("%v sec", v)
+		})
+	mgr.statAvgBootTime = stats.Create("instance restart", "Average VM restart time (sec)",
+		stats.NoGraph,
+		func() int {
+			return int(mgr.bootTime.Value().Seconds())
+		},
+		func(v int, _ time.Duration) string {
 			return fmt.Sprintf("%v sec", v)
 		})
 


### PR DESCRIPTION
Non-finished requests at the time of a crash are dangerous because one of them is likely to reproduce the crash.

Let's give these inputs one more chance, but under certain conditions:
1) The VM has been running long enough, so we may risk crashing it. The PR sets the restart budget to 10%.
2) Don't feed more than 1 unsafe input per minute.
