### PR TITLE
dashboard/app: make coverage menu and page optional

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -121,6 +121,13 @@ type Config struct {
 	DisplayDiscussions bool
 	// Cache what we display on the web dashboard.
 	CacheUIPages bool
+	// Enables coverage aggregation.
+	Coverage *CoverageConfig
+}
+
+type CoverageConfig struct {
+	BatchProject        string
+	BatchServiceAccount string
 }
 
 // DiscussionEmailConfig defines the correspondence between an email and a DiscussionSource.

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -206,6 +206,7 @@ type uiHeader struct {
 	MissingBackports    int
 	Namespaces          []uiNamespace
 	ShowSubsystems      bool
+	ShowCoverageMenu    bool
 }
 
 type uiNamespace struct {
@@ -290,6 +291,7 @@ func commonHeader(c context.Context, r *http.Request, w http.ResponseWriter, ns 
 		}
 		h.BugCounts = &cached.Total
 		h.MissingBackports = cached.MissingBackports
+		h.ShowCoverageMenu = getNsConfig(c, ns).Coverage != nil
 	}
 	return h, nil
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -55,7 +55,7 @@ func initHTTPHandlers() {
 	http.Handle("/x/bisect.txt", handlerWrapper(handleTextX(textLog)))
 	http.Handle("/x/error.txt", handlerWrapper(handleTextX(textError)))
 	http.Handle("/x/minfo.txt", handlerWrapper(handleTextX(textMachineInfo)))
-	for ns := range getConfig(context.Background()).Namespaces {
+	for ns, nsConfig := range getConfig(context.Background()).Namespaces {
 		http.Handle("/"+ns, handlerWrapper(handleMain))
 		http.Handle("/"+ns+"/fixed", handlerWrapper(handleFixed)) // nolint: goconst // remove it with goconst 1.7.0+
 		http.Handle("/"+ns+"/invalid", handlerWrapper(handleInvalid))
@@ -64,7 +64,9 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/graph/fuzzing", handlerWrapper(handleGraphFuzzing))
 		http.Handle("/"+ns+"/graph/crashes", handlerWrapper(handleGraphCrashes))
 		http.Handle("/"+ns+"/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
-		http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
+		if nsConfig.Coverage != nil {
+			http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
+		}
 		http.Handle("/"+ns+"/repos", handlerWrapper(handleRepos))
 		http.Handle("/"+ns+"/bug-summaries", handlerWrapper(handleBugSummaries))
 		http.Handle("/"+ns+"/subsystems", handlerWrapper(handleSubsystemsList))

--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -84,8 +84,10 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					  <span style="color:DarkOrange;">📈</span> Fuzzing</a>
 					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/crashes" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/graph/crashes'>
 						<span style="color:DarkOrange;">📈</span> Crashes</a>
+          {{if .ShowCoverageMenu}}
           <a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/coverage" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/graph/coverage'>
             <span style="color:DarkOrange;">📈</span> Coverage</a>
+          {{end}}
 				</td>
                                 {{if .ContactEmail}}
 				<td class="navigation-right">


### PR DESCRIPTION
Is also needed to #4979 .
2 unused options will be needed there.