### PR TITLE
pkg/repro: don't clear the Repro flag

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -553,10 +553,8 @@ static void execute_one(void)
 static void loop(void)
 #endif
 {
-#if SYZ_REPRO
 	if (write(1, "executing program\n", sizeof("executing program\n") - 1)) {
 	}
-#endif
 #if SYZ_TRACE
 	fprintf(stderr, "### start\n");
 #endif

--- a/pkg/csource/common.go
+++ b/pkg/csource/common.go
@@ -123,7 +123,6 @@ func commonDefines(p *prog.Prog, opts Options) map[string]bool {
 		"SYZ_VHCI_INJECTION":            opts.VhciInjection,
 		"SYZ_USE_TMP_DIR":               opts.UseTmpDir,
 		"SYZ_HANDLE_SEGV":               opts.HandleSegv,
-		"SYZ_REPRO":                     opts.Repro,
 		"SYZ_TRACE":                     opts.Trace,
 		"SYZ_WIFI":                      opts.Wifi,
 		"SYZ_802154":                    opts.IEEE802154,

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -188,9 +188,7 @@ func (ctx *context) generateSyscalls(calls []string, hasVars bool) string {
 		if len(calls) > 0 && (hasVars || opts.Trace) {
 			fmt.Fprintf(buf, "\tintptr_t res = 0;\n")
 		}
-		if opts.Repro {
-			fmt.Fprintf(buf, "\tif (write(1, \"executing program\\n\", sizeof(\"executing program\\n\") - 1)) {}\n")
-		}
+		fmt.Fprintf(buf, "\tif (write(1, \"executing program\\n\", sizeof(\"executing program\\n\") - 1)) {}\n")
 		if opts.Trace {
 			fmt.Fprintf(buf, "\tfprintf(stderr, \"### start\\n\");\n")
 		}

--- a/pkg/csource/options.go
+++ b/pkg/csource/options.go
@@ -48,9 +48,6 @@ type Options struct {
 	UseTmpDir  bool `json:"tmpdir,omitempty"`
 	HandleSegv bool `json:"segv,omitempty"`
 
-	// Generate code for use with repro package to prints log messages,
-	// which allows to detect hangs.
-	Repro bool `json:"repro,omitempty"`
 	Trace bool `json:"trace,omitempty"`
 	LegacyOptions
 }
@@ -169,7 +166,6 @@ func DefaultOpts(cfg *mgrconfig.Config) Options {
 		Sandbox:    cfg.Sandbox,
 		UseTmpDir:  true,
 		HandleSegv: true,
-		Repro:      true,
 	}
 	if cfg.TargetOS == targets.Linux {
 		opts.NetInjection = true
@@ -222,7 +218,7 @@ func deserializeLegacyOptions(data string, opts *Options) (int, error) {
 		"HandleSegv":    &opts.HandleSegv,
 		"WaitRepeat":    &ignoreBool,
 		"Debug":         &ignoreBool,
-		"Repro":         &opts.Repro,
+		"Repro":         &ignoreBool,
 	}
 
 	data = strings.TrimSpace(data)
@@ -366,6 +362,5 @@ var ExecutorOpts = Options{
 	Procs:     2,
 	Slowdown:  1,
 	Sandbox:   "none",
-	Repro:     true,
 	UseTmpDir: true,
 }

--- a/pkg/csource/options_test.go
+++ b/pkg/csource/options_test.go
@@ -47,7 +47,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        true,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     true,
@@ -72,7 +71,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        true,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     true,
@@ -98,7 +96,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        true,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     true,
@@ -118,7 +115,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        false,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     false,
@@ -138,7 +134,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        false,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     false,
@@ -158,7 +153,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        false,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     false,
@@ -179,7 +173,6 @@ func TestParseOptionsCanned(t *testing.T) {
 			CloseFDs:     true,
 			UseTmpDir:    true,
 			HandleSegv:   true,
-			Repro:        false,
 			LegacyOptions: LegacyOptions{
 				Collide:   true,
 				Fault:     false,

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -235,11 +235,6 @@ func (ctx *context) repro() (*Result, error) {
 	if res == nil {
 		return nil, nil
 	}
-	defer func() {
-		if res != nil {
-			res.Opts.Repro = false
-		}
-	}()
 	res, err = ctx.minimizeProg(res)
 	if err != nil {
 		return nil, err

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -91,7 +91,6 @@ func TestSimplifies(t *testing.T) {
 		Cgroups:      true,
 		UseTmpDir:    true,
 		HandleSegv:   true,
-		Repro:        true,
 	}
 	var check func(opts csource.Options, i int)
 	check = func(opts csource.Options, i int) {

--- a/tools/syz-prog2c/prog2c.go
+++ b/tools/syz-prog2c/prog2c.go
@@ -29,7 +29,6 @@ var (
 	flagHandleSegv = flag.Bool("segv", false, "catch and ignore SIGSEGV")
 	flagUseTmpDir  = flag.Bool("tmpdir", false, "create a temporary dir and execute inside it")
 	flagTrace      = flag.Bool("trace", false, "trace syscall results")
-	flagRepro      = flag.Bool("repro", false, "add heartbeats used by pkg/repro")
 	flagStrict     = flag.Bool("strict", false, "parse input program in strict mode")
 	flagLeak       = flag.Bool("leak", false, "do leak checking")
 	flagEnable     = flag.String("enable", "none", "enable only listed additional features")
@@ -95,7 +94,6 @@ func main() {
 		Swap:          features["swap"].Enabled,
 		UseTmpDir:     *flagUseTmpDir,
 		HandleSegv:    *flagHandleSegv,
-		Repro:         *flagRepro,
 		Trace:         *flagTrace,
 	}
 	src, err := csource.Write(p, opts)


### PR DESCRIPTION
If C reproducers keep on printing "executing program" lines, it will be easier to re-use them during the repro and patch testing.
