### PR TITLE
pkg/rpcserver: move kernel test/data range checks from executor

### DIFF
--- a/executor/common_test.h
+++ b/executor/common_test.h
@@ -170,7 +170,7 @@ static long syz_test_fuzzer1(volatile long a, volatile long b, volatile long c)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_inject_cover
-static long syz_inject_cover(volatile long a, volatile long b, volatile long c)
+static long syz_inject_cover(volatile long a, volatile long b)
 #if SYZ_EXECUTOR
     ; // defined in executor_test.h
 #else

--- a/executor/cover_filter.h
+++ b/executor/cover_filter.h
@@ -44,12 +44,6 @@ public:
 		byte |= bit;
 	}
 
-	void Remove(uint64 pc)
-	{
-		auto [byte, bit] = FindByte(pc, true);
-		byte &= ~bit;
-	}
-
 	bool Contains(uint64 pc)
 	{
 		auto [byte, bit] = FindByte(pc, false);

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -179,21 +179,6 @@ static void cover_collect(cover_t* cov)
 	cov->size = *(uint64*)cov->data;
 }
 
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}
-
 #if GOOS_netbsd
 #define SYZ_HAVE_FEATURES 1
 static feature_t features[] = {

--- a/executor/executor_darwin.h
+++ b/executor/executor_darwin.h
@@ -121,18 +121,3 @@ static void cover_collect(cover_t* cov)
 	cov->data_offset = ((int64_t) & (trace->pcs)) - ((int64_t)(cov->data));
 	cov->pc_offset = trace->offset;
 }
-
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -628,13 +628,11 @@ private:
 
 	void Handle(const rpc::SignalUpdateRawT& msg)
 	{
-		debug("recv signal update: new=%zu drop=%zu\n", msg.new_max.size(), msg.drop_max.size());
+		debug("recv signal update: new=%zu\n", msg.new_max.size());
 		if (!max_signal_)
 			fail("signal update when no signal filter installed");
 		for (auto pc : msg.new_max)
 			max_signal_->Insert(pc);
-		for (auto pc : msg.drop_max)
-			max_signal_->Remove(pc);
 	}
 
 	void Handle(const rpc::StartLeakChecksRawT& msg)

--- a/executor/nocover.h
+++ b/executor/nocover.h
@@ -28,18 +28,3 @@ static void cover_mmap(cover_t* cov)
 static void cover_unprotect(cover_t* cov)
 {
 }
-
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}

--- a/executor/test.h
+++ b/executor/test.h
@@ -269,13 +269,6 @@ static int test_cover_filter()
 			ret = 1;
 		}
 	}
-
-	filter.Remove(105);
-	if (filter.Contains(104) || filter.Contains(105) || filter.Contains(111))
-		printf("filter contains 105 after removal\n");
-	if (!filter.Contains(103))
-		printf("filter doesn't contains 103 after 105 removal\n");
-
 	return ret;
 }
 

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -162,7 +162,6 @@ table ExecRequestRaw {
 
 table SignalUpdateRaw {
 	new_max			:[uint64];
-	drop_max		:[uint64];
 }
 
 // Leak checking is very slow so we don't do it while triaging the corpus

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -37,6 +37,8 @@ table ConnectRequestRaw {
 table ConnectReplyRaw {
 	debug			:bool;
 	cover			:bool;
+	cover_edges		:bool;
+	kernel_64_bit		:bool;
 	procs			:int32;
 	slowdown		:int32;
 	syscall_timeout_ms	:int32;

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -2025,8 +2025,7 @@ func ExecRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 }
 
 type SignalUpdateRawT struct {
-	NewMax  []uint64 `json:"new_max"`
-	DropMax []uint64 `json:"drop_max"`
+	NewMax []uint64 `json:"new_max"`
 }
 
 func (t *SignalUpdateRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
@@ -2042,18 +2041,8 @@ func (t *SignalUpdateRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 		}
 		newMaxOffset = builder.EndVector(newMaxLength)
 	}
-	dropMaxOffset := flatbuffers.UOffsetT(0)
-	if t.DropMax != nil {
-		dropMaxLength := len(t.DropMax)
-		SignalUpdateRawStartDropMaxVector(builder, dropMaxLength)
-		for j := dropMaxLength - 1; j >= 0; j-- {
-			builder.PrependUint64(t.DropMax[j])
-		}
-		dropMaxOffset = builder.EndVector(dropMaxLength)
-	}
 	SignalUpdateRawStart(builder)
 	SignalUpdateRawAddNewMax(builder, newMaxOffset)
-	SignalUpdateRawAddDropMax(builder, dropMaxOffset)
 	return SignalUpdateRawEnd(builder)
 }
 
@@ -2062,11 +2051,6 @@ func (rcv *SignalUpdateRaw) UnPackTo(t *SignalUpdateRawT) {
 	t.NewMax = make([]uint64, newMaxLength)
 	for j := 0; j < newMaxLength; j++ {
 		t.NewMax[j] = rcv.NewMax(j)
-	}
-	dropMaxLength := rcv.DropMaxLength()
-	t.DropMax = make([]uint64, dropMaxLength)
-	for j := 0; j < dropMaxLength; j++ {
-		t.DropMax[j] = rcv.DropMax(j)
 	}
 }
 
@@ -2132,45 +2116,13 @@ func (rcv *SignalUpdateRaw) MutateNewMax(j int, n uint64) bool {
 	return false
 }
 
-func (rcv *SignalUpdateRaw) DropMax(j int) uint64 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		a := rcv._tab.Vector(o)
-		return rcv._tab.GetUint64(a + flatbuffers.UOffsetT(j*8))
-	}
-	return 0
-}
-
-func (rcv *SignalUpdateRaw) DropMaxLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		return rcv._tab.VectorLen(o)
-	}
-	return 0
-}
-
-func (rcv *SignalUpdateRaw) MutateDropMax(j int, n uint64) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		a := rcv._tab.Vector(o)
-		return rcv._tab.MutateUint64(a+flatbuffers.UOffsetT(j*8), n)
-	}
-	return false
-}
-
 func SignalUpdateRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(2)
