### PR TITLE
sys/linux/filesystems: add the inlinecrypt mount flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -121,3 +121,4 @@ Arm Ltd
  Andrew Turner
 h0wdy
 Dylan Yudaken
+Viacheslav Sablin

--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -679,6 +679,7 @@ ext4_options [
 	noinit_itable		stringnoz["noinit_itable"]
 	test_dummy_encryption	stringnoz["test_dummy_encryption"]
 	nombcache		stringnoz["nombcache"]
+	inlinecrypt		stringnoz["inlinecrypt"]
 	resgid			fs_opt_hex["resgid", gid]
 	resuid			fs_opt_hex["resuid", uid]
 	sb			fs_opt_hex["sb", int32]
@@ -759,6 +760,7 @@ f2fs_options [
 	fsync_mode_posix	stringnoz["fsync_mode=posix"]
 	fsync_mode_strict	stringnoz["fsync_mode=strict"]
 	test_dummy_encryption	stringnoz["test_dummy_encryption"]
+	inlinecrypt		stringnoz["inlinecrypt"]
 ] [varlen]
 
 bpf_options [


### PR DESCRIPTION
Added inlinecrypt mount flag to the ext4, f2fs.
