### PR TITLE
tools/syz-cover: explain file coverage source

### DIFF
--- a/pkg/cover/file.go
+++ b/pkg/cover/file.go
@@ -12,10 +12,26 @@ import (
 	"github.com/google/syzkaller/pkg/covermerger"
 )
 
-type lineRender func(string, bool, int, int) string
+type lineRender func(string, int, *covermerger.MergeResult, *CoverageRenderConfig) string
+
+type CoverageRenderConfig struct {
+	Render                    lineRender
+	ShowLineCoverage          bool
+	ShowLineNumbers           bool
+	ShowLineSourceExplanation bool
+}
+
+func DefaultTextRenderConfig() *CoverageRenderConfig {
+	return &CoverageRenderConfig{
+		Render:                    RendTextLine,
+		ShowLineCoverage:          true,
+		ShowLineNumbers:           true,
+		ShowLineSourceExplanation: false,
+	}
+}
 
 func RendFileCoverage(c context.Context, ns, repo, commit, filePath string,
-	fromDate, toDate civil.Date, render lineRender) (string, error) {
+	fromDate, toDate civil.Date, renderConfig *CoverageRenderConfig) (string, error) {
 	fileContent, err := covermerger.GetFileVersion(filePath, repo, commit)
 	if err != nil {
 		return "", fmt.Errorf("failed to GetFileVersion for file %s, commit %s from repo %s: %w",
@@ -28,6 +44,7 @@ func RendFileCoverage(c context.Context, ns, repo, commit, filePath string,
 			Commit: commit,
 		},
 		FileVersProvider: covermerger.MakeWebGit(),
+		StoreDetails:     true,
 	}
 
 	dbReader := covermerger.MakeBQCSVReader()
@@ -50,24 +67,51 @@ func RendFileCoverage(c context.Context, ns, repo, commit, filePath string,
 		return "", fmt.Errorf("error merging coverage: %w", err)
 	}
 
-	return rendResult(fileContent, mergeResult[filePath], render), nil
+	return rendResult(fileContent, mergeResult[filePath], renderConfig), nil
 }
 
-func rendResult(content string, coverage *covermerger.MergeResult, render lineRender) string {
-	srclines := strings.Split(content, "\n")
+func rendResult(content string, coverage *covermerger.MergeResult, renderConfig *CoverageRenderConfig) string {
+	srcLines := strings.Split(content, "\n")
 	var htmlLines []string
-	for i, srcLine := range srclines {
-		lineNum := i + 1
-		covered, instrumented := coverage.HitCounts[lineNum]
-		htmlLines = append(htmlLines, render(srcLine, instrumented, covered, lineNum))
+	for i, srcLine := range srcLines {
+		htmlLines = append(htmlLines, renderConfig.Render(srcLine, i+1, coverage, renderConfig))
 	}
 	return strings.Join(htmlLines, "\n")
 }
 
-func RendTextLine(code string, instrumented bool, covered, num int) string {
-	covStr := fmt.Sprintf("%6d", covered)
-	if !instrumented {
-		covStr = strings.Repeat(" ", 6)
+func RendTextLine(code string, line int, coverage *covermerger.MergeResult, config *CoverageRenderConfig) string {
+	res := ""
+	if config.ShowLineSourceExplanation {
+		explanation := ""
+		lineDetails, exist := coverage.LineDetails[line]
+		if exist {
+			explanation = fmt.Sprintf("(%d)%s ", len(lineDetails), mainSignalSource(lineDetails))
+		}
+		res += fmt.Sprintf("%50s", explanation)
 	}
-	return fmt.Sprintf("%s %6d %s", covStr, num, code)
+	covered, instrumented := coverage.HitCounts[line]
+	if config.ShowLineCoverage {
+		covStr := fmt.Sprintf("%6d", covered)
+		if !instrumented {
+			covStr = strings.Repeat(" ", 6)
+		}
+		res += fmt.Sprintf("%s ", covStr)
+	}
+	if config.ShowLineNumbers {
+		res += fmt.Sprintf("%6d ", line)
+	}
+	res += code
+	return res
+}
+
+func mainSignalSource(sources []*covermerger.FileRecord) string {
+	res := ""
+	prevMax := -1
+	for _, source := range sources {
+		if source.HitCount > prevMax {
+			prevMax = source.HitCount
+			res = fmt.Sprintf("%s:%d", source.Commit, source.StartLine)
+		}
+	}
+	return res
 }

--- a/pkg/covermerger/covermerger.go
+++ b/pkg/covermerger/covermerger.go
@@ -40,8 +40,9 @@ type RepoBranchCommit struct {
 }
 
 type MergeResult struct {
-	HitCounts  map[int]int
-	FileExists bool
+	HitCounts   map[int]int
+	FileExists  bool
+	LineDetails map[int][]*FileRecord
 }
 
 type FileCoverageMerger interface {
@@ -61,7 +62,7 @@ func batchFileData(c *Config, targetFilePath string, records []*FileRecord) (*Me
 	if err != nil {
 		return nil, fmt.Errorf("failed to getFileVersions: %w", err)
 	}
-	merger := makeFileLineCoverMerger(fvs, c.Base)
+	merger := makeFileLineCoverMerger(fvs, c.Base, c.StoreDetails)
 	for _, record := range records {
 		merger.Add(record)
 	}
@@ -111,6 +112,7 @@ type Config struct {
 	skipRepoClone    bool
 	Base             RepoBranchCommit
 	FileVersProvider FileVersProvider
+	StoreDetails     bool
 }
 
 func isSchema(fields, schema []string) bool {

--- a/pkg/covermerger/deleted_file_merger.go
+++ b/pkg/covermerger/deleted_file_merger.go
@@ -6,7 +6,7 @@ package covermerger
 type DeletedFileLineMerger struct {
 }
 
-func (a *DeletedFileLineMerger) AddRecord(RepoBranchCommit, *Frame, int) {
+func (a *DeletedFileLineMerger) Add(*FileRecord) {
 }
 
 func (a *DeletedFileLineMerger) Result() *MergeResult {

--- a/pkg/covermerger/file_line_merger.go
+++ b/pkg/covermerger/file_line_merger.go
@@ -40,15 +40,15 @@ type FileLineCoverMerger struct {
 	lostFrames map[RepoBranchCommit]int64
 }
 
-func (a *FileLineCoverMerger) AddRecord(rbc RepoBranchCommit, f *Frame, hitCount int) {
-	if a.matchers[rbc] == nil {
-		if hitCount > 0 {
-			a.lostFrames[rbc]++
+func (a *FileLineCoverMerger) Add(record *FileRecord) {
+	if a.matchers[record.RepoBranchCommit] == nil {
+		if record.HitCount > 0 {
+			a.lostFrames[record.RepoBranchCommit]++
 		}
 		return
 	}
-	if targetLine := a.matchers[rbc].SameLinePos(f.StartLine); targetLine != -1 {
-		a.hitCounts[targetLine] += hitCount
+	if targetLine := a.matchers[record.RepoBranchCommit].SameLinePos(record.StartLine); targetLine != -1 {
+		a.hitCounts[targetLine] += record.HitCount
 	}
 }
 

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -61,6 +61,7 @@ var (
 		"[optional] repo to be used by -for-file")
 	flagCommit    = flag.String("commit", "latest", "[optional] commit to be used by -for-file")
 	flagNamespace = flag.String("namespace", "upstream", "[optional] used by -for-file")
+	flagDebug     = flag.Bool("debug", false, "[optional] enables detailed output")
 )
 
 func parseDates() (civil.Date, civil.Date) {
@@ -98,6 +99,8 @@ func toolBuildNsHeatmap() {
 
 func toolFileCover() {
 	dateFrom, dateTo := parseDates()
+	config := cover.DefaultTextRenderConfig()
+	config.ShowLineSourceExplanation = *flagDebug
 	details, err := cover.RendFileCoverage(
 		context.Background(),
 		*flagNamespace,
@@ -106,7 +109,7 @@ func toolFileCover() {
 		*flagForFile,
 		dateFrom,
 		dateTo,
-		cover.RendTextLine,
+		config,
 	)
 	if err != nil {
 		tool.Fail(err)


### PR DESCRIPTION
To test use ```go run ./tools/syz-cover -for-file virt/kvm/kvm_main.c -from 2024-08-10 -to 2024-08-10```.
Knowing the source of the "strange" signals I'll be able to debug what went wrong calling "github.com/sergi/go-diff/diffmatchpatch".

We can alternatively merge this PR by parts starting with #5184 .