### PR TITLE
syz-manager: still ignore log parse problems

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -81,11 +81,13 @@ func Run(crashLog []byte, cfg *mgrconfig.Config, features flatrpc.Feature, repor
 	return ctx.run()
 }
 
+var ErrEmptyCrashLog = errors.New("no programs")
+
 func prepareCtx(crashLog []byte, cfg *mgrconfig.Config, features flatrpc.Feature, reporter *report.Reporter,
 	exec execInterface) (*reproContext, error) {
 	entries := cfg.Target.ParseLog(crashLog)
 	if len(entries) == 0 {
-		return nil, fmt.Errorf("crash log (%d bytes) does not contain any programs", len(crashLog))
+		return nil, fmt.Errorf("log (%d bytes) parse failed: %w", len(crashLog), ErrEmptyCrashLog)
 	}
 	crashStart := len(crashLog)
 	crashTitle, crashType := "", crash.UnknownType

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -457,8 +457,11 @@ func reportReproError(err error) {
 	default:
 	}
 
-	switch err {
-	case repro.ErrNoVMs:
+	if errors.Is(err, repro.ErrEmptyCrashLog) {
+		// The kernel could have crashed before we executed any programs.
+		log.Logf(0, "repro failed: %v", err)
+		return
+	} else if errors.Is(err, repro.ErrNoVMs) {
 		// This error is to be expected if we're shutting down.
 		if shutdown {
 			return


### PR DESCRIPTION
It seems that this error may come up in absolutely valid and reasonable cases. Restore the special casing.