### PR TITLE
RFC: vm: split no output from test machine errors

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -447,10 +447,8 @@ func (inst *inst) testRepro() ([]byte, error) {
 			inst.cfg.Timeouts.NoOutputRunningTime, opts))
 	}
 	if err == nil && len(inst.reproC) > 0 {
-		// We should test for more than full "no output" timeout, but the problem is that C reproducers
-		// don't print anything, so we will get a false "no output" crash.
 		out, err = transformError(execProg.RunCProgRaw(inst.reproC, inst.cfg.Target,
-			inst.cfg.Timeouts.NoOutput/2))
+			inst.cfg.Timeouts.NoOutputRunningTime))
 	}
 	return out, err
 }

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -15,6 +15,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ import (
 )
 
 func init() {
+	var _ vmimpl.Aliver = (*instance)(nil)
 	vmimpl.Register("gce", ctor, true)
 }
 
@@ -426,6 +428,11 @@ func (inst *instance) Diagnose(rep *report.Report) ([]byte, bool) {
 		return vmimpl.DiagnoseOpenBSD(inst.consolew)
 	}
 	return nil, false
+}
+
+func (inst *instance) Alive(ctx context.Context) (bool, error) {
+	_, err := osutil.RunCmd(30*time.Second, "", "ssh", inst.sshArgs()...)
+	return err == nil, nil
 }
 
 func (inst *instance) ssh(args ...string) ([]byte, error) {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -5,6 +5,7 @@ package qemu
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,6 +28,7 @@ import (
 
 func init() {
 	var _ vmimpl.Infoer = (*instance)(nil)
+	var _ vmimpl.Aliver = (*instance)(nil)
 	vmimpl.Register("qemu", ctor, true)
 }
 
@@ -738,6 +740,11 @@ func (inst *instance) Diagnose(rep *report.Report) ([]byte, bool) {
 		}
 	}
 	return ret, false
+}
+
+func (inst *instance) Alive(ctx context.Context) (bool, error) {
+	_, err := osutil.RunCmd(30*time.Second, "", "ssh", inst.sshArgs()...)
+	return err == nil, nil
 }
 
 func (inst *instance) ssh(args ...string) ([]byte, error) {

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -8,6 +8,7 @@
 package vmimpl
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -70,6 +71,11 @@ type Infoer interface {
 // PprofPortProvider is used when the instance wants to define a custom pprof port.
 type PprofPortProvider interface {
 	PprofPort() int
+}
+
+// Aliver is an optional interface that allows to check whether the instance is alive.
+type Aliver interface {
+	Alive(ctx context.Context) (bool, error)
 }
 
 // Env contains global constant parameters for a pool of VMs.


### PR DESCRIPTION
It's quite confusing that we in fact combine two kinds of problems into one:
1) We are no longer able to execute syzkaller-generated programs.
2) The VM has hanged.

Let's use different error messages and different timeouts for these issues.

In the first case, keep on monitoring for the program execution logs. In the second case, look at any output from the VM. Additionally, attempt periodic SSH connections.

Now it becomes possible to test (2) using C reproducers.

TODO: 
- [ ] Update the documentation.
- [ ] Update tests.