### PR TITLE
docs: remove mentions of strconst

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -9,7 +9,7 @@ arg = argname type
 argname = identifier
 type = typename [ "[" type-options "]" ]
 typename = "const" | "intN" | "intptr" | "flags" | "array" | "ptr" |
-	   "string" | "strconst" | "filename" | "glob" | "len" |
+	   "string" | "filename" | "glob" | "len" |
 	   "bytesize" | "bytesizeN" | "bitsize" | "vma" | "proc" |
 	   "compressed_image"
 type-options = [type-opt ["," type-opt]]

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2400,7 +2400,7 @@ static long syz_open_dev(volatile long a0, volatile long a1, volatile long a2)
 		sprintf(buf, "/dev/%s/%d:%d", a0 == 0xc ? "char" : "block", (uint8)a1, (uint8)a2);
 		return open(buf, O_RDWR, 0);
 	} else {
-		// syz_open_dev(dev strconst, id intptr, flags flags[open_flags]) fd
+		// syz_open_dev(dev ptr[in, string["/dev/foo"]], id intptr, flags flags[open_flags]) fd
 		char buf[1024];
 		char* hash;
 		strncpy(buf, (char*)a0, sizeof(buf) - 1);


### PR DESCRIPTION
strconst["foo"] was replaced by ptr[in, string["foo"]].