### PR TITLE
pkg/fuzzer: retry inputs from crashed VMs

### DIFF
--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -114,7 +114,7 @@ func BenchmarkFuzzer(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			req := fuzzer.NextInput()
+			req := fuzzer.NextInput(RequestOpts{})
 			res, _, _ := emulateExec(req)
 			fuzzer.Done(req, res)
 		}
@@ -238,13 +238,13 @@ func (f *testFuzzer) oneMore() bool {
 func (f *testFuzzer) registerExecutor(proc *executorProc) {
 	f.eg.Go(func() error {
 		for f.oneMore() {
-			req := f.fuzzer.NextInput()
+			req := f.fuzzer.NextInput(RequestOpts{})
 			res, crash, err := proc.execute(req)
 			if err != nil {
 				return err
 			}
 			if crash != "" {
-				res = &Result{Stop: true}
+				res = &Result{Crashed: true}
 				if !f.expectedCrashes[crash] {
 					return fmt.Errorf("unexpected crash: %q", crash)
 				}

--- a/pkg/fuzzer/prio_queue.go
+++ b/pkg/fuzzer/prio_queue.go
@@ -52,8 +52,20 @@ func (pq *priorityQueue[T]) push(item *priorityQueueItem[T]) {
 }
 
 func (pq *priorityQueue[T]) tryPop() *priorityQueueItem[T] {
+	if !pq.mu.TryLock() {
+		return nil
+	}
+	defer pq.mu.Unlock()
+	return pq.popLocked()
+}
+
+func (pq *priorityQueue[T]) pop() *priorityQueueItem[T] {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
+	return pq.popLocked()
+}
+
+func (pq *priorityQueue[T]) popLocked() *priorityQueueItem[T] {
 	if len(pq.impl) == 0 {
 		return nil
 	}

--- a/pkg/fuzzer/retry.go
+++ b/pkg/fuzzer/retry.go
@@ -1,0 +1,55 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzer
+
+import "github.com/google/syzkaller/pkg/stats"
+
+// Retryer gives a second chance to the inputs from crashed VMs.
+type Retryer struct {
+	fuzzer           FuzzerOps
+	delayed          *priorityQueue[*Request]
+	statRiskyRetries *stats.Val
+}
+
+func NewRetryer(base FuzzerOps) *Retryer {
+	ret := &Retryer{
+		fuzzer:  base,
+		delayed: makePriorityQueue[*Request](),
+		statRiskyRetries: stats.Create("risky prog reruns", "Reexecuted inputs from crashed VMs",
+			stats.Rate{}, stats.StackedGraph("prog reruns")),
+	}
+	stats.Create("risky prog queue", "Queued inputs from crashed VMs",
+		func() int {
+			return ret.delayed.Len()
+		}, stats.StackedGraph("prog reruns"))
+	return ret
+}
+
+func (retryer *Retryer) NextInput(opts RequestOpts) *Request {
+	if opts.MayRisk {
+		item := retryer.delayed.tryPop()
+		if item != nil {
+			item.value.retried = true
+			retryer.statRiskyRetries.Add(1)
+			return item.value
+		}
+	}
+	return retryer.fuzzer.NextInput(opts)
+}
+
+// No sense to let the queue grow infinitely.
+// If we're going above the limit, something is seriously wrong with the DUT.
+const retryerQueueLimit = 10000
+
+func (retryer *Retryer) Done(req *Request, res *Result) {
+	if !res.Crashed || req.noRetry || req.retried ||
+		retryer.delayed.Len() > retryerQueueLimit {
+		retryer.fuzzer.Done(req, res)
+		return
+	}
+	// Let's push without using priorities for now.
+	retryer.delayed.push(&priorityQueueItem[*Request]{
+		value: req,
+	})
+}

--- a/pkg/fuzzer/retry.go
+++ b/pkg/fuzzer/retry.go
@@ -3,39 +3,142 @@
 
 package fuzzer
 
-import "github.com/google/syzkaller/pkg/stats"
+import (
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/stats"
+	"github.com/google/syzkaller/prog"
+)
 
 // Retryer gives a second chance to the inputs from crashed VMs.
 type Retryer struct {
 	fuzzer           FuzzerOps
-	delayed          *priorityQueue[*Request]
-	statRiskyRetries *stats.Val
+	delayedFromCrash *priorityQueue[*Request]
+	delayedRisky     *priorityQueue[*Request]
+
+	statRiskyRetries   *stats.Val
+	statRiskyDiscarded *stats.Val
+	statRiskyRun       *stats.Val
+
+	mu             sync.Mutex
+	rnd            *rand.Rand
+	dangerousCalls map[*prog.Syscall]struct{}
+
+	crashEstimator
 }
 
 func NewRetryer(base FuzzerOps) *Retryer {
 	ret := &Retryer{
-		fuzzer:  base,
-		delayed: makePriorityQueue[*Request](),
-		statRiskyRetries: stats.Create("risky prog reruns", "Reexecuted inputs from crashed VMs",
+		fuzzer:           base,
+		delayedFromCrash: makePriorityQueue[*Request](),
+		delayedRisky:     makePriorityQueue[*Request](),
+
+		statRiskyRetries: stats.Create("risky prog reruns", "Reexecuted risky progs",
 			stats.Rate{}, stats.StackedGraph("prog reruns")),
+		statRiskyDiscarded: stats.Create("risky progs discarded", "Inputs deemeed too risky for execution",
+			stats.Rate{}, stats.StackedGraph("risky progs")),
+		statRiskyRun: stats.Create("risky progs run", "New risky progs",
+			stats.Rate{}, stats.StackedGraph("risky progs")),
+		rnd: rand.New(rand.NewSource(0)),
 	}
-	stats.Create("risky prog queue", "Queued inputs from crashed VMs",
+	stats.Create("risky prog queue", "Queued risky inputs",
 		func() int {
-			return ret.delayed.Len()
+			return ret.delayedRisky.Len()
 		}, stats.StackedGraph("prog reruns"))
+	stats.Create("crashed prog queue", "Queued inputs from crashed VMs",
+		func() int {
+			return ret.delayedFromCrash.Len()
+		}, stats.StackedGraph("prog reruns"))
+
+	stats.Create("risky syscalls", "Risky syscall count",
+		func() int {
+			ret.mu.Lock()
+			defer ret.mu.Unlock()
+			return len(ret.dangerousCalls)
+		}, stats.StackedGraph("risky syscalls"))
+
+	go func() {
+		i := 0
+		for range time.NewTicker(time.Minute / 2).C {
+			disabled := ret.getDangerousCalls(0.025, 750)
+			if i%2 == 0 {
+				base.SetUnsafeSyscalls(disabled)
+				ret.printCallEstimates()
+			}
+			i++
+
+			ret.mu.Lock()
+			ret.dangerousCalls = disabled
+			ret.mu.Unlock()
+		}
+	}()
 	return ret
+}
+
+func (retryer *Retryer) nextRand() float64 {
+	retryer.mu.Lock()
+	defer retryer.mu.Unlock()
+	return retryer.rnd.Float64()
 }
 
 func (retryer *Retryer) NextInput(opts RequestOpts) *Request {
 	if opts.MayRisk {
-		item := retryer.delayed.tryPop()
+		var item *priorityQueueItem[*Request]
+		if retryer.nextRand() < 0.05 {
+			// Once in 20 times, pick an item from the queue of crashed inputs.
+			item = retryer.delayedFromCrash.tryPop()
+			if item != nil {
+				item.value.retried = true
+			}
+		}
+		if item == nil {
+			// If there are no inputs from crashed VMs, look at the delayed ones.
+			// Note that we don't set retried=true since we have never executed the input yet.
+			item = retryer.delayedRisky.tryPop()
+		}
 		if item != nil {
-			item.value.retried = true
 			retryer.statRiskyRetries.Add(1)
 			return item.value
 		}
 	}
-	return retryer.fuzzer.NextInput(opts)
+
+	for attempts := 0; ; attempts++ {
+		input := retryer.fuzzer.NextInput(opts)
+		dangerous := retryer.isDangerous(input.Prog)
+		if !dangerous || opts.MayRisk {
+			if dangerous {
+				retryer.statRiskyRun.Add(1)
+			}
+			return input
+		}
+		if input.preserveProg {
+			// The input must be preserved - delay it until there comes a MayRisk=true VM.
+			retryer.toBacklog(input, false)
+		} else {
+			// Just ignore the input.
+			retryer.statRiskyDiscarded.Add(1)
+			retryer.fuzzer.Done(input, &Result{Crashed: true})
+		}
+	}
+}
+
+func (retryer *Retryer) isDangerous(p *prog.Prog) bool {
+	retryer.mu.Lock()
+	defer retryer.mu.Unlock()
+	for _, call := range p.Calls {
+		if _, ok := retryer.dangerousCalls[call.Meta]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (retryer *Retryer) SetUnsafeSyscalls(syscalls map[*prog.Syscall]struct{}) {
+	panic("not implemented")
 }
 
 // No sense to let the queue grow infinitely.
@@ -43,13 +146,127 @@ func (retryer *Retryer) NextInput(opts RequestOpts) *Request {
 const retryerQueueLimit = 10000
 
 func (retryer *Retryer) Done(req *Request, res *Result) {
-	if !res.Crashed || req.noRetry || req.retried ||
-		retryer.delayed.Len() > retryerQueueLimit {
+	if res.Crashed {
+		retryer.Avoid(req.Prog)
+		retryer.toBacklog(req, true)
+	} else {
+		retryer.OK(req.Prog)
 		retryer.fuzzer.Done(req, res)
+	}
+}
+
+func (retryer *Retryer) toBacklog(req *Request, fromCrash bool) {
+	queue := retryer.delayedRisky
+	if fromCrash {
+		queue = retryer.delayedFromCrash
+	}
+	if !req.preserveProg || req.retried || queue.Len() > retryerQueueLimit {
+		retryer.fuzzer.Done(req, &Result{Crashed: true})
 		return
 	}
-	// Let's push without using priorities for now.
-	retryer.delayed.push(&priorityQueueItem[*Request]{
-		value: req,
+	queue.push(&priorityQueueItem[*Request]{
+		value: req, prio: req.prio,
 	})
+}
+
+type crashEstimator struct {
+	mu        sync.RWMutex
+	callProbs map[*prog.Syscall]*stats.AverageValue[float64]
+}
+
+func (ce *crashEstimator) OK(p *prog.Prog) {
+	// We are okay to miss some good executions.
+	ce.save(p, 0, false)
+}
+
+func (ce *crashEstimator) Avoid(p *prog.Prog) {
+	// But all bad executions must be recorded.
+	ce.save(p, 1.0, false)
+}
+
+func (ce *crashEstimator) CrashProbability(p *prog.Prog) float64 {
+	ce.mu.RLock()
+	defer ce.mu.RUnlock()
+
+	prob := 0.0
+	for _, call := range p.Calls {
+		estimate := ce.callProbs[call.Meta]
+		if estimate == nil || estimate.Count() < 3 {
+			continue
+		}
+		value := estimate.Value()
+		if value > prob {
+			prob = value
+		}
+	}
+	return prob
+}
+
+func (ce *crashEstimator) save(p *prog.Prog, prob float64, tentative bool) {
+	if !ce.mu.TryLock() {
+		if tentative {
+			return
+		}
+		ce.mu.Lock()
+	}
+	defer ce.mu.Unlock()
+
+	if ce.callProbs == nil {
+		ce.callProbs = map[*prog.Syscall]*stats.AverageValue[float64]{}
+	}
+	for _, call := range p.Calls {
+		estimate := ce.callProbs[call.Meta]
+		if estimate == nil {
+			estimate = &stats.AverageValue[float64]{}
+			ce.callProbs[call.Meta] = estimate
+		}
+		estimate.Save(prob)
+	}
+}
+
+func (ce *crashEstimator) getDangerousCalls(cutOff float64, max int) map[*prog.Syscall]struct{} {
+	ce.mu.RLock()
+	defer ce.mu.RUnlock()
+
+	items := ce.sortedProbabilities()
+	if max > len(items)/4 {
+		max = len(items) / 4
+	}
+
+	ret := map[*prog.Syscall]struct{}{}
+	for _, item := range items {
+		if item.prob < cutOff || len(ret) == max {
+			break
+		}
+		ret[item.call] = struct{}{}
+	}
+	return ret
+}
+
+type syscallProb struct {
+	call *prog.Syscall
+	prob float64
+}
+
+func (ce *crashEstimator) sortedProbabilities() []syscallProb {
+	ce.mu.RLock()
+	var items []syscallProb
+	for key, v := range ce.callProbs {
+		items = append(items, syscallProb{key, v.Value()})
+	}
+	ce.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool { return items[i].prob > items[j].prob })
+	return items
+}
+
+// Needed for debugging.
+func (ce *crashEstimator) printCallEstimates() {
+	items := ce.sortedProbabilities()
+	const limit = 50
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	for _, info := range items {
+		log.Logf(0, "call %s: prob %.3f", info.call.Name, info.prob)
+	}
 }

--- a/pkg/stats/avg.go
+++ b/pkg/stats/avg.go
@@ -9,13 +9,19 @@ import (
 )
 
 type AverageParameter interface {
-	time.Duration
+	time.Duration | float64
 }
 
 type AverageValue[T AverageParameter] struct {
 	mu    sync.Mutex
 	total int64
 	avg   T
+}
+
+func (av *AverageValue[T]) Count() int64 {
+	av.mu.Lock()
+	defer av.mu.Unlock()
+	return av.total
 }
 
 func (av *AverageValue[T]) Value() T {

--- a/prog/prio.go
+++ b/prog/prio.go
@@ -182,10 +182,9 @@ func normalizePrio(prios [][]int32) {
 // ChooseTable allows to do a weighted choice of a syscall for a given syscall
 // based on call-to-call priorities and a set of enabled and generatable syscalls.
 type ChoiceTable struct {
-	target          *Target
-	runs            [][]int32
-	calls           []*Syscall
-	noGenerateCalls map[int]bool
+	target *Target
+	runs   [][]int32
+	calls  []*Syscall
 }
 
 func (target *Target) BuildChoiceTable(corpus []*Prog, enabled map[*Syscall]bool) *ChoiceTable {
@@ -243,11 +242,7 @@ func (target *Target) BuildChoiceTable(corpus []*Prog, enabled map[*Syscall]bool
 			run[i][j] = sum
 		}
 	}
-	return &ChoiceTable{target, run, generatableCalls, noGenerateCalls}
-}
-
-func (ct *ChoiceTable) Enabled(call int) bool {
-	return ct.Generatable(call) || ct.noGenerateCalls[call]
+	return &ChoiceTable{target, run, generatableCalls}
 }
 
 func (ct *ChoiceTable) Generatable(call int) bool {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/syzkaller/pkg/report"
 	crash_pkg "github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/repro"
+	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/stats"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
@@ -70,8 +71,10 @@ type Manager struct {
 
 	dash *dashapi.Dashboard
 
-	mu                    sync.Mutex
-	fuzzer                atomic.Pointer[fuzzer.Fuzzer]
+	mu        sync.Mutex
+	fuzzer    atomic.Pointer[fuzzer.Fuzzer]
+	fuzzerOps atomic.Value
+
 	phase                 int
 	targetEnabledSyscalls map[*prog.Syscall]bool
 
@@ -1331,7 +1334,7 @@ func (mgr *Manager) collectSyscallInfo() map[string]*corpus.CallCov {
 }
 
 func (mgr *Manager) fuzzerConnect(modules []host.KernelModule) (
-	BugFrames, map[uint32]uint32, map[uint32]uint32, error) {
+	BugFrames, map[uint32]uint32, map[uint32]uint32, signal.Signal, error) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
@@ -1355,7 +1358,14 @@ func (mgr *Manager) fuzzerConnect(modules []host.KernelModule) (
 		}
 		mgr.modulesInitialized = true
 	}
-	return frames, mgr.coverFilter, mgr.execCoverFilter, nil
+
+	var maxSignal signal.Signal
+	if fuzzer := mgr.fuzzer.Load(); fuzzer != nil {
+		// A Fuzzer object is created after the first Check() call.
+		// If there was none, there would be no collected max signal either.
+		maxSignal = fuzzer.Cover.CopyMaxSignal()
+	}
+	return frames, mgr.coverFilter, mgr.execCoverFilter, maxSignal, nil
 }
 
 func (mgr *Manager) machineChecked(features *host.Features, globFiles map[string][]string,
@@ -1397,6 +1407,7 @@ func (mgr *Manager) machineChecked(features *host.Features, globFiles map[string
 		},
 	}, rnd, mgr.target)
 	mgr.fuzzer.Store(fuzzerObj)
+	mgr.fuzzerOps.Store(fuzzer.NewRetryer(fuzzerObj))
 
 	mgr.loadCorpus()
 	go mgr.fuzzerLoop(fuzzerObj)
@@ -1404,8 +1415,11 @@ func (mgr *Manager) machineChecked(features *host.Features, globFiles map[string
 }
 
 // We need this method since we're not supposed to access Manager fields from RPCServer.
-func (mgr *Manager) getFuzzer() *fuzzer.Fuzzer {
-	return mgr.fuzzer.Load()
+func (mgr *Manager) getFuzzerOps() fuzzer.FuzzerOps {
+	if val := mgr.fuzzerOps.Load(); val != nil {
+		return val.(fuzzer.FuzzerOps)
+	}
+	return nil
 }
 
 func (mgr *Manager) fuzzerSignalRotation(fuzzer *fuzzer.Fuzzer) {
@@ -1594,6 +1608,10 @@ func (mgr *Manager) dashboardReproTasks() {
 			}
 		}
 	}
+}
+
+func (mgr *Manager) avgBootTime() time.Duration {
+	return mgr.bootTime.Value()
 }
 
 func publicWebAddr(addr string) string {


### PR DESCRIPTION
Non-finished requests at the time of a crash are dangerous because one of them is likely to crash the instance again.

Let's give these inputs one more chance, but under certain conditions:

1) The VM has been running long enough, so we may risk crashing it.
   The PR sets the restart budget to 10%.
2) Don't feed more than 1 unsafe input per 30 seconds

***

This is another way to implement #4666