### PR TITLE
syz-manager: fix web interface in VM-less mode

### DIFF
--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -560,9 +560,12 @@ func (mgr *Manager) httpFilterPCs(w http.ResponseWriter, r *http.Request) {
 
 func (mgr *Manager) collectCrashes(workdir string) ([]*UICrashType, error) {
 	// Note: mu is not locked here.
-	reproReply := make(chan map[string]bool)
-	mgr.reproRequest <- reproReply
-	repros := <-reproReply
+	var repros map[string]bool
+	if !mgr.cfg.VMLess {
+		reproReply := make(chan map[string]bool)
+		mgr.reproRequest <- reproReply
+		repros = <-reproReply
+	}
 
 	crashdir := filepath.Join(workdir, "crashes")
 	dirs, err := osutil.ListDir(crashdir)


### PR DESCRIPTION
There is no VM loop an answer reproRequest, so don't wait for it.