### PR TITLE
Makefile: remove dummy syz-fuzzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,6 @@ endif
 all: host target
 host: manager repro mutate prog2c db upgrade
 target: execprog executor
-	# Temporal hack to pre-created removed syz-fuzzer,
-	# since old version of syz-ci still wants to copy it.
-	touch ./bin/$(TARGETOS)_$(TARGETVMARCH)/syz-fuzzer
 
 executor: descriptions
 ifeq ($(TARGETOS),fuchsia)


### PR DESCRIPTION
All syz-ci instances must have updated by this time, so we no longer need this noisy hack.
