### PR TITLE
dashboard: support manual reproduction requests

### DIFF
--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -722,6 +722,15 @@ func (status BisectStatus) String() string {
 	}
 }
 
+// ReproTask is a manually requested reproduction attempt.
+type ReproTask struct {
+	Namespace    string
+	Manager      string
+	Log          int64 // Reference to CrashLog text entity.
+	AttemptsLeft int64
+	LastAttempt  time.Time
+}
+
 func mgrKey(c context.Context, ns, name string) *db.Key {
 	return db.NewKey(c, "Manager", fmt.Sprintf("%v-%v", ns, name), 0, nil)
 }

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -256,3 +256,9 @@ indexes:
   properties:
   - name: Namespace
   - name: Type
+
+- kind: ReproTask
+  properties:
+  - name: Namespace
+  - name: Manager
+  - name: AttemptsLeft

--- a/dashboard/app/manager.html
+++ b/dashboard/app/manager.html
@@ -11,7 +11,28 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 </head>
 <body>
 	{{template "header" .Header}}
-	{{optlink .Manager.Link "[Syz-Manager]"}}
+	<div>{{optlink .Manager.Link "[Syz-Manager]"}}</div><br>
+	{{if .Message}}<b>{{.Message}}</b><br>{{end}}
+	{{if .ShowReproForm}}
+	<div class="collapsible collapsible-hide">
+		<div class="head">
+			<span class="show-icon">▶</span>
+			<span class="hide-icon">▼</span>
+			<span>Send a reproducer to {{.Manager.Name}}</span>
+		</div>
+		<div class="content">
+			<div class="input-values">
+				<form method="POST">
+					<span class="input-group">
+					<textarea name="send-repro"></textarea>
+					</span>
+					<input type="submit" name="show-crashers" value="Submit"></div>
+				</form>
+			</div>
+		</div>
+	</div>
+	{{end}}
+	<br><b>Kernel images history:</b><br>
 	<table class="list_table">
 		<tr>
 			<th>Time</th>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -354,6 +354,11 @@ aside {
 	margin-bottom: 7px;
 }
 
+.input-values textarea {
+	width: 750pt;
+	height: 250pt;
+}
+
 .input-group {
 	margin-top: 7px;
 	margin-bottom: 7px;

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1791,10 +1791,14 @@ func (mgr *Manager) dashboardReproTasks() {
 			continue
 		}
 		if len(resp.CrashLog) > 0 {
+			title := resp.Title
+			if title == "" {
+				title = "repro from the dashboard"
+			}
 			mgr.externalReproQueue <- &Crash{
 				fromDashboard: true,
 				Report: &report.Report{
-					Title:  resp.Title,
+					Title:  title,
 					Output: resp.CrashLog,
 				},
 			}


### PR DESCRIPTION
As it is problematic to set up automatic bidirectional sharing of reproducer files between namespaces, let's support the ability to manually request a reproduction attempt on a specific syz-manager instance. That should help in the time being.

