### PR TITLE
tools/docker: add missing node in syz-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ clean:
 # For a tupical Ubuntu/Debian distribution.
 # We use "|| true" for apt-get install because packages are all different on different distros.
 # Also see tools/syz-env for container approach.
-install_prerequisites:
+install_prerequisites: act
 	uname -a
 	sudo apt-get update
 	sudo apt-get install -y -q libc6-dev-i386 linux-libc-dev \
@@ -437,3 +437,6 @@ check_diff:
 
 check_shebang:
 	./tools/check-shebang.sh
+
+act:
+	curl https://raw.githubusercontent.com/nektos/act/master/install.sh | bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,3 +150,16 @@ and then pull the image and retag it to the name expacted by `syz-env`:
 docker pull docker.pkg.github.com/google/syzkaller/env
 docker tag docker.pkg.github.com/google/syzkaller/env gcr.io/syzkaller/env
 ```
+
+### Using [act](https://github.com/nektos/act)
+.github/workflows has more tests compared to `syz-env make presubmit`. To have the same tests as the workflow, we can run these workflow jobs locally.
+```
+# install act
+make act
+# list all jobs
+bin/act -l
+# run all jobs
+bin/act
+# run job with name build
+bin/act -j build
+```

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -94,6 +94,9 @@ RUN cd /tmp/Python-2.7.18 && ./configure
 RUN cd /tmp/Python-2.7.18 && make -j2 && make altinstall
 RUN ln -s /usr/local/bin/python2.7 /usr/bin/python2
 
+# Install node to pass act jobs (https://github.com/nektos/act)
+RUN apt-get install -y -q nodejs
+
 # Install gcloud sdk for dashboard/app tests.
 # The newest version (as of 07/10/23) is 437, however, it seems to expect to be run with python3
 # (but still requires python2). But Go's aetest package still runs dev_appserver.py with python2.7.


### PR DESCRIPTION
When act -j build in local host, it reports:
exec failed: unable to start container process: exec: "node": executable file
 not found in $PATH: unknown

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
