### PR TITLE
vm/qemu: use the new options format for NetBSD

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -231,10 +231,11 @@ var archConfigs = map[string]*archConfig{
 		RngDev:    "virtio-rng-pci",
 	},
 	"netbsd/amd64": {
-		Qemu:     "qemu-system-x86_64",
-		QemuArgs: "-enable-kvm",
-		NetDev:   "e1000",
-		RngDev:   "virtio-rng-pci",
+		Qemu:                   "qemu-system-x86_64",
+		QemuArgs:               "-enable-kvm",
+		NetDev:                 "e1000",
+		RngDev:                 "virtio-rng-pci",
+		UseNewQemuImageOptions: true,
 	},
 	"fuchsia/amd64": {
 		Qemu:      "qemu-system-x86_64",


### PR DESCRIPTION
We're seeing a lot of `Image format was not specified for '%PATH' and probing guessed raw.` errors.
