### PR TITLE
syz-manager: collect avg instance create time

### DIFF
--- a/pkg/stats/avg.go
+++ b/pkg/stats/avg.go
@@ -1,0 +1,32 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package stats
+
+import (
+	"sync"
+	"time"
+)
+
+type AverageParameter interface {
+	time.Duration
+}
+
+type AverageValue[T AverageParameter] struct {
+	mu    sync.Mutex
+	total int64
+	avg   T
+}
+
+func (av *AverageValue[T]) Value() T {
+	av.mu.Lock()
+	defer av.mu.Unlock()
+	return av.avg
+}
+
+func (av *AverageValue[T]) Save(val T) {
+	av.mu.Lock()
+	defer av.mu.Unlock()
+	av.total++
+	av.avg += (val - av.avg) / T(av.total)
+}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -99,6 +99,8 @@ type Manager struct {
 
 	assetStorage *asset.Storage
 
+	bootTime stats.AverageValue[time.Duration]
+
 	Stats
 }
 
@@ -760,6 +762,8 @@ func (mgr *Manager) runInstance(index int) (*Crash, error) {
 }
 
 func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Report, []byte, error) {
+	start := time.Now()
+
 	inst, err := mgr.vmPool.Create(index)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create instance: %w", err)
@@ -794,7 +798,8 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string) (*report.Re
 	}
 
 	// Run the fuzzer binary.
-	start := time.Now()
+	mgr.bootTime.Save(time.Since(start))
+	start = time.Now()
 	mgr.statNumFuzzing.Add(1)
 	defer mgr.statNumFuzzing.Add(-1)
 

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -20,6 +20,7 @@ type Stats struct {
 	statSuppressed     *stats.Val
 	statUptime         *stats.Val
 	statFuzzingTime    *stats.Val
+	statAvgBootTime    *stats.Val
 }
 
 func (mgr *Manager) initStats() {
@@ -46,6 +47,14 @@ func (mgr *Manager) initStats() {
 			}
 			return int(time.Now().Unix() - firstConnect)
 		}, func(v int, period time.Duration) string {
+			return fmt.Sprintf("%v sec", v)
+		})
+	mgr.statAvgBootTime = stats.Create("instance restart", "Average VM restart time (sec)",
+		stats.NoGraph,
+		func() int {
+			return int(mgr.bootTime.Value().Seconds())
+		},
+		func(v int, _ time.Duration) string {
 			return fmt.Sprintf("%v sec", v)
 		})
 


### PR DESCRIPTION
We will also use it to determine when we are ready to schedule programs that are very likely to crash instances.

It was initially a part of #4666.
