### PR TITLE
Another s390x unit test fix

### DIFF
--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -369,6 +369,10 @@ func testCover(t *testing.T, target *prog.Target) {
 			if test.Is64Bit {
 				vmArch = targets.TestArch64
 			}
+			sysTarget := targets.Get(targets.TestOS, vmArch)
+			if sysTarget.BrokenCompiler != "" {
+				t.Skipf("skipping due to broken compiler:\n%v", sysTarget.BrokenCompiler)
+			}
 			ctx := startRPCServer(t, target, executor, source, rpcParams{
 				vmArch:      vmArch,
 				maxSignal:   test.MaxSignal,


### PR DESCRIPTION

s390x doesn't support 32bit TestOS.