### PR TITLE
pkg/vminfo: add more details to an execution error

### DIFF
--- a/pkg/vminfo/features.go
+++ b/pkg/vminfo/features.go
@@ -188,7 +188,7 @@ func (ctx *checkContext) featureSucceeded(feat flatrpc.Feature, testProg *prog.P
 		if res.Err != nil {
 			return res.Err.Error()
 		}
-		return "test program execution failed"
+		return fmt.Sprintf("test program execution failed: status=%v", res.Status)
 	}
 	if len(res.Info.Calls) != len(testProg.Calls) {
 		return fmt.Sprintf("only %v calls are executed out of %v",


### PR DESCRIPTION
We're seeing ci failures:

```
2024/07/08 16:29:56 [FATAL] check failed: execution of simple program fails: test program execution failed
```

Let's make it more clear why it might have failed.