### PR TITLE
syz-manager: deprioritize hub reproducers

### DIFF
--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -60,7 +60,8 @@ func (mgr *Manager) hubSyncLoop(keyGet keyGetter) {
 		statRecvReproDrop: stats.Create("hub recv repro drop", "", stats.NoGraph),
 	}
 	if mgr.cfg.Reproduce && mgr.dash != nil {
-		hc.needMoreRepros = mgr.reproMgr.CanReproMore
+		// Request reproducers from hub only if there is nothing else to reproduce.
+		hc.needMoreRepros = mgr.reproMgr.Empty
 	}
 	hc.loop()
 }

--- a/syz-manager/repro.go
+++ b/syz-manager/repro.go
@@ -91,6 +91,13 @@ func (m *reproManager) Reproducing() map[string]bool {
 	return maps.Clone(m.reproducing)
 }
 
+// Empty returns true if there are neither running nor planned bug reproductions.
+func (m *reproManager) Empty() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.reproducing) == 0 && len(m.queue) == 0
+}
+
 func (m *reproManager) Enqueue(crash *Crash) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Only request them if there's nothing else to reproduce.