### PR TITLE
pkg/cover/backend: remove RestorePC

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -133,7 +133,7 @@ type builder interface {
 
 func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 	if targetOS == targets.Linux {
-		if vmType == "gvisor" {
+		if vmType == targets.GVisor {
 			return gvisor{}, nil
 		} else if vmType == "cuttlefish" {
 			return cuttlefish{}, nil

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -70,10 +70,10 @@ func Make(target *targets.Target, vm, objDir, srcDir, buildDir string, splitBuil
 	if objDir == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
-	if target.OS == "darwin" {
+	if target.OS == targets.Darwin {
 		return makeMachO(target, objDir, srcDir, buildDir, moduleObj, modules)
 	}
-	if vm == "gvisor" {
+	if vm == targets.GVisor {
 		return makeGvisor(target, objDir, srcDir, buildDir, modules)
 	}
 	var delimiters []string

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -14,7 +14,6 @@ type Impl struct {
 	Symbols         []*Symbol
 	Frames          []Frame
 	Symbolize       func(pcs map[*Module][]uint64) ([]Frame, error)
-	RestorePC       func(pc uint64) uint64
 	CallbackPoints  []uint64
 	PreciseCoverage bool
 }

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -223,17 +223,10 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 		Symbolize: func(pcs map[*Module][]uint64) ([]Frame, error) {
 			return symbolize(target, &interner, objDir, srcDir, buildDir, splitBuildDelimiters, pcs)
 		},
-		RestorePC:       makeRestorePC(params),
 		CallbackPoints:  allCoverPoints[0],
 		PreciseCoverage: preciseCoverage,
 	}
 	return impl, nil
-}
-
-func makeRestorePC(params *dwarfParams) func(pc uint64) uint64 {
-	return func(pc uint64) uint64 {
-		return PreviousInstructionPC(params.target, pc)
-	}
 }
 
 func buildSymbols(symbols []*Symbol, ranges []pcRange, coverPoints [2][]uint64) []*Symbol {

--- a/pkg/cover/backend/gvisor.go
+++ b/pkg/cover/backend/gvisor.go
@@ -48,9 +48,6 @@ func makeGvisor(target *targets.Target, objDir, srcDir, buildDir string, modules
 	impl := &Impl{
 		Units:  units,
 		Frames: frames,
-		RestorePC: func(pc uint64) uint64 {
-			return pc
-		},
 	}
 	return impl, nil
 }

--- a/pkg/cover/backend/pc.go
+++ b/pkg/cover/backend/pc.go
@@ -10,7 +10,7 @@ import (
 )
 
 func PreviousInstructionPC(target *targets.Target, vm string, pc uint64) uint64 {
-	if vm == "gvisor" {
+	if vm == targets.GVisor {
 		// gVisor coverage returns real PCs that don't need adjustment.
 		return pc
 	}
@@ -25,7 +25,7 @@ func PreviousInstructionPC(target *targets.Target, vm string, pc uint64) uint64 
 }
 
 func NextInstructionPC(target *targets.Target, vm string, pc uint64) uint64 {
-	if vm == "gvisor" {
+	if vm == targets.GVisor {
 		return pc
 	}
 	offset := instructionLen(target.Arch)

--- a/pkg/cover/backend/pc.go
+++ b/pkg/cover/backend/pc.go
@@ -9,7 +9,11 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
+func PreviousInstructionPC(target *targets.Target, vm string, pc uint64) uint64 {
+	if vm == "gvisor" {
+		// gVisor coverage returns real PCs that don't need adjustment.
+		return pc
+	}
 	offset := instructionLen(target.Arch)
 	pc -= offset
 	// THUMB instructions are 2 or 4 bytes with low bit set.
@@ -20,7 +24,10 @@ func PreviousInstructionPC(target *targets.Target, pc uint64) uint64 {
 	return pc
 }
 
-func NextInstructionPC(target *targets.Target, pc uint64) uint64 {
+func NextInstructionPC(target *targets.Target, vm string, pc uint64) uint64 {
+	if vm == "gvisor" {
+		return pc
+	}
 	offset := instructionLen(target.Arch)
 	pc += offset
 	// THUMB instructions are 2 or 4 bytes with low bit set.

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -348,7 +348,7 @@ func generateReport(t *testing.T, target *targets.Target, test *Test) (*reports,
 			if err != nil {
 				t.Fatal(err)
 			}
-			pcs = append(pcs, backend.PreviousInstructionPC(target, pc))
+			pcs = append(pcs, backend.PreviousInstructionPC(target, "", pc))
 			t.Logf("using exact coverage PC 0x%x", pcs[0])
 		} else if target.OS == runtime.GOOS && (target.Arch == runtime.GOARCH || target.VMArch == runtime.GOARCH) {
 			t.Fatal(err)

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -207,7 +207,7 @@ func (cfg *Config) initTimeouts() {
 		// Assuming qemu emulation.
 		// Quick tests of mmap syscall on arm64 show ~9x slowdown.
 		slowdown = 10
-	case cfg.Type == "gvisor" && cfg.Cover && strings.Contains(cfg.Name, "-race"):
+	case cfg.Type == targets.GVisor && cfg.Cover && strings.Contains(cfg.Name, "-race"):
 		// Go coverage+race has insane slowdown of ~350x. We can't afford such large value,
 		// but a smaller value should be enough to finish at least some syscalls.
 		// Note: the name check is a hack.

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -83,7 +83,7 @@ const unspecifiedType = crash.Type("UNSPECIFIED")
 // NewReporter creates reporter for the specified OS/Type.
 func NewReporter(cfg *mgrconfig.Config) (*Reporter, error) {
 	typ := cfg.TargetOS
-	if cfg.Type == "gvisor" || cfg.Type == "starnix" {
+	if cfg.Type == targets.GVisor || cfg.Type == targets.Starnix {
 		typ = cfg.Type
 	}
 	ctor := ctors[typ]
@@ -139,8 +139,8 @@ const (
 
 var ctors = map[string]fn{
 	targets.Linux:   ctorLinux,
-	"starnix":       ctorFuchsia,
-	"gvisor":        ctorGvisor,
+	targets.Starnix: ctorFuchsia,
+	targets.GVisor:  ctorGvisor,
 	targets.FreeBSD: ctorFreebsd,
 	targets.Darwin:  ctorDarwin,
 	targets.NetBSD:  ctorNetbsd,

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -193,7 +193,7 @@ func linuxGCCPath(tags map[string]bool, binDir, defaultCompiler string) string {
 }
 
 func (ctx *linux) PrepareBisect() error {
-	if ctx.vmType != "gvisor" {
+	if ctx.vmType != targets.GVisor {
 		// Some linux repos we fuzz don't import the upstream release git tags. We need tags
 		// to decide which compiler versions to use. Let's fetch upstream for its tags.
 		err := ctx.git.fetchRemote("https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git", "")

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -135,6 +135,10 @@ const (
 	Trusty  = "trusty"
 	Windows = "windows"
 
+	// These are VM types, but we put them here to prevent string duplication.
+	GVisor  = "gvisor"
+	Starnix = "starnix"
+
 	AMD64               = "amd64"
 	ARM64               = "arm64"
 	ARM                 = "arm"

--- a/syz-manager/cover.go
+++ b/syz-manager/cover.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
@@ -36,10 +37,11 @@ func resetReportGenerator() {
 	cachedRepGen = nil
 }
 
-func coverToPCs(rg *cover.ReportGenerator, cov []uint64) []uint64 {
+func coverToPCs(cfg *mgrconfig.Config, cov []uint64) []uint64 {
 	pcs := make([]uint64, 0, len(cov))
 	for _, pc := range cov {
-		pcs = append(pcs, rg.RestorePC(pc))
+		prev := backend.PreviousInstructionPC(cfg.SysTarget, cfg.Type, pc)
+		pcs = append(pcs, prev)
 	}
 	return pcs
 }

--- a/syz-manager/covfilter_test.go
+++ b/syz-manager/covfilter_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"testing"
 
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -16,7 +17,12 @@ func TestCreateBitmap(t *testing.T) {
 	}
 	target := targets.Get("test", "64")
 	order := target.HostEndian
-	bitmap := createCoverageBitmap(target, pcs)
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			SysTarget: target,
+		},
+	}
+	bitmap := createCoverageBitmap(cfg, pcs)
 	start := order.Uint64(bitmap[0:])
 	size := order.Uint32(bitmap[8:])
 	if start != 0x81000002 || size != 0x20001b {
@@ -38,24 +44,28 @@ func TestCreateBitmap(t *testing.T) {
 		0:          1,
 		0xffffffff: 1,
 	}
-	createCoverageBitmap(target, pcs)
+	createCoverageBitmap(cfg, pcs)
 	pcs = map[uint64]uint32{
 		0x81000000: 1,
 		0x81000100: 1,
 	}
-	createCoverageBitmap(target, pcs)
+	createCoverageBitmap(cfg, pcs)
 	pcs = map[uint64]uint32{
 		0x81000002: 1,
 		0x81000010: 1,
 		0x81000102: 1,
 	}
-	createCoverageBitmap(target, pcs)
+	createCoverageBitmap(cfg, pcs)
 }
 
 func TestNilCoverageBitmap(t *testing.T) {
 	pcs := map[uint64]uint32(nil)
-	target := targets.Get("test", "64")
-	bitmap := createCoverageBitmap(target, pcs)
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			SysTarget: targets.Get("test", "64"),
+		},
+	}
+	bitmap := createCoverageBitmap(cfg, pcs)
 	if bitmap != nil {
 		t.Errorf("created a bitmap on nil pcs")
 	}

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -288,13 +288,13 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 			progs = append(progs, cover.Prog{
 				Sig:  sig,
 				Data: string(inp.ProgData),
-				PCs:  coverToPCs(rg, inp.Updates[updateID].RawCover),
+				PCs:  coverToPCs(mgr.cfg, inp.Updates[updateID].RawCover),
 			})
 		} else {
 			progs = append(progs, cover.Prog{
 				Sig:  sig,
 				Data: string(inp.ProgData),
-				PCs:  coverToPCs(rg, inp.Cover),
+				PCs:  coverToPCs(mgr.cfg, inp.Cover),
 			})
 		}
 	} else {
@@ -306,7 +306,7 @@ func (mgr *Manager) httpCoverCover(w http.ResponseWriter, r *http.Request, funcF
 			progs = append(progs, cover.Prog{
 				Sig:  inp.Sig,
 				Data: string(inp.ProgData),
-				PCs:  coverToPCs(rg, inp.Cover),
+				PCs:  coverToPCs(mgr.cfg, inp.Cover),
 			})
 		}
 	}

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -297,7 +297,7 @@ func (ctx *Context) dumpCallCoverage(coverFile string, info *flatrpc.CallInfo) {
 	}
 	buf := new(bytes.Buffer)
 	for _, pc := range info.Cover {
-		prev := backend.PreviousInstructionPC(ctx.sysTarget, pc)
+		prev := backend.PreviousInstructionPC(ctx.sysTarget, "", pc)
 		fmt.Fprintf(buf, "0x%x\n", prev)
 	}
 	err := osutil.WriteFile(coverFile, buf.Bytes())

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -21,11 +21,12 @@ import (
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
 )
 
 func init() {
-	vmimpl.Register("gvisor", ctor, true)
+	vmimpl.Register(targets.GVisor, ctor, true)
 }
 
 type Config struct {
@@ -146,8 +147,8 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 		tee = os.Stdout
 	}
 	merger := vmimpl.NewOutputMerger(tee)
-	merger.Add("gvisor", rpipe)
-	merger.Add("gvisor-goruntime", panicLogReadFD)
+	merger.Add("runsc", rpipe)
+	merger.Add("runsc-goruntime", panicLogReadFD)
 
 	inst := &instance{
 		cfg:      pool.cfg,

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -17,12 +17,13 @@ import (
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
 )
 
 func init() {
 	var _ vmimpl.Infoer = (*instance)(nil)
-	vmimpl.Register("starnix", ctor, true)
+	vmimpl.Register(targets.Starnix, ctor, true)
 }
 
 type Config struct {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -431,7 +431,7 @@ func TestVMType(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"gvisor", "gvisor"},
+		{targets.GVisor, targets.GVisor},
 		{"proxyapp:android", "proxyapp"},
 	}
 


### PR DESCRIPTION
Now that PCs are 64-bit we don't need RestorePC callback.
Now we can just use PreviousInstructionPC, which does not require
creation of ReportGenerator.
