### PR TITLE
prog: restricts hints to at most 10 attempts per single kernel PC

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -462,7 +462,7 @@ static void copyin(char* addr, uint64 val, uint64 size, uint64 bf, uint64 bf_off
 static bool copyout(char* addr, uint64 size, uint64* res);
 static void setup_control_pipes();
 static bool coverage_filter(uint64 pc);
-static std::tuple<rpc::ComparisonRaw, bool, bool> convert(const kcov_comparison_t& cmp);
+static rpc::ComparisonRaw convert(const kcov_comparison_t& cmp);
 static flatbuffers::span<uint8_t> finish_output(OutputData* output, int proc_id, uint64 req_id,
 						uint64 elapsed, uint64 freshness, uint32 status, const std::vector<uint8_t>* process_output);
 
@@ -1102,29 +1102,23 @@ uint32 write_comparisons(flatbuffers::FlatBufferBuilder& fbb, cover_t* cov)
 	cover_unprotect(cov);
 	rpc::ComparisonRaw* start = (rpc::ComparisonRaw*)cov_start;
 	rpc::ComparisonRaw* end = start;
-	// We will convert kcov_comparison_t to ComparisonRaw inplace
-	// and potentially double number of elements, so ensure we have space.
-	static_assert(sizeof(kcov_comparison_t) >= 2 * sizeof(rpc::ComparisonRaw));
+	// We will convert kcov_comparison_t to ComparisonRaw inplace.
+	static_assert(sizeof(kcov_comparison_t) >= sizeof(rpc::ComparisonRaw));
 	for (uint32 i = 0; i < ncomps; i++) {
-		auto [raw, swap, ok] = convert(cov_start[i]);
-		if (!ok)
+		auto raw = convert(cov_start[i]);
+		if (!raw.pc())
 			continue;
 		*end++ = raw;
-		// Compiler marks comparisons with a const with KCOV_CMP_CONST flag.
-		// If the flag is set, then we need to export only one order of operands
-		// (because only one of them could potentially come from the input).
-		// If the flag is not set, then we export both orders as both operands
-		// could come from the input.
-		if (swap)
-			*end++ = {raw.op2(), raw.op1()};
 	}
 	std::sort(start, end, [](rpc::ComparisonRaw a, rpc::ComparisonRaw b) -> bool {
+		if (a.pc() != b.pc())
+			return a.pc() < b.pc();
 		if (a.op1() != b.op1())
 			return a.op1() < b.op1();
 		return a.op2() < b.op2();
 	});
 	ncomps = std::unique(start, end, [](rpc::ComparisonRaw a, rpc::ComparisonRaw b) -> bool {
-			 return a.op1() == b.op1() && a.op2() == b.op2();
+			 return a.pc() == b.pc() && a.op1() == b.op1() && a.op2() == b.op2();
 		 }) -
 		 start;
 	cover_protect(cov);
@@ -1646,7 +1640,7 @@ uint64 read_input(uint8** input_posp, bool peek)
 	return v;
 }
 
-std::tuple<rpc::ComparisonRaw, bool, bool> convert(const kcov_comparison_t& cmp)
+rpc::ComparisonRaw convert(const kcov_comparison_t& cmp)
 {
 	if (cmp.type > (KCOV_CMP_CONST | KCOV_CMP_SIZE_MASK))
 		failmsg("invalid kcov comp type", "type=%llx", cmp.type);
@@ -1692,7 +1686,7 @@ std::tuple<rpc::ComparisonRaw, bool, bool> convert(const kcov_comparison_t& cmp)
 
 	// Prog package expects operands in the opposite order (first operand may come from the input,
 	// the second operand was computed in the kernel), so swap operands.
-	return {{arg2, arg1}, !(cmp.type & KCOV_CMP_CONST), true};
+	return {cmp.pc, arg2, arg1, !!(cmp.type & KCOV_CMP_CONST)};
 }
 
 void failmsg(const char* err, const char* msg, ...)

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -208,8 +208,12 @@ table CallInfoRaw {
 }
 
 struct ComparisonRaw {
+	pc			:uint64;
 	op1			:uint64;
 	op2			:uint64;
+	// If is_const is set, op2 was a source code const (could not come from the input),
+	// otherwise both operands were dynamic and could come from the input.
+	is_const		:bool;
 }
 
 table ProgInfoRaw {

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -2594,7 +2594,7 @@ func (rcv *CallInfoRaw) Comps(obj *ComparisonRaw, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
-		x += flatbuffers.UOffsetT(j) * 16
+		x += flatbuffers.UOffsetT(j) * 32
 		obj.Init(rcv._tab.Bytes, x)
 		return true
 	}
@@ -2634,26 +2634,30 @@ func CallInfoRawAddComps(builder *flatbuffers.Builder, comps flatbuffers.UOffset
 	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(comps), 0)
 }
 func CallInfoRawStartCompsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