+	builder.StartObject(1)
 }
 func SignalUpdateRawAddNewMax(builder *flatbuffers.Builder, newMax flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(newMax), 0)
 }
 func SignalUpdateRawStartNewMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
-	return builder.StartVector(8, numElems, 8)
-}
-func SignalUpdateRawAddDropMax(builder *flatbuffers.Builder, dropMax flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(dropMax), 0)
-}
-func SignalUpdateRawStartDropMaxVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(8, numElems, 8)
 }
 func SignalUpdateRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -509,6 +509,8 @@ func ConnectRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 type ConnectReplyRawT struct {
 	Debug            bool     `json:"debug"`
 	Cover            bool     `json:"cover"`
+	CoverEdges       bool     `json:"cover_edges"`
+	Kernel64Bit      bool     `json:"kernel_64_bit"`
 	Procs            int32    `json:"procs"`
 	Slowdown         int32    `json:"slowdown"`
 	SyscallTimeoutMs int32    `json:"syscall_timeout_ms"`
@@ -579,6 +581,8 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 	ConnectReplyRawStart(builder)
 	ConnectReplyRawAddDebug(builder, t.Debug)
 	ConnectReplyRawAddCover(builder, t.Cover)
+	ConnectReplyRawAddCoverEdges(builder, t.CoverEdges)
+	ConnectReplyRawAddKernel64Bit(builder, t.Kernel64Bit)
 	ConnectReplyRawAddProcs(builder, t.Procs)
 	ConnectReplyRawAddSlowdown(builder, t.Slowdown)
 	ConnectReplyRawAddSyscallTimeoutMs(builder, t.SyscallTimeoutMs)
@@ -594,6 +598,8 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 func (rcv *ConnectReplyRaw) UnPackTo(t *ConnectReplyRawT) {
 	t.Debug = rcv.Debug()
 	t.Cover = rcv.Cover()
+	t.CoverEdges = rcv.CoverEdges()
+	t.Kernel64Bit = rcv.Kernel64Bit()
 	t.Procs = rcv.Procs()
 	t.Slowdown = rcv.Slowdown()
 	t.SyscallTimeoutMs = rcv.SyscallTimeoutMs()
@@ -681,31 +687,31 @@ func (rcv *ConnectReplyRaw) MutateCover(n bool) bool {
 	return rcv._tab.MutateBoolSlot(6, n)
 }
 
-func (rcv *ConnectReplyRaw) Procs() int32 {
+func (rcv *ConnectReplyRaw) CoverEdges() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
 	}
-	return 0
+	return false
 }
 
-func (rcv *ConnectReplyRaw) MutateProcs(n int32) bool {
-	return rcv._tab.MutateInt32Slot(8, n)
+func (rcv *ConnectReplyRaw) MutateCoverEdges(n bool) bool {
+	return rcv._tab.MutateBoolSlot(8, n)
 }
 
-func (rcv *ConnectReplyRaw) Slowdown() int32 {
+func (rcv *ConnectReplyRaw) Kernel64Bit() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
 	}
-	return 0
+	return false
 }
 
-func (rcv *ConnectReplyRaw) MutateSlowdown(n int32) bool {
-	return rcv._tab.MutateInt32Slot(10, n)
+func (rcv *ConnectReplyRaw) MutateKernel64Bit(n bool) bool {
+	return rcv._tab.MutateBoolSlot(10, n)
 }
 
-func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
+func (rcv *ConnectReplyRaw) Procs() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -713,11 +719,11 @@ func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
 	return 0
 }
 
-func (rcv *ConnectReplyRaw) MutateSyscallTimeoutMs(n int32) bool {
+func (rcv *ConnectReplyRaw) MutateProcs(n int32) bool {
 	return rcv._tab.MutateInt32Slot(12, n)
 }
 
-func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
+func (rcv *ConnectReplyRaw) Slowdown() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -725,12 +731,36 @@ func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
 	return 0
 }
 
-func (rcv *ConnectReplyRaw) MutateProgramTimeoutMs(n int32) bool {
+func (rcv *ConnectReplyRaw) MutateSlowdown(n int32) bool {
 	return rcv._tab.MutateInt32Slot(14, n)
 }
 
-func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
+func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) MutateSyscallTimeoutMs(n int32) bool {
+	return rcv._tab.MutateInt32Slot(16, n)
+}
+
+func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) MutateProgramTimeoutMs(n int32) bool {
+	return rcv._tab.MutateInt32Slot(18, n)
+}
+
+func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -739,7 +769,7 @@ func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) LeakFramesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -747,7 +777,7 @@ func (rcv *ConnectReplyRaw) LeakFramesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) RaceFrames(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -756,7 +786,7 @@ func (rcv *ConnectReplyRaw) RaceFrames(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) RaceFramesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -764,7 +794,7 @@ func (rcv *ConnectReplyRaw) RaceFramesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) Features() Feature {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
 	if o != 0 {
 		return Feature(rcv._tab.GetUint64(o + rcv._tab.Pos))
 	}
@@ -772,11 +802,11 @@ func (rcv *ConnectReplyRaw) Features() Feature {
 }
 
 func (rcv *ConnectReplyRaw) MutateFeatures(n Feature) bool {
-	return rcv._tab.MutateUint64Slot(20, uint64(n))
+	return rcv._tab.MutateUint64Slot(24, uint64(n))
 }
 
 func (rcv *ConnectReplyRaw) Files(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -785,7 +815,7 @@ func (rcv *ConnectReplyRaw) Files(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) FilesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -793,7 +823,7 @@ func (rcv *ConnectReplyRaw) FilesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) Globs(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -802,7 +832,7 @@ func (rcv *ConnectReplyRaw) Globs(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) GlobsLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -810,7 +840,7 @@ func (rcv *ConnectReplyRaw) GlobsLength() int {
 }
 
 func ConnectReplyRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(11)
+	builder.StartObject(13)
 }
 func ConnectReplyRawAddDebug(builder *flatbuffers.Builder, debug bool) {
 	builder.PrependBoolSlot(0, debug, false)
@@ -818,41 +848,47 @@ func ConnectReplyRawAddDebug(builder *flatbuffers.Builder, debug bool) {
 func ConnectReplyRawAddCover(builder *flatbuffers.Builder, cover bool) {
 	builder.PrependBoolSlot(1, cover, false)
 }
+func ConnectReplyRawAddCoverEdges(builder *flatbuffers.Builder, coverEdges bool) {
+	builder.PrependBoolSlot(2, coverEdges, false)
+}
+func ConnectReplyRawAddKernel64Bit(builder *flatbuffers.Builder, kernel64Bit bool) {
+	builder.PrependBoolSlot(3, kernel64Bit, false)
+}
 func ConnectReplyRawAddProcs(builder *flatbuffers.Builder, procs int32) {
-	builder.PrependInt32Slot(2, procs, 0)
+	builder.PrependInt32Slot(4, procs, 0)
 }
 func ConnectReplyRawAddSlowdown(builder *flatbuffers.Builder, slowdown int32) {
-	builder.PrependInt32Slot(3, slowdown, 0)
+	builder.PrependInt32Slot(5, slowdown, 0)
 }
 func ConnectReplyRawAddSyscallTimeoutMs(builder *flatbuffers.Builder, syscallTimeoutMs int32) {
-	builder.PrependInt32Slot(4, syscallTimeoutMs, 0)
+	builder.PrependInt32Slot(6, syscallTimeoutMs, 0)
 }
 func ConnectReplyRawAddProgramTimeoutMs(builder *flatbuffers.Builder, programTimeoutMs int32) {
-	builder.PrependInt32Slot(5, programTimeoutMs, 0)
+	builder.PrependInt32Slot(7, programTimeoutMs, 0)
 }
 func ConnectReplyRawAddLeakFrames(builder *flatbuffers.Builder, leakFrames flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(leakFrames), 0)
+	builder.PrependUOffsetTSlot(8, flatbuffers.UOffsetT(leakFrames), 0)
 }
 func ConnectReplyRawStartLeakFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddRaceFrames(builder *flatbuffers.Builder, raceFrames flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(raceFrames), 0)
+	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(raceFrames), 0)
 }
 func ConnectReplyRawStartRaceFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddFeatures(builder *flatbuffers.Builder, features Feature) {
-	builder.PrependUint64Slot(8, uint64(features), 0)
+	builder.PrependUint64Slot(10, uint64(features), 0)
 }
 func ConnectReplyRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(files), 0)
