### PR TITLE
pkg/runtest: fix a race during startup

### DIFF
--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -85,6 +85,7 @@ func test(t *testing.T, sysTarget *targets.Target) {
 		Verbose: true,
 		Debug:   *flagDebug,
 	}
+	ctx.Init()
 	waitCtx := startRPCServer(t, target, executor, ctx, rpcParams{
 		manyProcs: true,
 		machineChecked: func(features flatrpc.Feature) {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1389,6 +1389,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map
 			Verbose: true,
 			Debug:   *flagDebug,
 		}
+		ctx.Init()
 		go func() {
 			err := ctx.Run(context.Background())
 			if err != nil {


### PR DESCRIPTION
Run method usually runs in a separate goroutine concurrently with request consumer
(Next calls), so at least executor needs to be initialized before Run.
Otherwise we can get episodic nil derefs in Next method.
