### PR TITLE
Send exec encoded programs to the fuzzer

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -759,6 +759,7 @@ void execute_one()
 	call_props_t call_props;
 	memset(&call_props, 0, sizeof(call_props));
 
+	read_input(&input_pos); // total number of calls
 	for (;;) {
 		uint64 call_num = read_input(&input_pos);
 		if (call_num == instr_eof)

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -239,12 +239,11 @@ func (ctx *context) generateSyscallDefines() string {
 }
 
 func (ctx *context) generateProgCalls(p *prog.Prog, trace bool) ([]string, []uint64, error) {
-	exec := make([]byte, prog.ExecBufferSize)
-	progSize, err := p.SerializeForExec(exec)
+	exec, err := p.SerializeForExec()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to serialize program: %w", err)
 	}
-	decoded, err := ctx.target.DeserializeExec(exec[:progSize], nil)
+	decoded, err := ctx.target.DeserializeExec(exec, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/rpctype/rpc.go
+++ b/pkg/rpctype/rpc.go
@@ -110,6 +110,10 @@ func (cli *RPCClient) Call(method string, args, reply interface{}) error {
 	return cli.c.Call(method, args, reply)
 }
 
+func (cli *RPCClient) AsyncCall(method string, args interface{}) {
+	cli.c.Go(method, args, nil, nil)
+}
+
 func (cli *RPCClient) Close() {
 	cli.c.Close()
 }

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -37,8 +37,10 @@ type ExecutionRequest struct {
 
 // ExecutionResult is sent after ExecutionRequest is completed.
 type ExecutionResult struct {
-	ID   int64
-	Info ipc.ProgInfo
+	ID     int64
+	ProcID int
+	Try    int
+	Info   ipc.ProgInfo
 }
 
 // ExchangeInfoRequest is periodically sent by syz-fuzzer to syz-manager.
@@ -55,6 +57,17 @@ type ExchangeInfoReply struct {
 	Requests      []ExecutionRequest
 	NewMaxSignal  []uint32
 	DropMaxSignal []uint32
+}
+
+// ExecutingRequest is notification from the fuzzer that it started executing
+// the program ProgID. We want this request to be as small and as fast as possible
+// b/c we want it to reach manager (or at least leave the VM) before it crashes
+// executing this program.
+type ExecutingRequest struct {
+	Name   string
+	ID     int64
+	ProcID int
+	Try    int
 }
 
 // TODO: merge ExecutionRequest and ExecTask.

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -589,8 +589,8 @@ func checkCallResult(req *RunRequest, isC bool, run, call int, info *ipc.ProgInf
 		}
 		calls[callName] = true
 	} else {
-		if len(inf.Signal) == 0 {
-			return fmt.Errorf("run %v: call %v: no fallback signal", run, call)
+		if len(inf.Signal) != 0 {
+			return fmt.Errorf("run %v: call %v: got %v unwanted signal", run, call, len(inf.Signal))
 		}
 	}
 	return nil

--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -75,6 +75,7 @@ func (p *Prog) SerializeForExec() ([]byte, error) {
 		buf:    make([]byte, 0, 4<<10),
 		args:   make(map[Arg]argInfo),
 	}
+	w.write(uint64(len(p.Calls)))
 	for _, c := range p.Calls {
 		w.csumMap, w.csumUses = calcChecksumsCall(c)
 		w.serializeCall(c)

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -26,9 +26,14 @@ func TestSerializeForExecRandom(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to serialize: %v", err)
 		}
-		_, err = target.DeserializeExec(buf, sizes)
+		got, err := target.DeserializeExec(buf, sizes)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if n, err := ExecCallCount(buf); err != nil {
+			t.Fatal(err)
+		} else if n != len(got.Calls) {
+			t.Fatalf("mismatching number of calls: %v/%v", n, len(got.Calls))
 		}
 		totalSize += len(buf)
 		execSizes.Add(float64(len(buf)))
@@ -660,7 +665,7 @@ test$res1(r0)
 			if err != nil {
 				t.Fatalf("failed to serialize: %v", err)
 			}
-			var want []byte
+			want := binary.AppendVarint(nil, int64(len(p.Calls)))
 			for _, e := range test.serialized {
 				switch elem := e.(type) {
 				case uint64:

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -752,8 +752,8 @@ func TestSerializeForExecOverflow(t *testing.T) {
 				t.Fatal(err)
 			}
 			_, err = p.SerializeForExec()
-			if test.overflow && err != ErrExecBufferTooSmall {
-				t.Fatalf("want overflow but got %v", err)
+			if test.overflow && err == nil {
+				t.Fatalf("want overflow but got no error")
 			}
 			if !test.overflow && err != nil {
 				t.Fatalf("want no overflow but got %v", err)

--- a/prog/target.go
+++ b/prog/target.go
@@ -361,7 +361,7 @@ func (pg *Builder) Finalize() (*Prog, error) {
 	if err := pg.p.validate(); err != nil {
 		return nil, err
 	}
-	if _, err := pg.p.SerializeForExec(make([]byte, ExecBufferSize)); err != nil {
+	if _, err := pg.p.SerializeForExec(); err != nil {
 		return nil, err
 	}
 	p := pg.p

--- a/prog/test/fuzz.go
+++ b/prog/test/fuzz.go
@@ -48,8 +48,8 @@ func FuzzDeserialize(data []byte) int {
 	if !bytes.Equal(data0, p3.Serialize()) {
 		panic("got different data")
 	}
-	if n, err := p0.SerializeForExec(fuzzBuffer); err == nil {
-		if _, err := fuzzTarget.DeserializeExec(fuzzBuffer[:n], nil); err != nil {
+	if prodData, err := p0.SerializeForExec(); err == nil {
+		if _, err := fuzzTarget.DeserializeExec(prodData, nil); err != nil {
 			panic(err)
 		}
 	}
@@ -64,7 +64,6 @@ func FuzzParseLog(data []byte) int {
 	return 0
 }
 
-var fuzzBuffer = make([]byte, prog.ExecBufferSize)
 var fuzzTarget, fuzzChoiceTable = func() (*prog.Target, *prog.ChoiceTable) {
 	prog.Debug()
 	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)

--- a/prog/test_util.go
+++ b/prog/test_util.go
@@ -27,7 +27,6 @@ type DeserializeTest struct {
 
 func TestDeserializeHelper(t *testing.T, OS, arch string, transform func(*Target, *Prog), tests []DeserializeTest) {
 	target := InitTargetTest(t, OS, arch)
-	buf := make([]byte, ExecBufferSize)
 	for testidx, test := range tests {
 		t.Run(fmt.Sprint(testidx), func(t *testing.T) {
 			if test.StrictErr == "" {
@@ -75,7 +74,7 @@ func TestDeserializeHelper(t *testing.T, OS, arch string, transform func(*Target
 					if want != output && want != outputVerbose {
 						t.Fatalf("wrong serialized data:\n%s\nexpect:\n%s\n", outputVerbose, want)
 					}
-					p.SerializeForExec(buf)
+					p.SerializeForExec()
 				}
 			}
 		})

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -383,13 +383,10 @@ func (tool *FuzzerTool) convertExecutionResult(res executionResult) rpctype.Exec
 }
 
 func (tool *FuzzerTool) grabStats() map[string]uint64 {
-	stats := map[string]uint64{}
-	for _, proc := range tool.procs {
-		stats["executor restarts"] += atomic.SwapUint64(&proc.env.StatRestarts, 0)
+	return map[string]uint64{
+		"no exec requests": tool.noExecRequests.Swap(0),
+		"no exec duration": tool.noExecDuration.Swap(0),
 	}
-	stats["no exec requests"] = tool.noExecRequests.Swap(0)
-	stats["no exec duration"] = tool.noExecDuration.Swap(0)
-	return stats
 }
 
 func (tool *FuzzerTool) diffMaxSignal(info *ipc.ProgInfo, mask signal.Signal, maskCall int) {

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -61,11 +60,13 @@ func (proc *Proc) loop() {
 			(req.NeedCover || req.NeedSignal != rpctype.NoSignal || req.NeedHints) {
 			proc.env.ForceRestart()
 		}
-		info := proc.executeRaw(&opts, req.prog)
+		info, try := proc.executeRaw(&opts, req.ID, req.prog)
 		// Let's perform signal filtering in a separate thread to get the most
 		// exec/sec out of a syz-executor instance.
 		proc.tool.results <- executionResult{
 			ExecutionRequest: req.ExecutionRequest,
+			procID:           proc.pid,
+			try:              try,
 			info:             info,
 		}
 	}
@@ -86,7 +87,7 @@ func (proc *Proc) nextRequest() executionRequest {
 	return req
 }
 
-func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog) *ipc.ProgInfo {
+func (proc *Proc) executeRaw(opts *ipc.ExecOpts, progID int64, p *prog.Prog) (*ipc.ProgInfo, int) {
 	for try := 0; ; try++ {
 		var output []byte
 		var info *ipc.ProgInfo
@@ -97,7 +98,7 @@ func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog) *ipc.ProgInfo {
 		if err == nil {
 			// Limit concurrency.
 			ticket := proc.tool.gate.Enter()
-			proc.logProgram(p)
+			proc.tool.startExecutingCall(progID, proc.pid, try)
 			output, info, hanged, err = proc.env.Exec(opts, p)
 			proc.tool.gate.Leave(ticket)
 		}
@@ -107,9 +108,8 @@ func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog) *ipc.ProgInfo {
 				// but so far we don't have a better handling than counting this.
 				// This error is observed a lot on the seeded syz_mount_image calls.
 				proc.tool.bufferTooSmall.Add(1)
-				return nil
+				return nil, try
 			}
-			proc.tool.execRetries.Add(1)
 			if try > 10 {
 				log.SyzFatalf("executor %v failed %v times: %v\n%s", proc.pid, try, err, output)
 			}
@@ -120,17 +120,6 @@ func (proc *Proc) executeRaw(opts *ipc.ExecOpts, p *prog.Prog) *ipc.ProgInfo {
 			continue
 		}
 		log.Logf(2, "result hanged=%v: %s", hanged, output)
-		return info
+		return info, try
 	}
-}
-
-func (proc *Proc) logProgram(p *prog.Prog) {
-	// The following output helps to understand what program crashed kernel.
-	// It must not be intermixed.
-	now := time.Now()
-	data := p.Serialize()
-	proc.tool.logMu.Lock()
-	fmt.Printf("%02v:%02v:%02v executing program %v:\n%s\n",
-		now.Hour(), now.Minute(), now.Second(), proc.pid, data)
-	proc.tool.logMu.Unlock()
 }

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -272,9 +272,6 @@ func checkSimpleProgram(args *checkArgs, features *host.Features) error {
 	if args.ipcConfig.Flags&ipc.FlagSignal != 0 && len(info.Calls[0].Signal) < 2 {
 		return fmt.Errorf("got no coverage:\n%s", output)
 	}
-	if len(info.Calls[0].Signal) < 1 {
-		return fmt.Errorf("got no fallback coverage:\n%s", output)
-	}
 	return nil
 }
 

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -78,7 +78,6 @@ func (mgr *Manager) initStats() {
 	// Stats imported from the fuzzer (names must match the the fuzzer names).
 	stats.Create("executor restarts", "Number of times executor process was restarted",
 		stats.Rate{}, stats.Graph("executor"))
-	stats.Create("buffer too small", "Program serialization overflowed exec buffer", stats.NoGraph)
 	stats.Create("no exec requests", "Number of times fuzzer was stalled with no exec requests", stats.Rate{})
 	stats.Create("no exec duration", "Total duration fuzzer was stalled with no exec requests (ns/sec)", stats.Rate{})
 }

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -78,9 +78,6 @@ func (mgr *Manager) initStats() {
 	// Stats imported from the fuzzer (names must match the the fuzzer names).
 	stats.Create("executor restarts", "Number of times executor process was restarted",
 		stats.Rate{}, stats.Graph("executor"))
-	stats.Create("exec retries",
-		"Number of times a test program was restarted because the first run failed",
-		stats.Rate{}, stats.Graph("executor"))
 	stats.Create("buffer too small", "Program serialization overflowed exec buffer", stats.NoGraph)
 	stats.Create("no exec requests", "Number of times fuzzer was stalled with no exec requests", stats.Rate{})
 	stats.Create("no exec duration", "Total duration fuzzer was stalled with no exec requests (ns/sec)", stats.Rate{})

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -76,8 +76,6 @@ func (mgr *Manager) initStats() {
 		})
 
 	// Stats imported from the fuzzer (names must match the the fuzzer names).
-	stats.Create("executor restarts", "Number of times executor process was restarted",
-		stats.Rate{}, stats.Graph("executor"))
 	stats.Create("no exec requests", "Number of times fuzzer was stalled with no exec requests", stats.Rate{})
 	stats.Create("no exec duration", "Total duration fuzzer was stalled with no exec requests (ns/sec)", stats.Rate{})
 }

--- a/tools/syz-imagegen/imagegen.go
+++ b/tools/syz-imagegen/imagegen.go
@@ -825,8 +825,7 @@ func (img *Image) generateSize() error {
 	if err != nil {
 		return fmt.Errorf("failed to deserialize resulting program: %w", err)
 	}
-	exec := make([]byte, prog.ExecBufferSize)
-	if _, err := p.SerializeForExec(exec); err != nil {
+	if _, err := p.SerializeForExec(); err != nil {
 		return fmt.Errorf("failed to serialize for execution: %w", err)
 	}
 


### PR DESCRIPTION
- prog: don't require preallocated buffer for exec encoding
- syz-manager, syz-fuzzer: send RPC notifications about executing programs
- pkg/ipc: pass only exec encoding to Exec
- syz-manager, syz-fuzzer: send exec encoded programs to fuzzer
