### PR TITLE
tools/docker: update old-env to Go 1.21

### DIFF
--- a/tools/docker/old-env/Dockerfile
+++ b/tools/docker/old-env/Dockerfile
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN curl https://dl.google.com/go/go1.20.11.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl https://dl.google.com/go/go1.21.9.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath
 


### PR DESCRIPTION
Go 1.22 is already released.
We try to support up 2 latest Go releases,
so we can switch to 1.21 for old-env.

Go 1.21 has a number of useful things like
new slices/maps/cmp/slog packages,
min/max builtin functions, PGO builds.
