### PR TITLE
tools/docker/syzbot: add run-syz-command.sh

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -69,3 +69,5 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 # pkg/osutil uses syzkaller user for sandboxing.
 RUN useradd --create-home syzkaller
 RUN echo "export PS1='\n\W🤖 '" >> /root/.bashrc
+
+COPY run-syz-command.sh /run-syz-command.sh

--- a/tools/docker/syzbot/run-syz-command.sh
+++ b/tools/docker/syzbot/run-syz-command.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright 2024 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+set -e # exit on any problem
+set -o pipefail
+
+syzDir=$(mktemp -d)
+
+git clone --depth 1 --branch master --single-branch \
+  https://github.com/google/syzkaller $syzDir
+cd $syzDir
+"$@"
+cd -
+rm -rf $syzDir


### PR DESCRIPTION
It enables us to use CloudRun.
The goal is to run syzkaller tools as a gcp job.

I've created gcr.io/syzkaller/syzbot-cloudrun for the testing purposes.
And it is the tool I need to periodically trigger covermerge.