### PR TITLE
Dashapi useragent

### DIFF
--- a/dashboard/dashapi/dashapi_test.go
+++ b/dashboard/dashapi/dashapi_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package dashapi
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewOpts(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+	}{
+		{
+			name: "no_options",
+		},
+		{
+			name:      "custom_user_agent",
+			userAgent: "Custom Agent/2.3",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := []DashboardOpts{}
+			if test.userAgent != "" {
+				opts = append(opts, UserAgent(test.userAgent))
+			}
+			dash, err := New("some_client", "some_addr", "some_key", opts...)
+			if err != nil {
+				t.Fatalf("call to New() returned unexpected error, got: %v, want: nil", err)
+			}
+
+			req, err := dash.ctor("GET", "http://www.example.com", bytes.NewBuffer([]byte("body")))
+			if err != nil {
+				t.Errorf("ctor() returned unexpected error, got: %v, want: nil", err)
+			}
+
+			got := req.Header.Get("User-Agent")
+			if got != test.userAgent {
+				t.Errorf("created request has unexpected header. got: %s, want: 'Custom Agent/2.3'", got)
+			}
+		})
+	}
+}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -96,9 +96,10 @@ type Config struct {
 	// Mailx is the only supported mailer. Please set it up prior to using this function.
 	EmailAddrs []string `json:"email_addrs,omitempty"`
 
-	DashboardClient string `json:"dashboard_client,omitempty"`
-	DashboardAddr   string `json:"dashboard_addr,omitempty"`
-	DashboardKey    string `json:"dashboard_key,omitempty"`
+	DashboardClient    string `json:"dashboard_client,omitempty"`
+	DashboardAddr      string `json:"dashboard_addr,omitempty"`
+	DashboardKey       string `json:"dashboard_key,omitempty"`
+	DashboardUserAgent string `json:"dashboard_user_agent,omitempty"`
 	// If set, only consult dashboard if it needs reproducers for crashes,
 	// but otherwise don't send any info to dashboard (default: false).
 	DashboardOnlyRepro bool `json:"dashboard_only_repro,omitempty"`

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -261,7 +261,11 @@ func RunManager(cfg *mgrconfig.Config) {
 	log.Logf(0, "serving rpc on tcp://%v", mgr.serv.Port)
 
 	if cfg.DashboardAddr != "" {
-		dash, err := dashapi.New(cfg.DashboardClient, cfg.DashboardAddr, cfg.DashboardKey)
+		opts := []dashapi.DashboardOpts{}
+		if cfg.DashboardUserAgent != "" {
+			opts = append(opts, dashapi.UserAgent(cfg.DashboardUserAgent))
+		}
+		dash, err := dashapi.New(cfg.DashboardClient, cfg.DashboardAddr, cfg.DashboardKey, opts...)
 		if err != nil {
 			log.Fatalf("failed to create dashapi connection: %v", err)
 		}


### PR DESCRIPTION
Some proxies have requirements on the user-agent used. If the default user-agent that the go `http` lib uses is not satisfying them, there should be a way to customize that header.

So we add a `DashboardUserAgent` config option, and if it is set we use it in the request constructor. 