### PR TITLE
dashboard/app: sort discussions as text

### DIFF
--- a/dashboard/app/templates.html
+++ b/dashboard/app/templates.html
@@ -154,7 +154,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Last activity', timeSort, desc=true)" href="#">Last activity</a></th>
 		{{end}}
 		{{if $.DispDiscuss}}
-		<th><a onclick="return sortTable(this, 'Discussions', timeSort, desc=true)" href="#">Discussions</a></th>
+		<th><a onclick="return sortTable(this, 'Discussions', textSort)" href="#">Discussions</a></th>
 		{{end}}
 		{{if $.ShowPatched}}
 			<th><a onclick="return sortTable(this, 'Patched', patchedSort)" href="#">Patched</a></th>


### PR DESCRIPTION
The current time sorting produces some random order (text is not time).
Let's sort as text, it should produce at least some order (e.g. group PATCH together).
