### PR TITLE
prog: reduce amount of hint replacements

### DIFF
--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -13,17 +13,17 @@ import (
 
 type Sig [sha1.Size]byte
 
-func Hash(pieces ...[]byte) Sig {
+func Hash(pieces ...any) Sig {
 	h := sha1.New()
 	for _, data := range pieces {
-		h.Write(data)
+		binary.Write(h, binary.LittleEndian, data)
 	}
 	var sig Sig
 	copy(sig[:], h.Sum(nil))
 	return sig
 }
 
-func String(pieces ...[]byte) string {
+func String(pieces ...any) string {
 	sig := Hash(pieces...)
 	return sig.String()
 }

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -66,8 +66,8 @@ func (r *randGen) rand64() uint64 {
 var (
 	// Some potentially interesting integers.
 	specialInts = []uint64{
-		0, 1, 31, 32, 63, 64, 127, 128,
-		129, 255, 256, 257, 511, 512,
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		64, 127, 128, 129, 255, 256, 257, 511, 512,
 		1023, 1024, 1025, 2047, 2048, 4095, 4096,
 		(1 << 15) - 1, (1 << 15), (1 << 15) + 1,
 		(1 << 16) - 1, (1 << 16), (1 << 16) + 1,
@@ -153,11 +153,12 @@ func (r *randGen) biasedRand(n, k int) int {
 	return int(bf)
 }
 
+const maxArrayLen = 10
+
 func (r *randGen) randArrayLen() uint64 {
-	const maxLen = 10
 	// biasedRand produces: 10, 9, ..., 1, 0,
 	// we want: 1, 2, ..., 9, 10, 0
-	return uint64(maxLen-r.biasedRand(maxLen+1, 10)+1) % (maxLen + 1)
+	return uint64(maxArrayLen-r.biasedRand(maxArrayLen+1, 10)+1) % (maxArrayLen + 1)
 }
 
 func (r *randGen) randBufLen() (n uint64) {

--- a/prog/target.go
+++ b/prog/target.go
@@ -6,10 +6,13 @@ package prog
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/google/syzkaller/pkg/hash"
 )
 
 // Target describes target OS/arch pair.
@@ -130,6 +133,8 @@ func (target *Target) lazyInit() {
 	target.Neutralize = func(c *Call, fixStructure bool) error { return nil }
 	target.AnnotateCall = func(c ExecCall) string { return "" }
 	target.initTarget()
+	target.initUselessHints()
+	target.initRelatedFields()
 	target.initArch(target)
 	// Give these 2 known addresses fixed positions and prepend target-specific ones at the end.
 	target.SpecialPointers = append([]uint64{
@@ -178,6 +183,113 @@ func (target *Target) initTarget() {
 	target.resourceCtors = make(map[string][]ResourceCtor)
 	for _, res := range target.Resources {
 		target.resourceCtors[res.Name] = target.calcResourceCtors(res, false)
+	}
+}
+
+func (target *Target) initUselessHints() {
+	// Pre-compute useless hints for each type and deduplicate resulting maps
+	// (there will be lots of duplicates).
+	computed := make(map[Type]bool)
+	dedup := make(map[string]map[uint64]struct{})
+	ForeachType(target.Syscalls, func(t Type, ctx *TypeCtx) {
+		hinter, ok := t.(uselessHinter)
+		if !ok || computed[t] {
+			return
+		}
+		computed[t] = true
+		hints := hinter.calcUselessHints()
+		if len(hints) == 0 {
+			return
+		}
+		slices.Sort(hints)
+		hints = slices.Compact(hints)
+		sig := hash.String(hints)
+		m := dedup[sig]
+		if m == nil {
+			m = make(map[uint64]struct{})
+			for _, v := range hints {
+				m[v] = struct{}{}
+			}
+			dedup[sig] = m
+		}
+		hinter.setUselessHints(m)
+	})
+}
+
+func (target *Target) initRelatedFields() {
+	// Compute sets of related fields that are used to reduce amount of produced hint replacements.
+	// Related fields are sets of arguments to the same syscall, in the same position, that operate
+	// on the same resource. The best example of related fields is a set of ioctl commands on the same fd:
+	//
+	// 	ioctl$FOO1(fd fd_foo, cmd const[FOO1], ...)
+	// 	ioctl$FOO2(fd fd_foo, cmd const[FOO2], ...)
+	// 	ioctl$FOO3(fd fd_foo, cmd const[FOO3], ...)
+	//
+	// All cmd args related and we should not try to replace them with each other
+	// (e.g. try to morph ioctl$FOO1 into ioctl$FOO2). This is both unnecessary, leads to confusing reproducers,
+	// and in some cases to badly confused argument types, see e.g.:
+	// https://github.com/google/syzkaller/issues/502
+	// https://github.com/google/syzkaller/issues/4939
+	//
+	// However, notion of related fields is wider and includes e.g. socket syscall family/type/proto,
+	// setsockopt consts, and in some cases even openat flags/mode.
+	//
+	// Related fields can include const, flags and int types.
+	//
+	// Notion of "same resource" is also quite generic b/c syscalls can accept several resource types,
+	// and filenames/strings are also considered as a resource in this context. For example, openat syscalls
+	// that operate on the same file are related, but are not related to openat calls that operate on other files.
+	groups := make(map[string]map[Type]struct{})
+	for _, call := range target.Syscalls {
+		// Id is used to identify related syscalls.
+		// We first collect all resources/strings/files. This needs to be done first b/c e.g. mmap has
+		// fd resource at the end, so we need to do this before the next loop.
+		id := call.CallName
+		for i, field := range call.Args {
+			switch arg := field.Type.(type) {
+			case *ResourceType:
+				id += fmt.Sprintf("-%v:%v", i, arg.Name())
+			case *PtrType:
+				if typ, ok := arg.Elem.(*BufferType); ok && typ.Kind == BufferString && len(typ.Values) == 1 {
+					id += fmt.Sprintf("-%v:%v", i, typ.Values[0])
+				}
+			}
+		}
+		// Now we group const/flags args together.
+		// But also if we see a const, we update id to include it. This is required for e.g.
+		// socket/socketpair/setsockopt calls. For these calls all families can be groups, but types should be
+		// grouped only for the same family, and protocols should be grouped only for the same family+type.
+		// We assume the "more important" discriminating arguments come first (this is not necessary true,
+		// but seems to be the case in real syscalls as it's unreasonable to pass less important things first).
+		for i, field := range call.Args {
+			switch field.Type.(type) {
+			case *ConstType:
+			case *FlagsType:
+			case *IntType:
+			default:
+				continue
+			}
+			argId := fmt.Sprintf("%v/%v", id, i)
+			group := groups[argId]
+			if group == nil {
+				group = make(map[Type]struct{})
+				groups[argId] = group
+			}
+			call.Args[i].relatedFields = group
+			group[field.Type] = struct{}{}
+			switch arg := field.Type.(type) {
+			case *ConstType:
+				id += fmt.Sprintf("-%v:%v", i, arg.Val)
+			}
+		}
+	}
+	// Drop groups that consist of only a single field as they are not useful.
+	for _, call := range target.Syscalls {
+		for i := range call.Args {
+			if len(call.Args[i].relatedFields) == 1 {
+				call.Args[i].relatedFields = nil
+			}
+		}
 	}
 }
 

--- a/sys/test/related.txt
+++ b/sys/test/related.txt
@@ -1,0 +1,32 @@
+# Copyright 2024 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+ioctl(fd fd, cmd int32, arg intptr)
+ioctl$1(fd fd, cmd const[0x111], arg intptr)
+ioctl$2(fd fd, cmd const[0x222], arg intptr)
+ioctl$4(fd fd, cmd flags[ioctl_commands], arg intptr)
+
+ioctl_commands = 0x333, 0x444
+
+resource sock[fd]
+
+socket(domain flags[socket_domain], type flags[socket_type], protocol flags[socket_protocol]) sock
+socket$generic(domain int32, type int32, protocol int32) sock
+socket$inet6(domain const[0x111], type flags[socket_type], protocol const[0x10000]) sock
+socket$inet6_tcp(domain const[0x111], type const[0x1000], protocol const[0x10000]) sock
+socket$netlink(domain const[0x211], type const[0x1000], protocol flags[socket_protocol]) sock
+socket$netlink2(domain const[0x211], type const[0x1000], protocol int32) sock
+socket$netlink_foo(domain const[0x211], type const[0x1000], protocol const[0x10200]) sock
+socket$foo(domain const[0x311], type const[0x1000], protocol const[0x10200]) sock
+socket$foo2(domain const[0x311], type flags[socket_type], protocol const[0x10200]) sock
+socket$foo3(domain const[0x311], type int32, protocol const[0x10200]) sock
+socket$foo4(domain const[0x411], type int32, protocol const[0x10000]) sock
+socket$foo5(domain const[0x411], type int32, protocol int32) sock
+socket$foo6(domain int32, type int32, protocol int32) sock
+socket$foo7(domain int32, type int32, protocol int32) sock
+
+listen(fd sock)
+
+socket_domain = 0x111, 0x211, 0x311
+socket_type = 0x1000, 0x1100, 0x1200
+socket_protocol = 0x10000, 0x10100, 0x10200


### PR DESCRIPTION
Several optimizations to reduce amount of hint replacements:
1. Don't mutate int's that are <= 8 bits.
2. Don't mutate data that is <= 3 bytes.
3. Restrict mutation of len only value >10 and < 1<<20.
   Values <= 10 we can produce during normal mutation.
   Values > 1<<20 are presumably not length of something
   and we have logic to produce various large bogus lengths.
4. Include all small ints <= 16 into specialInts and remove 31, 32, 63
   (don't remember where they come from).
5. Don't produce other known flags (and combinations) for flags.

And a larger part computes groups of related arguments
so that we don't try to produce known ioctl's from other known ioctl's,
and similarly for socket/socketpair/setsockopt/etc.
See comments in Target.initRelatedFields for details.

Update #477