### PR TITLE
tools/syz-runtest: switch to the generic program execution 

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -459,7 +459,6 @@ type OptionalFuzzerArgs struct {
 	Slowdown       int
 	SandboxArg     int
 	PprofPort      int
-	ResetAccState  bool
 	NetCompression bool
 }
 
@@ -476,7 +475,6 @@ type FuzzerCmdArgs struct {
 	Cover     bool
 	Debug     bool
 	Test      bool
-	Runtest   bool
 	Optional  *OptionalFuzzerArgs
 }
 
@@ -488,10 +486,6 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 		// because old execprog does not have os flag.
 		osArg = " -os=" + args.OS
 	}
-	runtestArg := ""
-	if args.Runtest {
-		runtestArg = " -runtest"
-	}
 	verbosityArg := ""
 	if args.Verbosity != 0 {
 		verbosityArg = fmt.Sprintf(" -vv=%v", args.Verbosity)
@@ -502,15 +496,14 @@ func FuzzerCmd(args *FuzzerCmdArgs) string {
 			{Name: "slowdown", Value: fmt.Sprint(args.Optional.Slowdown)},
 			{Name: "sandbox_arg", Value: fmt.Sprint(args.Optional.SandboxArg)},
 			{Name: "pprof_port", Value: fmt.Sprint(args.Optional.PprofPort)},
-			{Name: "reset_acc_state", Value: fmt.Sprint(args.Optional.ResetAccState)},
 			{Name: "net_compression", Value: fmt.Sprint(args.Optional.NetCompression)},
 		}
 		optionalArg = " " + tool.OptionalFlags(flags)
 	}
 	return fmt.Sprintf("%v -executor=%v -name=%v -arch=%v%v -manager=%v -sandbox=%v"+
-		" -procs=%v -cover=%v -debug=%v -test=%v%v%v%v",
+		" -procs=%v -cover=%v -debug=%v -test=%v%v%v",
 		args.Fuzzer, args.Executor, args.Name, args.Arch, osArg, args.FwdAddr, args.Sandbox,
-		args.Procs, args.Cover, args.Debug, args.Test, runtestArg, verbosityArg, optionalArg)
+		args.Procs, args.Cover, args.Debug, args.Test, verbosityArg, optionalArg)
 }
 
 func OldFuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string, sandboxArg, procs int,
