### PR TITLE
executor: avoid setsid() errors

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -396,7 +396,7 @@ static void sandbox_common()
 #if SYZ_EXECUTOR
 	if (!flag_threaded)
 #endif
-		if (setsid() == -1)
+		if (setsid() == -1 && errno != EPERM)
 			fail("setsid failed");
 #endif
 


### PR DESCRIPTION
See commit bc144f9a58782daa2399d417b56aad80e82a219e.  The justification applies to other BSDs as well, so apply the same workaround.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
