### PR TITLE
syz-manager: don't overcount executed programs in snapshot mode

### DIFF
--- a/syz-manager/snapshot.go
+++ b/syz-manager/snapshot.go
@@ -127,7 +127,6 @@ func (mgr *Manager) snapshotRun(inst *vm.Instance, builder *flatbuffers.Builder,
 		return nil, nil, err
 	}
 	elapsed := time.Since(start)
-	queue.StatExecs.Add(1)
 
 	execError := ""
 	var info *flatrpc.ProgInfo


### PR DESCRIPTION
We increment StatExecs in both snapshotVM and snapshotRun,
which leads to 2x overcounting. Remove one increment.
