### PR TITLE
pkg/compiler: 'fmt' fixes for baseless arguments

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -72,6 +72,7 @@ Mark Johnston
 Intel Corporation
  Pengfei Xu
  Yanting Jiang
+ Igor Chervatyuk
 NVIDIA Corporation & Affiliates
  Noa Osherovich
  Jason Gunthorpe

--- a/pkg/compiler/check.go
+++ b/pkg/compiler/check.go
@@ -959,25 +959,29 @@ func (comp *compiler) checkStructRecursion(checked map[string]bool, n *ast.Struc
 			Struct: name,
 			Field:  f.Name.Name,
 		})
-		comp.recurseField(checked, f.Type, path)
+		isArg := false
+		if f.Type.Ident == "fmt" {
+			isArg = true
+		}
+		comp.recurseField(checked, f.Type, path, isArg)
 		path = path[:len(path)-1]
 	}
 	checked[name] = true
 }
 
-func (comp *compiler) recurseField(checked map[string]bool, t *ast.Type, path []pathElem) {
+func (comp *compiler) recurseField(checked map[string]bool, t *ast.Type, path []pathElem, isArg bool) {
 	desc := comp.getTypeDesc(t)
 	if desc == typeStruct {
 		comp.checkStructRecursion(checked, comp.structs[t.Ident], path)
 		return
 	}
-	_, args, base := comp.getArgsBase(t, false)
+	_, args, base := comp.getArgsBase(t, isArg)
 	if desc == typePtr && base.IsOptional {
 		return // optional pointers prune recursion
 	}
 	for i, arg := range args {
 		if desc.Args[i].Type == typeArgType {
-			comp.recurseField(checked, arg, path)
+			comp.recurseField(checked, arg, path, isArg)
 		}
 	}
 }

--- a/pkg/compiler/testdata/all.txt
+++ b/pkg/compiler/testdata/all.txt
@@ -330,6 +330,8 @@ foo_fmt6(a ptr[in, fmt[dec, flags[flags_with_one_value]]])
 
 struct$fmt0 {
 	f0	fmt[dec, int8]
+	f1	fmt[hex, const[0x1]]
+	f2	fmt[oct, proc[0, 1]]
 }
 
 flags_with_one_value = 0

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -830,7 +830,7 @@ var typeFmt = &typeDesc{
 	Check: func(comp *compiler, t *ast.Type, args []*ast.Type, base prog.IntTypeCommon) {
 		desc, _, _ := comp.getArgsBase(args[1], true)
 		switch desc {
-		case typeResource, typeInt, typeLen, typeFlags, typeProc:
+		case typeResource, typeInt, typeLen, typeFlags, typeProc, typeConst:
 		default:
 			comp.error(t.Pos, "bad fmt value %v, expect an integer", args[1].Ident)
 			return


### PR DESCRIPTION
Pull request addresses two following issues:

1. 'fmt' type does not work properly with 'proc' type if used inside a structure. recurseField() compiler pass fails due to lack of type specifier in 'proc'. 
2. 'fmt' type does not work with 'const' type, despite the documentation states it should.

More detailed explanation of the issues is [here](https://groups.google.com/g/syzkaller/c/8NZ63tZ_PSo)
