### PR TITLE
syz-manager,  syz-fuzzer: switch communication to flatrpc

### DIFF
--- a/syz-fuzzer/fuzzer_test.go
+++ b/syz-fuzzer/fuzzer_test.go
@@ -6,7 +6,7 @@ package main
 import (
 	"testing"
 
-	"github.com/google/syzkaller/pkg/ipc"
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,8 +14,8 @@ import (
 func TestFilterProgInfo(t *testing.T) {
 	max := signal.FromRaw([]uint32{5, 6, 7}, 0)
 	mask := signal.FromRaw([]uint32{2, 4, 6, 8}, 0)
-	info := ipc.ProgInfo{
-		Calls: []ipc.CallInfo{
+	info := flatrpc.ProgInfo{
+		Calls: []*flatrpc.CallInfo{
 			{
 				Signal: []uint32{1, 2, 3, 5, 6},
 				Cover:  []uint32{1, 2, 3},
@@ -25,14 +25,14 @@ func TestFilterProgInfo(t *testing.T) {
 				Cover:  []uint32{2, 3, 4},
 			},
 		},
-		Extra: ipc.CallInfo{
+		Extra: &flatrpc.CallInfo{
 			Signal: []uint32{3, 4, 5},
 			Cover:  []uint32{3, 4, 5},
 		},
 	}
 	diffMaxSignal(&info, max, mask, 1)
-	assert.Equal(t, ipc.ProgInfo{
-		Calls: []ipc.CallInfo{
+	assert.Equal(t, flatrpc.ProgInfo{
+		Calls: []*flatrpc.CallInfo{
 			{
 				Signal: []uint32{1, 2, 3},
 				Cover:  []uint32{1, 2, 3},
@@ -42,7 +42,7 @@ func TestFilterProgInfo(t *testing.T) {
 				Cover:  []uint32{2, 3, 4},
 			},
 		},
-		Extra: ipc.CallInfo{
+		Extra: &flatrpc.CallInfo{
 			Signal: []uint32{3, 4},
 			Cover:  []uint32{3, 4, 5},
 		},

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -73,8 +73,4 @@ func (mgr *Manager) initStats() {
 		}, func(v int, period time.Duration) string {
 			return fmt.Sprintf("%v MB", v>>20)
 		})
-
-	// Stats imported from the fuzzer (names must match the the fuzzer names).
-	stats.Create("no exec requests", "Number of times fuzzer was stalled with no exec requests", stats.Rate{})
-	stats.Create("no exec duration", "Total duration fuzzer was stalled with no exec requests (ns/sec)", stats.Rate{})
 }


### PR DESCRIPTION
syz-manager,  syz-fuzzer: switch communication to flatrpc

Switch to flatrpc connection between manager and fuzzer.
With flatrpc we have a goroutine per connection instead of async RPC,
which makes things a bit simpler. Now don't reordered messages
(in particular start executing and finish executing for programs),
race on the program during printing is no longer possible
since we finish handlign start executing request before we even
receive finish executing.
We also don't need to lookup Runner for every RPC since it's
now local to the handling goroutine.
We also don't need to protect requests map since only single
goroutine accesses it.
We also send new programs to the fuzzer as soon as we receive
start executing message, which provides better buffering.
We also don't batch new requests and finish executing requests
in a single RPC, which makes things a bit simpler.

Update #1541