### PR TITLE
executor fixes

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2046,8 +2046,11 @@ static long syz_usbip_server_init(volatile long a0)
 	bool usb3 = (speed == USB_SPEED_SUPER);
 
 	int socket_pair[2];
-	if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair))
-		fail("syz_usbip_server_init: socketpair failed");
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair)) {
+		// This can happen if the test calls prlimit(RLIMIT_AS).
+		debug("syz_usbip_server_init: socketpair failed (%d)\n", errno);
+		return -1;
+	}
 
 	int client_fd = socket_pair[0];
 	int server_fd = socket_pair[1];

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -1749,8 +1749,9 @@ static int read_tun(char* data, int size)
 
 	int rv = read(tunfd, data, size);
 	if (rv < 0) {
+		// EBADF can be returned if the test closes tunfd with close_range syscall.
 		// Tun sometimes returns EBADFD, unclear if it's a kernel bug or not.
-		if (errno == EAGAIN || errno == EBADFD)
+		if (errno == EAGAIN || errno == EBADF || errno == EBADFD)
 			return -1;
 		fail("tun read failed");
 	}

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -4479,8 +4479,10 @@ static long syz_usbip_server_init(volatile long a0)
 	bool usb3 = (speed == USB_SPEED_SUPER);
 
 	int socket_pair[2];
-	if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair))
-		fail("syz_usbip_server_init: socketpair failed");
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair)) {
+		debug("syz_usbip_server_init: socketpair failed (%d)\n", errno);
+		return -1;
+	}
 
 	int client_fd = socket_pair[0];
 	int server_fd = socket_pair[1];

--- a/pkg/csource/generated.go
+++ b/pkg/csource/generated.go
@@ -4258,7 +4258,7 @@ static int read_tun(char* data, int size)
 
 	int rv = read(tunfd, data, size);
 	if (rv < 0) {
-		if (errno == EAGAIN || errno == EBADFD)
+		if (errno == EAGAIN || errno == EBADF || errno == EBADFD)
 			return -1;
 		fail("tun read failed");
 	}


### PR DESCRIPTION
- executor: ignore socketpair error in syz_usbip_server_init
- executor: ignore EBADF when reading tun
