### PR TITLE
starnix: syz-fuzzer runs on VM and talks to syz-manager over ssh

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -732,11 +732,6 @@ func initTarget(target *Target, OS, arch string) {
 	if target.BigEndian {
 		target.HostEndian = binary.BigEndian
 	}
-	// Temporal hack.
-	if OS == Linux && os.Getenv("SYZ_STARNIX_HACK") != "" {
-		target.ExecutorUsesForkServer = false
-		target.HostFuzzer = true
-	}
 	target.initAddr2Line()
 }
 

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -137,7 +137,11 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 func (inst *instance) boot() error {
 	inst.port = vmimpl.UnusedTCPPort()
 	// Start output merger.
-	inst.merger = vmimpl.NewOutputMerger(nil)
+	var tee io.Writer
+	if inst.debug {
+		tee = os.Stdout
+	}
+	inst.merger = vmimpl.NewOutputMerger(tee)
 
 	inst.ffx("doctor", "--restart-daemon")
 


### PR DESCRIPTION
Changes:
1. Don't require adb to communicate with the starnix instance; instead, use ssh/scp.
2. After https://github.com/google/syzkaller/pull/4883, starnix can handle the standard linux fuzzing workflow. Instead of running in host fuzzer mode, push syz-fuzzer to the VM and use shared memory to communicate with syz-executor. This is much faster and eliminates the need for special timeouts for starnix.
3. Improve the log output when syz-manager is run with `-debug`, sending both syzkaller logs and the now-relatively-quiet kernel logs to stdout.

Caveats (numbers correspond to changes above):
2. Once every ~10-100 restarts, syz-manager fails to start with message "mismatching target/executor arches" (probably due to truncated RPC message reads). With `-debug` there are frequent "control pipe read fail" errors when syz-executor reads messages from syz-fuzzer.
3. When the `-debug` flag is passed, the `log` file that is generated for a crash does not look as it should. In the section for "kernel logs, not intermixed with test programs", the program texts are indeed mixed with the kernel logs. The files are fine when syz-manager is run without `-debug`. I'd guess this is okay since `-debug` is not used for real fuzzing.