### PR TITLE
pkg/rpcserver: exit on connection loop abortion

### DIFF
--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -44,6 +44,7 @@ type Runner struct {
 	lastExec      *LastExecuting
 	rnd           *rand.Rand
 	updInfo       dispatcher.UpdateInfo
+	resultCh      chan error
 
 	// The mutex protects all the fields below.
 	mu          sync.Mutex


### PR DESCRIPTION
For local rpcserver runs, we do not reboot the executor in case of errors. Moreover, if the error did not lead to the executor process exit, we may never detect that something went wrong.

Return an error channel from CreateInstance() to be able to act on connection loop errors.

Explicitly register the instance during local executions and exit from RunLocal() in case of connection problems.