### PR TITLE
pkg/cover: fix pc for core kernel

### DIFF
--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -74,9 +74,7 @@ func elfReadSymbols(module *vminfo.KernelModule, info *symbolInfo) ([]*Symbol, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ELF symbols: %w", err)
 	}
-	if module.Name == "" {
-		info.textAddr = text.Addr
-	}
+	info.textAddr = text.Addr
 	var symbols []*Symbol
 	for i, symb := range allSymbols {
 		if symb.Info&0xf != uint8(elf.STT_FUNC) && symb.Info&0xf != uint8(elf.STT_NOTYPE) {
@@ -85,7 +83,10 @@ func elfReadSymbols(module *vminfo.KernelModule, info *symbolInfo) ([]*Symbol, e
 		}
 		text := symb.Value >= text.Addr && symb.Value+symb.Size <= text.Addr+text.Size
 		if text && symb.Size != 0 {
-			start := symb.Value + module.Addr
+			start := symb.Value
+			if module.Name != "" {
+				start += module.Addr
+			}
 			symbols = append(symbols, &Symbol{
 				Module: module,
 				ObjectUnit: ObjectUnit{

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -170,10 +170,6 @@ func FixModules(localModules, modules []*vminfo.KernelModule, pcBase uint64) []*
 			continue
 		}
 		addr := mod.Addr - kaslrOffset
-		if mod.Name == "" {
-			// mod.Addr for core kernel from target is _stext addr
-			addr = 0
-		}
 		modules1 = append(modules1, &vminfo.KernelModule{
 			Name: mod.Name,
 			Size: size,


### PR DESCRIPTION
we use offset to symbolize pc for module,
while use absolute pc for core kernel.

Fix by removing base address from module only.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
