### PR TITLE
pkg/corpus: don't overwrite ProgsList

### DIFF
--- a/pkg/corpus/minimize.go
+++ b/pkg/corpus/minimize.go
@@ -32,12 +32,11 @@ func (corpus *Corpus) Minimize(cover bool) {
 	})
 
 	corpus.progs = make(map[string]*Item)
-	// ProgramsList has its own mutex, so it'd be unsafe to
-	// overwrite it here, so let's create a new object.
-	corpus.ProgramsList = &ProgramsList{}
+	programsList := &ProgramsList{}
 	for _, ctx := range signal.Minimize(inputs) {
 		inp := ctx.(*Item)
 		corpus.progs[inp.Sig] = inp
-		corpus.saveProgram(inp.Prog, inp.Signal)
+		programsList.saveProgram(inp.Prog, inp.Signal)
 	}
+	corpus.ProgramsList.replace(programsList)
 }

--- a/pkg/corpus/prio.go
+++ b/pkg/corpus/prio.go
@@ -19,18 +19,6 @@ type ProgramsList struct {
 	accPrios []int64
 }
 
-func (pl *ProgramsList) saveProgram(p *prog.Prog, signal signal.Signal) {
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-	prio := int64(len(signal))
-	if prio == 0 {
-		prio = 1
-	}
-	pl.sumPrios += prio
-	pl.accPrios = append(pl.accPrios, pl.sumPrios)
-	pl.progs = append(pl.progs, p)
-}
-
 func (pl *ProgramsList) ChooseProgram(r *rand.Rand) *prog.Prog {
 	pl.mu.RLock()
 	defer pl.mu.RUnlock()
@@ -48,4 +36,24 @@ func (pl *ProgramsList) Programs() []*prog.Prog {
 	pl.mu.RLock()
 	defer pl.mu.RUnlock()
 	return pl.progs
+}
+
+func (pl *ProgramsList) saveProgram(p *prog.Prog, signal signal.Signal) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	prio := int64(len(signal))
+	if prio == 0 {
+		prio = 1
+	}
+	pl.sumPrios += prio
+	pl.accPrios = append(pl.accPrios, pl.sumPrios)
+	pl.progs = append(pl.progs, p)
+}
+
+func (pl *ProgramsList) replace(other *ProgramsList) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	pl.sumPrios = other.sumPrios
+	pl.accPrios = other.accPrios
+	pl.progs = other.progs
 }


### PR DESCRIPTION
There's still a risk of a race between the pointer overwriting and accesses to the embedded object.

Let's use an internal replace() method instead.

Sample race:

```
WARNING: DATA RACE
Write at 0x00c0014b0668 by goroutine 5727:
  github.com/google/syzkaller/pkg/corpus.(*Corpus).Minimize()
      /syzkaller/gopath/src/github.com/google/syzkaller/pkg/corpus/minimize.go:37 +0x44e
  main.(*Manager).minimizeCorpusLocked()
      /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/manager.go:1246 +0x150
  main.(*Manager).corpusMinimization()
      /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/manager.go:1393 +0x96
  main.(*Manager).machineChecked.func4()
      /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/manager.go:1380 +0x33

Previous read at 0x00c0014b0668 by goroutine 113982:
  github.com/google/syzkaller/pkg/fuzzer.mutateProgRequest()
      /syzkaller/gopath/src/github.com/google/syzkaller/pkg/fuzzer/job.go:88 +0x1b5
  github.com/google/syzkaller/pkg/fuzzer.(*Fuzzer).nextInput()
      /syzkaller/gopath/src/github.com/google/syzkaller/pkg/fuzzer/fuzzer.go:203 +0x338
  github.com/google/syzkaller/pkg/fuzzer.(*Fuzzer).NextInput()
      /syzkaller/gopath/src/github.com/google/syzkaller/pkg/fuzzer/fuzzer.go:174 +0x2e
  main.(*RPCServer).ExchangeInfo()
      /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/rpc.go:387 +0x767
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:748 +0x42
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:380 +0xb5
  net/rpc.(*service).call()
      /usr/local/go/src/net/rpc/server.go:382 +0x26c
  net/rpc.(*Server).ServeCodec.func2()
      /usr/local/go/src/net/rpc/server.go:479 +0x15e
```