### PR TITLE
executor: use a loop to deal with EAGAIN

### DIFF
--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -403,7 +403,11 @@ private:
 	bool ReadResponse(bool out_of_requests)
 	{
 		uint32 status;
-		ssize_t n = read(resp_pipe_, &status, sizeof(status));
+		ssize_t n;
+		while ((n = read(resp_pipe_, &status, sizeof(status))) == -1) {
+			if (errno != EINTR && errno != EAGAIN)
+				break;
+		}
 		if (n == 0) {
 			debug("proc %d: response pipe EOF\n", id_);
 			return false;


### PR DESCRIPTION
OpenBSD seems to be more prone to returning `EAGAIN` from read than Linux. So [this problem happens fairly often](https://syzkaller.appspot.com/bug?extid=5a40af22a61b0bd8bbb5):
```
SYZFAIL: proc resp pipe read failed
n=-1 (errno 35: Resource temporarily unavailable)
```

