### PR TITLE
tools/create-openbsd: bump up the limits for syz-bit

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -66,11 +66,11 @@ EOF2
   echo "starting syz-ci"
   fsck -y /dev/sd1a
   mount /syzkaller
-  su -l syzkaller <<EOF2
+  su -c vmd -l syzkaller <<EOF2
     cd /syzkaller
     export HOME=/syzkaller
     set -eux
-    ulimit -d 8000000
+    ulimit -n 1024 -d 16000000
     mkdir -p /syzkaller/go-cache
     export GOCACHE=/syzkaller/go-cache
     test -d /syzkaller/gopath/src/github.com/google/syzkaller || (


### PR DESCRIPTION
As syz-bot became much more aggressive about resource usage lately it started running over the limits and is getting blocked. Give it all the rope it wants. There's nothing else on the VM anyway.

Used the vmd class as it is given the most memory in login.conf.
