### PR TITLE
pkg/vminfo: don't parse modules for gvisor or starnix

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -33,6 +33,7 @@ import (
 type Config struct {
 	vminfo.Config
 	VMArch string
+	VMType string
 	RPC    string
 	VMLess bool
 	// Hash adjacent PCs to form fuzzing feedback signal (otherwise just use coverage PCs as signal).
@@ -105,6 +106,7 @@ func New(cfg *mgrconfig.Config, mgr Manager, debug bool) (*Server, error) {
 	return newImpl(context.Background(), &Config{
 		Config: vminfo.Config{
 			Target:     cfg.Target,
+			VMType:     cfg.Type,
 			Features:   features,
 			Syscalls:   cfg.Syscalls,
 			Debug:      debug,

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -466,6 +466,7 @@ func makeComps(comps ...Comparison) []byte {
 type rpcParams struct {
 	manyProcs      bool
 	vmArch         string
+	vmType         string
 	maxSignal      []uint64
 	coverFilter    []uint64
 	machineChecked func(features flatrpc.Feature)
@@ -488,6 +489,7 @@ func startRPCServer(t *testing.T, target *prog.Target, executor string,
 		Config: rpcserver.Config{
 			Config: vminfo.Config{
 				Target:   target,
+				VMType:   extra.vmType,
 				Cover:    true,
 				Debug:    *flagDebug,
 				Features: flatrpc.AllFeatures,

--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -22,7 +22,6 @@ func (linux) RequiredFiles() []string {
 		"/proc/cpuinfo",
 		"/proc/modules",
 		"/proc/kallsyms",
-		"/proc/sentry-meminfo",
 		"/sys/module/*/sections/.text",
 		"/sys/module/kvm*/parameters/*",
 	}
@@ -44,11 +43,6 @@ func (linux) machineInfos() []machineInfoFunc {
 }
 
 func (linux) parseModules(files filesystem) ([]*KernelModule, error) {
-	_, err := files.ReadFile("/proc/sentry-meminfo")
-	if err == nil {
-		// This is gVisor.
-		return nil, nil
-	}
 	var modules []*KernelModule
 	re := regexp.MustCompile(`(\w+) ([0-9]+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
 	modulesText, _ := files.ReadFile("/proc/modules")


### PR DESCRIPTION
Starnix doesn't implement `/proc/kallsyms` (at least not yet), and there is already a short-circuit for gVisor in `parseModules`. This change pipes the VM type through to the machine info checker so that it can handle these cases separately from other linux VMs.