### PR TITLE
dashboard: fix TestAccess

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -693,6 +693,7 @@ func testCrashWithRepro(build *dashapi.Build, id int) *dashapi.Crash {
 	crash.ReproOpts = []byte(fmt.Sprintf("repro opts %v", id))
 	crash.ReproSyz = []byte(fmt.Sprintf("syncfs(%v)", id))
 	crash.ReproC = []byte(fmt.Sprintf("int main() { return %v; }", id))
+	crash.ReproLog = []byte(fmt.Sprintf("repro log %d", id))
 	return crash
 }
 

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -107,23 +107,19 @@ func (c *Ctx) expectFail(msg string, err error) {
 	}
 }
 
-func (c *Ctx) expectFailureStatus(err error, code int) {
-	c.t.Helper()
+func expectFailureStatus(t *testing.T, err error, code int) {
+	t.Helper()
 	if err == nil {
-		c.t.Fatalf("expected to fail as %d, but it does not", code)
+		t.Fatalf("expected to fail as %d, but it does not", code)
 	}
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) || httpErr.Code != code {
-		c.t.Fatalf("expected to fail as %d, but it failed as %v", code, err)
+		t.Fatalf("expected to fail as %d, but it failed as %v", code, err)
 	}
 }
 
-func (c *Ctx) expectForbidden(err error) {
-	c.expectFailureStatus(err, http.StatusForbidden)
-}
-
 func (c *Ctx) expectBadReqest(err error) {
-	c.expectFailureStatus(err, http.StatusBadRequest)
+	expectFailureStatus(c.t, err, http.StatusBadRequest)
 }
 
 func (c *Ctx) expectEQ(got, want interface{}) {


### PR DESCRIPTION
The test has recently become broken, but we didn't notice it in our presubmit testing.

Fix the problem (ReproLog being set to 0).

Use subtests to be able to identify the exact failing test case.

Run TestAccess in `-short` mode, but limit it to ensuring that non-public URLs are not accessible publicly. The short test now takes 60 seconds compared to 104 seconds without `-short`.
