### PR TITLE
vm/dispatcher: move boot duration calculation to vm

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -118,8 +118,6 @@ type Manager struct {
 
 	assetStorage *asset.Storage
 
-	bootTime stat.AverageValue[time.Duration]
-
 	reproMgr *reproManager
 
 	Stats
@@ -730,8 +728,6 @@ func (mgr *Manager) fuzzerInstance(ctx context.Context, inst *vm.Instance, updIn
 
 func (mgr *Manager) runInstanceInner(ctx context.Context, inst *vm.Instance, instanceName string,
 	injectExec <-chan bool) (*report.Report, []byte, error) {
-	start := time.Now()
-
 	fwdAddr, err := inst.Forward(mgr.serv.Port)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to setup port forwarding: %w", err)
@@ -748,8 +744,7 @@ func (mgr *Manager) runInstanceInner(ctx context.Context, inst *vm.Instance, ins
 	}
 
 	// Run the fuzzer binary.
-	mgr.bootTime.Save(time.Since(start))
-	start = time.Now()
+	start := time.Now()
 
 	host, port, err := net.SplitHostPort(fwdAddr)
 	if err != nil {

--- a/syz-manager/stats.go
+++ b/syz-manager/stats.go
@@ -44,7 +44,7 @@ func (mgr *Manager) initStats() {
 	mgr.statAvgBootTime = stat.New("instance restart", "Average VM restart time (sec)",
 		stat.NoGraph,
 		func() int {
-			return int(mgr.bootTime.Value().Seconds())
+			return int(mgr.pool.BootTime.Value().Seconds())
 		},
 		func(v int, _ time.Duration) string {
 			return fmt.Sprintf("%v sec", v)


### PR DESCRIPTION
This should be calculated in dispatcher.Pool that actually does boot VMs.
