### PR TITLE
executor: only report unknown setsid errors

### DIFF
--- a/executor/common_openbsd.h
+++ b/executor/common_openbsd.h
@@ -299,7 +299,7 @@ static void sandbox_common()
 #if SYZ_EXECUTOR
 	if (!flag_threaded)
 #endif
-		if (setsid() == -1)
+		if (setsid() == -1 && errno != EPERM)
 			fail("setsid failed");
 #endif
 


### PR DESCRIPTION
Unlike linux the BSDs used to check the result of setsid.

This suddenly became a problem a couple of weeks ago. It's hard to figure out why because there was a number of problems in the area preventing the test from working:
```
gmake executor execprog && \
./bin/openbsd_amd64/syz-execprog -stress -executor ./bin/openbsd_amd64/syz-executor
```
At least with this change the test above successfully executes some coverage and exits cleanly.
