### PR TITLE
syz-manager: Check GitRevisionBase length

### DIFF
--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -72,10 +72,11 @@ func (mgr *Manager) initHTTP() {
 }
 
 func (mgr *Manager) httpSummary(w http.ResponseWriter, r *http.Request) {
+	revision, link := revisionAndLink()
 	data := &UISummaryData{
 		Name:         mgr.cfg.Name,
-		Revision:     prog.GitRevisionBase[:8],
-		RevisionLink: vcs.LogLink(vcs.SyzkallerRepo, prog.GitRevisionBase),
+		Revision:     revision,
+		RevisionLink: link,
 		Expert:       mgr.expertMode,
 		Log:          log.CachedLogOutput(),
 	}
@@ -99,6 +100,20 @@ func (mgr *Manager) httpSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	executeTemplate(w, summaryTemplate, data)
+}
+
+func revisionAndLink() (string, string) {
+	var revision string
+	var link string
+	if len(prog.GitRevisionBase) > 8 {
+		revision = prog.GitRevisionBase[:8]
+		link = vcs.LogLink(vcs.SyzkallerRepo, prog.GitRevisionBase)
+	} else {
+		revision = prog.GitRevisionBase
+		link = ""
+	}
+
+	return revision, link
 }
 
 func (mgr *Manager) httpConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
In the summary page of the http server, the GitRevisionBase is truncated to 8 characters and displayed in the UI. However, when building syzkaller through other build systems, this value is not properly set and remains "unknown".

Unfortunately, "unknown" has only 7 letters, which causes the code that truncates to 8 letters to panic, and the UI page can't be shown.

To fix this without doing any more invasive changes to the logic behind how GitRevisionBase is set, we will simply check if it has more than 8 characters, and truncate it only if it does. Otherwise we will display it in full.
