### PR TITLE
syz-manager: support stdin as port forwarding result

### DIFF
--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -765,11 +765,23 @@ static void SigsegvHandler(int sig, siginfo_t* info, void* ucontext)
 
 static void runner(char** argv, int argc)
 {
-	if (argc != 5)
-		fail("usage: syz-executor runner <name> <manager-addr> <manager-port>");
+	const char* const usage_msg = "usage: syz-executor runner <name> <manager-addr> "
+				      "<manager-port> OR syz-executor runner <name> stdin";
+	if (argc < 4 || argc > 5)
+		fail(usage_msg);
+
 	const char* const name = argv[2];
 	const char* const manager_addr = argv[3];
-	const char* const manager_port = argv[4];
+	const char* manager_port = NULL;
+
+	if (strcmp(manager_addr, "stdin") == 0) {
+		// Do not expect a port number for stdin.
+		if (argc == 5)
+			fail(usage_msg);
+	} else if (argc != 5)
+		fail(usage_msg);
+	else
+		manager_port = argv[4];
 
 	struct rlimit rlim;
 	rlim.rlim_cur = rlim.rlim_max = kFdLimit;

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -905,8 +905,12 @@ func (mgr *Manager) runInstanceInner(index int, instanceName string, injectExec 
 	mgr.bootTime.Save(time.Since(start))
 	start = time.Now()
 
-	addrPort := strings.Split(fwdAddr, ":")
-	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, instanceName, addrPort[0], addrPort[1])
+	addr := fwdAddr
+	if strings.Contains(fwdAddr, ":") {
+		addrPort := strings.Split(fwdAddr, ":")
+		addr = fmt.Sprintf("%v %v", addrPort[0], addrPort[1])
+	}
+	cmd := fmt.Sprintf("%v runner %v %v", executorBin, instanceName, addr)
 	_, rep, err := inst.Run(mgr.cfg.Timeouts.VMRunningTime, mgr.reporter, cmd,
 		vm.ExitTimeout, vm.StopChan(mgr.vmStop), vm.InjectExecuting(injectExec),
 		vm.EarlyFinishCb(func() {


### PR DESCRIPTION
It is returned by `vm/gvisor`.
