### PR TITLE
pkg/rpcserver: move kernel test/data range checks from executor

### DIFF
--- a/executor/common_test.h
+++ b/executor/common_test.h
@@ -170,7 +170,7 @@ static long syz_test_fuzzer1(volatile long a, volatile long b, volatile long c)
 #endif
 
 #if SYZ_EXECUTOR || __NR_syz_inject_cover
-static long syz_inject_cover(volatile long a, volatile long b, volatile long c)
+static long syz_inject_cover(volatile long a, volatile long b)
 #if SYZ_EXECUTOR
     ; // defined in executor_test.h
 #else

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -179,21 +179,6 @@ static void cover_collect(cover_t* cov)
 	cov->size = *(uint64*)cov->data;
 }
 
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}
-
 #if GOOS_netbsd
 #define SYZ_HAVE_FEATURES 1
 static feature_t features[] = {

--- a/executor/executor_darwin.h
+++ b/executor/executor_darwin.h
@@ -121,18 +121,3 @@ static void cover_collect(cover_t* cov)
 	cov->data_offset = ((int64_t) & (trace->pcs)) - ((int64_t)(cov->data));
 	cov->pc_offset = trace->offset;
 }
-
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}

--- a/executor/executor_test.h
+++ b/executor/executor_test.h
@@ -9,6 +9,7 @@
 #include <sys/prctl.h>
 #endif
 
+// sys/targets also know about these consts.
 static uint64 kernel_text_start = 0xc0dec0dec0000000;
 static uint64 kernel_text_mask = 0xffffff;
 
