### PR TITLE
executor: increase kExtraCoverSize to 1024k

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #if SYZ_EXECUTOR
-const int kExtraCoverSize = 256 << 10;
+const int kExtraCoverSize = 1024 << 10;
 struct cover_t;
 static void cover_reset(cover_t* cov);
 #endif


### PR DESCRIPTION
Running the vusb_ath9k runtest (with [1] and [2] applied) produces ~100k of extra coverage, which is somewhat close to the current 256k limit. A more complicated program might produce more extra coverage and overflow the coverage buffer.

Increase kExtraCoverSize to 1024k.

As the extra coverage buffer is maintained per-executor and not per-thread, the total increase of the coverage mapping is ~9%, which is not too bad.

[1] https://lore.kernel.org/all/eaf54b8634970b73552dcd38bf9be6ef55238c10.1718092070.git.dvyukov@google.com/
[2] https://lore.kernel.org/all/20240722223726.194658-1-andrey.konovalov@linux.dev/T/#u