### PR TITLE
executor: Remove including <error.h> in test_linux.h

### DIFF
--- a/executor/test_linux.h
+++ b/executor/test_linux.h
@@ -1,7 +1,6 @@
 // Copyright 2017 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-#include <error.h>
 #include <stdint.h>
 #include <sys/utsname.h>
 


### PR DESCRIPTION
it seems to be redundant and moreover it lets us compile on musl which does not provide this system header