+	builder.PrependUOffsetTSlot(11, flatbuffers.UOffsetT(files), 0)
 }
 func ConnectReplyRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(globs), 0)
+	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(globs), 0)
 }
 func ConnectReplyRawStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -1752,28 +1752,21 @@ flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(flatbuffers::FlatBuffer
 struct SignalUpdateRawT : public flatbuffers::NativeTable {
   typedef SignalUpdateRaw TableType;
   std::vector<uint64_t> new_max{};
-  std::vector<uint64_t> drop_max{};
 };
 
 struct SignalUpdateRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SignalUpdateRawT NativeTableType;
   typedef SignalUpdateRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_NEW_MAX = 4,
-    VT_DROP_MAX = 6
+    VT_NEW_MAX = 4
   };
   const flatbuffers::Vector<uint64_t> *new_max() const {
     return GetPointer<const flatbuffers::Vector<uint64_t> *>(VT_NEW_MAX);
-  }
-  const flatbuffers::Vector<uint64_t> *drop_max() const {
-    return GetPointer<const flatbuffers::Vector<uint64_t> *>(VT_DROP_MAX);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NEW_MAX) &&
            verifier.VerifyVector(new_max()) &&
-           VerifyOffset(verifier, VT_DROP_MAX) &&
-           verifier.VerifyVector(drop_max()) &&
            verifier.EndTable();
   }
   SignalUpdateRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -1788,9 +1781,6 @@ struct SignalUpdateRawBuilder {
   void add_new_max(flatbuffers::Offset<flatbuffers::Vector<uint64_t>> new_max) {
     fbb_.AddOffset(SignalUpdateRaw::VT_NEW_MAX, new_max);
   }
-  void add_drop_max(flatbuffers::Offset<flatbuffers::Vector<uint64_t>> drop_max) {
-    fbb_.AddOffset(SignalUpdateRaw::VT_DROP_MAX, drop_max);
-  }
   explicit SignalUpdateRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -1804,24 +1794,19 @@ struct SignalUpdateRawBuilder {
 
 inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<uint64_t>> new_max = 0,
-    flatbuffers::Offset<flatbuffers::Vector<uint64_t>> drop_max = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint64_t>> new_max = 0) {
   SignalUpdateRawBuilder builder_(_fbb);
-  builder_.add_drop_max(drop_max);
   builder_.add_new_max(new_max);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<uint64_t> *new_max = nullptr,
-    const std::vector<uint64_t> *drop_max = nullptr) {
+    const std::vector<uint64_t> *new_max = nullptr) {
   auto new_max__ = new_max ? _fbb.CreateVector<uint64_t>(*new_max) : 0;
-  auto drop_max__ = drop_max ? _fbb.CreateVector<uint64_t>(*drop_max) : 0;
   return rpc::CreateSignalUpdateRaw(
       _fbb,
-      new_max__,
-      drop_max__);
+      new_max__);
 }
 
 flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -2789,7 +2774,6 @@ inline void SignalUpdateRaw::UnPackTo(SignalUpdateRawT *_o, const flatbuffers::r
   (void)_o;
   (void)_resolver;
   { auto _e = new_max(); if (_e) { _o->new_max.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->new_max[_i] = _e->Get(_i); } } }
