### PR TITLE
pkg/instance: adjust FuzzingVMs in OverrideVMCount()

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -212,6 +212,7 @@ func OverrideVMCount(cfg *mgrconfig.Config, n int) error {
 		return fmt.Errorf("failed to serialize VM config: %w", err)
 	}
 	cfg.VM = vmCfg
+	cfg.FuzzingVMs = min(cfg.FuzzingVMs, n)
 	return nil
 }
 


### PR DESCRIPTION
We should not be setting FuzzingVMs to a value below the overall VM count.

Closes #5175.