### PR TITLE
prog: optimize exec format encoding

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -216,7 +216,7 @@ static int running;
 uint32 completed;
 bool is_kernel_64_bit = true;
 
-static char* input_data;
+static uint8* input_data;
 
 // Checksum kinds.
 static const uint64 arg_csum_inet = 0;
@@ -260,7 +260,7 @@ struct thread_t {
 	bool created;
 	event_t ready;
 	event_t done;
-	uint64* copyout_pos;
+	uint8* copyout_pos;
 	uint64 copyout_index;
 	bool executing;
 	int call_index;
@@ -368,7 +368,7 @@ struct feature_t {
 	void (*setup)();
 };
 
-static thread_t* schedule_call(int call_index, int call_num, uint64 copyout_index, uint64 num_args, uint64* args, uint64* pos, call_props_t call_props);
+static thread_t* schedule_call(int call_index, int call_num, uint64 copyout_index, uint64 num_args, uint64* args, uint8* pos, call_props_t call_props);
 static void handle_completion(thread_t* th);
 static void copyout_call_results(thread_t* th);
 static void write_call_output(thread_t* th, bool finished);
@@ -377,10 +377,10 @@ static void execute_call(thread_t* th);
 static void thread_create(thread_t* th, int id, bool need_coverage);
 static void thread_mmap_cover(thread_t* th);
 static void* worker_thread(void* arg);
-static uint64 read_input(uint64** input_posp, bool peek = false);
-static uint64 read_arg(uint64** input_posp);
-static uint64 read_const_arg(uint64** input_posp, uint64* size_p, uint64* bf, uint64* bf_off_p, uint64* bf_len_p);
-static uint64 read_result(uint64** input_posp);
+static uint64 read_input(uint8** input_posp, bool peek = false);
+static uint64 read_arg(uint8** input_posp);
+static uint64 read_const_arg(uint8** input_posp, uint64* size_p, uint64* bf, uint64* bf_off_p, uint64* bf_len_p);
+static uint64 read_result(uint8** input_posp);
 static uint64 swap(uint64 v, uint64 size, uint64 bf);
 static void copyin(char* addr, uint64 val, uint64 size, uint64 bf, uint64 bf_off, uint64 bf_len);
 static bool copyout(char* addr, uint64 size, uint64* res);
@@ -459,7 +459,7 @@ int main(int argc, char** argv)
 #endif
 	if (mmap_out == MAP_FAILED)
 		fail("mmap of input file failed");
-	input_data = static_cast<char*>(mmap_out);
+	input_data = static_cast<uint8*>(mmap_out);
 
 #if SYZ_EXECUTOR_USES_SHMEM
 	mmap_output(kInitialOutput);
@@ -742,7 +742,7 @@ void execute_one()
 	write_output(0); // Number of executed syscalls (updated later).
 #endif // if SYZ_EXECUTOR_USES_SHMEM
 	uint64 start = current_time_ms();
-	uint64* input_pos = (uint64*)input_data;
+	uint8* input_pos = input_data;
 
 	if (cover_collection_required()) {
 		if (!flag_threaded)
@@ -782,10 +782,11 @@ void execute_one()
 			case arg_data: {
 				uint64 size = read_input(&input_pos);
 				size &= ~(1ull << 63); // readable flag
+				uint64 padded = (size + 7) & ~7;
+				if (input_pos + padded > input_data + kMaxInput)
+					fail("data arg overflow");
 				NONFAILING(memcpy(addr, input_pos, size));
-				// Read out the data.
-				for (uint64 i = 0; i < (size + 7) / 8; i++)
-					read_input(&input_pos);
+				input_pos += padded;
 				break;
 			}
 			case arg_csum: {
@@ -950,7 +951,7 @@ void execute_one()
 	}
 }
 
-thread_t* schedule_call(int call_index, int call_num, uint64 copyout_index, uint64 num_args, uint64* args, uint64* pos, call_props_t call_props)
+thread_t* schedule_call(int call_index, int call_num, uint64 copyout_index, uint64 num_args, uint64* args, uint8* pos, call_props_t call_props)
 {
 	// Find a spare thread to execute the call.
 	int i = 0;
@@ -1421,7 +1422,7 @@ bool copyout(char* addr, uint64 size, uint64* res)
 	    });
 }
 
