### PR TITLE
pkg/{runtest, rpcserver, vminfo}: ensure graceful exit

### DIFF
--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -5,11 +5,9 @@ package rpcserver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/flatrpc"
@@ -99,23 +97,6 @@ func RunLocal(cfg *LocalConfig) error {
 	if cmdErr == nil {
 		cmd.Process.Kill()
 		<-res
-	}
-	if !cfg.HandleInterrupts {
-		// If the executor has crashed early, reply to all remaining requests to unblock tests.
-	loop:
-		for {
-			req := serv.execSource.Next()
-			if req == nil {
-				select {
-				case <-cfg.Context.Done():
-					break loop
-				default:
-					time.Sleep(time.Millisecond)
-					continue loop
-				}
-			}
-			req.Done(&queue.Result{Status: queue.ExecFailure, Err: errors.New("executor crashed")})
-		}
 	}
 	return cmdErr
 }

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -50,7 +50,7 @@ func RunLocal(cfg *LocalConfig) error {
 		cfg:       cfg,
 		setupDone: make(chan bool),
 	}
-	serv, err := newImpl(&cfg.Config, ctx)
+	serv, err := newImpl(cfg.Context, &cfg.Config, ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -5,6 +5,7 @@ package rpcserver
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -105,7 +106,7 @@ func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
 	if !cfg.Experimental.RemoteCover {
 		features &= ^flatrpc.FeatureExtraCoverage
 	}
-	return newImpl(&Config{
+	return newImpl(context.Background(), &Config{
 		Config: vminfo.Config{
 			Target:     cfg.Target,
 			Features:   features,
@@ -130,9 +131,9 @@ func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
 	}, mgr)
 }
 
-func newImpl(cfg *Config, mgr Manager) (*Server, error) {
+func newImpl(ctx context.Context, cfg *Config, mgr Manager) (*Server, error) {
 	cfg.Procs = min(cfg.Procs, prog.MaxPids)
-	checker := vminfo.New(&cfg.Config)
+	checker := vminfo.New(ctx, &cfg.Config)
 	baseSource := queue.DynamicSource(checker)
 	// Note that we use VMArch, rather than Arch. We need the kernel address ranges and bitness.
 	sysTarget := targets.Get(cfg.Target.OS, cfg.VMArch)

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -164,7 +164,10 @@ func (runner *Runner) ConnectionLoop() error {
 			}
 		}
 		if len(runner.requests) == 0 {
-			// The runner has not requests at all, so don't wait to receive anything from it.
+			if !runner.Alive() {
+				return nil
+			}
+			// The runner has no new requests, so don't wait to receive anything from it.
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -67,7 +67,7 @@ func (ctx *Context) log(msg string, args ...interface{}) {
 	ctx.LogFunc(fmt.Sprintf(msg, args...))
 }
 
-func (ctx *Context) Run() error {
+func (ctx *Context) Run(waitCtx context.Context) error {
 	ctx.buildSem = make(chan bool, runtime.GOMAXPROCS(0))
 	ctx.executor = queue.DynamicOrder()
 	ctx.generatePrograms()
@@ -84,7 +84,7 @@ func (ctx *Context) Run() error {
 			result = fmt.Sprintf("SKIP (%v)", req.skip)
 			verbose = true
 		} else {
-			req.Request.Wait(context.Background())
+			req.Request.Wait(waitCtx)
 			if req.err != nil {
 				fail++
 				result = fmt.Sprintf("FAIL: %v",

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -85,7 +85,7 @@ func test(t *testing.T, sysTarget *targets.Target) {
 		Verbose: true,
 		Debug:   *flagDebug,
 	}
-	startRPCServer(t, target, executor, "", ctx, nil, nil, func(features flatrpc.Feature) {
+	waitCtx := startRPCServer(t, target, executor, "", ctx, nil, nil, func(features flatrpc.Feature) {
 		// Features we expect to be enabled on the test OS.
 		// All sandboxes except for none are not implemented, coverage is not returned,
 		// and setup for few features is failing specifically to test feature detection.
@@ -113,7 +113,7 @@ func test(t *testing.T, sysTarget *targets.Target) {
 	if t.Failed() {
 		return
 	}
-	if err := ctx.Run(); err != nil {
+	if err := ctx.Run(waitCtx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/vminfo/linux_test.go
+++ b/pkg/vminfo/linux_test.go
@@ -6,6 +6,7 @@ package vminfo
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -20,7 +21,7 @@ import (
 
 func TestLinuxSyscalls(t *testing.T) {
 	cfg := testConfig(t, targets.Linux, targets.AMD64)
-	checker := New(cfg)
+	checker := New(context.Background(), cfg)
 	filesystems := []string{
 		// Without sysfs, the checks would also disable mount().
 		"", "sysfs", "ext4", "binder", "",

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -47,7 +47,7 @@ type Config struct {
 	SandboxArg int64
 }
 
-func New(cfg *Config) *Checker {
+func New(ctx context.Context, cfg *Config) *Checker {
 	var impl checker
 	switch cfg.Target.OS {
 	case targets.Linux:
@@ -59,7 +59,6 @@ func New(cfg *Config) *Checker {
 	default:
 		impl = new(stub)
 	}
-	ctx := context.Background()
 	executor := queue.Plain()
 	return &Checker{
 		checker:      impl,

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -4,6 +4,7 @@
 package vminfo
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -54,7 +55,7 @@ func TestSyscalls(t *testing.T) {
 			t.Run(target.OS+"/"+target.Arch, func(t *testing.T) {
 				t.Parallel()
 				cfg := testConfig(t, target.OS, target.Arch)
-				checker := New(cfg)
+				checker := New(context.Background(), cfg)
 				stop := make(chan struct{})
 				go createSuccessfulResults(checker, stop)
 				enabled, disabled, _, err := checker.Run(nil, allFeatures())
@@ -119,7 +120,7 @@ func createSuccessfulResults(source queue.Source, stop chan struct{}) {
 
 func hostChecker(t *testing.T) (*Checker, []*flatrpc.FileInfo) {
 	cfg := testConfig(t, runtime.GOOS, runtime.GOARCH)
-	checker := New(cfg)
+	checker := New(context.Background(), cfg)
 	files := readFiles(checker.RequiredFiles())
 	return checker, files
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1566,7 +1566,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map
 			Debug:   *flagDebug,
 		}
 		go func() {
-			err := ctx.Run()
+			err := ctx.Run(context.Background())
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
These changes should hopefully convert the timeouts we're seeing in #4954 into more actionable errors.

See individual commits.