### PR TITLE
syz-manager: harden against bad fuzzer replies

### DIFF
--- a/syz-manager/rpc.go
+++ b/syz-manager/rpc.go
@@ -295,13 +295,17 @@ func (serv *RPCServer) connectionLoop(runner *Runner) error {
 		if err != nil {
 			return err
 		}
+		unpacked := raw.UnPack()
+		if unpacked.Msg == nil || unpacked.Msg.Value == nil {
+			return errors.New("received no message")
+		}
 		switch msg := raw.UnPack().Msg.Value.(type) {
 		case *flatrpc.ExecutingMessage:
 			err = serv.handleExecutingMessage(runner, msg)
 		case *flatrpc.ExecResult:
 			err = serv.handleExecResult(runner, msg)
 		default:
-			panic(fmt.Sprintf("unknown message %T", msg))
+			return fmt.Errorf("received unknown message type %T", msg)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Fuzzer memory may be corrupted, but it may contain a bug.
Don't crash on bad replies.