### PR TITLE
dashboard: make repro logs public

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -99,6 +99,15 @@ func checkTextAccess(c context.Context, r *http.Request, tag string, id int64) (
 		return checkCrashTextAccess(c, r, "ReproSyz", id)
 	case textReproC:
 		return checkCrashTextAccess(c, r, "ReproC", id)
+	case textReproLog:
+		bug, crash, err := checkCrashTextAccess(c, r, "ReproLog", id)
+		if err == nil || err == ErrAccess {
+			return bug, crash, err
+		}
+		// ReproLog might also be referenced from Bug.ReproAttempts.Log
+		// for failed repro attempts, but those are not exposed to non-admins
+		// as of yet, so fallback to normal admin access check.
+		return nil, nil, checkAccessLevel(c, r, AccessAdmin)
 	case textMachineInfo:
 		// MachineInfo is deduplicated, so we can't find the exact crash/bug.
 		// But since machine info is usually the same for all bugs and is not secret,

--- a/dashboard/app/access_test.go
+++ b/dashboard/app/access_test.go
@@ -226,6 +226,17 @@ func TestAccess(t *testing.T) {
 					strconv.FormatUint(uint64(crash.ReproSyz), 16)),
 			},
 			{
+				level: level,
+				ref:   fmt.Sprint(crash.ReproLog),
+				url:   fmt.Sprintf("/text?tag=ReproLog&id=%v", crash.ReproLog),
+			},
+			{
+				level: level,
+				ref:   fmt.Sprint(crash.ReproLog),
+				url: fmt.Sprintf("/text?tag=ReproLog&x=%v",
+					strconv.FormatUint(uint64(crash.ReproLog), 16)),
+			},
+			{
 				level: nsLevel,
 				ref:   fmt.Sprint(crash.MachineInfo),
 				url:   fmt.Sprintf("/text?tag=MachineInfo&id=%v", crash.MachineInfo),
@@ -326,6 +337,7 @@ func TestAccess(t *testing.T) {
 			crashOpen.Report = []byte(accessPrefix + "report")
 			crashOpen.ReproC = []byte(accessPrefix + "repro c")
 			crashOpen.ReproSyz = []byte(accessPrefix + "repro syz")
+			crashOpen.ReproLog = []byte(accessPrefix + "repro log")
 			crashOpen.MachineInfo = []byte(ns + "machine info")
 			client.ReportCrash(crashOpen)
 			repOpen := client.pollBug()


### PR DESCRIPTION
PR #4837 added displaying repro logs to syzbot but didn't make the logs publicly-accessible. Fix that.
