### PR TITLE
executor: fix diagnostic message typo

### DIFF
--- a/executor/conn.h
+++ b/executor/conn.h
@@ -89,7 +89,7 @@ private:
 				sleep_ms(1);
 				continue;
 			}
-			failmsg("failed to recv rpc", "fd=%d want=%zu sent=%zu n=%zd", fd_, size, recv, n);
+			failmsg("failed to recv rpc", "fd=%d want=%zu recv=%zu n=%zd", fd_, size, recv, n);
 		}
 	}
 


### PR DESCRIPTION
This is a trivial change. A more interesting question is why the error is reported on openbsd:
https://syzkaller.appspot.com/bug?extid=7115badc143affd20158
