### PR TITLE
pkg/ipc: refactor rate limiting

### DIFF
--- a/pkg/ipc/ipcconfig/ipcconfig.go
+++ b/pkg/ipc/ipcconfig/ipcconfig.go
@@ -41,6 +41,7 @@ func Default(target *prog.Target) (*ipc.Config, *ipc.ExecOpts, error) {
 	c.Flags |= sandboxFlags
 	c.UseShmem = sysTarget.ExecutorUsesShmem
 	c.UseForkServer = sysTarget.ExecutorUsesForkServer
+	c.RateLimit = sysTarget.HostFuzzer && target.OS != targets.TestOS
 	opts := &ipc.ExecOpts{
 		Flags: ipc.FlagDedupCover,
 	}

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -93,7 +93,7 @@ func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog) *ipc.ProgInfo {
 		var hanged bool
 		// On a heavily loaded VM, syz-executor may take significant time to start.
 		// Let's do it outside of the gate ticket.
-		err := proc.env.RestartIfNeeded(p.Target)
+		err := proc.env.RestartIfNeeded()
 		if err == nil {
 			// Limit concurrency.
 			ticket := proc.tool.gate.Enter()


### PR DESCRIPTION
1. Move the flag to Config (logically belongs there).
2. Create rate limter lazily (it's not needed most of the time).

This will help to stop passing *prog.Prog to Exec method.