@@ -35,17 +36,30 @@ static void os_init(int argc, char** argv, void* data, size_t data_size)
 
 extern "C" notrace void __sanitizer_cov_trace_pc(void)
 {
-	unsigned long ip = (unsigned long)__builtin_return_address(0);
-	// Convert to what is_kernel_pc will accept as valid coverage;
-	ip = kernel_text_start | (ip & kernel_text_mask);
 	if (current_thread == nullptr || current_thread->cov.data == nullptr || current_thread->cov.collect_comps)
 		return;
-	unsigned long* start = (unsigned long*)current_thread->cov.data;
-	unsigned long* end = (unsigned long*)current_thread->cov.data_end;
-	int pos = start[0];
-	if (start + pos + 1 < end) {
-		start[0] = pos + 1;
-		start[pos + 1] = ip;
+	uint64 pc = (uint64)__builtin_return_address(0);
+	// Convert to what is_kernel_pc will accept as valid coverage;
+	pc = kernel_text_start | (pc & kernel_text_mask);
+	// Note: we duplicate the following code instead of using a template function
+	// because it must not be instrumented which is hard to achieve for all compiler
+	// if the code is in a separate function.
+	if (is_kernel_64_bit) {
+		uint64* start = (uint64*)current_thread->cov.data;
+		uint64* end = (uint64*)current_thread->cov.data_end;
+		uint64 pos = start[0];
+		if (start + pos + 1 < end) {
+			start[0] = pos + 1;
+			start[pos + 1] = pc;
+		}
+	} else {
+		uint32* start = (uint32*)current_thread->cov.data;
+		uint32* end = (uint32*)current_thread->cov.data_end;
+		uint32 pos = start[0];
+		if (start + pos + 1 < end) {
+			start[0] = pos + 1;
+			start[pos + 1] = pc;
+		}
 	}
 }
 
@@ -97,7 +111,7 @@ static void cover_mmap(cover_t* cov)
 	if (cov->data == MAP_FAILED)
 		exitf("cover mmap failed");
 	cov->data_end = cov->data + cov->mmap_alloc_size;
-	cov->data_offset = sizeof(unsigned long);
+	cov->data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
 	// We don't care about the specific PC values for now.
 	// Once we do, we might want to consider ASLR here.
 	cov->pc_offset = 0;
@@ -107,36 +121,13 @@ static void cover_unprotect(cover_t* cov)
 {
 }
 
-static bool is_kernel_data(uint64 addr)
-{
-	return addr >= 0xda1a0000 && addr <= 0xda1a1000;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	uint64 start = kernel_text_start;
-	uint64 end = kernel_text_start | kernel_text_mask;
-	if (!is_kernel_64_bit) {
-		start = (uint32)start;
-		end = (uint32)end;
-	}
-	return pc >= start && pc <= end ? 1 : -1;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}
-
-static long syz_inject_cover(volatile long a, volatile long b, volatile long c)
+static long syz_inject_cover(volatile long a, volatile long b)
 {
 	cover_t* cov = &current_thread->cov;
 	if (cov->data == nullptr)
 		return ENOENT;
-	is_kernel_64_bit = a;
-	cov->data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
-	uint32 size = std::min((uint32)c, cov->mmap_alloc_size);
-	memcpy(cov->data, (void*)b, size);
+	uint32 size = std::min((uint32)b, cov->mmap_alloc_size);
+	memcpy(cov->data, (void*)a, size);
 	memset(cov->data + size, 0xcd, std::min<uint64>(100, cov->mmap_alloc_size - size));
 	return 0;
 }

--- a/executor/nocover.h
+++ b/executor/nocover.h
@@ -28,18 +28,3 @@ static void cover_mmap(cover_t* cov)
 static void cover_unprotect(cover_t* cov)
 {
 }
-
-static bool is_kernel_data(uint64 addr)
-{
-	return false;
-}
-
-static int is_kernel_pc(uint64 pc)
-{
-	return 0;
-}
-
-static bool use_cover_edges(uint64 pc)
-{
-	return true;
-}

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -37,6 +37,8 @@ table ConnectRequestRaw {
 table ConnectReplyRaw {
 	debug			:bool;
 	cover			:bool;
+	cover_edges		:bool;
+	kernel_64_bit		:bool;
 	procs			:int32;
 	slowdown		:int32;
 	syscall_timeout_ms	:int32;

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -509,6 +509,8 @@ func ConnectRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 type ConnectReplyRawT struct {
 	Debug            bool     `json:"debug"`
 	Cover            bool     `json:"cover"`
+	CoverEdges       bool     `json:"cover_edges"`
+	Kernel64Bit      bool     `json:"kernel_64_bit"`
 	Procs            int32    `json:"procs"`
 	Slowdown         int32    `json:"slowdown"`
 	SyscallTimeoutMs int32    `json:"syscall_timeout_ms"`
@@ -579,6 +581,8 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 	ConnectReplyRawStart(builder)
 	ConnectReplyRawAddDebug(builder, t.Debug)
 	ConnectReplyRawAddCover(builder, t.Cover)
+	ConnectReplyRawAddCoverEdges(builder, t.CoverEdges)
+	ConnectReplyRawAddKernel64Bit(builder, t.Kernel64Bit)
 	ConnectReplyRawAddProcs(builder, t.Procs)
 	ConnectReplyRawAddSlowdown(builder, t.Slowdown)
 	ConnectReplyRawAddSyscallTimeoutMs(builder, t.SyscallTimeoutMs)
@@ -594,6 +598,8 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 func (rcv *ConnectReplyRaw) UnPackTo(t *ConnectReplyRawT) {
 	t.Debug = rcv.Debug()
 	t.Cover = rcv.Cover()
+	t.CoverEdges = rcv.CoverEdges()
+	t.Kernel64Bit = rcv.Kernel64Bit()
 	t.Procs = rcv.Procs()
 	t.Slowdown = rcv.Slowdown()
 	t.SyscallTimeoutMs = rcv.SyscallTimeoutMs()
@@ -681,31 +687,31 @@ func (rcv *ConnectReplyRaw) MutateCover(n bool) bool {
 	return rcv._tab.MutateBoolSlot(6, n)
 }
 
-func (rcv *ConnectReplyRaw) Procs() int32 {
+func (rcv *ConnectReplyRaw) CoverEdges() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
 	}
-	return 0
+	return false
 }
 
-func (rcv *ConnectReplyRaw) MutateProcs(n int32) bool {
-	return rcv._tab.MutateInt32Slot(8, n)
+func (rcv *ConnectReplyRaw) MutateCoverEdges(n bool) bool {
+	return rcv._tab.MutateBoolSlot(8, n)
 }
 
-func (rcv *ConnectReplyRaw) Slowdown() int32 {
+func (rcv *ConnectReplyRaw) Kernel64Bit() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
 	}
-	return 0
+	return false
 }
 
-func (rcv *ConnectReplyRaw) MutateSlowdown(n int32) bool {
-	return rcv._tab.MutateInt32Slot(10, n)
+func (rcv *ConnectReplyRaw) MutateKernel64Bit(n bool) bool {
+	return rcv._tab.MutateBoolSlot(10, n)
 }
 
-func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
+func (rcv *ConnectReplyRaw) Procs() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -713,11 +719,11 @@ func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
 	return 0
 }
 
-func (rcv *ConnectReplyRaw) MutateSyscallTimeoutMs(n int32) bool {
+func (rcv *ConnectReplyRaw) MutateProcs(n int32) bool {
 	return rcv._tab.MutateInt32Slot(12, n)
 }
 
-func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
+func (rcv *ConnectReplyRaw) Slowdown() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		return rcv._tab.GetInt32(o + rcv._tab.Pos)
@@ -725,12 +731,36 @@ func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
 	return 0
 }
 
-func (rcv *ConnectReplyRaw) MutateProgramTimeoutMs(n int32) bool {
+func (rcv *ConnectReplyRaw) MutateSlowdown(n int32) bool {
 	return rcv._tab.MutateInt32Slot(14, n)
 }
 
-func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
+func (rcv *ConnectReplyRaw) SyscallTimeoutMs() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) MutateSyscallTimeoutMs(n int32) bool {
+	return rcv._tab.MutateInt32Slot(16, n)
+}
+
+func (rcv *ConnectReplyRaw) ProgramTimeoutMs() int32 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) MutateProgramTimeoutMs(n int32) bool {
+	return rcv._tab.MutateInt32Slot(18, n)
+}
+
+func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -739,7 +769,7 @@ func (rcv *ConnectReplyRaw) LeakFrames(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) LeakFramesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -747,7 +777,7 @@ func (rcv *ConnectReplyRaw) LeakFramesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) RaceFrames(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -756,7 +786,7 @@ func (rcv *ConnectReplyRaw) RaceFrames(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) RaceFramesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -764,7 +794,7 @@ func (rcv *ConnectReplyRaw) RaceFramesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) Features() Feature {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
 	if o != 0 {
 		return Feature(rcv._tab.GetUint64(o + rcv._tab.Pos))
 	}
@@ -772,11 +802,11 @@ func (rcv *ConnectReplyRaw) Features() Feature {
 }
 
 func (rcv *ConnectReplyRaw) MutateFeatures(n Feature) bool {
-	return rcv._tab.MutateUint64Slot(20, uint64(n))
+	return rcv._tab.MutateUint64Slot(24, uint64(n))
 }
 
 func (rcv *ConnectReplyRaw) Files(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -785,7 +815,7 @@ func (rcv *ConnectReplyRaw) Files(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) FilesLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -793,7 +823,7 @@ func (rcv *ConnectReplyRaw) FilesLength() int {
 }
 
 func (rcv *ConnectReplyRaw) Globs(j int) []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
@@ -802,7 +832,7 @@ func (rcv *ConnectReplyRaw) Globs(j int) []byte {
 }
 
 func (rcv *ConnectReplyRaw) GlobsLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -810,7 +840,7 @@ func (rcv *ConnectReplyRaw) GlobsLength() int {
 }
 
 func ConnectReplyRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(11)
+	builder.StartObject(13)
 }
 func ConnectReplyRawAddDebug(builder *flatbuffers.Builder, debug bool) {
 	builder.PrependBoolSlot(0, debug, false)
@@ -818,41 +848,47 @@ func ConnectReplyRawAddDebug(builder *flatbuffers.Builder, debug bool) {
 func ConnectReplyRawAddCover(builder *flatbuffers.Builder, cover bool) {
 	builder.PrependBoolSlot(1, cover, false)
 }
+func ConnectReplyRawAddCoverEdges(builder *flatbuffers.Builder, coverEdges bool) {
+	builder.PrependBoolSlot(2, coverEdges, false)
+}
+func ConnectReplyRawAddKernel64Bit(builder *flatbuffers.Builder, kernel64Bit bool) {
+	builder.PrependBoolSlot(3, kernel64Bit, false)
+}
 func ConnectReplyRawAddProcs(builder *flatbuffers.Builder, procs int32) {
-	builder.PrependInt32Slot(2, procs, 0)
+	builder.PrependInt32Slot(4, procs, 0)
 }
 func ConnectReplyRawAddSlowdown(builder *flatbuffers.Builder, slowdown int32) {
-	builder.PrependInt32Slot(3, slowdown, 0)
+	builder.PrependInt32Slot(5, slowdown, 0)
 }
 func ConnectReplyRawAddSyscallTimeoutMs(builder *flatbuffers.Builder, syscallTimeoutMs int32) {
-	builder.PrependInt32Slot(4, syscallTimeoutMs, 0)
+	builder.PrependInt32Slot(6, syscallTimeoutMs, 0)
 }
 func ConnectReplyRawAddProgramTimeoutMs(builder *flatbuffers.Builder, programTimeoutMs int32) {
-	builder.PrependInt32Slot(5, programTimeoutMs, 0)
+	builder.PrependInt32Slot(7, programTimeoutMs, 0)
 }
 func ConnectReplyRawAddLeakFrames(builder *flatbuffers.Builder, leakFrames flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(leakFrames), 0)
+	builder.PrependUOffsetTSlot(8, flatbuffers.UOffsetT(leakFrames), 0)
 }
 func ConnectReplyRawStartLeakFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddRaceFrames(builder *flatbuffers.Builder, raceFrames flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(raceFrames), 0)
+	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(raceFrames), 0)
 }
 func ConnectReplyRawStartRaceFramesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddFeatures(builder *flatbuffers.Builder, features Feature) {
-	builder.PrependUint64Slot(8, uint64(features), 0)
+	builder.PrependUint64Slot(10, uint64(features), 0)
 }
 func ConnectReplyRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(files), 0)
+	builder.PrependUOffsetTSlot(11, flatbuffers.UOffsetT(files), 0)
 }
 func ConnectReplyRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func ConnectReplyRawAddGlobs(builder *flatbuffers.Builder, globs flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(globs), 0)
