### PR TITLE
all: switch to a generic instance pool functionality

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -183,17 +183,17 @@ func (serv *Server) Close() error {
 	return serv.serv.Close()
 }
 
-type VMState struct {
-	State     int
-	Timestamp time.Time
-}
-
 const (
 	StateOffline = iota
 	StateBooting
 	StateFuzzing
 	StateStopping
 )
+
+type VMState struct {
+	State     int
+	Timestamp time.Time
+}
 
 func (serv *Server) VMState() map[string]VMState {
 	serv.mu.Lock()

--- a/syz-manager/repro.go
+++ b/syz-manager/repro.go
@@ -1,0 +1,209 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/stats"
+)
+
+type reproManagerView interface {
+	runRepro(crash *Crash) *ReproResult // TODO: consider moving runRepro() to repro.go.
+	needRepro(crash *Crash) bool
+	resizeReproPool(size int)
+}
+
+type reproManager struct {
+	Done chan *ReproResult
+
+	statNumReproducing *stats.Val
+	statPending        *stats.Val
+
+	onlyOnce  bool
+	mgr       reproManagerView
+	parallel  chan struct{}
+	pingQueue chan struct{}
+	reproVMs  int
+
+	mu          sync.Mutex
+	queue       []*Crash
+	reproducing map[string]bool
+}
+
+func newReproManager(mgr reproManagerView, reproVMs int, onlyOnce bool) *reproManager {
+	ret := &reproManager{
+		Done: make(chan *ReproResult, 10),
+
+		mgr:         mgr,
+		onlyOnce:    onlyOnce,
+		parallel:    make(chan struct{}, reproVMs),
+		reproVMs:    reproVMs,
+		reproducing: map[string]bool{},
+		pingQueue:   make(chan struct{}, 1),
+	}
+	ret.statNumReproducing = stats.Create("reproducing", "Number of crashes being reproduced",
+		stats.Console, stats.NoGraph, func() int {
+			ret.mu.Lock()
+			defer ret.mu.Unlock()
+			return len(ret.reproducing)
+		})
+	ret.statPending = stats.Create("pending", "Number of pending repro tasks",
+		stats.Console, stats.NoGraph, func() int {
+			ret.mu.Lock()
+			defer ret.mu.Unlock()
+			return len(ret.queue)
+		})
+	return ret
+}
+
+// startReproduction() is assumed to be called only once.
+// The agument is the maximum number of VMs dedicated to the bug reproduction.
+func (m *reproManager) StartReproduction() {
+	log.Logf(1, "starting reproductions (max %d VMs)", m.reproVMs)
+
+	for count := 1; m.calculateReproVMs(count) <= m.reproVMs; count++ {
+		m.parallel <- struct{}{}
+	}
+}
+
+func (m *reproManager) calculateReproVMs(repros int) int {
+	// Let's allocate 1.33 VMs per a reproducer thread.
+	if m.reproVMs == 1 && repros == 1 {
+		// With one exception -- if we have only one VM, let's still do one repro.
+		return 1
+	}
+	return (repros*4 + 2) / 3
+}
+
+func (m *reproManager) CanReproMore() bool {
+	return len(m.parallel) != 0
+}
+
+func (m *reproManager) Reproducing() map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return maps.Clone(m.reproducing)
+}
+
+func (m *reproManager) Enqueue(crash *Crash) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.onlyOnce {
+		// Try to reproduce each bug at most 1 time in this mode.
+		// Since we don't upload bugs/repros to dashboard, it likely won't have
+		// the reproducer even if we succeeded last time, and will repeatedly
+		// say it needs a repro.
+		for _, queued := range m.queue {
+			if queued.Title == crash.Title {
+				return
+			}
+		}
+	}
+	log.Logf(1, "scheduled a reproduction of '%v'", crash.Title)
+	m.queue = append(m.queue, crash)
+
+	// Ping the loop.
+	select {
+	case m.pingQueue <- struct{}{}:
+	default:
+	}
+}
+
+func (m *reproManager) popCrash() *Crash {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, crash := range m.queue {
+		if m.reproducing[crash.Title] {
+			continue
+		}
+		m.queue = slices.Delete(m.queue, i, i+1)
+		return crash
+	}
+	return nil
+}
+
+func (m *reproManager) Loop(ctx context.Context) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for {
+		crash := m.popCrash()
+		for crash == nil {
+			select {
+			case <-m.pingQueue:
+				crash = m.popCrash()
+			case <-ctx.Done():
+				return
+			}
+			if !m.mgr.needRepro(crash) {
+				continue
+			}
+		}
+
+		// Now wait until we can schedule another runner.
+		select {
+		case <-m.parallel:
+		case <-ctx.Done():
+			return
+		}
+
+		m.mu.Lock()
+		m.reproducing[crash.Title] = true
+		m.adjustPoolSizeLocked()
+		m.mu.Unlock()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			m.handle(crash)
+
+			m.mu.Lock()
+			delete(m.reproducing, crash.Title)
+			m.adjustPoolSizeLocked()
+			m.mu.Unlock()
+
+			m.parallel <- struct{}{}
+			m.pingQueue <- struct{}{}
+		}()
+	}
+}
+
+func (m *reproManager) handle(crash *Crash) {
+	log.Logf(0, "start reproducing '%v'", crash.Title)
+
+	res := m.mgr.runRepro(crash)
+
+	crepro := false
+	title := ""
+	if res.repro != nil {
+		crepro = res.repro.CRepro
+		title = res.repro.Report.Title
+	}
+	log.Logf(0, "repro finished '%v', repro=%v crepro=%v desc='%v' hub=%v from_dashboard=%v",
+		res.report0.Title, res.repro != nil, crepro, title, res.fromHub, res.fromDashboard,
+	)
+	m.Done <- res
+}
+
+func (m *reproManager) adjustPoolSizeLocked() {
+	// Avoid the +-1 jitter by considering the repro queue size as well.
+
+	// We process same-titled crashes sequentially, so only count unique ones.
+	uniqueTitles := make(map[string]bool)
+	for _, crash := range m.queue {
+		uniqueTitles[crash.Title] = true
+	}
+
+	needRepros := len(m.reproducing) + len(uniqueTitles)
+	VMs := min(m.reproVMs, m.calculateReproVMs(needRepros))
+	m.mgr.resizeReproPool(VMs)
+}

