### PR TITLE
pkg/stats: split out pkg/stats/sample

### DIFF
--- a/pkg/stats/sample/pvalue.go
+++ b/pkg/stats/sample/pvalue.go
@@ -1,7 +1,7 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package stats
+package sample
 
 // TODO: I didn't find the substitution as of Feb 2023. Let's keep it as is while it works.
 import "golang.org/x/perf/benchstat" // nolint:all

--- a/pkg/stats/sample/sample.go
+++ b/pkg/stats/sample/sample.go
@@ -1,8 +1,8 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-// Package stats provides various statistical operations and algorithms.
-package stats
+// Package sample provides various statistical operations and algorithms.
+package sample
 
 import (
 	"math"

--- a/pkg/stats/sample/sample_test.go
+++ b/pkg/stats/sample/sample_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package stats
+package sample
 
 import (
 	"reflect"

--- a/tools/syz-testbed/table.go
+++ b/tools/syz-testbed/table.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/syzkaller/pkg/stats"
+	"github.com/google/syzkaller/pkg/stats/sample"
 )
 
 type Cell = interface{}
@@ -25,7 +25,7 @@ type Table struct {
 
 type ValueCell struct {
 	Value         float64
-	Sample        *stats.Sample
+	Sample        *sample.Sample
 	PercentChange *float64
 	PValue        *float64
 }
@@ -39,7 +39,7 @@ type BoolCell struct {
 	Value bool
 }
 
-func NewValueCell(sample *stats.Sample) *ValueCell {
+func NewValueCell(sample *sample.Sample) *ValueCell {
 	return &ValueCell{Value: sample.Median(), Sample: sample}
 }
 
@@ -183,7 +183,7 @@ func (t *Table) SetRelativeValues(baseColumn string) error {
 			}
 
 			cellSample := valueCell.Sample.RemoveOutliers()
-			pval, err := stats.UTest(baseSample, cellSample)
+			pval, err := sample.UTest(baseSample, cellSample)
 			if err == nil {
 				// Sometimes it fails because there are too few samples.
 				valueCell.PValue = new(float64)

--- a/tools/syz-testbed/table_test.go
+++ b/tools/syz-testbed/table_test.go
@@ -6,16 +6,16 @@ package main
 import (
 	"testing"
 
-	"github.com/google/syzkaller/pkg/stats"
+	"github.com/google/syzkaller/pkg/stats/sample"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRelativeValues(t *testing.T) {
 	table := NewTable("", "A", "B")
-	table.Set("row1", "A", NewValueCell(&stats.Sample{Xs: []float64{2, 2}}))
-	table.Set("row1", "B", NewValueCell(&stats.Sample{Xs: []float64{3, 3}}))
+	table.Set("row1", "A", NewValueCell(&sample.Sample{Xs: []float64{2, 2}}))
+	table.Set("row1", "B", NewValueCell(&sample.Sample{Xs: []float64{3, 3}}))
 	// Don't set row2/A.
-	table.Set("row2", "B", NewValueCell(&stats.Sample{Xs: []float64{1, 1}}))
+	table.Set("row2", "B", NewValueCell(&sample.Sample{Xs: []float64{1, 1}}))
 
 	err := table.SetRelativeValues("A")
 	assert.NoError(t, err)


### PR DESCRIPTION
This will reduce the number of dependencies needed for the main syzkaller tools.

Cc @Mandragorian