### PR TITLE
syz-manager: tolerate Check() calls from unknown runners

### DIFF
--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -166,6 +166,11 @@ func (serv *RPCServer) Check(a *rpctype.CheckArgs, r *rpctype.CheckRes) error {
 	bugFrames, execCoverFilter, maxSignal := serv.mgr.fuzzerConnect()
 
 	runner := serv.findRunner(a.Name)
+	if runner == nil {
+		// There may be a parallel shutdownInstance() call that removes the runner.
+		return fmt.Errorf("unknown runner %s", a.Name)
+	}
+
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
 	if runner.machineInfo != nil {


### PR DESCRIPTION
We have seen a number of syz-manager crashes on syzbot, which have very likely been caused by a race between shutdownInstance() and Check().
