### PR TITLE
syz-manager: re-minimize a subset of corpus programs

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -654,6 +655,10 @@ func (mgr *Manager) loadCorpus() []fuzzer.Candidate {
 		candidates = append(candidates, item)
 	}
 	log.Logf(0, "%-24v: %v (%v seeds)", "corpus", len(candidates), seeds)
+	// Let's favorize smaller programs, otherwise the poorly minimized ones may overshadow the rest.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return len(candidates[i].Prog.Calls) < len(candidates[j].Prog.Calls)
+	})
 	return candidates
 }
 


### PR DESCRIPTION
The current fuzzing algorithm in syzkaller may preserve the poorly
minimized corpus programs forever - they trigger a lot of coverage and
will very likely survive all syzkaller restarts.

As a result, more than 18% of the current syzbot corpus programs are
larger than 25 calls, which is an unreasonably big figure.

Introduce a way to prevent the domination of the bigprograms in the
corpus.

Every corpus retriage, pick up to 50 seeds among the 10% largest corpus
programs and re-minimize them. Hopefully, this should reduce the
magnitude of the problem.