### PR TITLE
executor: fix writing of remote coverage

### DIFF
--- a/executor/common_test.h
+++ b/executor/common_test.h
@@ -180,6 +180,17 @@ static long syz_inject_cover(volatile long a, volatile long b)
 #endif
 #endif
 
+#if SYZ_EXECUTOR || __NR_syz_inject_remote_cover
+static long syz_inject_remote_cover(volatile long a, volatile long b)
+#if SYZ_EXECUTOR
+    ; // defined in executor_test.h
+#else
+{
+	return 0;
+}
+#endif
+#endif
+
 #if SYZ_EXECUTOR || SYZ_SYSCTL
 static void setup_sysctl()
 {

--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -997,7 +997,9 @@ void execute_one()
 		// that we were killed on timeout before we write any.
 		// Check for extra coverage is very cheap, effectively a memory load.
 		const uint64 kSleepMs = 100;
-		for (uint64 i = 0; i < prog_extra_cover_timeout / kSleepMs; i++) {
+		for (uint64 i = 0; i < prog_extra_cover_timeout / kSleepMs &&
+				   output_data->completed.load(std::memory_order_relaxed) < kMaxCalls;
+		     i++) {
 			sleep_ms(kSleepMs);
 			write_extra_output();
 		}
@@ -1263,6 +1265,7 @@ void write_extra_output()
 	if (!extra_cov.size)
 		return;
 	write_output(-1, &extra_cov, rpc::CallFlag::NONE, 997, all_extra_signal);
+	cover_reset(&extra_cov);
 }
 
 flatbuffers::span<uint8_t> finish_output(OutputData* output, int proc_id, uint64 req_id, uint64 elapsed,

--- a/executor/executor_test.h
+++ b/executor/executor_test.h
@@ -121,15 +121,24 @@ static void cover_unprotect(cover_t* cov)
 {
 }
 
-static long syz_inject_cover(volatile long a, volatile long b)
+static long inject_cover(cover_t* cov, long a, long b)
 {
-	cover_t* cov = &current_thread->cov;
 	if (cov->data == nullptr)
 		return ENOENT;
 	uint32 size = std::min((uint32)b, cov->mmap_alloc_size);
 	memcpy(cov->data, (void*)a, size);
 	memset(cov->data + size, 0xcd, std::min<uint64>(100, cov->mmap_alloc_size - size));
 	return 0;
+}
+
+static long syz_inject_cover(volatile long a, volatile long b)
+{
+	return inject_cover(&current_thread->cov, a, b);
+}
+
+static long syz_inject_remote_cover(volatile long a, volatile long b)
+{
+	return inject_cover(&extra_cov, a, b);
 }
 
 static const char* setup_fault()

--- a/sys/test/exec.txt
+++ b/sys/test/exec.txt
@@ -13,6 +13,7 @@ syz_compare_zlib(data ptr[in, array[int8]], size bytesize[data], zdata ptr[in, c
 
 # Copies the data into KCOV buffer verbatim.
 syz_inject_cover(ptr ptr[in, array[int8]], size bytesize[ptr])
+syz_inject_remote_cover(ptr ptr[in, array[int8]], size bytesize[ptr]) (prog_timeout[1000], remote_cover)
 
 compare_data [
 	align0		align0


### PR DESCRIPTION
We never reset remote coverage, so if there is one block,
we will write it after every call and multiple times at the end.
It can lead to "too many calls in output" and just writes quadratic
amount of coverage/signal.
Reset remote coverage after writing.
