### PR TITLE
executor/linux: fix compilation error with old compilers

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4528,13 +4528,20 @@ static void remove_dir(const char* dir)
 {
 	int iter = 0;
 	DIR* dp = 0;
-retry:
+
 #if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
 	// Starting from v6.9, it does no longer make sense to use MNT_DETACH, because
 	// a loop device may only be reused in RW mode if no mounted filesystem keeps a
 	// reference to it. So we have to umount them synchronously.
 	// MNT_FORCE should hopefully prevent hangs for filesystems that may require a complex cleanup.
+	//
+	// This declaration should not be moved under retry label, since label followed by a declaration
+	// is not supported by old compilers.
 	const int umount_flags = MNT_FORCE | UMOUNT_NOFOLLOW;
+#endif
+
+retry:
+#if SYZ_EXECUTOR || !SYZ_SANDBOX_ANDROID
 #if SYZ_EXECUTOR
 	if (!flag_sandbox_android)
 #endif


### PR DESCRIPTION
My gcc-10 in testing vm compainls during reproducer [0] build with following error:

rep.c: In function ‘remove_dir’:
rep.c:662:3: error: a label can only be part of a statement and a declaration is not a statement
  662 |   const int umount_flags = MNT_FORCE | UMOUNT_NOFOLLOW;
      |   ^~~~~

Label followed by declaration is C23 extension, so only new compilers support it.

Fix it by moving declaration above `retry` label and put unused attribute to suppress possible warning.

[0] https://syzkaller.appspot.com/bug?extid=dcc068159182a4c31ca3

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