+	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(globs), 0)
 }
 func ConnectReplyRawStartGlobsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -807,6 +807,8 @@ struct ConnectReplyRawT : public flatbuffers::NativeTable {
   typedef ConnectReplyRaw TableType;
   bool debug = false;
   bool cover = false;
+  bool cover_edges = false;
+  bool kernel_64_bit = false;
   int32_t procs = 0;
   int32_t slowdown = 0;
   int32_t syscall_timeout_ms = 0;
@@ -824,21 +826,29 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_DEBUG = 4,
     VT_COVER = 6,
-    VT_PROCS = 8,
-    VT_SLOWDOWN = 10,
-    VT_SYSCALL_TIMEOUT_MS = 12,
-    VT_PROGRAM_TIMEOUT_MS = 14,
-    VT_LEAK_FRAMES = 16,
-    VT_RACE_FRAMES = 18,
-    VT_FEATURES = 20,
-    VT_FILES = 22,
-    VT_GLOBS = 24
+    VT_COVER_EDGES = 8,
+    VT_KERNEL_64_BIT = 10,
+    VT_PROCS = 12,
+    VT_SLOWDOWN = 14,
+    VT_SYSCALL_TIMEOUT_MS = 16,
+    VT_PROGRAM_TIMEOUT_MS = 18,
+    VT_LEAK_FRAMES = 20,
+    VT_RACE_FRAMES = 22,
+    VT_FEATURES = 24,
+    VT_FILES = 26,
+    VT_GLOBS = 28
   };
   bool debug() const {
     return GetField<uint8_t>(VT_DEBUG, 0) != 0;
   }
   bool cover() const {
     return GetField<uint8_t>(VT_COVER, 0) != 0;
+  }
+  bool cover_edges() const {
+    return GetField<uint8_t>(VT_COVER_EDGES, 0) != 0;
+  }
+  bool kernel_64_bit() const {
+    return GetField<uint8_t>(VT_KERNEL_64_BIT, 0) != 0;
   }
   int32_t procs() const {
     return GetField<int32_t>(VT_PROCS, 0);
@@ -871,6 +881,8 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_DEBUG, 1) &&
            VerifyField<uint8_t>(verifier, VT_COVER, 1) &&
