### PR TITLE
pkg/fuzzer/throttler: avoid repetitive crashes

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -90,6 +90,8 @@ type NewItemEvent struct {
 }
 
 func (corpus *Corpus) Save(inp NewInput) {
+	validateCorpusProg(inp.Prog)
+
 	progData := inp.Prog.Serialize()
 	sig := hash.String(progData)
 
@@ -150,6 +152,18 @@ func (corpus *Corpus) Save(inp NewInput) {
 		}
 	}
 }
+
+func validateCorpusProg(p *prog.Prog) {
+	for _, call := range p.Calls {
+		if call.Props.Async {
+			panic("attempting to save a Async=true prog to corpus")
+		}
+		if call.Props.Skip {
+			panic("attempting to save a Skip=true prog to corpus")
+		}
+	}
+}
+
 func (corpus *Corpus) Signal() signal.Signal {
 	corpus.mu.RLock()
 	defer corpus.mu.RUnlock()

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -253,6 +253,10 @@ func (ctx *context) generateCalls(p prog.ExecProg, trace bool) ([]string, []uint
 	var calls []string
 	csumSeq := 0
 	for ci, call := range p.Calls {
+		if call.Props.Skip {
+			continue
+		}
+
 		w := new(bytes.Buffer)
 		// Copyin.
 		for _, copyin := range call.Copyin {

--- a/pkg/fuzzer/queue/queue.go
+++ b/pkg/fuzzer/queue/queue.go
@@ -42,6 +42,9 @@ type Request struct {
 	// Important requests will be retried even from crashed VMs.
 	Important bool
 
+	// Risky requests will not be retried, even if they are important.
+	Risky bool
+
 	// The callback will be called on request completion in the LIFO order.
 	// If it returns false, all further processing will be stopped.
 	// It allows wrappers to intercept Done() requests.
@@ -93,11 +96,6 @@ func (r *Request) Wait(ctx context.Context) *Result {
 	case <-r.done:
 		return r.result
 	}
-}
-
-// Risky() returns true if there's a substantial risk of the input crashing the VM.
-func (r *Request) Risky() bool {
-	return r.onceCrashed
 }
 
 func (r *Request) Validate() error {

--- a/pkg/fuzzer/queue/retry.go
+++ b/pkg/fuzzer/queue/retry.go
@@ -34,8 +34,8 @@ func (r *retryer) done(req *Request, res *Result) bool {
 		return false
 	}
 	// Retry important requests from crashed VMs once.
-	if res.Status == Crashed && req.Important && !req.onceCrashed {
-		req.onceCrashed = true
+	if res.Status == Crashed && req.Important && !req.Risky {
+		req.Risky = true
 		r.pq.Submit(req)
 		return false
 	}

--- a/pkg/fuzzer/throttler/wrapper.go
+++ b/pkg/fuzzer/throttler/wrapper.go
@@ -1,0 +1,334 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// The throttler package implements the functionality to rate limit the repetitive kernel crashes.
+
+package throttler
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/stats"
+	"github.com/google/syzkaller/prog"
+	_ "github.com/google/syzkaller/sys/targets"
+)
+
+type WrapperObject struct {
+	base     queue.Source
+	syscalls []perSyscall
+
+	disableThreshold float64
+	targetCrashRate  float64
+	maxDisabled      int
+	windowSize       int
+	newPolicyExecs   int
+	newPolicyCrashes int
+
+	statRiskyExecs     *stats.Val
+	statDeniedExecs    *stats.Val
+	statImportantExecs *stats.Val
+	statThrottledCalls *stats.Val
+
+	mu sync.Mutex
+
+	// Policy is "syscall" -> "execute it no more often than once in N executions".
+	policy        map[int]int
+	policyExecs   int
+	policyCrashes int
+
+	counter    int64 // number of executed programs.
+	nextUnsafe int64
+}
+
+type perSyscall struct {
+	crashed  atomic.Int64
+	denied   atomic.Int64
+	lastExec int64
+
+	rate weightedAvg
+}
+
+func Wrapper(baseSource queue.Source, syscalls []*prog.Syscall) *WrapperObject {
+	maxID := 0
+	for _, call := range syscalls {
+		maxID = max(maxID, call.ID)
+	}
+
+	ret := &WrapperObject{
+		base: baseSource,
+
+		// Start disabling syscalls after the risk exceeds 3%.
+		disableThreshold: 0.03,
+		// Disable no more than 10% of syscalls.
+		maxDisabled: max(1, len(syscalls)/10),
+		// Sample dangerous calls to the 0.1% crash risk.
+		targetCrashRate: 0.0005,
+		windowSize:      20,
+		// Regenerate the policy every 10k requests or every 10 new crashes.
+		newPolicyExecs:   10000,
+		newPolicyCrashes: 10,
+
+		syscalls: make([]perSyscall, maxID+1),
+		statDeniedExecs: stats.Create("denied execs", "Risky calls denied from execution",
+			stats.Rate{}, stats.StackedGraph("throttle")),
+		statRiskyExecs: stats.Create("risky execs", "Risky calls executed (exploration)",
+			stats.Rate{}, stats.StackedGraph("throttle")),
+		statImportantExecs: stats.Create("important risky execs", "Risky calls in important execs",
+			stats.Rate{}, stats.StackedGraph("throttle")),
+	}
+	ret.statThrottledCalls = stats.Create("throttled syscalls",
+		"The number of syscalls blocked by the current policy",
+		stats.Graph("throttled syscalls"),
+		func() int {
+			ret.mu.Lock()
+			defer ret.mu.Unlock()
+			return len(ret.policy)
+		})
+	return ret
+}
+
+func (w *WrapperObject) Next() *queue.Request {
+	req := w.base.Next()
+	if req == nil {
+		return nil
+	}
+	if req.Prog == nil {
+		// Ignore binaries executions.
+		return req
+	}
+
+	w.updatePolicy()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.policyExecs++
+	w.counter++
+
+	for _, call := range req.Prog.Calls {
+		id := call.Meta.ID
+		onceIn := int64(w.policy[id])
+		if onceIn == 0 {
+			continue
+		}
+
+		req.Risky = true
+		if req.Important {
+			// Don't patch important requests.
+			w.statImportantExecs.Add(1)
+			continue
+		}
+
+		mayRisk := w.nextUnsafe < w.counter
+
+		// Demand that:
+		// 1. In general, we execute an unsafe program no more often than once per the window.
+		// 2. The individual rate limits are obeyed.
+
+		info := &w.syscalls[id]
+		if mayRisk && (info.lastExec == w.counter || w.counter-info.lastExec > onceIn) {
+			w.nextUnsafe = max(w.nextUnsafe, w.counter+int64(w.windowSize+1))
+			info.lastExec = w.counter
+			w.statRiskyExecs.Add(1)
+		} else {
+			call.Props.Skip = true
+			w.syscalls[id].denied.Add(1)
+			w.statDeniedExecs.Add(1)
+		}
+	}
+	return req
+}
+
+func (w *WrapperObject) updatePolicy() {
+	w.mu.Lock()
+	update := false
+	if w.policyCrashes > w.newPolicyCrashes {
+		update = true
+		w.policyCrashes = 0
+	}
+	if w.policyExecs > w.newPolicyExecs {
+		update = true
+		w.policyExecs = 0
+	}
+	w.mu.Unlock()
+	if update {
+		policy := w.generatePolicy()
+		w.mu.Lock()
+		w.policy = policy
+		w.mu.Unlock()
+	}
+}
+
+func (w *WrapperObject) generatePolicy() map[int]int {
+	type record struct {
+		id   int
+		prob float64
+	}
+	rates := []record{}
+	for id := range w.syscalls {
+		info := &w.syscalls[id]
+		crashed := float64(info.crashed.Load())
+		if crashed < 5 {
+			// We consider everything below as still too noisy.
+			continue
+		}
+		// Only consider the syscalls that cause a high enough crash rate.
+		prob := info.rate.Get()
+		if prob > w.disableThreshold {
+			rates = append(rates, record{id, prob})
+		}
+	}
+	sort.Slice(rates, func(i, j int) bool {
+		return rates[i].prob > rates[j].prob
+	})
+
+	newPolicy := map[int]int{}
+	for _, obj := range rates[:min(len(rates), w.maxDisabled)] {
+		newPolicy[obj.id] = max(w.windowSize, int(obj.prob/w.targetCrashRate))
+	}
+	return newPolicy
+}
+
+func (w *WrapperObject) recordCalls(calls []*prog.Syscall, crashed bool) {
+	if len(calls) == 0 {
+		return
+	}
+
+	w.mu.Lock()
+	policy := w.policy
+	if crashed {
+		w.policyCrashes++
+	}
+	w.mu.Unlock()
+
+	onlyDisabled := false
+	if crashed {
+		// If we crashed and there have been already executed disabled calls,
+		// only update the information for them.
+		known := 0
+		for _, call := range calls {
+			if policy[call.ID] > 0 {
+				onlyDisabled = true
+				known++
+			}
+		}
+	}
+	for _, call := range calls {
+		if onlyDisabled && policy[call.ID] == 0 {
+			continue
+		}
+		info := &w.syscalls[call.ID]
+		if crashed {
+			info.rate.Save(1.0)
+			info.crashed.Add(1)
+		} else {
+			info.rate.Save(0)
+		}
+	}
+}
+
+func (w *WrapperObject) InstanceMonitor() InstanceMonitor {
+	return &callTracker{
+		window: make([][]*prog.Syscall, w.windowSize),
+		record: w.recordCalls,
+	}
+}
+
+type CallInfo struct {
+	Crashed   int64
+	Denied    int64
+	CrashRate float64
+	Throttled bool
+}
+
+func (w *WrapperObject) Info(call *prog.Syscall) CallInfo {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	data := &w.syscalls[call.ID]
+	return CallInfo{
+		Crashed:   data.crashed.Load(),
+		Denied:    data.denied.Load(),
+		CrashRate: data.rate.Get(),
+		Throttled: w.policy[call.ID] > 0,
+	}
+}
+
+type InstanceMonitor interface {
+	// Record() is assumed to get called once an instance starts executing a program.
+	Record(req *queue.Request)
+	// Shutdown() is expected to be called as soon as possible after the VM has crashed.
+	Shutdown(crashed bool)
+}
+
+// callTracker is a sliding window of the last executed syscalls.
+// Due to delayed crashed, we only consider a program to be unharmful after
+// the whole window has passed afterwards.
+type callTracker struct {
+	mu     sync.Mutex
+	pos    int
+	window [][]*prog.Syscall
+	record func(calls []*prog.Syscall, crashed bool)
+}
+
+func (t *callTracker) Record(req *queue.Request) {
+	if req.Prog == nil {
+		return
+	}
+	calls := make([]*prog.Syscall, 0, len(req.Prog.Calls))
+	for _, info := range req.Prog.Calls {
+		if !info.Props.Skip {
+			calls = append(calls, info.Meta)
+		}
+	}
+	var prev []*prog.Syscall
+	t.mu.Lock()
+	prev = t.window[t.pos]
+	t.window[t.pos] = calls
+	t.pos = (t.pos + 1) % len(t.window)
+	t.mu.Unlock()
+
+	t.record(prev, false)
+}
+
+func (t *callTracker) Shutdown(crashed bool) {
+	if !crashed {
+		return
+	}
+	m := map[*prog.Syscall]struct{}{}
+	for _, calls := range t.window {
+		for _, call := range calls {
+			m[call] = struct{}{}
+		}
+	}
+	var merged []*prog.Syscall
+	for call := range m {
+		merged = append(merged, call)
+	}
+	t.record(merged, true)
+}
+
+// Until we need to configure it, let it stay const.
+const weightedAvgStep = 0.005
+
+type weightedAvg struct {
+	mu    sync.Mutex
+	total int64
+	val   float64
+}
+
+func (wa *weightedAvg) Save(val float64) {
+	wa.mu.Lock()
+	defer wa.mu.Unlock()
+	wa.total++
+	step := max(weightedAvgStep, 1.0/float64(wa.total))
+	wa.val += (val - wa.val) * step
+}
+
+func (wa *weightedAvg) Get() float64 {
+	wa.mu.Lock()
+	defer wa.mu.Unlock()
+	return wa.val
+}

--- a/pkg/fuzzer/throttler/wrapper_test.go
+++ b/pkg/fuzzer/throttler/wrapper_test.go
@@ -1,0 +1,115 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package throttler
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/testutil"
+	"github.com/google/syzkaller/prog"
+	_ "github.com/google/syzkaller/sys"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThrottler(t *testing.T) {
+	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rs := testutil.RandSource(t)
+
+	var calls []*prog.Syscall
+	bad := map[*prog.Syscall]bool{}
+	for i, call := range target.Syscalls {
+		calls = append(calls, call)
+		if i <= 2 {
+			bad[call] = true
+		}
+		if i == 40 {
+			break
+		}
+	}
+
+	rnd := rand.New(rs)
+
+	// Generate random progs.
+	limit := 100000
+	base := queue.Callback(func() *queue.Request {
+		limit--
+		if limit < 0 {
+			return nil
+		}
+		return &queue.Request{
+			Prog: &prog.Prog{
+				Calls: []*prog.Call{
+					{
+						Meta: calls[rnd.Intn(len(calls))],
+					},
+				},
+			},
+		}
+	})
+
+	wrapper := Wrapper(base, calls)
+	crashes := 0
+outer:
+	for {
+		monitor := wrapper.InstanceMonitor()
+		crashIn := 10000
+		count := 0
+		for {
+			count++
+			req := wrapper.Next()
+			if req == nil {
+				break outer
+			}
+			monitor.Record(req)
+			if crashIn == 0 {
+				monitor.Shutdown(true)
+				crashes++
+				t.Logf("crashed after %d progs", count)
+				break
+			}
+			crashIn--
+			call := req.Prog.Calls[0]
+			// Fail bad calls with a 33% probability, but delay it.
+			if !call.Props.Skip && bad[call.Meta] && rnd.Intn(3) == 0 {
+				crashIn = min(crashIn, rnd.Intn(10))
+			}
+		}
+	}
+
+	t.Logf("total crashes: %v", crashes)
+	t.Logf("total risky calls run: %v", wrapper.statRiskyExecs.Val())
+	totalDenied := wrapper.statDeniedExecs.Val()
+	t.Logf("total denied calls: %v", totalDenied)
+
+	var badDenials int64
+	for _, call := range calls {
+		info := wrapper.Info(call)
+		typ := "good"
+		if bad[call] {
+			typ = "bad"
+			badDenials += info.Denied
+		}
+		if info.Throttled {
+			typ += " [IN POLICY]"
+		}
+		assert.Equal(t, bad[call], info.Throttled, "all & only bad calls must be throttled")
+		t.Logf("[%d] %s call %s: %d crashed (%.2f%%), %d denied",
+			call.ID, typ, call.Name, info.Crashed,
+			info.CrashRate*100.0, info.Denied)
+	}
+
+	// There can be 100000*(1/3)*(3/40) > 2.5k crashes if the algorithm did not work.
+	// Let's consider it a success if it finished with less than 333.
+	assert.Less(t, crashes, 333)
+
+	// Also, demand that >2/3 of all execution denials happened on the 3 bad calls.
+	assert.Greater(t, badDenials, int64(totalDenied*2/3))
+}

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -471,7 +471,7 @@ func TestSerializeCallProps(t *testing.T) {
 		},
 		{
 			"serialize0(0x0) (fail_nth: 5)\n",
-			[]CallProps{{5, false, 0}},
+			[]CallProps{{5, false, 0, false}},
 		},
 		{
 			"serialize0(0x0) (fail_nth)\n",
@@ -483,11 +483,15 @@ func TestSerializeCallProps(t *testing.T) {
 		},
 		{
 			"serialize0(0x0) (async)\n",
-			[]CallProps{{0, true, 0}},
+			[]CallProps{{0, true, 0, false}},
 		},
 		{
 			"serialize0(0x0) (async, rerun: 10)\n",
-			[]CallProps{{0, true, 10}},
+			[]CallProps{{0, true, 10, false}},
+		},
+		{
+			"serialize0(0x0) (skip)\n",
+			[]CallProps{{0, false, 0, true}},
 		},
 	}
 

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -578,13 +578,16 @@ func TestSerializeForExec(t *testing.T) {
 			`test() (fail_nth: 3)
 test() (fail_nth: 4)
 test() (async, rerun: 10)
+test() (skip)
 `,
 			[]any{
-				execInstrSetProps, 3, 0, 0,
+				execInstrSetProps, 3, 0, 0, 0,
 				callID("test"), ExecNoCopyout, 0,
-				execInstrSetProps, 4, 0, 0,
+				execInstrSetProps, 4, 0, 0, 0,
 				callID("test"), ExecNoCopyout, 0,
-				execInstrSetProps, 0, 1, 10,
+				execInstrSetProps, 0, 1, 10, 0,
+				callID("test"), ExecNoCopyout, 0,
+				execInstrSetProps, 0, 0, 0, 1,
 				callID("test"), ExecNoCopyout, 0,
 				execInstrEOF,
 			},
@@ -593,17 +596,22 @@ test() (async, rerun: 10)
 					{
 						Meta:  target.SyscallMap["test"],
 						Index: ExecNoCopyout,
-						Props: CallProps{3, false, 0},
+						Props: CallProps{3, false, 0, false},
 					},
 					{
 						Meta:  target.SyscallMap["test"],
 						Index: ExecNoCopyout,
-						Props: CallProps{4, false, 0},
+						Props: CallProps{4, false, 0, false},
 					},
 					{
 						Meta:  target.SyscallMap["test"],
 						Index: ExecNoCopyout,
-						Props: CallProps{0, true, 10},
+						Props: CallProps{0, true, 10, false},
+					},
+					{
+						Meta:  target.SyscallMap["test"],
+						Index: ExecNoCopyout,
+						Props: CallProps{0, false, 0, true},
 					},
 				},
 			},

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -35,6 +35,7 @@ type CallProps struct {
 	FailNth int  `key:"fail_nth"`
 	Async   bool `key:"async"`
 	Rerun   int  `key:"rerun"`
+	Skip    bool `key:"skip"`
 }
 
 type Call struct {


### PR DESCRIPTION
Yet another attempt to address the problem.

The changes may conflict with #4905 a bit, but the changes to the conflicting files here are actually minimal possible, so we should be able to easily rebase these PRs either way.

TODO:
- [x] Finish debugging.
- [x] Integrate with the syz-manager web UI.

***

Track the crash rate for the individual syscalls and rate limit the execution of those which happen too often.

For determining the most unsafe syscalls, let's keep a sliding window of the last executed progs on every instance.
* If a program has been evicted from the sliding window, it's safe enough.
* If an instance crashed, all programs in the window are under suspicion.

For preventing the execution of banned syscalls, let's add a special (skip) call parameter that is understood by the executor.

The parameter is not supposed to leak into the corpus, so add appropriate assertions.

