### PR TITLE
pkg/corpus: prefer smaller programs during minimization

### DIFF
--- a/pkg/corpus/minimize.go
+++ b/pkg/corpus/minimize.go
@@ -25,10 +25,16 @@ func (corpus *Corpus) Minimize(cover bool) {
 	// This gives some intentional non-determinism during minimization.
 	// However, we want to give preference to non-squashed inputs,
 	// so let's sort by this criteria.
+	// We also want to give preference to smaller corpus programs:
+	// - they are faster to execute,
+	// - minimization occasionally fails, so we need to clean it up over time.
 	sort.SliceStable(inputs, func(i, j int) bool {
-		firstAny := inputs[i].Context.(*Item).HasAny
-		secondAny := inputs[j].Context.(*Item).HasAny
-		return !firstAny && secondAny
+		first := inputs[i].Context.(*Item)
+		second := inputs[j].Context.(*Item)
+		if first.HasAny != second.HasAny {
+			return !first.HasAny
+		}
+		return len(first.Prog.Calls) < len(second.Prog.Calls)
 	})
 
 	corpus.progs = make(map[string]*Item)


### PR DESCRIPTION
Occasionally, deflake() and minimize() fail and we end up with huge programs in the syzkaller corpus. Huge programs in the corpus, in turn, lead to slower corpus triage and slower exec/sec overall, since many of the executed programs are based on the ones from the corpus.

A slightly bigger corpus with on average shorter and more focused programs sounds like a more desirable outcome.

Give preference to smaller programs during minimization. It should hopefully improve the situation over time.
