### PR TITLE
syz-manager: tidy ReproResult

### DIFF
--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/syzkaller/pkg/auth"
@@ -79,7 +78,6 @@ type HubConnector struct {
 	hubReproQueue  chan *Crash
 	needMoreRepros func() bool
 	keyGet         keyGetter
-	reproSeq       atomic.Int64
 
 	statSendProgAdd   *stats.Val
 	statSendProgDel   *stats.Val
@@ -309,7 +307,6 @@ func (hc *HubConnector) processRepros(repros [][]byte) int {
 		hc.hubReproQueue <- &Crash{
 			fromHub: true,
 			Report: &report.Report{
-				Title:  fmt.Sprintf("external repro #%d", hc.reproSeq.Add(1)),
 				Type:   typ,
 				Output: repro,
 			},

--- a/syz-manager/repro_test.go
+++ b/syz-manager/repro_test.go
@@ -53,8 +53,8 @@ func TestReproManager(t *testing.T) {
 	assert.EqualValues(t, 3, mock.reserved.Load())
 
 	// Pretend that reproducers have finished.
-	called.ret <- &ReproResult{report0: &report.Report{}}
-	called2.ret <- &ReproResult{report0: &report.Report{}}
+	called.ret <- &ReproResult{crash: &Crash{fromHub: true}}
+	called2.ret <- &ReproResult{crash: &Crash{fromHub: true}}
 
 	// Wait until the number of reserved VMs goes to 0.
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
There have been some mess and duplication around Crash/ReproResult data structures. As a result, we've been attempting to upload repro failure logs to the dashboard for bugs, which did not originate from the dashboard. It litters the syz-manager logs.

Refactor the code.