+           VerifyField<uint8_t>(verifier, VT_COVER_EDGES, 1) &&
+           VerifyField<uint8_t>(verifier, VT_KERNEL_64_BIT, 1) &&
            VerifyField<int32_t>(verifier, VT_PROCS, 4) &&
            VerifyField<int32_t>(verifier, VT_SLOWDOWN, 4) &&
            VerifyField<int32_t>(verifier, VT_SYSCALL_TIMEOUT_MS, 4) &&
@@ -904,6 +916,12 @@ struct ConnectReplyRawBuilder {
   }
   void add_cover(bool cover) {
     fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_COVER, static_cast<uint8_t>(cover), 0);
+  }
+  void add_cover_edges(bool cover_edges) {
+    fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_COVER_EDGES, static_cast<uint8_t>(cover_edges), 0);
+  }
+  void add_kernel_64_bit(bool kernel_64_bit) {
+    fbb_.AddElement<uint8_t>(ConnectReplyRaw::VT_KERNEL_64_BIT, static_cast<uint8_t>(kernel_64_bit), 0);
   }
   void add_procs(int32_t procs) {
     fbb_.AddElement<int32_t>(ConnectReplyRaw::VT_PROCS, procs, 0);
@@ -947,6 +965,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool debug = false,
     bool cover = false,
+    bool cover_edges = false,
+    bool kernel_64_bit = false,
     int32_t procs = 0,
     int32_t slowdown = 0,
     int32_t syscall_timeout_ms = 0,
@@ -966,6 +986,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
   builder_.add_syscall_timeout_ms(syscall_timeout_ms);
   builder_.add_slowdown(slowdown);
   builder_.add_procs(procs);
+  builder_.add_kernel_64_bit(kernel_64_bit);
+  builder_.add_cover_edges(cover_edges);
   builder_.add_cover(cover);
   builder_.add_debug(debug);
   return builder_.Finish();
@@ -975,6 +997,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool debug = false,
     bool cover = false,
+    bool cover_edges = false,
+    bool kernel_64_bit = false,
     int32_t procs = 0,
     int32_t slowdown = 0,
     int32_t syscall_timeout_ms = 0,
@@ -992,6 +1016,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
       _fbb,
       debug,
       cover,
+      cover_edges,
+      kernel_64_bit,
       procs,
       slowdown,
       syscall_timeout_ms,
@@ -2446,6 +2472,8 @@ inline void ConnectReplyRaw::UnPackTo(ConnectReplyRawT *_o, const flatbuffers::r
   (void)_resolver;
   { auto _e = debug(); _o->debug = _e; }
   { auto _e = cover(); _o->cover = _e; }
+  { auto _e = cover_edges(); _o->cover_edges = _e; }
+  { auto _e = kernel_64_bit(); _o->kernel_64_bit = _e; }
   { auto _e = procs(); _o->procs = _e; }
   { auto _e = slowdown(); _o->slowdown = _e; }
   { auto _e = syscall_timeout_ms(); _o->syscall_timeout_ms = _e; }
@@ -2467,6 +2495,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::F
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectReplyRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _debug = _o->debug;
   auto _cover = _o->cover;
+  auto _cover_edges = _o->cover_edges;
+  auto _kernel_64_bit = _o->kernel_64_bit;
   auto _procs = _o->procs;
   auto _slowdown = _o->slowdown;
   auto _syscall_timeout_ms = _o->syscall_timeout_ms;
@@ -2480,6 +2510,8 @@ inline flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(flatbuffers::F
       _fbb,
       _debug,
       _cover,
+      _cover_edges,
+      _kernel_64_bit,
       _procs,
       _slowdown,
       _syscall_timeout_ms,

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -38,6 +38,11 @@ type LocalConfig struct {
 }
 
 func RunLocal(cfg *LocalConfig) error {
+	if cfg.VMArch == "" {
+		cfg.VMArch = cfg.Target.Arch
+	}
+	cfg.UseCoverEdges = true
+	cfg.FilterSignal = true
 	cfg.RPC = ":0"
 	cfg.VMLess = true
 	cfg.PrintMachineCheck = log.V(1)

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -30,8 +30,14 @@ import (
 
 type Config struct {
 	vminfo.Config
-	RPC               string
-	VMLess            bool
+	VMArch string
+	RPC    string
+	VMLess bool
+	// Hash adjacent PCs to form fuzzing feedback signal (otherwise just use coverage PCs as signal).
+	UseCoverEdges bool
+	// Filter signal/comparisons against target kernel text/data ranges.
+	// Disabled for gVisor/Starnix which are not Linux.
+	FilterSignal      bool
 	PrintMachineCheck bool
 	Procs             int
 	Slowdown          int
@@ -49,12 +55,13 @@ type Server struct {
 	StatExecs      *stats.Val
 	StatNumFuzzing *stats.Val
 
-	cfg      *Config
-	mgr      Manager
-	serv     *flatrpc.Serv
-	target   *prog.Target
-	timeouts targets.Timeouts
-	checker  *vminfo.Checker
+	cfg       *Config
+	mgr       Manager
+	serv      *flatrpc.Serv
+	target    *prog.Target
+	sysTarget *targets.Target
+	timeouts  targets.Timeouts
+	checker   *vminfo.Checker
 
 	infoOnce         sync.Once
 	checkDone        atomic.Bool
@@ -88,8 +95,13 @@ func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
 			Sandbox:    sandbox,
 			SandboxArg: cfg.SandboxArg,
 		},
-		RPC:               cfg.RPC,
-		VMLess:            cfg.VMLess,
+		VMArch: cfg.TargetVMArch,
+		RPC:    cfg.RPC,
+		VMLess: cfg.VMLess,
+		// gVisor coverage is not a trace, so producing edges won't work.
+		UseCoverEdges: cfg.Type != targets.GVisor,
+		// gVisor/Starnix are not Linux, so filtering against Linux ranges won't work.
+		FilterSignal:      cfg.Type != targets.GVisor && cfg.Type != targets.Starnix,
 		PrintMachineCheck: true,
 		Procs:             cfg.Procs,
 		Slowdown:          cfg.Timeouts.Slowdown,
@@ -100,11 +112,14 @@ func newImpl(cfg *Config, mgr Manager) (*Server, error) {
 	cfg.Procs = min(cfg.Procs, prog.MaxPids)
 	checker := vminfo.New(&cfg.Config)
 	baseSource := queue.DynamicSource(checker)
+	// Note that we use VMArch, rather than Arch. We need the kernel address ranges and bitness.
+	sysTarget := targets.Get(cfg.Target.OS, cfg.VMArch)
 	serv := &Server{
 		cfg:        cfg,
 		mgr:        mgr,
 		target:     cfg.Target,
-		timeouts:   targets.Get(cfg.Target.OS, cfg.Target.Arch).Timeouts(cfg.Slowdown),
+		sysTarget:  sysTarget,
+		timeouts:   sysTarget.Timeouts(cfg.Slowdown),
 		runners:    make(map[string]*Runner),
 		info:       make(map[string]VMState),
 		checker:    checker,
@@ -245,6 +260,8 @@ func (serv *Server) handshake(conn *flatrpc.Conn) (string, []byte, *cover.Canoni
 	connectReply := &flatrpc.ConnectReply{
 		Debug:            serv.cfg.Debug,
 		Cover:            serv.cfg.Cover,
+		CoverEdges:       serv.cfg.UseCoverEdges,
+		Kernel64Bit:      serv.sysTarget.PtrSize == 8,
 		Procs:            int32(serv.cfg.Procs),
 		Slowdown:         int32(serv.timeouts.Slowdown),
 		SyscallTimeoutMs: int32(serv.timeouts.Syscall / time.Millisecond),
@@ -421,18 +438,20 @@ func (serv *Server) printMachineCheck(checkFilesInfo []*flatrpc.FileInfo, enable
 
 func (serv *Server) CreateInstance(name string, injectExec chan<- bool) {
 	runner := &Runner{
-		source:     serv.execSource,
-		cover:      serv.cfg.Cover,
-		debug:      serv.cfg.Debug,
-		injectExec: injectExec,
-		infoc:      make(chan chan []byte),
-		finished:   make(chan bool),
-		requests:   make(map[int64]*queue.Request),
-		executing:  make(map[int64]bool),
-		lastExec:   MakeLastExecuting(serv.cfg.Procs, 6),
-		rnd:        rand.New(rand.NewSource(time.Now().UnixNano())),
-		stats:      serv.runnerStats,
-		procs:      serv.cfg.Procs,
+		source:       serv.execSource,
+		cover:        serv.cfg.Cover,
+		filterSignal: serv.cfg.FilterSignal,
+		debug:        serv.cfg.Debug,
+		sysTarget:    serv.sysTarget,
+		injectExec:   injectExec,
+		infoc:        make(chan chan []byte),
+		finished:     make(chan bool),
+		requests:     make(map[int64]*queue.Request),
+		executing:    make(map[int64]bool),
+		lastExec:     MakeLastExecuting(serv.cfg.Procs, 6),
+		rnd:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		stats:        serv.runnerStats,
+		procs:        serv.cfg.Procs,
 	}
 	serv.mu.Lock()
 	if serv.runners[name] != nil {

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -18,13 +18,16 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/stats"
 	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type Runner struct {
 	source        queue.Source
 	procs         int
 	cover         bool
+	filterSignal  bool
 	debug         bool
+	sysTarget     *targets.Target
 	stats         *runnerStats
 	stopped       bool
 	finished      chan bool
@@ -235,10 +238,8 @@ func (runner *Runner) handleExecResult(msg *flatrpc.ExecResult) error {
 			// Coverage collection is disabled, but signal was requested => use a substitute signal.
 			addFallbackSignal(req.Prog, msg.Info)
 		}
-		for i := 0; i < len(msg.Info.Calls); i++ {
-			call := msg.Info.Calls[i]
-			call.Cover = runner.canonicalizer.Canonicalize(call.Cover)
-			call.Signal = runner.canonicalizer.Canonicalize(call.Signal)
+		for _, call := range msg.Info.Calls {
+			runner.convertCallInfo(call)
 		}
 		if len(msg.Info.ExtraRaw) != 0 {
 			msg.Info.Extra = msg.Info.ExtraRaw[0]
@@ -248,9 +249,8 @@ func (runner *Runner) handleExecResult(msg *flatrpc.ExecResult) error {
 				msg.Info.Extra.Cover = append(msg.Info.Extra.Cover, info.Cover...)
 				msg.Info.Extra.Signal = append(msg.Info.Extra.Signal, info.Signal...)
 			}
-			msg.Info.Extra.Cover = runner.canonicalizer.Canonicalize(msg.Info.Extra.Cover)
-			msg.Info.Extra.Signal = runner.canonicalizer.Canonicalize(msg.Info.Extra.Signal)
 			msg.Info.ExtraRaw = nil
+			runner.convertCallInfo(msg.Info.Extra)
 		}
 	}
 	status := queue.Success
@@ -266,6 +266,49 @@ func (runner *Runner) handleExecResult(msg *flatrpc.ExecResult) error {
 		Err:    resErr,
 	})
 	return nil
+}
+
+func (runner *Runner) convertCallInfo(call *flatrpc.CallInfo) {
+	call.Cover = runner.canonicalizer.Canonicalize(call.Cover)
+	call.Signal = runner.canonicalizer.Canonicalize(call.Signal)
+
+	// Check signal belongs to kernel addresses.
+	// Mismatching addresses can mean either corrupted VM memory, or that the fuzzer somehow
+	// managed to inject output signal. If we see any bogus signal, drop whole signal
+	// (we don't want programs that can inject bogus coverage to end up in the corpus).
+	var kernelAddresses targets.KernelAddresses
+	if runner.filterSignal {
+		kernelAddresses = runner.sysTarget.KernelAddresses
+	}
+	textStart, textEnd := kernelAddresses.TextStart, kernelAddresses.TextEnd
+	if textStart != 0 {
+		for _, sig := range call.Signal {
+			if sig < textStart || sig > textEnd {
+				call.Signal = []uint64{}
+				call.Cover = []uint64{}
+				break
+			}
+		}
+	}
+
+	// Filter out kernel physical memory addresses.
+	// These are internal kernel comparisons and should not be interesting.
+	dataStart, dataEnd := kernelAddresses.DataStart, kernelAddresses.DataEnd
+	if len(call.Comps) != 0 && (textStart != 0 || dataStart != 0) {
+		if runner.sysTarget.PtrSize == 4 {
+			// These will appear sign-extended in comparison operands.
+			textStart = uint64(int64(int32(textStart)))
+			textEnd = uint64(int64(int32(textEnd)))
+			dataStart = uint64(int64(int32(dataStart)))
+			dataEnd = uint64(int64(int32(dataEnd)))
+		}
+		isKptr := func(val uint64) bool {
+			return val >= textStart && val <= textEnd || val >= dataStart && val <= dataEnd || val == 0
+		}
+		call.Comps = slices.DeleteFunc(call.Comps, func(cmp *flatrpc.Comparison) bool {
+			return isKptr(cmp.Op1) && isKptr(cmp.Op2)
+		})
+	}
 }
 
 func (runner *Runner) sendSignalUpdate(plus, minus []uint64) error {

--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -61,7 +61,7 @@ func TestZlib(t *testing.T) {
 	}
 	executor := csource.BuildExecutor(t, target, "../..")
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil, nil, nil)
+	startRPCServer(t, target, executor, "", source, nil, nil, nil)
 	r := rand.New(testutil.RandSource(t))
 	for i := 0; i < 10; i++ {
 		data := testutil.RandMountImage(r)
@@ -111,7 +111,7 @@ func TestExecutorCommonExt(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := queue.Plain()
-	startRpcserver(t, target, executor, source, nil, nil, nil)
+	startRPCServer(t, target, executor, "", source, nil, nil, nil)
 	req := &queue.Request{
 		Prog:         p,
 		ReturnError:  true,

--- a/sys/test/exec.txt
+++ b/sys/test/exec.txt
@@ -11,8 +11,8 @@ syz_compare_int$3(n const[3], v0 intptr, v1 intptr, v2 intptr)
 syz_compare_int$4(n const[4], v0 intptr, v1 intptr, v2 intptr, v3 intptr)
 syz_compare_zlib(data ptr[in, array[int8]], size bytesize[data], zdata ptr[in, compressed_image], zsize bytesize[zdata]) (timeout[4000], no_generate, no_minimize)
 
-# Copies the data into KCOV buffer verbatim and sets assumed kernel bitness.
-syz_inject_cover(is64 bool8, ptr ptr[in, array[int8]], size bytesize[ptr])
+# Copies the data into KCOV buffer verbatim.
+syz_inject_cover(ptr ptr[in, array[int8]], size bytesize[ptr])
 
 compare_data [
 	align0		align0


### PR DESCRIPTION
We see some errors of the form:

SYZFAIL: coverage filter is full
pc=0x80007000c0008 regions=[0xffffffffbfffffff 0x243fffffff 0x143fffffff 0xc3fffffff] alloc=156

Executor shouldn't send non kernel addresses in signal,
but somehow it does. It can happen if the VM memory is corrupted,
or if the test program does something very nasty (e.g. discovers
the output region and writes to it).

It's not possible to reliably filter signal in the tested VM.
Move all of the filtering logic to the host.

Fixes #4942
