### PR TITLE
executor: set `source` for the proc mount

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3912,7 +3912,7 @@ static void sandbox_common_mount_tmpfs(void)
 		fail("mount(dev) failed");
 	if (mkdir("./syz-tmp/newroot/proc", 0700))
 		fail("mkdir failed");
-	if (mount(NULL, "./syz-tmp/newroot/proc", "proc", 0, NULL))
+	if (mount("syz-proc", "./syz-tmp/newroot/proc", "proc", 0, NULL))
 		fail("mount(proc) failed");
 	if (mkdir("./syz-tmp/newroot/selinux", 0700))
 		fail("mkdir failed");


### PR DESCRIPTION
mount() in gVisor returns EFAULT if source is NULL. It is a gVisor issue and we will fix it. Let's explicitly sets a string source for the proc mount to unblock gVisor jobs. The source string will additionally be useful for troubleshooting mount-related problems in the future, because it is shown in /prod/pid/mountinfo.

