### PR TITLE
prog: update the choice table aglorithm

### DIFF
--- a/prog/prio_test.go
+++ b/prog/prio_test.go
@@ -11,19 +11,19 @@ import (
 	"github.com/google/syzkaller/pkg/testutil"
 )
 
-func TestNormalizePrio(t *testing.T) {
+func TestNormalizePrios(t *testing.T) {
 	prios := [][]int32{
 		{2, 2, 2},
 		{1, 2, 4},
 		{1, 2, 0},
 	}
 	want := [][]int32{
-		{1000, 1000, 1000},
-		{257, 505, 1000},
-		{505, 1000, 10},
+		{10, 10, 10},
+		{4, 8, 17},
+		{10, 20, 0},
 	}
 	t.Logf("had:  %+v", prios)
-	normalizePrio(prios)
+	normalizePrios(prios)
 	if !reflect.DeepEqual(prios, want) {
 		t.Logf("got:  %+v", prios)
 		t.Errorf("want: %+v", want)


### PR DESCRIPTION
Two changes:
1) Instead of multiplying static and dynamic prios, add them 1:1.
2) For dynamic priorities, limit the effect of too frequent call
   combinations by taking a sqrt() of the value.

On syz-testbed experiments, the updated algorithm triggers 5-10% more different crash types.

As before, there is no big theory behind the approach :)