### PR TITLE
syz-fuzzer: set executor binary

### DIFF
--- a/syz-fuzzer/fuzzer.go
+++ b/syz-fuzzer/fuzzer.go
@@ -175,6 +175,7 @@ func main() {
 	inputsCount := *flagProcs * 2
 	fuzzerTool := &FuzzerTool{
 		name:     *flagName,
+		executor: executor,
 		manager:  manager,
 		timeouts: timeouts,
 


### PR DESCRIPTION
Currently KCSAN instances fail with:

2024/04/30 16:07:00 SYZFATAL: failed to set KCSAN filterlist: failed to start
	[ setup_kcsan_filter ...]: exec: no command
