### PR TITLE
sys/linux/filesystems: add the inlinecrypt mount flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -132,3 +132,4 @@ Krzysztof Pawlaczyk
 Simone Weiß
 Amazon
  Bjoern Doebel
+Viacheslav Sablin

--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -680,6 +680,7 @@ ext4_options [
 	noinit_itable		stringnoz["noinit_itable"]
 	test_dummy_encryption	stringnoz["test_dummy_encryption"]
 	nombcache		stringnoz["nombcache"]
+	inlinecrypt		stringnoz["inlinecrypt"]
 	resgid			fs_opt_hex["resgid", gid]
 	resuid			fs_opt_hex["resuid", uid]
 	sb			fs_opt_hex["sb", int32]
@@ -762,6 +763,7 @@ f2fs_options [
 	test_dummy_encryption	stringnoz["test_dummy_encryption"]
 	errors_continue		stringnoz["errors=continue"]
 	errors_remount		stringnoz["errors=remount-ro"]
+	inlinecrypt		stringnoz["inlinecrypt"]
 ] [varlen]
 
 bpf_options [


### PR DESCRIPTION
Added the inlinecrypt mount flag for ext4, f2fs. 
