### PR TITLE
vm: fix logical race in a test

### DIFF
--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -329,6 +329,7 @@ var tests = []*Test{
 		Exit:         ExitNormal,
 		InjectOutput: "BUG: foo\n",
 		Body: func(outc chan []byte, errc chan error) {
+			time.Sleep(time.Second)
 			errc <- nil
 		},
 		Report: &report.Report{


### PR DESCRIPTION
Currently the inject-error test injects "BUG: foo\n"
and expects VM to fail with this error.
However, the command immidiatly exists, so it may exist
before the output is injected. In that case the test fails with:

=== NAME  TestMonitorExecution/inject-error
    vm_test.go:431: got no report

Make the command execute for a second so that output
is always injected.
