### PR TITLE
pkg/host: remove FileInfo

### DIFF
--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -7,17 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/syzkaller/pkg/flatrpc"
 )
 
-type FileInfo struct {
-	Name   string
-	Exists bool
-	Error  string
-	Data   []byte
-}
-
-func ReadFiles(files []string) []FileInfo {
-	var res []FileInfo
+func ReadFiles(files []string) []flatrpc.FileInfoT {
+	var res []flatrpc.FileInfoT
 	for _, glob := range files {
 		glob = filepath.FromSlash(glob)
 		if !strings.Contains(glob, "*") {
@@ -26,7 +21,7 @@ func ReadFiles(files []string) []FileInfo {
 		}
 		matches, err := filepath.Glob(glob)
 		if err != nil {
-			res = append(res, FileInfo{
+			res = append(res, flatrpc.FileInfoT{
 				Name:  glob,
 				Error: err.Error(),
 			})
@@ -39,13 +34,13 @@ func ReadFiles(files []string) []FileInfo {
 	return res
 }
 
-func readFile(file string) FileInfo {
+func readFile(file string) flatrpc.FileInfoT {
 	data, err := os.ReadFile(file)
 	exists, errStr := true, ""
 	if err != nil {
 		exists, errStr = !os.IsNotExist(err), err.Error()
 	}
-	return FileInfo{
+	return flatrpc.FileInfoT{
 		Name:   file,
 		Exists: exists,
 		Error:  errStr,

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/signal"
@@ -103,7 +104,7 @@ type CheckArgs struct {
 	Error    string
 	Features *host.Features
 	Globs    map[string][]string
-	Files    []host.FileInfo
+	Files    []flatrpc.FileInfoT
 }
 
 type CheckRes struct {

--- a/pkg/vminfo/linux_test.go
+++ b/pkg/vminfo/linux_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/sys/targets"
@@ -35,7 +35,7 @@ func TestLinuxSyscalls(t *testing.T) {
 		"minix", "adfs", "ufs", "sysv", "reiserfs", "ocfs2", "nilfs2",
 		"iso9660", "hpfs", "binder", "bcachefs", "",
 	}
-	files := []host.FileInfo{
+	files := []flatrpc.FileInfoT{
 		{
 			Name:   "/proc/version",
 			Exists: true,
@@ -128,7 +128,7 @@ func TestCannedCPUInfoLinux(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			files := createVirtualFilesystem([]host.FileInfo{{
+			files := createVirtualFilesystem([]flatrpc.FileInfoT{{
 				Name:   "/proc/cpuinfo",
 				Exists: true,
 				Data:   []byte(test.data),

--- a/pkg/vminfo/syscalls.go
+++ b/pkg/vminfo/syscalls.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/hash"
-	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/rpctype"
@@ -148,7 +148,7 @@ func (ctx *checkContext) startCheck() []rpctype.ExecutionRequest {
 	return progs
 }
 
-func (ctx *checkContext) finishCheck(fileInfos []host.FileInfo, progs []rpctype.ExecutionResult) (
+func (ctx *checkContext) finishCheck(fileInfos []flatrpc.FileInfoT, progs []rpctype.ExecutionResult) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
 	ctx.fs = createVirtualFilesystem(fileInfos)
 	for i := range progs {

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/google/syzkaller/pkg/cover"
-	"github.com/google/syzkaller/pkg/host"
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/rpctype"
 	"github.com/google/syzkaller/prog"
@@ -48,7 +48,7 @@ func New(cfg *mgrconfig.Config) *Checker {
 	}
 }
 
-func (checker *Checker) MachineInfo(fileInfos []host.FileInfo) ([]cover.KernelModule, []byte, error) {
+func (checker *Checker) MachineInfo(fileInfos []flatrpc.FileInfoT) ([]cover.KernelModule, []byte, error) {
 	files := createVirtualFilesystem(fileInfos)
 	modules, err := checker.parseModules(files)
 	if err != nil {
@@ -77,7 +77,7 @@ func (checker *Checker) StartCheck() ([]string, []rpctype.ExecutionRequest) {
 	return checker.checkFiles(), checker.checkContext.startCheck()
 }
 
-func (checker *Checker) FinishCheck(files []host.FileInfo, progs []rpctype.ExecutionResult) (
+func (checker *Checker) FinishCheck(files []flatrpc.FileInfoT, progs []rpctype.ExecutionResult) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
 	ctx := checker.checkContext
 	checker.checkContext = nil
@@ -94,9 +94,9 @@ type checker interface {
 	syscallCheck(*checkContext, *prog.Syscall) string
 }
 
-type filesystem map[string]host.FileInfo
+type filesystem map[string]flatrpc.FileInfoT
 
-func createVirtualFilesystem(fileInfos []host.FileInfo) filesystem {
+func createVirtualFilesystem(fileInfos []flatrpc.FileInfoT) filesystem {
 	files := make(filesystem)
 	for _, file := range fileInfos {
 		if file.Exists {

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -41,7 +42,7 @@ func TestHostMachineInfo(t *testing.T) {
 	}
 }
 
-func hostChecker(t *testing.T) (*Checker, []host.FileInfo) {
+func hostChecker(t *testing.T) (*Checker, []flatrpc.FileInfoT) {
 	cfg := testConfig(t, runtime.GOOS, runtime.GOARCH)
 	checker := New(cfg)
 	files := host.ReadFiles(checker.RequiredFiles())

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/ipc"
@@ -36,7 +37,7 @@ type RPCServer struct {
 
 	checkDone        atomic.Bool
 	checkFiles       []string
-	checkFilesInfo   []host.FileInfo
+	checkFilesInfo   []flatrpc.FileInfoT
 	checkProgs       []rpctype.ExecutionRequest
 	checkResults     []rpctype.ExecutionResult
 	needCheckResults int

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/host"
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -146,7 +147,7 @@ type Manager struct {
 	vmPool             *vm.Pool
 	checker            *vminfo.Checker
 	checkFiles         []string
-	checkFilesInfo     []host.FileInfo
+	checkFilesInfo     []flatrpc.FileInfoT
 	checkProgs         []rpctype.ExecutionRequest
 	checkResults       []rpctype.ExecutionResult
 	needCheckResults   int


### PR DESCRIPTION
Switch to flatrpc.FileInfoT instead.
In preparation for pkg/host removal and to avoid
circular dependencies in future changes.