### PR TITLE
all: do comparison substitution for extra coverage

### DIFF
--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -403,6 +403,9 @@ func convertExtra(extraParts []flatrpc.CallInfo, dedupCover bool) *flatrpc.CallI
 		extra.Signal[i] = uint64(s)
 		i++
 	}
+	for _, part := range extraParts {
+		extra.Comps = append(extra.Comps, part.Comps...)
+	}
 	return &extra
 }
 


### PR DESCRIPTION
Collect comparison arguments for extra coverage.
For that, we now need to start remote coverage collection for every forked program.

Substitute the arguments into all calls that have remote_cover set.

***

Do we need any special handling for the `SYZ_EXECUTOR_USES_FORK_SERVER == 0` case?