### PR TITLE
syz-manager: add a missing nil check

### DIFF
--- a/syz-manager/repro.go
+++ b/syz-manager/repro.go
@@ -150,7 +150,7 @@ func (m *reproManager) Loop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			}
-			if !m.mgr.needRepro(crash) {
+			if crash == nil || !m.mgr.needRepro(crash) {
 				continue
 			}
 		}


### PR DESCRIPTION
We should expect popCrash() to return nil.