### PR TITLE
dvyukov executor bsd fixes

### DIFF
--- a/executor/conn.h
+++ b/executor/conn.h
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -747,10 +747,10 @@ static void SigchldHandler(int sig)
 static void SigsegvHandler(int sig, siginfo_t* info, void* ucontext)
 {
 	// Print minimal debugging info we can extract reasonably easy.
-	auto& mctx = static_cast<ucontext_t*>(ucontext)->uc_mcontext;
-	(void)mctx;
 	uintptr_t pc = 0xdeadbeef;
 #if GOOS_linux
+	auto& mctx = static_cast<ucontext_t*>(ucontext)->uc_mcontext;
+	(void)mctx;
 #if GOARCH_amd64
 	pc = mctx.gregs[REG_RIP];
 #elif GOARCH_arm64


### PR DESCRIPTION
- **executor: use mcontext_t only on linux**
- **executor: include missing header**
