### PR TITLE
pkg/flatrpc: refactor names

### DIFF
--- a/pkg/flatrpc/conn_test.go
+++ b/pkg/flatrpc/conn_test.go
@@ -10,23 +10,23 @@ import (
 )
 
 func TestConn(t *testing.T) {
-	connectReq := &ConnectRequestT{
+	connectReq := &ConnectRequest{
 		Name:        "foo",
 		Arch:        "arch",
 		GitRevision: "rev1",
 		SyzRevision: "rev2",
 	}
-	connectReply := &ConnectReplyT{
+	connectReply := &ConnectReply{
 		LeakFrames: []string{"foo", "bar"},
 		RaceFrames: []string{"bar", "baz"},
 		Features:   FeatureCoverage | FeatureLeak,
 		Files:      []string{"file1"},
 		Globs:      []string{"glob1"},
 	}
-	executorMsg := &ExecutorMessageT{
-		Msg: &ExecutorMessagesT{
-			Type: ExecutorMessagesExecuting,
-			Value: &ExecutingMessageT{
+	executorMsg := &ExecutorMessage{
+		Msg: &ExecutorMessages{
+			Type: ExecutorMessagesRawExecuting,
+			Value: &ExecutingMessage{
 				Id:     1,
 				ProcId: 2,
 				Try:    3,
@@ -40,7 +40,7 @@ func TestConn(t *testing.T) {
 	}()
 	serv, err := ListenAndServe(":0", func(c *Conn) {
 		defer close(done)
-		connectReqGot, err := Recv[ConnectRequest](c)
+		connectReqGot, err := Recv[ConnectRequestRaw](c)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -51,7 +51,7 @@ func TestConn(t *testing.T) {
 		}
 
 		for i := 0; i < 10; i++ {
-			got, err := Recv[ExecutorMessage](c)
+			got, err := Recv[ExecutorMessageRaw](c)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +73,7 @@ func TestConn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	connectReplyGot, err := Recv[ConnectReply](c)
+	connectReplyGot, err := Recv[ConnectReplyRaw](c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,13 +87,13 @@ func TestConn(t *testing.T) {
 }
 
 func BenchmarkConn(b *testing.B) {
-	connectReq := &ConnectRequestT{
+	connectReq := &ConnectRequest{
 		Name:        "foo",
 		Arch:        "arch",
 		GitRevision: "rev1",
 		SyzRevision: "rev2",
 	}
-	connectReply := &ConnectReplyT{
+	connectReply := &ConnectReply{
 		LeakFrames: []string{"foo", "bar"},
 		RaceFrames: []string{"bar", "baz"},
 		Features:   FeatureCoverage | FeatureLeak,
@@ -108,7 +108,7 @@ func BenchmarkConn(b *testing.B) {
 	serv, err := ListenAndServe(":0", func(c *Conn) {
 		defer close(done)
 		for i := 0; i < b.N; i++ {
-			_, err := Recv[ConnectRequest](c)
+			_, err := Recv[ConnectRequestRaw](c)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func BenchmarkConn(b *testing.B) {
 		if err := Send(c, connectReq); err != nil {
 			b.Fatal(err)
 		}
-		_, err := Recv[ConnectReply](c)
+		_, err := Recv[ConnectReplyRaw](c)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -26,65 +26,71 @@ enum Feature : uint64 (bit_flags) {
 	Swap,
 }
  
-table ConnectRequest {
+table ConnectRequestRaw {
 	name			:string;
 	arch			:string;
 	git_revision		:string;
 	syz_revision		:string;
 }
 
-table ConnectReply {
+table ConnectReplyRaw {
 	leak_frames		:[string];
 	race_frames		:[string];
-	// Features are forwarded from CheckArgs, if checking was already done.
+	// Fuzzer sets up these features and returns results in InfoRequest.features.
 	features		:Feature;
-	// Fuzzer reads these files inside of the VM and returns contents in CheckArgs.Files.
+	// Fuzzer reads these files inside of the VM and returns contents in InfoRequest.files.
 	files			:[string];
 	globs			:[string];
 }
 
-table InfoRequest {
+table InfoRequestRaw {
 	error			:string;
-	features		:Feature;
-	globs			:[GlobInfo];
-	files			:[FileInfo];
+	features		:[FeatureInfoRaw];
+	files			:[FileInfoRaw];
+	globs			:[GlobInfoRaw];
 }
 
-table InfoReply {
+table InfoReplyRaw {
 	cover_filter		:[uint32];
 }
 
-table FileInfo {
+table FileInfoRaw {
 	name			:string;
 	exists			:bool;
 	error			:string;
 	data			:[uint8];
 }
 
-table GlobInfo {
+table GlobInfoRaw {
 	name			:string;
 	files			:[string];
 }
 
-// Messages sent from the host to the executor.
-union HostMessages {
-	ExecRequest		:ExecRequest,
-	SignalUpdate		:SignalUpdate,
+table FeatureInfoRaw {
+	id			:Feature;
+	need_setup		:bool;
+	reason			:string;
 }
 
-table HostMessage {
-	msg			:HostMessages;
+// Messages sent from the host to the executor.
+union HostMessagesRaw {
+	ExecRequest		:ExecRequestRaw,
+	SignalUpdate		:SignalUpdateRaw,
+}
+
+table HostMessageRaw {
+	msg			:HostMessagesRaw;
 }
 
 // Messages sent from the executor to the host.
-union ExecutorMessages {
-	ExecResult		:ExecResult,
-	Executing		:ExecutingMessage,
-	Stats			:StatsMessage,
+union ExecutorMessagesRaw {
+	ExecResult		:ExecResultRaw,
+	Executing		:ExecutingMessageRaw,
+	Stats			:StatsMessageRaw,
 }
 
-table ExecutorMessage {
-	msg			:ExecutorMessages;
+table ExecutorMessageRaw {
+	msg			:ExecutorMessagesRaw;
 }
 
 enum RequestFlag : uint64 (bit_flags) {
@@ -131,7 +137,7 @@ enum ExecFlag : uint64 (bit_flags) {
 }
 
 // Request to execute a test program.
-table ExecRequest {
+table ExecRequestRaw {
 	id			:int64;
 	prog_data		:[uint8];
 	flags			:RequestFlag;
@@ -144,7 +150,7 @@ table ExecRequest {
 	repeat			:int32;
 }
 
-table SignalUpdate {
+table SignalUpdateRaw {
 	new_max			:[uint32];
 	drop_max		:[uint32];
 }
@@ -153,13 +159,13 @@ table SignalUpdate {
 // We want this request to be as small and as fast as possible b/c we need it
 // to reach the host (or at least leave the VM) before the VM crashes
 // executing this program.
-table ExecutingMessage {
+table ExecutingMessageRaw {
 	id			:int64;
 	proc_id			:int32;
 	try			:int32;
 }
 
-table StatsMessage {
+table StatsMessageRaw {
 	noexec_count		:int64;
 	noexec_duration		:int64;
 }
@@ -171,7 +177,7 @@ enum CallFlag : uint8 (bit_flags) {
 	FaultInjected,		// fault was injected into this call
 }
 
-table CallInfo {
+table CallInfoRaw {
 	flags			:CallFlag;
 	// Call errno (0 if the call was successful).
 	error			:int32;
@@ -181,18 +187,18 @@ table CallInfo {
 	// If ExecFlag.DedupCover is set, then duplicates are removed, otherwise it contains a trace.
 	cover			:[uint32];
 	// Comparison operands.
-	comps			:[Comparison];
+	comps			:[ComparisonRaw];
 }
 
-struct Comparison {
+struct ComparisonRaw {
 	op1			:uint64;
 	op2			:uint64;
 }
 
-table ProgInfo {
-	calls			:[CallInfo];
+table ProgInfoRaw {
+	calls			:[CallInfoRaw];
 	// Contains signal and cover collected from background threads.
-	extra			:CallInfo;
+	extra			:CallInfoRaw;
 	// Total execution time of the program in nanoseconds.
 	elapsed			:uint64;
 	// Number of programs executed in the same process before this one.
@@ -200,9 +206,9 @@ table ProgInfo {
 }
 
 // Result of executing a test program.
-table ExecResult {
-	executing	:ExecutingMessage;
+table ExecResultRaw {
+	executing	:ExecutingMessageRaw;
 	output		:[uint8];
 	error		:string;
-	info		:ProgInfo;
+	info		:ProgInfoRaw;
 }

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -86,124 +86,124 @@ func (v Feature) String() string {
 	return "Feature(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type HostMessages byte
+type HostMessagesRaw byte
 
 const (
-	HostMessagesNONE         HostMessages = 0
-	HostMessagesExecRequest  HostMessages = 1
-	HostMessagesSignalUpdate HostMessages = 2
+	HostMessagesRawNONE         HostMessagesRaw = 0
+	HostMessagesRawExecRequest  HostMessagesRaw = 1
+	HostMessagesRawSignalUpdate HostMessagesRaw = 2
 )
 
-var EnumNamesHostMessages = map[HostMessages]string{
-	HostMessagesNONE:         "NONE",
-	HostMessagesExecRequest:  "ExecRequest",
-	HostMessagesSignalUpdate: "SignalUpdate",
+var EnumNamesHostMessagesRaw = map[HostMessagesRaw]string{
+	HostMessagesRawNONE:         "NONE",
+	HostMessagesRawExecRequest:  "ExecRequest",
+	HostMessagesRawSignalUpdate: "SignalUpdate",
 }
 
-var EnumValuesHostMessages = map[string]HostMessages{
-	"NONE":         HostMessagesNONE,
-	"ExecRequest":  HostMessagesExecRequest,
-	"SignalUpdate": HostMessagesSignalUpdate,
+var EnumValuesHostMessagesRaw = map[string]HostMessagesRaw{
+	"NONE":         HostMessagesRawNONE,
+	"ExecRequest":  HostMessagesRawExecRequest,
+	"SignalUpdate": HostMessagesRawSignalUpdate,
 }
 
-func (v HostMessages) String() string {
-	if s, ok := EnumNamesHostMessages[v]; ok {
+func (v HostMessagesRaw) String() string {
+	if s, ok := EnumNamesHostMessagesRaw[v]; ok {
 		return s
 	}
-	return "HostMessages(" + strconv.FormatInt(int64(v), 10) + ")"
+	return "HostMessagesRaw(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type HostMessagesT struct {
-	Type  HostMessages
+type HostMessagesRawT struct {
+	Type  HostMessagesRaw
 	Value interface{}
 }
 
-func (t *HostMessagesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *HostMessagesRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	switch t.Type {
-	case HostMessagesExecRequest:
-		return t.Value.(*ExecRequestT).Pack(builder)
-	case HostMessagesSignalUpdate:
-		return t.Value.(*SignalUpdateT).Pack(builder)
+	case HostMessagesRawExecRequest:
+		return t.Value.(*ExecRequestRawT).Pack(builder)
+	case HostMessagesRawSignalUpdate:
+		return t.Value.(*SignalUpdateRawT).Pack(builder)
 	}
 	return 0
 }
 
-func (rcv HostMessages) UnPack(table flatbuffers.Table) *HostMessagesT {
+func (rcv HostMessagesRaw) UnPack(table flatbuffers.Table) *HostMessagesRawT {
 	switch rcv {
-	case HostMessagesExecRequest:
-		x := ExecRequest{_tab: table}
-		return &HostMessagesT{Type: HostMessagesExecRequest, Value: x.UnPack()}
-	case HostMessagesSignalUpdate:
-		x := SignalUpdate{_tab: table}
-		return &HostMessagesT{Type: HostMessagesSignalUpdate, Value: x.UnPack()}
+	case HostMessagesRawExecRequest:
+		x := ExecRequestRaw{_tab: table}
+		return &HostMessagesRawT{Type: HostMessagesRawExecRequest, Value: x.UnPack()}
+	case HostMessagesRawSignalUpdate:
+		x := SignalUpdateRaw{_tab: table}
+		return &HostMessagesRawT{Type: HostMessagesRawSignalUpdate, Value: x.UnPack()}
 	}
 	return nil
 }
 
-type ExecutorMessages byte
+type ExecutorMessagesRaw byte
 
 const (
-	ExecutorMessagesNONE       ExecutorMessages = 0
-	ExecutorMessagesExecResult ExecutorMessages = 1
-	ExecutorMessagesExecuting  ExecutorMessages = 2
-	ExecutorMessagesStats      ExecutorMessages = 3
+	ExecutorMessagesRawNONE       ExecutorMessagesRaw = 0
+	ExecutorMessagesRawExecResult ExecutorMessagesRaw = 1
+	ExecutorMessagesRawExecuting  ExecutorMessagesRaw = 2
+	ExecutorMessagesRawStats      ExecutorMessagesRaw = 3
 )
 
-var EnumNamesExecutorMessages = map[ExecutorMessages]string{
-	ExecutorMessagesNONE:       "NONE",
-	ExecutorMessagesExecResult: "ExecResult",
-	ExecutorMessagesExecuting:  "Executing",
-	ExecutorMessagesStats:      "Stats",
+var EnumNamesExecutorMessagesRaw = map[ExecutorMessagesRaw]string{
+	ExecutorMessagesRawNONE:       "NONE",
+	ExecutorMessagesRawExecResult: "ExecResult",
+	ExecutorMessagesRawExecuting:  "Executing",
+	ExecutorMessagesRawStats:      "Stats",
 }
 
-var EnumValuesExecutorMessages = map[string]ExecutorMessages{
-	"NONE":       ExecutorMessagesNONE,
-	"ExecResult": ExecutorMessagesExecResult,
-	"Executing":  ExecutorMessagesExecuting,
-	"Stats":      ExecutorMessagesStats,
+var EnumValuesExecutorMessagesRaw = map[string]ExecutorMessagesRaw{
+	"NONE":       ExecutorMessagesRawNONE,
+	"ExecResult": ExecutorMessagesRawExecResult,
+	"Executing":  ExecutorMessagesRawExecuting,
+	"Stats":      ExecutorMessagesRawStats,
 }
 
-func (v ExecutorMessages) String() string {
-	if s, ok := EnumNamesExecutorMessages[v]; ok {
+func (v ExecutorMessagesRaw) String() string {
+	if s, ok := EnumNamesExecutorMessagesRaw[v]; ok {
 		return s
 	}
-	return "ExecutorMessages(" + strconv.FormatInt(int64(v), 10) + ")"
+	return "ExecutorMessagesRaw(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type ExecutorMessagesT struct {
-	Type  ExecutorMessages
+type ExecutorMessagesRawT struct {
+	Type  ExecutorMessagesRaw
 	Value interface{}
 }
 
-func (t *ExecutorMessagesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ExecutorMessagesRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	switch t.Type {
-	case ExecutorMessagesExecResult:
-		return t.Value.(*ExecResultT).Pack(builder)
-	case ExecutorMessagesExecuting:
-		return t.Value.(*ExecutingMessageT).Pack(builder)
-	case ExecutorMessagesStats:
-		return t.Value.(*StatsMessageT).Pack(builder)
+	case ExecutorMessagesRawExecResult:
+		return t.Value.(*ExecResultRawT).Pack(builder)
+	case ExecutorMessagesRawExecuting:
+		return t.Value.(*ExecutingMessageRawT).Pack(builder)
+	case ExecutorMessagesRawStats:
+		return t.Value.(*StatsMessageRawT).Pack(builder)
 	}
 	return 0
 }
 
-func (rcv ExecutorMessages) UnPack(table flatbuffers.Table) *ExecutorMessagesT {
+func (rcv ExecutorMessagesRaw) UnPack(table flatbuffers.Table) *ExecutorMessagesRawT {
 	switch rcv {
-	case ExecutorMessagesExecResult:
-		x := ExecResult{_tab: table}
-		return &ExecutorMessagesT{Type: ExecutorMessagesExecResult, Value: x.UnPack()}
-	case ExecutorMessagesExecuting:
-		x := ExecutingMessage{_tab: table}
-		return &ExecutorMessagesT{Type: ExecutorMessagesExecuting, Value: x.UnPack()}
-	case ExecutorMessagesStats:
-		x := StatsMessage{_tab: table}
-		return &ExecutorMessagesT{Type: ExecutorMessagesStats, Value: x.UnPack()}
+	case ExecutorMessagesRawExecResult:
+		x := ExecResultRaw{_tab: table}
+		return &ExecutorMessagesRawT{Type: ExecutorMessagesRawExecResult, Value: x.UnPack()}
+	case ExecutorMessagesRawExecuting:
+		x := ExecutingMessageRaw{_tab: table}
+		return &ExecutorMessagesRawT{Type: ExecutorMessagesRawExecuting, Value: x.UnPack()}
+	case ExecutorMessagesRawStats:
+		x := StatsMessageRaw{_tab: table}
+		return &ExecutorMessagesRawT{Type: ExecutorMessagesRawStats, Value: x.UnPack()}
 	}
 	return nil
 }
@@ -373,14 +373,14 @@ func (v CallFlag) String() string {
 	return "CallFlag(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type ConnectRequestT struct {
+type ConnectRequestRawT struct {
 	Name        string `json:"name"`
 	Arch        string `json:"arch"`
 	GitRevision string `json:"git_revision"`
 	SyzRevision string `json:"syz_revision"`
 }
 
-func (t *ConnectRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ConnectRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -388,58 +388,58 @@ func (t *ConnectRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffset
 	archOffset := builder.CreateString(t.Arch)
 	gitRevisionOffset := builder.CreateString(t.GitRevision)
 	syzRevisionOffset := builder.CreateString(t.SyzRevision)
-	ConnectRequestStart(builder)
-	ConnectRequestAddName(builder, nameOffset)
-	ConnectRequestAddArch(builder, archOffset)
-	ConnectRequestAddGitRevision(builder, gitRevisionOffset)
-	ConnectRequestAddSyzRevision(builder, syzRevisionOffset)
-	return ConnectRequestEnd(builder)
+	ConnectRequestRawStart(builder)
+	ConnectRequestRawAddName(builder, nameOffset)
+	ConnectRequestRawAddArch(builder, archOffset)
+	ConnectRequestRawAddGitRevision(builder, gitRevisionOffset)
+	ConnectRequestRawAddSyzRevision(builder, syzRevisionOffset)
+	return ConnectRequestRawEnd(builder)
 }
 
-func (rcv *ConnectRequest) UnPackTo(t *ConnectRequestT) {
+func (rcv *ConnectRequestRaw) UnPackTo(t *ConnectRequestRawT) {
 	t.Name = string(rcv.Name())
 	t.Arch = string(rcv.Arch())
 	t.GitRevision = string(rcv.GitRevision())
 	t.SyzRevision = string(rcv.SyzRevision())
 }
 
-func (rcv *ConnectRequest) UnPack() *ConnectRequestT {
+func (rcv *ConnectRequestRaw) UnPack() *ConnectRequestRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ConnectRequestT{}
+	t := &ConnectRequestRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ConnectRequest struct {
+type ConnectRequestRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsConnectRequest(buf []byte, offset flatbuffers.UOffsetT) *ConnectRequest {
+func GetRootAsConnectRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ConnectRequest{}
+	x := &ConnectRequestRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsConnectRequest(buf []byte, offset flatbuffers.UOffsetT) *ConnectRequest {
+func GetSizePrefixedRootAsConnectRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ConnectRequest{}
+	x := &ConnectRequestRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ConnectRequest) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ConnectRequestRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ConnectRequest) Table() flatbuffers.Table {
+func (rcv *ConnectRequestRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ConnectRequest) Name() []byte {
+func (rcv *ConnectRequestRaw) Name() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -447,7 +447,7 @@ func (rcv *ConnectRequest) Name() []byte {
 	return nil
 }
 
-func (rcv *ConnectRequest) Arch() []byte {
+func (rcv *ConnectRequestRaw) Arch() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -455,7 +455,7 @@ func (rcv *ConnectRequest) Arch() []byte {
 	return nil
 }
 
-func (rcv *ConnectRequest) GitRevision() []byte {
+func (rcv *ConnectRequestRaw) GitRevision() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -463,7 +463,7 @@ func (rcv *ConnectRequest) GitRevision() []byte {
 	return nil
 }
 
-func (rcv *ConnectRequest) SyzRevision() []byte {
+func (rcv *ConnectRequestRaw) SyzRevision() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -471,26 +471,26 @@ func (rcv *ConnectRequest) SyzRevision() []byte {
 	return nil
 }
 
-func ConnectRequestStart(builder *flatbuffers.Builder) {
+func ConnectRequestRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func ConnectRequestAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
+func ConnectRequestRawAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
 }
-func ConnectRequestAddArch(builder *flatbuffers.Builder, arch flatbuffers.UOffsetT) {
+func ConnectRequestRawAddArch(builder *flatbuffers.Builder, arch flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(arch), 0)
 }
-func ConnectRequestAddGitRevision(builder *flatbuffers.Builder, gitRevision flatbuffers.UOffsetT) {
+func ConnectRequestRawAddGitRevision(builder *flatbuffers.Builder, gitRevision flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(gitRevision), 0)
 }
-func ConnectRequestAddSyzRevision(builder *flatbuffers.Builder, syzRevision flatbuffers.UOffsetT) {
+func ConnectRequestRawAddSyzRevision(builder *flatbuffers.Builder, syzRevision flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(syzRevision), 0)
 }
-func ConnectRequestEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ConnectRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ConnectReplyT struct {
+type ConnectReplyRawT struct {
 	LeakFrames []string `json:"leak_frames"`
 	RaceFrames []string `json:"race_frames"`
 	Features   Feature  `json:"features"`
@@ -498,7 +498,7 @@ type ConnectReplyT struct {
 	Globs      []string `json:"globs"`
 }
 
-func (t *ConnectReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -509,7 +509,7 @@ func (t *ConnectReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT 
 		for j := 0; j < leakFramesLength; j++ {
 			leakFramesOffsets[j] = builder.CreateString(t.LeakFrames[j])
 		}
-		ConnectReplyStartLeakFramesVector(builder, leakFramesLength)
+		ConnectReplyRawStartLeakFramesVector(builder, leakFramesLength)
 		for j := leakFramesLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(leakFramesOffsets[j])
 		}
@@ -522,7 +522,7 @@ func (t *ConnectReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT 
 		for j := 0; j < raceFramesLength; j++ {
 			raceFramesOffsets[j] = builder.CreateString(t.RaceFrames[j])
 		}
-		ConnectReplyStartRaceFramesVector(builder, raceFramesLength)
+		ConnectReplyRawStartRaceFramesVector(builder, raceFramesLength)
 		for j := raceFramesLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(raceFramesOffsets[j])
 		}
@@ -535,7 +535,7 @@ func (t *ConnectReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT 
 		for j := 0; j < filesLength; j++ {
 			filesOffsets[j] = builder.CreateString(t.Files[j])
 		}
-		ConnectReplyStartFilesVector(builder, filesLength)
+		ConnectReplyRawStartFilesVector(builder, filesLength)
 		for j := filesLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(filesOffsets[j])
 		}
@@ -548,22 +548,22 @@ func (t *ConnectReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT 
 		for j := 0; j < globsLength; j++ {
 			globsOffsets[j] = builder.CreateString(t.Globs[j])
 		}
-		ConnectReplyStartGlobsVector(builder, globsLength)
+		ConnectReplyRawStartGlobsVector(builder, globsLength)
 		for j := globsLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(globsOffsets[j])
 		}
 		globsOffset = builder.EndVector(globsLength)
 	}
-	ConnectReplyStart(builder)
-	ConnectReplyAddLeakFrames(builder, leakFramesOffset)
-	ConnectReplyAddRaceFrames(builder, raceFramesOffset)
-	ConnectReplyAddFeatures(builder, t.Features)
-	ConnectReplyAddFiles(builder, filesOffset)
-	ConnectReplyAddGlobs(builder, globsOffset)
-	return ConnectReplyEnd(builder)
+	ConnectReplyRawStart(builder)
+	ConnectReplyRawAddLeakFrames(builder, leakFramesOffset)
+	ConnectReplyRawAddRaceFrames(builder, raceFramesOffset)
+	ConnectReplyRawAddFeatures(builder, t.Features)
+	ConnectReplyRawAddFiles(builder, filesOffset)
+	ConnectReplyRawAddGlobs(builder, globsOffset)
+	return ConnectReplyRawEnd(builder)
 }
 
-func (rcv *ConnectReply) UnPackTo(t *ConnectReplyT) {
+func (rcv *ConnectReplyRaw) UnPackTo(t *ConnectReplyRawT) {
 	leakFramesLength := rcv.LeakFramesLength()
 	t.LeakFrames = make([]string, leakFramesLength)
 	for j := 0; j < leakFramesLength; j++ {
@@ -587,43 +587,43 @@ func (rcv *ConnectReply) UnPackTo(t *ConnectReplyT) {
 	}
 }
 
-func (rcv *ConnectReply) UnPack() *ConnectReplyT {
+func (rcv *ConnectReplyRaw) UnPack() *ConnectReplyRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ConnectReplyT{}
+	t := &ConnectReplyRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ConnectReply struct {
+type ConnectReplyRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsConnectReply(buf []byte, offset flatbuffers.UOffsetT) *ConnectReply {
+func GetRootAsConnectReplyRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectReplyRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ConnectReply{}
+	x := &ConnectReplyRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsConnectReply(buf []byte, offset flatbuffers.UOffsetT) *ConnectReply {
+func GetSizePrefixedRootAsConnectReplyRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectReplyRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ConnectReply{}
+	x := &ConnectReplyRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ConnectReply) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ConnectReplyRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ConnectReply) Table() flatbuffers.Table {
+func (rcv *ConnectReplyRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ConnectReply) LeakFrames(j int) []byte {
+func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -632,7 +632,7 @@ func (rcv *ConnectReply) LeakFrames(j int) []byte {
 	return nil
 }
 
-func (rcv *ConnectReply) LeakFramesLength() int {
+func (rcv *ConnectReplyRaw) LeakFramesLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -640,7 +640,7 @@ func (rcv *ConnectReply) LeakFramesLength() int {
 	return 0
 }
 
-func (rcv *ConnectReply) RaceFrames(j int) []byte {
+func (rcv *ConnectReplyRaw) RaceFrames(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -649,7 +649,7 @@ func (rcv *ConnectReply) RaceFrames(j int) []byte {
 	return nil
 }
 
-func (rcv *ConnectReply) RaceFramesLength() int {
+func (rcv *ConnectReplyRaw) RaceFramesLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -657,7 +657,7 @@ func (rcv *ConnectReply) RaceFramesLength() int {
 	return 0
 }
 
-func (rcv *ConnectReply) Features() Feature {
+func (rcv *ConnectReplyRaw) Features() Feature {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return Feature(rcv._tab.GetUint64(o + rcv._tab.Pos))
@@ -665,11 +665,11 @@ func (rcv *ConnectReply) Features() Feature {
 	return 0
 }
 
-func (rcv *ConnectReply) MutateFeatures(n Feature) bool {
+func (rcv *ConnectReplyRaw) MutateFeatures(n Feature) bool {
 	return rcv._tab.MutateUint64Slot(8, uint64(n))
 }
 
-func (rcv *ConnectReply) Files(j int) []byte {
+func (rcv *ConnectReplyRaw) Files(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -678,7 +678,7 @@ func (rcv *ConnectReply) Files(j int) []byte {
 	return nil
 }
 
-func (rcv *ConnectReply) FilesLength() int {
+func (rcv *ConnectReplyRaw) FilesLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -686,7 +686,7 @@ func (rcv *ConnectReply) FilesLength() int {
 	return 0
 }
 
-func (rcv *ConnectReply) Globs(j int) []byte {
+func (rcv *ConnectReplyRaw) Globs(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -695,7 +695,7 @@ func (rcv *ConnectReply) Globs(j int) []byte {
 	return nil
 }
 
-func (rcv *ConnectReply) GlobsLength() int {
+func (rcv *ConnectReplyRaw) GlobsLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -703,64 +703,64 @@ func (rcv *ConnectReply) GlobsLength() int {
 	return 0
 }
 
-func ConnectReplyStart(builder *flatbuffers.Builder) {
+func ConnectReplyRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(5)
 }
-func ConnectReplyAddLeakFrames(builder *flatbuffers.Builder, leakFrames flatbuffers.UOffsetT) {
+func ConnectReplyRawAddLeakFrames(builder *flatbuffers.Builder, leakFrames flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(leakFrames), 0)
 }
-func ConnectReplyStartLeakFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ConnectReplyRawStartLeakFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ConnectReplyAddRaceFrames(builder *flatbuffers.Builder, raceFrames flatbuffers.UOffsetT) {
+func ConnectReplyRawAddRaceFrames(builder *flatbuffers.Builder, raceFrames flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(raceFrames), 0)
 }
-func ConnectReplyStartRaceFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ConnectReplyRawStartRaceFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ConnectReplyAddFeatures(builder *flatbuffers.Builder, features Feature) {
+func ConnectReplyRawAddFeatures(builder *flatbuffers.Builder, features Feature) {
 	builder.PrependUint64Slot(2, uint64(features), 0)
 }
-func ConnectReplyAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
+func ConnectReplyRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(files), 0)
 }
-func ConnectReplyStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ConnectReplyRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ConnectReplyAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
+func ConnectReplyRawAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(globs), 0)
 }
-func ConnectReplyStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ConnectReplyRawStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ConnectReplyEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ConnectReplyRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type InfoRequestT struct {
-	Error    string       `json:"error"`
-	Features Feature      `json:"features"`
-	Globs    []*GlobInfoT `json:"globs"`
-	Files    []*FileInfoT `json:"files"`
+type InfoRequestRawT struct {
+	Error    string             `json:"error"`
+	Features []*FeatureInfoRawT `json:"features"`
+	Files    []*FileInfoRawT    `json:"files"`
+	Globs    []*GlobInfoRawT    `json:"globs"`
 }
 
-func (t *InfoRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *InfoRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	errorOffset := builder.CreateString(t.Error)
-	globsOffset := flatbuffers.UOffsetT(0)
-	if t.Globs != nil {
-		globsLength := len(t.Globs)
-		globsOffsets := make([]flatbuffers.UOffsetT, globsLength)
-		for j := 0; j < globsLength; j++ {
-			globsOffsets[j] = t.Globs[j].Pack(builder)
+	featuresOffset := flatbuffers.UOffsetT(0)
+	if t.Features != nil {
+		featuresLength := len(t.Features)
+		featuresOffsets := make([]flatbuffers.UOffsetT, featuresLength)
+		for j := 0; j < featuresLength; j++ {
+			featuresOffsets[j] = t.Features[j].Pack(builder)
 		}
-		InfoRequestStartGlobsVector(builder, globsLength)
-		for j := globsLength - 1; j >= 0; j-- {
-			builder.PrependUOffsetT(globsOffsets[j])
+		InfoRequestRawStartFeaturesVector(builder, featuresLength)
+		for j := featuresLength - 1; j >= 0; j-- {
+			builder.PrependUOffsetT(featuresOffsets[j])
 		}
-		globsOffset = builder.EndVector(globsLength)
+		featuresOffset = builder.EndVector(featuresLength)
 	}
 	filesOffset := flatbuffers.UOffsetT(0)
 	if t.Files != nil {
@@ -769,76 +769,95 @@ func (t *InfoRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 		for j := 0; j < filesLength; j++ {
 			filesOffsets[j] = t.Files[j].Pack(builder)
 		}
-		InfoRequestStartFilesVector(builder, filesLength)
+		InfoRequestRawStartFilesVector(builder, filesLength)
 		for j := filesLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(filesOffsets[j])
 		}
 		filesOffset = builder.EndVector(filesLength)
 	}
-	InfoRequestStart(builder)
-	InfoRequestAddError(builder, errorOffset)
-	InfoRequestAddFeatures(builder, t.Features)
-	InfoRequestAddGlobs(builder, globsOffset)
-	InfoRequestAddFiles(builder, filesOffset)
-	return InfoRequestEnd(builder)
+	globsOffset := flatbuffers.UOffsetT(0)
+	if t.Globs != nil {
+		globsLength := len(t.Globs)
+		globsOffsets := make([]flatbuffers.UOffsetT, globsLength)
+		for j := 0; j < globsLength; j++ {
+			globsOffsets[j] = t.Globs[j].Pack(builder)
+		}
+		InfoRequestRawStartGlobsVector(builder, globsLength)
+		for j := globsLength - 1; j >= 0; j-- {
+			builder.PrependUOffsetT(globsOffsets[j])
+		}
+		globsOffset = builder.EndVector(globsLength)
+	}
+	InfoRequestRawStart(builder)
+	InfoRequestRawAddError(builder, errorOffset)
+	InfoRequestRawAddFeatures(builder, featuresOffset)
+	InfoRequestRawAddFiles(builder, filesOffset)
+	InfoRequestRawAddGlobs(builder, globsOffset)
+	return InfoRequestRawEnd(builder)
 }
 
-func (rcv *InfoRequest) UnPackTo(t *InfoRequestT) {
+func (rcv *InfoRequestRaw) UnPackTo(t *InfoRequestRawT) {
 	t.Error = string(rcv.Error())
-	t.Features = rcv.Features()
-	globsLength := rcv.GlobsLength()
-	t.Globs = make([]*GlobInfoT, globsLength)
-	for j := 0; j < globsLength; j++ {
-		x := GlobInfo{}
-		rcv.Globs(&x, j)
-		t.Globs[j] = x.UnPack()
+	featuresLength := rcv.FeaturesLength()
+	t.Features = make([]*FeatureInfoRawT, featuresLength)
+	for j := 0; j < featuresLength; j++ {
+		x := FeatureInfoRaw{}
+		rcv.Features(&x, j)
+		t.Features[j] = x.UnPack()
 	}
 	filesLength := rcv.FilesLength()
-	t.Files = make([]*FileInfoT, filesLength)
+	t.Files = make([]*FileInfoRawT, filesLength)
 	for j := 0; j < filesLength; j++ {
-		x := FileInfo{}
+		x := FileInfoRaw{}
 		rcv.Files(&x, j)
 		t.Files[j] = x.UnPack()
 	}
+	globsLength := rcv.GlobsLength()
+	t.Globs = make([]*GlobInfoRawT, globsLength)
+	for j := 0; j < globsLength; j++ {
+		x := GlobInfoRaw{}
+		rcv.Globs(&x, j)
+		t.Globs[j] = x.UnPack()
+	}
 }
 
-func (rcv *InfoRequest) UnPack() *InfoRequestT {
+func (rcv *InfoRequestRaw) UnPack() *InfoRequestRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &InfoRequestT{}
+	t := &InfoRequestRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type InfoRequest struct {
+type InfoRequestRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsInfoRequest(buf []byte, offset flatbuffers.UOffsetT) *InfoRequest {
+func GetRootAsInfoRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *InfoRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &InfoRequest{}
+	x := &InfoRequestRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsInfoRequest(buf []byte, offset flatbuffers.UOffsetT) *InfoRequest {
+func GetSizePrefixedRootAsInfoRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *InfoRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &InfoRequest{}
+	x := &InfoRequestRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *InfoRequest) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *InfoRequestRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *InfoRequest) Table() flatbuffers.Table {
+func (rcv *InfoRequestRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *InfoRequest) Error() []byte {
+func (rcv *InfoRequestRaw) Error() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -846,19 +865,27 @@ func (rcv *InfoRequest) Error() []byte {
 	return nil
 }
 
-func (rcv *InfoRequest) Features() Feature {
+func (rcv *InfoRequestRaw) Features(obj *FeatureInfoRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return Feature(rcv._tab.GetUint64(o + rcv._tab.Pos))
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
+		obj.Init(rcv._tab.Bytes, x)
+		return true
+	}
+	return false
+}
+
+func (rcv *InfoRequestRaw) FeaturesLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
 	}
 	return 0
 }
 
-func (rcv *InfoRequest) MutateFeatures(n Feature) bool {
-	return rcv._tab.MutateUint64Slot(6, uint64(n))
-}
-
-func (rcv *InfoRequest) Globs(obj *GlobInfo, j int) bool {
+func (rcv *InfoRequestRaw) Files(obj *FileInfoRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
@@ -870,7 +897,7 @@ func (rcv *InfoRequest) Globs(obj *GlobInfo, j int) bool {
 	return false
 }
 
-func (rcv *InfoRequest) GlobsLength() int {
+func (rcv *InfoRequestRaw) FilesLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -878,7 +905,7 @@ func (rcv *InfoRequest) GlobsLength() int {
 	return 0
 }
 
-func (rcv *InfoRequest) Files(obj *FileInfo, j int) bool {
+func (rcv *InfoRequestRaw) Globs(obj *GlobInfoRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
@@ -890,7 +917,7 @@ func (rcv *InfoRequest) Files(obj *FileInfo, j int) bool {
 	return false
 }
 
-func (rcv *InfoRequest) FilesLength() int {
+func (rcv *InfoRequestRaw) GlobsLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -898,54 +925,57 @@ func (rcv *InfoRequest) FilesLength() int {
 	return 0
 }
 
-func InfoRequestStart(builder *flatbuffers.Builder) {
+func InfoRequestRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func InfoRequestAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
+func InfoRequestRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(error), 0)
 }
-func InfoRequestAddFeatures(builder *flatbuffers.Builder, features Feature) {
-	builder.PrependUint64Slot(1, uint64(features), 0)
+func InfoRequestRawAddFeatures(builder *flatbuffers.Builder, features flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(features), 0)
 }
-func InfoRequestAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(globs), 0)
-}
-func InfoRequestStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func InfoRequestRawStartFeaturesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func InfoRequestAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(files), 0)
+func InfoRequestRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(files), 0)
 }
-func InfoRequestStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func InfoRequestRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func InfoRequestEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func InfoRequestRawAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(globs), 0)
+}
+func InfoRequestRawStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
+func InfoRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type InfoReplyT struct {
+type InfoReplyRawT struct {
 	CoverFilter []uint32 `json:"cover_filter"`
 }
 
-func (t *InfoReplyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *InfoReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	coverFilterOffset := flatbuffers.UOffsetT(0)
 	if t.CoverFilter != nil {
 		coverFilterLength := len(t.CoverFilter)
-		InfoReplyStartCoverFilterVector(builder, coverFilterLength)
+		InfoReplyRawStartCoverFilterVector(builder, coverFilterLength)
 		for j := coverFilterLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.CoverFilter[j])
 		}
 		coverFilterOffset = builder.EndVector(coverFilterLength)
 	}
-	InfoReplyStart(builder)
-	InfoReplyAddCoverFilter(builder, coverFilterOffset)
-	return InfoReplyEnd(builder)
+	InfoReplyRawStart(builder)
+	InfoReplyRawAddCoverFilter(builder, coverFilterOffset)
+	return InfoReplyRawEnd(builder)
 }
 
-func (rcv *InfoReply) UnPackTo(t *InfoReplyT) {
+func (rcv *InfoReplyRaw) UnPackTo(t *InfoReplyRawT) {
 	coverFilterLength := rcv.CoverFilterLength()
 	t.CoverFilter = make([]uint32, coverFilterLength)
 	for j := 0; j < coverFilterLength; j++ {
@@ -953,43 +983,43 @@ func (rcv *InfoReply) UnPackTo(t *InfoReplyT) {
 	}
 }
 
-func (rcv *InfoReply) UnPack() *InfoReplyT {
+func (rcv *InfoReplyRaw) UnPack() *InfoReplyRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &InfoReplyT{}
+	t := &InfoReplyRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type InfoReply struct {
+type InfoReplyRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsInfoReply(buf []byte, offset flatbuffers.UOffsetT) *InfoReply {
+func GetRootAsInfoReplyRaw(buf []byte, offset flatbuffers.UOffsetT) *InfoReplyRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &InfoReply{}
+	x := &InfoReplyRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsInfoReply(buf []byte, offset flatbuffers.UOffsetT) *InfoReply {
+func GetSizePrefixedRootAsInfoReplyRaw(buf []byte, offset flatbuffers.UOffsetT) *InfoReplyRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &InfoReply{}
+	x := &InfoReplyRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *InfoReply) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *InfoReplyRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *InfoReply) Table() flatbuffers.Table {
+func (rcv *InfoReplyRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *InfoReply) CoverFilter(j int) uint32 {
+func (rcv *InfoReplyRaw) CoverFilter(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -998,7 +1028,7 @@ func (rcv *InfoReply) CoverFilter(j int) uint32 {
 	return 0
 }
 
-func (rcv *InfoReply) CoverFilterLength() int {
+func (rcv *InfoReplyRaw) CoverFilterLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1006,7 +1036,7 @@ func (rcv *InfoReply) CoverFilterLength() int {
 	return 0
 }
 
-func (rcv *InfoReply) MutateCoverFilter(j int, n uint32) bool {
+func (rcv *InfoReplyRaw) MutateCoverFilter(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1015,27 +1045,27 @@ func (rcv *InfoReply) MutateCoverFilter(j int, n uint32) bool {
 	return false
 }
 
-func InfoReplyStart(builder *flatbuffers.Builder) {
+func InfoReplyRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(1)
 }
-func InfoReplyAddCoverFilter(builder *flatbuffers.Builder, coverFilter flatbuffers.UOffsetT) {
+func InfoReplyRawAddCoverFilter(builder *flatbuffers.Builder, coverFilter flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(coverFilter), 0)
 }
-func InfoReplyStartCoverFilterVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func InfoReplyRawStartCoverFilterVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func InfoReplyEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func InfoReplyRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type FileInfoT struct {
+type FileInfoRawT struct {
 	Name   string `json:"name"`
 	Exists bool   `json:"exists"`
 	Error  string `json:"error"`
 	Data   []byte `json:"data"`
 }
 
-func (t *FileInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *FileInfoRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -1045,58 +1075,58 @@ func (t *FileInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t.Data != nil {
 		dataOffset = builder.CreateByteString(t.Data)
 	}
-	FileInfoStart(builder)
-	FileInfoAddName(builder, nameOffset)
-	FileInfoAddExists(builder, t.Exists)
-	FileInfoAddError(builder, errorOffset)
-	FileInfoAddData(builder, dataOffset)
-	return FileInfoEnd(builder)
+	FileInfoRawStart(builder)
+	FileInfoRawAddName(builder, nameOffset)
+	FileInfoRawAddExists(builder, t.Exists)
+	FileInfoRawAddError(builder, errorOffset)
+	FileInfoRawAddData(builder, dataOffset)
+	return FileInfoRawEnd(builder)
 }
 
-func (rcv *FileInfo) UnPackTo(t *FileInfoT) {
+func (rcv *FileInfoRaw) UnPackTo(t *FileInfoRawT) {
 	t.Name = string(rcv.Name())
 	t.Exists = rcv.Exists()
 	t.Error = string(rcv.Error())
 	t.Data = rcv.DataBytes()
 }
 
-func (rcv *FileInfo) UnPack() *FileInfoT {
+func (rcv *FileInfoRaw) UnPack() *FileInfoRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &FileInfoT{}
+	t := &FileInfoRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type FileInfo struct {
+type FileInfoRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsFileInfo(buf []byte, offset flatbuffers.UOffsetT) *FileInfo {
+func GetRootAsFileInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *FileInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &FileInfo{}
+	x := &FileInfoRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsFileInfo(buf []byte, offset flatbuffers.UOffsetT) *FileInfo {
+func GetSizePrefixedRootAsFileInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *FileInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &FileInfo{}
+	x := &FileInfoRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *FileInfo) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *FileInfoRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *FileInfo) Table() flatbuffers.Table {
+func (rcv *FileInfoRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *FileInfo) Name() []byte {
+func (rcv *FileInfoRaw) Name() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -1104,7 +1134,7 @@ func (rcv *FileInfo) Name() []byte {
 	return nil
 }
 
-func (rcv *FileInfo) Exists() bool {
+func (rcv *FileInfoRaw) Exists() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetBool(o + rcv._tab.Pos)
@@ -1112,11 +1142,11 @@ func (rcv *FileInfo) Exists() bool {
 	return false
 }
 
-func (rcv *FileInfo) MutateExists(n bool) bool {
+func (rcv *FileInfoRaw) MutateExists(n bool) bool {
 	return rcv._tab.MutateBoolSlot(6, n)
 }
 
-func (rcv *FileInfo) Error() []byte {
+func (rcv *FileInfoRaw) Error() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -1124,7 +1154,7 @@ func (rcv *FileInfo) Error() []byte {
 	return nil
 }
 
-func (rcv *FileInfo) Data(j int) byte {
+func (rcv *FileInfoRaw) Data(j int) byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1133,7 +1163,7 @@ func (rcv *FileInfo) Data(j int) byte {
 	return 0
 }
 
-func (rcv *FileInfo) DataLength() int {
+func (rcv *FileInfoRaw) DataLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1141,7 +1171,7 @@ func (rcv *FileInfo) DataLength() int {
 	return 0
 }
 
-func (rcv *FileInfo) DataBytes() []byte {
+func (rcv *FileInfoRaw) DataBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -1149,7 +1179,7 @@ func (rcv *FileInfo) DataBytes() []byte {
 	return nil
 }
 
-func (rcv *FileInfo) MutateData(j int, n byte) bool {
+func (rcv *FileInfoRaw) MutateData(j int, n byte) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1158,34 +1188,34 @@ func (rcv *FileInfo) MutateData(j int, n byte) bool {
 	return false
 }
 
-func FileInfoStart(builder *flatbuffers.Builder) {
+func FileInfoRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func FileInfoAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
+func FileInfoRawAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
 }
-func FileInfoAddExists(builder *flatbuffers.Builder, exists bool) {
+func FileInfoRawAddExists(builder *flatbuffers.Builder, exists bool) {
 	builder.PrependBoolSlot(1, exists, false)
 }
-func FileInfoAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
+func FileInfoRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(error), 0)
 }
-func FileInfoAddData(builder *flatbuffers.Builder, data flatbuffers.UOffsetT) {
+func FileInfoRawAddData(builder *flatbuffers.Builder, data flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(data), 0)
 }
-func FileInfoStartDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func FileInfoRawStartDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
-func FileInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func FileInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type GlobInfoT struct {
+type GlobInfoRawT struct {
 	Name  string   `json:"name"`
 	Files []string `json:"files"`
 }
 
-func (t *GlobInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *GlobInfoRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -1197,19 +1227,19 @@ func (t *GlobInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 		for j := 0; j < filesLength; j++ {
 			filesOffsets[j] = builder.CreateString(t.Files[j])
 		}
-		GlobInfoStartFilesVector(builder, filesLength)
+		GlobInfoRawStartFilesVector(builder, filesLength)
 		for j := filesLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(filesOffsets[j])
 		}
 		filesOffset = builder.EndVector(filesLength)
 	}
-	GlobInfoStart(builder)
-	GlobInfoAddName(builder, nameOffset)
-	GlobInfoAddFiles(builder, filesOffset)
-	return GlobInfoEnd(builder)
+	GlobInfoRawStart(builder)
+	GlobInfoRawAddName(builder, nameOffset)
+	GlobInfoRawAddFiles(builder, filesOffset)
+	return GlobInfoRawEnd(builder)
 }
 
-func (rcv *GlobInfo) UnPackTo(t *GlobInfoT) {
+func (rcv *GlobInfoRaw) UnPackTo(t *GlobInfoRawT) {
 	t.Name = string(rcv.Name())
 	filesLength := rcv.FilesLength()
 	t.Files = make([]string, filesLength)
@@ -1218,43 +1248,43 @@ func (rcv *GlobInfo) UnPackTo(t *GlobInfoT) {
 	}
 }
 
-func (rcv *GlobInfo) UnPack() *GlobInfoT {
+func (rcv *GlobInfoRaw) UnPack() *GlobInfoRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &GlobInfoT{}
+	t := &GlobInfoRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type GlobInfo struct {
+type GlobInfoRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsGlobInfo(buf []byte, offset flatbuffers.UOffsetT) *GlobInfo {
+func GetRootAsGlobInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *GlobInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &GlobInfo{}
+	x := &GlobInfoRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsGlobInfo(buf []byte, offset flatbuffers.UOffsetT) *GlobInfo {
+func GetSizePrefixedRootAsGlobInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *GlobInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &GlobInfo{}
+	x := &GlobInfoRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *GlobInfo) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *GlobInfoRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *GlobInfo) Table() flatbuffers.Table {
+func (rcv *GlobInfoRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *GlobInfo) Name() []byte {
+func (rcv *GlobInfoRaw) Name() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -1262,7 +1292,7 @@ func (rcv *GlobInfo) Name() []byte {
 	return nil
 }
 
-func (rcv *GlobInfo) Files(j int) []byte {
+func (rcv *GlobInfoRaw) Files(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1271,7 +1301,7 @@ func (rcv *GlobInfo) Files(j int) []byte {
 	return nil
 }
 
-func (rcv *GlobInfo) FilesLength() int {
+func (rcv *GlobInfoRaw) FilesLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1279,96 +1309,204 @@ func (rcv *GlobInfo) FilesLength() int {
 	return 0
 }
 
-func GlobInfoStart(builder *flatbuffers.Builder) {
+func GlobInfoRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func GlobInfoAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
+func GlobInfoRawAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
 }
-func GlobInfoAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
+func GlobInfoRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(files), 0)
 }
-func GlobInfoStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func GlobInfoRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func GlobInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func GlobInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type HostMessageT struct {
-	Msg *HostMessagesT `json:"msg"`
+type FeatureInfoRawT struct {
+	Id        Feature `json:"id"`
+	NeedSetup bool    `json:"need_setup"`
+	Reason    string  `json:"reason"`
 }
 
-func (t *HostMessageT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *FeatureInfoRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil {
+		return 0
+	}
+	reasonOffset := builder.CreateString(t.Reason)
+	FeatureInfoRawStart(builder)
+	FeatureInfoRawAddId(builder, t.Id)
+	FeatureInfoRawAddNeedSetup(builder, t.NeedSetup)
+	FeatureInfoRawAddReason(builder, reasonOffset)
+	return FeatureInfoRawEnd(builder)
+}
+
+func (rcv *FeatureInfoRaw) UnPackTo(t *FeatureInfoRawT) {
+	t.Id = rcv.Id()
+	t.NeedSetup = rcv.NeedSetup()
+	t.Reason = string(rcv.Reason())
+}
+
+func (rcv *FeatureInfoRaw) UnPack() *FeatureInfoRawT {
+	if rcv == nil {
+		return nil
+	}
+	t := &FeatureInfoRawT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
+type FeatureInfoRaw struct {
+	_tab flatbuffers.Table
+}
+
+func GetRootAsFeatureInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *FeatureInfoRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset:])
+	x := &FeatureInfoRaw{}
+	x.Init(buf, n+offset)
+	return x
+}
+
+func GetSizePrefixedRootAsFeatureInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *FeatureInfoRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
+	x := &FeatureInfoRaw{}
+	x.Init(buf, n+offset+flatbuffers.SizeUint32)
+	return x
+}
+
+func (rcv *FeatureInfoRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *FeatureInfoRaw) Table() flatbuffers.Table {
+	return rcv._tab
+}
+
+func (rcv *FeatureInfoRaw) Id() Feature {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return Feature(rcv._tab.GetUint64(o + rcv._tab.Pos))
+	}
+	return 0
+}
+
+func (rcv *FeatureInfoRaw) MutateId(n Feature) bool {
+	return rcv._tab.MutateUint64Slot(4, uint64(n))
+}
+
+func (rcv *FeatureInfoRaw) NeedSetup() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *FeatureInfoRaw) MutateNeedSetup(n bool) bool {
+	return rcv._tab.MutateBoolSlot(6, n)
+}
+
+func (rcv *FeatureInfoRaw) Reason() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func FeatureInfoRawStart(builder *flatbuffers.Builder) {
+	builder.StartObject(3)
+}
+func FeatureInfoRawAddId(builder *flatbuffers.Builder, id Feature) {
+	builder.PrependUint64Slot(0, uint64(id), 0)
+}
+func FeatureInfoRawAddNeedSetup(builder *flatbuffers.Builder, needSetup bool) {
+	builder.PrependBoolSlot(1, needSetup, false)
+}
+func FeatureInfoRawAddReason(builder *flatbuffers.Builder, reason flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(reason), 0)
+}
+func FeatureInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	return builder.EndObject()
+}
+
+type HostMessageRawT struct {
+	Msg *HostMessagesRawT `json:"msg"`
+}
+
+func (t *HostMessageRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	msgOffset := t.Msg.Pack(builder)
 
-	HostMessageStart(builder)
+	HostMessageRawStart(builder)
 	if t.Msg != nil {
-		HostMessageAddMsgType(builder, t.Msg.Type)
+		HostMessageRawAddMsgType(builder, t.Msg.Type)
 	}
-	HostMessageAddMsg(builder, msgOffset)
-	return HostMessageEnd(builder)
+	HostMessageRawAddMsg(builder, msgOffset)
+	return HostMessageRawEnd(builder)
 }
 
-func (rcv *HostMessage) UnPackTo(t *HostMessageT) {
+func (rcv *HostMessageRaw) UnPackTo(t *HostMessageRawT) {
 	msgTable := flatbuffers.Table{}
 	if rcv.Msg(&msgTable) {
 		t.Msg = rcv.MsgType().UnPack(msgTable)
 	}
 }
 
-func (rcv *HostMessage) UnPack() *HostMessageT {
+func (rcv *HostMessageRaw) UnPack() *HostMessageRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &HostMessageT{}
+	t := &HostMessageRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type HostMessage struct {
+type HostMessageRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsHostMessage(buf []byte, offset flatbuffers.UOffsetT) *HostMessage {
+func GetRootAsHostMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *HostMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &HostMessage{}
+	x := &HostMessageRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsHostMessage(buf []byte, offset flatbuffers.UOffsetT) *HostMessage {
+func GetSizePrefixedRootAsHostMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *HostMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &HostMessage{}
+	x := &HostMessageRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *HostMessage) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *HostMessageRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *HostMessage) Table() flatbuffers.Table {
+func (rcv *HostMessageRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *HostMessage) MsgType() HostMessages {
+func (rcv *HostMessageRaw) MsgType() HostMessagesRaw {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return HostMessages(rcv._tab.GetByte(o + rcv._tab.Pos))
+		return HostMessagesRaw(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *HostMessage) MutateMsgType(n HostMessages) bool {
+func (rcv *HostMessageRaw) MutateMsgType(n HostMessagesRaw) bool {
 	return rcv._tab.MutateByteSlot(4, byte(n))
 }
 
-func (rcv *HostMessage) Msg(obj *flatbuffers.Table) bool {
+func (rcv *HostMessageRaw) Msg(obj *flatbuffers.Table) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		rcv._tab.Union(obj, o)
@@ -1377,93 +1515,93 @@ func (rcv *HostMessage) Msg(obj *flatbuffers.Table) bool {
 	return false
 }
 
-func HostMessageStart(builder *flatbuffers.Builder) {
+func HostMessageRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func HostMessageAddMsgType(builder *flatbuffers.Builder, msgType HostMessages) {
+func HostMessageRawAddMsgType(builder *flatbuffers.Builder, msgType HostMessagesRaw) {
 	builder.PrependByteSlot(0, byte(msgType), 0)
 }
-func HostMessageAddMsg(builder *flatbuffers.Builder, msg flatbuffers.UOffsetT) {
+func HostMessageRawAddMsg(builder *flatbuffers.Builder, msg flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(msg), 0)
 }
-func HostMessageEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func HostMessageRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ExecutorMessageT struct {
-	Msg *ExecutorMessagesT `json:"msg"`
+type ExecutorMessageRawT struct {
+	Msg *ExecutorMessagesRawT `json:"msg"`
 }
 
-func (t *ExecutorMessageT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ExecutorMessageRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	msgOffset := t.Msg.Pack(builder)
 
-	ExecutorMessageStart(builder)
+	ExecutorMessageRawStart(builder)
 	if t.Msg != nil {
-		ExecutorMessageAddMsgType(builder, t.Msg.Type)
+		ExecutorMessageRawAddMsgType(builder, t.Msg.Type)
 	}
-	ExecutorMessageAddMsg(builder, msgOffset)
-	return ExecutorMessageEnd(builder)
+	ExecutorMessageRawAddMsg(builder, msgOffset)
+	return ExecutorMessageRawEnd(builder)
 }
 
-func (rcv *ExecutorMessage) UnPackTo(t *ExecutorMessageT) {
+func (rcv *ExecutorMessageRaw) UnPackTo(t *ExecutorMessageRawT) {
 	msgTable := flatbuffers.Table{}
 	if rcv.Msg(&msgTable) {
 		t.Msg = rcv.MsgType().UnPack(msgTable)
 	}
 }
 
-func (rcv *ExecutorMessage) UnPack() *ExecutorMessageT {
+func (rcv *ExecutorMessageRaw) UnPack() *ExecutorMessageRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ExecutorMessageT{}
+	t := &ExecutorMessageRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ExecutorMessage struct {
+type ExecutorMessageRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsExecutorMessage(buf []byte, offset flatbuffers.UOffsetT) *ExecutorMessage {
+func GetRootAsExecutorMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecutorMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ExecutorMessage{}
+	x := &ExecutorMessageRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsExecutorMessage(buf []byte, offset flatbuffers.UOffsetT) *ExecutorMessage {
+func GetSizePrefixedRootAsExecutorMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecutorMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ExecutorMessage{}
+	x := &ExecutorMessageRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ExecutorMessage) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ExecutorMessageRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ExecutorMessage) Table() flatbuffers.Table {
+func (rcv *ExecutorMessageRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ExecutorMessage) MsgType() ExecutorMessages {
+func (rcv *ExecutorMessageRaw) MsgType() ExecutorMessagesRaw {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return ExecutorMessages(rcv._tab.GetByte(o + rcv._tab.Pos))
+		return ExecutorMessagesRaw(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *ExecutorMessage) MutateMsgType(n ExecutorMessages) bool {
+func (rcv *ExecutorMessageRaw) MutateMsgType(n ExecutorMessagesRaw) bool {
 	return rcv._tab.MutateByteSlot(4, byte(n))
 }
 
-func (rcv *ExecutorMessage) Msg(obj *flatbuffers.Table) bool {
+func (rcv *ExecutorMessageRaw) Msg(obj *flatbuffers.Table) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		rcv._tab.Union(obj, o)
@@ -1472,20 +1610,20 @@ func (rcv *ExecutorMessage) Msg(obj *flatbuffers.Table) bool {
 	return false
 }
 
-func ExecutorMessageStart(builder *flatbuffers.Builder) {
+func ExecutorMessageRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func ExecutorMessageAddMsgType(builder *flatbuffers.Builder, msgType ExecutorMessages) {
+func ExecutorMessageRawAddMsgType(builder *flatbuffers.Builder, msgType ExecutorMessagesRaw) {
 	builder.PrependByteSlot(0, byte(msgType), 0)
 }
-func ExecutorMessageAddMsg(builder *flatbuffers.Builder, msg flatbuffers.UOffsetT) {
+func ExecutorMessageRawAddMsg(builder *flatbuffers.Builder, msg flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(msg), 0)
 }
-func ExecutorMessageEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ExecutorMessageRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ExecRequestT struct {
+type ExecRequestRawT struct {
 	Id               int64       `json:"id"`
 	ProgData         []byte      `json:"prog_data"`
 	Flags            RequestFlag `json:"flags"`
@@ -1497,7 +1635,7 @@ type ExecRequestT struct {
 	Repeat           int32       `json:"repeat"`
 }
 
-func (t *ExecRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ExecRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -1508,26 +1646,26 @@ func (t *ExecRequestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	signalFilterOffset := flatbuffers.UOffsetT(0)
 	if t.SignalFilter != nil {
 		signalFilterLength := len(t.SignalFilter)
-		ExecRequestStartSignalFilterVector(builder, signalFilterLength)
+		ExecRequestRawStartSignalFilterVector(builder, signalFilterLength)
 		for j := signalFilterLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.SignalFilter[j])
 		}
 		signalFilterOffset = builder.EndVector(signalFilterLength)
 	}
-	ExecRequestStart(builder)
-	ExecRequestAddId(builder, t.Id)
-	ExecRequestAddProgData(builder, progDataOffset)
-	ExecRequestAddFlags(builder, t.Flags)
-	ExecRequestAddExecEnv(builder, t.ExecEnv)
-	ExecRequestAddExecFlags(builder, t.ExecFlags)
-	ExecRequestAddSandboxArg(builder, t.SandboxArg)
-	ExecRequestAddSignalFilter(builder, signalFilterOffset)
-	ExecRequestAddSignalFilterCall(builder, t.SignalFilterCall)
-	ExecRequestAddRepeat(builder, t.Repeat)
-	return ExecRequestEnd(builder)
+	ExecRequestRawStart(builder)
+	ExecRequestRawAddId(builder, t.Id)
+	ExecRequestRawAddProgData(builder, progDataOffset)
+	ExecRequestRawAddFlags(builder, t.Flags)
+	ExecRequestRawAddExecEnv(builder, t.ExecEnv)
+	ExecRequestRawAddExecFlags(builder, t.ExecFlags)
+	ExecRequestRawAddSandboxArg(builder, t.SandboxArg)
+	ExecRequestRawAddSignalFilter(builder, signalFilterOffset)
+	ExecRequestRawAddSignalFilterCall(builder, t.SignalFilterCall)
+	ExecRequestRawAddRepeat(builder, t.Repeat)
+	return ExecRequestRawEnd(builder)
 }
 
-func (rcv *ExecRequest) UnPackTo(t *ExecRequestT) {
+func (rcv *ExecRequestRaw) UnPackTo(t *ExecRequestRawT) {
 	t.Id = rcv.Id()
 	t.ProgData = rcv.ProgDataBytes()
 	t.Flags = rcv.Flags()
@@ -1543,43 +1681,43 @@ func (rcv *ExecRequest) UnPackTo(t *ExecRequestT) {
 	t.Repeat = rcv.Repeat()
 }
 
-func (rcv *ExecRequest) UnPack() *ExecRequestT {
+func (rcv *ExecRequestRaw) UnPack() *ExecRequestRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ExecRequestT{}
+	t := &ExecRequestRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ExecRequest struct {
+type ExecRequestRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsExecRequest(buf []byte, offset flatbuffers.UOffsetT) *ExecRequest {
+func GetRootAsExecRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ExecRequest{}
+	x := &ExecRequestRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsExecRequest(buf []byte, offset flatbuffers.UOffsetT) *ExecRequest {
+func GetSizePrefixedRootAsExecRequestRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecRequestRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ExecRequest{}
+	x := &ExecRequestRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ExecRequest) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ExecRequestRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ExecRequest) Table() flatbuffers.Table {
+func (rcv *ExecRequestRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ExecRequest) Id() int64 {
+func (rcv *ExecRequestRaw) Id() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
@@ -1587,11 +1725,11 @@ func (rcv *ExecRequest) Id() int64 {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateId(n int64) bool {
+func (rcv *ExecRequestRaw) MutateId(n int64) bool {
 	return rcv._tab.MutateInt64Slot(4, n)
 }
 
-func (rcv *ExecRequest) ProgData(j int) byte {
+func (rcv *ExecRequestRaw) ProgData(j int) byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1600,7 +1738,7 @@ func (rcv *ExecRequest) ProgData(j int) byte {
 	return 0
 }
 
-func (rcv *ExecRequest) ProgDataLength() int {
+func (rcv *ExecRequestRaw) ProgDataLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1608,7 +1746,7 @@ func (rcv *ExecRequest) ProgDataLength() int {
 	return 0
 }
 
-func (rcv *ExecRequest) ProgDataBytes() []byte {
+func (rcv *ExecRequestRaw) ProgDataBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -1616,7 +1754,7 @@ func (rcv *ExecRequest) ProgDataBytes() []byte {
 	return nil
 }
 
-func (rcv *ExecRequest) MutateProgData(j int, n byte) bool {
+func (rcv *ExecRequestRaw) MutateProgData(j int, n byte) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1625,7 +1763,7 @@ func (rcv *ExecRequest) MutateProgData(j int, n byte) bool {
 	return false
 }
 
-func (rcv *ExecRequest) Flags() RequestFlag {
+func (rcv *ExecRequestRaw) Flags() RequestFlag {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return RequestFlag(rcv._tab.GetUint64(o + rcv._tab.Pos))
@@ -1633,11 +1771,11 @@ func (rcv *ExecRequest) Flags() RequestFlag {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateFlags(n RequestFlag) bool {
+func (rcv *ExecRequestRaw) MutateFlags(n RequestFlag) bool {
 	return rcv._tab.MutateUint64Slot(8, uint64(n))
 }
 
-func (rcv *ExecRequest) ExecEnv() ExecEnv {
+func (rcv *ExecRequestRaw) ExecEnv() ExecEnv {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return ExecEnv(rcv._tab.GetUint64(o + rcv._tab.Pos))
@@ -1645,11 +1783,11 @@ func (rcv *ExecRequest) ExecEnv() ExecEnv {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateExecEnv(n ExecEnv) bool {
+func (rcv *ExecRequestRaw) MutateExecEnv(n ExecEnv) bool {
 	return rcv._tab.MutateUint64Slot(10, uint64(n))
 }
 
-func (rcv *ExecRequest) ExecFlags() ExecFlag {
+func (rcv *ExecRequestRaw) ExecFlags() ExecFlag {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return ExecFlag(rcv._tab.GetUint64(o + rcv._tab.Pos))
@@ -1657,11 +1795,11 @@ func (rcv *ExecRequest) ExecFlags() ExecFlag {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateExecFlags(n ExecFlag) bool {
+func (rcv *ExecRequestRaw) MutateExecFlags(n ExecFlag) bool {
 	return rcv._tab.MutateUint64Slot(12, uint64(n))
 }
 
-func (rcv *ExecRequest) SandboxArg() int64 {
+func (rcv *ExecRequestRaw) SandboxArg() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
@@ -1669,11 +1807,11 @@ func (rcv *ExecRequest) SandboxArg() int64 {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateSandboxArg(n int64) bool {
+func (rcv *ExecRequestRaw) MutateSandboxArg(n int64) bool {
 	return rcv._tab.MutateInt64Slot(14, n)
 }
 
-func (rcv *ExecRequest) SignalFilter(j int) uint32 {
+func (rcv *ExecRequestRaw) SignalFilter(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1682,7 +1820,7 @@ func (rcv *ExecRequest) SignalFilter(j int) uint32 {
 	return 0
 }
 
-func (rcv *ExecRequest) SignalFilterLength() int {
+func (rcv *ExecRequestRaw) SignalFilterLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1690,7 +1828,7 @@ func (rcv *ExecRequest) SignalFilterLength() int {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateSignalFilter(j int, n uint32) bool {
+func (rcv *ExecRequestRaw) MutateSignalFilter(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1699,7 +1837,7 @@ func (rcv *ExecRequest) MutateSignalFilter(j int, n uint32) bool {
 	return false
 }
 
-func (rcv *ExecRequest) SignalFilterCall() int32 {
+func (rcv *ExecRequestRaw) SignalFilterCall() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -1707,11 +1845,11 @@ func (rcv *ExecRequest) SignalFilterCall() int32 {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateSignalFilterCall(n int32) bool {
+func (rcv *ExecRequestRaw) MutateSignalFilterCall(n int32) bool {
 	return rcv._tab.MutateInt32Slot(18, n)
 }
 
-func (rcv *ExecRequest) Repeat() int32 {
+func (rcv *ExecRequestRaw) Repeat() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -1719,63 +1857,63 @@ func (rcv *ExecRequest) Repeat() int32 {
 	return 0
 }
 
-func (rcv *ExecRequest) MutateRepeat(n int32) bool {
+func (rcv *ExecRequestRaw) MutateRepeat(n int32) bool {
 	return rcv._tab.MutateInt32Slot(20, n)
 }
 
-func ExecRequestStart(builder *flatbuffers.Builder) {
+func ExecRequestRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(9)
 }
-func ExecRequestAddId(builder *flatbuffers.Builder, id int64) {
+func ExecRequestRawAddId(builder *flatbuffers.Builder, id int64) {
 	builder.PrependInt64Slot(0, id, 0)
 }
-func ExecRequestAddProgData(builder *flatbuffers.Builder, progData flatbuffers.UOffsetT) {
+func ExecRequestRawAddProgData(builder *flatbuffers.Builder, progData flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(progData), 0)
 }
-func ExecRequestStartProgDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ExecRequestRawStartProgDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
-func ExecRequestAddFlags(builder *flatbuffers.Builder, flags RequestFlag) {
+func ExecRequestRawAddFlags(builder *flatbuffers.Builder, flags RequestFlag) {
 	builder.PrependUint64Slot(2, uint64(flags), 0)
 }
-func ExecRequestAddExecEnv(builder *flatbuffers.Builder, execEnv ExecEnv) {
+func ExecRequestRawAddExecEnv(builder *flatbuffers.Builder, execEnv ExecEnv) {
 	builder.PrependUint64Slot(3, uint64(execEnv), 0)
 }
-func ExecRequestAddExecFlags(builder *flatbuffers.Builder, execFlags ExecFlag) {
+func ExecRequestRawAddExecFlags(builder *flatbuffers.Builder, execFlags ExecFlag) {
 	builder.PrependUint64Slot(4, uint64(execFlags), 0)
 }
-func ExecRequestAddSandboxArg(builder *flatbuffers.Builder, sandboxArg int64) {
+func ExecRequestRawAddSandboxArg(builder *flatbuffers.Builder, sandboxArg int64) {
 	builder.PrependInt64Slot(5, sandboxArg, 0)
 }
-func ExecRequestAddSignalFilter(builder *flatbuffers.Builder, signalFilter flatbuffers.UOffsetT) {
+func ExecRequestRawAddSignalFilter(builder *flatbuffers.Builder, signalFilter flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(signalFilter), 0)
 }
-func ExecRequestStartSignalFilterVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ExecRequestRawStartSignalFilterVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ExecRequestAddSignalFilterCall(builder *flatbuffers.Builder, signalFilterCall int32) {
+func ExecRequestRawAddSignalFilterCall(builder *flatbuffers.Builder, signalFilterCall int32) {
 	builder.PrependInt32Slot(7, signalFilterCall, 0)
 }
-func ExecRequestAddRepeat(builder *flatbuffers.Builder, repeat int32) {
+func ExecRequestRawAddRepeat(builder *flatbuffers.Builder, repeat int32) {
 	builder.PrependInt32Slot(8, repeat, 0)
 }
-func ExecRequestEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ExecRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type SignalUpdateT struct {
+type SignalUpdateRawT struct {
 	NewMax  []uint32 `json:"new_max"`
 	DropMax []uint32 `json:"drop_max"`
 }
 
-func (t *SignalUpdateT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *SignalUpdateRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	newMaxOffset := flatbuffers.UOffsetT(0)
 	if t.NewMax != nil {
 		newMaxLength := len(t.NewMax)
-		SignalUpdateStartNewMaxVector(builder, newMaxLength)
+		SignalUpdateRawStartNewMaxVector(builder, newMaxLength)
 		for j := newMaxLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.NewMax[j])
 		}
@@ -1784,19 +1922,19 @@ func (t *SignalUpdateT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT 
 	dropMaxOffset := flatbuffers.UOffsetT(0)
 	if t.DropMax != nil {
 		dropMaxLength := len(t.DropMax)
-		SignalUpdateStartDropMaxVector(builder, dropMaxLength)
+		SignalUpdateRawStartDropMaxVector(builder, dropMaxLength)
 		for j := dropMaxLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.DropMax[j])
 		}
 		dropMaxOffset = builder.EndVector(dropMaxLength)
 	}
-	SignalUpdateStart(builder)
-	SignalUpdateAddNewMax(builder, newMaxOffset)
-	SignalUpdateAddDropMax(builder, dropMaxOffset)
-	return SignalUpdateEnd(builder)
+	SignalUpdateRawStart(builder)
+	SignalUpdateRawAddNewMax(builder, newMaxOffset)
+	SignalUpdateRawAddDropMax(builder, dropMaxOffset)
+	return SignalUpdateRawEnd(builder)
 }
 
-func (rcv *SignalUpdate) UnPackTo(t *SignalUpdateT) {
+func (rcv *SignalUpdateRaw) UnPackTo(t *SignalUpdateRawT) {
 	newMaxLength := rcv.NewMaxLength()
 	t.NewMax = make([]uint32, newMaxLength)
 	for j := 0; j < newMaxLength; j++ {
@@ -1809,43 +1947,43 @@ func (rcv *SignalUpdate) UnPackTo(t *SignalUpdateT) {
 	}
 }
 
-func (rcv *SignalUpdate) UnPack() *SignalUpdateT {
+func (rcv *SignalUpdateRaw) UnPack() *SignalUpdateRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &SignalUpdateT{}
+	t := &SignalUpdateRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type SignalUpdate struct {
+type SignalUpdateRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsSignalUpdate(buf []byte, offset flatbuffers.UOffsetT) *SignalUpdate {
+func GetRootAsSignalUpdateRaw(buf []byte, offset flatbuffers.UOffsetT) *SignalUpdateRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &SignalUpdate{}
+	x := &SignalUpdateRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsSignalUpdate(buf []byte, offset flatbuffers.UOffsetT) *SignalUpdate {
+func GetSizePrefixedRootAsSignalUpdateRaw(buf []byte, offset flatbuffers.UOffsetT) *SignalUpdateRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &SignalUpdate{}
+	x := &SignalUpdateRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *SignalUpdate) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *SignalUpdateRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *SignalUpdate) Table() flatbuffers.Table {
+func (rcv *SignalUpdateRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *SignalUpdate) NewMax(j int) uint32 {
+func (rcv *SignalUpdateRaw) NewMax(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1854,7 +1992,7 @@ func (rcv *SignalUpdate) NewMax(j int) uint32 {
 	return 0
 }
 
-func (rcv *SignalUpdate) NewMaxLength() int {
+func (rcv *SignalUpdateRaw) NewMaxLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1862,7 +2000,7 @@ func (rcv *SignalUpdate) NewMaxLength() int {
 	return 0
 }
 
-func (rcv *SignalUpdate) MutateNewMax(j int, n uint32) bool {
+func (rcv *SignalUpdateRaw) MutateNewMax(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1871,7 +2009,7 @@ func (rcv *SignalUpdate) MutateNewMax(j int, n uint32) bool {
 	return false
 }
 
-func (rcv *SignalUpdate) DropMax(j int) uint32 {
+func (rcv *SignalUpdateRaw) DropMax(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1880,7 +2018,7 @@ func (rcv *SignalUpdate) DropMax(j int) uint32 {
 	return 0
 }
 
-func (rcv *SignalUpdate) DropMaxLength() int {
+func (rcv *SignalUpdateRaw) DropMaxLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -1888,7 +2026,7 @@ func (rcv *SignalUpdate) DropMaxLength() int {
 	return 0
 }
 
-func (rcv *SignalUpdate) MutateDropMax(j int, n uint32) bool {
+func (rcv *SignalUpdateRaw) MutateDropMax(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -1897,85 +2035,85 @@ func (rcv *SignalUpdate) MutateDropMax(j int, n uint32) bool {
 	return false
 }
 
-func SignalUpdateStart(builder *flatbuffers.Builder) {
+func SignalUpdateRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func SignalUpdateAddNewMax(builder *flatbuffers.Builder, newMax flatbuffers.UOffsetT) {
+func SignalUpdateRawAddNewMax(builder *flatbuffers.Builder, newMax flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(newMax), 0)
 }
-func SignalUpdateStartNewMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func SignalUpdateRawStartNewMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func SignalUpdateAddDropMax(builder *flatbuffers.Builder, dropMax flatbuffers.UOffsetT) {
+func SignalUpdateRawAddDropMax(builder *flatbuffers.Builder, dropMax flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(dropMax), 0)
 }
-func SignalUpdateStartDropMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func SignalUpdateRawStartDropMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func SignalUpdateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func SignalUpdateRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ExecutingMessageT struct {
+type ExecutingMessageRawT struct {
 	Id     int64 `json:"id"`
 	ProcId int32 `json:"proc_id"`
 	Try    int32 `json:"try"`
 }
 
-func (t *ExecutingMessageT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ExecutingMessageRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
-	ExecutingMessageStart(builder)
-	ExecutingMessageAddId(builder, t.Id)
-	ExecutingMessageAddProcId(builder, t.ProcId)
-	ExecutingMessageAddTry(builder, t.Try)
-	return ExecutingMessageEnd(builder)
+	ExecutingMessageRawStart(builder)
+	ExecutingMessageRawAddId(builder, t.Id)
+	ExecutingMessageRawAddProcId(builder, t.ProcId)
+	ExecutingMessageRawAddTry(builder, t.Try)
+	return ExecutingMessageRawEnd(builder)
 }
 
-func (rcv *ExecutingMessage) UnPackTo(t *ExecutingMessageT) {
+func (rcv *ExecutingMessageRaw) UnPackTo(t *ExecutingMessageRawT) {
 	t.Id = rcv.Id()
 	t.ProcId = rcv.ProcId()
 	t.Try = rcv.Try()
 }
 
-func (rcv *ExecutingMessage) UnPack() *ExecutingMessageT {
+func (rcv *ExecutingMessageRaw) UnPack() *ExecutingMessageRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ExecutingMessageT{}
+	t := &ExecutingMessageRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ExecutingMessage struct {
+type ExecutingMessageRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsExecutingMessage(buf []byte, offset flatbuffers.UOffsetT) *ExecutingMessage {
+func GetRootAsExecutingMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecutingMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ExecutingMessage{}
+	x := &ExecutingMessageRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsExecutingMessage(buf []byte, offset flatbuffers.UOffsetT) *ExecutingMessage {
+func GetSizePrefixedRootAsExecutingMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecutingMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ExecutingMessage{}
+	x := &ExecutingMessageRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ExecutingMessage) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ExecutingMessageRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ExecutingMessage) Table() flatbuffers.Table {
+func (rcv *ExecutingMessageRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ExecutingMessage) Id() int64 {
+func (rcv *ExecutingMessageRaw) Id() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
@@ -1983,11 +2121,11 @@ func (rcv *ExecutingMessage) Id() int64 {
 	return 0
 }
 
-func (rcv *ExecutingMessage) MutateId(n int64) bool {
+func (rcv *ExecutingMessageRaw) MutateId(n int64) bool {
 	return rcv._tab.MutateInt64Slot(4, n)
 }
 
-func (rcv *ExecutingMessage) ProcId() int32 {
+func (rcv *ExecutingMessageRaw) ProcId() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -1995,11 +2133,11 @@ func (rcv *ExecutingMessage) ProcId() int32 {
 	return 0
 }
 
-func (rcv *ExecutingMessage) MutateProcId(n int32) bool {
+func (rcv *ExecutingMessageRaw) MutateProcId(n int32) bool {
 	return rcv._tab.MutateInt32Slot(6, n)
 }
 
-func (rcv *ExecutingMessage) Try() int32 {
+func (rcv *ExecutingMessageRaw) Try() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -2007,83 +2145,83 @@ func (rcv *ExecutingMessage) Try() int32 {
 	return 0
 }
 
-func (rcv *ExecutingMessage) MutateTry(n int32) bool {
+func (rcv *ExecutingMessageRaw) MutateTry(n int32) bool {
 	return rcv._tab.MutateInt32Slot(8, n)
 }
 
-func ExecutingMessageStart(builder *flatbuffers.Builder) {
+func ExecutingMessageRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(3)
 }
-func ExecutingMessageAddId(builder *flatbuffers.Builder, id int64) {
+func ExecutingMessageRawAddId(builder *flatbuffers.Builder, id int64) {
 	builder.PrependInt64Slot(0, id, 0)
 }
-func ExecutingMessageAddProcId(builder *flatbuffers.Builder, procId int32) {
+func ExecutingMessageRawAddProcId(builder *flatbuffers.Builder, procId int32) {
 	builder.PrependInt32Slot(1, procId, 0)
 }
-func ExecutingMessageAddTry(builder *flatbuffers.Builder, try int32) {
+func ExecutingMessageRawAddTry(builder *flatbuffers.Builder, try int32) {
 	builder.PrependInt32Slot(2, try, 0)
 }
-func ExecutingMessageEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ExecutingMessageRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type StatsMessageT struct {
+type StatsMessageRawT struct {
 	NoexecCount    int64 `json:"noexec_count"`
 	NoexecDuration int64 `json:"noexec_duration"`
 }
 
-func (t *StatsMessageT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *StatsMessageRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
-	StatsMessageStart(builder)
-	StatsMessageAddNoexecCount(builder, t.NoexecCount)
-	StatsMessageAddNoexecDuration(builder, t.NoexecDuration)
-	return StatsMessageEnd(builder)
+	StatsMessageRawStart(builder)
+	StatsMessageRawAddNoexecCount(builder, t.NoexecCount)
+	StatsMessageRawAddNoexecDuration(builder, t.NoexecDuration)
+	return StatsMessageRawEnd(builder)
 }
 
-func (rcv *StatsMessage) UnPackTo(t *StatsMessageT) {
+func (rcv *StatsMessageRaw) UnPackTo(t *StatsMessageRawT) {
 	t.NoexecCount = rcv.NoexecCount()
 	t.NoexecDuration = rcv.NoexecDuration()
 }
 
-func (rcv *StatsMessage) UnPack() *StatsMessageT {
+func (rcv *StatsMessageRaw) UnPack() *StatsMessageRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &StatsMessageT{}
+	t := &StatsMessageRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type StatsMessage struct {
+type StatsMessageRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsStatsMessage(buf []byte, offset flatbuffers.UOffsetT) *StatsMessage {
+func GetRootAsStatsMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *StatsMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &StatsMessage{}
+	x := &StatsMessageRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsStatsMessage(buf []byte, offset flatbuffers.UOffsetT) *StatsMessage {
+func GetSizePrefixedRootAsStatsMessageRaw(buf []byte, offset flatbuffers.UOffsetT) *StatsMessageRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &StatsMessage{}
+	x := &StatsMessageRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *StatsMessage) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *StatsMessageRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *StatsMessage) Table() flatbuffers.Table {
+func (rcv *StatsMessageRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *StatsMessage) NoexecCount() int64 {
+func (rcv *StatsMessageRaw) NoexecCount() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
@@ -2091,11 +2229,11 @@ func (rcv *StatsMessage) NoexecCount() int64 {
 	return 0
 }
 
-func (rcv *StatsMessage) MutateNoexecCount(n int64) bool {
+func (rcv *StatsMessageRaw) MutateNoexecCount(n int64) bool {
 	return rcv._tab.MutateInt64Slot(4, n)
 }
 
-func (rcv *StatsMessage) NoexecDuration() int64 {
+func (rcv *StatsMessageRaw) NoexecDuration() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
@@ -2103,39 +2241,39 @@ func (rcv *StatsMessage) NoexecDuration() int64 {
 	return 0
 }
 
-func (rcv *StatsMessage) MutateNoexecDuration(n int64) bool {
+func (rcv *StatsMessageRaw) MutateNoexecDuration(n int64) bool {
 	return rcv._tab.MutateInt64Slot(6, n)
 }
 
-func StatsMessageStart(builder *flatbuffers.Builder) {
+func StatsMessageRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func StatsMessageAddNoexecCount(builder *flatbuffers.Builder, noexecCount int64) {
+func StatsMessageRawAddNoexecCount(builder *flatbuffers.Builder, noexecCount int64) {
 	builder.PrependInt64Slot(0, noexecCount, 0)
 }
-func StatsMessageAddNoexecDuration(builder *flatbuffers.Builder, noexecDuration int64) {
+func StatsMessageRawAddNoexecDuration(builder *flatbuffers.Builder, noexecDuration int64) {
 	builder.PrependInt64Slot(1, noexecDuration, 0)
 }
-func StatsMessageEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func StatsMessageRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type CallInfoT struct {
-	Flags  CallFlag       `json:"flags"`
-	Error  int32          `json:"error"`
-	Signal []uint32       `json:"signal"`
-	Cover  []uint32       `json:"cover"`
-	Comps  []*ComparisonT `json:"comps"`
+type CallInfoRawT struct {
+	Flags  CallFlag          `json:"flags"`
+	Error  int32             `json:"error"`
+	Signal []uint32          `json:"signal"`
+	Cover  []uint32          `json:"cover"`
+	Comps  []*ComparisonRawT `json:"comps"`
 }
 
-func (t *CallInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *CallInfoRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	signalOffset := flatbuffers.UOffsetT(0)
 	if t.Signal != nil {
 		signalLength := len(t.Signal)
-		CallInfoStartSignalVector(builder, signalLength)
+		CallInfoRawStartSignalVector(builder, signalLength)
 		for j := signalLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.Signal[j])
 		}
@@ -2144,7 +2282,7 @@ func (t *CallInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	coverOffset := flatbuffers.UOffsetT(0)
 	if t.Cover != nil {
 		coverLength := len(t.Cover)
-		CallInfoStartCoverVector(builder, coverLength)
+		CallInfoRawStartCoverVector(builder, coverLength)
 		for j := coverLength - 1; j >= 0; j-- {
 			builder.PrependUint32(t.Cover[j])
 		}
@@ -2153,22 +2291,22 @@ func (t *CallInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	compsOffset := flatbuffers.UOffsetT(0)
 	if t.Comps != nil {
 		compsLength := len(t.Comps)
-		CallInfoStartCompsVector(builder, compsLength)
+		CallInfoRawStartCompsVector(builder, compsLength)
 		for j := compsLength - 1; j >= 0; j-- {
 			t.Comps[j].Pack(builder)
 		}
 		compsOffset = builder.EndVector(compsLength)
 	}
-	CallInfoStart(builder)
-	CallInfoAddFlags(builder, t.Flags)
-	CallInfoAddError(builder, t.Error)
-	CallInfoAddSignal(builder, signalOffset)
-	CallInfoAddCover(builder, coverOffset)
-	CallInfoAddComps(builder, compsOffset)
-	return CallInfoEnd(builder)
+	CallInfoRawStart(builder)
+	CallInfoRawAddFlags(builder, t.Flags)
+	CallInfoRawAddError(builder, t.Error)
+	CallInfoRawAddSignal(builder, signalOffset)
+	CallInfoRawAddCover(builder, coverOffset)
+	CallInfoRawAddComps(builder, compsOffset)
+	return CallInfoRawEnd(builder)
 }
 
-func (rcv *CallInfo) UnPackTo(t *CallInfoT) {
+func (rcv *CallInfoRaw) UnPackTo(t *CallInfoRawT) {
 	t.Flags = rcv.Flags()
 	t.Error = rcv.Error()
 	signalLength := rcv.SignalLength()
@@ -2182,51 +2320,51 @@ func (rcv *CallInfo) UnPackTo(t *CallInfoT) {
 		t.Cover[j] = rcv.Cover(j)
 	}
 	compsLength := rcv.CompsLength()
-	t.Comps = make([]*ComparisonT, compsLength)
+	t.Comps = make([]*ComparisonRawT, compsLength)
 	for j := 0; j < compsLength; j++ {
-		x := Comparison{}
+		x := ComparisonRaw{}
 		rcv.Comps(&x, j)
 		t.Comps[j] = x.UnPack()
 	}
 }
 
-func (rcv *CallInfo) UnPack() *CallInfoT {
+func (rcv *CallInfoRaw) UnPack() *CallInfoRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &CallInfoT{}
+	t := &CallInfoRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type CallInfo struct {
+type CallInfoRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsCallInfo(buf []byte, offset flatbuffers.UOffsetT) *CallInfo {
+func GetRootAsCallInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *CallInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &CallInfo{}
+	x := &CallInfoRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsCallInfo(buf []byte, offset flatbuffers.UOffsetT) *CallInfo {
+func GetSizePrefixedRootAsCallInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *CallInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &CallInfo{}
+	x := &CallInfoRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *CallInfo) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *CallInfoRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *CallInfo) Table() flatbuffers.Table {
+func (rcv *CallInfoRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *CallInfo) Flags() CallFlag {
+func (rcv *CallInfoRaw) Flags() CallFlag {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return CallFlag(rcv._tab.GetByte(o + rcv._tab.Pos))
@@ -2234,11 +2372,11 @@ func (rcv *CallInfo) Flags() CallFlag {
 	return 0
 }
 
-func (rcv *CallInfo) MutateFlags(n CallFlag) bool {
+func (rcv *CallInfoRaw) MutateFlags(n CallFlag) bool {
 	return rcv._tab.MutateByteSlot(4, byte(n))
 }
 
-func (rcv *CallInfo) Error() int32 {
+func (rcv *CallInfoRaw) Error() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -2246,11 +2384,11 @@ func (rcv *CallInfo) Error() int32 {
 	return 0
 }
 
-func (rcv *CallInfo) MutateError(n int32) bool {
+func (rcv *CallInfoRaw) MutateError(n int32) bool {
 	return rcv._tab.MutateInt32Slot(6, n)
 }
 
-func (rcv *CallInfo) Signal(j int) uint32 {
+func (rcv *CallInfoRaw) Signal(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2259,7 +2397,7 @@ func (rcv *CallInfo) Signal(j int) uint32 {
 	return 0
 }
 
-func (rcv *CallInfo) SignalLength() int {
+func (rcv *CallInfoRaw) SignalLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -2267,7 +2405,7 @@ func (rcv *CallInfo) SignalLength() int {
 	return 0
 }
 
-func (rcv *CallInfo) MutateSignal(j int, n uint32) bool {
+func (rcv *CallInfoRaw) MutateSignal(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2276,7 +2414,7 @@ func (rcv *CallInfo) MutateSignal(j int, n uint32) bool {
 	return false
 }
 
-func (rcv *CallInfo) Cover(j int) uint32 {
+func (rcv *CallInfoRaw) Cover(j int) uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2285,7 +2423,7 @@ func (rcv *CallInfo) Cover(j int) uint32 {
 	return 0
 }
 
-func (rcv *CallInfo) CoverLength() int {
+func (rcv *CallInfoRaw) CoverLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -2293,7 +2431,7 @@ func (rcv *CallInfo) CoverLength() int {
 	return 0
 }
 
-func (rcv *CallInfo) MutateCover(j int, n uint32) bool {
+func (rcv *CallInfoRaw) MutateCover(j int, n uint32) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2302,7 +2440,7 @@ func (rcv *CallInfo) MutateCover(j int, n uint32) bool {
 	return false
 }
 
-func (rcv *CallInfo) Comps(obj *Comparison, j int) bool {
+func (rcv *CallInfoRaw) Comps(obj *ComparisonRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
@@ -2313,7 +2451,7 @@ func (rcv *CallInfo) Comps(obj *Comparison, j int) bool {
 	return false
 }
 
-func (rcv *CallInfo) CompsLength() int {
+func (rcv *CallInfoRaw) CompsLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -2321,104 +2459,104 @@ func (rcv *CallInfo) CompsLength() int {
 	return 0
 }
 
-func CallInfoStart(builder *flatbuffers.Builder) {
+func CallInfoRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(5)
 }
-func CallInfoAddFlags(builder *flatbuffers.Builder, flags CallFlag) {
+func CallInfoRawAddFlags(builder *flatbuffers.Builder, flags CallFlag) {
 	builder.PrependByteSlot(0, byte(flags), 0)
 }
-func CallInfoAddError(builder *flatbuffers.Builder, error int32) {
+func CallInfoRawAddError(builder *flatbuffers.Builder, error int32) {
 	builder.PrependInt32Slot(1, error, 0)
 }
-func CallInfoAddSignal(builder *flatbuffers.Builder, signal flatbuffers.UOffsetT) {
+func CallInfoRawAddSignal(builder *flatbuffers.Builder, signal flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(signal), 0)
 }
-func CallInfoStartSignalVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func CallInfoRawStartSignalVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func CallInfoAddCover(builder *flatbuffers.Builder, cover flatbuffers.UOffsetT) {
+func CallInfoRawAddCover(builder *flatbuffers.Builder, cover flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(cover), 0)
 }
-func CallInfoStartCoverVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func CallInfoRawStartCoverVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func CallInfoAddComps(builder *flatbuffers.Builder, comps flatbuffers.UOffsetT) {
+func CallInfoRawAddComps(builder *flatbuffers.Builder, comps flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(comps), 0)
 }
-func CallInfoStartCompsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func CallInfoRawStartCompsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(16, numElems, 8)
 }
-func CallInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func CallInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ComparisonT struct {
+type ComparisonRawT struct {
 	Op1 uint64 `json:"op1"`
 	Op2 uint64 `json:"op2"`
 }
 
-func (t *ComparisonT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ComparisonRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
-	return CreateComparison(builder, t.Op1, t.Op2)
+	return CreateComparisonRaw(builder, t.Op1, t.Op2)
 }
-func (rcv *Comparison) UnPackTo(t *ComparisonT) {
+func (rcv *ComparisonRaw) UnPackTo(t *ComparisonRawT) {
 	t.Op1 = rcv.Op1()
 	t.Op2 = rcv.Op2()
 }
 
-func (rcv *Comparison) UnPack() *ComparisonT {
+func (rcv *ComparisonRaw) UnPack() *ComparisonRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ComparisonT{}
+	t := &ComparisonRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type Comparison struct {
+type ComparisonRaw struct {
 	_tab flatbuffers.Struct
 }
 
-func (rcv *Comparison) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ComparisonRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *Comparison) Table() flatbuffers.Table {
+func (rcv *ComparisonRaw) Table() flatbuffers.Table {
 	return rcv._tab.Table
 }
 
-func (rcv *Comparison) Op1() uint64 {
+func (rcv *ComparisonRaw) Op1() uint64 {
 	return rcv._tab.GetUint64(rcv._tab.Pos + flatbuffers.UOffsetT(0))
 }
-func (rcv *Comparison) MutateOp1(n uint64) bool {
+func (rcv *ComparisonRaw) MutateOp1(n uint64) bool {
 	return rcv._tab.MutateUint64(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
 }
 
-func (rcv *Comparison) Op2() uint64 {
+func (rcv *ComparisonRaw) Op2() uint64 {
 	return rcv._tab.GetUint64(rcv._tab.Pos + flatbuffers.UOffsetT(8))
 }
-func (rcv *Comparison) MutateOp2(n uint64) bool {
+func (rcv *ComparisonRaw) MutateOp2(n uint64) bool {
 	return rcv._tab.MutateUint64(rcv._tab.Pos+flatbuffers.UOffsetT(8), n)
 }
 
-func CreateComparison(builder *flatbuffers.Builder, op1 uint64, op2 uint64) flatbuffers.UOffsetT {
+func CreateComparisonRaw(builder *flatbuffers.Builder, op1 uint64, op2 uint64) flatbuffers.UOffsetT {
 	builder.Prep(8, 16)
 	builder.PrependUint64(op2)
 	builder.PrependUint64(op1)
 	return builder.Offset()
 }
 
-type ProgInfoT struct {
-	Calls     []*CallInfoT `json:"calls"`
-	Extra     *CallInfoT   `json:"extra"`
-	Elapsed   uint64       `json:"elapsed"`
-	Freshness uint64       `json:"freshness"`
+type ProgInfoRawT struct {
+	Calls     []*CallInfoRawT `json:"calls"`
+	Extra     *CallInfoRawT   `json:"extra"`
+	Elapsed   uint64          `json:"elapsed"`
+	Freshness uint64          `json:"freshness"`
 }
 
-func (t *ProgInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ProgInfoRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -2429,26 +2567,26 @@ func (t *ProgInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 		for j := 0; j < callsLength; j++ {
 			callsOffsets[j] = t.Calls[j].Pack(builder)
 		}
-		ProgInfoStartCallsVector(builder, callsLength)
+		ProgInfoRawStartCallsVector(builder, callsLength)
 		for j := callsLength - 1; j >= 0; j-- {
 			builder.PrependUOffsetT(callsOffsets[j])
 		}
 		callsOffset = builder.EndVector(callsLength)
 	}
 	extraOffset := t.Extra.Pack(builder)
-	ProgInfoStart(builder)
-	ProgInfoAddCalls(builder, callsOffset)
-	ProgInfoAddExtra(builder, extraOffset)
-	ProgInfoAddElapsed(builder, t.Elapsed)
-	ProgInfoAddFreshness(builder, t.Freshness)
-	return ProgInfoEnd(builder)
+	ProgInfoRawStart(builder)
+	ProgInfoRawAddCalls(builder, callsOffset)
+	ProgInfoRawAddExtra(builder, extraOffset)
+	ProgInfoRawAddElapsed(builder, t.Elapsed)
+	ProgInfoRawAddFreshness(builder, t.Freshness)
+	return ProgInfoRawEnd(builder)
 }
 
-func (rcv *ProgInfo) UnPackTo(t *ProgInfoT) {
+func (rcv *ProgInfoRaw) UnPackTo(t *ProgInfoRawT) {
 	callsLength := rcv.CallsLength()
-	t.Calls = make([]*CallInfoT, callsLength)
+	t.Calls = make([]*CallInfoRawT, callsLength)
 	for j := 0; j < callsLength; j++ {
-		x := CallInfo{}
+		x := CallInfoRaw{}
 		rcv.Calls(&x, j)
 		t.Calls[j] = x.UnPack()
 	}
@@ -2457,43 +2595,43 @@ func (rcv *ProgInfo) UnPackTo(t *ProgInfoT) {
 	t.Freshness = rcv.Freshness()
 }
 
-func (rcv *ProgInfo) UnPack() *ProgInfoT {
+func (rcv *ProgInfoRaw) UnPack() *ProgInfoRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ProgInfoT{}
+	t := &ProgInfoRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ProgInfo struct {
+type ProgInfoRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsProgInfo(buf []byte, offset flatbuffers.UOffsetT) *ProgInfo {
+func GetRootAsProgInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *ProgInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ProgInfo{}
+	x := &ProgInfoRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsProgInfo(buf []byte, offset flatbuffers.UOffsetT) *ProgInfo {
+func GetSizePrefixedRootAsProgInfoRaw(buf []byte, offset flatbuffers.UOffsetT) *ProgInfoRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ProgInfo{}
+	x := &ProgInfoRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ProgInfo) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ProgInfoRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ProgInfo) Table() flatbuffers.Table {
+func (rcv *ProgInfoRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ProgInfo) Calls(obj *CallInfo, j int) bool {
+func (rcv *ProgInfoRaw) Calls(obj *CallInfoRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
@@ -2505,7 +2643,7 @@ func (rcv *ProgInfo) Calls(obj *CallInfo, j int) bool {
 	return false
 }
 
-func (rcv *ProgInfo) CallsLength() int {
+func (rcv *ProgInfoRaw) CallsLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -2513,12 +2651,12 @@ func (rcv *ProgInfo) CallsLength() int {
 	return 0
 }
 
-func (rcv *ProgInfo) Extra(obj *CallInfo) *CallInfo {
+func (rcv *ProgInfoRaw) Extra(obj *CallInfoRaw) *CallInfoRaw {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		x := rcv._tab.Indirect(o + rcv._tab.Pos)
 		if obj == nil {
-			obj = new(CallInfo)
+			obj = new(CallInfoRaw)
 		}
 		obj.Init(rcv._tab.Bytes, x)
 		return obj
@@ -2526,7 +2664,7 @@ func (rcv *ProgInfo) Extra(obj *CallInfo) *CallInfo {
 	return nil
 }
 
-func (rcv *ProgInfo) Elapsed() uint64 {
+func (rcv *ProgInfoRaw) Elapsed() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.GetUint64(o + rcv._tab.Pos)
@@ -2534,11 +2672,11 @@ func (rcv *ProgInfo) Elapsed() uint64 {
 	return 0
 }
 
-func (rcv *ProgInfo) MutateElapsed(n uint64) bool {
+func (rcv *ProgInfoRaw) MutateElapsed(n uint64) bool {
 	return rcv._tab.MutateUint64Slot(8, n)
 }
 
-func (rcv *ProgInfo) Freshness() uint64 {
+func (rcv *ProgInfoRaw) Freshness() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.GetUint64(o + rcv._tab.Pos)
@@ -2546,40 +2684,40 @@ func (rcv *ProgInfo) Freshness() uint64 {
 	return 0
 }
 
-func (rcv *ProgInfo) MutateFreshness(n uint64) bool {
+func (rcv *ProgInfoRaw) MutateFreshness(n uint64) bool {
 	return rcv._tab.MutateUint64Slot(10, n)
 }
 
-func ProgInfoStart(builder *flatbuffers.Builder) {
+func ProgInfoRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func ProgInfoAddCalls(builder *flatbuffers.Builder, calls flatbuffers.UOffsetT) {
+func ProgInfoRawAddCalls(builder *flatbuffers.Builder, calls flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(calls), 0)
 }
-func ProgInfoStartCallsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ProgInfoRawStartCallsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func ProgInfoAddExtra(builder *flatbuffers.Builder, extra flatbuffers.UOffsetT) {
+func ProgInfoRawAddExtra(builder *flatbuffers.Builder, extra flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(extra), 0)
 }
-func ProgInfoAddElapsed(builder *flatbuffers.Builder, elapsed uint64) {
+func ProgInfoRawAddElapsed(builder *flatbuffers.Builder, elapsed uint64) {
 	builder.PrependUint64Slot(2, elapsed, 0)
 }
-func ProgInfoAddFreshness(builder *flatbuffers.Builder, freshness uint64) {
+func ProgInfoRawAddFreshness(builder *flatbuffers.Builder, freshness uint64) {
 	builder.PrependUint64Slot(3, freshness, 0)
 }
-func ProgInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ProgInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type ExecResultT struct {
-	Executing *ExecutingMessageT `json:"executing"`
-	Output    []byte             `json:"output"`
-	Error     string             `json:"error"`
-	Info      *ProgInfoT         `json:"info"`
+type ExecResultRawT struct {
+	Executing *ExecutingMessageRawT `json:"executing"`
+	Output    []byte                `json:"output"`
+	Error     string                `json:"error"`
+	Info      *ProgInfoRawT         `json:"info"`
 }
 
-func (t *ExecResultT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func (t *ExecResultRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
@@ -2590,63 +2728,63 @@ func (t *ExecResultT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	}
 	errorOffset := builder.CreateString(t.Error)
 	infoOffset := t.Info.Pack(builder)
-	ExecResultStart(builder)
-	ExecResultAddExecuting(builder, executingOffset)
-	ExecResultAddOutput(builder, outputOffset)
-	ExecResultAddError(builder, errorOffset)
-	ExecResultAddInfo(builder, infoOffset)
-	return ExecResultEnd(builder)
+	ExecResultRawStart(builder)
+	ExecResultRawAddExecuting(builder, executingOffset)
+	ExecResultRawAddOutput(builder, outputOffset)
+	ExecResultRawAddError(builder, errorOffset)
+	ExecResultRawAddInfo(builder, infoOffset)
+	return ExecResultRawEnd(builder)
 }
 
-func (rcv *ExecResult) UnPackTo(t *ExecResultT) {
+func (rcv *ExecResultRaw) UnPackTo(t *ExecResultRawT) {
 	t.Executing = rcv.Executing(nil).UnPack()
 	t.Output = rcv.OutputBytes()
 	t.Error = string(rcv.Error())
 	t.Info = rcv.Info(nil).UnPack()
 }
 
-func (rcv *ExecResult) UnPack() *ExecResultT {
+func (rcv *ExecResultRaw) UnPack() *ExecResultRawT {
 	if rcv == nil {
 		return nil
 	}
-	t := &ExecResultT{}
+	t := &ExecResultRawT{}
 	rcv.UnPackTo(t)
 	return t
 }
 
-type ExecResult struct {
+type ExecResultRaw struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsExecResult(buf []byte, offset flatbuffers.UOffsetT) *ExecResult {
+func GetRootAsExecResultRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecResultRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &ExecResult{}
+	x := &ExecResultRaw{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsExecResult(buf []byte, offset flatbuffers.UOffsetT) *ExecResult {
+func GetSizePrefixedRootAsExecResultRaw(buf []byte, offset flatbuffers.UOffsetT) *ExecResultRaw {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &ExecResult{}
+	x := &ExecResultRaw{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *ExecResult) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *ExecResultRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *ExecResult) Table() flatbuffers.Table {
+func (rcv *ExecResultRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ExecResult) Executing(obj *ExecutingMessage) *ExecutingMessage {
+func (rcv *ExecResultRaw) Executing(obj *ExecutingMessageRaw) *ExecutingMessageRaw {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		x := rcv._tab.Indirect(o + rcv._tab.Pos)
 		if obj == nil {
-			obj = new(ExecutingMessage)
+			obj = new(ExecutingMessageRaw)
 		}
 		obj.Init(rcv._tab.Bytes, x)
 		return obj
@@ -2654,7 +2792,7 @@ func (rcv *ExecResult) Executing(obj *ExecutingMessage) *ExecutingMessage {
 	return nil
 }
 
-func (rcv *ExecResult) Output(j int) byte {
+func (rcv *ExecResultRaw) Output(j int) byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2663,7 +2801,7 @@ func (rcv *ExecResult) Output(j int) byte {
 	return 0
 }
 
-func (rcv *ExecResult) OutputLength() int {
+func (rcv *ExecResultRaw) OutputLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -2671,7 +2809,7 @@ func (rcv *ExecResult) OutputLength() int {
 	return 0
 }
 
-func (rcv *ExecResult) OutputBytes() []byte {
+func (rcv *ExecResultRaw) OutputBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -2679,7 +2817,7 @@ func (rcv *ExecResult) OutputBytes() []byte {
 	return nil
 }
 
-func (rcv *ExecResult) MutateOutput(j int, n byte) bool {
+func (rcv *ExecResultRaw) MutateOutput(j int, n byte) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -2688,7 +2826,7 @@ func (rcv *ExecResult) MutateOutput(j int, n byte) bool {
 	return false
 }
 
-func (rcv *ExecResult) Error() []byte {
+func (rcv *ExecResultRaw) Error() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -2696,12 +2834,12 @@ func (rcv *ExecResult) Error() []byte {
 	return nil
 }
 
-func (rcv *ExecResult) Info(obj *ProgInfo) *ProgInfo {
+func (rcv *ExecResultRaw) Info(obj *ProgInfoRaw) *ProgInfoRaw {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		x := rcv._tab.Indirect(o + rcv._tab.Pos)
 		if obj == nil {
-			obj = new(ProgInfo)
+			obj = new(ProgInfoRaw)
 		}
 		obj.Init(rcv._tab.Bytes, x)
 		return obj
@@ -2709,24 +2847,24 @@ func (rcv *ExecResult) Info(obj *ProgInfo) *ProgInfo {
 	return nil
 }
 
-func ExecResultStart(builder *flatbuffers.Builder) {
+func ExecResultRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func ExecResultAddExecuting(builder *flatbuffers.Builder, executing flatbuffers.UOffsetT) {
+func ExecResultRawAddExecuting(builder *flatbuffers.Builder, executing flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(executing), 0)
 }
-func ExecResultAddOutput(builder *flatbuffers.Builder, output flatbuffers.UOffsetT) {
+func ExecResultRawAddOutput(builder *flatbuffers.Builder, output flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(output), 0)
 }
-func ExecResultStartOutputVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func ExecResultRawStartOutputVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
-func ExecResultAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
+func ExecResultRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(error), 0)
 }
-func ExecResultAddInfo(builder *flatbuffers.Builder, info flatbuffers.UOffsetT) {
+func ExecResultRawAddInfo(builder *flatbuffers.Builder, info flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(info), 0)
 }
-func ExecResultEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func ExecResultRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -15,67 +15,71 @@ static_assert(FLATBUFFERS_VERSION_MAJOR == 2 &&
 
 namespace rpc {
 
-struct ConnectRequest;
-struct ConnectRequestBuilder;
-struct ConnectRequestT;
+struct ConnectRequestRaw;
+struct ConnectRequestRawBuilder;
+struct ConnectRequestRawT;
 
-struct ConnectReply;
-struct ConnectReplyBuilder;
-struct ConnectReplyT;
+struct ConnectReplyRaw;
+struct ConnectReplyRawBuilder;
+struct ConnectReplyRawT;
 
-struct InfoRequest;
-struct InfoRequestBuilder;
-struct InfoRequestT;
+struct InfoRequestRaw;
+struct InfoRequestRawBuilder;
+struct InfoRequestRawT;
 
-struct InfoReply;
-struct InfoReplyBuilder;
-struct InfoReplyT;
+struct InfoReplyRaw;
+struct InfoReplyRawBuilder;
+struct InfoReplyRawT;
 
-struct FileInfo;
-struct FileInfoBuilder;
-struct FileInfoT;
+struct FileInfoRaw;
+struct FileInfoRawBuilder;
+struct FileInfoRawT;
 
-struct GlobInfo;
-struct GlobInfoBuilder;
-struct GlobInfoT;
+struct GlobInfoRaw;
+struct GlobInfoRawBuilder;
+struct GlobInfoRawT;
 
-struct HostMessage;
-struct HostMessageBuilder;
-struct HostMessageT;
+struct FeatureInfoRaw;
+struct FeatureInfoRawBuilder;
+struct FeatureInfoRawT;
 
-struct ExecutorMessage;
-struct ExecutorMessageBuilder;
-struct ExecutorMessageT;
+struct HostMessageRaw;
+struct HostMessageRawBuilder;
+struct HostMessageRawT;
 
-struct ExecRequest;
-struct ExecRequestBuilder;
-struct ExecRequestT;
+struct ExecutorMessageRaw;
+struct ExecutorMessageRawBuilder;
+struct ExecutorMessageRawT;
 
-struct SignalUpdate;
-struct SignalUpdateBuilder;
-struct SignalUpdateT;
+struct ExecRequestRaw;
+struct ExecRequestRawBuilder;
+struct ExecRequestRawT;
 
-struct ExecutingMessage;
-struct ExecutingMessageBuilder;
-struct ExecutingMessageT;
+struct SignalUpdateRaw;
+struct SignalUpdateRawBuilder;
+struct SignalUpdateRawT;
 
-struct StatsMessage;
-struct StatsMessageBuilder;
-struct StatsMessageT;
+struct ExecutingMessageRaw;
+struct ExecutingMessageRawBuilder;
+struct ExecutingMessageRawT;
 
-struct CallInfo;
-struct CallInfoBuilder;
-struct CallInfoT;
+struct StatsMessageRaw;
+struct StatsMessageRawBuilder;
+struct StatsMessageRawT;
 
-struct Comparison;
+struct CallInfoRaw;
+struct CallInfoRawBuilder;
+struct CallInfoRawT;
 
-struct ProgInfo;
-struct ProgInfoBuilder;
-struct ProgInfoT;
+struct ComparisonRaw;
 
-struct ExecResult;
-struct ExecResultBuilder;
-struct ExecResultT;
+struct ProgInfoRaw;
+struct ProgInfoRawBuilder;
+struct ProgInfoRawT;
+
+struct ExecResultRaw;
+struct ExecResultRawBuilder;
+struct ExecResultRawT;
 
 enum class Feature : uint64_t {
   Coverage = 1ULL,
@@ -155,7 +159,7 @@ inline const char *EnumNameFeature(Feature e) {
   }
 }
 
-enum class HostMessages : uint8_t {
+enum class HostMessagesRaw : uint8_t {
   NONE = 0,
   ExecRequest = 1,
   SignalUpdate = 2,
@@ -163,16 +167,16 @@ enum class HostMessages : uint8_t {
   MAX = SignalUpdate
 };
 
-inline const HostMessages (&EnumValuesHostMessages())[3] {
-  static const HostMessages values[] = {
-    HostMessages::NONE,
-    HostMessages::ExecRequest,
-    HostMessages::SignalUpdate
+inline const HostMessagesRaw (&EnumValuesHostMessagesRaw())[3] {
+  static const HostMessagesRaw values[] = {
+    HostMessagesRaw::NONE,
+    HostMessagesRaw::ExecRequest,
+    HostMessagesRaw::SignalUpdate
   };
   return values;
 }
 
-inline const char * const *EnumNamesHostMessages() {
+inline const char * const *EnumNamesHostMessagesRaw() {
   static const char * const names[4] = {
     "NONE",
     "ExecRequest",
@@ -182,50 +186,50 @@ inline const char * const *EnumNamesHostMessages() {
   return names;
 }
 
-inline const char *EnumNameHostMessages(HostMessages e) {
-  if (flatbuffers::IsOutRange(e, HostMessages::NONE, HostMessages::SignalUpdate)) return "";
+inline const char *EnumNameHostMessagesRaw(HostMessagesRaw e) {
+  if (flatbuffers::IsOutRange(e, HostMessagesRaw::NONE, HostMessagesRaw::SignalUpdate)) return "";
   const size_t index = static_cast<size_t>(e);
-  return EnumNamesHostMessages()[index];
+  return EnumNamesHostMessagesRaw()[index];
 }
 
-template<typename T> struct HostMessagesTraits {
-  static const HostMessages enum_value = HostMessages::NONE;
+template<typename T> struct HostMessagesRawTraits {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::NONE;
 };
 
-template<> struct HostMessagesTraits<rpc::ExecRequest> {
-  static const HostMessages enum_value = HostMessages::ExecRequest;
+template<> struct HostMessagesRawTraits<rpc::ExecRequestRaw> {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::ExecRequest;
 };
 
-template<> struct HostMessagesTraits<rpc::SignalUpdate> {
-  static const HostMessages enum_value = HostMessages::SignalUpdate;
+template<> struct HostMessagesRawTraits<rpc::SignalUpdateRaw> {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::SignalUpdate;
 };
 
-template<typename T> struct HostMessagesUnionTraits {
-  static const HostMessages enum_value = HostMessages::NONE;
+template<typename T> struct HostMessagesRawUnionTraits {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::NONE;
 };
 
-template<> struct HostMessagesUnionTraits<rpc::ExecRequestT> {
-  static const HostMessages enum_value = HostMessages::ExecRequest;
+template<> struct HostMessagesRawUnionTraits<rpc::ExecRequestRawT> {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::ExecRequest;
 };
 
-template<> struct HostMessagesUnionTraits<rpc::SignalUpdateT> {
-  static const HostMessages enum_value = HostMessages::SignalUpdate;
+template<> struct HostMessagesRawUnionTraits<rpc::SignalUpdateRawT> {
+  static const HostMessagesRaw enum_value = HostMessagesRaw::SignalUpdate;
 };
 
-struct HostMessagesUnion {
-  HostMessages type;
+struct HostMessagesRawUnion {
+  HostMessagesRaw type;
   void *value;
 
-  HostMessagesUnion() : type(HostMessages::NONE), value(nullptr) {}
-  HostMessagesUnion(HostMessagesUnion&& u) FLATBUFFERS_NOEXCEPT :
-    type(HostMessages::NONE), value(nullptr)
+  HostMessagesRawUnion() : type(HostMessagesRaw::NONE), value(nullptr) {}
+  HostMessagesRawUnion(HostMessagesRawUnion&& u) FLATBUFFERS_NOEXCEPT :
+    type(HostMessagesRaw::NONE), value(nullptr)
     { std::swap(type, u.type); std::swap(value, u.value); }
-  HostMessagesUnion(const HostMessagesUnion &);
-  HostMessagesUnion &operator=(const HostMessagesUnion &u)
-    { HostMessagesUnion t(u); std::swap(type, t.type); std::swap(value, t.value); return *this; }
-  HostMessagesUnion &operator=(HostMessagesUnion &&u) FLATBUFFERS_NOEXCEPT
+  HostMessagesRawUnion(const HostMessagesRawUnion &);
+  HostMessagesRawUnion &operator=(const HostMessagesRawUnion &u)
+    { HostMessagesRawUnion t(u); std::swap(type, t.type); std::swap(value, t.value); return *this; }
+  HostMessagesRawUnion &operator=(HostMessagesRawUnion &&u) FLATBUFFERS_NOEXCEPT
     { std::swap(type, u.type); std::swap(value, u.value); return *this; }
-  ~HostMessagesUnion() { Reset(); }
+  ~HostMessagesRawUnion() { Reset(); }
 
   void Reset();
 
@@ -233,37 +237,37 @@ struct HostMessagesUnion {
   void Set(T&& val) {
     typedef typename std::remove_reference<T>::type RT;
     Reset();
-    type = HostMessagesUnionTraits<RT>::enum_value;
-    if (type != HostMessages::NONE) {
+    type = HostMessagesRawUnionTraits<RT>::enum_value;
+    if (type != HostMessagesRaw::NONE) {
       value = new RT(std::forward<T>(val));
     }
   }
 
-  static void *UnPack(const void *obj, HostMessages type, const flatbuffers::resolver_function_t *resolver);
+  static void *UnPack(const void *obj, HostMessagesRaw type, const flatbuffers::resolver_function_t *resolver);
   flatbuffers::Offset<void> Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher = nullptr) const;
 
-  rpc::ExecRequestT *AsExecRequest() {
-    return type == HostMessages::ExecRequest ?
-      reinterpret_cast<rpc::ExecRequestT *>(value) : nullptr;
+  rpc::ExecRequestRawT *AsExecRequest() {
+    return type == HostMessagesRaw::ExecRequest ?
+      reinterpret_cast<rpc::ExecRequestRawT *>(value) : nullptr;
   }
-  const rpc::ExecRequestT *AsExecRequest() const {
-    return type == HostMessages::ExecRequest ?
-      reinterpret_cast<const rpc::ExecRequestT *>(value) : nullptr;
+  const rpc::ExecRequestRawT *AsExecRequest() const {
+    return type == HostMessagesRaw::ExecRequest ?
+      reinterpret_cast<const rpc::ExecRequestRawT *>(value) : nullptr;
   }
-  rpc::SignalUpdateT *AsSignalUpdate() {
-    return type == HostMessages::SignalUpdate ?
-      reinterpret_cast<rpc::SignalUpdateT *>(value) : nullptr;
+  rpc::SignalUpdateRawT *AsSignalUpdate() {
+    return type == HostMessagesRaw::SignalUpdate ?
+      reinterpret_cast<rpc::SignalUpdateRawT *>(value) : nullptr;
   }
-  const rpc::SignalUpdateT *AsSignalUpdate() const {
-    return type == HostMessages::SignalUpdate ?
-      reinterpret_cast<const rpc::SignalUpdateT *>(value) : nullptr;
+  const rpc::SignalUpdateRawT *AsSignalUpdate() const {
+    return type == HostMessagesRaw::SignalUpdate ?
+      reinterpret_cast<const rpc::SignalUpdateRawT *>(value) : nullptr;
   }
 };
 
-bool VerifyHostMessages(flatbuffers::Verifier &verifier, const void *obj, HostMessages type);
-bool VerifyHostMessagesVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<HostMessages> *types);
+bool VerifyHostMessagesRaw(flatbuffers::Verifier &verifier, const void *obj, HostMessagesRaw type);
+bool VerifyHostMessagesRawVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<HostMessagesRaw> *types);
 
-enum class ExecutorMessages : uint8_t {
+enum class ExecutorMessagesRaw : uint8_t {
   NONE = 0,
   ExecResult = 1,
   Executing = 2,
@@ -272,17 +276,17 @@ enum class ExecutorMessages : uint8_t {
   MAX = Stats
 };
 
-inline const ExecutorMessages (&EnumValuesExecutorMessages())[4] {
-  static const ExecutorMessages values[] = {
-    ExecutorMessages::NONE,
-    ExecutorMessages::ExecResult,
-    ExecutorMessages::Executing,
-    ExecutorMessages::Stats
+inline const ExecutorMessagesRaw (&EnumValuesExecutorMessagesRaw())[4] {
+  static const ExecutorMessagesRaw values[] = {
+    ExecutorMessagesRaw::NONE,
+    ExecutorMessagesRaw::ExecResult,
+    ExecutorMessagesRaw::Executing,
+    ExecutorMessagesRaw::Stats
   };
   return values;
 }
 
-inline const char * const *EnumNamesExecutorMessages() {
+inline const char * const *EnumNamesExecutorMessagesRaw() {
   static const char * const names[5] = {
     "NONE",
     "ExecResult",
@@ -293,58 +297,58 @@ inline const char * const *EnumNamesExecutorMessages() {
   return names;
 }
 
-inline const char *EnumNameExecutorMessages(ExecutorMessages e) {
-  if (flatbuffers::IsOutRange(e, ExecutorMessages::NONE, ExecutorMessages::Stats)) return "";
+inline const char *EnumNameExecutorMessagesRaw(ExecutorMessagesRaw e) {
+  if (flatbuffers::IsOutRange(e, ExecutorMessagesRaw::NONE, ExecutorMessagesRaw::Stats)) return "";
   const size_t index = static_cast<size_t>(e);
-  return EnumNamesExecutorMessages()[index];
+  return EnumNamesExecutorMessagesRaw()[index];
 }
 
-template<typename T> struct ExecutorMessagesTraits {
-  static const ExecutorMessages enum_value = ExecutorMessages::NONE;
+template<typename T> struct ExecutorMessagesRawTraits {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::NONE;
 };
 
-template<> struct ExecutorMessagesTraits<rpc::ExecResult> {
-  static const ExecutorMessages enum_value = ExecutorMessages::ExecResult;
+template<> struct ExecutorMessagesRawTraits<rpc::ExecResultRaw> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::ExecResult;
 };
 
-template<> struct ExecutorMessagesTraits<rpc::ExecutingMessage> {
-  static const ExecutorMessages enum_value = ExecutorMessages::Executing;
+template<> struct ExecutorMessagesRawTraits<rpc::ExecutingMessageRaw> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::Executing;
 };
 
-template<> struct ExecutorMessagesTraits<rpc::StatsMessage> {
-  static const ExecutorMessages enum_value = ExecutorMessages::Stats;
+template<> struct ExecutorMessagesRawTraits<rpc::StatsMessageRaw> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::Stats;
 };
 
-template<typename T> struct ExecutorMessagesUnionTraits {
-  static const ExecutorMessages enum_value = ExecutorMessages::NONE;
+template<typename T> struct ExecutorMessagesRawUnionTraits {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::NONE;
 };
 
-template<> struct ExecutorMessagesUnionTraits<rpc::ExecResultT> {
-  static const ExecutorMessages enum_value = ExecutorMessages::ExecResult;
+template<> struct ExecutorMessagesRawUnionTraits<rpc::ExecResultRawT> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::ExecResult;
 };
 
-template<> struct ExecutorMessagesUnionTraits<rpc::ExecutingMessageT> {
-  static const ExecutorMessages enum_value = ExecutorMessages::Executing;
+template<> struct ExecutorMessagesRawUnionTraits<rpc::ExecutingMessageRawT> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::Executing;
 };
 
-template<> struct ExecutorMessagesUnionTraits<rpc::StatsMessageT> {
-  static const ExecutorMessages enum_value = ExecutorMessages::Stats;
+template<> struct ExecutorMessagesRawUnionTraits<rpc::StatsMessageRawT> {
+  static const ExecutorMessagesRaw enum_value = ExecutorMessagesRaw::Stats;
 };
 
-struct ExecutorMessagesUnion {
-  ExecutorMessages type;
+struct ExecutorMessagesRawUnion {
+  ExecutorMessagesRaw type;
   void *value;
 
-  ExecutorMessagesUnion() : type(ExecutorMessages::NONE), value(nullptr) {}
-  ExecutorMessagesUnion(ExecutorMessagesUnion&& u) FLATBUFFERS_NOEXCEPT :
-    type(ExecutorMessages::NONE), value(nullptr)
+  ExecutorMessagesRawUnion() : type(ExecutorMessagesRaw::NONE), value(nullptr) {}
+  ExecutorMessagesRawUnion(ExecutorMessagesRawUnion&& u) FLATBUFFERS_NOEXCEPT :
+    type(ExecutorMessagesRaw::NONE), value(nullptr)
     { std::swap(type, u.type); std::swap(value, u.value); }
-  ExecutorMessagesUnion(const ExecutorMessagesUnion &);
-  ExecutorMessagesUnion &operator=(const ExecutorMessagesUnion &u)
-    { ExecutorMessagesUnion t(u); std::swap(type, t.type); std::swap(value, t.value); return *this; }
-  ExecutorMessagesUnion &operator=(ExecutorMessagesUnion &&u) FLATBUFFERS_NOEXCEPT
+  ExecutorMessagesRawUnion(const ExecutorMessagesRawUnion &);
+  ExecutorMessagesRawUnion &operator=(const ExecutorMessagesRawUnion &u)
+    { ExecutorMessagesRawUnion t(u); std::swap(type, t.type); std::swap(value, t.value); return *this; }
+  ExecutorMessagesRawUnion &operator=(ExecutorMessagesRawUnion &&u) FLATBUFFERS_NOEXCEPT
     { std::swap(type, u.type); std::swap(value, u.value); return *this; }
-  ~ExecutorMessagesUnion() { Reset(); }
+  ~ExecutorMessagesRawUnion() { Reset(); }
 
   void Reset();
 
@@ -352,43 +356,43 @@ struct ExecutorMessagesUnion {
   void Set(T&& val) {
     typedef typename std::remove_reference<T>::type RT;
     Reset();
-    type = ExecutorMessagesUnionTraits<RT>::enum_value;
-    if (type != ExecutorMessages::NONE) {
+    type = ExecutorMessagesRawUnionTraits<RT>::enum_value;
+    if (type != ExecutorMessagesRaw::NONE) {
       value = new RT(std::forward<T>(val));
     }
   }
 
-  static void *UnPack(const void *obj, ExecutorMessages type, const flatbuffers::resolver_function_t *resolver);
+  static void *UnPack(const void *obj, ExecutorMessagesRaw type, const flatbuffers::resolver_function_t *resolver);
   flatbuffers::Offset<void> Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher = nullptr) const;
 
-  rpc::ExecResultT *AsExecResult() {
-    return type == ExecutorMessages::ExecResult ?
-      reinterpret_cast<rpc::ExecResultT *>(value) : nullptr;
+  rpc::ExecResultRawT *AsExecResult() {
+    return type == ExecutorMessagesRaw::ExecResult ?
+      reinterpret_cast<rpc::ExecResultRawT *>(value) : nullptr;
   }
-  const rpc::ExecResultT *AsExecResult() const {
-    return type == ExecutorMessages::ExecResult ?
-      reinterpret_cast<const rpc::ExecResultT *>(value) : nullptr;
+  const rpc::ExecResultRawT *AsExecResult() const {
+    return type == ExecutorMessagesRaw::ExecResult ?
+      reinterpret_cast<const rpc::ExecResultRawT *>(value) : nullptr;
   }
-  rpc::ExecutingMessageT *AsExecuting() {
-    return type == ExecutorMessages::Executing ?
-      reinterpret_cast<rpc::ExecutingMessageT *>(value) : nullptr;
+  rpc::ExecutingMessageRawT *AsExecuting() {
+    return type == ExecutorMessagesRaw::Executing ?
+      reinterpret_cast<rpc::ExecutingMessageRawT *>(value) : nullptr;
   }
-  const rpc::ExecutingMessageT *AsExecuting() const {
-    return type == ExecutorMessages::Executing ?
-      reinterpret_cast<const rpc::ExecutingMessageT *>(value) : nullptr;
+  const rpc::ExecutingMessageRawT *AsExecuting() const {
+    return type == ExecutorMessagesRaw::Executing ?
+      reinterpret_cast<const rpc::ExecutingMessageRawT *>(value) : nullptr;
   }
-  rpc::StatsMessageT *AsStats() {
-    return type == ExecutorMessages::Stats ?
-      reinterpret_cast<rpc::StatsMessageT *>(value) : nullptr;
+  rpc::StatsMessageRawT *AsStats() {
+    return type == ExecutorMessagesRaw::Stats ?
+      reinterpret_cast<rpc::StatsMessageRawT *>(value) : nullptr;
   }
-  const rpc::StatsMessageT *AsStats() const {
-    return type == ExecutorMessages::Stats ?
-      reinterpret_cast<const rpc::StatsMessageT *>(value) : nullptr;
+  const rpc::StatsMessageRawT *AsStats() const {
+    return type == ExecutorMessagesRaw::Stats ?
+      reinterpret_cast<const rpc::StatsMessageRawT *>(value) : nullptr;
   }
 };
 
-bool VerifyExecutorMessages(flatbuffers::Verifier &verifier, const void *obj, ExecutorMessages type);
-bool VerifyExecutorMessagesVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<ExecutorMessages> *types);
+bool VerifyExecutorMessagesRaw(flatbuffers::Verifier &verifier, const void *obj, ExecutorMessagesRaw type);
+bool VerifyExecutorMessagesRawVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<ExecutorMessagesRaw> *types);
 
 enum class RequestFlag : uint64_t {
   IsBinary = 1ULL,
@@ -584,17 +588,17 @@ inline const char *EnumNameCallFlag(CallFlag e) {
   return EnumNamesCallFlag()[index];
 }
 
-FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Comparison FLATBUFFERS_FINAL_CLASS {
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) ComparisonRaw FLATBUFFERS_FINAL_CLASS {
  private:
   uint64_t op1_;
   uint64_t op2_;
 
  public:
-  Comparison()
+  ComparisonRaw()
       : op1_(0),
         op2_(0) {
   }
-  Comparison(uint64_t _op1, uint64_t _op2)
+  ComparisonRaw(uint64_t _op1, uint64_t _op2)
       : op1_(flatbuffers::EndianScalar(_op1)),
         op2_(flatbuffers::EndianScalar(_op2)) {
   }
@@ -605,19 +609,19 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Comparison FLATBUFFERS_FINAL_CLASS {
     return flatbuffers::EndianScalar(op2_);
   }
 };
-FLATBUFFERS_STRUCT_END(Comparison, 16);
+FLATBUFFERS_STRUCT_END(ComparisonRaw, 16);
 
-struct ConnectRequestT : public flatbuffers::NativeTable {
-  typedef ConnectRequest TableType;
+struct ConnectRequestRawT : public flatbuffers::NativeTable {
+  typedef ConnectRequestRaw TableType;
   std::string name{};
   std::string arch{};
   std::string git_revision{};
   std::string syz_revision{};
 };
 
-struct ConnectRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ConnectRequestT NativeTableType;
-  typedef ConnectRequestBuilder Builder;
+struct ConnectRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ConnectRequestRawT NativeTableType;
+  typedef ConnectRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_ARCH = 6,
@@ -648,45 +652,45 @@ struct ConnectRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyString(syz_revision()) &&
            verifier.EndTable();
   }
-  ConnectRequestT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ConnectRequestT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ConnectRequest> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ConnectRequestRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ConnectRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ConnectRequestRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ConnectRequestBuilder {
-  typedef ConnectRequest Table;
+struct ConnectRequestRawBuilder {
+  typedef ConnectRequestRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
-    fbb_.AddOffset(ConnectRequest::VT_NAME, name);
+    fbb_.AddOffset(ConnectRequestRaw::VT_NAME, name);
   }
   void add_arch(flatbuffers::Offset<flatbuffers::String> arch) {
-    fbb_.AddOffset(ConnectRequest::VT_ARCH, arch);
+    fbb_.AddOffset(ConnectRequestRaw::VT_ARCH, arch);
   }
   void add_git_revision(flatbuffers::Offset<flatbuffers::String> git_revision) {
-    fbb_.AddOffset(ConnectRequest::VT_GIT_REVISION, git_revision);
+    fbb_.AddOffset(ConnectRequestRaw::VT_GIT_REVISION, git_revision);
   }
   void add_syz_revision(flatbuffers::Offset<flatbuffers::String> syz_revision) {
-    fbb_.AddOffset(ConnectRequest::VT_SYZ_REVISION, syz_revision);
+    fbb_.AddOffset(ConnectRequestRaw::VT_SYZ_REVISION, syz_revision);
   }
-  explicit ConnectRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ConnectRequestRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ConnectRequest> Finish() {
+  flatbuffers::Offset<ConnectRequestRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ConnectRequest>(end);
+    auto o = flatbuffers::Offset<ConnectRequestRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ConnectRequest> CreateConnectRequest(
+inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     flatbuffers::Offset<flatbuffers::String> arch = 0,
     flatbuffers::Offset<flatbuffers::String> git_revision = 0,
     flatbuffers::Offset<flatbuffers::String> syz_revision = 0) {
-  ConnectRequestBuilder builder_(_fbb);
+  ConnectRequestRawBuilder builder_(_fbb);
   builder_.add_syz_revision(syz_revision);
   builder_.add_git_revision(git_revision);
   builder_.add_arch(arch);
@@ -694,7 +698,7 @@ inline flatbuffers::Offset<ConnectRequest> CreateConnectRequest(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<ConnectRequest> CreateConnectRequestDirect(
+inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     const char *arch = nullptr,
@@ -704,7 +708,7 @@ inline flatbuffers::Offset<ConnectRequest> CreateConnectRequestDirect(
   auto arch__ = arch ? _fbb.CreateString(arch) : 0;
   auto git_revision__ = git_revision ? _fbb.CreateString(git_revision) : 0;
   auto syz_revision__ = syz_revision ? _fbb.CreateString(syz_revision) : 0;
-  return rpc::CreateConnectRequest(
+  return rpc::CreateConnectRequestRaw(
       _fbb,
       name__,
       arch__,
@@ -712,10 +716,10 @@ inline flatbuffers::Offset<ConnectRequest> CreateConnectRequestDirect(
       syz_revision__);
 }
 
-flatbuffers::Offset<ConnectRequest> CreateConnectRequest(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ConnectReplyT : public flatbuffers::NativeTable {
-  typedef ConnectReply TableType;
+struct ConnectReplyRawT : public flatbuffers::NativeTable {
+  typedef ConnectReplyRaw TableType;
   std::vector<std::string> leak_frames{};
   std::vector<std::string> race_frames{};
   rpc::Feature features = static_cast<rpc::Feature>(0);
@@ -723,9 +727,9 @@ struct ConnectReplyT : public flatbuffers::NativeTable {
   std::vector<std::string> globs{};
 };
 
-struct ConnectReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ConnectReplyT NativeTableType;
-  typedef ConnectReplyBuilder Builder;
+struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ConnectReplyRawT NativeTableType;
+  typedef ConnectReplyRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_LEAK_FRAMES = 4,
     VT_RACE_FRAMES = 6,
@@ -765,49 +769,49 @@ struct ConnectReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfStrings(globs()) &&
            verifier.EndTable();
   }
-  ConnectReplyT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ConnectReplyT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ConnectReply> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ConnectReplyRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ConnectReplyRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ConnectReplyRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ConnectReplyBuilder {
-  typedef ConnectReply Table;
+struct ConnectReplyRawBuilder {
+  typedef ConnectReplyRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_leak_frames(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> leak_frames) {
-    fbb_.AddOffset(ConnectReply::VT_LEAK_FRAMES, leak_frames);
+    fbb_.AddOffset(ConnectReplyRaw::VT_LEAK_FRAMES, leak_frames);
   }
   void add_race_frames(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> race_frames) {
-    fbb_.AddOffset(ConnectReply::VT_RACE_FRAMES, race_frames);
+    fbb_.AddOffset(ConnectReplyRaw::VT_RACE_FRAMES, race_frames);
   }
   void add_features(rpc::Feature features) {
-    fbb_.AddElement<uint64_t>(ConnectReply::VT_FEATURES, static_cast<uint64_t>(features), 0);
+    fbb_.AddElement<uint64_t>(ConnectReplyRaw::VT_FEATURES, static_cast<uint64_t>(features), 0);
   }
   void add_files(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> files) {
-    fbb_.AddOffset(ConnectReply::VT_FILES, files);
+    fbb_.AddOffset(ConnectReplyRaw::VT_FILES, files);
   }
   void add_globs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> globs) {
-    fbb_.AddOffset(ConnectReply::VT_GLOBS, globs);
+    fbb_.AddOffset(ConnectReplyRaw::VT_GLOBS, globs);
   }
-  explicit ConnectReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ConnectReplyRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ConnectReply> Finish() {
+  flatbuffers::Offset<ConnectReplyRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ConnectReply>(end);
+    auto o = flatbuffers::Offset<ConnectReplyRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ConnectReply> CreateConnectReply(
+inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> leak_frames = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> race_frames = 0,
     rpc::Feature features = static_cast<rpc::Feature>(0),
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> files = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> globs = 0) {
-  ConnectReplyBuilder builder_(_fbb);
+  ConnectReplyRawBuilder builder_(_fbb);
   builder_.add_features(features);
   builder_.add_globs(globs);
   builder_.add_files(files);
@@ -816,7 +820,7 @@ inline flatbuffers::Offset<ConnectReply> CreateConnectReply(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<ConnectReply> CreateConnectReplyDirect(
+inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *leak_frames = nullptr,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *race_frames = nullptr,
@@ -827,7 +831,7 @@ inline flatbuffers::Offset<ConnectReply> CreateConnectReplyDirect(
   auto race_frames__ = race_frames ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*race_frames) : 0;
   auto files__ = files ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*files) : 0;
   auto globs__ = globs ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*globs) : 0;
-  return rpc::CreateConnectReply(
+  return rpc::CreateConnectReplyRaw(
       _fbb,
       leak_frames__,
       race_frames__,
@@ -836,127 +840,130 @@ inline flatbuffers::Offset<ConnectReply> CreateConnectReplyDirect(
       globs__);
 }
 
-flatbuffers::Offset<ConnectReply> CreateConnectReply(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct InfoRequestT : public flatbuffers::NativeTable {
-  typedef InfoRequest TableType;
+struct InfoRequestRawT : public flatbuffers::NativeTable {
+  typedef InfoRequestRaw TableType;
   std::string error{};
-  rpc::Feature features = static_cast<rpc::Feature>(0);
-  std::vector<std::unique_ptr<rpc::GlobInfoT>> globs{};
-  std::vector<std::unique_ptr<rpc::FileInfoT>> files{};
-  InfoRequestT() = default;
-  InfoRequestT(const InfoRequestT &o);
-  InfoRequestT(InfoRequestT&&) FLATBUFFERS_NOEXCEPT = default;
-  InfoRequestT &operator=(InfoRequestT o) FLATBUFFERS_NOEXCEPT;
+  std::vector<std::unique_ptr<rpc::FeatureInfoRawT>> features{};
+  std::vector<std::unique_ptr<rpc::FileInfoRawT>> files{};
+  std::vector<std::unique_ptr<rpc::GlobInfoRawT>> globs{};
+  InfoRequestRawT() = default;
+  InfoRequestRawT(const InfoRequestRawT &o);
+  InfoRequestRawT(InfoRequestRawT&&) FLATBUFFERS_NOEXCEPT = default;
+  InfoRequestRawT &operator=(InfoRequestRawT o) FLATBUFFERS_NOEXCEPT;
 };
 
-struct InfoRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef InfoRequestT NativeTableType;
-  typedef InfoRequestBuilder Builder;
+struct InfoRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef InfoRequestRawT NativeTableType;
+  typedef InfoRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4,
     VT_FEATURES = 6,
-    VT_GLOBS = 8,
-    VT_FILES = 10
+    VT_FILES = 8,
+    VT_GLOBS = 10
   };
   const flatbuffers::String *error() const {
     return GetPointer<const flatbuffers::String *>(VT_ERROR);
   }
-  rpc::Feature features() const {
-    return static_cast<rpc::Feature>(GetField<uint64_t>(VT_FEATURES, 0));
+  const flatbuffers::Vector<flatbuffers::Offset<rpc::FeatureInfoRaw>> *features() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::FeatureInfoRaw>> *>(VT_FEATURES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfo>> *globs() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfo>> *>(VT_GLOBS);
+  const flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfoRaw>> *files() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfoRaw>> *>(VT_FILES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfo>> *files() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfo>> *>(VT_FILES);
+  const flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfoRaw>> *globs() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfoRaw>> *>(VT_GLOBS);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_ERROR) &&
            verifier.VerifyString(error()) &&
-           VerifyField<uint64_t>(verifier, VT_FEATURES, 8) &&
-           VerifyOffset(verifier, VT_GLOBS) &&
-           verifier.VerifyVector(globs()) &&
-           verifier.VerifyVectorOfTables(globs()) &&
+           VerifyOffset(verifier, VT_FEATURES) &&
+           verifier.VerifyVector(features()) &&
+           verifier.VerifyVectorOfTables(features()) &&
            VerifyOffset(verifier, VT_FILES) &&
            verifier.VerifyVector(files()) &&
            verifier.VerifyVectorOfTables(files()) &&
+           VerifyOffset(verifier, VT_GLOBS) &&
+           verifier.VerifyVector(globs()) &&
+           verifier.VerifyVectorOfTables(globs()) &&
            verifier.EndTable();
   }
-  InfoRequestT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(InfoRequestT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<InfoRequest> Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  InfoRequestRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(InfoRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<InfoRequestRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct InfoRequestBuilder {
-  typedef InfoRequest Table;
+struct InfoRequestRawBuilder {
+  typedef InfoRequestRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_error(flatbuffers::Offset<flatbuffers::String> error) {
-    fbb_.AddOffset(InfoRequest::VT_ERROR, error);
+    fbb_.AddOffset(InfoRequestRaw::VT_ERROR, error);
   }
-  void add_features(rpc::Feature features) {
-    fbb_.AddElement<uint64_t>(InfoRequest::VT_FEATURES, static_cast<uint64_t>(features), 0);
+  void add_features(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FeatureInfoRaw>>> features) {
+    fbb_.AddOffset(InfoRequestRaw::VT_FEATURES, features);
   }
-  void add_globs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfo>>> globs) {
-    fbb_.AddOffset(InfoRequest::VT_GLOBS, globs);
+  void add_files(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfoRaw>>> files) {
+    fbb_.AddOffset(InfoRequestRaw::VT_FILES, files);
   }
-  void add_files(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfo>>> files) {
-    fbb_.AddOffset(InfoRequest::VT_FILES, files);
+  void add_globs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfoRaw>>> globs) {
+    fbb_.AddOffset(InfoRequestRaw::VT_GLOBS, globs);
   }
-  explicit InfoRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit InfoRequestRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<InfoRequest> Finish() {
+  flatbuffers::Offset<InfoRequestRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<InfoRequest>(end);
+    auto o = flatbuffers::Offset<InfoRequestRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<InfoRequest> CreateInfoRequest(
+inline flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> error = 0,
-    rpc::Feature features = static_cast<rpc::Feature>(0),
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfo>>> globs = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfo>>> files = 0) {
-  InfoRequestBuilder builder_(_fbb);
-  builder_.add_features(features);
-  builder_.add_files(files);
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FeatureInfoRaw>>> features = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::FileInfoRaw>>> files = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::GlobInfoRaw>>> globs = 0) {
+  InfoRequestRawBuilder builder_(_fbb);
   builder_.add_globs(globs);
+  builder_.add_files(files);
+  builder_.add_features(features);
   builder_.add_error(error);
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<InfoRequest> CreateInfoRequestDirect(
+inline flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *error = nullptr,
-    rpc::Feature features = static_cast<rpc::Feature>(0),
-    const std::vector<flatbuffers::Offset<rpc::GlobInfo>> *globs = nullptr,
-    const std::vector<flatbuffers::Offset<rpc::FileInfo>> *files = nullptr) {
+    const std::vector<flatbuffers::Offset<rpc::FeatureInfoRaw>> *features = nullptr,
+    const std::vector<flatbuffers::Offset<rpc::FileInfoRaw>> *files = nullptr,
+    const std::vector<flatbuffers::Offset<rpc::GlobInfoRaw>> *globs = nullptr) {
   auto error__ = error ? _fbb.CreateString(error) : 0;
-  auto globs__ = globs ? _fbb.CreateVector<flatbuffers::Offset<rpc::GlobInfo>>(*globs) : 0;
-  auto files__ = files ? _fbb.CreateVector<flatbuffers::Offset<rpc::FileInfo>>(*files) : 0;
-  return rpc::CreateInfoRequest(
+  auto features__ = features ? _fbb.CreateVector<flatbuffers::Offset<rpc::FeatureInfoRaw>>(*features) : 0;
+  auto files__ = files ? _fbb.CreateVector<flatbuffers::Offset<rpc::FileInfoRaw>>(*files) : 0;
+  auto globs__ = globs ? _fbb.CreateVector<flatbuffers::Offset<rpc::GlobInfoRaw>>(*globs) : 0;
+  return rpc::CreateInfoRequestRaw(
       _fbb,
       error__,
-      features,
-      globs__,
-      files__);
+      features__,
+      files__,
+      globs__);
 }
 
-flatbuffers::Offset<InfoRequest> CreateInfoRequest(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct InfoReplyT : public flatbuffers::NativeTable {
-  typedef InfoReply TableType;
+struct InfoReplyRawT : public flatbuffers::NativeTable {
+  typedef InfoReplyRaw TableType;
   std::vector<uint32_t> cover_filter{};
 };
 
-struct InfoReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef InfoReplyT NativeTableType;
-  typedef InfoReplyBuilder Builder;
+struct InfoReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef InfoReplyRawT NativeTableType;
+  typedef InfoReplyRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_COVER_FILTER = 4
   };
@@ -969,59 +976,59 @@ struct InfoReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(cover_filter()) &&
            verifier.EndTable();
   }
-  InfoReplyT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(InfoReplyT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<InfoReply> Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  InfoReplyRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(InfoReplyRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<InfoReplyRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct InfoReplyBuilder {
-  typedef InfoReply Table;
+struct InfoReplyRawBuilder {
+  typedef InfoReplyRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_cover_filter(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> cover_filter) {
-    fbb_.AddOffset(InfoReply::VT_COVER_FILTER, cover_filter);
+    fbb_.AddOffset(InfoReplyRaw::VT_COVER_FILTER, cover_filter);
   }
-  explicit InfoReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit InfoReplyRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<InfoReply> Finish() {
+  flatbuffers::Offset<InfoReplyRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<InfoReply>(end);
+    auto o = flatbuffers::Offset<InfoReplyRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<InfoReply> CreateInfoReply(
+inline flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> cover_filter = 0) {
-  InfoReplyBuilder builder_(_fbb);
+  InfoReplyRawBuilder builder_(_fbb);
   builder_.add_cover_filter(cover_filter);
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<InfoReply> CreateInfoReplyDirect(
+inline flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<uint32_t> *cover_filter = nullptr) {
   auto cover_filter__ = cover_filter ? _fbb.CreateVector<uint32_t>(*cover_filter) : 0;
-  return rpc::CreateInfoReply(
+  return rpc::CreateInfoReplyRaw(
       _fbb,
       cover_filter__);
 }
 
-flatbuffers::Offset<InfoReply> CreateInfoReply(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRaw(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct FileInfoT : public flatbuffers::NativeTable {
-  typedef FileInfo TableType;
+struct FileInfoRawT : public flatbuffers::NativeTable {
+  typedef FileInfoRaw TableType;
   std::string name{};
   bool exists = false;
   std::string error{};
   std::vector<uint8_t> data{};
 };
 
-struct FileInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef FileInfoT NativeTableType;
-  typedef FileInfoBuilder Builder;
+struct FileInfoRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FileInfoRawT NativeTableType;
+  typedef FileInfoRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_EXISTS = 6,
@@ -1051,45 +1058,45 @@ struct FileInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(data()) &&
            verifier.EndTable();
   }
-  FileInfoT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(FileInfoT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<FileInfo> Pack(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  FileInfoRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(FileInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<FileInfoRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct FileInfoBuilder {
-  typedef FileInfo Table;
+struct FileInfoRawBuilder {
+  typedef FileInfoRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
-    fbb_.AddOffset(FileInfo::VT_NAME, name);
+    fbb_.AddOffset(FileInfoRaw::VT_NAME, name);
   }
   void add_exists(bool exists) {
-    fbb_.AddElement<uint8_t>(FileInfo::VT_EXISTS, static_cast<uint8_t>(exists), 0);
+    fbb_.AddElement<uint8_t>(FileInfoRaw::VT_EXISTS, static_cast<uint8_t>(exists), 0);
   }
   void add_error(flatbuffers::Offset<flatbuffers::String> error) {
-    fbb_.AddOffset(FileInfo::VT_ERROR, error);
+    fbb_.AddOffset(FileInfoRaw::VT_ERROR, error);
   }
   void add_data(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> data) {
-    fbb_.AddOffset(FileInfo::VT_DATA, data);
+    fbb_.AddOffset(FileInfoRaw::VT_DATA, data);
   }
-  explicit FileInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit FileInfoRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<FileInfo> Finish() {
+  flatbuffers::Offset<FileInfoRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<FileInfo>(end);
+    auto o = flatbuffers::Offset<FileInfoRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<FileInfo> CreateFileInfo(
+inline flatbuffers::Offset<FileInfoRaw> CreateFileInfoRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     bool exists = false,
     flatbuffers::Offset<flatbuffers::String> error = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> data = 0) {
-  FileInfoBuilder builder_(_fbb);
+  FileInfoRawBuilder builder_(_fbb);
   builder_.add_data(data);
   builder_.add_error(error);
   builder_.add_name(name);
@@ -1097,7 +1104,7 @@ inline flatbuffers::Offset<FileInfo> CreateFileInfo(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<FileInfo> CreateFileInfoDirect(
+inline flatbuffers::Offset<FileInfoRaw> CreateFileInfoRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     bool exists = false,
@@ -1106,7 +1113,7 @@ inline flatbuffers::Offset<FileInfo> CreateFileInfoDirect(
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto error__ = error ? _fbb.CreateString(error) : 0;
   auto data__ = data ? _fbb.CreateVector<uint8_t>(*data) : 0;
-  return rpc::CreateFileInfo(
+  return rpc::CreateFileInfoRaw(
       _fbb,
       name__,
       exists,
@@ -1114,17 +1121,17 @@ inline flatbuffers::Offset<FileInfo> CreateFileInfoDirect(
       data__);
 }
 
-flatbuffers::Offset<FileInfo> CreateFileInfo(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<FileInfoRaw> CreateFileInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct GlobInfoT : public flatbuffers::NativeTable {
-  typedef GlobInfo TableType;
+struct GlobInfoRawT : public flatbuffers::NativeTable {
+  typedef GlobInfoRaw TableType;
   std::string name{};
   std::vector<std::string> files{};
 };
 
-struct GlobInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef GlobInfoT NativeTableType;
-  typedef GlobInfoBuilder Builder;
+struct GlobInfoRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef GlobInfoRawT NativeTableType;
+  typedef GlobInfoRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_FILES = 6
@@ -1144,221 +1151,309 @@ struct GlobInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfStrings(files()) &&
            verifier.EndTable();
   }
-  GlobInfoT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(GlobInfoT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<GlobInfo> Pack(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  GlobInfoRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(GlobInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<GlobInfoRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct GlobInfoBuilder {
-  typedef GlobInfo Table;
+struct GlobInfoRawBuilder {
+  typedef GlobInfoRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
-    fbb_.AddOffset(GlobInfo::VT_NAME, name);
+    fbb_.AddOffset(GlobInfoRaw::VT_NAME, name);
   }
   void add_files(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> files) {
-    fbb_.AddOffset(GlobInfo::VT_FILES, files);
+    fbb_.AddOffset(GlobInfoRaw::VT_FILES, files);
   }
-  explicit GlobInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit GlobInfoRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<GlobInfo> Finish() {
+  flatbuffers::Offset<GlobInfoRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<GlobInfo>(end);
+    auto o = flatbuffers::Offset<GlobInfoRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<GlobInfo> CreateGlobInfo(
+inline flatbuffers::Offset<GlobInfoRaw> CreateGlobInfoRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> files = 0) {
-  GlobInfoBuilder builder_(_fbb);
+  GlobInfoRawBuilder builder_(_fbb);
   builder_.add_files(files);
   builder_.add_name(name);
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<GlobInfo> CreateGlobInfoDirect(
+inline flatbuffers::Offset<GlobInfoRaw> CreateGlobInfoRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *files = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto files__ = files ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*files) : 0;
-  return rpc::CreateGlobInfo(
+  return rpc::CreateGlobInfoRaw(
       _fbb,
       name__,
       files__);
 }
 
-flatbuffers::Offset<GlobInfo> CreateGlobInfo(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<GlobInfoRaw> CreateGlobInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct HostMessageT : public flatbuffers::NativeTable {
-  typedef HostMessage TableType;
-  rpc::HostMessagesUnion msg{};
+struct FeatureInfoRawT : public flatbuffers::NativeTable {
+  typedef FeatureInfoRaw TableType;
+  rpc::Feature id = static_cast<rpc::Feature>(0);
+  bool need_setup = false;
+  std::string reason{};
 };
 
-struct HostMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef HostMessageT NativeTableType;
-  typedef HostMessageBuilder Builder;
+struct FeatureInfoRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FeatureInfoRawT NativeTableType;
+  typedef FeatureInfoRawBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_ID = 4,
+    VT_NEED_SETUP = 6,
+    VT_REASON = 8
+  };
+  rpc::Feature id() const {
+    return static_cast<rpc::Feature>(GetField<uint64_t>(VT_ID, 0));
+  }
+  bool need_setup() const {
+    return GetField<uint8_t>(VT_NEED_SETUP, 0) != 0;
+  }
+  const flatbuffers::String *reason() const {
+    return GetPointer<const flatbuffers::String *>(VT_REASON);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint64_t>(verifier, VT_ID, 8) &&
+           VerifyField<uint8_t>(verifier, VT_NEED_SETUP, 1) &&
+           VerifyOffset(verifier, VT_REASON) &&
+           verifier.VerifyString(reason()) &&
+           verifier.EndTable();
+  }
+  FeatureInfoRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(FeatureInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<FeatureInfoRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const FeatureInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct FeatureInfoRawBuilder {
+  typedef FeatureInfoRaw Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_id(rpc::Feature id) {
+    fbb_.AddElement<uint64_t>(FeatureInfoRaw::VT_ID, static_cast<uint64_t>(id), 0);
+  }
+  void add_need_setup(bool need_setup) {
+    fbb_.AddElement<uint8_t>(FeatureInfoRaw::VT_NEED_SETUP, static_cast<uint8_t>(need_setup), 0);
+  }
+  void add_reason(flatbuffers::Offset<flatbuffers::String> reason) {
+    fbb_.AddOffset(FeatureInfoRaw::VT_REASON, reason);
+  }
+  explicit FeatureInfoRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<FeatureInfoRaw> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<FeatureInfoRaw>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<FeatureInfoRaw> CreateFeatureInfoRaw(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    rpc::Feature id = static_cast<rpc::Feature>(0),
+    bool need_setup = false,
+    flatbuffers::Offset<flatbuffers::String> reason = 0) {
+  FeatureInfoRawBuilder builder_(_fbb);
+  builder_.add_id(id);
+  builder_.add_reason(reason);
+  builder_.add_need_setup(need_setup);
+  return builder_.Finish();
+}
+
+inline flatbuffers::Offset<FeatureInfoRaw> CreateFeatureInfoRawDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    rpc::Feature id = static_cast<rpc::Feature>(0),
+    bool need_setup = false,
+    const char *reason = nullptr) {
+  auto reason__ = reason ? _fbb.CreateString(reason) : 0;
+  return rpc::CreateFeatureInfoRaw(
+      _fbb,
+      id,
+      need_setup,
+      reason__);
+}
+
+flatbuffers::Offset<FeatureInfoRaw> CreateFeatureInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const FeatureInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+struct HostMessageRawT : public flatbuffers::NativeTable {
+  typedef HostMessageRaw TableType;
+  rpc::HostMessagesRawUnion msg{};
+};
+
+struct HostMessageRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef HostMessageRawT NativeTableType;
+  typedef HostMessageRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MSG_TYPE = 4,
     VT_MSG = 6
   };
-  rpc::HostMessages msg_type() const {
-    return static_cast<rpc::HostMessages>(GetField<uint8_t>(VT_MSG_TYPE, 0));
+  rpc::HostMessagesRaw msg_type() const {
+    return static_cast<rpc::HostMessagesRaw>(GetField<uint8_t>(VT_MSG_TYPE, 0));
   }
   const void *msg() const {
     return GetPointer<const void *>(VT_MSG);
   }
   template<typename T> const T *msg_as() const;
-  const rpc::ExecRequest *msg_as_ExecRequest() const {
-    return msg_type() == rpc::HostMessages::ExecRequest ? static_cast<const rpc::ExecRequest *>(msg()) : nullptr;
+  const rpc::ExecRequestRaw *msg_as_ExecRequest() const {
+    return msg_type() == rpc::HostMessagesRaw::ExecRequest ? static_cast<const rpc::ExecRequestRaw *>(msg()) : nullptr;
   }
-  const rpc::SignalUpdate *msg_as_SignalUpdate() const {
-    return msg_type() == rpc::HostMessages::SignalUpdate ? static_cast<const rpc::SignalUpdate *>(msg()) : nullptr;
+  const rpc::SignalUpdateRaw *msg_as_SignalUpdate() const {
+    return msg_type() == rpc::HostMessagesRaw::SignalUpdate ? static_cast<const rpc::SignalUpdateRaw *>(msg()) : nullptr;
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_MSG_TYPE, 1) &&
            VerifyOffset(verifier, VT_MSG) &&
-           VerifyHostMessages(verifier, msg(), msg_type()) &&
+           VerifyHostMessagesRaw(verifier, msg(), msg_type()) &&
            verifier.EndTable();
   }
-  HostMessageT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(HostMessageT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<HostMessage> Pack(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  HostMessageRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(HostMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<HostMessageRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-template<> inline const rpc::ExecRequest *HostMessage::msg_as<rpc::ExecRequest>() const {
+template<> inline const rpc::ExecRequestRaw *HostMessageRaw::msg_as<rpc::ExecRequestRaw>() const {
   return msg_as_ExecRequest();
 }
 
-template<> inline const rpc::SignalUpdate *HostMessage::msg_as<rpc::SignalUpdate>() const {
+template<> inline const rpc::SignalUpdateRaw *HostMessageRaw::msg_as<rpc::SignalUpdateRaw>() const {
   return msg_as_SignalUpdate();
 }
 
-struct HostMessageBuilder {
-  typedef HostMessage Table;
+struct HostMessageRawBuilder {
+  typedef HostMessageRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_msg_type(rpc::HostMessages msg_type) {
-    fbb_.AddElement<uint8_t>(HostMessage::VT_MSG_TYPE, static_cast<uint8_t>(msg_type), 0);
+  void add_msg_type(rpc::HostMessagesRaw msg_type) {
+    fbb_.AddElement<uint8_t>(HostMessageRaw::VT_MSG_TYPE, static_cast<uint8_t>(msg_type), 0);
   }
   void add_msg(flatbuffers::Offset<void> msg) {
-    fbb_.AddOffset(HostMessage::VT_MSG, msg);
+    fbb_.AddOffset(HostMessageRaw::VT_MSG, msg);
   }
-  explicit HostMessageBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit HostMessageRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<HostMessage> Finish() {
+  flatbuffers::Offset<HostMessageRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<HostMessage>(end);
+    auto o = flatbuffers::Offset<HostMessageRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<HostMessage> CreateHostMessage(
+inline flatbuffers::Offset<HostMessageRaw> CreateHostMessageRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    rpc::HostMessages msg_type = rpc::HostMessages::NONE,
+    rpc::HostMessagesRaw msg_type = rpc::HostMessagesRaw::NONE,
     flatbuffers::Offset<void> msg = 0) {
-  HostMessageBuilder builder_(_fbb);
+  HostMessageRawBuilder builder_(_fbb);
   builder_.add_msg(msg);
   builder_.add_msg_type(msg_type);
   return builder_.Finish();
 }
 
-flatbuffers::Offset<HostMessage> CreateHostMessage(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<HostMessageRaw> CreateHostMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ExecutorMessageT : public flatbuffers::NativeTable {
-  typedef ExecutorMessage TableType;
-  rpc::ExecutorMessagesUnion msg{};
+struct ExecutorMessageRawT : public flatbuffers::NativeTable {
+  typedef ExecutorMessageRaw TableType;
+  rpc::ExecutorMessagesRawUnion msg{};
 };
 
-struct ExecutorMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ExecutorMessageT NativeTableType;
-  typedef ExecutorMessageBuilder Builder;
+struct ExecutorMessageRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ExecutorMessageRawT NativeTableType;
+  typedef ExecutorMessageRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MSG_TYPE = 4,
     VT_MSG = 6
   };
-  rpc::ExecutorMessages msg_type() const {
-    return static_cast<rpc::ExecutorMessages>(GetField<uint8_t>(VT_MSG_TYPE, 0));
+  rpc::ExecutorMessagesRaw msg_type() const {
+    return static_cast<rpc::ExecutorMessagesRaw>(GetField<uint8_t>(VT_MSG_TYPE, 0));
   }
   const void *msg() const {
     return GetPointer<const void *>(VT_MSG);
   }
   template<typename T> const T *msg_as() const;
-  const rpc::ExecResult *msg_as_ExecResult() const {
-    return msg_type() == rpc::ExecutorMessages::ExecResult ? static_cast<const rpc::ExecResult *>(msg()) : nullptr;
+  const rpc::ExecResultRaw *msg_as_ExecResult() const {
+    return msg_type() == rpc::ExecutorMessagesRaw::ExecResult ? static_cast<const rpc::ExecResultRaw *>(msg()) : nullptr;
   }
-  const rpc::ExecutingMessage *msg_as_Executing() const {
-    return msg_type() == rpc::ExecutorMessages::Executing ? static_cast<const rpc::ExecutingMessage *>(msg()) : nullptr;
+  const rpc::ExecutingMessageRaw *msg_as_Executing() const {
+    return msg_type() == rpc::ExecutorMessagesRaw::Executing ? static_cast<const rpc::ExecutingMessageRaw *>(msg()) : nullptr;
   }
-  const rpc::StatsMessage *msg_as_Stats() const {
-    return msg_type() == rpc::ExecutorMessages::Stats ? static_cast<const rpc::StatsMessage *>(msg()) : nullptr;
+  const rpc::StatsMessageRaw *msg_as_Stats() const {
+    return msg_type() == rpc::ExecutorMessagesRaw::Stats ? static_cast<const rpc::StatsMessageRaw *>(msg()) : nullptr;
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_MSG_TYPE, 1) &&
            VerifyOffset(verifier, VT_MSG) &&
-           VerifyExecutorMessages(verifier, msg(), msg_type()) &&
+           VerifyExecutorMessagesRaw(verifier, msg(), msg_type()) &&
            verifier.EndTable();
   }
-  ExecutorMessageT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ExecutorMessageT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ExecutorMessage> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ExecutorMessageRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ExecutorMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ExecutorMessageRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-template<> inline const rpc::ExecResult *ExecutorMessage::msg_as<rpc::ExecResult>() const {
+template<> inline const rpc::ExecResultRaw *ExecutorMessageRaw::msg_as<rpc::ExecResultRaw>() const {
   return msg_as_ExecResult();
 }
 
-template<> inline const rpc::ExecutingMessage *ExecutorMessage::msg_as<rpc::ExecutingMessage>() const {
+template<> inline const rpc::ExecutingMessageRaw *ExecutorMessageRaw::msg_as<rpc::ExecutingMessageRaw>() const {
   return msg_as_Executing();
 }
 
-template<> inline const rpc::StatsMessage *ExecutorMessage::msg_as<rpc::StatsMessage>() const {
+template<> inline const rpc::StatsMessageRaw *ExecutorMessageRaw::msg_as<rpc::StatsMessageRaw>() const {
   return msg_as_Stats();
 }
 
-struct ExecutorMessageBuilder {
-  typedef ExecutorMessage Table;
+struct ExecutorMessageRawBuilder {
+  typedef ExecutorMessageRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_msg_type(rpc::ExecutorMessages msg_type) {
-    fbb_.AddElement<uint8_t>(ExecutorMessage::VT_MSG_TYPE, static_cast<uint8_t>(msg_type), 0);
+  void add_msg_type(rpc::ExecutorMessagesRaw msg_type) {
+    fbb_.AddElement<uint8_t>(ExecutorMessageRaw::VT_MSG_TYPE, static_cast<uint8_t>(msg_type), 0);
   }
   void add_msg(flatbuffers::Offset<void> msg) {
-    fbb_.AddOffset(ExecutorMessage::VT_MSG, msg);
+    fbb_.AddOffset(ExecutorMessageRaw::VT_MSG, msg);
   }
-  explicit ExecutorMessageBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ExecutorMessageRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ExecutorMessage> Finish() {
+  flatbuffers::Offset<ExecutorMessageRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ExecutorMessage>(end);
+    auto o = flatbuffers::Offset<ExecutorMessageRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ExecutorMessage> CreateExecutorMessage(
+inline flatbuffers::Offset<ExecutorMessageRaw> CreateExecutorMessageRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    rpc::ExecutorMessages msg_type = rpc::ExecutorMessages::NONE,
+    rpc::ExecutorMessagesRaw msg_type = rpc::ExecutorMessagesRaw::NONE,
     flatbuffers::Offset<void> msg = 0) {
-  ExecutorMessageBuilder builder_(_fbb);
+  ExecutorMessageRawBuilder builder_(_fbb);
   builder_.add_msg(msg);
   builder_.add_msg_type(msg_type);
   return builder_.Finish();
 }
 
-flatbuffers::Offset<ExecutorMessage> CreateExecutorMessage(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ExecutorMessageRaw> CreateExecutorMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ExecRequestT : public flatbuffers::NativeTable {
-  typedef ExecRequest TableType;
+struct ExecRequestRawT : public flatbuffers::NativeTable {
+  typedef ExecRequestRaw TableType;
   int64_t id = 0;
   std::vector<uint8_t> prog_data{};
   rpc::RequestFlag flags = static_cast<rpc::RequestFlag>(0);
@@ -1370,9 +1465,9 @@ struct ExecRequestT : public flatbuffers::NativeTable {
   int32_t repeat = 0;
 };
 
-struct ExecRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ExecRequestT NativeTableType;
-  typedef ExecRequestBuilder Builder;
+struct ExecRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ExecRequestRawT NativeTableType;
+  typedef ExecRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
     VT_PROG_DATA = 6,
@@ -1426,54 +1521,54 @@ struct ExecRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int32_t>(verifier, VT_REPEAT, 4) &&
            verifier.EndTable();
   }
-  ExecRequestT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ExecRequestT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ExecRequest> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ExecRequestRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ExecRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ExecRequestRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ExecRequestBuilder {
-  typedef ExecRequest Table;
+struct ExecRequestRawBuilder {
+  typedef ExecRequestRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
-    fbb_.AddElement<int64_t>(ExecRequest::VT_ID, id, 0);
+    fbb_.AddElement<int64_t>(ExecRequestRaw::VT_ID, id, 0);
   }
   void add_prog_data(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> prog_data) {
-    fbb_.AddOffset(ExecRequest::VT_PROG_DATA, prog_data);
+    fbb_.AddOffset(ExecRequestRaw::VT_PROG_DATA, prog_data);
   }
   void add_flags(rpc::RequestFlag flags) {
-    fbb_.AddElement<uint64_t>(ExecRequest::VT_FLAGS, static_cast<uint64_t>(flags), 0);
+    fbb_.AddElement<uint64_t>(ExecRequestRaw::VT_FLAGS, static_cast<uint64_t>(flags), 0);
   }
   void add_exec_env(rpc::ExecEnv exec_env) {
-    fbb_.AddElement<uint64_t>(ExecRequest::VT_EXEC_ENV, static_cast<uint64_t>(exec_env), 0);
+    fbb_.AddElement<uint64_t>(ExecRequestRaw::VT_EXEC_ENV, static_cast<uint64_t>(exec_env), 0);
   }
   void add_exec_flags(rpc::ExecFlag exec_flags) {
-    fbb_.AddElement<uint64_t>(ExecRequest::VT_EXEC_FLAGS, static_cast<uint64_t>(exec_flags), 0);
+    fbb_.AddElement<uint64_t>(ExecRequestRaw::VT_EXEC_FLAGS, static_cast<uint64_t>(exec_flags), 0);
   }
   void add_sandbox_arg(int64_t sandbox_arg) {
-    fbb_.AddElement<int64_t>(ExecRequest::VT_SANDBOX_ARG, sandbox_arg, 0);
+    fbb_.AddElement<int64_t>(ExecRequestRaw::VT_SANDBOX_ARG, sandbox_arg, 0);
   }
   void add_signal_filter(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> signal_filter) {
-    fbb_.AddOffset(ExecRequest::VT_SIGNAL_FILTER, signal_filter);
+    fbb_.AddOffset(ExecRequestRaw::VT_SIGNAL_FILTER, signal_filter);
   }
   void add_signal_filter_call(int32_t signal_filter_call) {
-    fbb_.AddElement<int32_t>(ExecRequest::VT_SIGNAL_FILTER_CALL, signal_filter_call, 0);
+    fbb_.AddElement<int32_t>(ExecRequestRaw::VT_SIGNAL_FILTER_CALL, signal_filter_call, 0);
   }
   void add_repeat(int32_t repeat) {
-    fbb_.AddElement<int32_t>(ExecRequest::VT_REPEAT, repeat, 0);
+    fbb_.AddElement<int32_t>(ExecRequestRaw::VT_REPEAT, repeat, 0);
   }
-  explicit ExecRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ExecRequestRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ExecRequest> Finish() {
+  flatbuffers::Offset<ExecRequestRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ExecRequest>(end);
+    auto o = flatbuffers::Offset<ExecRequestRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ExecRequest> CreateExecRequest(
+inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> prog_data = 0,
@@ -1484,7 +1579,7 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequest(
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> signal_filter = 0,
     int32_t signal_filter_call = 0,
     int32_t repeat = 0) {
-  ExecRequestBuilder builder_(_fbb);
+  ExecRequestRawBuilder builder_(_fbb);
   builder_.add_sandbox_arg(sandbox_arg);
   builder_.add_exec_flags(exec_flags);
   builder_.add_exec_env(exec_env);
@@ -1497,7 +1592,7 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequest(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<ExecRequest> CreateExecRequestDirect(
+inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
     const std::vector<uint8_t> *prog_data = nullptr,
@@ -1510,7 +1605,7 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequestDirect(
     int32_t repeat = 0) {
   auto prog_data__ = prog_data ? _fbb.CreateVector<uint8_t>(*prog_data) : 0;
   auto signal_filter__ = signal_filter ? _fbb.CreateVector<uint32_t>(*signal_filter) : 0;
-  return rpc::CreateExecRequest(
+  return rpc::CreateExecRequestRaw(
       _fbb,
       id,
       prog_data__,
@@ -1523,17 +1618,17 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequestDirect(
       repeat);
 }
 
-flatbuffers::Offset<ExecRequest> CreateExecRequest(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct SignalUpdateT : public flatbuffers::NativeTable {
-  typedef SignalUpdate TableType;
+struct SignalUpdateRawT : public flatbuffers::NativeTable {
+  typedef SignalUpdateRaw TableType;
   std::vector<uint32_t> new_max{};
   std::vector<uint32_t> drop_max{};
 };
 
-struct SignalUpdate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef SignalUpdateT NativeTableType;
-  typedef SignalUpdateBuilder Builder;
+struct SignalUpdateRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SignalUpdateRawT NativeTableType;
+  typedef SignalUpdateRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NEW_MAX = 4,
     VT_DROP_MAX = 6
@@ -1552,66 +1647,66 @@ struct SignalUpdate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(drop_max()) &&
            verifier.EndTable();
   }
-  SignalUpdateT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(SignalUpdateT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<SignalUpdate> Pack(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  SignalUpdateRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(SignalUpdateRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<SignalUpdateRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct SignalUpdateBuilder {
-  typedef SignalUpdate Table;
+struct SignalUpdateRawBuilder {
+  typedef SignalUpdateRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_new_max(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> new_max) {
-    fbb_.AddOffset(SignalUpdate::VT_NEW_MAX, new_max);
+    fbb_.AddOffset(SignalUpdateRaw::VT_NEW_MAX, new_max);
   }
   void add_drop_max(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> drop_max) {
-    fbb_.AddOffset(SignalUpdate::VT_DROP_MAX, drop_max);
+    fbb_.AddOffset(SignalUpdateRaw::VT_DROP_MAX, drop_max);
   }
-  explicit SignalUpdateBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit SignalUpdateRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<SignalUpdate> Finish() {
+  flatbuffers::Offset<SignalUpdateRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<SignalUpdate>(end);
+    auto o = flatbuffers::Offset<SignalUpdateRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<SignalUpdate> CreateSignalUpdate(
+inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> new_max = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> drop_max = 0) {
-  SignalUpdateBuilder builder_(_fbb);
+  SignalUpdateRawBuilder builder_(_fbb);
   builder_.add_drop_max(drop_max);
   builder_.add_new_max(new_max);
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<SignalUpdate> CreateSignalUpdateDirect(
+inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<uint32_t> *new_max = nullptr,
     const std::vector<uint32_t> *drop_max = nullptr) {
   auto new_max__ = new_max ? _fbb.CreateVector<uint32_t>(*new_max) : 0;
   auto drop_max__ = drop_max ? _fbb.CreateVector<uint32_t>(*drop_max) : 0;
-  return rpc::CreateSignalUpdate(
+  return rpc::CreateSignalUpdateRaw(
       _fbb,
       new_max__,
       drop_max__);
 }
 
-flatbuffers::Offset<SignalUpdate> CreateSignalUpdate(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ExecutingMessageT : public flatbuffers::NativeTable {
-  typedef ExecutingMessage TableType;
+struct ExecutingMessageRawT : public flatbuffers::NativeTable {
+  typedef ExecutingMessageRaw TableType;
   int64_t id = 0;
   int32_t proc_id = 0;
   int32_t try_ = 0;
 };
 
-struct ExecutingMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ExecutingMessageT NativeTableType;
-  typedef ExecutingMessageBuilder Builder;
+struct ExecutingMessageRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ExecutingMessageRawT NativeTableType;
+  typedef ExecutingMessageRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
     VT_PROC_ID = 6,
@@ -1633,58 +1728,58 @@ struct ExecutingMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int32_t>(verifier, VT_TRY_, 4) &&
            verifier.EndTable();
   }
-  ExecutingMessageT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ExecutingMessageT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ExecutingMessage> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ExecutingMessageRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ExecutingMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ExecutingMessageRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ExecutingMessageBuilder {
-  typedef ExecutingMessage Table;
+struct ExecutingMessageRawBuilder {
+  typedef ExecutingMessageRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
-    fbb_.AddElement<int64_t>(ExecutingMessage::VT_ID, id, 0);
+    fbb_.AddElement<int64_t>(ExecutingMessageRaw::VT_ID, id, 0);
   }
   void add_proc_id(int32_t proc_id) {
-    fbb_.AddElement<int32_t>(ExecutingMessage::VT_PROC_ID, proc_id, 0);
+    fbb_.AddElement<int32_t>(ExecutingMessageRaw::VT_PROC_ID, proc_id, 0);
   }
   void add_try_(int32_t try_) {
-    fbb_.AddElement<int32_t>(ExecutingMessage::VT_TRY_, try_, 0);
+    fbb_.AddElement<int32_t>(ExecutingMessageRaw::VT_TRY_, try_, 0);
   }
-  explicit ExecutingMessageBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ExecutingMessageRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ExecutingMessage> Finish() {
+  flatbuffers::Offset<ExecutingMessageRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ExecutingMessage>(end);
+    auto o = flatbuffers::Offset<ExecutingMessageRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ExecutingMessage> CreateExecutingMessage(
+inline flatbuffers::Offset<ExecutingMessageRaw> CreateExecutingMessageRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
     int32_t proc_id = 0,
     int32_t try_ = 0) {
-  ExecutingMessageBuilder builder_(_fbb);
+  ExecutingMessageRawBuilder builder_(_fbb);
   builder_.add_id(id);
   builder_.add_try_(try_);
   builder_.add_proc_id(proc_id);
   return builder_.Finish();
 }
 
-flatbuffers::Offset<ExecutingMessage> CreateExecutingMessage(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ExecutingMessageRaw> CreateExecutingMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct StatsMessageT : public flatbuffers::NativeTable {
-  typedef StatsMessage TableType;
+struct StatsMessageRawT : public flatbuffers::NativeTable {
+  typedef StatsMessageRaw TableType;
   int64_t noexec_count = 0;
   int64_t noexec_duration = 0;
 };
 
-struct StatsMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef StatsMessageT NativeTableType;
-  typedef StatsMessageBuilder Builder;
+struct StatsMessageRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef StatsMessageRawT NativeTableType;
+  typedef StatsMessageRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NOEXEC_COUNT = 4,
     VT_NOEXEC_DURATION = 6
@@ -1701,56 +1796,56 @@ struct StatsMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int64_t>(verifier, VT_NOEXEC_DURATION, 8) &&
            verifier.EndTable();
   }
-  StatsMessageT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(StatsMessageT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<StatsMessage> Pack(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  StatsMessageRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(StatsMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<StatsMessageRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct StatsMessageBuilder {
-  typedef StatsMessage Table;
+struct StatsMessageRawBuilder {
+  typedef StatsMessageRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_noexec_count(int64_t noexec_count) {
-    fbb_.AddElement<int64_t>(StatsMessage::VT_NOEXEC_COUNT, noexec_count, 0);
+    fbb_.AddElement<int64_t>(StatsMessageRaw::VT_NOEXEC_COUNT, noexec_count, 0);
   }
   void add_noexec_duration(int64_t noexec_duration) {
-    fbb_.AddElement<int64_t>(StatsMessage::VT_NOEXEC_DURATION, noexec_duration, 0);
+    fbb_.AddElement<int64_t>(StatsMessageRaw::VT_NOEXEC_DURATION, noexec_duration, 0);
   }
-  explicit StatsMessageBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit StatsMessageRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<StatsMessage> Finish() {
+  flatbuffers::Offset<StatsMessageRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<StatsMessage>(end);
+    auto o = flatbuffers::Offset<StatsMessageRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<StatsMessage> CreateStatsMessage(
+inline flatbuffers::Offset<StatsMessageRaw> CreateStatsMessageRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t noexec_count = 0,
     int64_t noexec_duration = 0) {
-  StatsMessageBuilder builder_(_fbb);
+  StatsMessageRawBuilder builder_(_fbb);
   builder_.add_noexec_duration(noexec_duration);
   builder_.add_noexec_count(noexec_count);
   return builder_.Finish();
 }
 
-flatbuffers::Offset<StatsMessage> CreateStatsMessage(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<StatsMessageRaw> CreateStatsMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct CallInfoT : public flatbuffers::NativeTable {
-  typedef CallInfo TableType;
+struct CallInfoRawT : public flatbuffers::NativeTable {
+  typedef CallInfoRaw TableType;
   rpc::CallFlag flags = static_cast<rpc::CallFlag>(0);
   int32_t error = 0;
   std::vector<uint32_t> signal{};
   std::vector<uint32_t> cover{};
-  std::vector<rpc::Comparison> comps{};
+  std::vector<rpc::ComparisonRaw> comps{};
 };
 
-struct CallInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef CallInfoT NativeTableType;
-  typedef CallInfoBuilder Builder;
+struct CallInfoRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef CallInfoRawT NativeTableType;
+  typedef CallInfoRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FLAGS = 4,
     VT_ERROR = 6,
@@ -1770,8 +1865,8 @@ struct CallInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<uint32_t> *cover() const {
     return GetPointer<const flatbuffers::Vector<uint32_t> *>(VT_COVER);
   }
-  const flatbuffers::Vector<const rpc::Comparison *> *comps() const {
-    return GetPointer<const flatbuffers::Vector<const rpc::Comparison *> *>(VT_COMPS);
+  const flatbuffers::Vector<const rpc::ComparisonRaw *> *comps() const {
+    return GetPointer<const flatbuffers::Vector<const rpc::ComparisonRaw *> *>(VT_COMPS);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1785,49 +1880,49 @@ struct CallInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(comps()) &&
            verifier.EndTable();
   }
-  CallInfoT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(CallInfoT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<CallInfo> Pack(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  CallInfoRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(CallInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<CallInfoRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct CallInfoBuilder {
-  typedef CallInfo Table;
+struct CallInfoRawBuilder {
+  typedef CallInfoRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_flags(rpc::CallFlag flags) {
-    fbb_.AddElement<uint8_t>(CallInfo::VT_FLAGS, static_cast<uint8_t>(flags), 0);
+    fbb_.AddElement<uint8_t>(CallInfoRaw::VT_FLAGS, static_cast<uint8_t>(flags), 0);
   }
   void add_error(int32_t error) {
-    fbb_.AddElement<int32_t>(CallInfo::VT_ERROR, error, 0);
+    fbb_.AddElement<int32_t>(CallInfoRaw::VT_ERROR, error, 0);
   }
   void add_signal(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> signal) {
-    fbb_.AddOffset(CallInfo::VT_SIGNAL, signal);
+    fbb_.AddOffset(CallInfoRaw::VT_SIGNAL, signal);
   }
   void add_cover(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> cover) {
-    fbb_.AddOffset(CallInfo::VT_COVER, cover);
+    fbb_.AddOffset(CallInfoRaw::VT_COVER, cover);
   }
-  void add_comps(flatbuffers::Offset<flatbuffers::Vector<const rpc::Comparison *>> comps) {
-    fbb_.AddOffset(CallInfo::VT_COMPS, comps);
+  void add_comps(flatbuffers::Offset<flatbuffers::Vector<const rpc::ComparisonRaw *>> comps) {
+    fbb_.AddOffset(CallInfoRaw::VT_COMPS, comps);
   }
-  explicit CallInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit CallInfoRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<CallInfo> Finish() {
+  flatbuffers::Offset<CallInfoRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<CallInfo>(end);
+    auto o = flatbuffers::Offset<CallInfoRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<CallInfo> CreateCallInfo(
+inline flatbuffers::Offset<CallInfoRaw> CreateCallInfoRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     rpc::CallFlag flags = static_cast<rpc::CallFlag>(0),
     int32_t error = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> signal = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> cover = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const rpc::Comparison *>> comps = 0) {
-  CallInfoBuilder builder_(_fbb);
+    flatbuffers::Offset<flatbuffers::Vector<const rpc::ComparisonRaw *>> comps = 0) {
+  CallInfoRawBuilder builder_(_fbb);
   builder_.add_comps(comps);
   builder_.add_cover(cover);
   builder_.add_signal(signal);
@@ -1836,17 +1931,17 @@ inline flatbuffers::Offset<CallInfo> CreateCallInfo(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<CallInfo> CreateCallInfoDirect(
+inline flatbuffers::Offset<CallInfoRaw> CreateCallInfoRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     rpc::CallFlag flags = static_cast<rpc::CallFlag>(0),
     int32_t error = 0,
     const std::vector<uint32_t> *signal = nullptr,
     const std::vector<uint32_t> *cover = nullptr,
-    const std::vector<rpc::Comparison> *comps = nullptr) {
+    const std::vector<rpc::ComparisonRaw> *comps = nullptr) {
   auto signal__ = signal ? _fbb.CreateVector<uint32_t>(*signal) : 0;
   auto cover__ = cover ? _fbb.CreateVector<uint32_t>(*cover) : 0;
-  auto comps__ = comps ? _fbb.CreateVectorOfStructs<rpc::Comparison>(*comps) : 0;
-  return rpc::CreateCallInfo(
+  auto comps__ = comps ? _fbb.CreateVectorOfStructs<rpc::ComparisonRaw>(*comps) : 0;
+  return rpc::CreateCallInfoRaw(
       _fbb,
       flags,
       error,
@@ -1855,34 +1950,34 @@ inline flatbuffers::Offset<CallInfo> CreateCallInfoDirect(
       comps__);
 }
 
-flatbuffers::Offset<CallInfo> CreateCallInfo(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<CallInfoRaw> CreateCallInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ProgInfoT : public flatbuffers::NativeTable {
-  typedef ProgInfo TableType;
-  std::vector<std::unique_ptr<rpc::CallInfoT>> calls{};
-  std::unique_ptr<rpc::CallInfoT> extra{};
+struct ProgInfoRawT : public flatbuffers::NativeTable {
+  typedef ProgInfoRaw TableType;
+  std::vector<std::unique_ptr<rpc::CallInfoRawT>> calls{};
+  std::unique_ptr<rpc::CallInfoRawT> extra{};
   uint64_t elapsed = 0;
   uint64_t freshness = 0;
-  ProgInfoT() = default;
-  ProgInfoT(const ProgInfoT &o);
-  ProgInfoT(ProgInfoT&&) FLATBUFFERS_NOEXCEPT = default;
-  ProgInfoT &operator=(ProgInfoT o) FLATBUFFERS_NOEXCEPT;
+  ProgInfoRawT() = default;
+  ProgInfoRawT(const ProgInfoRawT &o);
+  ProgInfoRawT(ProgInfoRawT&&) FLATBUFFERS_NOEXCEPT = default;
+  ProgInfoRawT &operator=(ProgInfoRawT o) FLATBUFFERS_NOEXCEPT;
 };
 
-struct ProgInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ProgInfoT NativeTableType;
-  typedef ProgInfoBuilder Builder;
+struct ProgInfoRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ProgInfoRawT NativeTableType;
+  typedef ProgInfoRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_CALLS = 4,
     VT_EXTRA = 6,
     VT_ELAPSED = 8,
     VT_FRESHNESS = 10
   };
-  const flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfo>> *calls() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfo>> *>(VT_CALLS);
+  const flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfoRaw>> *calls() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfoRaw>> *>(VT_CALLS);
   }
-  const rpc::CallInfo *extra() const {
-    return GetPointer<const rpc::CallInfo *>(VT_EXTRA);
+  const rpc::CallInfoRaw *extra() const {
+    return GetPointer<const rpc::CallInfoRaw *>(VT_EXTRA);
   }
   uint64_t elapsed() const {
     return GetField<uint64_t>(VT_ELAPSED, 0);
@@ -1901,45 +1996,45 @@ struct ProgInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<uint64_t>(verifier, VT_FRESHNESS, 8) &&
            verifier.EndTable();
   }
-  ProgInfoT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ProgInfoT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ProgInfo> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ProgInfoRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ProgInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ProgInfoRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ProgInfoBuilder {
-  typedef ProgInfo Table;
+struct ProgInfoRawBuilder {
+  typedef ProgInfoRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_calls(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfo>>> calls) {
-    fbb_.AddOffset(ProgInfo::VT_CALLS, calls);
+  void add_calls(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfoRaw>>> calls) {
+    fbb_.AddOffset(ProgInfoRaw::VT_CALLS, calls);
   }
-  void add_extra(flatbuffers::Offset<rpc::CallInfo> extra) {
-    fbb_.AddOffset(ProgInfo::VT_EXTRA, extra);
+  void add_extra(flatbuffers::Offset<rpc::CallInfoRaw> extra) {
+    fbb_.AddOffset(ProgInfoRaw::VT_EXTRA, extra);
   }
   void add_elapsed(uint64_t elapsed) {
-    fbb_.AddElement<uint64_t>(ProgInfo::VT_ELAPSED, elapsed, 0);
+    fbb_.AddElement<uint64_t>(ProgInfoRaw::VT_ELAPSED, elapsed, 0);
   }
   void add_freshness(uint64_t freshness) {
-    fbb_.AddElement<uint64_t>(ProgInfo::VT_FRESHNESS, freshness, 0);
+    fbb_.AddElement<uint64_t>(ProgInfoRaw::VT_FRESHNESS, freshness, 0);
   }
-  explicit ProgInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ProgInfoRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ProgInfo> Finish() {
+  flatbuffers::Offset<ProgInfoRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ProgInfo>(end);
+    auto o = flatbuffers::Offset<ProgInfoRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ProgInfo> CreateProgInfo(
+inline flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfo>>> calls = 0,
-    flatbuffers::Offset<rpc::CallInfo> extra = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<rpc::CallInfoRaw>>> calls = 0,
+    flatbuffers::Offset<rpc::CallInfoRaw> extra = 0,
     uint64_t elapsed = 0,
     uint64_t freshness = 0) {
-  ProgInfoBuilder builder_(_fbb);
+  ProgInfoRawBuilder builder_(_fbb);
   builder_.add_freshness(freshness);
   builder_.add_elapsed(elapsed);
   builder_.add_extra(extra);
@@ -1947,14 +2042,14 @@ inline flatbuffers::Offset<ProgInfo> CreateProgInfo(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<ProgInfo> CreateProgInfoDirect(
+inline flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<rpc::CallInfo>> *calls = nullptr,
-    flatbuffers::Offset<rpc::CallInfo> extra = 0,
+    const std::vector<flatbuffers::Offset<rpc::CallInfoRaw>> *calls = nullptr,
+    flatbuffers::Offset<rpc::CallInfoRaw> extra = 0,
     uint64_t elapsed = 0,
     uint64_t freshness = 0) {
-  auto calls__ = calls ? _fbb.CreateVector<flatbuffers::Offset<rpc::CallInfo>>(*calls) : 0;
-  return rpc::CreateProgInfo(
+  auto calls__ = calls ? _fbb.CreateVector<flatbuffers::Offset<rpc::CallInfoRaw>>(*calls) : 0;
+  return rpc::CreateProgInfoRaw(
       _fbb,
       calls__,
       extra,
@@ -1962,31 +2057,31 @@ inline flatbuffers::Offset<ProgInfo> CreateProgInfoDirect(
       freshness);
 }
 
-flatbuffers::Offset<ProgInfo> CreateProgInfo(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-struct ExecResultT : public flatbuffers::NativeTable {
-  typedef ExecResult TableType;
-  std::unique_ptr<rpc::ExecutingMessageT> executing{};
+struct ExecResultRawT : public flatbuffers::NativeTable {
+  typedef ExecResultRaw TableType;
+  std::unique_ptr<rpc::ExecutingMessageRawT> executing{};
   std::vector<uint8_t> output{};
   std::string error{};
-  std::unique_ptr<rpc::ProgInfoT> info{};
-  ExecResultT() = default;
-  ExecResultT(const ExecResultT &o);
-  ExecResultT(ExecResultT&&) FLATBUFFERS_NOEXCEPT = default;
-  ExecResultT &operator=(ExecResultT o) FLATBUFFERS_NOEXCEPT;
+  std::unique_ptr<rpc::ProgInfoRawT> info{};
+  ExecResultRawT() = default;
+  ExecResultRawT(const ExecResultRawT &o);
+  ExecResultRawT(ExecResultRawT&&) FLATBUFFERS_NOEXCEPT = default;
+  ExecResultRawT &operator=(ExecResultRawT o) FLATBUFFERS_NOEXCEPT;
 };
 
-struct ExecResult FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef ExecResultT NativeTableType;
-  typedef ExecResultBuilder Builder;
+struct ExecResultRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ExecResultRawT NativeTableType;
+  typedef ExecResultRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_EXECUTING = 4,
     VT_OUTPUT = 6,
     VT_ERROR = 8,
     VT_INFO = 10
   };
-  const rpc::ExecutingMessage *executing() const {
-    return GetPointer<const rpc::ExecutingMessage *>(VT_EXECUTING);
+  const rpc::ExecutingMessageRaw *executing() const {
+    return GetPointer<const rpc::ExecutingMessageRaw *>(VT_EXECUTING);
   }
   const flatbuffers::Vector<uint8_t> *output() const {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_OUTPUT);
@@ -1994,8 +2089,8 @@ struct ExecResult FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *error() const {
     return GetPointer<const flatbuffers::String *>(VT_ERROR);
   }
-  const rpc::ProgInfo *info() const {
-    return GetPointer<const rpc::ProgInfo *>(VT_INFO);
+  const rpc::ProgInfoRaw *info() const {
+    return GetPointer<const rpc::ProgInfoRaw *>(VT_INFO);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2009,45 +2104,45 @@ struct ExecResult FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyTable(info()) &&
            verifier.EndTable();
   }
-  ExecResultT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  void UnPackTo(ExecResultT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
-  static flatbuffers::Offset<ExecResult> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+  ExecResultRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ExecResultRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ExecResultRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 };
 
-struct ExecResultBuilder {
-  typedef ExecResult Table;
+struct ExecResultRawBuilder {
+  typedef ExecResultRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_executing(flatbuffers::Offset<rpc::ExecutingMessage> executing) {
-    fbb_.AddOffset(ExecResult::VT_EXECUTING, executing);
+  void add_executing(flatbuffers::Offset<rpc::ExecutingMessageRaw> executing) {
+    fbb_.AddOffset(ExecResultRaw::VT_EXECUTING, executing);
   }
   void add_output(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> output) {
-    fbb_.AddOffset(ExecResult::VT_OUTPUT, output);
+    fbb_.AddOffset(ExecResultRaw::VT_OUTPUT, output);
   }
   void add_error(flatbuffers::Offset<flatbuffers::String> error) {
-    fbb_.AddOffset(ExecResult::VT_ERROR, error);
+    fbb_.AddOffset(ExecResultRaw::VT_ERROR, error);
   }
-  void add_info(flatbuffers::Offset<rpc::ProgInfo> info) {
-    fbb_.AddOffset(ExecResult::VT_INFO, info);
+  void add_info(flatbuffers::Offset<rpc::ProgInfoRaw> info) {
+    fbb_.AddOffset(ExecResultRaw::VT_INFO, info);
   }
-  explicit ExecResultBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit ExecResultRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<ExecResult> Finish() {
+  flatbuffers::Offset<ExecResultRaw> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<ExecResult>(end);
+    auto o = flatbuffers::Offset<ExecResultRaw>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<ExecResult> CreateExecResult(
+inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<rpc::ExecutingMessage> executing = 0,
+    flatbuffers::Offset<rpc::ExecutingMessageRaw> executing = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> output = 0,
     flatbuffers::Offset<flatbuffers::String> error = 0,
-    flatbuffers::Offset<rpc::ProgInfo> info = 0) {
-  ExecResultBuilder builder_(_fbb);
+    flatbuffers::Offset<rpc::ProgInfoRaw> info = 0) {
+  ExecResultRawBuilder builder_(_fbb);
   builder_.add_info(info);
   builder_.add_error(error);
   builder_.add_output(output);
@@ -2055,15 +2150,15 @@ inline flatbuffers::Offset<ExecResult> CreateExecResult(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<ExecResult> CreateExecResultDirect(
+inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<rpc::ExecutingMessage> executing = 0,
+    flatbuffers::Offset<rpc::ExecutingMessageRaw> executing = 0,
     const std::vector<uint8_t> *output = nullptr,
     const char *error = nullptr,
-    flatbuffers::Offset<rpc::ProgInfo> info = 0) {
+    flatbuffers::Offset<rpc::ProgInfoRaw> info = 0) {
   auto output__ = output ? _fbb.CreateVector<uint8_t>(*output) : 0;
   auto error__ = error ? _fbb.CreateString(error) : 0;
-  return rpc::CreateExecResult(
+  return rpc::CreateExecResultRaw(
       _fbb,
       executing,
       output__,
@@ -2071,15 +2166,15 @@ inline flatbuffers::Offset<ExecResult> CreateExecResultDirect(
       info);
 }
 
-flatbuffers::Offset<ExecResult> CreateExecResult(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
-inline ConnectRequestT *ConnectRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ConnectRequestT>(new ConnectRequestT());
+inline ConnectRequestRawT *ConnectRequestRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ConnectRequestRawT>(new ConnectRequestRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ConnectRequest::UnPackTo(ConnectRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ConnectRequestRaw::UnPackTo(ConnectRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = _e->str(); }
@@ -2088,19 +2183,19 @@ inline void ConnectRequest::UnPackTo(ConnectRequestT *_o, const flatbuffers::res
   { auto _e = syz_revision(); if (_e) _o->syz_revision = _e->str(); }
 }
 
-inline flatbuffers::Offset<ConnectRequest> ConnectRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateConnectRequest(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ConnectRequestRaw> ConnectRequestRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateConnectRequestRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ConnectRequest> CreateConnectRequest(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectRequestT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
   auto _arch = _o->arch.empty() ? 0 : _fbb.CreateString(_o->arch);
   auto _git_revision = _o->git_revision.empty() ? 0 : _fbb.CreateString(_o->git_revision);
   auto _syz_revision = _o->syz_revision.empty() ? 0 : _fbb.CreateString(_o->syz_revision);
-  return rpc::CreateConnectRequest(
+  return rpc::CreateConnectRequestRaw(
       _fbb,
       _name,
       _arch,
@@ -2108,13 +2203,13 @@ inline flatbuffers::Offset<ConnectRequest> CreateConnectRequest(flatbuffers::Fla
       _syz_revision);
 }
 
-inline ConnectReplyT *ConnectReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ConnectReplyT>(new ConnectReplyT());
+inline ConnectReplyRawT *ConnectReplyRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ConnectReplyRawT>(new ConnectReplyRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ConnectReply::UnPackTo(ConnectReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ConnectReplyRaw::UnPackTo(ConnectReplyRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = leak_frames(); if (_e) { _o->leak_frames.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->leak_frames[_i] = _e->Get(_i)->str(); } } }
@@ -2124,20 +2219,20 @@ inline void ConnectReply::UnPackTo(ConnectReplyT *_o, const flatbuffers::resolve
   { auto _e = globs(); if (_e) { _o->globs.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->globs[_i] = _e->Get(_i)->str(); } } }
 }
 
-inline flatbuffers::Offset<ConnectReply> ConnectReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateConnectReply(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ConnectReplyRaw> ConnectReplyRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateConnectReplyRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ConnectReply> CreateConnectReply(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectReplyT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectReplyRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _leak_frames = _o->leak_frames.size() ? _fbb.CreateVectorOfStrings(_o->leak_frames) : 0;
   auto _race_frames = _o->race_frames.size() ? _fbb.CreateVectorOfStrings(_o->race_frames) : 0;
   auto _features = _o->features;
   auto _files = _o->files.size() ? _fbb.CreateVectorOfStrings(_o->files) : 0;
   auto _globs = _o->globs.size() ? _fbb.CreateVectorOfStrings(_o->globs) : 0;
-  return rpc::CreateConnectReply(
+  return rpc::CreateConnectReplyRaw(
       _fbb,
       _leak_frames,
       _race_frames,
@@ -2146,91 +2241,92 @@ inline flatbuffers::Offset<ConnectReply> CreateConnectReply(flatbuffers::FlatBuf
       _globs);
 }
 
-inline InfoRequestT::InfoRequestT(const InfoRequestT &o)
-      : error(o.error),
-        features(o.features) {
-  globs.reserve(o.globs.size());
-  for (const auto &globs_ : o.globs) { globs.emplace_back((globs_) ? new rpc::GlobInfoT(*globs_) : nullptr); }
+inline InfoRequestRawT::InfoRequestRawT(const InfoRequestRawT &o)
+      : error(o.error) {
+  features.reserve(o.features.size());
+  for (const auto &features_ : o.features) { features.emplace_back((features_) ? new rpc::FeatureInfoRawT(*features_) : nullptr); }
   files.reserve(o.files.size());
-  for (const auto &files_ : o.files) { files.emplace_back((files_) ? new rpc::FileInfoT(*files_) : nullptr); }
+  for (const auto &files_ : o.files) { files.emplace_back((files_) ? new rpc::FileInfoRawT(*files_) : nullptr); }
+  globs.reserve(o.globs.size());
+  for (const auto &globs_ : o.globs) { globs.emplace_back((globs_) ? new rpc::GlobInfoRawT(*globs_) : nullptr); }
 }
 
-inline InfoRequestT &InfoRequestT::operator=(InfoRequestT o) FLATBUFFERS_NOEXCEPT {
+inline InfoRequestRawT &InfoRequestRawT::operator=(InfoRequestRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(error, o.error);
   std::swap(features, o.features);
-  std::swap(globs, o.globs);
   std::swap(files, o.files);
+  std::swap(globs, o.globs);
   return *this;
 }
 
-inline InfoRequestT *InfoRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<InfoRequestT>(new InfoRequestT());
+inline InfoRequestRawT *InfoRequestRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<InfoRequestRawT>(new InfoRequestRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void InfoRequest::UnPackTo(InfoRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void InfoRequestRaw::UnPackTo(InfoRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = error(); if (_e) _o->error = _e->str(); }
-  { auto _e = features(); _o->features = _e; }
-  { auto _e = globs(); if (_e) { _o->globs.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->globs[_i] = std::unique_ptr<rpc::GlobInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
-  { auto _e = files(); if (_e) { _o->files.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->files[_i] = std::unique_ptr<rpc::FileInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
+  { auto _e = features(); if (_e) { _o->features.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->features[_i] = std::unique_ptr<rpc::FeatureInfoRawT>(_e->Get(_i)->UnPack(_resolver)); } } }
+  { auto _e = files(); if (_e) { _o->files.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->files[_i] = std::unique_ptr<rpc::FileInfoRawT>(_e->Get(_i)->UnPack(_resolver)); } } }
+  { auto _e = globs(); if (_e) { _o->globs.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->globs[_i] = std::unique_ptr<rpc::GlobInfoRawT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
-inline flatbuffers::Offset<InfoRequest> InfoRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateInfoRequest(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<InfoRequestRaw> InfoRequestRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateInfoRequestRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<InfoRequest> CreateInfoRequest(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const InfoRequestT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const InfoRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
-  auto _features = _o->features;
-  auto _globs = _o->globs.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::GlobInfo>> (_o->globs.size(), [](size_t i, _VectorArgs *__va) { return CreateGlobInfo(*__va->__fbb, __va->__o->globs[i].get(), __va->__rehasher); }, &_va ) : 0;
-  auto _files = _o->files.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::FileInfo>> (_o->files.size(), [](size_t i, _VectorArgs *__va) { return CreateFileInfo(*__va->__fbb, __va->__o->files[i].get(), __va->__rehasher); }, &_va ) : 0;
-  return rpc::CreateInfoRequest(
+  auto _features = _o->features.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::FeatureInfoRaw>> (_o->features.size(), [](size_t i, _VectorArgs *__va) { return CreateFeatureInfoRaw(*__va->__fbb, __va->__o->features[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _files = _o->files.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::FileInfoRaw>> (_o->files.size(), [](size_t i, _VectorArgs *__va) { return CreateFileInfoRaw(*__va->__fbb, __va->__o->files[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _globs = _o->globs.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::GlobInfoRaw>> (_o->globs.size(), [](size_t i, _VectorArgs *__va) { return CreateGlobInfoRaw(*__va->__fbb, __va->__o->globs[i].get(), __va->__rehasher); }, &_va ) : 0;
+  return rpc::CreateInfoRequestRaw(
       _fbb,
       _error,
       _features,
-      _globs,
-      _files);
+      _files,
+      _globs);
 }
 
-inline InfoReplyT *InfoReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<InfoReplyT>(new InfoReplyT());
+inline InfoReplyRawT *InfoReplyRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<InfoReplyRawT>(new InfoReplyRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void InfoReply::UnPackTo(InfoReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void InfoReplyRaw::UnPackTo(InfoReplyRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = cover_filter(); if (_e) { _o->cover_filter.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->cover_filter[_i] = _e->Get(_i); } } }
 }
 
-inline flatbuffers::Offset<InfoReply> InfoReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateInfoReply(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<InfoReplyRaw> InfoReplyRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateInfoReplyRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<InfoReply> CreateInfoReply(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRaw(flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const InfoReplyT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const InfoReplyRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _cover_filter = _o->cover_filter.size() ? _fbb.CreateVector(_o->cover_filter) : 0;
-  return rpc::CreateInfoReply(
+  return rpc::CreateInfoReplyRaw(
       _fbb,
       _cover_filter);
 }
 
-inline FileInfoT *FileInfo::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<FileInfoT>(new FileInfoT());
+inline FileInfoRawT *FileInfoRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<FileInfoRawT>(new FileInfoRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void FileInfo::UnPackTo(FileInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void FileInfoRaw::UnPackTo(FileInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = _e->str(); }
@@ -2239,19 +2335,19 @@ inline void FileInfo::UnPackTo(FileInfoT *_o, const flatbuffers::resolver_functi
   { auto _e = data(); if (_e) { _o->data.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->data.begin()); } }
 }
 
-inline flatbuffers::Offset<FileInfo> FileInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateFileInfo(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<FileInfoRaw> FileInfoRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateFileInfoRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<FileInfo> CreateFileInfo(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<FileInfoRaw> CreateFileInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const FileInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const FileInfoT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const FileInfoRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
   auto _exists = _o->exists;
   auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
   auto _data = _o->data.size() ? _fbb.CreateVector(_o->data) : 0;
-  return rpc::CreateFileInfo(
+  return rpc::CreateFileInfoRaw(
       _fbb,
       _name,
       _exists,
@@ -2259,100 +2355,132 @@ inline flatbuffers::Offset<FileInfo> CreateFileInfo(flatbuffers::FlatBufferBuild
       _data);
 }
 
-inline GlobInfoT *GlobInfo::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<GlobInfoT>(new GlobInfoT());
+inline GlobInfoRawT *GlobInfoRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<GlobInfoRawT>(new GlobInfoRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void GlobInfo::UnPackTo(GlobInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void GlobInfoRaw::UnPackTo(GlobInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = name(); if (_e) _o->name = _e->str(); }
   { auto _e = files(); if (_e) { _o->files.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->files[_i] = _e->Get(_i)->str(); } } }
 }
 
-inline flatbuffers::Offset<GlobInfo> GlobInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateGlobInfo(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<GlobInfoRaw> GlobInfoRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateGlobInfoRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<GlobInfo> CreateGlobInfo(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<GlobInfoRaw> CreateGlobInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const GlobInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const GlobInfoT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const GlobInfoRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
   auto _files = _o->files.size() ? _fbb.CreateVectorOfStrings(_o->files) : 0;
-  return rpc::CreateGlobInfo(
+  return rpc::CreateGlobInfoRaw(
       _fbb,
       _name,
       _files);
 }
 
-inline HostMessageT *HostMessage::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<HostMessageT>(new HostMessageT());
+inline FeatureInfoRawT *FeatureInfoRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<FeatureInfoRawT>(new FeatureInfoRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void HostMessage::UnPackTo(HostMessageT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void FeatureInfoRaw::UnPackTo(FeatureInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = id(); _o->id = _e; }
+  { auto _e = need_setup(); _o->need_setup = _e; }
+  { auto _e = reason(); if (_e) _o->reason = _e->str(); }
+}
+
+inline flatbuffers::Offset<FeatureInfoRaw> FeatureInfoRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const FeatureInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateFeatureInfoRaw(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<FeatureInfoRaw> CreateFeatureInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const FeatureInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const FeatureInfoRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _id = _o->id;
+  auto _need_setup = _o->need_setup;
+  auto _reason = _o->reason.empty() ? 0 : _fbb.CreateString(_o->reason);
+  return rpc::CreateFeatureInfoRaw(
+      _fbb,
+      _id,
+      _need_setup,
+      _reason);
+}
+
+inline HostMessageRawT *HostMessageRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<HostMessageRawT>(new HostMessageRawT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void HostMessageRaw::UnPackTo(HostMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = msg_type(); _o->msg.type = _e; }
-  { auto _e = msg(); if (_e) _o->msg.value = rpc::HostMessagesUnion::UnPack(_e, msg_type(), _resolver); }
+  { auto _e = msg(); if (_e) _o->msg.value = rpc::HostMessagesRawUnion::UnPack(_e, msg_type(), _resolver); }
 }
 
-inline flatbuffers::Offset<HostMessage> HostMessage::Pack(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateHostMessage(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<HostMessageRaw> HostMessageRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateHostMessageRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<HostMessage> CreateHostMessage(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<HostMessageRaw> CreateHostMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const HostMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const HostMessageT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const HostMessageRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _msg_type = _o->msg.type;
   auto _msg = _o->msg.Pack(_fbb);
-  return rpc::CreateHostMessage(
+  return rpc::CreateHostMessageRaw(
       _fbb,
       _msg_type,
       _msg);
 }
 
-inline ExecutorMessageT *ExecutorMessage::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ExecutorMessageT>(new ExecutorMessageT());
+inline ExecutorMessageRawT *ExecutorMessageRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ExecutorMessageRawT>(new ExecutorMessageRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ExecutorMessage::UnPackTo(ExecutorMessageT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ExecutorMessageRaw::UnPackTo(ExecutorMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = msg_type(); _o->msg.type = _e; }
-  { auto _e = msg(); if (_e) _o->msg.value = rpc::ExecutorMessagesUnion::UnPack(_e, msg_type(), _resolver); }
+  { auto _e = msg(); if (_e) _o->msg.value = rpc::ExecutorMessagesRawUnion::UnPack(_e, msg_type(), _resolver); }
 }
 
-inline flatbuffers::Offset<ExecutorMessage> ExecutorMessage::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateExecutorMessage(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ExecutorMessageRaw> ExecutorMessageRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateExecutorMessageRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ExecutorMessage> CreateExecutorMessage(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ExecutorMessageRaw> CreateExecutorMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecutorMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecutorMessageT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecutorMessageRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _msg_type = _o->msg.type;
   auto _msg = _o->msg.Pack(_fbb);
-  return rpc::CreateExecutorMessage(
+  return rpc::CreateExecutorMessageRaw(
       _fbb,
       _msg_type,
       _msg);
 }
 
-inline ExecRequestT *ExecRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ExecRequestT>(new ExecRequestT());
+inline ExecRequestRawT *ExecRequestRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ExecRequestRawT>(new ExecRequestRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ExecRequest::UnPackTo(ExecRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ExecRequestRaw::UnPackTo(ExecRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = id(); _o->id = _e; }
@@ -2366,14 +2494,14 @@ inline void ExecRequest::UnPackTo(ExecRequestT *_o, const flatbuffers::resolver_
   { auto _e = repeat(); _o->repeat = _e; }
 }
 
-inline flatbuffers::Offset<ExecRequest> ExecRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateExecRequest(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ExecRequestRaw> ExecRequestRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateExecRequestRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ExecRequest> CreateExecRequest(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecRequestRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecRequestT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _id = _o->id;
   auto _prog_data = _o->prog_data.size() ? _fbb.CreateVector(_o->prog_data) : 0;
   auto _flags = _o->flags;
@@ -2383,7 +2511,7 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequest(flatbuffers::FlatBuffe
   auto _signal_filter = _o->signal_filter.size() ? _fbb.CreateVector(_o->signal_filter) : 0;
   auto _signal_filter_call = _o->signal_filter_call;
   auto _repeat = _o->repeat;
-  return rpc::CreateExecRequest(
+  return rpc::CreateExecRequestRaw(
       _fbb,
       _id,
       _prog_data,
@@ -2396,42 +2524,42 @@ inline flatbuffers::Offset<ExecRequest> CreateExecRequest(flatbuffers::FlatBuffe
       _repeat);
 }
 
-inline SignalUpdateT *SignalUpdate::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<SignalUpdateT>(new SignalUpdateT());
+inline SignalUpdateRawT *SignalUpdateRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<SignalUpdateRawT>(new SignalUpdateRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void SignalUpdate::UnPackTo(SignalUpdateT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void SignalUpdateRaw::UnPackTo(SignalUpdateRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = new_max(); if (_e) { _o->new_max.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->new_max[_i] = _e->Get(_i); } } }
   { auto _e = drop_max(); if (_e) { _o->drop_max.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->drop_max[_i] = _e->Get(_i); } } }
 }
 
-inline flatbuffers::Offset<SignalUpdate> SignalUpdate::Pack(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateSignalUpdate(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<SignalUpdateRaw> SignalUpdateRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateSignalUpdateRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<SignalUpdate> CreateSignalUpdate(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const SignalUpdateT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const SignalUpdateRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _new_max = _o->new_max.size() ? _fbb.CreateVector(_o->new_max) : 0;
   auto _drop_max = _o->drop_max.size() ? _fbb.CreateVector(_o->drop_max) : 0;
-  return rpc::CreateSignalUpdate(
+  return rpc::CreateSignalUpdateRaw(
       _fbb,
       _new_max,
       _drop_max);
 }
 
-inline ExecutingMessageT *ExecutingMessage::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ExecutingMessageT>(new ExecutingMessageT());
+inline ExecutingMessageRawT *ExecutingMessageRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ExecutingMessageRawT>(new ExecutingMessageRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ExecutingMessage::UnPackTo(ExecutingMessageT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ExecutingMessageRaw::UnPackTo(ExecutingMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = id(); _o->id = _e; }
@@ -2439,60 +2567,60 @@ inline void ExecutingMessage::UnPackTo(ExecutingMessageT *_o, const flatbuffers:
   { auto _e = try_(); _o->try_ = _e; }
 }
 
-inline flatbuffers::Offset<ExecutingMessage> ExecutingMessage::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateExecutingMessage(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ExecutingMessageRaw> ExecutingMessageRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateExecutingMessageRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ExecutingMessage> CreateExecutingMessage(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ExecutingMessageRaw> CreateExecutingMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecutingMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecutingMessageT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecutingMessageRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _id = _o->id;
   auto _proc_id = _o->proc_id;
   auto _try_ = _o->try_;
-  return rpc::CreateExecutingMessage(
+  return rpc::CreateExecutingMessageRaw(
       _fbb,
       _id,
       _proc_id,
       _try_);
 }
 
-inline StatsMessageT *StatsMessage::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<StatsMessageT>(new StatsMessageT());
+inline StatsMessageRawT *StatsMessageRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<StatsMessageRawT>(new StatsMessageRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void StatsMessage::UnPackTo(StatsMessageT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void StatsMessageRaw::UnPackTo(StatsMessageRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = noexec_count(); _o->noexec_count = _e; }
   { auto _e = noexec_duration(); _o->noexec_duration = _e; }
 }
 
-inline flatbuffers::Offset<StatsMessage> StatsMessage::Pack(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateStatsMessage(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<StatsMessageRaw> StatsMessageRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateStatsMessageRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<StatsMessage> CreateStatsMessage(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<StatsMessageRaw> CreateStatsMessageRaw(flatbuffers::FlatBufferBuilder &_fbb, const StatsMessageRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const StatsMessageT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const StatsMessageRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _noexec_count = _o->noexec_count;
   auto _noexec_duration = _o->noexec_duration;
-  return rpc::CreateStatsMessage(
+  return rpc::CreateStatsMessageRaw(
       _fbb,
       _noexec_count,
       _noexec_duration);
 }
 
-inline CallInfoT *CallInfo::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<CallInfoT>(new CallInfoT());
+inline CallInfoRawT *CallInfoRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<CallInfoRawT>(new CallInfoRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void CallInfo::UnPackTo(CallInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void CallInfoRaw::UnPackTo(CallInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
   { auto _e = flags(); _o->flags = _e; }
@@ -2502,20 +2630,20 @@ inline void CallInfo::UnPackTo(CallInfoT *_o, const flatbuffers::resolver_functi
   { auto _e = comps(); if (_e) { _o->comps.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->comps[_i] = *_e->Get(_i); } } }
 }
 
-inline flatbuffers::Offset<CallInfo> CallInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateCallInfo(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<CallInfoRaw> CallInfoRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateCallInfoRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<CallInfo> CreateCallInfo(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<CallInfoRaw> CreateCallInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const CallInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const CallInfoT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const CallInfoRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _flags = _o->flags;
   auto _error = _o->error;
   auto _signal = _o->signal.size() ? _fbb.CreateVector(_o->signal) : 0;
   auto _cover = _o->cover.size() ? _fbb.CreateVector(_o->cover) : 0;
   auto _comps = _o->comps.size() ? _fbb.CreateVectorOfStructs(_o->comps) : 0;
-  return rpc::CreateCallInfo(
+  return rpc::CreateCallInfoRaw(
       _fbb,
       _flags,
       _error,
@@ -2524,15 +2652,15 @@ inline flatbuffers::Offset<CallInfo> CreateCallInfo(flatbuffers::FlatBufferBuild
       _comps);
 }
 
-inline ProgInfoT::ProgInfoT(const ProgInfoT &o)
-      : extra((o.extra) ? new rpc::CallInfoT(*o.extra) : nullptr),
+inline ProgInfoRawT::ProgInfoRawT(const ProgInfoRawT &o)
+      : extra((o.extra) ? new rpc::CallInfoRawT(*o.extra) : nullptr),
         elapsed(o.elapsed),
         freshness(o.freshness) {
   calls.reserve(o.calls.size());
-  for (const auto &calls_ : o.calls) { calls.emplace_back((calls_) ? new rpc::CallInfoT(*calls_) : nullptr); }
+  for (const auto &calls_ : o.calls) { calls.emplace_back((calls_) ? new rpc::CallInfoRawT(*calls_) : nullptr); }
 }
 
-inline ProgInfoT &ProgInfoT::operator=(ProgInfoT o) FLATBUFFERS_NOEXCEPT {
+inline ProgInfoRawT &ProgInfoRawT::operator=(ProgInfoRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(calls, o.calls);
   std::swap(extra, o.extra);
   std::swap(elapsed, o.elapsed);
@@ -2540,34 +2668,34 @@ inline ProgInfoT &ProgInfoT::operator=(ProgInfoT o) FLATBUFFERS_NOEXCEPT {
   return *this;
 }
 
-inline ProgInfoT *ProgInfo::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ProgInfoT>(new ProgInfoT());
+inline ProgInfoRawT *ProgInfoRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ProgInfoRawT>(new ProgInfoRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ProgInfo::UnPackTo(ProgInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ProgInfoRaw::UnPackTo(ProgInfoRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = calls(); if (_e) { _o->calls.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->calls[_i] = std::unique_ptr<rpc::CallInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
-  { auto _e = extra(); if (_e) _o->extra = std::unique_ptr<rpc::CallInfoT>(_e->UnPack(_resolver)); }
+  { auto _e = calls(); if (_e) { _o->calls.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->calls[_i] = std::unique_ptr<rpc::CallInfoRawT>(_e->Get(_i)->UnPack(_resolver)); } } }
+  { auto _e = extra(); if (_e) _o->extra = std::unique_ptr<rpc::CallInfoRawT>(_e->UnPack(_resolver)); }
   { auto _e = elapsed(); _o->elapsed = _e; }
   { auto _e = freshness(); _o->freshness = _e; }
 }
 
-inline flatbuffers::Offset<ProgInfo> ProgInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateProgInfo(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ProgInfoRaw> ProgInfoRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateProgInfoRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ProgInfo> CreateProgInfo(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRaw(flatbuffers::FlatBufferBuilder &_fbb, const ProgInfoRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ProgInfoT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _calls = _o->calls.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::CallInfo>> (_o->calls.size(), [](size_t i, _VectorArgs *__va) { return CreateCallInfo(*__va->__fbb, __va->__o->calls[i].get(), __va->__rehasher); }, &_va ) : 0;
-  auto _extra = _o->extra ? CreateCallInfo(_fbb, _o->extra.get(), _rehasher) : 0;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ProgInfoRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _calls = _o->calls.size() ? _fbb.CreateVector<flatbuffers::Offset<rpc::CallInfoRaw>> (_o->calls.size(), [](size_t i, _VectorArgs *__va) { return CreateCallInfoRaw(*__va->__fbb, __va->__o->calls[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _extra = _o->extra ? CreateCallInfoRaw(_fbb, _o->extra.get(), _rehasher) : 0;
   auto _elapsed = _o->elapsed;
   auto _freshness = _o->freshness;
-  return rpc::CreateProgInfo(
+  return rpc::CreateProgInfoRaw(
       _fbb,
       _calls,
       _extra,
@@ -2575,14 +2703,14 @@ inline flatbuffers::Offset<ProgInfo> CreateProgInfo(flatbuffers::FlatBufferBuild
       _freshness);
 }
 
-inline ExecResultT::ExecResultT(const ExecResultT &o)
-      : executing((o.executing) ? new rpc::ExecutingMessageT(*o.executing) : nullptr),
+inline ExecResultRawT::ExecResultRawT(const ExecResultRawT &o)
+      : executing((o.executing) ? new rpc::ExecutingMessageRawT(*o.executing) : nullptr),
         output(o.output),
         error(o.error),
-        info((o.info) ? new rpc::ProgInfoT(*o.info) : nullptr) {
+        info((o.info) ? new rpc::ProgInfoRawT(*o.info) : nullptr) {
 }
 
-inline ExecResultT &ExecResultT::operator=(ExecResultT o) FLATBUFFERS_NOEXCEPT {
+inline ExecResultRawT &ExecResultRawT::operator=(ExecResultRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(executing, o.executing);
   std::swap(output, o.output);
   std::swap(error, o.error);
@@ -2590,34 +2718,34 @@ inline ExecResultT &ExecResultT::operator=(ExecResultT o) FLATBUFFERS_NOEXCEPT {
   return *this;
 }
 
-inline ExecResultT *ExecResult::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = std::unique_ptr<ExecResultT>(new ExecResultT());
+inline ExecResultRawT *ExecResultRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ExecResultRawT>(new ExecResultRawT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
 
-inline void ExecResult::UnPackTo(ExecResultT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+inline void ExecResultRaw::UnPackTo(ExecResultRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = executing(); if (_e) _o->executing = std::unique_ptr<rpc::ExecutingMessageT>(_e->UnPack(_resolver)); }
+  { auto _e = executing(); if (_e) _o->executing = std::unique_ptr<rpc::ExecutingMessageRawT>(_e->UnPack(_resolver)); }
   { auto _e = output(); if (_e) { _o->output.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->output.begin()); } }
   { auto _e = error(); if (_e) _o->error = _e->str(); }
-  { auto _e = info(); if (_e) _o->info = std::unique_ptr<rpc::ProgInfoT>(_e->UnPack(_resolver)); }
+  { auto _e = info(); if (_e) _o->info = std::unique_ptr<rpc::ProgInfoRawT>(_e->UnPack(_resolver)); }
 }
 
-inline flatbuffers::Offset<ExecResult> ExecResult::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
-  return CreateExecResult(_fbb, _o, _rehasher);
+inline flatbuffers::Offset<ExecResultRaw> ExecResultRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateExecResultRaw(_fbb, _o, _rehasher);
 }
 
-inline flatbuffers::Offset<ExecResult> CreateExecResult(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(flatbuffers::FlatBufferBuilder &_fbb, const ExecResultRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
   (void)_rehasher;
   (void)_o;
-  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecResultT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _executing = _o->executing ? CreateExecutingMessage(_fbb, _o->executing.get(), _rehasher) : 0;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecResultRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _executing = _o->executing ? CreateExecutingMessageRaw(_fbb, _o->executing.get(), _rehasher) : 0;
   auto _output = _o->output.size() ? _fbb.CreateVector(_o->output) : 0;
   auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
-  auto _info = _o->info ? CreateProgInfo(_fbb, _o->info.get(), _rehasher) : 0;
-  return rpc::CreateExecResult(
+  auto _info = _o->info ? CreateProgInfoRaw(_fbb, _o->info.get(), _rehasher) : 0;
+  return rpc::CreateExecResultRaw(
       _fbb,
       _executing,
       _output,
@@ -2625,73 +2753,73 @@ inline flatbuffers::Offset<ExecResult> CreateExecResult(flatbuffers::FlatBufferB
       _info);
 }
 
-inline bool VerifyHostMessages(flatbuffers::Verifier &verifier, const void *obj, HostMessages type) {
+inline bool VerifyHostMessagesRaw(flatbuffers::Verifier &verifier, const void *obj, HostMessagesRaw type) {
   switch (type) {
-    case HostMessages::NONE: {
+    case HostMessagesRaw::NONE: {
       return true;
     }
-    case HostMessages::ExecRequest: {
-      auto ptr = reinterpret_cast<const rpc::ExecRequest *>(obj);
+    case HostMessagesRaw::ExecRequest: {
+      auto ptr = reinterpret_cast<const rpc::ExecRequestRaw *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case HostMessages::SignalUpdate: {
-      auto ptr = reinterpret_cast<const rpc::SignalUpdate *>(obj);
+    case HostMessagesRaw::SignalUpdate: {
+      auto ptr = reinterpret_cast<const rpc::SignalUpdateRaw *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default: return true;
   }
 }
 
-inline bool VerifyHostMessagesVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<HostMessages> *types) {
+inline bool VerifyHostMessagesRawVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<HostMessagesRaw> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
-    if (!VerifyHostMessages(
-        verifier,  values->Get(i), types->GetEnum<HostMessages>(i))) {
+    if (!VerifyHostMessagesRaw(
+        verifier,  values->Get(i), types->GetEnum<HostMessagesRaw>(i))) {
       return false;
     }
   }
   return true;
 }
 
-inline void *HostMessagesUnion::UnPack(const void *obj, HostMessages type, const flatbuffers::resolver_function_t *resolver) {
+inline void *HostMessagesRawUnion::UnPack(const void *obj, HostMessagesRaw type, const flatbuffers::resolver_function_t *resolver) {
   (void)resolver;
   switch (type) {
-    case HostMessages::ExecRequest: {
-      auto ptr = reinterpret_cast<const rpc::ExecRequest *>(obj);
+    case HostMessagesRaw::ExecRequest: {
+      auto ptr = reinterpret_cast<const rpc::ExecRequestRaw *>(obj);
       return ptr->UnPack(resolver);
     }
-    case HostMessages::SignalUpdate: {
-      auto ptr = reinterpret_cast<const rpc::SignalUpdate *>(obj);
+    case HostMessagesRaw::SignalUpdate: {
+      auto ptr = reinterpret_cast<const rpc::SignalUpdateRaw *>(obj);
       return ptr->UnPack(resolver);
     }
     default: return nullptr;
   }
 }
 
-inline flatbuffers::Offset<void> HostMessagesUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher) const {
+inline flatbuffers::Offset<void> HostMessagesRawUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher) const {
   (void)_rehasher;
   switch (type) {
-    case HostMessages::ExecRequest: {
-      auto ptr = reinterpret_cast<const rpc::ExecRequestT *>(value);
-      return CreateExecRequest(_fbb, ptr, _rehasher).Union();
+    case HostMessagesRaw::ExecRequest: {
+      auto ptr = reinterpret_cast<const rpc::ExecRequestRawT *>(value);
+      return CreateExecRequestRaw(_fbb, ptr, _rehasher).Union();
     }
-    case HostMessages::SignalUpdate: {
-      auto ptr = reinterpret_cast<const rpc::SignalUpdateT *>(value);
-      return CreateSignalUpdate(_fbb, ptr, _rehasher).Union();
+    case HostMessagesRaw::SignalUpdate: {
+      auto ptr = reinterpret_cast<const rpc::SignalUpdateRawT *>(value);
+      return CreateSignalUpdateRaw(_fbb, ptr, _rehasher).Union();
     }
     default: return 0;
   }
 }
 
-inline HostMessagesUnion::HostMessagesUnion(const HostMessagesUnion &u) : type(u.type), value(nullptr) {
+inline HostMessagesRawUnion::HostMessagesRawUnion(const HostMessagesRawUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
-    case HostMessages::ExecRequest: {
-      value = new rpc::ExecRequestT(*reinterpret_cast<rpc::ExecRequestT *>(u.value));
+    case HostMessagesRaw::ExecRequest: {
+      value = new rpc::ExecRequestRawT(*reinterpret_cast<rpc::ExecRequestRawT *>(u.value));
       break;
     }
-    case HostMessages::SignalUpdate: {
-      value = new rpc::SignalUpdateT(*reinterpret_cast<rpc::SignalUpdateT *>(u.value));
+    case HostMessagesRaw::SignalUpdate: {
+      value = new rpc::SignalUpdateRawT(*reinterpret_cast<rpc::SignalUpdateRawT *>(u.value));
       break;
     }
     default:
@@ -2699,107 +2827,107 @@ inline HostMessagesUnion::HostMessagesUnion(const HostMessagesUnion &u) : type(u
   }
 }
 
-inline void HostMessagesUnion::Reset() {
+inline void HostMessagesRawUnion::Reset() {
   switch (type) {
-    case HostMessages::ExecRequest: {
-      auto ptr = reinterpret_cast<rpc::ExecRequestT *>(value);
+    case HostMessagesRaw::ExecRequest: {
+      auto ptr = reinterpret_cast<rpc::ExecRequestRawT *>(value);
       delete ptr;
       break;
     }
-    case HostMessages::SignalUpdate: {
-      auto ptr = reinterpret_cast<rpc::SignalUpdateT *>(value);
+    case HostMessagesRaw::SignalUpdate: {
+      auto ptr = reinterpret_cast<rpc::SignalUpdateRawT *>(value);
       delete ptr;
       break;
     }
     default: break;
   }
   value = nullptr;
-  type = HostMessages::NONE;
+  type = HostMessagesRaw::NONE;
 }
 
-inline bool VerifyExecutorMessages(flatbuffers::Verifier &verifier, const void *obj, ExecutorMessages type) {
+inline bool VerifyExecutorMessagesRaw(flatbuffers::Verifier &verifier, const void *obj, ExecutorMessagesRaw type) {
   switch (type) {
-    case ExecutorMessages::NONE: {
+    case ExecutorMessagesRaw::NONE: {
       return true;
     }
-    case ExecutorMessages::ExecResult: {
-      auto ptr = reinterpret_cast<const rpc::ExecResult *>(obj);
+    case ExecutorMessagesRaw::ExecResult: {
+      auto ptr = reinterpret_cast<const rpc::ExecResultRaw *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case ExecutorMessages::Executing: {
-      auto ptr = reinterpret_cast<const rpc::ExecutingMessage *>(obj);
+    case ExecutorMessagesRaw::Executing: {
+      auto ptr = reinterpret_cast<const rpc::ExecutingMessageRaw *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case ExecutorMessages::Stats: {
-      auto ptr = reinterpret_cast<const rpc::StatsMessage *>(obj);
+    case ExecutorMessagesRaw::Stats: {
+      auto ptr = reinterpret_cast<const rpc::StatsMessageRaw *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default: return true;
   }
 }
 
-inline bool VerifyExecutorMessagesVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<ExecutorMessages> *types) {
+inline bool VerifyExecutorMessagesRawVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<ExecutorMessagesRaw> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
-    if (!VerifyExecutorMessages(
-        verifier,  values->Get(i), types->GetEnum<ExecutorMessages>(i))) {
+    if (!VerifyExecutorMessagesRaw(
+        verifier,  values->Get(i), types->GetEnum<ExecutorMessagesRaw>(i))) {
       return false;
     }
   }
   return true;
 }
 
-inline void *ExecutorMessagesUnion::UnPack(const void *obj, ExecutorMessages type, const flatbuffers::resolver_function_t *resolver) {
+inline void *ExecutorMessagesRawUnion::UnPack(const void *obj, ExecutorMessagesRaw type, const flatbuffers::resolver_function_t *resolver) {
   (void)resolver;
   switch (type) {
-    case ExecutorMessages::ExecResult: {
-      auto ptr = reinterpret_cast<const rpc::ExecResult *>(obj);
+    case ExecutorMessagesRaw::ExecResult: {
+      auto ptr = reinterpret_cast<const rpc::ExecResultRaw *>(obj);
       return ptr->UnPack(resolver);
     }
-    case ExecutorMessages::Executing: {
-      auto ptr = reinterpret_cast<const rpc::ExecutingMessage *>(obj);
+    case ExecutorMessagesRaw::Executing: {
+      auto ptr = reinterpret_cast<const rpc::ExecutingMessageRaw *>(obj);
       return ptr->UnPack(resolver);
     }
-    case ExecutorMessages::Stats: {
-      auto ptr = reinterpret_cast<const rpc::StatsMessage *>(obj);
+    case ExecutorMessagesRaw::Stats: {
+      auto ptr = reinterpret_cast<const rpc::StatsMessageRaw *>(obj);
       return ptr->UnPack(resolver);
     }
     default: return nullptr;
   }
 }
 
-inline flatbuffers::Offset<void> ExecutorMessagesUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher) const {
+inline flatbuffers::Offset<void> ExecutorMessagesRawUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb, const flatbuffers::rehasher_function_t *_rehasher) const {
   (void)_rehasher;
   switch (type) {
-    case ExecutorMessages::ExecResult: {
-      auto ptr = reinterpret_cast<const rpc::ExecResultT *>(value);
-      return CreateExecResult(_fbb, ptr, _rehasher).Union();
+    case ExecutorMessagesRaw::ExecResult: {
+      auto ptr = reinterpret_cast<const rpc::ExecResultRawT *>(value);
+      return CreateExecResultRaw(_fbb, ptr, _rehasher).Union();
     }
-    case ExecutorMessages::Executing: {
-      auto ptr = reinterpret_cast<const rpc::ExecutingMessageT *>(value);
-      return CreateExecutingMessage(_fbb, ptr, _rehasher).Union();
+    case ExecutorMessagesRaw::Executing: {
+      auto ptr = reinterpret_cast<const rpc::ExecutingMessageRawT *>(value);
+      return CreateExecutingMessageRaw(_fbb, ptr, _rehasher).Union();
     }
-    case ExecutorMessages::Stats: {
-      auto ptr = reinterpret_cast<const rpc::StatsMessageT *>(value);
-      return CreateStatsMessage(_fbb, ptr, _rehasher).Union();
+    case ExecutorMessagesRaw::Stats: {
+      auto ptr = reinterpret_cast<const rpc::StatsMessageRawT *>(value);
+      return CreateStatsMessageRaw(_fbb, ptr, _rehasher).Union();
     }
     default: return 0;
   }
 }
 
-inline ExecutorMessagesUnion::ExecutorMessagesUnion(const ExecutorMessagesUnion &u) : type(u.type), value(nullptr) {
+inline ExecutorMessagesRawUnion::ExecutorMessagesRawUnion(const ExecutorMessagesRawUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
-    case ExecutorMessages::ExecResult: {
-      value = new rpc::ExecResultT(*reinterpret_cast<rpc::ExecResultT *>(u.value));
+    case ExecutorMessagesRaw::ExecResult: {
+      value = new rpc::ExecResultRawT(*reinterpret_cast<rpc::ExecResultRawT *>(u.value));
       break;
     }
-    case ExecutorMessages::Executing: {
-      value = new rpc::ExecutingMessageT(*reinterpret_cast<rpc::ExecutingMessageT *>(u.value));
+    case ExecutorMessagesRaw::Executing: {
+      value = new rpc::ExecutingMessageRawT(*reinterpret_cast<rpc::ExecutingMessageRawT *>(u.value));
       break;
     }
-    case ExecutorMessages::Stats: {
-      value = new rpc::StatsMessageT(*reinterpret_cast<rpc::StatsMessageT *>(u.value));
+    case ExecutorMessagesRaw::Stats: {
+      value = new rpc::StatsMessageRawT(*reinterpret_cast<rpc::StatsMessageRawT *>(u.value));
       break;
     }
     default:
@@ -2807,27 +2935,27 @@ inline ExecutorMessagesUnion::ExecutorMessagesUnion(const ExecutorMessagesUnion 
   }
 }
 
-inline void ExecutorMessagesUnion::Reset() {
+inline void ExecutorMessagesRawUnion::Reset() {
   switch (type) {
-    case ExecutorMessages::ExecResult: {
-      auto ptr = reinterpret_cast<rpc::ExecResultT *>(value);
+    case ExecutorMessagesRaw::ExecResult: {
+      auto ptr = reinterpret_cast<rpc::ExecResultRawT *>(value);
       delete ptr;
       break;
     }
-    case ExecutorMessages::Executing: {
-      auto ptr = reinterpret_cast<rpc::ExecutingMessageT *>(value);
+    case ExecutorMessagesRaw::Executing: {
+      auto ptr = reinterpret_cast<rpc::ExecutingMessageRawT *>(value);
       delete ptr;
       break;
     }
-    case ExecutorMessages::Stats: {
-      auto ptr = reinterpret_cast<rpc::StatsMessageT *>(value);
+    case ExecutorMessagesRaw::Stats: {
+      auto ptr = reinterpret_cast<rpc::StatsMessageRawT *>(value);
       delete ptr;
       break;
     }
     default: break;
   }
   value = nullptr;
-  type = ExecutorMessages::NONE;
+  type = ExecutorMessagesRaw::NONE;
 }
 
 }  // namespace rpc

--- a/pkg/flatrpc/helpers.go
+++ b/pkg/flatrpc/helpers.go
@@ -1,0 +1,29 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package flatrpc
+
+const AllFeatures = ^Feature(0)
+
+// Flatbuffers compiler adds T suffix to object API types, which are actual structs representing types.
+// This leads to non-idiomatic Go code, e.g. we would have to use []FileInfoT in Go code.
+// So we use Raw suffix for all flatbuffers tables and rename object API types here to idiomatic names.
+type ConnectRequest = ConnectRequestRawT
+type ConnectReply = ConnectReplyRawT
+type InfoRequest = InfoRequestRawT
+type InfoReply = InfoReplyRawT
+type FileInfo = FileInfoRawT
+type GlobInfo = GlobInfoRawT
+type FeatureInfo = FeatureInfoRawT
+type HostMessages = HostMessagesRawT
+type HostMessage = HostMessageRawT
+type ExecutorMessages = ExecutorMessagesRawT
+type ExecutorMessage = ExecutorMessageRawT
+type ExecRequest = ExecRequestRawT
+type SignalUpdate = SignalUpdateRawT
+type ExecutingMessage = ExecutingMessageRawT
+type StatsMessage = StatsMessageRawT
+type CallInfo = CallInfoRawT
+type Comparison = ComparisonRawT
+type ProgInfo = ProgInfoRawT
+type ExecResult = ExecResultRawT

--- a/pkg/host/machine_info.go
+++ b/pkg/host/machine_info.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/syzkaller/pkg/flatrpc"
 )
 
-func ReadFiles(files []string) []flatrpc.FileInfoT {
-	var res []flatrpc.FileInfoT
+func ReadFiles(files []string) []flatrpc.FileInfo {
+	var res []flatrpc.FileInfo
 	for _, glob := range files {
 		glob = filepath.FromSlash(glob)
 		if !strings.Contains(glob, "*") {
@@ -21,7 +21,7 @@ func ReadFiles(files []string) []flatrpc.FileInfoT {
 		}
 		matches, err := filepath.Glob(glob)
 		if err != nil {
-			res = append(res, flatrpc.FileInfoT{
+			res = append(res, flatrpc.FileInfo{
 				Name:  glob,
 				Error: err.Error(),
 			})
@@ -34,13 +34,13 @@ func ReadFiles(files []string) []flatrpc.FileInfoT {
 	return res
 }
 
-func readFile(file string) flatrpc.FileInfoT {
+func readFile(file string) flatrpc.FileInfo {
 	data, err := os.ReadFile(file)
 	exists, errStr := true, ""
 	if err != nil {
 		exists, errStr = !os.IsNotExist(err), err.Error()
 	}
-	return flatrpc.FileInfoT{
+	return flatrpc.FileInfo{
 		Name:   file,
 		Exists: exists,
 		Error:  errStr,

--- a/pkg/rpctype/rpctype.go
+++ b/pkg/rpctype/rpctype.go
@@ -104,7 +104,7 @@ type CheckArgs struct {
 	Error    string
 	Features *host.Features
 	Globs    map[string][]string
-	Files    []flatrpc.FileInfoT
+	Files    []flatrpc.FileInfo
 }
 
 type CheckRes struct {

--- a/pkg/vminfo/linux_test.go
+++ b/pkg/vminfo/linux_test.go
@@ -35,7 +35,7 @@ func TestLinuxSyscalls(t *testing.T) {
 		"minix", "adfs", "ufs", "sysv", "reiserfs", "ocfs2", "nilfs2",
 		"iso9660", "hpfs", "binder", "bcachefs", "",
 	}
-	files := []flatrpc.FileInfoT{
+	files := []flatrpc.FileInfo{
 		{
 			Name:   "/proc/version",
 			Exists: true,
@@ -128,7 +128,7 @@ func TestCannedCPUInfoLinux(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			files := createVirtualFilesystem([]flatrpc.FileInfoT{{
+			files := createVirtualFilesystem([]flatrpc.FileInfo{{
 				Name:   "/proc/cpuinfo",
 				Exists: true,
 				Data:   []byte(test.data),

--- a/pkg/vminfo/syscalls.go
+++ b/pkg/vminfo/syscalls.go
@@ -148,7 +148,7 @@ func (ctx *checkContext) startCheck() []rpctype.ExecutionRequest {
 	return progs
 }
 
-func (ctx *checkContext) finishCheck(fileInfos []flatrpc.FileInfoT, progs []rpctype.ExecutionResult) (
+func (ctx *checkContext) finishCheck(fileInfos []flatrpc.FileInfo, progs []rpctype.ExecutionResult) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
 	ctx.fs = createVirtualFilesystem(fileInfos)
 	for i := range progs {

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -48,7 +48,7 @@ func New(cfg *mgrconfig.Config) *Checker {
 	}
 }
 
-func (checker *Checker) MachineInfo(fileInfos []flatrpc.FileInfoT) ([]cover.KernelModule, []byte, error) {
+func (checker *Checker) MachineInfo(fileInfos []flatrpc.FileInfo) ([]cover.KernelModule, []byte, error) {
 	files := createVirtualFilesystem(fileInfos)
 	modules, err := checker.parseModules(files)
 	if err != nil {
@@ -77,7 +77,7 @@ func (checker *Checker) StartCheck() ([]string, []rpctype.ExecutionRequest) {
 	return checker.checkFiles(), checker.checkContext.startCheck()
 }
 
-func (checker *Checker) FinishCheck(files []flatrpc.FileInfoT, progs []rpctype.ExecutionResult) (
+func (checker *Checker) FinishCheck(files []flatrpc.FileInfo, progs []rpctype.ExecutionResult) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, error) {
 	ctx := checker.checkContext
 	checker.checkContext = nil
@@ -94,9 +94,9 @@ type checker interface {
 	syscallCheck(*checkContext, *prog.Syscall) string
 }
 
-type filesystem map[string]flatrpc.FileInfoT
+type filesystem map[string]flatrpc.FileInfo
 
-func createVirtualFilesystem(fileInfos []flatrpc.FileInfoT) filesystem {
+func createVirtualFilesystem(fileInfos []flatrpc.FileInfo) filesystem {
 	files := make(filesystem)
 	for _, file := range fileInfos {
 		if file.Exists {

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -42,7 +42,7 @@ func TestHostMachineInfo(t *testing.T) {
 	}
 }
 
-func hostChecker(t *testing.T) (*Checker, []flatrpc.FileInfoT) {
+func hostChecker(t *testing.T) (*Checker, []flatrpc.FileInfo) {
 	cfg := testConfig(t, runtime.GOOS, runtime.GOARCH)
 	checker := New(cfg)
 	files := host.ReadFiles(checker.RequiredFiles())

--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -37,7 +37,7 @@ type RPCServer struct {
 
 	checkDone        atomic.Bool
 	checkFiles       []string
-	checkFilesInfo   []flatrpc.FileInfoT
+	checkFilesInfo   []flatrpc.FileInfo
 	checkProgs       []rpctype.ExecutionRequest
 	checkResults     []rpctype.ExecutionResult
 	needCheckResults int

--- a/tools/syz-runtest/runtest.go
+++ b/tools/syz-runtest/runtest.go
@@ -147,7 +147,7 @@ type Manager struct {
 	vmPool             *vm.Pool
 	checker            *vminfo.Checker
 	checkFiles         []string
-	checkFilesInfo     []flatrpc.FileInfoT
+	checkFilesInfo     []flatrpc.FileInfo
 	checkProgs         []rpctype.ExecutionRequest
 	checkResults       []rpctype.ExecutionResult
 	needCheckResults   int


### PR DESCRIPTION
Remove T suffix from object API types.
It seems that we will use these types thoughout the code,
and the suffix looks alien in Go code.
So it's better to remove it before we started using
these names more widely.
Also add few extensions we will need to move feature
checking to the host.