### PR TITLE
Revert "tools/syz-env: allow commands with double quote in parameters"

### DIFF
--- a/tools/syz-env
+++ b/tools/syz-env
@@ -81,4 +81,4 @@ docker run \
 	--env GITHUB_PR_COMMITS \
 	--env CI \
 	${DOCKERARGS[@]} \
-	gcr.io/syzkaller/${IMAGE} -c '$COMMAND'
+	gcr.io/syzkaller/${IMAGE} -c "$COMMAND"


### PR DESCRIPTION
Reverts google/syzkaller#5073