### PR TITLE
pkg/instance: don't require a syz reproducer

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -418,10 +418,10 @@ func (inst *inst) testRepro() ([]byte, error) {
 
 func (inst *inst) csourceOptions() (csource.Options, error) {
 	if len(inst.reproSyz) == 0 {
-		// This function is expected to be used only when we have a syz reproducer:
-		// either during syz reproducer testing, or during image testing
-		// for bisection or patch testing.
-		panic("no syz reproducer")
+		// If no syz repro is provided, the functionality is likely being used to test
+		// for the crashes that don't need a reproducer (e.g. kernel build/boot/test errors).
+		// Use the default options, that's the best we can do.
+		return csource.DefaultOpts(inst.cfg), nil
 	}
 	opts, err := csource.DeserializeOptions(inst.reproOpts)
 	if err != nil {


### PR DESCRIPTION
We currently panic if the syz reproducer was not provided, but it's actually a valid situation - it happens if we perform patch testing for build/boot/test errors.

Closes #4907.