-	return builder.StartVector(16, numElems, 8)
+	return builder.StartVector(32, numElems, 8)
 }
 func CallInfoRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
 type ComparisonRawT struct {
-	Op1 uint64 `json:"op1"`
-	Op2 uint64 `json:"op2"`
+	Pc      uint64 `json:"pc"`
+	Op1     uint64 `json:"op1"`
+	Op2     uint64 `json:"op2"`
+	IsConst bool   `json:"is_const"`
 }
 
 func (t *ComparisonRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
-	return CreateComparisonRaw(builder, t.Op1, t.Op2)
+	return CreateComparisonRaw(builder, t.Pc, t.Op1, t.Op2, t.IsConst)
 }
 func (rcv *ComparisonRaw) UnPackTo(t *ComparisonRawT) {
+	t.Pc = rcv.Pc()
 	t.Op1 = rcv.Op1()
 	t.Op2 = rcv.Op2()
+	t.IsConst = rcv.IsConst()
 }
 
 func (rcv *ComparisonRaw) UnPack() *ComparisonRawT {
@@ -2678,24 +2682,41 @@ func (rcv *ComparisonRaw) Table() flatbuffers.Table {
 	return rcv._tab.Table
 }
 
-func (rcv *ComparisonRaw) Op1() uint64 {
+func (rcv *ComparisonRaw) Pc() uint64 {
 	return rcv._tab.GetUint64(rcv._tab.Pos + flatbuffers.UOffsetT(0))
 }
-func (rcv *ComparisonRaw) MutateOp1(n uint64) bool {
+func (rcv *ComparisonRaw) MutatePc(n uint64) bool {
 	return rcv._tab.MutateUint64(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
 }
 
-func (rcv *ComparisonRaw) Op2() uint64 {
+func (rcv *ComparisonRaw) Op1() uint64 {
 	return rcv._tab.GetUint64(rcv._tab.Pos + flatbuffers.UOffsetT(8))
 }
-func (rcv *ComparisonRaw) MutateOp2(n uint64) bool {
+func (rcv *ComparisonRaw) MutateOp1(n uint64) bool {
 	return rcv._tab.MutateUint64(rcv._tab.Pos+flatbuffers.UOffsetT(8), n)
 }
 
-func CreateComparisonRaw(builder *flatbuffers.Builder, op1 uint64, op2 uint64) flatbuffers.UOffsetT {
-	builder.Prep(8, 16)
+func (rcv *ComparisonRaw) Op2() uint64 {
+	return rcv._tab.GetUint64(rcv._tab.Pos + flatbuffers.UOffsetT(16))
+}
+func (rcv *ComparisonRaw) MutateOp2(n uint64) bool {
+	return rcv._tab.MutateUint64(rcv._tab.Pos+flatbuffers.UOffsetT(16), n)
+}
+
+func (rcv *ComparisonRaw) IsConst() bool {
+	return rcv._tab.GetBool(rcv._tab.Pos + flatbuffers.UOffsetT(24))
+}
+func (rcv *ComparisonRaw) MutateIsConst(n bool) bool {
+	return rcv._tab.MutateBool(rcv._tab.Pos+flatbuffers.UOffsetT(24), n)
+}
+
+func CreateComparisonRaw(builder *flatbuffers.Builder, pc uint64, op1 uint64, op2 uint64, isConst bool) flatbuffers.UOffsetT {
+	builder.Prep(8, 32)
+	builder.Pad(7)
+	builder.PrependBool(isConst)
 	builder.PrependUint64(op2)
 	builder.PrependUint64(op1)
+	builder.PrependUint64(pc)
 	return builder.Offset()
 }
 

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -675,17 +675,39 @@ FLATBUFFERS_STRUCT_END(ExecOptsRaw, 24);
 
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) ComparisonRaw FLATBUFFERS_FINAL_CLASS {
  private:
+  uint64_t pc_;
   uint64_t op1_;
   uint64_t op2_;
+  uint8_t is_const_;
+  int8_t padding0__;  int16_t padding1__;  int32_t padding2__;
 
  public:
   ComparisonRaw()
-      : op1_(0),
-        op2_(0) {
+      : pc_(0),
+        op1_(0),
+        op2_(0),
+        is_const_(0),
+        padding0__(0),
+        padding1__(0),
+        padding2__(0) {
+    (void)padding0__;
+    (void)padding1__;
+    (void)padding2__;
   }
-  ComparisonRaw(uint64_t _op1, uint64_t _op2)
-      : op1_(flatbuffers::EndianScalar(_op1)),
-        op2_(flatbuffers::EndianScalar(_op2)) {
+  ComparisonRaw(uint64_t _pc, uint64_t _op1, uint64_t _op2, bool _is_const)
+      : pc_(flatbuffers::EndianScalar(_pc)),
+        op1_(flatbuffers::EndianScalar(_op1)),
+        op2_(flatbuffers::EndianScalar(_op2)),
+        is_const_(flatbuffers::EndianScalar(static_cast<uint8_t>(_is_const))),
+        padding0__(0),
+        padding1__(0),
+        padding2__(0) {
+    (void)padding0__;
+    (void)padding1__;
+    (void)padding2__;
+  }
+  uint64_t pc() const {
+    return flatbuffers::EndianScalar(pc_);
   }
   uint64_t op1() const {
     return flatbuffers::EndianScalar(op1_);
@@ -693,8 +715,11 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) ComparisonRaw FLATBUFFERS_FINAL_CLASS {
   uint64_t op2() const {
     return flatbuffers::EndianScalar(op2_);
   }
+  bool is_const() const {
+    return flatbuffers::EndianScalar(is_const_) != 0;
+  }
 };
-FLATBUFFERS_STRUCT_END(ComparisonRaw, 16);
+FLATBUFFERS_STRUCT_END(ComparisonRaw, 32);
 
 struct ConnectRequestRawT : public flatbuffers::NativeTable {
   typedef ConnectRequestRaw TableType;

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -24,10 +24,11 @@ type Fuzzer struct {
 	Config *Config
 	Cover  *Cover
 
-	ctx    context.Context
-	mu     sync.Mutex
-	rnd    *rand.Rand
-	target *prog.Target
+	ctx          context.Context
+	mu           sync.Mutex
+	rnd          *rand.Rand
+	target       *prog.Target
+	hintsLimiter prog.HintsLimiter
 
 	ct           *prog.ChoiceTable
 	ctProgs      int

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -456,7 +456,7 @@ func (job *hintsJob) run(fuzzer *Fuzzer) {
 		}
 		got := make(prog.CompMap)
 		for _, cmp := range result.Info.Calls[job.call].Comps {
-			got.AddComp(cmp.Op1, cmp.Op2)
+			got.Add(cmp.Pc, cmp.Op1, cmp.Op2, cmp.IsConst)
 		}
 		if i == 0 {
 			comps = got
@@ -464,6 +464,8 @@ func (job *hintsJob) run(fuzzer *Fuzzer) {
 			comps.InplaceIntersect(got)
 		}
 	}
+
+	fuzzer.hintsLimiter.Limit(comps)
 
 	// Then mutate the initial program for every match between
 	// a syscall argument and a comparison operand.

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -420,6 +420,15 @@ func (runner *Runner) convertCallInfo(call *flatrpc.CallInfo) {
 	call.Cover = runner.canonicalizer.Canonicalize(call.Cover)
 	call.Signal = runner.canonicalizer.Canonicalize(call.Signal)
 
+	call.Comps = slices.DeleteFunc(call.Comps, func(cmp *flatrpc.Comparison) bool {
+		converted := runner.canonicalizer.Canonicalize([]uint64{cmp.Pc})
+		if len(converted) == 0 {
+			return true
+		}
+		cmp.Pc = converted[0]
+		return false
+	})
+
 	// Check signal belongs to kernel addresses.
 	// Mismatching addresses can mean either corrupted VM memory, or that the fuzzer somehow
 	// managed to inject output signal. If we see any bogus signal, drop whole signal

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -60,8 +60,8 @@ func generateProg(t *testing.T, target *Target, rs rand.Source, ct *ChoiceTable,
 	for i, c := range p.Calls {
 		comps := make(CompMap)
 		for v := range extractValues(c) {
-			comps.AddComp(v, v+1)
-			comps.AddComp(v, v+10)
+			comps.Add(1, v, v+1, true)
+			comps.Add(1, v, v+10, true)
 		}
 		// If unbounded, this code may take O(N^2) time to complete.
 		// Since large programs are not uncommon, let's limit the number of hint iterations.

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -288,7 +288,7 @@ func (ctx *Context) printHints(p *prog.Prog, info *flatrpc.ProgInfo) {
 		}
 		comps := make(prog.CompMap)
 		for _, cmp := range info.Calls[i].Comps {
-			comps.AddComp(cmp.Op1, cmp.Op2)
+			comps.Add(cmp.Pc, cmp.Op1, cmp.Op2, cmp.IsConst)
 			if ctx.output {
 				fmt.Printf("comp 0x%x ? 0x%x\n", cmp.Op1, cmp.Op2)
 			}

--- a/tools/syz-mutate/mutate.go
+++ b/tools/syz-mutate/mutate.go
@@ -88,7 +88,7 @@ func main() {
 		}
 		if *flagHintCall != -1 {
 			comps := make(prog.CompMap)
-			comps.AddComp(*flagHintSrc, *flagHintCmp)
+			comps.Add(0, *flagHintSrc, *flagHintCmp, true)
 			p.MutateWithHints(*flagHintCall, comps, func(p *prog.Prog) bool {
 				fmt.Printf("%s\n\n", p.Serialize())
 				return true


### PR DESCRIPTION
We are getting too many generated candidates, the fuzzer may not keep up
with them at all (hints jobs keep growing infinitely). If a hint indeed came
from the input w/o transformation, then we should guess it on the first
attempt (or at least after few attempts). If it did not come from the input,
or came with a non-trivial transformation, then any number of attempts won't
help. So limit the total number of attempts (until the next restart).
