### PR TITLE
syz-ci: fix RPC connections to test syz-managers

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -549,9 +549,10 @@ func (mgr *Manager) createTestConfig(imageDir string, info *BuildInfo) (*mgrconf
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Name += "-test"
 	mgrcfg.Tag = info.KernelCommit
-	// Use random free ports to not collide with the actual manager.
+	// Use designated ports not to collide with the ports of other managers.
 	mgrcfg.HTTP = fmt.Sprintf("localhost:%v", mgr.mgrcfg.testHTTPPort)
-	mgrcfg.RPC = fmt.Sprintf("localhost:%v", mgr.mgrcfg.testRPCPort)
+	// For GCE VMs, we need to bind to a real networking interface, so no localhost.
+	mgrcfg.RPC = fmt.Sprintf(":%v", mgr.mgrcfg.testRPCPort)
 	mgrcfg.Workdir = filepath.Join(imageDir, "workdir")
 	if err := instance.SetConfigImage(mgrcfg, imageDir, true); err != nil {
 		return nil, err


### PR DESCRIPTION
For GCE-based fuzzing, we need to bind to a real networking interface to accept connections from the VMs.
