### PR TITLE
docs/syscall_descriptions_syntax.md: remove a redundant square bracket

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -557,7 +557,7 @@ If you want to reference a field's value, you can do it via
 sub_struct {
   f0 int
   # Reference a field in a parent struct.
-  f1 int (if[value[struct:f2]]) # Same as if[value[struct:f2] != 0]].
+  f1 int (if[value[struct:f2]]) # Same as if[value[struct:f2] != 0].
 }
 
 struct {


### PR DESCRIPTION
Remove a redundant square bracket in section "Expression syntax".
