### PR TITLE
syz-manager: refactor empty crash log errors

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -66,8 +66,6 @@ type execInterface interface {
 		*instance.RunResult, error)
 }
 
-var ErrNoPrograms = errors.New("crash log does not contain any programs")
-
 func Run(crashLog []byte, cfg *mgrconfig.Config, features flatrpc.Feature, reporter *report.Reporter,
 	pool *dispatcher.Pool[*vm.Instance]) (*Result, *Stats, error) {
 	exec := &poolWrapper{
@@ -87,7 +85,7 @@ func prepareCtx(crashLog []byte, cfg *mgrconfig.Config, features flatrpc.Feature
 	exec execInterface) (*reproContext, error) {
 	entries := cfg.Target.ParseLog(crashLog)
 	if len(entries) == 0 {
-		return nil, ErrNoPrograms
+		return nil, fmt.Errorf("crash log (%d bytes) does not contain any programs", len(crashLog))
 	}
 	crashStart := len(crashLog)
 	crashTitle, crashType := "", crash.UnknownType

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -458,10 +458,6 @@ func reportReproError(err error) {
 	}
 
 	switch err {
-	case repro.ErrNoPrograms:
-		// This is not extraordinary as programs are collected via SSH.
-		log.Logf(0, "repro failed: %v", err)
-		return
 	case repro.ErrNoVMs:
 		// This error is to be expected if we're shutting down.
 		if shutdown {


### PR DESCRIPTION
Now that we do not take the programs from the SSH-based logs, the error does look surprising, so let's print it with log.Errorf().