### PR TITLE
fuzzer jobs optimizations

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1334,7 +1334,7 @@ flatbuffers::span<uint8_t> finish_output(OutputData* output, int proc_id, uint64
 	flatbuffers::Offset<flatbuffers::Vector<uint8_t>> output_off = 0;
 	if (process_output)
 		output_off = fbb.CreateVector(*process_output);
-	auto exec_off = rpc::CreateExecResultRaw(fbb, req_id, output_off, error_off, prog_info_off);
+	auto exec_off = rpc::CreateExecResultRaw(fbb, req_id, proc_id, output_off, error_off, prog_info_off);
 	auto msg_off = rpc::CreateExecutorMessageRaw(fbb, rpc::ExecutorMessagesRaw::ExecResult,
 						     flatbuffers::Offset<void>(exec_off.o));
 	fbb.FinishSizePrefixed(msg_off);

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -55,6 +55,8 @@ public:
 	{
 		if (state_ != State::Started && state_ != State::Idle)
 			return false;
+		if (msg.avoid & (1ull << id_))
+			return false;
 		if (msg_)
 			fail("already have pending msg");
 		if (wait_start_)

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -32,11 +32,13 @@ inline std::ostream& operator<<(std::ostream& ss, const rpc::ExecRequestRawT& re
 class Proc
 {
 public:
-	Proc(Connection& conn, const char* bin, int id, int max_signal_fd, int cover_filter_fd,
+	Proc(Connection& conn, const char* bin, int id, int& restarting, const bool& corpus_triaged, int max_signal_fd, int cover_filter_fd,
 	     bool use_cover_edges, bool is_kernel_64_bit, uint32 slowdown, uint32 syscall_timeout_ms, uint32 program_timeout_ms)
 	    : conn_(conn),
 	      bin_(bin),
 	      id_(id),
+	      restarting_(restarting),
+	      corpus_triaged_(corpus_triaged),
 	      max_signal_fd_(max_signal_fd),
 	      cover_filter_fd_(cover_filter_fd),
 	      use_cover_edges_(use_cover_edges),
@@ -61,8 +63,10 @@ public:
 			fail("already have pending msg");
 		if (wait_start_)
 			wait_end_ = current_time_ms();
-		if (state_ == State::Idle &&
-		    (exec_env_ != msg.exec_opts->env_flags() || sandbox_arg_ != msg.exec_opts->sandbox_arg()))
+		// Restart every once in a while to not let too much state accumulate.
+		constexpr uint64 kRestartEvery = 600;
+		if (state_ == State::Idle && ((corpus_triaged_ && restarting_ == 0 && freshness_ >= kRestartEvery) ||
+					      exec_env_ != msg.exec_opts->env_flags() || sandbox_arg_ != msg.exec_opts->sandbox_arg()))
 			Restart();
 		attempts_ = 0;
 		msg_ = std::move(msg);
@@ -131,6 +135,8 @@ private:
 	Connection& conn_;
 	const char* const bin_;
 	const int id_;
+	int& restarting_;
+	const bool& corpus_triaged_;
 	const int max_signal_fd_;
 	const int cover_filter_fd_;
 	const bool use_cover_edges_;
@@ -168,6 +174,15 @@ private:
 		if (proc.msg_)
 			ss << "\tcurrent request: " << *proc.msg_;
 		return ss;
+	}
+
+	void ChangeState(State state)
+	{
+		if (state_ == State::Handshaking)
+			restarting_--;
+		if (state == State::Handshaking)
+			restarting_++;
+		state_ = state;
 	}
 
 	void Restart()
@@ -217,7 +232,7 @@ private:
 
 	void Start()
 	{
-		state_ = State::Started;
+		ChangeState(State::Started);
 		freshness_ = 0;
 		int req_pipe[2];
 		if (pipe(req_pipe))
@@ -265,7 +280,7 @@ private:
 		if (state_ != State::Started || !msg_)
 			fail("wrong handshake state");
 		debug("proc %d: handshaking to execute request %llu\n", id_, static_cast<uint64>(msg_->id));
-		state_ = State::Handshaking;
+		ChangeState(State::Handshaking);
 		exec_start_ = current_time_ms();
 		exec_env_ = msg_->exec_opts->env_flags() & ~rpc::ExecEnv::ResetState;
 		sandbox_arg_ = msg_->exec_opts->sandbox_arg();
@@ -328,7 +343,7 @@ private:
 		    .all_extra_signal = all_extra_signal,
 		};
 		exec_start_ = current_time_ms();
-		state_ = State::Executing;
+		ChangeState(State::Executing);
 		if (write(req_pipe_, &req, sizeof(req)) != sizeof(req)) {
 			debug("request pipe write failed (errno=%d)\n", errno);
 			Restart();
@@ -362,7 +377,7 @@ private:
 		msg_.reset();
 		output_.clear();
 		debug_output_pos_ = 0;
-		state_ = State::Idle;
+		ChangeState(State::Idle);
 #if !SYZ_EXECUTOR_USES_FORK_SERVER
 		if (process_)
 			Restart();
@@ -385,7 +400,7 @@ private:
 			failmsg("proc resp pipe read failed", "n=%zd", n);
 		if (state_ == State::Handshaking) {
 			debug("proc %d: got handshake reply\n", id_);
-			state_ = State::Idle;
+			ChangeState(State::Idle);
 			Execute();
 		} else if (state_ == State::Executing) {
 			debug("proc %d: got execute reply\n", id_);
@@ -444,7 +459,7 @@ public:
 		int max_signal_fd = max_signal_ ? max_signal_->FD() : -1;
 		int cover_filter_fd = cover_filter_ ? cover_filter_->FD() : -1;
 		for (size_t i = 0; i < num_procs; i++)
-			procs_.emplace_back(new Proc(conn, bin, i, max_signal_fd, cover_filter_fd,
+			procs_.emplace_back(new Proc(conn, bin, i, restarting_, corpus_triaged_, max_signal_fd, cover_filter_fd,
 						     use_cover_edges_, is_kernel_64_bit_, slowdown_, syscall_timeout_ms_, program_timeout_ms_));
 
 		for (;;)
@@ -459,6 +474,8 @@ private:
 	std::vector<std::unique_ptr<Proc>> procs_;
 	std::deque<rpc::ExecRequestRawT> requests_;
 	std::vector<std::string> leak_frames_;
+	int restarting_ = 0;
+	bool corpus_triaged_ = false;
 	bool use_cover_edges_ = false;
 	bool is_kernel_64_bit_ = false;
 	uint32 slowdown_ = 0;
@@ -467,6 +484,17 @@ private:
 
 	friend std::ostream& operator<<(std::ostream& ss, const Runner& runner)
 	{
+		ss << "name=" << runner.name_
+		   << " max_signal=" << !!runner.max_signal_
+		   << " cover_filter=" << !!runner.cover_filter_
+		   << " restarting=" << runner.restarting_
+		   << " corpus_triaged=" << runner.corpus_triaged_
+		   << " use_cover_edges=" << runner.use_cover_edges_
+		   << " is_kernel_64_bit=" << runner.is_kernel_64_bit_
+		   << " slowdown=" << runner.slowdown_
+		   << " syscall_timeout_ms=" << runner.syscall_timeout_ms_
+		   << " program_timeout_ms=" << runner.program_timeout_ms_
+		   << "\n";
 		ss << "procs:\n";
 		for (const auto& proc : runner.procs_)
 			ss << *proc;
@@ -509,6 +537,9 @@ private:
 					requests_.pop_front();
 			}
 		}
+
+		if (restarting_ < 0 || restarting_ > static_cast<int>(procs_.size()))
+			failmsg("bad restarting", "restarting=%d", restarting_);
 	}
 
 	size_t Handshake()
@@ -627,6 +658,7 @@ private:
 	{
 		// TODO: repair leak checking (#4728).
 		debug("recv corpus triaged\n");
+		corpus_triaged_ = true;
 	}
 
 	void Handle(const rpc::StateRequestRawT& msg)

--- a/pkg/flatrpc/conn_test.go
+++ b/pkg/flatrpc/conn_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestConn(t *testing.T) {
 	connectReq := &ConnectRequest{
-		Name:        "foo",
+		Id:          1,
 		Arch:        "arch",
 		GitRevision: "rev1",
 		SyzRevision: "rev2",
@@ -92,7 +92,7 @@ func TestConn(t *testing.T) {
 
 func BenchmarkConn(b *testing.B) {
 	connectReq := &ConnectRequest{
-		Name:        "foo",
+		Id:          1,
 		Arch:        "arch",
 		GitRevision: "rev1",
 		SyzRevision: "rev2",

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -36,7 +36,7 @@ enum Feature : uint64 (bit_flags) {
 }
  
 table ConnectRequestRaw {
-	name			:string;
+	id			:int64;
 	arch			:string;
 	git_revision		:string;
 	syz_revision		:string;

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -163,6 +163,8 @@ struct ExecOptsRaw {
 // Request to execute a test program.
 table ExecRequestRaw {
 	id			:int64;
+	// Bitmask of procs to avoid when executing this request, if possible.
+	avoid			:uint64;
 	prog_data		:[uint8];
 	exec_opts		:ExecOptsRaw;
 	flags			:RequestFlag;
@@ -239,6 +241,7 @@ table ProgInfoRaw {
 // Result of executing a test program.
 table ExecResultRaw {
 	id			:int64;
+	proc			:int32;
 	output			:[uint8];
 	error			:string;
 	info			:ProgInfoRaw;

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -1923,6 +1923,7 @@ func CreateExecOptsRaw(builder *flatbuffers.Builder, envFlags ExecEnv, execFlags
 
 type ExecRequestRawT struct {
 	Id        int64         `json:"id"`
+	Avoid     uint64        `json:"avoid"`
 	ProgData  []byte        `json:"prog_data"`
 	ExecOpts  *ExecOptsRawT `json:"exec_opts"`
 	Flags     RequestFlag   `json:"flags"`
@@ -1948,6 +1949,7 @@ func (t *ExecRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffset
 	}
 	ExecRequestRawStart(builder)
 	ExecRequestRawAddId(builder, t.Id)
+	ExecRequestRawAddAvoid(builder, t.Avoid)
 	ExecRequestRawAddProgData(builder, progDataOffset)
 	execOptsOffset := t.ExecOpts.Pack(builder)
 	ExecRequestRawAddExecOpts(builder, execOptsOffset)
@@ -1958,6 +1960,7 @@ func (t *ExecRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffset
 
 func (rcv *ExecRequestRaw) UnPackTo(t *ExecRequestRawT) {
 	t.Id = rcv.Id()
+	t.Avoid = rcv.Avoid()
 	t.ProgData = rcv.ProgDataBytes()
 	t.ExecOpts = rcv.ExecOpts(nil).UnPack()
 	t.Flags = rcv.Flags()
@@ -2016,8 +2019,20 @@ func (rcv *ExecRequestRaw) MutateId(n int64) bool {
 	return rcv._tab.MutateInt64Slot(4, n)
 }
 
-func (rcv *ExecRequestRaw) ProgData(j int) byte {
+func (rcv *ExecRequestRaw) Avoid() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ExecRequestRaw) MutateAvoid(n uint64) bool {
+	return rcv._tab.MutateUint64Slot(6, n)
+}
+
+func (rcv *ExecRequestRaw) ProgData(j int) byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
@@ -2026,7 +2041,7 @@ func (rcv *ExecRequestRaw) ProgData(j int) byte {
 }
 
 func (rcv *ExecRequestRaw) ProgDataLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -2034,7 +2049,7 @@ func (rcv *ExecRequestRaw) ProgDataLength() int {
 }
 
 func (rcv *ExecRequestRaw) ProgDataBytes() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -2042,7 +2057,7 @@ func (rcv *ExecRequestRaw) ProgDataBytes() []byte {
 }
 
 func (rcv *ExecRequestRaw) MutateProgData(j int, n byte) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), n)
@@ -2051,7 +2066,7 @@ func (rcv *ExecRequestRaw) MutateProgData(j int, n byte) bool {
 }
 
 func (rcv *ExecRequestRaw) ExecOpts(obj *ExecOptsRaw) *ExecOptsRaw {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		x := o + rcv._tab.Pos
 		if obj == nil {
@@ -2064,7 +2079,7 @@ func (rcv *ExecRequestRaw) ExecOpts(obj *ExecOptsRaw) *ExecOptsRaw {
 }
 
 func (rcv *ExecRequestRaw) Flags() RequestFlag {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return RequestFlag(rcv._tab.GetUint64(o + rcv._tab.Pos))
 	}
@@ -2072,11 +2087,11 @@ func (rcv *ExecRequestRaw) Flags() RequestFlag {
 }
 
 func (rcv *ExecRequestRaw) MutateFlags(n RequestFlag) bool {
-	return rcv._tab.MutateUint64Slot(10, uint64(n))
+	return rcv._tab.MutateUint64Slot(12, uint64(n))
 }
 
 func (rcv *ExecRequestRaw) AllSignal(j int) int32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.GetInt32(a + flatbuffers.UOffsetT(j*4))
@@ -2085,7 +2100,7 @@ func (rcv *ExecRequestRaw) AllSignal(j int) int32 {
 }
 
 func (rcv *ExecRequestRaw) AllSignalLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -2093,7 +2108,7 @@ func (rcv *ExecRequestRaw) AllSignalLength() int {
 }
 
 func (rcv *ExecRequestRaw) MutateAllSignal(j int, n int32) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.MutateInt32(a+flatbuffers.UOffsetT(j*4), n)
@@ -2102,25 +2117,28 @@ func (rcv *ExecRequestRaw) MutateAllSignal(j int, n int32) bool {
 }
 
 func ExecRequestRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(5)
+	builder.StartObject(6)
 }
 func ExecRequestRawAddId(builder *flatbuffers.Builder, id int64) {
 	builder.PrependInt64Slot(0, id, 0)
 }
+func ExecRequestRawAddAvoid(builder *flatbuffers.Builder, avoid uint64) {
+	builder.PrependUint64Slot(1, avoid, 0)
+}
 func ExecRequestRawAddProgData(builder *flatbuffers.Builder, progData flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(progData), 0)
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(progData), 0)
 }
 func ExecRequestRawStartProgDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
 func ExecRequestRawAddExecOpts(builder *flatbuffers.Builder, execOpts flatbuffers.UOffsetT) {
-	builder.PrependStructSlot(2, flatbuffers.UOffsetT(execOpts), 0)
+	builder.PrependStructSlot(3, flatbuffers.UOffsetT(execOpts), 0)
 }
 func ExecRequestRawAddFlags(builder *flatbuffers.Builder, flags RequestFlag) {
-	builder.PrependUint64Slot(3, uint64(flags), 0)
+	builder.PrependUint64Slot(4, uint64(flags), 0)
 }
 func ExecRequestRawAddAllSignal(builder *flatbuffers.Builder, allSignal flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(allSignal), 0)
+	builder.PrependUOffsetTSlot(5, flatbuffers.UOffsetT(allSignal), 0)
 }
 func ExecRequestRawStartAllSignalVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
@@ -3000,6 +3018,7 @@ func ProgInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 
 type ExecResultRawT struct {
 	Id     int64         `json:"id"`
+	Proc   int32         `json:"proc"`
 	Output []byte        `json:"output"`
 	Error  string        `json:"error"`
 	Info   *ProgInfoRawT `json:"info"`
@@ -3017,6 +3036,7 @@ func (t *ExecResultRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT
 	infoOffset := t.Info.Pack(builder)
 	ExecResultRawStart(builder)
 	ExecResultRawAddId(builder, t.Id)
+	ExecResultRawAddProc(builder, t.Proc)
 	ExecResultRawAddOutput(builder, outputOffset)
 	ExecResultRawAddError(builder, errorOffset)
 	ExecResultRawAddInfo(builder, infoOffset)
@@ -3025,6 +3045,7 @@ func (t *ExecResultRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT
 
 func (rcv *ExecResultRaw) UnPackTo(t *ExecResultRawT) {
 	t.Id = rcv.Id()
+	t.Proc = rcv.Proc()
 	t.Output = rcv.OutputBytes()
 	t.Error = string(rcv.Error())
 	t.Info = rcv.Info(nil).UnPack()
@@ -3078,8 +3099,20 @@ func (rcv *ExecResultRaw) MutateId(n int64) bool {
 	return rcv._tab.MutateInt64Slot(4, n)
 }
 
-func (rcv *ExecResultRaw) Output(j int) byte {
+func (rcv *ExecResultRaw) Proc() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ExecResultRaw) MutateProc(n int32) bool {
+	return rcv._tab.MutateInt32Slot(6, n)
+}
+
+func (rcv *ExecResultRaw) Output(j int) byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
@@ -3088,7 +3121,7 @@ func (rcv *ExecResultRaw) Output(j int) byte {
 }
 
 func (rcv *ExecResultRaw) OutputLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -3096,7 +3129,7 @@ func (rcv *ExecResultRaw) OutputLength() int {
 }
 
 func (rcv *ExecResultRaw) OutputBytes() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -3104,7 +3137,7 @@ func (rcv *ExecResultRaw) OutputBytes() []byte {
 }
 
 func (rcv *ExecResultRaw) MutateOutput(j int, n byte) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
 		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), n)
@@ -3113,7 +3146,7 @@ func (rcv *ExecResultRaw) MutateOutput(j int, n byte) bool {
 }
 
 func (rcv *ExecResultRaw) Error() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -3121,7 +3154,7 @@ func (rcv *ExecResultRaw) Error() []byte {
 }
 
 func (rcv *ExecResultRaw) Info(obj *ProgInfoRaw) *ProgInfoRaw {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		x := rcv._tab.Indirect(o + rcv._tab.Pos)
 		if obj == nil {
@@ -3134,22 +3167,25 @@ func (rcv *ExecResultRaw) Info(obj *ProgInfoRaw) *ProgInfoRaw {
 }
 
 func ExecResultRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(4)
+	builder.StartObject(5)
 }
 func ExecResultRawAddId(builder *flatbuffers.Builder, id int64) {
 	builder.PrependInt64Slot(0, id, 0)
 }
+func ExecResultRawAddProc(builder *flatbuffers.Builder, proc int32) {
+	builder.PrependInt32Slot(1, proc, 0)
+}
 func ExecResultRawAddOutput(builder *flatbuffers.Builder, output flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(output), 0)
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(output), 0)
 }
 func ExecResultRawStartOutputVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
 func ExecResultRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(error), 0)
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(error), 0)
 }
 func ExecResultRawAddInfo(builder *flatbuffers.Builder, info flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(info), 0)
+	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(info), 0)
 }
 func ExecResultRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -459,7 +459,7 @@ func (v SnapshotState) String() string {
 }
 
 type ConnectRequestRawT struct {
-	Name        string `json:"name"`
+	Id          int64  `json:"id"`
 	Arch        string `json:"arch"`
 	GitRevision string `json:"git_revision"`
 	SyzRevision string `json:"syz_revision"`
@@ -469,12 +469,11 @@ func (t *ConnectRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOff
 	if t == nil {
 		return 0
 	}
-	nameOffset := builder.CreateString(t.Name)
 	archOffset := builder.CreateString(t.Arch)
 	gitRevisionOffset := builder.CreateString(t.GitRevision)
 	syzRevisionOffset := builder.CreateString(t.SyzRevision)
 	ConnectRequestRawStart(builder)
-	ConnectRequestRawAddName(builder, nameOffset)
+	ConnectRequestRawAddId(builder, t.Id)
 	ConnectRequestRawAddArch(builder, archOffset)
 	ConnectRequestRawAddGitRevision(builder, gitRevisionOffset)
 	ConnectRequestRawAddSyzRevision(builder, syzRevisionOffset)
@@ -482,7 +481,7 @@ func (t *ConnectRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOff
 }
 
 func (rcv *ConnectRequestRaw) UnPackTo(t *ConnectRequestRawT) {
-	t.Name = string(rcv.Name())
+	t.Id = rcv.Id()
 	t.Arch = string(rcv.Arch())
 	t.GitRevision = string(rcv.GitRevision())
 	t.SyzRevision = string(rcv.SyzRevision())
@@ -524,12 +523,16 @@ func (rcv *ConnectRequestRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ConnectRequestRaw) Name() []byte {
+func (rcv *ConnectRequestRaw) Id() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
-	return nil
+	return 0
+}
+
+func (rcv *ConnectRequestRaw) MutateId(n int64) bool {
+	return rcv._tab.MutateInt64Slot(4, n)
 }
 
 func (rcv *ConnectRequestRaw) Arch() []byte {
@@ -559,8 +562,8 @@ func (rcv *ConnectRequestRaw) SyzRevision() []byte {
 func ConnectRequestRawStart(builder *flatbuffers.Builder) {
 	builder.StartObject(4)
 }
-func ConnectRequestRawAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
+func ConnectRequestRawAddId(builder *flatbuffers.Builder, id int64) {
+	builder.PrependInt64Slot(0, id, 0)
 }
 func ConnectRequestRawAddArch(builder *flatbuffers.Builder, arch flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(arch), 0)

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -1769,6 +1769,7 @@ flatbuffers::Offset<ExecutorMessageRaw> CreateExecutorMessageRaw(flatbuffers::Fl
 struct ExecRequestRawT : public flatbuffers::NativeTable {
   typedef ExecRequestRaw TableType;
   int64_t id = 0;
+  uint64_t avoid = 0;
   std::vector<uint8_t> prog_data{};
   std::unique_ptr<rpc::ExecOptsRaw> exec_opts{};
   rpc::RequestFlag flags = static_cast<rpc::RequestFlag>(0);
@@ -1784,13 +1785,17 @@ struct ExecRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ExecRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
-    VT_PROG_DATA = 6,
-    VT_EXEC_OPTS = 8,
-    VT_FLAGS = 10,
-    VT_ALL_SIGNAL = 12
+    VT_AVOID = 6,
+    VT_PROG_DATA = 8,
+    VT_EXEC_OPTS = 10,
+    VT_FLAGS = 12,
+    VT_ALL_SIGNAL = 14
   };
   int64_t id() const {
     return GetField<int64_t>(VT_ID, 0);
+  }
+  uint64_t avoid() const {
+    return GetField<uint64_t>(VT_AVOID, 0);
   }
   const flatbuffers::Vector<uint8_t> *prog_data() const {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_PROG_DATA);
@@ -1807,6 +1812,7 @@ struct ExecRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int64_t>(verifier, VT_ID, 8) &&
+           VerifyField<uint64_t>(verifier, VT_AVOID, 8) &&
            VerifyOffset(verifier, VT_PROG_DATA) &&
            verifier.VerifyVector(prog_data()) &&
            VerifyField<rpc::ExecOptsRaw>(verifier, VT_EXEC_OPTS, 8) &&
@@ -1826,6 +1832,9 @@ struct ExecRequestRawBuilder {
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
     fbb_.AddElement<int64_t>(ExecRequestRaw::VT_ID, id, 0);
+  }
+  void add_avoid(uint64_t avoid) {
+    fbb_.AddElement<uint64_t>(ExecRequestRaw::VT_AVOID, avoid, 0);
   }
   void add_prog_data(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> prog_data) {
     fbb_.AddOffset(ExecRequestRaw::VT_PROG_DATA, prog_data);
@@ -1853,12 +1862,14 @@ struct ExecRequestRawBuilder {
 inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
+    uint64_t avoid = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> prog_data = 0,
     const rpc::ExecOptsRaw *exec_opts = nullptr,
     rpc::RequestFlag flags = static_cast<rpc::RequestFlag>(0),
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> all_signal = 0) {
   ExecRequestRawBuilder builder_(_fbb);
   builder_.add_flags(flags);
+  builder_.add_avoid(avoid);
   builder_.add_id(id);
   builder_.add_all_signal(all_signal);
   builder_.add_exec_opts(exec_opts);
@@ -1869,6 +1880,7 @@ inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(
 inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
+    uint64_t avoid = 0,
     const std::vector<uint8_t> *prog_data = nullptr,
     const rpc::ExecOptsRaw *exec_opts = nullptr,
     rpc::RequestFlag flags = static_cast<rpc::RequestFlag>(0),
@@ -1878,6 +1890,7 @@ inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRawDirect(
   return rpc::CreateExecRequestRaw(
       _fbb,
       id,
+      avoid,
       prog_data__,
       exec_opts,
       flags,
@@ -2355,6 +2368,7 @@ flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRaw(flatbuffers::FlatBufferBuilde
 struct ExecResultRawT : public flatbuffers::NativeTable {
   typedef ExecResultRaw TableType;
   int64_t id = 0;
+  int32_t proc = 0;
   std::vector<uint8_t> output{};
   std::string error{};
   std::unique_ptr<rpc::ProgInfoRawT> info{};
@@ -2369,12 +2383,16 @@ struct ExecResultRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ExecResultRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
-    VT_OUTPUT = 6,
-    VT_ERROR = 8,
-    VT_INFO = 10
+    VT_PROC = 6,
+    VT_OUTPUT = 8,
+    VT_ERROR = 10,
+    VT_INFO = 12
   };
   int64_t id() const {
     return GetField<int64_t>(VT_ID, 0);
+  }
+  int32_t proc() const {
+    return GetField<int32_t>(VT_PROC, 0);
   }
   const flatbuffers::Vector<uint8_t> *output() const {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_OUTPUT);
@@ -2388,6 +2406,7 @@ struct ExecResultRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int64_t>(verifier, VT_ID, 8) &&
+           VerifyField<int32_t>(verifier, VT_PROC, 4) &&
            VerifyOffset(verifier, VT_OUTPUT) &&
            verifier.VerifyVector(output()) &&
            VerifyOffset(verifier, VT_ERROR) &&
@@ -2407,6 +2426,9 @@ struct ExecResultRawBuilder {
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
     fbb_.AddElement<int64_t>(ExecResultRaw::VT_ID, id, 0);
+  }
+  void add_proc(int32_t proc) {
+    fbb_.AddElement<int32_t>(ExecResultRaw::VT_PROC, proc, 0);
   }
   void add_output(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> output) {
     fbb_.AddOffset(ExecResultRaw::VT_OUTPUT, output);
@@ -2431,6 +2453,7 @@ struct ExecResultRawBuilder {
 inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
+    int32_t proc = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> output = 0,
     flatbuffers::Offset<flatbuffers::String> error = 0,
     flatbuffers::Offset<rpc::ProgInfoRaw> info = 0) {
@@ -2439,12 +2462,14 @@ inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(
   builder_.add_info(info);
   builder_.add_error(error);
   builder_.add_output(output);
+  builder_.add_proc(proc);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
+    int32_t proc = 0,
     const std::vector<uint8_t> *output = nullptr,
     const char *error = nullptr,
     flatbuffers::Offset<rpc::ProgInfoRaw> info = 0) {
@@ -2453,6 +2478,7 @@ inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRawDirect(
   return rpc::CreateExecResultRaw(
       _fbb,
       id,
+      proc,
       output__,
       error__,
       info);
@@ -3171,6 +3197,7 @@ inline flatbuffers::Offset<ExecutorMessageRaw> CreateExecutorMessageRaw(flatbuff
 
 inline ExecRequestRawT::ExecRequestRawT(const ExecRequestRawT &o)
       : id(o.id),
+        avoid(o.avoid),
         prog_data(o.prog_data),
         exec_opts((o.exec_opts) ? new rpc::ExecOptsRaw(*o.exec_opts) : nullptr),
         flags(o.flags),
@@ -3179,6 +3206,7 @@ inline ExecRequestRawT::ExecRequestRawT(const ExecRequestRawT &o)
 
 inline ExecRequestRawT &ExecRequestRawT::operator=(ExecRequestRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(id, o.id);
+  std::swap(avoid, o.avoid);
   std::swap(prog_data, o.prog_data);
   std::swap(exec_opts, o.exec_opts);
   std::swap(flags, o.flags);
@@ -3196,6 +3224,7 @@ inline void ExecRequestRaw::UnPackTo(ExecRequestRawT *_o, const flatbuffers::res
   (void)_o;
   (void)_resolver;
   { auto _e = id(); _o->id = _e; }
+  { auto _e = avoid(); _o->avoid = _e; }
   { auto _e = prog_data(); if (_e) { _o->prog_data.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->prog_data.begin()); } }
   { auto _e = exec_opts(); if (_e) _o->exec_opts = std::unique_ptr<rpc::ExecOptsRaw>(new rpc::ExecOptsRaw(*_e)); }
   { auto _e = flags(); _o->flags = _e; }
@@ -3211,6 +3240,7 @@ inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(flatbuffers::Fla
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _id = _o->id;
+  auto _avoid = _o->avoid;
   auto _prog_data = _o->prog_data.size() ? _fbb.CreateVector(_o->prog_data) : 0;
   auto _exec_opts = _o->exec_opts ? _o->exec_opts.get() : nullptr;
   auto _flags = _o->flags;
@@ -3218,6 +3248,7 @@ inline flatbuffers::Offset<ExecRequestRaw> CreateExecRequestRaw(flatbuffers::Fla
   return rpc::CreateExecRequestRaw(
       _fbb,
       _id,
+      _avoid,
       _prog_data,
       _exec_opts,
       _flags,
@@ -3428,6 +3459,7 @@ inline flatbuffers::Offset<ProgInfoRaw> CreateProgInfoRaw(flatbuffers::FlatBuffe
 
 inline ExecResultRawT::ExecResultRawT(const ExecResultRawT &o)
       : id(o.id),
+        proc(o.proc),
         output(o.output),
         error(o.error),
         info((o.info) ? new rpc::ProgInfoRawT(*o.info) : nullptr) {
@@ -3435,6 +3467,7 @@ inline ExecResultRawT::ExecResultRawT(const ExecResultRawT &o)
 
 inline ExecResultRawT &ExecResultRawT::operator=(ExecResultRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(id, o.id);
+  std::swap(proc, o.proc);
   std::swap(output, o.output);
   std::swap(error, o.error);
   std::swap(info, o.info);
@@ -3451,6 +3484,7 @@ inline void ExecResultRaw::UnPackTo(ExecResultRawT *_o, const flatbuffers::resol
   (void)_o;
   (void)_resolver;
   { auto _e = id(); _o->id = _e; }
+  { auto _e = proc(); _o->proc = _e; }
   { auto _e = output(); if (_e) { _o->output.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->output.begin()); } }
   { auto _e = error(); if (_e) _o->error = _e->str(); }
   { auto _e = info(); if (_e) _o->info = std::unique_ptr<rpc::ProgInfoRawT>(_e->UnPack(_resolver)); }
@@ -3465,12 +3499,14 @@ inline flatbuffers::Offset<ExecResultRaw> CreateExecResultRaw(flatbuffers::FlatB
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ExecResultRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
   auto _id = _o->id;
+  auto _proc = _o->proc;
   auto _output = _o->output.size() ? _fbb.CreateVector(_o->output) : 0;
   auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
   auto _info = _o->info ? CreateProgInfoRaw(_fbb, _o->info.get(), _rehasher) : 0;
   return rpc::CreateExecResultRaw(
       _fbb,
       _id,
+      _proc,
       _output,
       _error,
       _info);

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -809,7 +809,7 @@ FLATBUFFERS_STRUCT_END(ComparisonRaw, 32);
 
 struct ConnectRequestRawT : public flatbuffers::NativeTable {
   typedef ConnectRequestRaw TableType;
-  std::string name{};
+  int64_t id = 0;
   std::string arch{};
   std::string git_revision{};
   std::string syz_revision{};
@@ -819,13 +819,13 @@ struct ConnectRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ConnectRequestRawT NativeTableType;
   typedef ConnectRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_NAME = 4,
+    VT_ID = 4,
     VT_ARCH = 6,
     VT_GIT_REVISION = 8,
     VT_SYZ_REVISION = 10
   };
-  const flatbuffers::String *name() const {
-    return GetPointer<const flatbuffers::String *>(VT_NAME);
+  int64_t id() const {
+    return GetField<int64_t>(VT_ID, 0);
   }
   const flatbuffers::String *arch() const {
     return GetPointer<const flatbuffers::String *>(VT_ARCH);
@@ -838,8 +838,7 @@ struct ConnectRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_NAME) &&
-           verifier.VerifyString(name()) &&
+           VerifyField<int64_t>(verifier, VT_ID, 8) &&
            VerifyOffset(verifier, VT_ARCH) &&
            verifier.VerifyString(arch()) &&
            VerifyOffset(verifier, VT_GIT_REVISION) &&
@@ -857,8 +856,8 @@ struct ConnectRequestRawBuilder {
   typedef ConnectRequestRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_name(flatbuffers::Offset<flatbuffers::String> name) {
-    fbb_.AddOffset(ConnectRequestRaw::VT_NAME, name);
+  void add_id(int64_t id) {
+    fbb_.AddElement<int64_t>(ConnectRequestRaw::VT_ID, id, 0);
   }
   void add_arch(flatbuffers::Offset<flatbuffers::String> arch) {
     fbb_.AddOffset(ConnectRequestRaw::VT_ARCH, arch);
@@ -882,31 +881,30 @@ struct ConnectRequestRawBuilder {
 
 inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> name = 0,
+    int64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> arch = 0,
     flatbuffers::Offset<flatbuffers::String> git_revision = 0,
     flatbuffers::Offset<flatbuffers::String> syz_revision = 0) {
   ConnectRequestRawBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_syz_revision(syz_revision);
   builder_.add_git_revision(git_revision);
   builder_.add_arch(arch);
-  builder_.add_name(name);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *name = nullptr,
+    int64_t id = 0,
     const char *arch = nullptr,
     const char *git_revision = nullptr,
     const char *syz_revision = nullptr) {
-  auto name__ = name ? _fbb.CreateString(name) : 0;
   auto arch__ = arch ? _fbb.CreateString(arch) : 0;
   auto git_revision__ = git_revision ? _fbb.CreateString(git_revision) : 0;
   auto syz_revision__ = syz_revision ? _fbb.CreateString(syz_revision) : 0;
   return rpc::CreateConnectRequestRaw(
       _fbb,
-      name__,
+      id,
       arch__,
       git_revision__,
       syz_revision__);
@@ -2874,7 +2872,7 @@ inline ConnectRequestRawT *ConnectRequestRaw::UnPack(const flatbuffers::resolver
 inline void ConnectRequestRaw::UnPackTo(ConnectRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = name(); if (_e) _o->name = _e->str(); }
+  { auto _e = id(); _o->id = _e; }
   { auto _e = arch(); if (_e) _o->arch = _e->str(); }
   { auto _e = git_revision(); if (_e) _o->git_revision = _e->str(); }
   { auto _e = syz_revision(); if (_e) _o->syz_revision = _e->str(); }
@@ -2888,13 +2886,13 @@ inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(flatbuffer
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
+  auto _id = _o->id;
   auto _arch = _o->arch.empty() ? 0 : _fbb.CreateString(_o->arch);
   auto _git_revision = _o->git_revision.empty() ? 0 : _fbb.CreateString(_o->git_revision);
   auto _syz_revision = _o->syz_revision.empty() ? 0 : _fbb.CreateString(_o->syz_revision);
   return rpc::CreateConnectRequestRaw(
       _fbb,
-      _name,
+      _id,
       _arch,
       _git_revision,
       _syz_revision);

--- a/pkg/flatrpc/helpers.go
+++ b/pkg/flatrpc/helpers.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"unsafe"
+
+	"github.com/google/syzkaller/prog"
 )
 
 const AllFeatures = ^Feature(0)
@@ -38,6 +40,13 @@ type ExecOpts = ExecOptsRawT
 type ProgInfo = ProgInfoRawT
 type ExecResult = ExecResultRawT
 type StateResult = StateResultRawT
+
+func init() {
+	var req ExecRequest
+	if prog.MaxPids > unsafe.Sizeof(req.Avoid)*8 {
+		panic("all procs won't fit ito ExecRequest.Avoid")
+	}
+}
 
 func (pi *ProgInfo) Clone() *ProgInfo {
 	if pi == nil {

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -137,10 +137,11 @@ func (fuzzer *Fuzzer) processResult(req *queue.Request, res *queue.Result, flags
 				queue, stat = fuzzer.triageCandidateQueue, fuzzer.statJobsTriageCandidate
 			}
 			fuzzer.startJob(stat, &triageJob{
-				p:     req.Prog.Clone(),
-				flags: flags,
-				queue: queue.Append(),
-				calls: triage,
+				p:        req.Prog.Clone(),
+				executor: res.Executor,
+				flags:    flags,
+				queue:    queue.Append(),
+				calls:    triage,
 			})
 		}
 	}

--- a/pkg/fuzzer/queue/distributor.go
+++ b/pkg/fuzzer/queue/distributor.go
@@ -1,0 +1,132 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package queue
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/syzkaller/pkg/stat"
+)
+
+// Distributor distributes requests to different VMs during input triage
+// (allows to avoid already used VMs).
+type Distributor struct {
+	source        Source
+	seq           atomic.Uint64
+	empty         atomic.Bool
+	active        atomic.Pointer[[]atomic.Uint64]
+	mu            sync.Mutex
+	queue         []*Request
+	statDelayed   *stat.Val
+	statUndelayed *stat.Val
+	statViolated  *stat.Val
+}
+
+func Distribute(source Source) *Distributor {
+	return &Distributor{
+		source: source,
+		statDelayed: stat.New("distributor delayed", "Number of test programs delayed due to VM avoidance",
+			stat.Graph("distributor")),
+		statUndelayed: stat.New("distributor undelayed", "Number of test programs undelayed for VM avoidance",
+			stat.Graph("distributor")),
+		statViolated: stat.New("distributor violated", "Number of test programs violated VM avoidance",
+			stat.Graph("distributor")),
+	}
+}
+
+// Next returns the next request to execute on the given vm.
+func (dist *Distributor) Next(vm int) *Request {
+	dist.noteActive(vm)
+	if req := dist.delayed(vm); req != nil {
+		return req
+	}
+	for {
+		req := dist.source.Next()
+		if req == nil || !contains(req.Avoid, vm) || !dist.hasOtherActive(req.Avoid) {
+			return req
+		}
+		dist.delay(req)
+	}
+}
+
+func (dist *Distributor) delay(req *Request) {
+	dist.mu.Lock()
+	defer dist.mu.Unlock()
+	req.delayedSince = dist.seq.Load()
+	dist.queue = append(dist.queue, req)
+	dist.statDelayed.Add(1)
+	dist.empty.Store(false)
+}
+
+func (dist *Distributor) delayed(vm int) *Request {
+	if dist.empty.Load() {
+		return nil
+	}
+	dist.mu.Lock()
+	defer dist.mu.Unlock()
+	seq := dist.seq.Load()
+	for i, req := range dist.queue {
+		violation := contains(req.Avoid, vm)
+		// The delayedSince check protects from a situation when we had another VM available,
+		// and delayed a request, but then the VM was taken for reproduction and does not
+		// serve requests any more. If we could not dispatch a request in 1000 attempts,
+		// we gave up and give it to any VM.
+		if violation && req.delayedSince+1000 > seq {
+			continue
+		}
+		dist.statUndelayed.Add(1)
+		if violation {
+			dist.statViolated.Add(1)
+		}
+		last := len(dist.queue) - 1
+		dist.queue[i] = dist.queue[last]
+		dist.queue[last] = nil
+		dist.queue = dist.queue[:last]
+		dist.empty.Store(len(dist.queue) == 0)
+		return req
+	}
+	return nil
+}
+
+func (dist *Distributor) noteActive(vm int) {
+	active := dist.active.Load()
+	if active == nil || len(*active) <= vm {
+		dist.mu.Lock()
+		active = dist.active.Load()
+		if active == nil || len(*active) <= vm {
+			tmp := make([]atomic.Uint64, vm+10)
+			active = &tmp
+			dist.active.Store(active)
+		}
+		dist.mu.Unlock()
+	}
+	(*active)[vm].Store(dist.seq.Add(1))
+}
+
+// hasOtherActive says if we recently seen activity from VMs not in the set.
+func (dist *Distributor) hasOtherActive(set []ExecutorID) bool {
+	seq := dist.seq.Load()
+	active := *dist.active.Load()
+	for vm := range active {
+		if contains(set, vm) {
+			continue
+		}
+		// 1000 is semi-random notion of recency.
+		if active[vm].Load()+1000 < seq {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func contains(set []ExecutorID, vm int) bool {
+	for _, id := range set {
+		if id.VM == vm {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/fuzzer/queue/distributor_test.go
+++ b/pkg/fuzzer/queue/distributor_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDistributor(t *testing.T) {
+	q := Plain()
+	dist := Distribute(q)
+
+	req := &Request{}
+	q.Submit(req)
+	assert.Equal(t, req, dist.Next(0))
+
+	q.Submit(req)
+	assert.Equal(t, req, dist.Next(1))
+
+	// Avoid VM 0.
+	req.Avoid = []ExecutorID{{VM: 0}}
+	q.Submit(req)
+	var noReq *Request
+	assert.Equal(t, noReq, dist.Next(0))
+	assert.Equal(t, noReq, dist.Next(0))
+	assert.Equal(t, req, dist.Next(1))
+
+	// If only VM 0 queries requests, it should eventually got it.
+	q.Submit(req)
+	assert.Equal(t, noReq, dist.Next(0))
+	for {
+		got := dist.Next(0)
+		if got == req {
+			break
+		}
+		assert.Equal(t, noReq, got)
+	}
+
+	// If all active VMs are in the avoid set, then they should get
+	// the request immidiatly.
+	assert.Equal(t, noReq, dist.Next(1))
+	req.Avoid = []ExecutorID{{VM: 0}, {VM: 1}}
+	q.Submit(req)
+	assert.Equal(t, req, dist.Next(1))
+}

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -57,12 +57,12 @@ func RunLocal(cfg *LocalConfig) error {
 	// for the race detector b/c it does not understand the synchronization via TCP socket connect/accept.
 	close(ctx.setupDone)
 
-	name := "local"
-	connErr := serv.CreateInstance(name, nil, nil)
-	defer serv.ShutdownInstance(name, true)
+	id := 0
+	connErr := serv.CreateInstance(id, nil, nil)
+	defer serv.ShutdownInstance(id, true)
 
 	bin := cfg.Executor
-	args := []string{"runner", name, "localhost", fmt.Sprint(serv.Port)}
+	args := []string{"runner", fmt.Sprint(id), "localhost", fmt.Sprint(serv.Port)}
 	if cfg.GDB {
 		bin = "gdb"
 		args = append([]string{

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -8,13 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/cover/backend"
@@ -404,7 +402,6 @@ func (serv *Server) CreateInstance(name string, injectExec chan<- bool, updInfo 
 		requests:      make(map[int64]*queue.Request),
 		executing:     make(map[int64]bool),
 		lastExec:      MakeLastExecuting(serv.cfg.Procs, 6),
-		rnd:           rand.New(rand.NewSource(time.Now().UnixNano())),
 		stats:         serv.runnerStats,
 		procs:         serv.cfg.Procs,
 		updInfo:       updInfo,

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"slices"
 	"sync"
@@ -43,7 +42,6 @@ type Runner struct {
 	requests      map[int64]*queue.Request
 	executing     map[int64]bool
 	lastExec      *LastExecuting
-	rnd           *rand.Rand
 	updInfo       dispatcher.UpdateInfo
 	resultCh      chan error
 
@@ -287,13 +285,7 @@ func (runner *Runner) sendRequest(req *queue.Request) error {
 	for i, call := range req.ReturnAllSignal {
 		allSignal[i] = int32(call)
 	}
-	// Do not let too much state accumulate.
-	const restartIn = 600
-	resetFlags := flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover | flatrpc.ExecFlagCollectComps
 	opts := req.ExecOpts
-	if req.ExecOpts.ExecFlags&resetFlags != 0 && runner.rnd.Intn(restartIn) == 0 {
-		opts.EnvFlags |= flatrpc.ExecEnvResetState
-	}
 	if runner.debug {
 		opts.EnvFlags |= flatrpc.ExecEnvDebug
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1502,7 +1502,7 @@ func (mgr *Manager) fuzzerLoop(fuzzer *fuzzer.Fuzzer) {
 			}
 			mgr.mu.Lock()
 			if mgr.phase == phaseLoadedCorpus {
-				if !mgr.cfg.Snapshot && mgr.enabledFeatures&flatrpc.FeatureLeak != 0 {
+				if !mgr.cfg.Snapshot {
 					mgr.serv.TriagedCorpus()
 				}
 				if mgr.cfg.HubClient != "" {


### PR DESCRIPTION
- **prog: reduce amount of hint replacements**
- **pkg/fuzzer: optimize smash jobs**
- **pkg/fuzzer: remove signal rotation**
- **pkg/fuzzer: try to triage on different VMs**
- **pkg/fuzzer: tune corpus triage**
- **pkg/fuzzer: issue minimize attempts in parallel**
- **executor: restart procs more deterministically**
- **pkg/fuzzer: deflake hints 3 times instead of 2**
