### PR TITLE
dashboard: include fix commits into terminal page JSONs

### DIFF
--- a/dashboard/app/getjson_test.go
+++ b/dashboard/app/getjson_test.go
@@ -63,7 +63,24 @@ func TestJSONAPIIntegration(t *testing.T) {
 
 	sampleFixedBugGroupDescr := []byte(`{
 	"version": 1,
-	"Bugs": null
+	"Bugs": [
+		{
+			"title": "title2",
+			"link": "/bug?extid=0267d1c87b9ed4eb5def",
+			"fix-commits": [
+				{
+					"title": "foo: fix1",
+					"repo": "git://syzkaller.org",
+					"branch": "branch10"
+				},
+				{
+					"title": "foo: fix2",
+					"repo": "git://syzkaller.org",
+					"branch": "branch10"
+				}
+			]
+		}
+	]
 }`)
 
 	c := NewCtx(t)
@@ -85,6 +102,13 @@ func TestJSONAPIIntegration(t *testing.T) {
 	checkBugPageJSONIs(c, bugReport2.ID, sampleCrashWithReproDescr)
 
 	checkBugGroupPageJSONIs(c, "/test1?json=1", sampleOpenBugGroupDescr)
+
+	c.client.ReportingUpdate(&dashapi.BugUpdate{
+		ID:         bugReport2.ID,
+		Status:     dashapi.BugStatusOpen,
+		FixCommits: []string{"foo: fix1", "foo: fix2"},
+	})
+
 	checkBugGroupPageJSONIs(c, "/test1/fixed?json=1", sampleFixedBugGroupDescr)
 }
 

--- a/dashboard/app/public_json_api.go
+++ b/dashboard/app/public_json_api.go
@@ -53,22 +53,7 @@ func getExtAPIDescrForBugPage(bugPage *uiBugPage) *publicAPIBugDescription {
 			}
 			return []string{bugPage.Bug.ExternalLink}
 		}(),
-		FixCommits: func() []vcsCommit {
-			if len(bugPage.Bug.Commits) == 0 {
-				return nil
-			}
-			var res []vcsCommit
-			for _, commit := range bugPage.Bug.Commits {
-				res = append(res, vcsCommit{
-					Title:  commit.Title,
-					Link:   commit.Link,
-					Hash:   commit.Hash,
-					Repo:   commit.Repo,
-					Branch: commit.Branch,
-				})
-			}
-			return res
-		}(),
+		FixCommits: getBugFixCommits(bugPage.Bug),
 		CauseCommit: func() *vcsCommit {
 			if bugPage.BisectCause == nil || bugPage.BisectCause.Commit == nil {
 				return nil
@@ -103,15 +88,30 @@ func getExtAPIDescrForBugPage(bugPage *uiBugPage) *publicAPIBugDescription {
 	}
 }
 
+func getBugFixCommits(bug *uiBug) []vcsCommit {
+	var res []vcsCommit
+	for _, commit := range bug.Commits {
+		res = append(res, vcsCommit{
+			Title:  commit.Title,
+			Link:   commit.Link,
+			Hash:   commit.Hash,
+			Repo:   commit.Repo,
+			Branch: commit.Branch,
+		})
+	}
+	return res
+}
+
 type publicAPIBugGroup struct {
 	Version int `json:"version"`
 	Bugs    []publicAPIBug
 }
 
 type publicAPIBug struct {
-	Title       string `json:"title,omitempty"`
-	Link        string `json:"link"`
-	LastUpdated string `json:"last-updated,omitempty"`
+	Title       string      `json:"title,omitempty"`
+	Link        string      `json:"link"`
+	LastUpdated string      `json:"last-updated,omitempty"`
+	FixCommits  []vcsCommit `json:"fix-commits,omitempty"`
 }
 
 func getExtAPIDescrForBugGroups(bugGroups []*uiBugGroup) *publicAPIBugGroup {
@@ -122,8 +122,9 @@ func getExtAPIDescrForBugGroups(bugGroups []*uiBugGroup) *publicAPIBugGroup {
 			for _, group := range bugGroups {
 				for _, bug := range group.Bugs {
 					res = append(res, publicAPIBug{
-						Title: bug.Title,
-						Link:  bug.Link,
+						Title:      bug.Title,
+						Link:       bug.Link,
+						FixCommits: getBugFixCommits(bug),
 					})
 				}
 			}


### PR DESCRIPTION
There's little sense to make users query that information in separate queries when we already have it available.
