### PR TITLE
docs/adding_new_os_support.md: fix a typo

### DIFF
--- a/docs/adding_new_os_support.md
+++ b/docs/adding_new_os_support.md
@@ -44,7 +44,7 @@ Adding the new kernel name with already existing supported kernels to the file `
 
 ## Editing `vm/qemu`
 
-Adding the new kernel name with already existing supported kernels to the file `qemo.go` which is located under `vm/qemu`.
+Adding the new kernel name with already existing supported kernels to the file `qemu.go` which is located under `vm/qemu`.
 
 ## Syzkaller description & pseudo-syscalls
 


### PR DESCRIPTION
Fix a typo in `docs/adding_new_os_support.md`: qemo.go to qemu.go