### PR TITLE
pkg/covermerger: allow to use namespaces with dash

### DIFF
--- a/pkg/covermerger/bq_csv_reader.go
+++ b/pkg/covermerger/bq_csv_reader.go
@@ -67,7 +67,7 @@ func (r *bqCSVReader) InitNsRecords(ctx context.Context, ns, filePath, commit st
 			AS (
 				SELECT
 					kernel_repo, kernel_branch, kernel_commit, file_path, sl, SUM(hit_count) as hit_count
-				FROM syzkaller.syzbot_coverage.%s
+				FROM syzkaller.syzbot_coverage.`+"`%s`"+`
 				WHERE
 					TIMESTAMP_TRUNC(timestamp, DAY) >= "%s" AND
 					TIMESTAMP_TRUNC(timestamp, DAY) <= "%s" AND


### PR DESCRIPTION
Current statement doesn't work for table names like "something-71".
The namespace was backticked here before the code migration to golang.
