### PR TITLE
tools/syz-cover: add missing DiscoverModules()

### DIFF
--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -35,6 +35,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	"github.com/google/syzkaller/pkg/cover"
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/tool"
@@ -128,7 +129,11 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	var modules []*vminfo.KernelModule
+
+	modules, err := backend.DiscoverModules(cfg.SysTarget, cfg.KernelObj, cfg.ModuleObj)
+	if err != nil {
+		tool.Fail(err)
+	}
 	if *flagModules != "" {
 		if modules, err = loadModules(*flagModules); err != nil {
 			tool.Fail(err)


### PR DESCRIPTION
This fixes syz-cover tool breaking after the removal of DiscoverModules() down the stack from MakeReportGenerator().

I'm not sure if syz-cover should overwrite modules if they're provided on the command line, or if they should be added to the manager config modules. If we're using the config, then it might even make sense to just strip that command line option entirely.

Fixes #5086