### PR TITLE
pkg/fuzzer: separate fault injection stats

### DIFF
--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -368,7 +368,7 @@ func (job *smashJob) faultInjection(fuzzer *Fuzzer) {
 		newProg.Calls[job.call].Props.FailNth = nth
 		result := fuzzer.execute(fuzzer.smashQueue, &queue.Request{
 			Prog: newProg,
-			Stat: fuzzer.statExecSmash,
+			Stat: fuzzer.statExecFaultInject,
 		})
 		if result.Stop() {
 			return

--- a/pkg/fuzzer/stats.go
+++ b/pkg/fuzzer/stats.go
@@ -20,6 +20,7 @@ type Stats struct {
 	statExecTriage          *stats.Val
 	statExecMinimize        *stats.Val
 	statExecSmash           *stats.Val
+	statExecFaultInject     *stats.Val
 	statExecHint            *stats.Val
 	statExecSeed            *stats.Val
 	statExecCollide         *stats.Val
@@ -49,6 +50,8 @@ func newStats() Stats {
 		statExecMinimize: stats.Create("exec minimize", "Executions of programs during minimization",
 			stats.Rate{}, stats.StackedGraph("exec")),
 		statExecSmash: stats.Create("exec smash", "Executions of smashed programs",
+			stats.Rate{}, stats.StackedGraph("exec")),
+		statExecFaultInject: stats.Create("exec inject", "Executions of fault injection",
 			stats.Rate{}, stats.StackedGraph("exec")),
 		statExecHint: stats.Create("exec hints", "Executions of programs generated using hints",
 			stats.Rate{}, stats.StackedGraph("exec")),


### PR DESCRIPTION
Let exec smash describe purely the mutation part of the smash job. Introduce a separate stat for fault injection executions.
