### PR TITLE
Experiment: pkg/runtest: reduce the parallelism of TestCover

### DIFF
--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -358,7 +358,6 @@ func testCover(t *testing.T, target *prog.Target) {
 	for i, test := range tests {
 		test := test
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			t.Parallel()
 			source := queue.Plain()
 			vmArch := targets.TestArch32
 			if test.Is64Bit {


### PR DESCRIPTION
Do targets in parallel, but per target tests sequentually.

***

Let's check how long it takes now. `ci/build` seems to take around 6 minutes on the mainline.