### PR TITLE
pkg/repro: avoid hitting the prog.MaxCalls limit

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -91,7 +91,7 @@ func testTarget(t *testing.T, target *prog.Target, full bool) {
 		opts = allOptionsSingle(target.OS)
 		opts = append(opts, ExecutorOpts)
 	} else {
-		minimized, _ := prog.Minimize(syzProg, -1, false, func(p *prog.Prog, call int) bool {
+		minimized, _ := prog.Minimize(syzProg, -1, prog.MinimizeParams{}, func(p *prog.Prog, call int) bool {
 			return len(p.Calls) == len(syzProg.Calls)
 		})
 		p.Calls = append(p.Calls, minimized.Calls...)

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -194,7 +194,7 @@ func (job *triageJob) deflake(exec func(*queue.Request, ProgTypes) *queue.Result
 
 func (job *triageJob) minimize(newSignal signal.Signal) (stop bool) {
 	const minimizeAttempts = 3
-	job.p, job.call = prog.Minimize(job.p, job.call, false,
+	job.p, job.call = prog.Minimize(job.p, job.call, prog.MinimizeParams{},
 		func(p1 *prog.Prog, call1 int) bool {
 			if stop {
 				return false

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -412,7 +412,7 @@ func (ctx *context) minimizeProg(res *Result) (*Result, error) {
 		ctx.stats.MinimizeProgTime = time.Since(start)
 	}()
 
-	res.Prog, _ = prog.Minimize(res.Prog, -1, true,
+	res.Prog, _ = prog.Minimize(res.Prog, -1, prog.MinimizeParams{Light: true},
 		func(p1 *prog.Prog, callIndex int) bool {
 			crashed, err := ctx.testProg(p1, res.Duration, res.Opts)
 			if err != nil {

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -408,7 +408,7 @@ func TestSerializeDeserializeRandom(t *testing.T) {
 			if _, _, ok := testSerializeDeserialize(t, p0); ok {
 				continue
 			}
-			p0, _ = Minimize(p0, -1, false, func(p1 *Prog, _ int) bool {
+			p0, _ = Minimize(p0, -1, MinimizeParams{}, func(p1 *Prog, _ int) bool {
 				_, _, ok := testSerializeDeserialize(t, p1)
 				return !ok
 			})

--- a/prog/expr_test.go
+++ b/prog/expr_test.go
@@ -186,7 +186,7 @@ func TestConditionalMinimize(t *testing.T) {
 			assert.NoError(tt, err)
 			p, err := target.Deserialize([]byte(test.input), Strict)
 			assert.NoError(tt, err)
-			p1, _ := Minimize(p, 0, false, test.pred)
+			p1, _ := Minimize(p, 0, MinimizeParams{}, test.pred)
 			res := p1.Serialize()
 			assert.Equal(tt, test.output, strings.TrimSpace(string(res)))
 		})

--- a/prog/minimization_test.go
+++ b/prog/minimization_test.go
@@ -251,7 +251,7 @@ func TestMinimize(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to deserialize original program #%v: %v", ti, err)
 		}
-		p1, ci := Minimize(p, test.callIndex, false, test.pred)
+		p1, ci := Minimize(p, test.callIndex, MinimizeParams{}, test.pred)
 		res := p1.Serialize()
 		if string(res) != test.result {
 			t.Fatalf("minimization produced wrong result #%v\norig:\n%v\nexpect:\n%v\ngot:\n%v",
@@ -273,7 +273,7 @@ func TestMinimizeRandom(t *testing.T) {
 		for _, crash := range []bool{false, true} {
 			p := target.Generate(rs, 5, ct)
 			copyP := p.Clone()
-			minP, _ := Minimize(p, len(p.Calls)-1, crash, func(p1 *Prog, callIndex int) bool {
+			minP, _ := Minimize(p, len(p.Calls)-1, MinimizeParams{Light: crash}, func(p1 *Prog, callIndex int) bool {
 				if r.Intn(2) == 0 {
 					return false
 				}
@@ -296,7 +296,7 @@ func TestMinimizeCallIndex(t *testing.T) {
 	for i := 0; i < iters; i++ {
 		p := target.Generate(rs, 5, ct)
 		ci := r.Intn(len(p.Calls))
-		p1, ci1 := Minimize(p, ci, r.Intn(2) == 0, func(p1 *Prog, callIndex int) bool {
+		p1, ci1 := Minimize(p, ci, MinimizeParams{Light: r.Intn(2) == 0}, func(p1 *Prog, callIndex int) bool {
 			return r.Intn(2) == 0
 		})
 		if ci1 < 0 || ci1 >= len(p1.Calls) || p.Calls[ci].Meta.Name != p1.Calls[ci1].Meta.Name {

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -195,7 +195,7 @@ func testCrossTarget(t *testing.T, target *Target, crossTargets []*Target) {
 		testCrossArchProg(t, p, crossTargets)
 		p.Mutate(rs, 20, ct, nil, nil)
 		testCrossArchProg(t, p, crossTargets)
-		p, _ = Minimize(p, -1, false, func(*Prog, int) bool {
+		p, _ = Minimize(p, -1, MinimizeParams{}, func(*Prog, int) bool {
 			return rs.Int63()%2 == 0
 		})
 		testCrossArchProg(t, p, crossTargets)

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -73,7 +73,7 @@ func generateProg(t *testing.T, target *Target, rs rand.Source, ct *ChoiceTable,
 		})
 	}
 	for _, crash := range []bool{false, true} {
-		p, _ = Minimize(p, -1, crash, func(*Prog, int) bool {
+		p, _ = Minimize(p, -1, MinimizeParams{Light: crash}, func(*Prog, int) bool {
 			return rs.Int63()%10 == 0
 		})
 	}


### PR DESCRIPTION
When we combine the progs found during prog bisection, there's a chance
that we may exceed the prog.MaxCalls limit. In that case, we get a
SYZFATAL error and proceed as if it were the target crash. That's
absolutely wrong.

Let's first minimize each single program before concatenating them, that
should work for almost all cases.