### PR TITLE
pkg/cover: remove symbols having the same Start Address

### DIFF
--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -203,6 +203,17 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 		allRanges = append(allRanges, result.ranges...)
 		allUnits = append(allUnits, result.units...)
 	}
+	// TODO: need better way to remove symbols having the same Start
+	uniqSymbs := make(map[uint64]*Symbol)
+	for _, sym := range allSymbols {
+		if _, ok := uniqSymbs[sym.Start]; !ok {
+			uniqSymbs[sym.Start] = sym
+		}
+	}
+	allSymbols = []*Symbol{}
+	for _, sym := range uniqSymbs {
+		allSymbols = append(allSymbols, sym)
+	}
 	sort.Slice(allSymbols, func(i, j int) bool {
 		return allSymbols[i].Start < allSymbols[j].Start
 	})


### PR DESCRIPTION
For modules, init_module and cleanup_module have the same sym.Start 0xffffffc014d310d0 even they are symbols for different sections.
Even we can keep symbols only in .text sections, there are still some symbols having the same Start.

Looking forward a better way, but currently to get constant behavior in buildSymbols, keep only one symbol incase there are other symbols having the same Start.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
