### PR TITLE
pkg/report: ignore __phys_addr

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1284,6 +1284,7 @@ var linuxStackParams = &stackParams{
 		"xas_(?:start|load|find)",
 		"find_lock_entries",
 		"truncate_inode_pages_range",
+		"__phys_addr",
 	},
 	corruptedLines: []*regexp.Regexp{
 		// Fault injection stacks are frequently intermixed with crash reports.

--- a/pkg/report/testdata/linux/report/713
+++ b/pkg/report/testdata/linux/report/713
@@ -1,0 +1,89 @@
+TITLE: kernel BUG in bch2_fs_recovery
+TYPE: BUG
+FRAME: bch2_fs_recovery
+
+[   58.951094][ T5076] ------------[ cut here ]------------
+[   58.956702][ T5076] kernel BUG at arch/x86/mm/physaddr.c:23!
+[   58.962569][ T5076] invalid opcode: 0000 [#1] PREEMPT SMP KASAN PTI
+[   58.968978][ T5076] CPU: 0 PID: 5076 Comm: syz-executor151 Not tainted 6.9.0-rc6-syzkaller-00131-gf03359bca01b #0
+[   58.979378][ T5076] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 03/27/2024
+[   58.989431][ T5076] RIP: 0010:__phys_addr+0x16a/0x170
+[   58.994644][ T5076] Code: c0 75 1a 8e 4c 89 f6 4c 89 fa e8 21 d6 9d 03 e9 45 ff ff ff e8 77 60 53 00 90 0f 0b e8 6f 60 53 00 90 0f 0b e8 67 60 53 00 90 <0f> 0b 0f 1f 40 00 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90
+[   59.014250][ T5076] RSP: 0018:ffffc90002e17198 EFLAGS: 00010293
+[   59.020314][ T5076] RAX: ffffffff8142af69 RBX: 000000007ffff75e RCX: ffff888024b00000
+[   59.028276][ T5076] RDX: 0000000000000000 RSI: 000000007ffff75e RDI: 000000001fffffff
+[   59.036422][ T5076] RBP: ffffc90002e175c8 R08: ffffffff8142af05 R09: 0000000000000000
+[   59.044816][ T5076] R10: ffff88807384afe0 R11: ffffed100e7095ff R12: dffffc0000000000
+[   59.052868][ T5076] R13: fffffffffffff75e R14: 000000007ffff75e R15: ffff888073800000
+[   59.060921][ T5076] FS:  00005555669aa380(0000) GS:ffff8880b9400000(0000) knlGS:0000000000000000
+[   59.069843][ T5076] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[   59.076417][ T5076] CR2: 00007ffc12562f08 CR3: 0000000022a80000 CR4: 00000000003506f0
+[   59.084382][ T5076] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[   59.092352][ T5076] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[   59.100323][ T5076] Call Trace:
+[   59.103592][ T5076]  <TASK>
+[   59.106515][ T5076]  ? __die_body+0x88/0xe0
+[   59.110840][ T5076]  ? die+0xcf/0x110
+[   59.114643][ T5076]  ? do_trap+0x15a/0x3a0
+[   59.118880][ T5076]  ? __phys_addr+0x16a/0x170
+[   59.123463][ T5076]  ? do_error_trap+0x1dc/0x2c0
+[   59.128219][ T5076]  ? __phys_addr+0x16a/0x170
+[   59.132801][ T5076]  ? bch2_fs_recovery+0x307a/0x6390
+[   59.137993][ T5076]  ? __pfx_do_error_trap+0x10/0x10
+[   59.143112][ T5076]  ? handle_invalid_op+0x34/0x40
+[   59.148040][ T5076]  ? __phys_addr+0x16a/0x170
+[   59.152623][ T5076]  ? exc_invalid_op+0x38/0x50
+[   59.157303][ T5076]  ? asm_exc_invalid_op+0x1a/0x20
+[   59.162327][ T5076]  ? __phys_addr+0x105/0x170
+[   59.166908][ T5076]  ? __phys_addr+0x169/0x170
+[   59.171493][ T5076]  ? __phys_addr+0x16a/0x170
+[   59.176076][ T5076]  ? __phys_addr+0x169/0x170
+[   59.180661][ T5076]  ? bch2_fs_recovery+0x3166/0x6390
+[   59.185854][ T5076]  kfree+0x71/0x3a0
+[   59.189661][ T5076]  bch2_fs_recovery+0x3166/0x6390
+[   59.194686][ T5076]  ? mark_lock+0x9a/0x350
+[   59.199011][ T5076]  ? __lock_acquire+0x1346/0x1fd0
+[   59.204024][ T5076]  ? __pfx_bch2_fs_recovery+0x10/0x10
+[   59.209396][ T5076]  ? __pfx_lock_acquire+0x10/0x10
+[   59.214406][ T5076]  ? bch2_get_next_online_dev+0x48/0x4b0
+[   59.220030][ T5076]  ? __pfx_lock_release+0x10/0x10
+[   59.225044][ T5076]  ? __mutex_lock+0x2ef/0xd70
+[   59.229716][ T5076]  ? bch2_get_next_online_dev+0x48/0x4b0
+[   59.235341][ T5076]  ? bch2_get_next_online_dev+0x47f/0x4b0
+[   59.241052][ T5076]  ? bch2_get_next_online_dev+0x48/0x4b0
+[   59.246676][ T5076]  ? llist_reverse_order+0x72/0x90
+[   59.251789][ T5076]  bch2_fs_start+0x356/0x5b0
+[   59.256377][ T5076]  bch2_fs_open+0xa8d/0xdf0
+[   59.260904][ T5076]  ? __pfx_bch2_fs_open+0x10/0x10
+[   59.265929][ T5076]  ? __pfx_lockdep_hardirqs_on_prepare+0x10/0x10
+[   59.272256][ T5076]  ? __pfx_bch2_test_super+0x10/0x10
+[   59.277532][ T5076]  ? sget+0x2b8/0x620
+[   59.281504][ T5076]  ? __pfx_bch2_noset_super+0x10/0x10
+[   59.286868][ T5076]  bch2_mount+0x71d/0x1320
+[   59.291297][ T5076]  ? __pfx_bch2_mount+0x10/0x10
+[   59.296149][ T5076]  ? vfs_parse_fs_string+0x190/0x230
+[   59.301426][ T5076]  ? kfree+0x4e/0x3a0
+[   59.305404][ T5076]  ? vfs_parse_fs_string+0x190/0x230
+[   59.310679][ T5076]  ? __pfx_vfs_parse_fs_string+0x10/0x10
+[   59.316303][ T5076]  ? cap_capable+0x1b4/0x250
+[   59.320887][ T5076]  legacy_get_tree+0xee/0x190
+[   59.325554][ T5076]  ? __pfx_bch2_mount+0x10/0x10
+[   59.330395][ T5076]  vfs_get_tree+0x90/0x2a0
+[   59.334802][ T5076]  do_new_mount+0x2be/0xb40
+[   59.339425][ T5076]  ? ns_capable+0x8a/0xf0
+[   59.343749][ T5076]  ? __pfx_do_new_mount+0x10/0x10
+[   59.348844][ T5076]  __se_sys_mount+0x2d9/0x3c0
+[   59.353520][ T5076]  ? __pfx___se_sys_mount+0x10/0x10
+[   59.358731][ T5076]  ? do_syscall_64+0x102/0x240
+[   59.363583][ T5076]  ? __x64_sys_mount+0x20/0xc0
+[   59.368346][ T5076]  do_syscall_64+0xf5/0x240
+[   59.372846][ T5076]  ? clear_bhb_loop+0x35/0x90
+[   59.377520][ T5076]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   59.383406][ T5076] RIP: 0033:0x7f17e2d558ba
+[   59.387907][ T5076] Code: d8 64 89 02 48 c7 c0 ff ff ff ff eb a6 e8 5e 04 00 00 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 49 89 ca b8 a5 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 b8 ff ff ff f7 d8 64 89 01 48
+[   59.407522][ T5076] RSP: 002b:00007ffd2175f708 EFLAGS: 00000282 ORIG_RAX: 00000000000000a5
+[   59.415932][ T5076] RAX: ffffffffffffffda RBX: 00007ffd2175f720 RCX: 00007f17e2d558ba
+[   59.423895][ T5076] RDX: 0000000020000000 RSI: 0000000020011a40 RDI: 00007ffd2175f720
+[   59.431873][ T5076] RBP: 0000000000000004 R08: 00007ffd2175f760 R09: 00000000000119ff
+[   59.439850][ T5076] R10: 0000000000000000 R11: 0000000000000282 R12: 0000000000000000
+[   59.447816][ T5076] R13: 00007ffd2175f760 R14: 0000000000000003 R15: 0000000001000000


### PR DESCRIPTION
This is not the place of the actual bug.

We end up collecting too many different reports in one place: https://syzkaller.appspot.com/bug?extid=daa1128e28d3c3961cb2
