### PR TITLE
few spot optimizations for executor

### DIFF
--- a/executor/common.h
+++ b/executor/common.h
@@ -658,7 +658,8 @@ static void loop(void)
 			close(kOutPipeFd);
 #endif
 			execute_one();
-#if SYZ_HAVE_CLOSE_FDS && !SYZ_THREADED
+#if !SYZ_EXECUTOR && SYZ_HAVE_CLOSE_FDS && !SYZ_THREADED
+			// Executor's execute_one has already called close_fds.
 			close_fds();
 #endif
 			doexit(0);

--- a/executor/common.h
+++ b/executor/common.h
@@ -678,9 +678,9 @@ static void loop(void)
 		uint32 executed_calls = __atomic_load_n(output_data, __ATOMIC_RELAXED);
 #endif
 		for (;;) {
+			sleep_ms(10);
 			if (waitpid(-1, &status, WNOHANG | WAIT_FLAGS) == pid)
 				break;
-			sleep_ms(1);
 #if SYZ_EXECUTOR
 			// Even though the test process executes exit at the end
 			// and execution time of each syscall is bounded by syscall_timeout_ms (~50ms),

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4818,11 +4818,16 @@ static void setup_test()
 #endif
 
 #if SYZ_EXECUTOR || SYZ_CLOSE_FDS
+#include <sys/syscall.h>
 #define SYZ_HAVE_CLOSE_FDS 1
 static void close_fds()
 {
 #if SYZ_EXECUTOR
 	if (!flag_close_fds)
+		return;
+#endif
+#ifdef SYS_close_range
+	if (!syscall(SYS_close_range, 3, MAX_FDS, 0))
 		return;
 #endif
 	// Keeping a 9p transport pipe open will hang the proccess dead,

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -41,6 +41,11 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 	struct rlimit rlim;
 	rlim.rlim_cur = rlim.rlim_max = kMaxFd;
 	setrlimit(RLIMIT_NOFILE, &rlim);
+
+	// A SIGCHLD handler makes sleep in loop exit immediately return with EINTR with a child exits.
+	struct sigaction act = {};
+	act.sa_handler = [](int) {};
+	sigaction(SIGCHLD, &act, nullptr);
 }
 
 static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -67,6 +67,11 @@ static void os_init(int argc, char** argv, char* data, size_t data_size)
 	got = mmap(data + data_size, SYZ_PAGE_SIZE, PROT_NONE, MAP_ANON | MAP_PRIVATE | MAP_FIXED, -1, 0);
 	if (data + data_size != got)
 		failmsg("mmap of right data PROT_NONE page failed", "want %p, got %p", data + data_size, got);
+
+	// A SIGCHLD handler makes sleep in loop exit immediately return with EINTR with a child exits.
+	struct sigaction act = {};
+	act.sa_handler = [](int) {};
+	sigaction(SIGCHLD, &act, nullptr);
 }
 
 static intptr_t execute_syscall(const call_t* c, intptr_t a[kMaxArgs])


### PR DESCRIPTION
- **executor: don't call close_fds twice**
- **executor: use close_range if available**
- **executor: optimize waiting for child processes exit**
