### PR TITLE
pkg/report: suppress executor SIGBUS

### DIFF
--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -759,8 +759,9 @@ static void SigsegvHandler(int sig, siginfo_t* info, void* ucontext)
 #endif
 	// Print the current function PC so that it's possible to map the failing PC
 	// to a symbol in the binary offline (we usually compile as PIE).
-	failmsg("SIGSEGV", "sig:%d handler:%p pc:%p addr:%p",
-		sig, SigsegvHandler, reinterpret_cast<void*>(pc), info->si_addr);
+	failmsg(sig == SIGSEGV ? "SIGSEGV" : "SIGBUS", "handler:0x%zx pc:%p addr:%p",
+		reinterpret_cast<uintptr_t>(reinterpret_cast<void*>(SigsegvHandler)) - pc,
+		reinterpret_cast<void*>(pc), info->si_addr);
 }
 
 static void runner(char** argv, int argc)

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -126,6 +126,7 @@ func ctorLinux(cfg *config) (reporterImpl, []string, error) {
 		"panic: failed to create temp dir",
 		"fatal error: unexpected signal during runtime execution", // presubmably OOM turned into SIGBUS
 		"signal SIGBUS: bus error",                                // presubmably OOM turned into SIGBUS
+		"SYZFAIL: SIGBUS",
 		"Out of memory: Kill process .* \\(syz-executor\\)",
 		"Out of memory: Kill process .* \\(sshd\\)",
 		"Killed process .* \\(syz-executor\\)",

--- a/pkg/report/testdata/linux/report/716
+++ b/pkg/report/testdata/linux/report/716
@@ -1,0 +1,5 @@
+TITLE: SYZFAIL: SIGSEGV
+TYPE: SYZ_FAILURE
+
+SYZFAIL: SIGSEGV
+handler:0x123 pc:0x7f88b7e4e673 addr:0x7f88b11ffffc (errno 9: Bad file descriptor)

--- a/pkg/report/testdata/linux/report/717
+++ b/pkg/report/testdata/linux/report/717
@@ -1,0 +1,6 @@
+TITLE: SYZFAIL: SIGBUS
+TYPE: SYZ_FAILURE
+SUPPRESSED: Y
+
+SYZFAIL: SIGBUS
+handler:0x123 pc:0x7f88b7e4e673 addr:0x7f88b11ffffc (errno 9: Bad file descriptor)

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -68,6 +68,7 @@ func main() {
 		}
 		fmt.Printf("TITLE: %v\n", rep.Title)
 		fmt.Printf("CORRUPTED: %v (%v)\n", rep.Corrupted, rep.CorruptedReason)
+		fmt.Printf("SUPPRESSED: %v\n", rep.Suppressed)
 		fmt.Printf("MAINTAINERS (TO): %v\n", rep.Recipients.GetEmails(vcs.To))
 		fmt.Printf("MAINTAINERS (CC): %v\n", rep.Recipients.GetEmails(vcs.Cc))
 		fmt.Printf("\n")


### PR DESCRIPTION
SIGBUS means OOM on Linux.
Most of the crashes that happen during fuzzing are SIGBUS,
so separate them from SIGSEGV and suppress.
