### PR TITLE
pkg/ifuzz/arm64: explicitly use uint32 for immediates

### DIFF
--- a/pkg/ifuzz/arm64/pseudo.go
+++ b/pkg/ifuzz/arm64/pseudo.go
@@ -36,31 +36,32 @@ func makeGen(cfg *iset.Config, r *rand.Rand) *generator {
 }
 
 func (gen *generator) smcccHvc() {
-	cmd := (1 << 31) | (gen.r.Intn(2) << 30) | ((gen.r.Intn(8) & 0x3F) << 24) | (gen.r.Intn(0x10000) & 0xFFFF)
+	cmd := (uint32(1) << 31) | (uint32(gen.r.Intn(2)) << 30) |
+		(uint32(gen.r.Intn(8)&0x3F) << 24) | (uint32(gen.r.Intn(0x10000)) & 0xFFFF)
 	gen.movRegImm32(0, cmd)
-	gen.movRegImm16(1, gen.r.Intn(16))
-	gen.movRegImm16(2, gen.r.Intn(16))
-	gen.movRegImm16(3, gen.r.Intn(16))
-	gen.movRegImm16(4, gen.r.Intn(16))
+	gen.movRegImm16(1, uint32(gen.r.Intn(16)))
+	gen.movRegImm16(2, uint32(gen.r.Intn(16)))
+	gen.movRegImm16(3, uint32(gen.r.Intn(16)))
+	gen.movRegImm16(4, uint32(gen.r.Intn(16)))
 	gen.byte(0x02, 0x00, 0x00, 0xd4)
 }
 
-func (gen *generator) movRegImm32(reg, imm int) {
+func (gen *generator) movRegImm32(reg, imm uint32) {
 	gen.movRegImm16(reg, imm)
 	// Encoding `movk reg, imm16, LSL #16`.
 	upper := (imm >> 16) & 0xffff
 	opcode := uint32(0xf2a00000)
-	opcode |= uint32(upper) << 5
-	opcode |= uint32(reg & 0xf)
+	opcode |= upper << 5
+	opcode |= reg & 0xf
 	gen.imm32(opcode)
 }
 
-func (gen *generator) movRegImm16(reg, imm int) {
+func (gen *generator) movRegImm16(reg, imm uint32) {
 	// Encoding `mov reg, imm16`.
 	imm = imm & 0xffff
 	opcode := uint32(0xd2800000)
-	opcode |= uint32(imm) << 5
-	opcode |= uint32(reg & 0xf)
+	opcode |= imm << 5
+	opcode |= reg & 0xf
 	gen.imm32(opcode)
 }
 


### PR DESCRIPTION
This should fix compile-time errors with GOARCH=386

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
