### PR TITLE
vm/qemu: don't use UseNewQemuImageOptions for NetBSD

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -231,11 +231,10 @@ var archConfigs = map[string]*archConfig{
 		RngDev:    "virtio-rng-pci",
 	},
 	"netbsd/amd64": {
-		Qemu:                   "qemu-system-x86_64",
-		QemuArgs:               "-enable-kvm",
-		NetDev:                 "e1000",
-		RngDev:                 "virtio-rng-pci",
-		UseNewQemuImageOptions: true,
+		Qemu:     "qemu-system-x86_64",
+		QemuArgs: "-enable-kvm",
+		NetDev:   "e1000",
+		RngDev:   "virtio-rng-pci",
 	},
 	"fuchsia/amd64": {
 		Qemu:      "qemu-system-x86_64",


### PR DESCRIPTION
It seems to bring more problems than it solves.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
