### PR TITLE
vm/qemu: don't log qmp on level 1

### DIFF
--- a/vm/qemu/qmp.go
+++ b/vm/qemu/qmp.go
@@ -91,7 +91,7 @@ func (inst *instance) qmpRecv() (*qmpResponse, error) {
 		if err != nil || qmp.Event == "" {
 			return qmp, err
 		}
-		log.Logf(1, "event: %v", qmp)
+		log.Logf(3, "event: %v", qmp)
 	}
 }
 


### PR DESCRIPTION
If qmp is used all the time for snapshotting,
it produces tons of uniniteresting logs at level 1 (manager web UI).
