### PR TITLE
tools/syz-declextract: run syz-declextract on files specified by a compilation database

### DIFF
--- a/tools/check-copyright.sh
+++ b/tools/check-copyright.sh
@@ -4,7 +4,7 @@
 
 FILES=0
 FAILED=""
-for F in $(find . -name "*.go" -o -name "*.sh" -o -name "*.cc" -o -name "*.h" \
+for F in $(find . -name "*.go" -o -name "*.sh" -o -name "*.cpp" -o -name "*.cc" -o -name "*.h" \
 	-o -name "*.S" -o -name "*.py" -o -name "*.yml" -o -name "*.yaml" -o -name "*.fbs" \
 	-o \( -path "./sys/*/*.txt" \) | egrep -v "/_include/|/vendor/|/gen/|/testdata/"); do
 	((FILES+=1))

--- a/tools/syz-declextract/.clang-format
+++ b/tools/syz-declextract/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 ColumnLimit: 120
+CommentPragmas: '^[^ ]'

--- a/tools/syz-declextract/README.md
+++ b/tools/syz-declextract/README.md
@@ -35,3 +35,9 @@ make -j`nproc` syz-declextract
 ```
 ./bin/syz-declextract $KERNEL/fs/read_write.c | less # or any other .c file
 ```
+## Running the tool
+Download `run.go`, build it and run it
+```
+go build run.go
+./run -p $KERNEL/compile_commands.json -b $SYZ/bin/syz-declextract
+```

--- a/tools/syz-declextract/run.go
+++ b/tools/syz-declextract/run.go
@@ -1,0 +1,86 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/tool"
+)
+
+type compileCommand struct {
+	Arguments []string
+	Directory string
+	File      string
+	Output    string
+}
+
+type output struct {
+	stdout []byte
+	stderr []byte
+}
+
+func main() {
+	compilationDatabase := flag.String("p", "compile_commands.json", "path to compilation database")
+	binary := flag.String("b", "syz-declextract", "path to binary")
+	flag.Parse()
+
+	fileData, err := os.ReadFile(*compilationDatabase)
+	if err != nil {
+		tool.Fail(err)
+	}
+
+	var cmds []compileCommand
+	if err := json.Unmarshal(fileData, &cmds); err != nil {
+		tool.Fail(err)
+	}
+
+	outputs := make(chan output, len(cmds))
+	files := make(chan string, len(cmds))
+
+	for w := 0; w < runtime.NumCPU(); w++ {
+		go worker(outputs, files, *binary, *compilationDatabase)
+	}
+
+	for _, v := range cmds {
+		files <- v.File
+	}
+	close(files)
+
+	for range cmds {
+		out := <-outputs
+		if out.stderr != nil {
+			tool.Failf("%s", out.stderr)
+		}
+		os.Stdout.Write(out.stdout) // To avoid converting to a string.
+	}
+}
+
+func worker(outputs chan output, files chan string, binary, compilationDatabase string) {
+	for file := range files {
+		if !strings.HasSuffix(file, ".c") {
+			outputs <- output{}
+			return
+		}
+
+		cmd := exec.Command(binary, "-p", compilationDatabase, file)
+		stdout, err := cmd.Output()
+		var stderr []byte
+		if err != nil {
+			var error *exec.ExitError
+			if errors.As(err, &error) {
+				stderr = error.Stderr
+			} else {
+				stderr = []byte(err.Error())
+			}
+		}
+		outputs <- output{stdout, stderr}
+	}
+}

--- a/tools/syz-declextract/syz-declextract.cpp
+++ b/tools/syz-declextract/syz-declextract.cpp
@@ -1,3 +1,7 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build ignore
 #include "clang/AST/APValue.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"


### PR DESCRIPTION
Run multiple instances of syz-declextract only on files specifed by a compilation database.