### PR TITLE
pkg/fuzzer: deflake comparisons

### DIFF
--- a/prog/hints.go
+++ b/prog/hints.go
@@ -63,6 +63,20 @@ func (m CompMap) String() string {
 	return buf.String()
 }
 
+// InplaceIntersect() only leaves the value pairs that are also present in other.
+func (m CompMap) InplaceIntersect(other CompMap) {
+	for val1, nested := range m {
+		for val2 := range nested {
+			if !other[val1][val2] {
+				delete(nested, val2)
+			}
+		}
+		if len(nested) == 0 {
+			delete(m, val1)
+		}
+	}
+}
+
 // Mutates the program using the comparison operands stored in compMaps.
 // For each of the mutants executes the exec callback.
 // The callback must return whether we should continue substitution (true)

--- a/prog/hints_test.go
+++ b/prog/hints_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/syzkaller/pkg/image"
+	"github.com/stretchr/testify/assert"
 )
 
 type ConstArgTest struct {
@@ -664,6 +665,24 @@ func TestHintsData(t *testing.T) {
 				test.comps, test.in, got, test.out)
 		}
 	}
+}
+
+func TestInplaceIntersect(t *testing.T) {
+	m1 := CompMap{
+		0xdead: compSet(0x1, 0x2),
+		0xbeef: compSet(0x3, 0x4),
+		0xffff: compSet(0x5),
+	}
+	m2 := CompMap{
+		0xdead: compSet(0x2),
+		0xbeef: compSet(0x3, 0x6),
+		0xeeee: compSet(0x6),
+	}
+	m1.InplaceIntersect(m2)
+	assert.Equal(t, CompMap{
+		0xdead: compSet(0x2),
+		0xbeef: compSet(0x3),
+	}, m1)
 }
 
 func BenchmarkHints(b *testing.B) {


### PR DESCRIPTION
Do two exec hints to only leave stable comparison argument pairs.
In local experiments, it allows to reduce their count by 30-40% (on average).