### PR TITLE
all: parallelize symbolize 

### DIFF
--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -153,9 +153,16 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 	var allRanges []pcRange
 	var allUnits []*CompileUnit
 	preciseCoverage := true
+	type binResult struct {
+		symbols     []*Symbol
+		coverPoints [2][]uint64
+		ranges      []pcRange
+		units       []*CompileUnit
+		err         error
+	}
+	binC := make(chan binResult, len(modules))
 	for _, module := range modules {
-		errc := make(chan error, 1)
-		go func() {
+		go func(m *Module) {
 			info := &symbolInfo{
 				tracePC:     make(map[uint64]bool),
 				traceCmp:    make(map[uint64]bool),
@@ -164,31 +171,38 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 			}
 			result, err := processModule(params, module, info, target)
 			if err != nil {
-				errc <- err
+				binC <- binResult{err: err}
 				return
 			}
-			allSymbols = append(allSymbols, result.Symbols...)
-			allCoverPoints[0] = append(allCoverPoints[0], result.CoverPoints[0]...)
-			allCoverPoints[1] = append(allCoverPoints[1], result.CoverPoints[1]...)
 			if module.Name == "" && len(result.CoverPoints[0]) == 0 {
 				err = fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y on linux)", module.Path)
+				if err != nil {
+					binC <- binResult{err: err}
+					return
+				}
 			}
-			errc <- err
-		}()
-		ranges, units, err := params.readTextRanges(module)
-		if err != nil {
-			return nil, err
-		}
-		if err := <-errc; err != nil {
-			return nil, err
-		}
-		allRanges = append(allRanges, ranges...)
-		allUnits = append(allUnits, units...)
+			ranges, units, err := params.readTextRanges(module)
+			if err != nil {
+				binC <- binResult{err: err}
+				return
+			}
+			binC <- binResult{symbols: result.Symbols, coverPoints: result.CoverPoints, ranges: ranges, units: units}
+		}(module)
 		if isKcovBrokenInCompiler(params.getCompilerVersion(module.Path)) {
 			preciseCoverage = false
 		}
 	}
-
+	for range modules {
+		result := <-binC
+		if err := result.err; err != nil {
+			return nil, err
+		}
+		allSymbols = append(allSymbols, result.symbols...)
+		allCoverPoints[0] = append(allCoverPoints[0], result.coverPoints[0]...)
+		allCoverPoints[1] = append(allCoverPoints[1], result.coverPoints[1]...)
+		allRanges = append(allRanges, result.ranges...)
+		allUnits = append(allUnits, result.units...)
+	}
 	sort.Slice(allSymbols, func(i, j int) bool {
 		return allSymbols[i].Start < allSymbols[j].Start
 	})

--- a/pkg/symbolizer/cache.go
+++ b/pkg/symbolizer/cache.go
@@ -49,17 +49,14 @@ func (c *Cache) Symbolize(inner func(string, uint64) ([]Frame, error), bin strin
 // buffer, it won't after interning (and won't prevent GC'ing of the large buffer).
 // The type is not thread-safe.
 type Interner struct {
-	m map[string]string
+	m sync.Map
 }
 
 func (in *Interner) Do(s string) string {
-	if in.m == nil {
-		in.m = make(map[string]string)
-	}
-	if interned, ok := in.m[s]; ok {
-		return interned
+	if interned, ok := in.m.Load(s); ok {
+		return interned.(string)
 	}
 	s = strings.Clone(s)
-	in.m[s] = s
+	in.m.Store(s, s)
 	return s
 }


### PR DESCRIPTION
1. symbolize takes much time especially if there are hundreds of modules and many pcs.
2. concurrent writing to slice without protection will result in race condition, see https://blog.sgkandale.com/appending-slice-from-multiple-goroutines-86bc1c821e9e.

The PR is to fix these two issues:
1. by symbolize each module in different goroutine.
2. protect concurrent writing to slice using channel.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
