### PR TITLE
executor: fix gvisor signal

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1015,11 +1015,11 @@ void write_coverage_signal(cover_t* cov, uint32* signal_count_pos, uint32* cover
 		bool prev_filter = true;
 		for (uint32 i = 0; i < cov->size; i++) {
 			cover_data_t pc = cover_data[i] + cov->pc_offset;
-			uint64 sig = pc & 0xFFFFFFFFFFFFF000;
+			uint64 sig = pc;
 			if (use_cover_edges(pc)) {
-				// Only hash the lower 12 bits so the hash is
-				// independent of any module offsets.
-				sig |= (pc & 0xFFF) ^ (hash(prev_pc & 0xFFF) & 0xFFF);
+				// Only hash the lower 12 bits so the hash is independent of any module offsets.
+				const uint64 mask = (1 << 12) - 1;
+				sig ^= hash(prev_pc & mask) & mask;
 			}
 			bool filter = coverage_filter(pc);
 			// Ignore the edge only if both current and previous PCs are filtered out

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -182,9 +182,11 @@ static bool use_cover_edges(uint32 pc)
 
 static bool use_cover_edges(uint64 pc)
 {
-#if defined(__i386__) || defined(__x86_64__)
+#if GOARCH_amd64 || GOARCH_arm64
 	if (is_gvisor)
 		return false; // gvisor coverage is not a trace, so producing edges won't work
+#endif
+#if GOARCH_386 || GOARCH_amd64
 	// Text/modules range for x86_64.
 	if (pc < 0xffffffff80000000ull || pc >= 0xffffffffff000000ull) {
 		debug("got bad pc: 0x%llx\n", pc);


### PR DESCRIPTION
Fix 2 bugs:
1. We remove low 12 bits of every PC on amd64 b/c use_cover_edges return true.
This results in extremly low signal (gvisor PC are dense integers).

2. We hash prev/next PC on arm64 which does not make sense
since gvisor coverage is not a trace. This results in falsely large signal.