### PR TITLE
dashboard: refactor job status links

### DIFF
--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -490,18 +490,20 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				<td class="result">
 					{{if $job.ErrorLink}}
 						{{link $job.ErrorLink "error"}}
-					{{end}}
-					{{if $job.LogLink}}
-						{{link $job.LogLink "job log"}}
-						({{if $job.Commit}}1{{else}}{{len $job.Commits}}{{end}})
-					{{else if $job.CrashTitle}}
+					{{else if and $job.CrashTitle (eq $job.Type 0)}}
 						{{optlink $job.CrashReportLink "report"}}
 					{{else if formatTime $job.Finished}}
 						OK
+						{{if ne $job.Type 0}}
+							({{if $job.Commit}}1{{else}}{{len $job.Commits}}{{end}})
+						{{end}}
 					{{else if formatTime $job.Started}}
 						running
 					{{else}}
 						pending
+					{{end}}
+					{{if $job.LogLink}}
+						{{link $job.LogLink "job log"}}
 					{{end}}
 					{{if $job.CrashLogLink}}
 						{{optlink $job.CrashLogLink "log"}}


### PR DESCRIPTION
Print OK only for non-failed and non-crashed jobs. Print links to independent assets independently.
