### PR TITLE
syz-manager: support bug reproduction in snapshot mode

### DIFF
--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -130,9 +130,6 @@ func Complete(cfg *Config) error {
 	); err != nil {
 		return err
 	}
-	if cfg.Snapshot && cfg.Reproduce {
-		return fmt.Errorf("reproduction is not (yet) supported in snapshot mode")
-	}
 	cfg.Workdir = osutil.Abs(cfg.Workdir)
 	if cfg.WorkdirTemplate != "" {
 		cfg.WorkdirTemplate = osutil.Abs(cfg.WorkdirTemplate)


### PR DESCRIPTION
For now, let's just reuse the already existing reproduction mechanism by plugging in snapshot-based VMs into `dispatcher.Pool`.