### PR TITLE
tools/syz-bq.sh: assume the dir is already a multirepo

### DIFF
--- a/tools/syz-bq.sh
+++ b/tools/syz-bq.sh
@@ -74,7 +74,8 @@ if [ ! -d $base_dir ]; then
   git clone $repo $base_dir
 fi
 cd $base_dir
-git checkout $branch
+remote=$(git remote -v | grep $repo | head -n1 | awk '{print $1;}')
+git checkout $remote/$branch
 cd -
 
 # get the last merged commit at to_date


### PR DESCRIPTION
It works good with empty workdirs.
If workdir has multiple remotes, git checkout is confused what version of "branch" to checkout.