--- a/syz-manager/repro_test.go
+++ b/syz-manager/repro_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReproManager(t *testing.T) {
+	mock := &reproMgrMock{
+		run: make(chan runCallback),
+	}
+	obj := newReproManager(mock, 3, false)
+
+	ctx, done := context.WithCancel(context.Background())
+	complete := make(chan struct{})
+	go func() {
+		obj.Loop(ctx)
+		close(complete)
+	}()
+
+	defer func() {
+		done()
+		<-complete
+	}()
+
+	// No reproductions until we've signaled to start.
+	assert.False(t, obj.CanReproMore())
+	obj.StartReproduction()
+
+	// No reproducers -- we can definitely take more.
+	assert.True(t, obj.CanReproMore())
+	obj.Enqueue(&Crash{Report: &report.Report{Title: "A"}})
+	called := <-mock.run
+	assert.Equal(t, "A", called.crash.Title)
+
+	// One reproducer is running -- we can take one more.
+	assert.True(t, obj.CanReproMore())
+	assert.EqualValues(t, 2, mock.reserved.Load())
+	obj.Enqueue(&Crash{Report: &report.Report{Title: "B"}})
+	called2 := <-mock.run
+	assert.Equal(t, "B", called2.crash.Title)
+
+	assert.False(t, obj.CanReproMore())
+	assert.Len(t, obj.Reproducing(), 2)
+	assert.EqualValues(t, 3, mock.reserved.Load())
+
+	// Pretend that reproducers have finished.
+	called.ret <- &ReproResult{report0: &report.Report{}}
+	called2.ret <- &ReproResult{report0: &report.Report{}}
+
+	// Wait until the number of reserved VMs goes to 0.
+	for i := 0; i < 100; i++ {
+		if mock.reserved.Load() == 0 {
+			assert.True(t, obj.CanReproMore())
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("reserved VMs must have dropped to 0")
+}
+
+type reproMgrMock struct {
+	reserved atomic.Int64
+	run      chan runCallback
+}
+
+type runCallback struct {
+	crash *Crash
+	ret   chan *ReproResult
+}
+
+func (m *reproMgrMock) runRepro(crash *Crash) *ReproResult {
+	retCh := make(chan *ReproResult)
+	m.run <- runCallback{crash: crash, ret: retCh}
+	ret := <-retCh
+	close(retCh)
+	return ret
+}
+
+func (m *reproMgrMock) needRepro(crash *Crash) bool {
+	return true
+}
+
+func (m *reproMgrMock) resizeReproPool(VMs int) {
+	m.reserved.Store(int64(VMs))
+}

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -13,19 +13,16 @@ import (
 )
 
 type Stats struct {
-	statNumReproducing *stats.Val
-	statCrashes        *stats.Val
-	statCrashTypes     *stats.Val
-	statSuppressed     *stats.Val
-	statUptime         *stats.Val
-	statFuzzingTime    *stats.Val
-	statAvgBootTime    *stats.Val
-	statCoverFiltered  *stats.Val
+	statCrashes       *stats.Val
+	statCrashTypes    *stats.Val
+	statSuppressed    *stats.Val
+	statUptime        *stats.Val
+	statFuzzingTime   *stats.Val
+	statAvgBootTime   *stats.Val
+	statCoverFiltered *stats.Val
 }
 
 func (mgr *Manager) initStats() {
-	mgr.statNumReproducing = stats.Create("reproducing", "Number of crashes being reproduced",
-		stats.Console, stats.NoGraph)
 	mgr.statCrashes = stats.Create("crashes", "Total number of VM crashes",
 		stats.Simple, stats.Prometheus("syz_crash_total"))
 	mgr.statCrashTypes = stats.Create("crash types", "Number of unique crashes types",

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -487,8 +487,9 @@ func (inst *instance) getBatteryLevel(numRetry int) (int, error) {
 	return val, nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	close(inst.closed)
+	return nil
 }
 
 func (inst *instance) Copy(hostSrc string) (string, error) {

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -276,7 +276,7 @@ func (inst *instance) Boot() error {
 	return nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	if inst.consolew != nil {
 		inst.consolew.Close()
 	}
@@ -294,6 +294,7 @@ func (inst *instance) Close() {
 		osutil.RunCmd(time.Minute, "", "ifconfig", inst.tapdev, "destroy")
 		inst.tapdev = ""
 	}
+	return nil
 }
 
 func (inst *instance) Forward(port int) (string, error) {

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -160,8 +160,8 @@ func (inst *instance) Forward(port int) (string, error) {
 	return "", fmt.Errorf("unable to forward port on device: %w", err)
 }
 
-func (inst *instance) Close() {
-	inst.gceInst.Close()
+func (inst *instance) Close() error {
+	return inst.gceInst.Close()
 }
 
 func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (

--- a/vm/dispatcher/pool.go
+++ b/vm/dispatcher/pool.go
@@ -1,0 +1,266 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package dispatcher
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+)
+
+type Instance interface {
+	io.Closer
+}
+
+type UpdateInfo func(cb func(info *Info))
+type Runner[T Instance] func(ctx context.Context, inst T, updInfo UpdateInfo)
+type CreateInstance[T Instance] func(int) (T, error)
+
+// Pool[T] provides the functionality of a generic pool of instances.
+// The instance is assumed to boot, be controlled by one Runner and then be re-created.
+// The pool is assumed to have one default Runner (e.g. to be used for fuzzing), while a
+// dynamically controlled sub-pool might be reserved for the arbitrary Runners.
+type Pool[T Instance] struct {
+	BootErrors chan error
+
+	creator    CreateInstance[T]
+	defaultJob Runner[T]
+	jobs       chan Runner[T]
+
+	// The mutex serializes ReserveForRun() calls.
+	mu        sync.Mutex
+	instances []*poolInstance[T]
+}
+
+func NewPool[T Instance](count int, creator CreateInstance[T], def Runner[T]) *Pool[T] {
+	instances := make([]*poolInstance[T], count)
+	for i := 0; i < count; i++ {
+		inst := &poolInstance[T]{
+			job: def,
+			idx: i,
+		}
+		inst.reset(func() {})
+		instances[i] = inst
+	}
+	return &Pool[T]{
+		BootErrors: make(chan error, 16),
+		creator:    creator,
+		defaultJob: def,
+		instances:  instances,
+		jobs:       make(chan Runner[T]),
+	}
+}
+
+func (p *Pool[T]) Loop(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(len(p.instances))
+	for _, inst := range p.instances {
+		inst := inst
+		go func() {
+			for ctx.Err() == nil {
+				p.runInstance(ctx, inst)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func (p *Pool[T]) runInstance(ctx context.Context, inst *poolInstance[T]) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	log.Logf(2, "pool: booting instance %d", inst.idx)
+
+	p.mu.Lock()
+	// Avoid races with ReserveForRun().
+	inst.reset(cancel)
+	p.mu.Unlock()
+
+	inst.status(StateBooting)
+	defer inst.status(StateOffline)
+
+	obj, err := p.creator(inst.idx)
+	if err != nil {
+		p.BootErrors <- err
+		return
+	}
+	defer obj.Close()
+
+	inst.status(StateWaiting)
+	// The job and jobChan fields are subject to concurrent updates.
+	inst.mu.Lock()
+	job, jobChan := inst.job, inst.jobChan
+	inst.mu.Unlock()
+
+	if job == nil {
+		select {
+		case newJob := <-jobChan:
+			job = newJob
+		case newJob := <-inst.switchToJob:
+			job = newJob
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	inst.status(StateRunning)
+	job(ctx, obj, inst.updateInfo)
+}
+
+// ReserveForRun specifies the size of the sub-pool for the execution of custom runners.
+// The reserved instances will be booted, but the pool will not start the default runner.
+// To unreserve all instances, execute ReserveForRun(0).
+func (p *Pool[T]) ReserveForRun(count int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if count > len(p.instances) {
+		panic("trying to reserve more VMs than present")
+	}
+
+	var free, reserved []*poolInstance[T]
+	for _, inst := range p.instances {
+		if inst.reserved() {
+			reserved = append(reserved, inst)
+		} else {
+			free = append(free, inst)
+		}
+	}
+
+	needReserve := count - len(reserved)
+	for i := 0; i < needReserve; i++ {
+		log.Logf(2, "pool: reserving instance %d", free[i].idx)
+		free[i].reserve(p.jobs)
+	}
+
+	needFree := len(reserved) - count
+	for i := 0; i < needFree; i++ {
+		log.Logf(2, "pool: releasing instance %d", reserved[i].idx)
+		reserved[i].free(p.defaultJob)
+	}
+}
+
+// Run blocks until it has found an instance to execute job and until job has finished.
+func (p *Pool[T]) Run(job Runner[T]) {
+	done := make(chan struct{})
+	p.jobs <- func(ctx context.Context, inst T, upd UpdateInfo) {
+		job(ctx, inst, upd)
+		close(done)
+	}
+	<-done
+}
+
+func (p *Pool[T]) Total() int {
+	return len(p.instances)
+}
+
+type Info struct {
+	State      InstanceState
+	Status     string
+	LastUpdate time.Time
+	Reserved   bool
+
+	// The optional callbacks.
+	MachineInfo    func() []byte
+	DetailedStatus func() []byte
+}
+
+func (p *Pool[T]) State() []Info {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	ret := make([]Info, len(p.instances))
+	for i, inst := range p.instances {
+		ret[i] = inst.getInfo()
+	}
+	return ret
+}
+
+// poolInstance is not thread safe.
+type poolInstance[T Instance] struct {
+	mu   sync.Mutex
+	info Info
+	idx  int
+
+	// Either job or jobChan will be set.
+	job         Runner[T]
+	jobChan     chan Runner[T]
+	switchToJob chan Runner[T]
+	stop        func()
+}
+
+type InstanceState int
+
+const (
+	StateOffline InstanceState = iota
+	StateBooting
+	StateWaiting
+	StateRunning
+)
+
+// reset() and status() may be called concurrently to all other methods.
+// Other methods themselves are serialized.
+func (pi *poolInstance[T]) reset(stop func()) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+
+	pi.info = Info{
+		State:      StateOffline,
+		LastUpdate: time.Now(),
+		Reserved:   pi.info.Reserved,
+	}
+	pi.stop = stop
+	pi.switchToJob = make(chan Runner[T])
+}
+
+func (pi *poolInstance[T]) updateInfo(upd func(*Info)) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	upd(&pi.info)
+	pi.info.LastUpdate = time.Now()
+}
+
+func (pi *poolInstance[T]) status(status InstanceState) {
+	pi.updateInfo(func(info *Info) {
+		info.State = status
+	})
+}
+
+func (pi *poolInstance[T]) reserved() bool {
+	return pi.jobChan != nil
+}
+
+func (pi *poolInstance[T]) getInfo() Info {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	return pi.info
+}
+
+func (pi *poolInstance[T]) reserve(ch chan Runner[T]) {
+	pi.stop()
+	pi.jobChan = ch
+	pi.job = nil
+	pi.updateInfo(func(info *Info) {
+		info.Reserved = true
+	})
+}
+
+func (pi *poolInstance[T]) free(job Runner[T]) {
+	pi.job = job
+	pi.jobChan = nil
+
+	pi.updateInfo(func(info *Info) {
+		info.Reserved = false
+	})
+
+	select {
+	case pi.switchToJob <- job:
+		// Just in case the instance has been waiting.
+		return
+	default:
+	}
+}

--- a/vm/dispatcher/pool_test.go
+++ b/vm/dispatcher/pool_test.go
@@ -1,0 +1,171 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package dispatcher
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoolDefault(t *testing.T) {
+	count := 3
+	pool := makePool(count)
+
+	mgr := NewPool[*testInstance](
+		count,
+		func(idx int) (*testInstance, error) {
+			pool[idx].reset()
+			return &pool[idx], nil
+		},
+		func(ctx context.Context, inst *testInstance, _ UpdateInfo) {
+			pool[inst.Index()].run(ctx)
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool)
+	go func() {
+		mgr.Loop(ctx)
+		close(done)
+	}()
+
+	// Eventually all instances are up and busy.
+	for i := 0; i < count; i++ {
+		pool[i].waitRun()
+	}
+
+	// The pool restarts failed jobs.
+	for i := 0; i < 10; i++ {
+		pool[0].stopRun()
+		pool[2].stopRun()
+
+		pool[0].waitRun()
+		pool[2].waitRun()
+	}
+
+	cancel()
+	<-done
+}
+
+func TestPoolSplit(t *testing.T) {
+	count := 3
+	pool := makePool(count)
+	var defaultCount atomic.Int64
+
+	mgr := NewPool[*testInstance](
+		count,
+		func(idx int) (*testInstance, error) {
+			pool[idx].reset()
+			return &pool[idx], nil
+		},
+		func(ctx context.Context, inst *testInstance, _ UpdateInfo) {
+			defaultCount.Add(1)
+			pool[inst.Index()].run(ctx)
+			defaultCount.Add(-1)
+		},
+	)
+
+	done := make(chan bool)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		mgr.Loop(ctx)
+		close(done)
+	}()
+
+	startedRuns := make(chan bool)
+	stopRuns := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			mgr.Run(func(ctx context.Context, _ *testInstance, _ UpdateInfo) {
+				startedRuns <- true
+				select {
+				case <-ctx.Done():
+				case <-stopRuns:
+				}
+			})
+		}()
+	}
+
+	// So far, there are no reserved instances.
+	for i := 0; i < count; i++ {
+		pool[i].waitRun()
+	}
+
+	// Dedicate one instance to the pool.
+	mgr.ReserveForRun(1)
+
+	// The first job must start.
+	<-startedRuns
+	// Two default jobs are running.
+	assert.EqualValues(t, 2, defaultCount.Load())
+	stopRuns <- true
+
+	// Take away the pool instance.
+	mgr.ReserveForRun(0)
+	// All instances must be busy with the default jobs.
+	for i := 0; i < count; i++ {
+		pool[i].waitRun()
+	}
+	assert.EqualValues(t, 3, defaultCount.Load())
+
+	// Now let's finish all jobs.
+	mgr.ReserveForRun(2)
+	for i := 0; i < 9; i++ {
+		<-startedRuns
+		stopRuns <- true
+	}
+
+	cancel()
+	<-done
+}
+
+func makePool(count int) []testInstance {
+	var ret []testInstance
+	for i := 0; i < count; i++ {
+		ret = append(ret, testInstance{index: i})
+	}
+	return ret
+}
+
+type testInstance struct {
+	index  int
+	hasRun atomic.Bool
+	stop   chan bool
+}
+
+func (ti *testInstance) reset() {
+	ti.stop = make(chan bool)
+	ti.hasRun.Store(false)
+}
+
+func (ti *testInstance) run(ctx context.Context) {
+	ti.hasRun.Store(true)
+	select {
+	case <-ti.stop:
+	case <-ctx.Done():
+	}
+}
+
+func (ti *testInstance) waitRun() {
+	for !ti.hasRun.Load() {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (ti *testInstance) stopRun() {
+	close(ti.stop)
+	ti.hasRun.Store(false) // make subsequent waitRun() actually wait for the next command.
+}
+
+func (ti *testInstance) Index() int {
+	return ti.index
+}
+
+func (ti *testInstance) Close() error {
+	return nil
+}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -241,12 +241,16 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	return inst, nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	close(inst.closed)
-	inst.GCE.DeleteInstance(inst.name, false)
+	err := inst.GCE.DeleteInstance(inst.name, false)
 	if inst.consolew != nil {
-		inst.consolew.Close()
+		err2 := inst.consolew.Close()
+		if err == nil {
+			err = err2
+		}
 	}
+	return err
 }
 
 func (inst *instance) Forward(port int) (string, error) {

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -257,7 +257,7 @@ func (inst *instance) runscCmd(add ...string) *exec.Cmd {
 	return cmd
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	time.Sleep(3 * time.Second)
 	osutil.Run(time.Minute, inst.runscCmd("delete", "-force", inst.name))
 	inst.cmd.Process.Kill()
@@ -265,6 +265,7 @@ func (inst *instance) Close() {
 	inst.cmd.Wait()
 	osutil.Run(time.Minute, inst.runscCmd("delete", "-force", inst.name))
 	time.Sleep(3 * time.Second)
+	return nil
 }
 
 func (inst *instance) Forward(port int) (string, error) {

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -282,8 +282,9 @@ func (inst *instance) waitForReboot(timeout int) error {
 	return fmt.Errorf("isolated: the machine did not reboot on repair")
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	close(inst.closed)
+	return nil
 }
 
 func (inst *instance) Copy(hostSrc string) (string, error) {

--- a/vm/proxyapp/proxyappclient.go
+++ b/vm/proxyapp/proxyappclient.go
@@ -578,7 +578,7 @@ func (inst *instance) Diagnose(r *report.Report) (diagnosis []byte, wait bool) {
 	return []byte(reply.Diagnosis), false
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	var reply proxyrpc.CloseReply
 	err := inst.ProxyApp.Call(
 		"ProxyVM.Close",
@@ -589,6 +589,7 @@ func (inst *instance) Close() {
 	if err != nil {
 		log.Logf(0, "error closing instance %v: %v", inst.ID, err)
 	}
+	return err
 }
 
 type stdInOutCloser struct {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -395,7 +395,7 @@ func (pool *Pool) ctor(workdir, sshkey, sshuser string, index int) (vmimpl.Insta
 	return inst, nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	if inst.qemu != nil {
 		inst.qemu.Process.Kill()
 		inst.qemu.Wait()
@@ -412,6 +412,7 @@ func (inst *instance) Close() {
 	if inst.mon != nil {
 		inst.mon.Close()
 	}
+	return nil
 }
 
 func (inst *instance) boot() error {

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -165,7 +165,7 @@ func (inst *instance) boot() error {
 	return nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	inst.ffx("emu", "stop", inst.name)
 	if inst.fuchsiaLogs != nil {
 		inst.fuchsiaLogs.Process.Kill()
@@ -180,6 +180,7 @@ func (inst *instance) Close() {
 	if inst.wpipe != nil {
 		inst.wpipe.Close()
 	}
+	return nil
 }
 
 func (inst *instance) startFuchsiaVM() error {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -260,6 +260,10 @@ func (inst *Instance) diagnose(rep *report.Report) ([]byte, bool) {
 	return inst.impl.Diagnose(rep)
 }
 
+func (inst *Instance) Index() int {
+	return inst.index
+}
+
 func (inst *Instance) Close() {
 	inst.impl.Close()
 	os.RemoveAll(inst.workdir)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/syzkaller/pkg/report"
 	"github.com/google/syzkaller/pkg/stats"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/google/syzkaller/vm/dispatcher"
 	"github.com/google/syzkaller/vm/vmimpl"
 
 	// Import all VM implementations, so that users only need to import vm.
@@ -271,6 +272,14 @@ func (inst *Instance) Close() error {
 	}
 	inst.onClose()
 	return err
+}
+
+func NewDispatcher(pool *Pool, def dispatcher.Runner[*Instance]) *dispatcher.Pool[*Instance] {
+	return dispatcher.NewPool(pool.Count(),
+		func(idx int) (*Instance, error) {
+			return pool.Create(idx)
+		},
+		def)
 }
 
 type monitor struct {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -264,10 +264,13 @@ func (inst *Instance) Index() int {
 	return inst.index
 }
 
-func (inst *Instance) Close() {
-	inst.impl.Close()
-	os.RemoveAll(inst.workdir)
+func (inst *Instance) Close() error {
+	err := inst.impl.Close()
+	if retErr := os.RemoveAll(inst.workdir); err == nil {
+		err = retErr
+	}
 	inst.onClose()
+	return err
 }
 
 type monitor struct {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -69,7 +69,8 @@ func (inst *testInstance) Diagnose(rep *report.Report) ([]byte, bool) {
 	return nil, true
 }
 
-func (inst *testInstance) Close() {
+func (inst *testInstance) Close() error {
+	return nil
 }
 
 func init() {

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -58,7 +58,7 @@ type Instance interface {
 	Diagnose(rep *report.Report) (diagnosis []byte, wait bool)
 
 	// Close stops and destroys the VM.
-	Close()
+	io.Closer
 }
 
 // Infoer is an optional interface that can be implemented by Instance.

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -216,7 +216,7 @@ func (inst *instance) lookupSSHAddress() (string, error) {
 	return fmt.Sprintf("100.64.%s.3", matches[1]), nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	inst.vmctl("stop", "-f", inst.vmName)
 	if inst.consolew != nil {
 		inst.consolew.Close()
@@ -226,6 +226,7 @@ func (inst *instance) Close() {
 		inst.vmm.Wait()
 	}
 	inst.merger.Wait()
+	return nil
 }
 
 func (inst *instance) Forward(port int) (string, error) {

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -144,7 +144,7 @@ func (inst *instance) Forward(port int) (string, error) {
 	return fmt.Sprintf("127.0.0.1:%v", port), nil
 }
 
-func (inst *instance) Close() {
+func (inst *instance) Close() error {
 	if inst.debug {
 		log.Logf(0, "stopping %v", inst.vmx)
 	}
@@ -154,6 +154,7 @@ func (inst *instance) Close() {
 	}
 	osutil.RunCmd(2*time.Minute, "", "vmrun", "deleteVM", inst.vmx)
 	close(inst.closed)
+	return nil
 }
 
 func (inst *instance) Copy(hostSrc string) (string, error) {


### PR DESCRIPTION
* Split off the instance pool support functionality into a package.
* Don't waste as many VMs for bug reproduction as we did before -- 1.33 instead of 3.  
* Move the instance list and status functionality from `rpcserver` to `instance.Pool`.