-  { auto _e = drop_max(); if (_e) { _o->drop_max.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->drop_max[_i] = _e->Get(_i); } } }
 }
 
 inline flatbuffers::Offset<SignalUpdateRaw> SignalUpdateRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const SignalUpdateRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2801,11 +2785,9 @@ inline flatbuffers::Offset<SignalUpdateRaw> CreateSignalUpdateRaw(flatbuffers::F
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const SignalUpdateRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _new_max = _o->new_max.size() ? _fbb.CreateVector(_o->new_max) : 0;
-  auto _drop_max = _o->drop_max.size() ? _fbb.CreateVector(_o->drop_max) : 0;
   return rpc::CreateSignalUpdateRaw(
       _fbb,
-      _new_max,
-      _drop_max);
+      _new_max);
 }
 
 inline StartLeakChecksRawT *StartLeakChecksRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -807,6 +807,8 @@ struct ConnectReplyRawT : public flatbuffers::NativeTable {
   typedef ConnectReplyRaw TableType;
   bool debug = false;
   bool cover = false;
+  bool cover_edges = false;
+  bool kernel_64_bit = false;
   int32_t procs = 0;
   int32_t slowdown = 0;
   int32_t syscall_timeout_ms = 0;
@@ -824,21 +826,29 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_DEBUG = 4,
     VT_COVER = 6,
-    VT_PROCS = 8,
-    VT_SLOWDOWN = 10,
-    VT_SYSCALL_TIMEOUT_MS = 12,
-    VT_PROGRAM_TIMEOUT_MS = 14,
-    VT_LEAK_FRAMES = 16,
-    VT_RACE_FRAMES = 18,
-    VT_FEATURES = 20,
-    VT_FILES = 22,
-    VT_GLOBS = 24
+    VT_COVER_EDGES = 8,
+    VT_KERNEL_64_BIT = 10,
+    VT_PROCS = 12,
+    VT_SLOWDOWN = 14,
+    VT_SYSCALL_TIMEOUT_MS = 16,
+    VT_PROGRAM_TIMEOUT_MS = 18,
+    VT_LEAK_FRAMES = 20,
+    VT_RACE_FRAMES = 22,
+    VT_FEATURES = 24,
+    VT_FILES = 26,
+    VT_GLOBS = 28
   };
   bool debug() const {
     return GetField<uint8_t>(VT_DEBUG, 0) != 0;
   }
   bool cover() const {
     return GetField<uint8_t>(VT_COVER, 0) != 0;
+  }
+  bool cover_edges() const {
+    return GetField<uint8_t>(VT_COVER_EDGES, 0) != 0;
+  }
+  bool kernel_64_bit() const {
+    return GetField<uint8_t>(VT_KERNEL_64_BIT, 0) != 0;
   }
   int32_t procs() const {
     return GetField<int32_t>(VT_PROCS, 0);
@@ -871,6 +881,8 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_DEBUG, 1) &&
            VerifyField<uint8_t>(verifier, VT_COVER, 1) &&
