### PR TITLE
support CONFIG_RANDOMIZE_BASE=y

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -58,6 +58,11 @@ type Range struct {
 	EndCol    int
 }
 
+type SecRange struct {
+	Start uint64
+	End   uint64
+}
+
 const LineEnd = 1 << 30
 
 func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuild bool,

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -6,6 +6,7 @@ package backend
 import (
 	"fmt"
 
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -78,4 +79,11 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuil
 		delimiters = []string{"/aosp/", "/private/"}
 	}
 	return makeELF(target, objDir, srcDir, buildDir, delimiters, moduleObj, modules)
+}
+
+func GetPCBase(cfg *mgrconfig.Config) (uint64, error) {
+	if cfg.Target.OS == targets.Linux {
+		return getPCBase(cfg)
+	}
+	return 0, nil
 }

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -141,10 +141,7 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 	srcDir := params.srcDir
 	buildDir := params.buildDir
 	splitBuildDelimiters := params.splitBuildDelimiters
-	modules, err := discoverModules(target, objDir, params.moduleObj, params.hostModules)
-	if err != nil {
-		return nil, err
-	}
+	modules := params.hostModules
 
 	// Here and below index 0 refers to coverage callbacks (__sanitizer_cov_trace_pc(_guard))
 	// and index 1 refers to comparison callbacks (__sanitizer_cov_trace_cmp*).

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -220,7 +220,7 @@ func elfGetCompilerVersion(path string) string {
 	return string(data[:])
 }
 
-func elfReadTextSecRange(module KernelModule) (*SecRange, error) {
+func elfReadTextSecRange(module *KernelModule) (*SecRange, error) {
 	text, err := elfReadTextSec(module)
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func elfReadTextSecRange(module KernelModule) (*SecRange, error) {
 	return r, nil
 }
 
-func elfReadTextSec(module KernelModule) (*elf.Section, error) {
+func elfReadTextSec(module *KernelModule) (*elf.Section, error) {
 	file, err := elf.Open(module.Path)
 	if err != nil {
 		return nil, err

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -220,6 +220,31 @@ func elfGetCompilerVersion(path string) string {
 	return string(data[:])
 }
 
+func elfReadTextSecRange(module KernelModule) (*SecRange, error) {
+	text, err := elfReadTextSec(module)
+	if err != nil {
+		return nil, err
+	}
+	r := &SecRange{
+		Start: text.Addr,
+		End:   text.Addr + text.Size,
+	}
+	return r, nil
+}
+
+func elfReadTextSec(module KernelModule) (*elf.Section, error) {
+	file, err := elf.Open(module.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	text := file.Section(".text")
+	if text == nil {
+		return nil, fmt.Errorf("no .text section in the object file")
+	}
+	return text, nil
+}
+
 func getPCBase(cfg *mgrconfig.Config) (uint64, error) {
 	bin := filepath.Join(cfg.KernelObj, cfg.SysTarget.KernelObject)
 	file, err := elf.Open(bin)

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -30,6 +30,10 @@ type Prog struct {
 
 type KernelModule = backend.KernelModule
 
+func GetPCBase(cfg *mgrconfig.Config) (uint64, error) {
+	return backend.GetPCBase(cfg)
+}
+
 func MakeReportGenerator(cfg *mgrconfig.Config, subsystem []mgrconfig.Subsystem,
 	modules []*KernelModule, rawCover bool) (*ReportGenerator, error) {
 	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelObj,

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -318,6 +318,10 @@ func generateReport(t *testing.T, target *targets.Target, test *Test) (*reports,
 			},
 		},
 	}
+	modules, err := backend.DiscoverModules(cfg.SysTarget, cfg.KernelObj, cfg.ModuleObj)
+	if err != nil {
+		return nil, err
+	}
 
 	// Deep copy, as we are going to modify progs. Our test generate multiple reports from the same
 	// test object in parallel. Without copying we have a datarace here.
@@ -326,7 +330,7 @@ func generateReport(t *testing.T, target *targets.Target, test *Test) (*reports,
 		progs = append(progs, Prog{Sig: p.Sig, Data: p.Data, PCs: append([]uint64{}, p.PCs...)})
 	}
 
-	rg, err := MakeReportGenerator(cfg, subsystem, nil, false)
+	rg, err := MakeReportGenerator(cfg, subsystem, modules, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -41,6 +41,7 @@ type Config struct {
 	PrintMachineCheck bool
 	Procs             int
 	Slowdown          int
+	PCBase            uint64
 }
 
 type Manager interface {
@@ -81,6 +82,10 @@ type Server struct {
 }
 
 func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
+	pcBase, err := cover.GetPCBase(cfg)
+	if err != nil {
+		return nil, err
+	}
 	sandbox, err := flatrpc.SandboxToFlags(cfg.Sandbox)
 	if err != nil {
 		return nil, err
@@ -109,6 +114,7 @@ func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
 		PrintMachineCheck: true,
 		Procs:             cfg.Procs,
 		Slowdown:          cfg.Timeouts.Slowdown,
+		PCBase:            pcBase,
 	}, mgr)
 }
 

--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -68,6 +68,10 @@ func (linux) parseModules(files filesystem) ([]*cover.KernelModule, error) {
 		modules = append(modules, &cover.KernelModule{
 			Name: name,
 			Addr: textAddr,
+			// The size is wrong as there is overlap in /proc/modules
+			// ex. module1['Addr'] + module1['Size'] > module2['Addr']
+			// runtime kernel doesn't export .text section size to /sys/module/*/sections/.text
+			// so we need to read it from elf
 			Size: modSize - offset,
 		})
 	}
@@ -75,7 +79,7 @@ func (linux) parseModules(files filesystem) ([]*cover.KernelModule, error) {
 	if err != nil {
 		return nil, err
 	}
-	modules = append(modules, cover.KernelModule{
+	modules = append(modules, &cover.KernelModule{
 		Name: "",
 		Addr: _stext,
 		Size: _etext - _stext,

--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -23,6 +23,7 @@ func (linux) RequiredFiles() []string {
 	return []string{
 		"/proc/cpuinfo",
 		"/proc/modules",
+		"/proc/kallsyms",
 		"/sys/module/*/sections/.text",
 		"/sys/module/kvm*/parameters/*",
 	}


### PR DESCRIPTION
The current implementation doesn't work well when CONFIG_RANDOMIZE_BASE enabled.

Taken some arm64 devices for example:
kaslr_offset is diff at bits 12-40, and kernel modules are loaded at 2GB space,
so we have `ffffffd342e10000 T _stext` where uppper 32bit is ffffffd3. However,
if we check modules range, the 1st module is loaded at 0xffffffd2eeb2a000,
while the last module is loaded at 0xffffffd2f42c4000.
We can see the upper 32bits are diff for core kernel and modules.
    
If we use current 32bits for covered PC, we will get wrong module address
recovered, which uses pcBase from core kernel + lower 32bits offset.
    
So we need to move to 64bit cover and signal.

Besides, there are some other fixes and improvement in the PR to align with the 64bits support:
- Fix wrong module size which should be .text size instead of that from /proc/modules.
- Calculate kaslr_offset by subtracting _stext address on device and _stext from elf file.
- Uniform Module and KernelModule which contains Name, Addr, Path, Size.