### PR TITLE
tools/syz-linter: check tool.Failf messages

### DIFF
--- a/sys/syz-extract/extract.go
+++ b/sys/syz-extract/extract.go
@@ -85,8 +85,8 @@ func main() {
 		tool.Fail(err)
 	}
 	if *flagSourceDir == "" {
-		tool.Fail(fmt.Errorf("provide path to kernel checkout via -sourcedir " +
-			"flag (or make extract SOURCEDIR)"))
+		tool.Failf("provide path to kernel checkout via -sourcedir " +
+			"flag (or make extract SOURCEDIR)")
 	}
 	if err := extractor.prepare(*flagSourceDir, *flagBuild, arches); err != nil {
 		tool.Fail(err)

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -303,6 +303,8 @@ func (pass *Pass) logFormatArg(n *ast.CallExpr) (arg int, newLine, sure bool) {
 		return 1, true, true
 	case "t.Errorf", "t.Fatalf":
 		return 0, false, true
+	case "tool.Failf":
+		return 0, false, true
 	}
 	if fun.Sel.String() == "Logf" {
 		return 0, false, true

--- a/tools/syz-linter/testdata/src/github.com/google/syzkaller/pkg/tool/tool.go
+++ b/tools/syz-linter/testdata/src/github.com/google/syzkaller/pkg/tool/tool.go
@@ -1,0 +1,7 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package tool
+
+func Failf(msg string, args ...interface{}) {}
+func Fail(err error) {}

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/google/syzkaller/pkg/tool"
 )
 
 /* some comment */ // want "Use C-style comments // instead of /* */"
@@ -86,6 +88,9 @@ func logErrorMessages() {
 	fmt.Printf("fragment")
 	fmt.Printf("Fragment Fragment %s", msg)
 	fmt.Fprintf(nil, "These can be anything")
+	tool.Fail(err)
+	tool.Failf("good message")
+	tool.Failf("good message %v", 0)
 
 	fmt.Errorf("Bad message")                                           // want "Don't start log/error messages with a Capital letter"
 	log.Fatalf("Bad message %v", 1)                                     // want "Don't start log/error messages with a Capital letter"
@@ -99,6 +104,7 @@ func logErrorMessages() {
 	fmt.Fprintf(os.Stderr, "Real output message with capital letter\n") // want "Don't start log/error messages with a Capital letter"
 	fmt.Fprintf(os.Stderr, "real output message without newline")       // want "Add \\\\n at the end of printed messages"
 	fmt.Fprintf(os.Stderr, "%v", err)                                   // want "Add \\\\n at the end of printed messages"
+	tool.Failf("Bad message")                                           // want "Don't start log/error messages with a Capital letter"
 }
 
 func testMessages(t *testing.T) {


### PR DESCRIPTION
Check tool.Failf messages for the common style as well.