-uint64 read_arg(uint64** input_posp)
+uint64 read_arg(uint8** input_posp)
 {
 	uint64 typ = read_input(input_posp);
 	switch (typ) {
@@ -1464,7 +1465,7 @@ uint64 swap(uint64 v, uint64 size, uint64 bf)
 	}
 }
 
-uint64 read_const_arg(uint64** input_posp, uint64* size_p, uint64* bf_p, uint64* bf_off_p, uint64* bf_len_p)
+uint64 read_const_arg(uint8** input_posp, uint64* size_p, uint64* bf_p, uint64* bf_off_p, uint64* bf_len_p)
 {
 	uint64 meta = read_input(input_posp);
 	uint64 val = read_input(input_posp);
@@ -1478,7 +1479,7 @@ uint64 read_const_arg(uint64** input_posp, uint64* size_p, uint64* bf_p, uint64*
 	return val;
 }
 
-uint64 read_result(uint64** input_posp)
+uint64 read_result(uint8** input_posp)
 {
 	uint64 idx = read_input(input_posp);
 	uint64 op_div = read_input(input_posp);
@@ -1495,14 +1496,33 @@ uint64 read_result(uint64** input_posp)
 	return arg;
 }
 
-uint64 read_input(uint64** input_posp, bool peek)
+uint64 read_input(uint8** input_posp, bool peek)
 {
-	uint64* input_pos = *input_posp;
-	if ((char*)input_pos >= input_data + kMaxInput)
-		failmsg("input command overflows input", "pos=%p: [%p:%p)", input_pos, input_data, input_data + kMaxInput);
+	uint64 v = 0;
+	unsigned shift = 0;
+	uint8* input_pos = *input_posp;
+	for (int i = 0;; i++, shift += 7) {
+		const int maxLen = 10;
+		if (i == maxLen)
+			failmsg("varint overflow", "pos=%zu", *input_posp - input_data);
+		if (input_pos >= input_data + kMaxInput)
+			failmsg("input command overflows input", "pos=%p: [%p:%p)",
+				input_pos, input_data, input_data + kMaxInput);
+		uint8 b = *input_pos++;
+		v |= uint64(b & 0x7f) << shift;
+		if (b < 0x80) {
+			if (i == maxLen - 1 && b > 1)
+				failmsg("varint overflow", "pos=%zu", *input_posp - input_data);
+			break;
+		}
+	}
+	if (v & 1)
+		v = ~(v >> 1);
+	else
+		v = v >> 1;
 	if (!peek)
-		*input_posp = input_pos + 1;
-	return *input_pos;
+		*input_posp = input_pos;
+	return v;
 }
 
 #if SYZ_EXECUTOR_USES_SHMEM

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -782,11 +782,10 @@ void execute_one()
 			case arg_data: {
 				uint64 size = read_input(&input_pos);
 				size &= ~(1ull << 63); // readable flag
-				uint64 padded = (size + 7) & ~7;
-				if (input_pos + padded > input_data + kMaxInput)
+				if (input_pos + size > input_data + kMaxInput)
 					fail("data arg overflow");
 				NONFAILING(memcpy(addr, input_pos, size));
-				input_pos += padded;
+				input_pos += size;
 				break;
 			}
 			case arg_csum: {

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -244,7 +244,7 @@ func (ctx *context) generateProgCalls(p *prog.Prog, trace bool) ([]string, []uin
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to serialize program: %w", err)
 	}
-	decoded, err := ctx.target.DeserializeExec(exec[:progSize])
+	decoded, err := ctx.target.DeserializeExec(exec[:progSize], nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/prog/decodeexec.go
+++ b/prog/decodeexec.go
@@ -4,6 +4,7 @@
 package prog
 
 import (
+	"encoding/binary"
 	"fmt"
 	"reflect"
 )
@@ -218,15 +219,16 @@ func (dec *execDecoder) readArg() ExecArg {
 }
 
 func (dec *execDecoder) read() uint64 {
-	if len(dec.data) < 8 {
-		dec.setErr(fmt.Errorf("exec program overflow"))
-	}
 	if dec.err != nil {
 		return 0
 	}
-	v := HostEndian.Uint64(dec.data)
-	dec.data = dec.data[8:]
-	return v
+	v, n := binary.Varint(dec.data)
+	if n <= 0 {
+		dec.setErr(fmt.Errorf("exec program overflow"))
+		return 0
+	}
+	dec.data = dec.data[n:]
+	return uint64(v)
 }
 
 func (dec *execDecoder) readBlob(size uint64) []byte {

--- a/prog/decodeexec.go
+++ b/prog/decodeexec.go
@@ -232,15 +232,14 @@ func (dec *execDecoder) read() uint64 {
 }
 
 func (dec *execDecoder) readBlob(size uint64) []byte {
-	padded := (size + 7) / 8 * 8
-	if uint64(len(dec.data)) < padded {
+	if uint64(len(dec.data)) < size {
 		dec.setErr(fmt.Errorf("exec program overflow"))
 	}
 	if dec.err != nil {
 		return nil
 	}
 	data := dec.data[:size]
-	dec.data = dec.data[padded:]
+	dec.data = dec.data[size:]
 	return data
 }
 

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -399,11 +399,11 @@ func TestSerializeDeserializeRandom(t *testing.T) {
 			if ok {
 				t.Log("flaky?")
 			}
-			decoded0, err := target.DeserializeExec(data0[:n0])
+			decoded0, err := target.DeserializeExec(data0[:n0], nil)
 			if err != nil {
 				t.Fatal(err)
 			}
-			decoded1, err := target.DeserializeExec(data1[:n1])
+			decoded1, err := target.DeserializeExec(data1[:n1], nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -20,6 +20,7 @@
 package prog
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"reflect"
@@ -251,8 +252,8 @@ func (w *execContext) write(v uint64) {
 		w.eof = true
 		return
 	}
-	HostEndian.PutUint64(w.buf, v)
-	w.buf = w.buf[8:]
+	n := binary.PutVarint(w.buf, int64(v))
+	w.buf = w.buf[n:]
 }
 
 func (w *execContext) writeArg(arg Arg) {

--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -283,7 +283,7 @@ func (w *execContext) writeArg(arg Arg) {
 	case *DataArg:
 		data := a.Data()
 		if len(data) == 0 {
-			return
+			panic("writing data arg with 0 size")
 		}
 		w.write(execArgData)
 		flags := uint64(len(data))
@@ -291,16 +291,11 @@ func (w *execContext) writeArg(arg Arg) {
 			flags |= execArgDataReadable
 		}
 		w.write(flags)
-		padded := len(data)
-		if pad := 8 - len(data)%8; pad != 8 {
-			padded += pad
-		}
-		if len(w.buf) < padded {
+		if len(w.buf) < len(data) {
 			w.eof = true
 		} else {
-			copy(w.buf, data)
-			copy(w.buf[len(data):], make([]byte, 8))
-			w.buf = w.buf[padded:]
+			n := copy(w.buf, data)
+			w.buf = w.buf[n:]
 		}
 	case *UnionArg:
 		w.writeArg(a.Option)

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -88,12 +88,12 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align0(&(0x7f0000000000)={0x1, 0x2, 0x3, 0x4, 0x5})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2, 1,
-				execInstrCopyin, dataOffset + 4, execArgConst, 4, 2,
-				execInstrCopyin, dataOffset + 8, execArgConst, 1, 3,
-				execInstrCopyin, dataOffset + 10, execArgConst, 2, 4,
-				execInstrCopyin, dataOffset + 16, execArgConst, 8, 5,
-				callID("test$align0"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 2, 1,
+				execInstrCopyin, 4, execArgConst, 4, 2,
+				execInstrCopyin, 8, execArgConst, 1, 3,
+				execInstrCopyin, 10, execArgConst, 2, 4,
+				execInstrCopyin, 16, execArgConst, 8, 5,
+				callID("test$align0"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -101,12 +101,12 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align1(&(0x7f0000000000)={0x1, 0x2, 0x3, 0x4, 0x5})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2, 1,
-				execInstrCopyin, dataOffset + 2, execArgConst, 4, 2,
-				execInstrCopyin, dataOffset + 6, execArgConst, 1, 3,
-				execInstrCopyin, dataOffset + 7, execArgConst, 2, 4,
-				execInstrCopyin, dataOffset + 9, execArgConst, 8, 5,
-				callID("test$align1"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 2, 1,
+				execInstrCopyin, 2, execArgConst, 4, 2,
+				execInstrCopyin, 6, execArgConst, 1, 3,
+				execInstrCopyin, 7, execArgConst, 2, 4,
+				execInstrCopyin, 9, execArgConst, 8, 5,
+				callID("test$align1"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -114,10 +114,10 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align2(&(0x7f0000000000)={0x42, {[0x43]}, {[0x44]}})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 1, execArgConst, 2, 0x43,
-				execInstrCopyin, dataOffset + 4, execArgConst, 2, 0x44,
-				callID("test$align2"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 1, execArgConst, 2, 0x43,
+				execInstrCopyin, 4, execArgConst, 2, 0x44,
+				callID("test$align2"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -125,10 +125,10 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align3(&(0x7f0000000000)={0x42, {0x43}, {0x44}})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 1, execArgConst, 1, 0x43,
-				execInstrCopyin, dataOffset + 4, execArgConst, 1, 0x44,
-				callID("test$align3"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 1, execArgConst, 1, 0x43,
+				execInstrCopyin, 4, execArgConst, 1, 0x44,
+				callID("test$align3"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -136,10 +136,10 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align4(&(0x7f0000000000)={{0x42, 0x43}, 0x44})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 1, execArgConst, 2, 0x43,
-				execInstrCopyin, dataOffset + 4, execArgConst, 1, 0x44,
-				callID("test$align4"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 1, execArgConst, 2, 0x43,
+				execInstrCopyin, 4, execArgConst, 1, 0x44,
+				callID("test$align4"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -147,13 +147,13 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align5(&(0x7f0000000000)={{0x42, []}, {0x43, [0x44, 0x45, 0x46]}, 0x47})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 8, 0x42,
-				execInstrCopyin, dataOffset + 8, execArgConst, 8, 0x43,
-				execInstrCopyin, dataOffset + 16, execArgConst, 2, 0x44,
-				execInstrCopyin, dataOffset + 18, execArgConst, 2, 0x45,
-				execInstrCopyin, dataOffset + 20, execArgConst, 2, 0x46,
-				execInstrCopyin, dataOffset + 22, execArgConst, 1, 0x47,
-				callID("test$align5"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 8, 0x42,
+				execInstrCopyin, 8, execArgConst, 8, 0x43,
+				execInstrCopyin, 16, execArgConst, 2, 0x44,
+				execInstrCopyin, 18, execArgConst, 2, 0x45,
+				execInstrCopyin, 20, execArgConst, 2, 0x46,
+				execInstrCopyin, 22, execArgConst, 1, 0x47,
+				callID("test$align5"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -161,9 +161,9 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align6(&(0x7f0000000000)={0x42, [0x43]})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 4, execArgConst, 4, 0x43,
-				callID("test$align6"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 4, execArgConst, 4, 0x43,
+				callID("test$align6"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -171,9 +171,9 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$union0(&(0x7f0000000000)={0x1, @f2=0x2})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 8, 1,
-				execInstrCopyin, dataOffset + 8, execArgConst, 1, 2,
-				callID("test$union0"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 8, 1,
+				execInstrCopyin, 8, execArgConst, 1, 2,
+				callID("test$union0"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -181,9 +181,9 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$union1(&(0x7f0000000000)={@f1=0x42, 0x43})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 4, 0x42,
-				execInstrCopyin, dataOffset + 8, execArgConst, 1, 0x43,
-				callID("test$union1"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 4, 0x42,
+				execInstrCopyin, 8, execArgConst, 1, 0x43,
+				callID("test$union1"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -191,9 +191,9 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$union2(&(0x7f0000000000)={@f1=0x42, 0x43})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 4, 0x42,
-				execInstrCopyin, dataOffset + 4, execArgConst, 1, 0x43,
-				callID("test$union2"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 4, 0x42,
+				execInstrCopyin, 4, execArgConst, 1, 0x43,
+				callID("test$union2"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -201,11 +201,11 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$array0(&(0x7f0000000000)={0x1, [@f0=0x2, @f1=0x3], 0x4})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 1,
-				execInstrCopyin, dataOffset + 1, execArgConst, 2, 2,
-				execInstrCopyin, dataOffset + 3, execArgConst, 8, 3,
-				execInstrCopyin, dataOffset + 11, execArgConst, 8, 4,
-				callID("test$array0"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 1,
+				execInstrCopyin, 1, execArgConst, 2, 2,
+				execInstrCopyin, 3, execArgConst, 8, 3,
+				execInstrCopyin, 11, execArgConst, 8, 4,
+				callID("test$array0"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -213,9 +213,9 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$array1(&(0x7f0000000000)={0x42, \"0102030405\"})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 1, execArgData, 5, []byte{0x01, 0x02, 0x03, 0x04, 0x05},
-				callID("test$array1"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 1, execArgData, 5, []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+				callID("test$array1"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -223,15 +223,15 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$array2(&(0x7f0000000000)={0x42, \"aaaaaaaabbbbbbbbccccccccdddddddd\", 0x43})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2, 0x42,
-				execInstrCopyin, dataOffset + 2, execArgData, 16, []byte{
+				execInstrCopyin, 0, execArgConst, 2, 0x42,
+				execInstrCopyin, 2, execArgData, 16, []byte{
 					0xaa, 0xaa, 0xaa, 0xaa,
 					0xbb, 0xbb, 0xbb, 0xbb,
 					0xcc, 0xcc, 0xcc, 0xcc,
 					0xdd, 0xdd, 0xdd, 0xdd,
 				},
-				execInstrCopyin, dataOffset + 18, execArgConst, 2, 0x43,
-				callID("test$array2"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 18, execArgConst, 2, 0x43,
+				callID("test$array2"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -239,11 +239,11 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$end0(&(0x7f0000000000)={0x42, 0x42, 0x42, 0x42})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1, 0x42,
-				execInstrCopyin, dataOffset + 1, execArgConst, 2 | 1<<8, 0x42,
-				execInstrCopyin, dataOffset + 3, execArgConst, 4 | 1<<8, 0x42,
-				execInstrCopyin, dataOffset + 7, execArgConst, 8 | 1<<8, 0x42,
-				callID("test$end0"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1, 0x42,
+				execInstrCopyin, 1, execArgConst, 2 | 1<<8, 0x42,
+				execInstrCopyin, 3, execArgConst, 4 | 1<<8, 0x42,
+				execInstrCopyin, 7, execArgConst, 8 | 1<<8, 0x42,
+				callID("test$end0"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -251,10 +251,10 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$end1(&(0x7f0000000000)={0xe, 0x42, 0x1})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2 | 1<<8, 0xe,
-				execInstrCopyin, dataOffset + 2, execArgConst, 4 | 1<<8, 0x42,
-				execInstrCopyin, dataOffset + 6, execArgConst, 8 | 1<<8, 0x1,
-				callID("test$end1"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 2 | 1<<8, 0xe,
+				execInstrCopyin, 2, execArgConst, 4 | 1<<8, 0x42,
+				execInstrCopyin, 6, execArgConst, 8 | 1<<8, 0x1,
+				callID("test$end1"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -262,15 +262,15 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$bf0(&(0x7f0000000000)={0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2 | 0<<16 | 10<<24, 0x42,
-				execInstrCopyin, dataOffset + 8, execArgConst, 8, 0x42,
-				execInstrCopyin, dataOffset + 16, execArgConst, 2 | 0<<16 | 5<<24, 0x42,
-				execInstrCopyin, dataOffset + 16, execArgConst, 2 | 5<<16 | 6<<24, 0x42,
-				execInstrCopyin, dataOffset + 16, execArgConst, 4 | 11<<16 | 15<<24, 0x42,
-				execInstrCopyin, dataOffset + 20, execArgConst, 2 | 0<<16 | 11<<24, 0x42,
-				execInstrCopyin, dataOffset + 22, execArgConst, 2 | 1<<8 | 0<<16 | 11<<24, 0x42,
-				execInstrCopyin, dataOffset + 24, execArgConst, 1, 0x42,
-				callID("test$bf0"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 2 | 0<<16 | 10<<24, 0x42,
+				execInstrCopyin, 8, execArgConst, 8, 0x42,
+				execInstrCopyin, 16, execArgConst, 2 | 0<<16 | 5<<24, 0x42,
+				execInstrCopyin, 16, execArgConst, 2 | 5<<16 | 6<<24, 0x42,
+				execInstrCopyin, 16, execArgConst, 4 | 11<<16 | 15<<24, 0x42,
+				execInstrCopyin, 20, execArgConst, 2 | 0<<16 | 11<<24, 0x42,
+				execInstrCopyin, 22, execArgConst, 2 | 1<<8 | 0<<16 | 11<<24, 0x42,
+				execInstrCopyin, 24, execArgConst, 1, 0x42,
+				callID("test$bf0"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			&ExecProg{
@@ -362,11 +362,11 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$bf1(&(0x7f0000000000)={{0x42, 0x42, 0x42}, 0x42})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 4 | 0<<16 | 10<<24, 0x42,
-				execInstrCopyin, dataOffset + 0, execArgConst, 4 | 10<<16 | 10<<24, 0x42,
-				execInstrCopyin, dataOffset + 0, execArgConst, 4 | 20<<16 | 10<<24, 0x42,
-				execInstrCopyin, dataOffset + 4, execArgConst, 1, 0x42,
-				callID("test$bf1"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 4 | 0<<16 | 10<<24, 0x42,
+				execInstrCopyin, 0, execArgConst, 4 | 10<<16 | 10<<24, 0x42,
+				execInstrCopyin, 0, execArgConst, 4 | 20<<16 | 10<<24, 0x42,
+				execInstrCopyin, 4, execArgConst, 1, 0x42,
+				callID("test$bf1"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -400,7 +400,7 @@ func TestSerializeForExec(t *testing.T) {
 			// NULL pointer must be encoded os 0.
 			"test$opt1(0x0)",
 			[]any{
-				callID("test$opt1"), ExecNoCopyout, 1, execArgConst, 8, 0,
+				callID("test$opt1"), ExecNoCopyout, 1, execArgAddr64, -dataOffset,
 				execInstrEOF,
 			},
 			nil,
@@ -408,14 +408,14 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$align7(&(0x7f0000000000)={{0x1, 0x2, 0x3, 0x4, 0x5, 0x6}, 0x42})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 1 | 0<<16 | 1<<24, 0x1,
-				execInstrCopyin, dataOffset + 0, execArgConst, 1 | 1<<16 | 1<<24, 0x2,
-				execInstrCopyin, dataOffset + 0, execArgConst, 1 | 2<<16 | 1<<24, 0x3,
-				execInstrCopyin, dataOffset + 0, execArgConst, 2 | 3<<16 | 1<<24, 0x4,
-				execInstrCopyin, dataOffset + 0, execArgConst, 2 | 4<<16 | 1<<24, 0x5,
-				execInstrCopyin, dataOffset + 0, execArgConst, 2 | 5<<16 | 1<<24, 0x6,
-				execInstrCopyin, dataOffset + 8, execArgConst, 1, 0x42,
-				callID("test$align7"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				execInstrCopyin, 0, execArgConst, 1 | 0<<16 | 1<<24, 0x1,
+				execInstrCopyin, 0, execArgConst, 1 | 1<<16 | 1<<24, 0x2,
+				execInstrCopyin, 0, execArgConst, 1 | 2<<16 | 1<<24, 0x3,
+				execInstrCopyin, 0, execArgConst, 2 | 3<<16 | 1<<24, 0x4,
+				execInstrCopyin, 0, execArgConst, 2 | 4<<16 | 1<<24, 0x5,
+				execInstrCopyin, 0, execArgConst, 2 | 5<<16 | 1<<24, 0x6,
+				execInstrCopyin, 8, execArgConst, 1, 0x42,
+				callID("test$align7"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
 			nil,
@@ -423,7 +423,7 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$excessive_fields1(0x0)",
 			[]any{
-				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgConst, ptrSize, 0x0,
+				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgAddr64, -dataOffset,
 				execInstrEOF,
 			},
 			nil,
@@ -431,7 +431,7 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$excessive_fields1(0xffffffffffffffff)",
 			[]any{
-				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgConst, ptrSize, uint64(0xffffffffffffffff),
+				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgAddr64, 0xffffffffffffffff - dataOffset,
 				execInstrEOF,
 			},
 			nil,
@@ -439,7 +439,7 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$excessive_fields1(0xfffffffffffffffe)",
 			[]any{
-				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgConst, ptrSize, uint64(0x9999999999999999),
+				callID("test$excessive_fields1"), ExecNoCopyout, 1, execArgAddr64, 0x9999999999999999 - dataOffset,
 				execInstrEOF,
 			},
 			nil,
@@ -447,23 +447,122 @@ func TestSerializeForExec(t *testing.T) {
 		{
 			"test$csum_ipv4_tcp(&(0x7f0000000000)={{0x0, 0x1, 0x2}, {{0x0}, \"ab\"}})",
 			[]any{
-				execInstrCopyin, dataOffset + 0, execArgConst, 2, 0x0,
-				execInstrCopyin, dataOffset + 2, execArgConst, 4 | 1<<8, 0x1,
-				execInstrCopyin, dataOffset + 6, execArgConst, 4 | 1<<8, 0x2,
-				execInstrCopyin, dataOffset + 10, execArgConst, 2, 0x0,
-				execInstrCopyin, dataOffset + 12, execArgData, 1, []byte{0xab},
-				execInstrCopyin, dataOffset + 10, execArgCsum, 2, ExecArgCsumInet, 5,
-				ExecArgCsumChunkData, dataOffset + 2, 4,
-				ExecArgCsumChunkData, dataOffset + 6, 4,
+				execInstrCopyin, 0, execArgConst, 2, 0x0,
+				execInstrCopyin, 2, execArgConst, 4 | 1<<8, 0x1,
+				execInstrCopyin, 6, execArgConst, 4 | 1<<8, 0x2,
+				execInstrCopyin, 10, execArgConst, 2, 0x0,
+				execInstrCopyin, 12, execArgData, 1, []byte{0xab},
+				execInstrCopyin, 10, execArgCsum, 2, ExecArgCsumInet, 5,
+				ExecArgCsumChunkData, 2, 4,
+				ExecArgCsumChunkData, 6, 4,
 				ExecArgCsumChunkConst, 0x0600, 2,
 				ExecArgCsumChunkConst, 0x0300, 2,
-				ExecArgCsumChunkData, dataOffset + 10, 3,
-				execInstrCopyin, dataOffset + 0, execArgCsum, 2, ExecArgCsumInet, 1,
-				ExecArgCsumChunkData, dataOffset + 0, 10,
-				callID("test$csum_ipv4_tcp"), ExecNoCopyout, 1, execArgConst, ptrSize, dataOffset,
+				ExecArgCsumChunkData, 10, 3,
+				execInstrCopyin, 0, execArgCsum, 2, ExecArgCsumInet, 1,
+				ExecArgCsumChunkData, 0, 10,
+				callID("test$csum_ipv4_tcp"), ExecNoCopyout, 1, execArgAddr64, 0,
 				execInstrEOF,
 			},
-			nil,
+			&ExecProg{
+				Calls: []ExecCall{
+					{
+						Meta:  target.SyscallMap["test$csum_ipv4_tcp"],
+						Index: ExecNoCopyout,
+						Args: []ExecArg{
+							ExecArgConst{
+								Value: dataOffset,
+								Size:  8,
+							},
+						},
+						Copyin: []ExecCopyin{
+							{
+								Addr: dataOffset,
+								Arg: ExecArgConst{
+									Value: 0,
+									Size:  2,
+								},
+							},
+							{
+								Addr: dataOffset + 2,
+								Arg: ExecArgConst{
+									Value:  1,
+									Size:   4,
+									Format: FormatBigEndian,
+								},
+							},
+							{
+								Addr: dataOffset + 6,
+								Arg: ExecArgConst{
+									Value:  2,
+									Size:   4,
+									Format: FormatBigEndian,
+								},
+							},
+							{
+								Addr: dataOffset + 10,
+								Arg: ExecArgConst{
+									Value: 0,
+									Size:  2,
+								},
+							},
+							{
+								Addr: dataOffset + 12,
+								Arg: ExecArgData{
+									Data: []byte{0xab},
+								},
+							},
+							{
+								Addr: dataOffset + 10,
+								Arg: ExecArgCsum{
+									Size: 2,
+									Kind: ExecArgCsumInet,
+									Chunks: []ExecCsumChunk{
+										{
+											Kind:  ExecArgCsumChunkData,
+											Value: dataOffset + 2,
+											Size:  4,
+										},
+										{
+											Kind:  ExecArgCsumChunkData,
+											Value: dataOffset + 6,
+											Size:  4,
+										},
+										{
+											Kind:  ExecArgCsumChunkConst,
+											Value: 0x0600,
+											Size:  2,
+										},
+										{
+											Kind:  ExecArgCsumChunkConst,
+											Value: 0x0300,
+											Size:  2,
+										},
+										{
+											Kind:  ExecArgCsumChunkData,
+											Value: dataOffset + 10,
+											Size:  3,
+										},
+									},
+								},
+							},
+							{
+								Addr: dataOffset,
+								Arg: ExecArgCsum{
+									Size: 2,
+									Kind: ExecArgCsumInet,
+									Chunks: []ExecCsumChunk{
+										{
+											Kind:  ExecArgCsumChunkData,
+											Value: dataOffset,
+											Size:  10,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			`test() (fail_nth: 3)
@@ -497,6 +596,50 @@ test() (async, rerun: 10)
 						Props: CallProps{0, true, 10},
 					},
 				},
+			},
+		},
+		{
+			`test$res3(&(0x7f0000000010)=<r0=>0x0)
+test$res1(r0)
+`,
+			[]any{
+				callID("test$res3"), ExecNoCopyout, 1, execArgAddr64, 0x10,
+				execInstrCopyout, 0, 0x10, 4,
+				callID("test$res1"), ExecNoCopyout, 1, execArgResult, 4, 0, 0, 0, 0xffff,
+				execInstrEOF,
+			},
+			&ExecProg{
+				Calls: []ExecCall{
+					{
+						Meta:  target.SyscallMap["test$res3"],
+						Index: ExecNoCopyout,
+						Args: []ExecArg{
+							ExecArgConst{
+								Value: dataOffset + 0x10,
+								Size:  8,
+							},
+						},
+						Copyout: []ExecCopyout{
+							{
+								Index: 0,
+								Addr:  dataOffset + 0x10,
+								Size:  4,
+							},
+						},
+					},
+					{
+						Meta:  target.SyscallMap["test$res1"],
+						Index: ExecNoCopyout,
+						Args: []ExecArg{
+							ExecArgResult{
+								Size:    4,
+								Index:   0,
+								Default: 0xffff,
+							},
+						},
+					},
+				},
+				Vars: []uint64{0xffff},
 			},
 		},
 	}

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -522,7 +522,6 @@ test() (async, rerun: 10)
 					want = binary.AppendVarint(want, int64(elem))
 				case []byte:
 					want = append(want, elem...)
-					want = append(want, make([]byte, ((len(elem)+7) & ^7)-len(elem))...)
 				default:
 					t.Fatalf("unexpected elem type %T %#v", e, e)
 				}

--- a/prog/test/fuzz.go
+++ b/prog/test/fuzz.go
@@ -49,7 +49,7 @@ func FuzzDeserialize(data []byte) int {
 		panic("got different data")
 	}
 	if n, err := p0.SerializeForExec(fuzzBuffer); err == nil {
-		if _, err := fuzzTarget.DeserializeExec(fuzzBuffer[:n]); err != nil {
+		if _, err := fuzzTarget.DeserializeExec(fuzzBuffer[:n], nil); err != nil {
 			panic(err)
 		}
 	}

--- a/sys/test/test.txt
+++ b/sys/test/test.txt
@@ -756,6 +756,7 @@ resource syz_res[int32]: 0xffff
 test$res0() syz_res
 test$res1(a0 syz_res)
 test$res2() fd
+test$res3(a0 ptr[out, syz_res])
 
 # ONLY_32BITS_CONST const is not present on all arches.
 # Ensure that it does not break build.


### PR DESCRIPTION
- prog: use leb128 for exec encoding
- prog: don't pad data in exec encoding
- prog: more compact exec encoding for addresses
- prog: profile what consumes space in exec encoding
