### PR TITLE
executor: map input buffer as shared

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -460,7 +460,7 @@ int main(int argc, char** argv)
 	os_init(argc, argv, (char*)SYZ_DATA_OFFSET, SYZ_NUM_PAGES * SYZ_PAGE_SIZE);
 	current_thread = &threads[0];
 
-	void* mmap_out = mmap(NULL, kMaxInput, PROT_READ, MAP_PRIVATE, kInFd, 0);
+	void* mmap_out = mmap(NULL, kMaxInput, PROT_READ, MAP_SHARED, kInFd, 0);
 	if (mmap_out == MAP_FAILED)
 		fail("mmap of input file failed");
 	input_data = static_cast<uint8*>(mmap_out);


### PR DESCRIPTION
To receive data, executor relies on changes propagating to its view of the shared memory buffer. This is only guaranteed with `MAP_SHARED`, whereas behavior is "unspecified" for `MAP_PRIVATE` (but happened to work on most implementations).

This came up as an issue when running under Starnix, which currently does not propagate changes in the `MAP_PRIVATE` case. This will likely change, but it seems that `MAP_SHARED` is the desired semantics in any case.