@@ -521,7 +514,7 @@ func OldFuzzerCmd(fuzzer, executor, name, OS, arch, fwdAddr, sandbox string, san
 	}
 	return FuzzerCmd(&FuzzerCmdArgs{Fuzzer: fuzzer, Executor: executor, Name: name,
 		OS: OS, Arch: arch, FwdAddr: fwdAddr, Sandbox: sandbox,
-		Procs: procs, Verbosity: 0, Cover: cover, Debug: false, Test: test, Runtest: false,
+		Procs: procs, Verbosity: 0, Cover: cover, Debug: false, Test: test,
 		Optional: optional})
 }
 

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -17,12 +17,23 @@ import (
 // ExecutionRequest describes the task of executing a particular program.
 // Corresponds to Fuzzer.Request.
 type ExecutionRequest struct {
-	ID               int64
-	ProgData         []byte
-	ExecOpts         ipc.ExecOpts
-	NewSignal        bool
+	ID        int64
+	ProgData  []byte
+	ExecOpts  ipc.ExecOpts
+	NewSignal bool
+	// If set, ProgData contains compiled executable binary
+	// that needs to be written to disk and executed.
+	IsBinary bool
+	// If set, fully reset executor state befor executing the test.
+	ResetState bool
+	// If set, collect program output and return in ExecutionResult.Output.
+	ReturnOutput bool
+	// If set, don't fail on program failures, instead return the error in ExecutionResult.Error.
+	ReturnError      bool
 	SignalFilter     signal.Signal
 	SignalFilterCall int
+	// Repeat the program that many times (0 means 1).
+	Repeat int
 }
 
 // ExecutionResult is sent after ExecutionRequest is completed.
@@ -31,6 +42,8 @@ type ExecutionResult struct {
 	ProcID int
 	Try    int
 	Info   ipc.ProgInfo
+	Output []byte
+	Error  string
 }
 
 // ExchangeInfoRequest is periodically sent by syz-fuzzer to syz-manager.
@@ -197,25 +210,4 @@ type HubInput struct {
 	// Domain of the source manager.
 	Domain string
 	Prog   []byte
-}
-
-type RunTestPollReq struct {
-	Name string
-}
-
-type RunTestPollRes struct {
-	ID     int
-	Bin    []byte
-	Prog   []byte
-	Cfg    *ipc.Config
-	Opts   *ipc.ExecOpts
-	Repeat int
-}
-
-type RunTestDoneArgs struct {
-	Name   string
-	ID     int
-	Output []byte
-	Info   []*ipc.ProgInfo
-	Error  string
 }

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -4,15 +4,18 @@
 package runtest
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/prog"
@@ -84,7 +87,11 @@ func test(t *testing.T, sysTarget *targets.Target) {
 	requests := make(chan *RunRequest, 2*runtime.GOMAXPROCS(0))
 	go func() {
 		for req := range requests {
-			RunTest(req, executor)
+			if req.Bin != "" {
+				runTestC(req)
+			} else {
+				runTest(req, executor)
+			}
 			close(req.Done)
 		}
 	}()
@@ -105,6 +112,63 @@ func test(t *testing.T, sysTarget *targets.Target) {
 	}
 	if err := ctx.Run(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func runTest(req *RunRequest, executor string) {
+	cfg := new(ipc.Config)
+	sysTarget := targets.Get(req.P.Target.OS, req.P.Target.Arch)
+	cfg.UseShmem = sysTarget.ExecutorUsesShmem
+	cfg.UseForkServer = sysTarget.ExecutorUsesForkServer
+	cfg.Timeouts = sysTarget.Timeouts(1)
+	cfg.Executor = executor
+	env, err := ipc.MakeEnv(cfg, 0)
+	if err != nil {
+		req.Err = fmt.Errorf("failed to create ipc env: %w", err)
+		return
+	}
+	defer env.Close()
+	for run := 0; run < req.Repeat; run++ {
+		if run%2 == 0 {
+			// Recreate Env every few iterations, this allows to cover more paths.
+			env.ForceRestart()
+		}
+		output, info, hanged, err := env.Exec(&req.Opts, req.P)
+		req.Output = append(req.Output, output...)
+		if err != nil {
+			req.Err = fmt.Errorf("run %v: failed to run: %w", run, err)
+			return
+		}
+		if hanged {
+			req.Err = fmt.Errorf("run %v: hanged", run)
+			return
+		}
+		if run == 0 {
+			req.Info = *info
+		} else {
+			req.Info.Calls = append(req.Info.Calls, info.Calls...)
+		}
+	}
+}
+
+func runTestC(req *RunRequest) {
+	tmpDir, err := os.MkdirTemp("", "syz-runtest")
+	if err != nil {
+		req.Err = fmt.Errorf("failed to create temp dir: %w", err)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	cmd := osutil.Command(req.Bin)
+	cmd.Dir = tmpDir
+	// Tell ASAN to not mess with our NONFAILING.
+	cmd.Env = append(append([]string{}, os.Environ()...), "ASAN_OPTIONS=handle_segv=0 allow_user_segv_handler=1")
+	req.Output, req.Err = osutil.Run(20*time.Second, cmd)
+	var verr *osutil.VerboseError
+	if errors.As(req.Err, &verr) {
+		// The process can legitimately do something like exit_group(1).
+		// So we ignore the error and rely on the rest of the checks (e.g. syscall return values).
+		req.Err = nil
+		req.Output = verr.Output
 	}
 }
 

--- a/syz-fuzzer/proc.go
+++ b/syz-fuzzer/proc.go
@@ -4,7 +4,11 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/google/syzkaller/pkg/ipc"
@@ -15,22 +19,20 @@ import (
 
 // Proc represents a single fuzzing process (executor).
 type Proc struct {
-	tool       *FuzzerTool
-	pid        int
-	env        *ipc.Env
-	resetState bool
+	tool *FuzzerTool
+	pid  int
+	env  *ipc.Env
 }
 
-func startProc(tool *FuzzerTool, pid int, config *ipc.Config, resetState bool) {
+func startProc(tool *FuzzerTool, pid int, config *ipc.Config) {
 	env, err := ipc.MakeEnv(config, pid)
 	if err != nil {
 		log.SyzFatalf("failed to create env: %v", err)
 	}
 	proc := &Proc{
-		tool:       tool,
-		pid:        pid,
-		env:        env,
-		resetState: resetState,
+		tool: tool,
+		pid:  pid,
+		env:  env,
 	}
 	go proc.loop()
 }
@@ -41,19 +43,36 @@ func (proc *Proc) loop() {
 		req := proc.nextRequest()
 		// Do not let too much state accumulate.
 		const restartIn = 600
-		if req.ExecOpts.ExecFlags&(ipc.FlagCollectSignal|ipc.FlagCollectCover|ipc.FlagCollectComps) != 0 &&
-			(proc.resetState || rnd.Intn(restartIn) == 0) {
+		if (req.ExecOpts.ExecFlags&(ipc.FlagCollectSignal|ipc.FlagCollectCover|ipc.FlagCollectComps) != 0 &&
+			rnd.Intn(restartIn) == 0) || req.ResetState {
 			proc.env.ForceRestart()
 		}
-		info, try := proc.execute(req)
-		// Let's perform signal filtering in a separate thread to get the most
-		// exec/sec out of a syz-executor instance.
-		proc.tool.results <- executionResult{
+		info, output, err, try := proc.execute(req)
+		res := executionResult{
 			ExecutionRequest: req,
 			procID:           proc.pid,
 			try:              try,
 			info:             info,
+			output:           output,
+			err:              err,
 		}
+		for i := 1; i < req.Repeat && res.err == ""; i++ {
+			// Recreate Env every few iterations, this allows to cover more paths.
+			if i%2 == 0 && !req.IsBinary {
+				proc.env.ForceRestart()
+			}
+			info, output, err, _ := proc.execute(req)
+			if res.info == nil {
+				res.info = info
+			} else {
+				res.info.Calls = append(res.info.Calls, info.Calls...)
+			}
+			res.output = append(res.output, output...)
+			res.err = err
+		}
+		// Let's perform signal filtering in a separate thread to get the most
+		// exec/sec out of a syz-executor instance.
+		proc.tool.results <- res
 	}
 }
 
@@ -72,7 +91,23 @@ func (proc *Proc) nextRequest() rpctype.ExecutionRequest {
 	return req
 }
 
-func (proc *Proc) execute(req rpctype.ExecutionRequest) (*ipc.ProgInfo, int) {
+func (proc *Proc) execute(req rpctype.ExecutionRequest) (info *ipc.ProgInfo, output []byte, errStr string, try int) {
+	var err error
+	if req.IsBinary {
+		output, err = executeBinary(req)
+	} else {
+		info, output, try, err = proc.executeProgram(req)
+	}
+	if !req.ReturnOutput {
+		output = nil
+	}
+	if err != nil {
+		errStr = err.Error()
+	}
+	return
+}
+
+func (proc *Proc) executeProgram(req rpctype.ExecutionRequest) (*ipc.ProgInfo, []byte, int, error) {
 	for try := 0; ; try++ {
 		var output []byte
 		var info *ipc.ProgInfo
@@ -86,10 +121,13 @@ func (proc *Proc) execute(req rpctype.ExecutionRequest) (*ipc.ProgInfo, int) {
 			proc.tool.startExecutingCall(req.ID, proc.pid, try)
 			output, info, hanged, err = proc.env.ExecProg(&req.ExecOpts, req.ProgData)
 			proc.tool.gate.Leave(ticket)
-			if err == nil {
-				log.Logf(2, "result hanged=%v: %s", hanged, output)
-				return info, try
+			log.Logf(2, "result hanged=%v err=%v: %s", hanged, err, output)
+			if hanged && err == nil && req.ReturnError {
+				err = errors.New("hanged")
 			}
+		}
+		if err == nil || req.ReturnError {
+			return info, output, try, err
 		}
 		log.Logf(4, "fuzzer detected executor failure='%v', retrying #%d", err, try+1)
 		if try > 10 {
@@ -98,4 +136,28 @@ func (proc *Proc) execute(req rpctype.ExecutionRequest) (*ipc.ProgInfo, int) {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
+}
+
+func executeBinary(req rpctype.ExecutionRequest) ([]byte, error) {
+	tmp, err := os.MkdirTemp("", "syz-runtest")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	bin := filepath.Join(tmp, "syz-executor")
+	if err := os.WriteFile(bin, req.ProgData, 0777); err != nil {
+		return nil, fmt.Errorf("failed to write binary: %w", err)
+	}
+	cmd := osutil.Command(bin)
+	cmd.Dir = tmp
+	// Tell ASAN to not mess with our NONFAILING.
+	cmd.Env = append(append([]string{}, os.Environ()...), "ASAN_OPTIONS=handle_segv=0 allow_user_segv_handler=1")
+	output, err := osutil.Run(20*time.Second, cmd)
+	var verr *osutil.VerboseError
+	if errors.As(err, &verr) {
+		// The process can legitimately do something like exit_group(1).
+		// So we ignore the error and rely on the rest of the checks (e.g. syscall return values).
+		return verr.Output, nil
+	}
+	return output, err
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -810,12 +810,10 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string, injectLog <
 		Cover:     mgr.cfg.Cover,
 		Debug:     *flagDebug,
 		Test:      false,
-		Runtest:   false,
 		Optional: &instance.OptionalFuzzerArgs{
 			Slowdown:       mgr.cfg.Timeouts.Slowdown,
 			SandboxArg:     mgr.cfg.SandboxArg,
 			PprofPort:      inst.PprofPort(),
-			ResetAccState:  mgr.cfg.Experimental.ResetAccState,
 			NetCompression: mgr.netCompression,
 		},
 	}

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -570,6 +570,7 @@ func (serv *RPCServer) newRequest(runner *Runner, req *fuzzer.Request) (rpctype.
 		NewSignal:        req.NeedSignal == fuzzer.NewSignal,
 		SignalFilter:     signalFilter,
 		SignalFilterCall: req.SignalFilterCall,
+		ResetState:       serv.cfg.Experimental.ResetAccState,
 	}, true
 }
 

--- a/tools/syz-runtest/empty.go
+++ b/tools/syz-runtest/empty.go
@@ -1,6 +1,0 @@
-// Copyright 2024 syzkaller project authors. All rights reserved.
-// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-
-package main
-
-func main() {}


### PR DESCRIPTION
syz-runtest effectively implemented the same execute program/return result
mechanism we use now for normal fuzzing.
So extend the general mechanism to allow collecting output/errors,
repeating program, and executing a precompiled binary as a test.
And switch syz-runtest to the general mechanism.
This removes another chunk of code from syz-fuzzer.