### PR TITLE
syz-manager: move more code to the packages

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -886,3 +886,13 @@ var cSimplifies = append(progSimplifies, []Simplify{
 		return true
 	},
 }...)
+
+func (stats *Stats) FullLog() []byte {
+	if stats == nil {
+		return nil
+	}
+	return []byte(fmt.Sprintf("Extracting prog: %v\nMinimizing prog: %v\n"+
+		"Simplifying prog options: %v\nExtracting C: %v\nSimplifying C: %v\n\n\n%s",
+		stats.ExtractProgTime, stats.MinimizeProgTime,
+		stats.SimplifyProgTime, stats.ExtractCTime, stats.SimplifyCTime, stats.Log))
+}

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -27,6 +27,28 @@ func (p *Prog) CallName(call int) string {
 	return p.Calls[call].Meta.Name
 }
 
+// OnlyContains determines whether the program only consists of the syscalls from the first argument.
+func (p *Prog) OnlyContains(syscalls map[*Syscall]bool) bool {
+	for _, c := range p.Calls {
+		if !syscalls[c.Meta] {
+			return false
+		}
+	}
+	return true
+}
+
+// FilterInplace only leaves the allowed system calls and deletes all remaining ones.
+func (p *Prog) FilterInplace(allowed map[*Syscall]bool) {
+	for i := 0; i < len(p.Calls); {
+		c := p.Calls[i]
+		if !allowed[c.Meta] {
+			p.RemoveCall(i)
+			continue
+		}
+		i++
+	}
+}
+
 // These properties are parsed and serialized according to the tag and the type
 // of the corresponding fields.
 // IMPORTANT: keep the exact values of "key" tag for existing props unchanged,

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -320,7 +320,7 @@ func (hc *HubConnector) parseProgram(data []byte) (*prog.Prog, error) {
 	if err != nil {
 		return nil, err
 	}
-	if containsDisabled(p, hc.enabledCalls) {
+	if !p.OnlyContains(hc.enabledCalls) {
 		return nil, fmt.Errorf("contains disabled calls")
 	}
 	return p, nil

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -687,7 +687,7 @@ func (mgr *Manager) fuzzerInstance(ctx context.Context, inst *vm.Instance, updIn
 	rep, vmInfo, err := mgr.runInstanceInner(ctx, inst, injectExec)
 	lastExec, machineInfo := mgr.serv.ShutdownInstance(inst.Index(), rep != nil)
 	if rep != nil {
-		prependExecuting(rep, lastExec)
+		rpcserver.PrependExecuting(rep, lastExec)
 		if len(vmInfo) != 0 {
 			machineInfo = append(append(vmInfo, '\n'), machineInfo...)
 		}
@@ -751,20 +751,6 @@ func (mgr *Manager) runInstanceInner(ctx context.Context, inst *vm.Instance,
 		vmInfo = []byte(fmt.Sprintf("error getting VM info: %v\n", err))
 	}
 	return rep, vmInfo, nil
-}
-
-func prependExecuting(rep *report.Report, lastExec []rpcserver.ExecRecord) {
-	buf := new(bytes.Buffer)
-	fmt.Fprintf(buf, "last executing test programs:\n\n")
-	for _, exec := range lastExec {
-		fmt.Fprintf(buf, "%v ago: executing program %v (id=%v):\n%s\n", exec.Time, exec.Proc, exec.ID, exec.Prog)
-	}
-	fmt.Fprintf(buf, "kernel console output (not intermixed with test programs):\n\n")
-	rep.Output = append(buf.Bytes(), rep.Output...)
-	n := len(buf.Bytes())
-	rep.StartPos += n
-	rep.EndPos += n
-	rep.SkipPos += n
 }
 
 func (mgr *Manager) emailCrash(crash *Crash) {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -956,7 +956,7 @@ func truncateReproLog(log []byte) []byte {
 }
 
 func (mgr *Manager) saveFailedRepro(rep *report.Report, stats *repro.Stats) {
-	reproLog := fullReproLog(stats)
+	reproLog := stats.FullLog()
 	if mgr.dash != nil {
 		if rep.Type == crash_pkg.MemoryLeak {
 			// Don't send failed leak repro attempts to dashboard
@@ -1049,7 +1049,7 @@ func (mgr *Manager) saveRepro(res *ReproResult) {
 			ReproOpts:     repro.Opts.Serialize(),
 			ReproSyz:      progText,
 			ReproC:        cprogText,
-			ReproLog:      truncateReproLog(fullReproLog(res.stats)),
+			ReproLog:      truncateReproLog(res.stats.FullLog()),
 			Assets:        mgr.uploadReproAssets(repro),
 			OriginalTitle: res.crash.Title,
 		}
@@ -1099,7 +1099,7 @@ func (mgr *Manager) saveRepro(res *ReproResult) {
 			osutil.WriteFile(filepath.Join(dir, "strace.log"), res.strace.Output)
 		}
 	}
-	if reproLog := fullReproLog(res.stats); len(reproLog) > 0 {
+	if reproLog := res.stats.FullLog(); len(reproLog) > 0 {
 		osutil.WriteFile(filepath.Join(dir, "repro.stats"), reproLog)
 	}
 }
@@ -1129,16 +1129,6 @@ func (mgr *Manager) uploadReproAssets(repro *repro.Result) []dashapi.NewAsset {
 		ret = append(ret, asset)
 	})
 	return ret
-}
-
-func fullReproLog(stats *repro.Stats) []byte {
-	if stats == nil {
-		return nil
-	}
-	return []byte(fmt.Sprintf("Extracting prog: %v\nMinimizing prog: %v\n"+
-		"Simplifying prog options: %v\nExtracting C: %v\nSimplifying C: %v\n\n\n%s",
-		stats.ExtractProgTime, stats.MinimizeProgTime,
-		stats.SimplifyProgTime, stats.ExtractCTime, stats.SimplifyCTime, stats.Log))
 }
 
 func (mgr *Manager) corpusInputHandler(updates <-chan corpus.NewItemEvent) {


### PR DESCRIPTION
This will facilitate code reuse in further PRs and will simplify the syz-manager code.