### PR TITLE
{dashboard, syz-manager}: prioritize manual repro requests

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1748,6 +1748,7 @@ func apiLogToReproduce(c context.Context, ns string, r *http.Request, payload []
 	if log != nil {
 		return &dashapi.LogToReproResp{
 			CrashLog: log,
+			Type:     dashapi.ManualLog,
 		}, nil
 	}
 
@@ -1803,6 +1804,7 @@ func logToReproForBug(c context.Context, bug *Bug, manager string) (*dashapi.Log
 		return &dashapi.LogToReproResp{
 			Title:    bug.Title,
 			CrashLog: crashLog,
+			Type:     dashapi.RetryReproLog,
 		}, nil
 	}
 	return nil, nil

--- a/dashboard/app/repro_test.go
+++ b/dashboard/app/repro_test.go
@@ -437,6 +437,7 @@ func TestLogToReproduce(t *testing.T) {
 	c.expectOK(err)
 	c.expectEQ(resp.Title, "title2")
 	c.expectEQ(resp.CrashLog, []byte("log2"))
+	c.expectEQ(resp.Type, dashapi.RetryReproLog)
 
 	// Suppose we tried to find a repro, but failed.
 	err = client.ReportFailedRepro(&dashapi.CrashID{
@@ -507,6 +508,7 @@ func TestReproTask(t *testing.T) {
 		resp, err := client.LogToRepro(&dashapi.LogToReproReq{BuildID: build.ID})
 		c.expectOK(err)
 		c.expectEQ(string(resp.CrashLog), reproValue)
+		c.expectEQ(resp.Type, dashapi.ManualLog)
 	}
 
 	// But no more.

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -380,9 +380,17 @@ type LogToReproReq struct {
 	BuildID string
 }
 
+type LogToReproType string
+
+const (
+	ManualLog     LogToReproType = "manual"
+	RetryReproLog LogToReproType = "retry"
+)
+
 type LogToReproResp struct {
 	Title    string
 	CrashLog []byte
+	Type     LogToReproType
 }
 
 // LogToRepro are crash logs for older bugs that need to be reproduced on the

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -161,6 +161,7 @@ type Crash struct {
 	instanceName  string
 	fromHub       bool // this crash was created based on a repro from syz-hub
 	fromDashboard bool // .. or from dashboard
+	manual        bool
 	*report.Report
 }
 
@@ -1620,6 +1621,7 @@ func (mgr *Manager) dashboardReproTasks() {
 			}
 			mgr.externalReproQueue <- &Crash{
 				fromDashboard: true,
+				manual:        resp.Type == dashapi.ManualLog,
 				Report: &report.Report{
 					Title:  title,
 					Output: resp.CrashLog,

--- a/syz-manager/repro.go
+++ b/syz-manager/repro.go
@@ -120,14 +120,33 @@ func (m *reproManager) popCrash() *Crash {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	newBetter := func(base, new *Crash) bool {
+		// First, serve manual requests.
+		if new.manual != base.manual {
+			return new.manual
+		}
+		// Then, deprioritize hub reproducers.
+		if new.fromHub != base.fromHub {
+			return !new.fromHub
+		}
+		return false
+	}
+
+	idx := -1
 	for i, crash := range m.queue {
 		if m.reproducing[crash.Title] {
 			continue
 		}
-		m.queue = slices.Delete(m.queue, i, i+1)
-		return crash
+		if idx == -1 || newBetter(m.queue[idx], m.queue[i]) {
+			idx = i
+		}
 	}
-	return nil
+	if idx == -1 {
+		return nil
+	}
+	crash := m.queue[idx]
+	m.queue = slices.Delete(m.queue, idx, idx+1)
+	return crash
 }
 
 func (m *reproManager) Loop(ctx context.Context) {


### PR DESCRIPTION
Share the kind of the dashboard-originated reproduction requests and prioritize them in syz-manager accordingly.