### PR TITLE
dvyukov coverfilter tests

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -340,6 +340,8 @@ struct cover_t {
 	uint32 mmap_alloc_size;
 	char* data;
 	char* data_end;
+	// Currently collecting comparisons.
+	bool collect_comps;
 	// Note: On everything but darwin the first value in data is the count of
 	// recorded PCs, followed by the PCs. We therefore set data_offset to the
 	// size of one PC.

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -797,5 +797,11 @@ static void runner(char** argv, int argc)
 		fail("signal(SIGBUS) failed");
 
 	Connection conn(manager_addr, manager_port);
+
+	// This is required to make Subprocess fd remapping logic work.
+	// kCoverFilterFd is the largest fd we set in the child processes.
+	for (int fd = conn.FD(); fd < kCoverFilterFd;)
+		fd = dup(fd);
+
 	Runner(conn, name, argv[0]);
 }

--- a/executor/executor_test.h
+++ b/executor/executor_test.h
@@ -43,7 +43,7 @@ extern "C" notrace void __sanitizer_cov_trace_pc(void)
 	unsigned long ip = (unsigned long)__builtin_return_address(0);
 	// Convert to what is_kernel_pc will accept as valid coverage;
 	ip = kernel_text_start | (ip & kernel_text_mask);
-	if (current_thread == nullptr || current_thread->cov.data == nullptr)
+	if (current_thread == nullptr || current_thread->cov.data == nullptr || current_thread->cov.collect_comps)
 		return;
 	unsigned long* start = (unsigned long*)current_thread->cov.data;
 	unsigned long* end = (unsigned long*)current_thread->cov.data_end;
@@ -61,6 +61,7 @@ static void cover_open(cover_t* cov, bool extra)
 
 static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
 {
+	cov->collect_comps = collect_comps;
 }
 
 static void cover_reset(cover_t* cov)

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -29,7 +29,9 @@ type LocalConfig struct {
 	// Handle ctrl+C and exit.
 	HandleInterrupts bool
 	// Run executor under gdb.
-	GDB bool
+	GDB         bool
+	MaxSignal   []uint64
+	CoverFilter []uint64
 	// RunLocal exits when the context is cancelled.
 	Context        context.Context
 	MachineChecked func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source
@@ -130,9 +132,9 @@ func (ctx *local) BugFrames() ([]string, []string) {
 }
 
 func (ctx *local) MaxSignal() signal.Signal {
-	return nil
+	return signal.FromRaw(ctx.cfg.MaxSignal, 0)
 }
 
 func (ctx *local) CoverageFilter(modules []*cover.KernelModule) []uint64 {
-	return nil
+	return ctx.cfg.CoverFilter
 }

--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -61,7 +61,7 @@ func TestZlib(t *testing.T) {
 	}
 	executor := csource.BuildExecutor(t, target, "../..")
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil)
+	startRpcserver(t, target, executor, source, nil, nil, nil)
 	r := rand.New(testutil.RandSource(t))
 	for i := 0; i < 10; i++ {
 		data := testutil.RandMountImage(r)
@@ -111,7 +111,7 @@ func TestExecutorCommonExt(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil)
+	startRpcserver(t, target, executor, source, nil, nil, nil)
 	req := &queue.Request{
 		Prog:         p,
 		ReturnError:  true,

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -385,12 +385,10 @@ func startRpcserver(t *testing.T, target *prog.Target, executor string, source q
 	cfg := &rpcserver.LocalConfig{
 		Config: rpcserver.Config{
 			Config: vminfo.Config{
-				Target:     target,
-				Debug:      *flagDebug,
-				Features:   flatrpc.AllFeatures,
-				Sandbox:    flatrpc.ExecEnvSandboxNone,
-				Cover:      true,
-				ForceCover: true,
+				Target:   target,
+				Debug:    *flagDebug,
+				Features: flatrpc.AllFeatures,
+				Sandbox:  flatrpc.ExecEnvSandboxNone,
 			},
 			Procs:    runtime.GOMAXPROCS(0),
 			Slowdown: 10, // to deflake slower tests
@@ -404,6 +402,7 @@ func startRpcserver(t *testing.T, target *prog.Target, executor string, source q
 		if machineChecked != nil {
 			machineChecked(features)
 		}
+		cfg.Cover = true
 		return source
 	}
 	errc := make(chan error)

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -386,6 +386,7 @@ func startRpcserver(t *testing.T, target *prog.Target, executor string, source q
 		Config: rpcserver.Config{
 			Config: vminfo.Config{
 				Target:   target,
+				Cover:    true,
 				Debug:    *flagDebug,
 				Features: flatrpc.AllFeatures,
 				Sandbox:  flatrpc.ExecEnvSandboxNone,
@@ -402,7 +403,6 @@ func startRpcserver(t *testing.T, target *prog.Target, executor string, source q
 		if machineChecked != nil {
 			machineChecked(features)
 		}
-		cfg.Cover = true
 		return source
 	}
 	errc := make(chan error)

--- a/pkg/vminfo/features.go
+++ b/pkg/vminfo/features.go
@@ -113,7 +113,7 @@ func (ctx *checkContext) finishFeatures(featureInfos []*flatrpc.FeatureInfo) (Fe
 	if feat := features[flatrpc.FeatureSandboxNone]; !feat.Enabled {
 		return features, fmt.Errorf("execution of simple program fails: %v", feat.Reason)
 	}
-	if feat := features[flatrpc.FeatureCoverage]; ctx.cfg.Cover && !ctx.cfg.ForceCover && !feat.Enabled {
+	if feat := features[flatrpc.FeatureCoverage]; ctx.cfg.Cover && !feat.Enabled {
 		return features, fmt.Errorf("coverage is not supported: %v", feat.Reason)
 	}
 	return features, nil

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -43,7 +43,6 @@ type Config struct {
 	Syscalls   []int
 	Debug      bool
 	Cover      bool
-	ForceCover bool // Pretend that the coverage is supported. We need it in pkg/runtest.
 	Sandbox    flatrpc.ExecEnv
 	SandboxArg int64
 }


### PR DESCRIPTION
- **executor: fix max signal/cover filter mapping into subprocesses**
- **executor: don't trace PCs as comparisons**
- **executor: always return some coverage for test OS**
- **pkg/runtest: add tests for max signal and cover filter**
