### PR TITLE
pkg/meminfo: move /proc/sentry-meminfo to the required files list

### DIFF
--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -22,6 +22,7 @@ func (linux) RequiredFiles() []string {
 		"/proc/cpuinfo",
 		"/proc/modules",
 		"/proc/kallsyms",
+		"/proc/sentry-meminfo",
 		"/sys/module/*/sections/.text",
 		"/sys/module/kvm*/parameters/*",
 	}
@@ -32,7 +33,6 @@ func (linux) checkFiles() []string {
 		"/proc/version",
 		"/proc/filesystems",
 		"/sys/kernel/security/lsm",
-		"/proc/sentry-meminfo",
 	}
 }
 


### PR DESCRIPTION
/proc/sentry-meminfo is read in checker.MachineInfo which can be called when serv.checkDone is set.