+           VerifyField<uint8_t>(verifier, VT_COVER_EDGES, 1) &&
+           VerifyField<uint8_t>(verifier, VT_KERNEL_64_BIT, 1) &&
            VerifyField<int32_t>(verifier, VT_PROCS, 4) &&
            VerifyField<int32_t>(verifier, VT_SLOWDOWN, 4) &&
            VerifyField<int32_t>(verifier, VT_SYSCALL_TIMEOUT_MS, 4) &&
@@ -904,6 +916,12 @@ struct ConnectReplyRawBuilder {
   }
   void add_cover(bool cover) {
     fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_COVER, static_cast<uint8_t>(cover), 0);
+  }
+  void add_cover_edges(bool cover_edges) {
+    fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_COVER_EDGES, static_cast<uint8_t>(cover_edges), 0);
+  }
+  void add_kernel_64_bit(bool kernel_64_bit) {
+    fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_KERNEL_64_BIT, static_cast<uint8_t>(kernel_64_bit), 0);
   }
   void add_procs(int32_t procs) {
     fbb_.AddElement<int32_t>(ConnectReplyRaw::VT_PROCS, procs, 0);
@@ -947,6 +965,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool debug = false,
     bool cover = false,
+    bool cover_edges = false,
+    bool kernel_64_bit = false,
     int32_t procs = 0,
     int32_t slowdown = 0,
     int32_t syscall_timeout_ms = 0,
@@ -966,6 +986,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
   builder_.add_syscall_timeout_ms(syscall_timeout_ms);
   builder_.add_slowdown(slowdown);
   builder_.add_procs(procs);
+  builder_.add_kernel_64_bit(kernel_64_bit);
+  builder_.add_cover_edges(cover_edges);
   builder_.add_cover(cover);
   builder_.add_debug(debug);
   return builder_.Finish();
@@ -975,6 +997,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool debug = false,
     bool cover = false,
+    bool cover_edges = false,
+    bool kernel_64_bit = false,
     int32_t procs = 0,
     int32_t slowdown = 0,
     int32_t syscall_timeout_ms = 0,
@@ -992,6 +1016,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
       _fbb,
       debug,
       cover,
+      cover_edges,
+      kernel_64_bit,
       procs,
       slowdown,
       syscall_timeout_ms,
@@ -2431,6 +2457,8 @@ inline void ConnectReplyRaw::UnPackTo(ConnectReplyRawT *_o, const flatbuffers::r
   (void)_resolver;
   { auto _e = debug(); _o->debug = _e; }
   { auto _e = cover(); _o->cover = _e; }
+  { auto _e = cover_edges(); _o->cover_edges = _e; }
+  { auto _e = kernel_64_bit(); _o->kernel_64_bit = _e; }
   { auto _e = procs(); _o->procs = _e; }
   { auto _e = slowdown(); _o->slowdown = _e; }
   { auto _e = syscall_timeout_ms(); _o->syscall_timeout_ms = _e; }
@@ -2452,6 +2480,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::F
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectReplyRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _debug = _o->debug;
   auto _cover = _o->cover;
+  auto _cover_edges = _o->cover_edges;
+  auto _kernel_64_bit = _o->kernel_64_bit;
   auto _procs = _o->procs;
   auto _slowdown = _o->slowdown;
   auto _syscall_timeout_ms = _o->syscall_timeout_ms;
@@ -2465,6 +2495,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::F
       _fbb,
       _debug,
       _cover,
+      _cover_edges,
+      _kernel_64_bit,
       _procs,
       _slowdown,
       _syscall_timeout_ms,

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -366,18 +366,6 @@ func (fuzzer *Fuzzer) logCurrentStats() {
 	}
 }
 
-func (fuzzer *Fuzzer) RotateMaxSignal(items int) {
-	corpusSignal := fuzzer.Config.Corpus.Signal()
-	pureMaxSignal := fuzzer.Cover.pureMaxSignal(corpusSignal)
-	if pureMaxSignal.Len() < items {
-		items = pureMaxSignal.Len()
-	}
-	fuzzer.Logf(1, "rotate %d max signal elements", items)
-
-	delta := pureMaxSignal.RandomSubset(fuzzer.rand(), items)
-	fuzzer.Cover.subtract(delta)
-}
-
 func setFlags(execFlags flatrpc.ExecFlag) flatrpc.ExecOpts {
 	return flatrpc.ExecOpts{
 		ExecFlags: execFlags,

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -123,8 +123,21 @@ func (job *triageJob) handleCall(call int, info *triageCall) {
 		job.fuzzer.startJob(job.fuzzer.statJobsSmash, &smashJob{
 			exec: job.fuzzer.smashQueue,
 			p:    p.Clone(),
-			call: call,
 		})
+		if job.fuzzer.Config.Comparisons && call >= 0 {
+			job.fuzzer.startJob(job.fuzzer.statJobsHints, &hintsJob{
+				exec: job.fuzzer.hintsQueue.Append(),
+				p:    p.Clone(),
+				call: call,
+			})
+		}
+		if job.fuzzer.Config.FaultInjection && call >= 0 {
+			job.fuzzer.startJob(job.fuzzer.statJobsFaultInjection, &faultInjectionJob{
+				exec: job.fuzzer.hintsQueue.Append(),
+				p:    p.Clone(),
+				call: call,
+			})
+		}
 	}
 	job.fuzzer.Logf(2, "added new input for %v to the corpus: %s", callName, p)
 	input := corpus.NewInput{
@@ -301,15 +314,8 @@ type smashJob struct {
 
 func (job *smashJob) run(fuzzer *Fuzzer) {
 	fuzzer.Logf(2, "smashing the program %s (call=%d):", job.p, job.call)
-	if fuzzer.Config.Comparisons && job.call >= 0 {
-		fuzzer.startJob(fuzzer.statJobsHints, &hintsJob{
-			exec: fuzzer.smashQueue,
-			p:    job.p.Clone(),
-			call: job.call,
-		})
-	}
 
-	const iters = 75
+	const iters = 25
 	rnd := fuzzer.rand()
 	for i := 0; i < iters; i++ {
 		p := job.p.Clone()
@@ -325,18 +331,6 @@ func (job *smashJob) run(fuzzer *Fuzzer) {
 		if result.Stop() {
 			return
 		}
-		if fuzzer.Config.Collide {
-			result := fuzzer.execute(job.exec, &queue.Request{
-				Prog: randomCollide(p, rnd),
-				Stat: fuzzer.statExecCollide,
-			})
-			if result.Stop() {
-				return
-			}
-		}
-	}
-	if fuzzer.Config.FaultInjection && job.call >= 0 {
-		job.faultInjection(fuzzer)
 	}
 }
 
@@ -362,7 +356,13 @@ func randomCollide(origP *prog.Prog, rnd *rand.Rand) *prog.Prog {
 	return p
 }
 
-func (job *smashJob) faultInjection(fuzzer *Fuzzer) {
+type faultInjectionJob struct {
+	exec queue.Executor
+	p    *prog.Prog
+	call int
+}
+
+func (job *faultInjectionJob) run(fuzzer *Fuzzer) {
 	for nth := 1; nth <= 100; nth++ {
 		fuzzer.Logf(2, "injecting fault into call %v, step %v",
 			job.call, nth)

--- a/pkg/fuzzer/job_test.go
+++ b/pkg/fuzzer/job_test.go
@@ -77,6 +77,7 @@ func TestDeflake(t *testing.T) {
 
 	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64Fuzz)
 	assert.NoError(t, err)
+	const anyTestProg = `syz_compare(&AUTO="00000000", 0x4, &AUTO=@conditional={0x0, @void, @void}, AUTO)`
 	prog, err := target.Deserialize([]byte(anyTestProg), prog.NonStrict)
 	assert.NoError(t, err)
 

--- a/pkg/fuzzer/stats.go
+++ b/pkg/fuzzer/stats.go
@@ -12,6 +12,7 @@ type Stats struct {
 	statJobsTriage          *stats.Val
 	statJobsTriageCandidate *stats.Val
 	statJobsSmash           *stats.Val
+	statJobsFaultInjection  *stats.Val
 	statJobsHints           *stats.Val
 	statExecTime            *stats.Val
 	statExecGenerate        *stats.Val
@@ -36,9 +37,10 @@ func newStats() Stats {
 		statJobsTriage: stats.Create("triage jobs", "Running triage jobs", stats.StackedGraph("jobs")),
 		statJobsTriageCandidate: stats.Create("candidate triage jobs", "Running candidate triage jobs",
 			stats.StackedGraph("jobs")),
-		statJobsSmash: stats.Create("smash jobs", "Running smash jobs", stats.StackedGraph("jobs")),
-		statJobsHints: stats.Create("hints jobs", "Running hints jobs", stats.StackedGraph("jobs")),
-		statExecTime:  stats.Create("prog exec time", "Test program execution time (ms)", stats.Distribution{}),
+		statJobsSmash:          stats.Create("smash jobs", "Running smash jobs", stats.StackedGraph("jobs")),
+		statJobsFaultInjection: stats.Create("fault jobs", "Running fault injection jobs", stats.StackedGraph("jobs")),
+		statJobsHints:          stats.Create("hints jobs", "Running hints jobs", stats.StackedGraph("jobs")),
+		statExecTime:           stats.Create("prog exec time", "Test program execution time (ms)", stats.Distribution{}),
 		statExecGenerate: stats.Create("exec gen", "Executions of generated programs", stats.Rate{},
 			stats.StackedGraph("exec")),
 		statExecFuzz: stats.Create("exec fuzz", "Executions of mutated programs",

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -13,17 +13,17 @@ import (
 
 type Sig [sha1.Size]byte
 
-func Hash(pieces ...[]byte) Sig {
+func Hash(pieces ...any) Sig {
 	h := sha1.New()
 	for _, data := range pieces {
-		h.Write(data)
+		binary.Write(h, binary.LittleEndian, data)
 	}
 	var sig Sig
 	copy(sig[:], h.Sum(nil))
 	return sig
 }
 
-func String(pieces ...[]byte) string {
+func String(pieces ...any) string {
 	sig := Hash(pieces...)
 	return sig.String()
 }

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -38,6 +38,11 @@ type LocalConfig struct {
 }
 
 func RunLocal(cfg *LocalConfig) error {
+	if cfg.VMArch == "" {
+		cfg.VMArch = cfg.Target.Arch
+	}
+	cfg.UseCoverEdges = true
+	cfg.FilterSignal = true
 	cfg.RPC = ":0"
 	cfg.VMLess = true
 	cfg.PrintMachineCheck = log.V(1)

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -323,7 +323,7 @@ func (serv *Server) connectionLoop(runner *Runner) error {
 			// buffer too much (we don't want to grow it larger than what will be needed
 			// to send programs).
 			n := min(len(maxSignal), 50000)
-			if err := runner.sendSignalUpdate(maxSignal[:n], nil); err != nil {
+			if err := runner.sendSignalUpdate(maxSignal[:n]); err != nil {
 				return err
 			}
 			maxSignal = maxSignal[n:]
@@ -466,11 +466,10 @@ func (serv *Server) ShutdownInstance(name string, crashed bool) ([]ExecRecord, [
 	return runner.shutdown(crashed)
 }
 
-func (serv *Server) DistributeSignalDelta(plus, minus signal.Signal) {
+func (serv *Server) DistributeSignalDelta(plus signal.Signal) {
 	plusRaw := plus.ToRaw()
-	minusRaw := minus.ToRaw()
 	serv.foreachRunnerAsync(func(runner *Runner) {
-		runner.sendSignalUpdate(plusRaw, minusRaw)
+		runner.sendSignalUpdate(plusRaw)
 	})
 }
 

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -268,13 +268,12 @@ func (runner *Runner) handleExecResult(msg *flatrpc.ExecResult) error {
 	return nil
 }
 
-func (runner *Runner) sendSignalUpdate(plus, minus []uint64) error {
+func (runner *Runner) sendSignalUpdate(plus []uint64) error {
 	msg := &flatrpc.HostMessage{
 		Msg: &flatrpc.HostMessages{
 			Type: flatrpc.HostMessagesRawSignalUpdate,
 			Value: &flatrpc.SignalUpdate{
-				NewMax:  runner.canonicalizer.Decanonicalize(plus),
-				DropMax: runner.canonicalizer.Decanonicalize(minus),
+				NewMax: runner.canonicalizer.Decanonicalize(plus),
 			},
 		},
 	}

--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -61,7 +61,7 @@ func TestZlib(t *testing.T) {
 	}
 	executor := csource.BuildExecutor(t, target, "../..")
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil, nil, nil)
+	startRPCServer(t, target, executor, "", source, nil, nil, nil)
 	r := rand.New(testutil.RandSource(t))
 	for i := 0; i < 10; i++ {
 		data := testutil.RandMountImage(r)
@@ -111,7 +111,7 @@ func TestExecutorCommonExt(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil, nil, nil)
+	startRPCServer(t, target, executor, "", source, nil, nil, nil)
 	req := &queue.Request{
 		Prog:         p,
 		ReturnError:  true,

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -4,8 +4,6 @@
 // Package signal provides types for working with feedback signal.
 package signal
 
-import "math/rand"
-
 type (
 	elemType uint64
 	prioType int8
@@ -140,23 +138,6 @@ func (s *Signal) Subtract(s1 Signal) {
 			delete(s0, e)
 		}
 	}
-}
-
-func (s Signal) RandomSubset(r *rand.Rand, size int) Signal {
-	if size > len(s) {
-		size = len(s)
-	}
-	keys := make([]elemType, 0, len(s))
-	for e := range s {
-		keys = append(keys, e)
-	}
-	r.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
-
-	ret := make(Signal, size)
-	for _, e := range keys[:size] {
-		ret[e] = s[e]
-	}
-	return ret
 }
 
 // FilterRaw returns a subset of original raw elements that either are not present in ignore,

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -4,24 +4,10 @@
 package signal
 
 import (
-	"math/rand"
 	"testing"
 
-	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestRandomSubset(t *testing.T) {
-	r := rand.New(testutil.RandSource(t))
-	base := FromRaw([]uint64{0, 1, 2, 3, 4}, 0)
-	var s Signal
-	for i := 0; i < 1000 && s.Len() < base.Len(); i++ {
-		delta := base.RandomSubset(r, 1)
-		assert.Equal(t, 1, delta.Len())
-		s.Merge(delta)
-	}
-	assert.Equal(t, base.Len(), s.Len())
-}
 
 func TestSubtract(t *testing.T) {
 	base := FromRaw([]uint64{0, 1, 2, 3, 4}, 0)

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -66,8 +66,8 @@ func (r *randGen) rand64() uint64 {
 var (
 	// Some potentially interesting integers.
 	specialInts = []uint64{
-		0, 1, 31, 32, 63, 64, 127, 128,
-		129, 255, 256, 257, 511, 512,
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		64, 127, 128, 129, 255, 256, 257, 511, 512,
 		1023, 1024, 1025, 2047, 2048, 4095, 4096,
 		(1 << 15) - 1, (1 << 15), (1 << 15) + 1,
 		(1 << 16) - 1, (1 << 16), (1 << 16) + 1,
@@ -153,11 +153,12 @@ func (r *randGen) biasedRand(n, k int) int {
 	return int(bf)
 }
 
+const maxArrayLen = 10
+
 func (r *randGen) randArrayLen() uint64 {
-	const maxLen = 10
 	// biasedRand produces: 10, 9, ..., 1, 0,
 	// we want: 1, 2, ..., 9, 10, 0
-	return uint64(maxLen-r.biasedRand(maxLen+1, 10)+1) % (maxLen + 1)
+	return uint64(maxArrayLen-r.biasedRand(maxArrayLen+1, 10)+1) % (maxArrayLen + 1)
 }
 
 func (r *randGen) randBufLen() (n uint64) {

--- a/sys/test/exec.txt
+++ b/sys/test/exec.txt
@@ -11,8 +11,8 @@ syz_compare_int$3(n const[3], v0 intptr, v1 intptr, v2 intptr)
 syz_compare_int$4(n const[4], v0 intptr, v1 intptr, v2 intptr, v3 intptr)
 syz_compare_zlib(data ptr[in, array[int8]], size bytesize[data], zdata ptr[in, compressed_image], zsize bytesize[zdata]) (timeout[4000], no_generate, no_minimize)
 
-# Copies the data into KCOV buffer verbatim and sets assumed kernel bitness.
-syz_inject_cover(is64 bool8, ptr ptr[in, array[int8]], size bytesize[ptr])
+# Copies the data into KCOV buffer verbatim.
+syz_inject_cover(ptr ptr[in, array[int8]], size bytesize[ptr])
 
 compare_data [
 	align0		align0

--- a/sys/test/related.txt
+++ b/sys/test/related.txt
@@ -1,0 +1,32 @@
+# Copyright 2024 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+ioctl(fd fd, cmd int32, arg intptr)
+ioctl$1(fd fd, cmd const[0x111], arg intptr)
+ioctl$2(fd fd, cmd const[0x222], arg intptr)
+ioctl$4(fd fd, cmd flags[ioctl_commands], arg intptr)
+
+ioctl_commands = 0x333, 0x444
+
+resource sock[fd]
+
+socket(domain flags[socket_domain], type flags[socket_type], protocol flags[socket_protocol]) sock
+socket$generic(domain int32, type int32, protocol int32) sock
+socket$inet6(domain const[0x111], type flags[socket_type], protocol const[0x10000]) sock
+socket$inet6_tcp(domain const[0x111], type const[0x1000], protocol const[0x10000]) sock
+socket$netlink(domain const[0x211], type const[0x1000], protocol flags[socket_protocol]) sock
+socket$netlink2(domain const[0x211], type const[0x1000], protocol int32) sock
+socket$netlink_foo(domain const[0x211], type const[0x1000], protocol const[0x10200]) sock
+socket$foo(domain const[0x311], type const[0x1000], protocol const[0x10200]) sock
+socket$foo2(domain const[0x311], type flags[socket_type], protocol const[0x10200]) sock
+socket$foo3(domain const[0x311], type int32, protocol const[0x10200]) sock
+socket$foo4(domain const[0x411], type int32, protocol const[0x10000]) sock
+socket$foo5(domain const[0x411], type int32, protocol int32) sock
+socket$foo6(domain int32, type int32, protocol int32) sock
+socket$foo7(domain int32, type int32, protocol int32) sock
+
+listen(fd sock)
+
+socket_domain = 0x111, 0x211, 0x311
+socket_type = 0x1000, 0x1100, 0x1200
+socket_protocol = 0x10000, 0x10100, 0x10200


### PR DESCRIPTION
We see some errors of the form:

SYZFAIL: coverage filter is full
pc=0x80007000c0008 regions=[0xffffffffbfffffff 0x243fffffff 0x143fffffff 0xc3fffffff] alloc=156

Executor shouldn't send non kernel addresses in signal,
but somehow it does. It can happen if the VM memory is corrupted,
or if the test program does something very nasty (e.g. discovers
the output region and writes to it).

It's not possible to reliably filter signal in the tested VM.
Move all of the filtering logic to the host.

Fixes https://github.com/google/syzkaller/issues/4942