### PR TITLE
pkg/rpcserver: debug executor stalls

### DIFF
--- a/pkg/flatrpc/conn.go
+++ b/pkg/flatrpc/conn.go
@@ -109,14 +109,16 @@ func Send[T sendMsg](c *Conn, msg T) error {
 	return nil
 }
 
+type RecvType[T any] interface {
+	UnPack() *T
+	flatbuffers.FlatBuffer
+}
+
 // Recv receives an RPC message.
 // The type T is supposed to be a pointer to a normal flatbuffers type (not ending with T, e.g. *ConnectRequestRaw).
 // Receiving should be done from a single goroutine, the received message is valid
 // only until the next Recv call (messages share the same underlying receive buffer).
-func Recv[Raw interface {
-	UnPack() *T
-	flatbuffers.FlatBuffer
-}, T any](c *Conn) (res *T, err0 error) {
+func Recv[Raw RecvType[T], T any](c *Conn) (res *T, err0 error) {
 	defer func() {
 		if err1 := recover(); err1 != nil {
 			if err2, ok := err1.(error); ok {

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -453,9 +453,10 @@ func startRPCServer(t *testing.T, target *prog.Target, executor, vmArch string, 
 				Features: flatrpc.AllFeatures,
 				Sandbox:  flatrpc.ExecEnvSandboxNone,
 			},
-			VMArch:   vmArch,
-			Procs:    runtime.GOMAXPROCS(0),
-			Slowdown: 10, // to deflake slower tests
+			VMArch:        vmArch,
+			Procs:         runtime.GOMAXPROCS(0),
+			Slowdown:      10, // to deflake slower tests
+			DebugTimeouts: true,
 		},
 		Executor:    executor,
 		Dir:         dir,


### PR DESCRIPTION
Context: #4954.

In some cases, the executor seems to be mysteriously silent when we were awaiting a reply.

During pkg/runtest tests, give it 1 minute to prepare a reply, then try to request the current state and abort the connection.
