### PR TITLE
syz-manager, syz-fuzzer: pass ExecOpts in exec requests

### DIFF
--- a/executor/common_ext_test.go
+++ b/executor/common_ext_test.go
@@ -52,7 +52,7 @@ func TestCommonExt(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.Executor = bin
-	cfg.Flags |= ipc.FlagDebug
+	opts.EnvFlags |= ipc.FlagDebug
 	env, err := ipc.MakeEnv(cfg, 0)
 	if err != nil {
 		t.Fatalf("failed to create env: %v", err)

--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -285,7 +285,7 @@ func newProc(t *testing.T, target *prog.Target, executor string) *executorProc {
 		t.Fatal(err)
 	}
 	config.Executor = executor
-	config.Flags |= ipc.FlagSignal
+	execOpts.EnvFlags |= ipc.FlagSignal
 	env, err := ipc.MakeEnv(config, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -303,10 +303,10 @@ func (proc *executorProc) execute(req *Request) (*Result, string, error) {
 	execOpts := proc.execOpts
 	// TODO: it's duplicated from fuzzer.go.
 	if req.NeedSignal != rpctype.NoSignal {
-		execOpts.Flags |= ipc.FlagCollectSignal
+		execOpts.ExecFlags |= ipc.FlagCollectSignal
 	}
 	if req.NeedCover {
-		execOpts.Flags |= ipc.FlagCollectCover
+		execOpts.ExecFlags |= ipc.FlagCollectCover
 	}
 	// TODO: support req.NeedHints.
 	output, info, _, err := proc.env.Exec(&execOpts, req.Prog)

--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/ipc/ipcconfig"
-	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/prog"
@@ -193,7 +192,7 @@ func emulateExec(req *Request) (*Result, string, error) {
 		if req.NeedCover {
 			callInfo.Cover = []uint32{cover}
 		}
-		if req.NeedSignal != rpctype.NoSignal {
+		if req.NeedSignal != NoSignal {
 			callInfo.Signal = []uint32{cover}
 		}
 		info.Calls = append(info.Calls, callInfo)
@@ -302,7 +301,7 @@ var crashRe = regexp.MustCompile(`{{CRASH: (.*?)}}`)
 func (proc *executorProc) execute(req *Request) (*Result, string, error) {
 	execOpts := proc.execOpts
 	// TODO: it's duplicated from fuzzer.go.
-	if req.NeedSignal != rpctype.NoSignal {
+	if req.NeedSignal != NoSignal {
 		execOpts.ExecFlags |= ipc.FlagCollectSignal
 	}
 	if req.NeedCover {

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -195,12 +195,11 @@ func (job *triageJob) deflake(exec func(job, *Request) *Result, stat *stats.Val,
 			break
 		}
 		result := exec(job, &Request{
-			Prog:         job.p,
-			NeedSignal:   AllSignal,
-			NeedCover:    true,
-			NeedRawCover: rawCover,
-			stat:         stat,
-			flags:        progInTriage,
+			Prog:       job.p,
+			NeedSignal: AllSignal,
+			NeedCover:  true,
+			stat:       stat,
+			flags:      progInTriage,
 		})
 		if result.Stop {
 			stop = true

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/syzkaller/pkg/corpus"
 	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/ipc"
-	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/stats"
 	"github.com/google/syzkaller/prog"
@@ -71,7 +70,7 @@ func genProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *Request {
 		fuzzer.ChoiceTable())
 	return &Request{
 		Prog:       p,
-		NeedSignal: rpctype.NewSignal,
+		NeedSignal: NewSignal,
 		stat:       fuzzer.statExecGenerate,
 	}
 }
@@ -90,7 +89,7 @@ func mutateProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *Request {
 	)
 	return &Request{
 		Prog:       newP,
-		NeedSignal: rpctype.NewSignal,
+		NeedSignal: NewSignal,
 		stat:       fuzzer.statExecFuzz,
 	}
 }
@@ -105,7 +104,7 @@ func candidateRequest(fuzzer *Fuzzer, input Candidate) *Request {
 	}
 	return &Request{
 		Prog:       input.Prog,
-		NeedSignal: rpctype.NewSignal,
+		NeedSignal: NewSignal,
 		stat:       fuzzer.statExecCandidate,
 		flags:      flags,
 	}
@@ -197,7 +196,7 @@ func (job *triageJob) deflake(exec func(job, *Request) *Result, stat *stats.Val,
 		}
 		result := exec(job, &Request{
 			Prog:         job.p,
-			NeedSignal:   rpctype.AllSignal,
+			NeedSignal:   AllSignal,
 			NeedCover:    true,
 			NeedRawCover: rawCover,
 			stat:         stat,
@@ -238,7 +237,7 @@ func (job *triageJob) minimize(fuzzer *Fuzzer, newSignal signal.Signal) (stop bo
 			for i := 0; i < minimizeAttempts; i++ {
 				result := fuzzer.exec(job, &Request{
 					Prog:             p1,
-					NeedSignal:       rpctype.NewSignal,
+					NeedSignal:       NewSignal,
 					SignalFilter:     newSignal,
 					SignalFilterCall: call1,
 					stat:             fuzzer.statExecMinimize,
@@ -313,7 +312,7 @@ func (job *smashJob) run(fuzzer *Fuzzer) {
 			fuzzer.Config.Corpus.Programs())
 		result := fuzzer.exec(job, &Request{
 			Prog:       p,
-			NeedSignal: rpctype.NewSignal,
+			NeedSignal: NewSignal,
 			stat:       fuzzer.statExecSmash,
 		})
 		if result.Stop {
@@ -404,7 +403,7 @@ func (job *hintsJob) run(fuzzer *Fuzzer) {
 		func(p *prog.Prog) bool {
 			result := fuzzer.exec(job, &Request{
 				Prog:       p,
-				NeedSignal: rpctype.NewSignal,
+				NeedSignal: NewSignal,
 				stat:       fuzzer.statExecHint,
 			})
 			return !result.Stop

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -457,7 +457,6 @@ func (inst *inst) testRepro() ([]byte, error) {
 
 type OptionalFuzzerArgs struct {
 	Slowdown       int
-	RawCover       bool
 	SandboxArg     int
 	PprofPort      int
 	ResetAccState  bool
@@ -501,7 +500,6 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 	if args.Optional != nil {
 		flags := []tool.Flag{
 			{Name: "slowdown", Value: fmt.Sprint(args.Optional.Slowdown)},
-			{Name: "raw_cover", Value: fmt.Sprint(args.Optional.RawCover)},
 			{Name: "sandbox_arg", Value: fmt.Sprint(args.Optional.SandboxArg)},
 			{Name: "pprof_port", Value: fmt.Sprint(args.Optional.PprofPort)},
 			{Name: "reset_acc_state", Value: fmt.Sprint(args.Optional.ResetAccState)},

--- a/pkg/ipc/ipc_priv_test.go
+++ b/pkg/ipc/ipc_priv_test.go
@@ -9,11 +9,16 @@ import (
 
 func TestOutputDeadline(t *testing.T) {
 	// Run the command that leaks stderr to a child process.
-	c, err := makeCommand(1, []string{
-		"sh",
-		"-c",
-		"exec 1>&2; ( sleep 100; echo fail ) & echo done",
-	}, &Config{}, nil, nil, nil, "/tmp")
+	env := &Env{
+		bin: []string{
+			"sh",
+			"-c",
+			"exec 1>&2; ( sleep 100; echo fail ) & echo done",
+		},
+		pid:    1,
+		config: &Config{},
+	}
+	c, err := env.makeCommand(&ExecOpts{}, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -100,7 +100,6 @@ func TestExecute(t *testing.T) {
 			UseShmem:      useShmem,
 			UseForkServer: useForkServer,
 			Timeouts:      timeouts,
-			SandboxArg:    0,
 		}
 		env, err := MakeEnv(cfg, 0)
 		if err != nil {
@@ -111,7 +110,7 @@ func TestExecute(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			p := prepareTestProgram(target)
 			opts := &ExecOpts{
-				Flags: flag,
+				ExecFlags: flag,
 			}
 			output, info, hanged, err := env.Exec(opts, p)
 			if err != nil {
@@ -142,7 +141,6 @@ func TestParallel(t *testing.T) {
 		UseShmem:      useShmem,
 		UseForkServer: useForkServer,
 		Timeouts:      timeouts,
-		SandboxArg:    0,
 	}
 	const P = 10
 	errs := make(chan error, P)
@@ -204,7 +202,7 @@ func TestZlib(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg.Flags |= FlagDebug
+	opts.EnvFlags |= FlagDebug
 	cfg.Executor = buildExecutor(t, target)
 	defer os.Remove(cfg.Executor)
 	env, err := MakeEnv(cfg, 0)

--- a/pkg/ipc/ipcconfig/ipcconfig.go
+++ b/pkg/ipc/ipcconfig/ipcconfig.go
@@ -27,30 +27,30 @@ func Default(target *prog.Target) (*ipc.Config, *ipc.ExecOpts, error) {
 		Executor: *flagExecutor,
 		Timeouts: sysTarget.Timeouts(*flagSlowdown),
 	}
+	c.UseShmem = sysTarget.ExecutorUsesShmem
+	c.UseForkServer = sysTarget.ExecutorUsesForkServer
+	c.RateLimit = sysTarget.HostFuzzer && target.OS != targets.TestOS
+
+	opts := &ipc.ExecOpts{
+		ExecFlags: ipc.FlagDedupCover,
+	}
+	if *flagThreaded {
+		opts.ExecFlags |= ipc.FlagThreaded
+	}
 	if *flagSignal {
-		c.Flags |= ipc.FlagSignal
+		opts.ExecFlags |= ipc.FlagCollectSignal
+	}
+	if *flagSignal {
+		opts.EnvFlags |= ipc.FlagSignal
 	}
 	if *flagDebug {
-		c.Flags |= ipc.FlagDebug
+		opts.EnvFlags |= ipc.FlagDebug
 	}
 	sandboxFlags, err := ipc.SandboxToFlags(*flagSandbox)
 	if err != nil {
 		return nil, nil, err
 	}
-	c.SandboxArg = *flagSandboxArg
-	c.Flags |= sandboxFlags
-	c.UseShmem = sysTarget.ExecutorUsesShmem
-	c.UseForkServer = sysTarget.ExecutorUsesForkServer
-	c.RateLimit = sysTarget.HostFuzzer && target.OS != targets.TestOS
-	opts := &ipc.ExecOpts{
-		Flags: ipc.FlagDedupCover,
-	}
-	if *flagThreaded {
-		opts.Flags |= ipc.FlagThreaded
-	}
-	if *flagSignal {
-		opts.Flags |= ipc.FlagCollectSignal
-	}
-
+	opts.SandboxArg = *flagSandboxArg
+	opts.EnvFlags |= sandboxFlags
 	return c, opts, nil
 }

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -220,6 +220,10 @@ func checkNonEmpty(fields ...string) error {
 	return nil
 }
 
+func (cfg *Config) HasCovFilter() bool {
+	return len(cfg.CovFilter.Functions)+len(cfg.CovFilter.Files)+len(cfg.CovFilter.RawPCs) != 0
+}
+
 func (cfg *Config) CompleteKernelDirs() {
 	cfg.KernelObj = osutil.Abs(cfg.KernelObj)
 	if cfg.KernelSrc == "" {

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -14,14 +14,6 @@ import (
 	"github.com/google/syzkaller/pkg/signal"
 )
 
-type SignalType int
-
-const (
-	NoSignal  SignalType = 0 // we don't need any signal
-	NewSignal SignalType = 1 // we need the newly seen signal
-	AllSignal SignalType = 2 // we need all signal
-)
-
 // ExecutionRequest describes the task of executing a particular program.
 // Corresponds to Fuzzer.Request.
 type ExecutionRequest struct {

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -27,10 +27,8 @@ const (
 type ExecutionRequest struct {
 	ID               int64
 	ProgData         []byte
-	NeedCover        bool
-	NeedRawCover     bool
-	NeedHints        bool
-	NeedSignal       SignalType
+	ExecOpts         ipc.ExecOpts
+	NewSignal        bool
 	SignalFilter     signal.Signal
 	SignalFilterCall int
 }

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -67,14 +67,17 @@ type ExecTask struct {
 }
 
 type ConnectArgs struct {
-	Name string
+	Name                string
+	GitRevision         string
+	SyzRevision         string
+	ExecutorArch        string
+	ExecutorGitRevision string
+	ExecutorSyzRevision string
 }
 
 type ConnectRes struct {
-	EnabledCalls   []int
-	GitRevision    string
-	TargetRevision string
-	AllSandboxes   bool
+	EnabledCalls []int
+	AllSandboxes bool
 	// This is forwarded from CheckArgs, if checking was already done.
 	Features *host.Features
 	// Fuzzer reads these files inside of the VM and returns contents in CheckArgs.Files.

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -419,32 +419,7 @@ func (ctx *Context) createSyzTest(p *prog.Prog, sandbox string, threaded, cov bo
 		opts.ExecFlags |= ipc.FlagCollectSignal
 		opts.ExecFlags |= ipc.FlagCollectCover
 	}
-	if ctx.Features[host.FeatureExtraCoverage].Enabled {
-		opts.EnvFlags |= ipc.FlagExtraCover
-	}
-	if ctx.Features[host.FeatureDelayKcovMmap].Enabled {
-		opts.EnvFlags |= ipc.FlagDelayKcovMmap
-	}
-	if ctx.Features[host.FeatureNetInjection].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableTun
-	}
-	if ctx.Features[host.FeatureNetDevices].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableNetDev
-	}
-	opts.EnvFlags |= ipc.FlagEnableNetReset
-	opts.EnvFlags |= ipc.FlagEnableCgroups
-	if ctx.Features[host.FeatureDevlinkPCI].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableDevlinkPCI
-	}
-	if ctx.Features[host.FeatureNicVF].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableNicVF
-	}
-	if ctx.Features[host.FeatureVhciInjection].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableVhciInjection
-	}
-	if ctx.Features[host.FeatureWifiEmulation].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableWifi
-	}
+	opts.EnvFlags |= ipc.FeaturesToFlags(ctx.Features, nil)
 	if ctx.Debug {
 		opts.EnvFlags |= ipc.FlagDebug
 	}

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -410,43 +410,43 @@ func (ctx *Context) createSyzTest(p *prog.Prog, sandbox string, threaded, cov bo
 	if err != nil {
 		return nil, err
 	}
-	cfg.Flags |= sandboxFlags
+	opts.EnvFlags |= sandboxFlags
 	if threaded {
-		opts.Flags |= ipc.FlagThreaded
+		opts.ExecFlags |= ipc.FlagThreaded
 	}
 	if cov {
-		cfg.Flags |= ipc.FlagSignal
-		opts.Flags |= ipc.FlagCollectSignal
-		opts.Flags |= ipc.FlagCollectCover
+		opts.EnvFlags |= ipc.FlagSignal
+		opts.ExecFlags |= ipc.FlagCollectSignal
+		opts.ExecFlags |= ipc.FlagCollectCover
 	}
 	if ctx.Features[host.FeatureExtraCoverage].Enabled {
-		cfg.Flags |= ipc.FlagExtraCover
+		opts.EnvFlags |= ipc.FlagExtraCover
 	}
 	if ctx.Features[host.FeatureDelayKcovMmap].Enabled {
-		cfg.Flags |= ipc.FlagDelayKcovMmap
+		opts.EnvFlags |= ipc.FlagDelayKcovMmap
 	}
 	if ctx.Features[host.FeatureNetInjection].Enabled {
-		cfg.Flags |= ipc.FlagEnableTun
+		opts.EnvFlags |= ipc.FlagEnableTun
 	}
 	if ctx.Features[host.FeatureNetDevices].Enabled {
-		cfg.Flags |= ipc.FlagEnableNetDev
+		opts.EnvFlags |= ipc.FlagEnableNetDev
 	}
-	cfg.Flags |= ipc.FlagEnableNetReset
-	cfg.Flags |= ipc.FlagEnableCgroups
+	opts.EnvFlags |= ipc.FlagEnableNetReset
+	opts.EnvFlags |= ipc.FlagEnableCgroups
 	if ctx.Features[host.FeatureDevlinkPCI].Enabled {
-		cfg.Flags |= ipc.FlagEnableDevlinkPCI
+		opts.EnvFlags |= ipc.FlagEnableDevlinkPCI
 	}
 	if ctx.Features[host.FeatureNicVF].Enabled {
-		cfg.Flags |= ipc.FlagEnableNicVF
+		opts.EnvFlags |= ipc.FlagEnableNicVF
 	}
 	if ctx.Features[host.FeatureVhciInjection].Enabled {
-		cfg.Flags |= ipc.FlagEnableVhciInjection
+		opts.EnvFlags |= ipc.FlagEnableVhciInjection
 	}
 	if ctx.Features[host.FeatureWifiEmulation].Enabled {
-		cfg.Flags |= ipc.FlagEnableWifi
+		opts.EnvFlags |= ipc.FlagEnableWifi
 	}
 	if ctx.Debug {
-		cfg.Flags |= ipc.FlagDebug
+		opts.EnvFlags |= ipc.FlagDebug
 	}
 	req := &RunRequest{
 		P:      p,
@@ -504,7 +504,7 @@ func (ctx *Context) createCTest(p *prog.Prog, sandbox string, threaded bool, tim
 		P:   p,
 		Bin: bin,
 		Opts: &ipc.ExecOpts{
-			Flags: ipcFlags,
+			ExecFlags: ipcFlags,
 		},
 		Repeat: times,
 	}
@@ -547,7 +547,7 @@ func checkCallResult(req *RunRequest, isC bool, run, call int, info *ipc.ProgInf
 				// C code does not detect blocked/non-finished calls.
 				continue
 			}
-			if req.Opts.Flags&ipc.FlagThreaded == 0 {
+			if req.Opts.ExecFlags&ipc.FlagThreaded == 0 {
 				// In non-threaded mode blocked syscalls will block main thread
 				// and we won't detect blocked/unfinished syscalls.
 				continue
@@ -573,7 +573,7 @@ func checkCallResult(req *RunRequest, isC bool, run, call int, info *ipc.ProgInf
 	if isC || inf.Flags&ipc.CallExecuted == 0 {
 		return nil
 	}
-	if req.Cfg.Flags&ipc.FlagSignal != 0 {
+	if req.Opts.EnvFlags&ipc.FlagSignal != 0 {
 		// Signal is always deduplicated, so we may not get any signal
 		// on a second invocation of the same syscall.
 		// For calls that are not meant to collect synchronous coverage we

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -132,7 +132,13 @@ func main() {
 
 	log.Logf(1, "connecting to manager...")
 	a := &rpctype.ConnectArgs{
-		Name: *flagName,
+		Name:        *flagName,
+		GitRevision: prog.GitRevision,
+		SyzRevision: target.Revision,
+	}
+	a.ExecutorArch, a.ExecutorSyzRevision, a.ExecutorGitRevision, err = executorVersion(executor)
+	if err != nil {
+		log.SyzFatalf("failed to run executor version: %v ", err)
 	}
 	r := &rpctype.ConnectRes{}
 	if err := manager.Call("Manager.Connect", a, r); err != nil {
@@ -144,8 +150,6 @@ func main() {
 	}
 	var checkReq *rpctype.CheckArgs
 	if r.Features == nil {
-		checkArgs.gitRevision = r.GitRevision
-		checkArgs.targetRevision = r.TargetRevision
 		checkArgs.enabledCalls = r.EnabledCalls
 		checkArgs.allSandboxes = r.AllSandboxes
 		checkArgs.featureFlags = featureFlags

--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -59,36 +59,6 @@ type executionResult struct {
 	info   *ipc.ProgInfo
 }
 
-func createIPCConfig(features *host.Features, opts *ipc.ExecOpts) {
-	if features[host.FeatureExtraCoverage].Enabled {
-		opts.EnvFlags |= ipc.FlagExtraCover
-	}
-	if features[host.FeatureDelayKcovMmap].Enabled {
-		opts.EnvFlags |= ipc.FlagDelayKcovMmap
-	}
-	if features[host.FeatureNetInjection].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableTun
-	}
-	if features[host.FeatureNetDevices].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableNetDev
-	}
-	opts.EnvFlags |= ipc.FlagEnableNetReset
-	opts.EnvFlags |= ipc.FlagEnableCgroups
-	opts.EnvFlags |= ipc.FlagEnableCloseFds
-	if features[host.FeatureDevlinkPCI].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableDevlinkPCI
-	}
-	if features[host.FeatureNicVF].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableNicVF
-	}
-	if features[host.FeatureVhciInjection].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableVhciInjection
-	}
-	if features[host.FeatureWifiEmulation].Enabled {
-		opts.EnvFlags |= ipc.FlagEnableWifi
-	}
-}
-
 // Gate size controls how deep in the log the last executed by every proc
 // program may be. The intent is to make sure that, given the output log,
 // we always understand what was happening.
@@ -218,7 +188,7 @@ func main() {
 	for _, feat := range r.Features.Supported() {
 		log.Logf(0, "%v: %v", feat.Name, feat.Reason)
 	}
-	createIPCConfig(r.Features, execOpts)
+	execOpts.EnvFlags |= ipc.FeaturesToFlags(r.Features, nil)
 
 	if *flagRunTest {
 		runTest(target, manager, *flagName, config.Executor)

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -41,16 +41,16 @@ func (proc *Proc) loop() {
 		req := proc.nextRequest()
 		opts := *proc.execOpts
 		if req.NeedSignal == rpctype.NoSignal {
-			opts.Flags &= ^ipc.FlagCollectSignal
+			opts.ExecFlags &= ^ipc.FlagCollectSignal
 		}
 		if req.NeedCover {
-			opts.Flags |= ipc.FlagCollectCover
+			opts.ExecFlags |= ipc.FlagCollectCover
 		}
 		if req.NeedHints {
-			opts.Flags |= ipc.FlagCollectComps
+			opts.ExecFlags |= ipc.FlagCollectComps
 		}
 		if req.NeedRawCover {
-			opts.Flags &= ^ipc.FlagDedupCover
+			opts.ExecFlags &= ^ipc.FlagDedupCover
 		}
 		// Do not let too much state accumulate.
 		const restartIn = 600
@@ -93,7 +93,7 @@ func (proc *Proc) execute(opts *ipc.ExecOpts, progID int64, progData []byte) (*i
 		var hanged bool
 		// On a heavily loaded VM, syz-executor may take significant time to start.
 		// Let's do it outside of the gate ticket.
-		err := proc.env.RestartIfNeeded()
+		err := proc.env.RestartIfNeeded(opts)
 		if err == nil {
 			// Limit concurrency.
 			ticket := proc.tool.gate.Enter()

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -129,22 +129,22 @@ func checkMachine(args *checkArgs) (*rpctype.CheckArgs, error) {
 		return nil, err
 	}
 	if feat := features[host.FeatureCoverage]; !feat.Enabled &&
-		args.ipcConfig.Flags&ipc.FlagSignal != 0 {
+		args.ipcExecOpts.EnvFlags&ipc.FlagSignal != 0 {
 		return nil, fmt.Errorf("coverage is not supported (%v)", feat.Reason)
 	}
 	if feat := features[host.FeatureSandboxSetuid]; !feat.Enabled &&
-		args.ipcConfig.Flags&ipc.FlagSandboxSetuid != 0 {
+		args.ipcExecOpts.EnvFlags&ipc.FlagSandboxSetuid != 0 {
 		return nil, fmt.Errorf("sandbox=setuid is not supported (%v)", feat.Reason)
 	}
 	if feat := features[host.FeatureSandboxNamespace]; !feat.Enabled &&
-		args.ipcConfig.Flags&ipc.FlagSandboxNamespace != 0 {
+		args.ipcExecOpts.EnvFlags&ipc.FlagSandboxNamespace != 0 {
 		return nil, fmt.Errorf("sandbox=namespace is not supported (%v)", feat.Reason)
 	}
 	if feat := features[host.FeatureSandboxAndroid]; !feat.Enabled &&
-		args.ipcConfig.Flags&ipc.FlagSandboxAndroid != 0 {
+		args.ipcExecOpts.EnvFlags&ipc.FlagSandboxAndroid != 0 {
 		return nil, fmt.Errorf("sandbox=android is not supported (%v)", feat.Reason)
 	}
-	createIPCConfig(features, args.ipcConfig)
+	createIPCConfig(features, args.ipcExecOpts)
 	if err := checkSimpleProgram(args, features); err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func checkSimpleProgram(args *checkArgs, features *host.Features) error {
 	if info.Calls[0].Errno != 0 {
 		return fmt.Errorf("simple call failed: %+v\n%s", info.Calls[0], output)
 	}
-	if args.ipcConfig.Flags&ipc.FlagSignal != 0 && len(info.Calls[0].Signal) < 2 {
+	if args.ipcExecOpts.EnvFlags&ipc.FlagSignal != 0 && len(info.Calls[0].Signal) < 2 {
 		return fmt.Errorf("got no coverage:\n%s", output)
 	}
 	return nil

--- a/syz-fuzzer/testing.go
+++ b/syz-fuzzer/testing.go
@@ -144,7 +144,7 @@ func checkMachine(args *checkArgs) (*rpctype.CheckArgs, error) {
 		args.ipcExecOpts.EnvFlags&ipc.FlagSandboxAndroid != 0 {
 		return nil, fmt.Errorf("sandbox=android is not supported (%v)", feat.Reason)
 	}
-	createIPCConfig(features, args.ipcExecOpts)
+	args.ipcExecOpts.EnvFlags |= ipc.FeaturesToFlags(features, nil)
 	if err := checkSimpleProgram(args, features); err != nil {
 		return nil, err
 	}

--- a/syz-manager/covfilter.go
+++ b/syz-manager/covfilter.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (mgr *Manager) createCoverageFilter() (map[uint32]uint32, map[uint32]uint32, error) {
-	if len(mgr.cfg.CovFilter.Functions)+len(mgr.cfg.CovFilter.Files)+len(mgr.cfg.CovFilter.RawPCs) == 0 {
+	if !mgr.cfg.HasCovFilter() {
 		return nil, nil, nil
 	}
 	// Always initialize ReportGenerator because RPCServer.NewInput will need it to filter coverage.

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -814,7 +814,6 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string, injectLog <
 		Runtest:   false,
 		Optional: &instance.OptionalFuzzerArgs{
 			Slowdown:       mgr.cfg.Timeouts.Slowdown,
-			RawCover:       mgr.cfg.RawCover,
 			SandboxArg:     mgr.cfg.SandboxArg,
 			PprofPort:      inst.PprofPort(),
 			ResetAccState:  mgr.cfg.Experimental.ResetAccState,

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -443,7 +443,7 @@ func (serv *RPCServer) newRequest(runner *Runner, req *fuzzer.Request) (rpctype.
 		ID:               id,
 		ProgData:         progData,
 		ExecOpts:         serv.createExecOpts(req),
-		NewSignal:        req.NeedSignal == rpctype.NewSignal,
+		NewSignal:        req.NeedSignal == fuzzer.NewSignal,
 		SignalFilter:     signalFilter,
 		SignalFilterCall: req.SignalFilterCall,
 	}, true
@@ -471,7 +471,7 @@ func (serv *RPCServer) createExecOpts(req *fuzzer.Request) ipc.ExecOpts {
 		exec |= ipc.FlagEnableCoverageFilter
 	}
 	if serv.cfg.Cover {
-		if req.NeedSignal != rpctype.NoSignal {
+		if req.NeedSignal != fuzzer.NoSignal {
 			exec |= ipc.FlagCollectSignal
 		}
 		if req.NeedCover {

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
@@ -68,7 +67,7 @@ type Runner struct {
 	mu            sync.Mutex
 	newMaxSignal  signal.Signal
 	dropMaxSignal signal.Signal
-	nextRequestID atomic.Int64
+	nextRequestID int64
 	requests      map[int64]Request
 }
 
@@ -430,8 +429,9 @@ func (runner *Runner) newRequest(req *fuzzer.Request) (rpctype.ExecutionRequest,
 		// We don't care about specific priorities here.
 		signalFilter = signal.FromRaw(newRawSignal, 0)
 	}
-	id := runner.nextRequestID.Add(1)
 	runner.mu.Lock()
+	runner.nextRequestID++
+	id := runner.nextRequestID
 	if runner.requests != nil {
 		runner.requests[id] = Request{
 			req: req,

--- a/syz-runner/runner.go
+++ b/syz-runner/runner.go
@@ -75,7 +75,8 @@ func main() {
 		enabled[c] = true
 	}
 	if r.CheckUnsupportedCalls {
-		_, unsupported, err := host.DetectSupportedSyscalls(target, ipc.FlagsToSandbox(config.Flags), enabled)
+		sandbox := ipc.FlagsToSandbox(opts.EnvFlags)
+		_, unsupported, err := host.DetectSupportedSyscalls(target, sandbox, enabled)
 		if err != nil {
 			log.Fatalf("failed to get unsupported system calls: %v", err)
 		}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -375,38 +375,6 @@ func createConfig(target *prog.Target, features *host.Features, featuresFlags cs
 		}
 		execOpts.ExecFlags |= ipc.FlagCollectComps
 	}
-	if features[host.FeatureExtraCoverage].Enabled {
-		execOpts.EnvFlags |= ipc.FlagExtraCover
-	}
-	if features[host.FeatureDelayKcovMmap].Enabled {
-		execOpts.EnvFlags |= ipc.FlagDelayKcovMmap
-	}
-	if featuresFlags["tun"].Enabled && features[host.FeatureNetInjection].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableTun
-	}
-	if featuresFlags["net_dev"].Enabled && features[host.FeatureNetDevices].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNetDev
-	}
-	if featuresFlags["net_reset"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNetReset
-	}
-	if featuresFlags["cgroups"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableCgroups
-	}
-	if featuresFlags["close_fds"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableCloseFds
-	}
-	if featuresFlags["devlink_pci"].Enabled && features[host.FeatureDevlinkPCI].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableDevlinkPCI
-	}
-	if featuresFlags["nic_vf"].Enabled && features[host.FeatureNicVF].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNicVF
-	}
-	if featuresFlags["vhci"].Enabled && features[host.FeatureVhciInjection].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableVhciInjection
-	}
-	if featuresFlags["wifi"].Enabled && features[host.FeatureWifiEmulation].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableWifi
-	}
+	execOpts.EnvFlags |= ipc.FeaturesToFlags(features, featuresFlags)
 	return config, execOpts
 }

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -185,7 +185,7 @@ func (ctx *Context) execute(pid int, env *ipc.Env, p *prog.Prog, progIndex int) 
 	for try := 0; ; try++ {
 		output, info, hanged, err := env.ExecProg(callOpts, progData)
 		if err != nil {
-			if ctx.config.Flags&ipc.FlagDebug != 0 {
+			if ctx.execOpts.EnvFlags&ipc.FlagDebug != 0 {
 				log.Logf(0, "result: hanged=%v err=%v\n\n%s", hanged, err, output)
 			}
 			if try > 10 {
@@ -361,52 +361,52 @@ func createConfig(target *prog.Target, features *host.Features, featuresFlags cs
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	if config.Flags&ipc.FlagSignal != 0 {
-		execOpts.Flags |= ipc.FlagCollectCover
+	if execOpts.EnvFlags&ipc.FlagSignal != 0 {
+		execOpts.ExecFlags |= ipc.FlagCollectCover
 	}
 	if *flagCoverFile != "" {
-		config.Flags |= ipc.FlagSignal
-		execOpts.Flags |= ipc.FlagCollectCover
-		execOpts.Flags &^= ipc.FlagDedupCover
+		execOpts.EnvFlags |= ipc.FlagSignal
+		execOpts.ExecFlags |= ipc.FlagCollectCover
+		execOpts.ExecFlags &^= ipc.FlagDedupCover
 	}
 	if *flagHints {
-		if execOpts.Flags&ipc.FlagCollectCover != 0 {
-			execOpts.Flags ^= ipc.FlagCollectCover
+		if execOpts.ExecFlags&ipc.FlagCollectCover != 0 {
+			execOpts.ExecFlags ^= ipc.FlagCollectCover
 		}
-		execOpts.Flags |= ipc.FlagCollectComps
+		execOpts.ExecFlags |= ipc.FlagCollectComps
 	}
 	if features[host.FeatureExtraCoverage].Enabled {
-		config.Flags |= ipc.FlagExtraCover
+		execOpts.EnvFlags |= ipc.FlagExtraCover
 	}
 	if features[host.FeatureDelayKcovMmap].Enabled {
-		config.Flags |= ipc.FlagDelayKcovMmap
+		execOpts.EnvFlags |= ipc.FlagDelayKcovMmap
 	}
 	if featuresFlags["tun"].Enabled && features[host.FeatureNetInjection].Enabled {
-		config.Flags |= ipc.FlagEnableTun
+		execOpts.EnvFlags |= ipc.FlagEnableTun
 	}
 	if featuresFlags["net_dev"].Enabled && features[host.FeatureNetDevices].Enabled {
-		config.Flags |= ipc.FlagEnableNetDev
+		execOpts.EnvFlags |= ipc.FlagEnableNetDev
 	}
 	if featuresFlags["net_reset"].Enabled {
-		config.Flags |= ipc.FlagEnableNetReset
+		execOpts.EnvFlags |= ipc.FlagEnableNetReset
 	}
 	if featuresFlags["cgroups"].Enabled {
-		config.Flags |= ipc.FlagEnableCgroups
+		execOpts.EnvFlags |= ipc.FlagEnableCgroups
 	}
 	if featuresFlags["close_fds"].Enabled {
-		config.Flags |= ipc.FlagEnableCloseFds
+		execOpts.EnvFlags |= ipc.FlagEnableCloseFds
 	}
 	if featuresFlags["devlink_pci"].Enabled && features[host.FeatureDevlinkPCI].Enabled {
-		config.Flags |= ipc.FlagEnableDevlinkPCI
+		execOpts.EnvFlags |= ipc.FlagEnableDevlinkPCI
 	}
 	if featuresFlags["nic_vf"].Enabled && features[host.FeatureNicVF].Enabled {
-		config.Flags |= ipc.FlagEnableNicVF
+		execOpts.EnvFlags |= ipc.FlagEnableNicVF
 	}
 	if featuresFlags["vhci"].Enabled && features[host.FeatureVhciInjection].Enabled {
-		config.Flags |= ipc.FlagEnableVhciInjection
+		execOpts.EnvFlags |= ipc.FlagEnableVhciInjection
 	}
 	if featuresFlags["wifi"].Enabled && features[host.FeatureWifiEmulation].Enabled {
-		config.Flags |= ipc.FlagEnableWifi
+		execOpts.EnvFlags |= ipc.FlagEnableWifi
 	}
 	return config, execOpts
 }

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -221,8 +221,6 @@ func (mgr *Manager) finishRequest(name string, rep *report.Report) error {
 }
 
 func (mgr *Manager) Connect(a *rpctype.ConnectArgs, r *rpctype.ConnectRes) error {
-	r.GitRevision = prog.GitRevision
-	r.TargetRevision = mgr.cfg.Target.Revision
 	r.AllSandboxes = true
 	select {
 	case <-mgr.checkFeaturesReady:

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -150,33 +150,7 @@ func createIPCConfig(target *prog.Target, features *host.Features, featuresFlags
 	if err != nil {
 		return nil, nil, err
 	}
-	if featuresFlags["tun"].Enabled && features[host.FeatureNetInjection].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableTun
-	}
-	if featuresFlags["net_dev"].Enabled && features[host.FeatureNetDevices].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNetDev
-	}
-	if featuresFlags["net_reset"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNetReset
-	}
-	if featuresFlags["cgroups"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableCgroups
-	}
-	if featuresFlags["close_fds"].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableCloseFds
-	}
-	if featuresFlags["devlink_pci"].Enabled && features[host.FeatureDevlinkPCI].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableDevlinkPCI
-	}
-	if featuresFlags["nic_vf"].Enabled && features[host.FeatureNicVF].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableNicVF
-	}
-	if featuresFlags["vhci"].Enabled && features[host.FeatureVhciInjection].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableVhciInjection
-	}
-	if featuresFlags["wifi"].Enabled && features[host.FeatureWifiEmulation].Enabled {
-		execOpts.EnvFlags |= ipc.FlagEnableWifi
-	}
+	execOpts.EnvFlags |= ipc.FeaturesToFlags(features, featuresFlags)
 	return config, execOpts, nil
 }
 

--- a/tools/syz-stress/stress.go
+++ b/tools/syz-stress/stress.go
@@ -151,31 +151,31 @@ func createIPCConfig(target *prog.Target, features *host.Features, featuresFlags
 		return nil, nil, err
 	}
 	if featuresFlags["tun"].Enabled && features[host.FeatureNetInjection].Enabled {
-		config.Flags |= ipc.FlagEnableTun
+		execOpts.EnvFlags |= ipc.FlagEnableTun
 	}
 	if featuresFlags["net_dev"].Enabled && features[host.FeatureNetDevices].Enabled {
-		config.Flags |= ipc.FlagEnableNetDev
+		execOpts.EnvFlags |= ipc.FlagEnableNetDev
 	}
 	if featuresFlags["net_reset"].Enabled {
-		config.Flags |= ipc.FlagEnableNetReset
+		execOpts.EnvFlags |= ipc.FlagEnableNetReset
 	}
 	if featuresFlags["cgroups"].Enabled {
-		config.Flags |= ipc.FlagEnableCgroups
+		execOpts.EnvFlags |= ipc.FlagEnableCgroups
 	}
 	if featuresFlags["close_fds"].Enabled {
-		config.Flags |= ipc.FlagEnableCloseFds
+		execOpts.EnvFlags |= ipc.FlagEnableCloseFds
 	}
 	if featuresFlags["devlink_pci"].Enabled && features[host.FeatureDevlinkPCI].Enabled {
-		config.Flags |= ipc.FlagEnableDevlinkPCI
+		execOpts.EnvFlags |= ipc.FlagEnableDevlinkPCI
 	}
 	if featuresFlags["nic_vf"].Enabled && features[host.FeatureNicVF].Enabled {
-		config.Flags |= ipc.FlagEnableNicVF
+		execOpts.EnvFlags |= ipc.FlagEnableNicVF
 	}
 	if featuresFlags["vhci"].Enabled && features[host.FeatureVhciInjection].Enabled {
-		config.Flags |= ipc.FlagEnableVhciInjection
+		execOpts.EnvFlags |= ipc.FlagEnableVhciInjection
 	}
 	if featuresFlags["wifi"].Enabled && features[host.FeatureWifiEmulation].Enabled {
-		config.Flags |= ipc.FlagEnableWifi
+		execOpts.EnvFlags |= ipc.FlagEnableWifi
 	}
 	return config, execOpts, nil
 }


### PR DESCRIPTION
- syz-manager: refactor periodic goroutines
- syz-manager: untie corpus minimization from fuzzer connects
- syz-manager: refactor filtered coverage updates
- pkg/vminfo: add package
- pkg/host: move glob parsing to host
- pkg/ipc: make it possible to change EnvFlags between executions
- pkg/ipc: dedup features to flags conversion
- syz-manager: make nextRequestID non-atomic
- syz-fuzzer: minor refactoring
- pkg/mgrconfig: add HasCovFilter helper
- syz-manager, syz-fuzzer: pass ExecOpts in exec requests
- pkg/fuzzer: move Signal type from rpctype
