### PR TITLE
ci.yml: cancel old workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   aux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every time we do force-push, the currently running workflows can be cancelled.
