### PR TITLE
prog: fix panic during squashing

### DIFF
--- a/pkg/compiler/gen.go
+++ b/pkg/compiler/gen.go
@@ -103,6 +103,14 @@ func (comp *compiler) genSyscalls() []*prog.Syscall {
 			calls = append(calls, comp.genSyscall(n, callArgSizes[n.CallName]))
 		}
 	}
+	// We assign SquashableElem here rather than during pointer type generation
+	// because during pointer generation recursive struct types may not be fully
+	// generated yet, thus ForeachArgType won't observe all types.
+	prog.ForeachTypePost(calls, func(typ prog.Type, ctx *prog.TypeCtx) {
+		if ptr, ok := typ.(*prog.PtrType); ok {
+			ptr.SquashableElem = isSquashableElem(ptr.Elem, ptr.ElemDir)
+		}
+	})
 	sort.Slice(calls, func(i, j int) bool {
 		return calls[i].Name < calls[j].Name
 	})

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -213,10 +213,9 @@ var typePtr = &typeDesc{
 		elem := comp.genType(args[1], 0)
 		elemDir := genDir(args[0])
 		return &prog.PtrType{
-			TypeCommon:     base.TypeCommon,
-			Elem:           elem,
-			ElemDir:        elemDir,
-			SquashableElem: isSquashableElem(elem, elemDir),
+			TypeCommon: base.TypeCommon,
+			Elem:       elem,
+			ElemDir:    elemDir,
 		}
 	},
 }

--- a/prog/any.go
+++ b/prog/any.go
@@ -175,7 +175,7 @@ func (target *Target) squashPtrImpl(a Arg, elems *[]Arg) {
 	case *GroupArg:
 		target.squashGroup(arg, elems)
 	default:
-		panic("bad arg kind")
+		panic(fmt.Sprintf("bad arg kind %v (%#v) %v", a, a, a.Type()))
 	}
 	if pad != 0 {
 		elem := target.ensureDataElem(elems)


### PR DESCRIPTION
Netbsd syzbot instance crashes trying to squash a pointer.
Pointers must not be squashed. This happens because of
recursive ucontext_t type that contains a pointer to itself.
When we assign SquashableElem recursive struct types may not be fully
generated yet, and ForeachArgType won't observe all types.
Assign SquashableElem after all types are fully generated.