### PR TITLE
dashboard/app: split Reported-and-tested-by tag

### DIFF
--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -258,7 +258,8 @@ patch:          %[3]v
 
 syzbot has tested the proposed patch and the reproducer did not trigger any issue:
 
-Reported-and-tested-by: syzbot+%v@testapp.appspotmail.com
+Reported-by: syzbot+%[1]v@testapp.appspotmail.com
+Tested-by: syzbot+%[1]v@testapp.appspotmail.com
 
 Tested on:
 
@@ -372,7 +373,8 @@ func TestJobWithoutPatch(t *testing.T) {
 
 syzbot has tested the proposed patch and the reproducer did not trigger any issue:
 
-Reported-and-tested-by: syzbot+%v@testapp.appspotmail.com
+Reported-by: syzbot+%[1]v@testapp.appspotmail.com
+Tested-by: syzbot+%[1]v@testapp.appspotmail.com
 
 Tested on:
 

--- a/dashboard/app/templates/mail_test_result.txt
+++ b/dashboard/app/templates/mail_test_result.txt
@@ -15,7 +15,12 @@ Error text is too large and was truncated, full error text is at:
 {{else}}
 syzbot has tested the proposed patch and the reproducer did not trigger any issue:
 
-Reported-and-tested-by: {{.CreditEmail}}
+{{/* Note: kernel prefers separate reported/tested tags rather than a single
+Reported-and-tested-by, see:
+https://lore.kernel.org/all/Zpb30HMt6jXtonhr@google.com/
+*/ -}}
+Reported-by: {{.CreditEmail}}
+Tested-by: {{.CreditEmail}}
 {{end}}
 Tested on:
 


### PR DESCRIPTION
Kernel community asks to split it for tooling purposes:
https://lore.kernel.org/all/Zpb30HMt6jXtonhr@google.com/
