### PR TITLE
tools: correct resolv.conf filename for  nameserver configuration

### DIFF
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -97,7 +97,7 @@ if [ "$SYZ_SYSCTL_FILE" != "" ]; then
 fi
 
 echo -en "127.0.0.1\tlocalhost\n" | sudo tee disk.mnt/etc/hosts
-echo "nameserver 8.8.8.8" | sudo tee -a disk.mnt/etc/resolve.conf
+echo "nameserver 8.8.8.8" | sudo tee -a disk.mnt/etc/resolv.conf
 echo "syzkaller" | sudo tee disk.mnt/etc/hostname
 sudo mkdir -p disk.mnt/boot/grub
 

--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -139,7 +139,7 @@ if [ "$SYZ_SYSCTL_FILE" != "" ]; then
 fi
 
 echo -en "127.0.0.1\tlocalhost\n" | sudo tee disk.mnt/etc/hosts
-echo "nameserver 8.8.8.8" | sudo tee -a disk.mnt/etc/resolve.conf
+echo "nameserver 8.8.8.8" | sudo tee -a disk.mnt/etc/resolv.conf
 echo "syzkaller" | sudo tee disk.mnt/etc/hostname
 sudo mkdir -p disk.mnt/boot/grub
 

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -172,7 +172,7 @@ echo 'securityfs /sys/kernel/security securityfs defaults 0 0' | sudo tee -a $DI
 echo 'configfs /sys/kernel/config/ configfs defaults 0 0' | sudo tee -a $DIR/etc/fstab
 echo 'binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc defaults 0 0' | sudo tee -a $DIR/etc/fstab
 echo -en "127.0.0.1\tlocalhost\n" | sudo tee $DIR/etc/hosts
-echo "nameserver 8.8.8.8" | sudo tee -a $DIR/etc/resolve.conf
+echo "nameserver 8.8.8.8" | sudo tee -a $DIR/etc/resolv.conf
 echo "syzkaller" | sudo tee $DIR/etc/hostname
 ssh-keygen -f $RELEASE.id_rsa -t rsa -N ''
 sudo mkdir -p $DIR/root/.ssh/


### PR DESCRIPTION
The name server configuration filename in the script is incorrect. Instead `/etc/resolve.conf`, it should be `/etc/resolv.conf`. Otherwise, it may lead to nameserver configuration issues.