### PR TITLE
syz-manager: refactor manager with dep. injection

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -4,11 +4,16 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/vminfo"
 	"github.com/google/syzkaller/sys/targets"
+)
+
+var (
+	ErrUnknownPCBase = errors.New("unknown PCBase")
 )
 
 type Impl struct {
@@ -91,5 +96,5 @@ func GetPCBase(cfg *mgrconfig.Config) (uint64, error) {
 	if cfg.Target.OS == targets.Linux && cfg.Type != targets.GVisor && cfg.Type != targets.Starnix {
 		return getLinuxPCBase(cfg)
 	}
-	return 0, nil
+	return 0, ErrUnknownPCBase
 }

--- a/pkg/report/mock.go
+++ b/pkg/report/mock.go
@@ -1,0 +1,33 @@
+// Copyright 2017 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package report
+
+import "github.com/stretchr/testify/mock"
+
+type testMock struct {
+	mock.Mock
+	*config
+}
+
+func ctorMock(cfg *config) (reporterImpl, []string, error) {
+	ctx := &testMock{
+		config: cfg,
+	}
+	return ctx, nil, nil
+}
+
+func (ctx *testMock) ContainsCrash(output []byte) bool {
+	ret := ctx.Called(output)
+	return ret.Get(0).(bool)
+}
+
+func (ctx *testMock) Parse(output []byte) *Report {
+	ret := ctx.Called(output)
+	return ret.Get(0).(*Report)
+}
+
+func (ctx *testMock) Symbolize(rep *Report) error {
+	ret := ctx.Called(rep)
+	return ret.Get(0).(error)
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -159,6 +159,7 @@ var ctors = map[string]fn{
 	targets.OpenBSD: ctorOpenbsd,
 	targets.Fuchsia: ctorFuchsia,
 	targets.Windows: ctorStub,
+	targets.TestOS:  ctorMock,
 }
 
 type config struct {

--- a/pkg/rpcserver/last_executing.go
+++ b/pkg/rpcserver/last_executing.go
@@ -57,6 +57,9 @@ func (last *LastExecuting) Note(id, proc int, prog []byte, now time.Duration) {
 func (last *LastExecuting) Collect() []ExecRecord {
 	procs := last.procs
 	last.procs = nil // The type must not be used after this.
+	if len(procs) == 0 {
+		return procs
+	}
 	sort.Slice(procs, func(i, j int) bool {
 		return procs[i].Time < procs[j].Time
 	})

--- a/pkg/rpcserver/last_executing_test.go
+++ b/pkg/rpcserver/last_executing_test.go
@@ -14,6 +14,11 @@ func TestLastExecutingEmpty(t *testing.T) {
 	assert.Empty(t, last.Collect())
 }
 
+func TestCollectEmpty(t *testing.T) {
+	last := MakeLastExecuting(0, 0)
+	assert.Empty(t, last.Collect())
+}
+
 func TestLastExecuting(t *testing.T) {
 	last := MakeLastExecuting(10, 3)
 	last.Note(1, 0, []byte("prog1"), 1)

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -51,6 +51,9 @@ func RunLocal(cfg *LocalConfig) error {
 	if err != nil {
 		return err
 	}
+	if err := serv.Start(); err != nil {
+		return err
+	}
 	defer serv.Close()
 	ctx.serv = serv
 	// setupDone synchronizes assignment to ctx.serv and read of ctx.serv in MachineChecked

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package rpcserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/google/syzkaller/pkg/cover/backend"
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func TestNew(t *testing.T) {
+	defaultCfg := mgrconfig.Config{
+		Type:    targets.Linux,
+		Sandbox: "none",
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.TestOS,
+			TargetArch:   targets.TestArch64,
+			TargetVMArch: targets.TestArch64,
+			Timeouts:     targets.Timeouts{Slowdown: 1},
+		},
+	}
+
+	nilServer := func(s *Server) {
+		assert.Nil(t, s)
+	}
+
+	tests := []struct {
+		name              string
+		modifyCfg         func() *mgrconfig.Config
+		debug             bool
+		expectedServCheck func(*Server)
+		expectsErr        bool
+		expectedErr       error
+	}{
+		{
+			name: "unknown PCBase",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.KernelObj = "test"
+				return &cfg
+			},
+			expectedServCheck: nilServer,
+			expectedErr:       backend.ErrUnknownPCBase,
+		},
+		{
+			name: "unknown Sandbox",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.Sandbox = "unknown"
+				return &cfg
+			},
+			expectedServCheck: nilServer,
+			expectsErr:        true,
+		},
+		{
+			name: "unknown target OS and VMArch",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.TargetVMArch = "unknown"
+				return &cfg
+			},
+			expectedServCheck: nilServer,
+			expectsErr:        true,
+		},
+		{
+			name: "experimental features",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.Experimental = mgrconfig.Experimental{
+					RemoteCover: false,
+					CoverEdges:  true,
+				}
+				return &cfg
+			},
+			expectedServCheck: func(s *Server) {
+				assert.Equal(t, s.cfg.Config.Features, flatrpc.AllFeatures&(^flatrpc.FeatureExtraCoverage))
+				assert.True(t, s.cfg.UseCoverEdges)
+				assert.True(t, s.cfg.FilterSignal)
+				assert.Nil(t, s.serv) // call Start() to start rpc server
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.modifyCfg()
+
+			var err error
+			cfg.Target, err = prog.GetTarget(cfg.TargetOS, cfg.TargetArch)
+			assert.NoError(t, err)
+
+			serv, err := New(cfg, nil, tt.debug)
+
+			tt.expectedServCheck(serv)
+
+			if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr, err)
+			} else if tt.expectsErr {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/syz-manager/http.go
+++ b/syz-manager/http.go
@@ -628,8 +628,8 @@ func (mgr *Manager) httpFilterPCs(w http.ResponseWriter, r *http.Request) {
 func (mgr *Manager) collectCrashes(workdir string) ([]*UICrashType, error) {
 	// Note: mu is not locked here.
 	var repros map[string]bool
-	if !mgr.cfg.VMLess && mgr.reproMgr != nil {
-		repros = mgr.reproMgr.Reproducing()
+	if !mgr.cfg.VMLess && mgr.impl.reproMgr != nil {
+		repros = mgr.impl.reproMgr.Reproducing()
 	}
 
 	crashdir := filepath.Join(workdir, "crashes")

--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -58,9 +58,9 @@ func (mgr *Manager) hubSyncLoop(keyGet keyGetter) {
 		statRecvRepro:     stat.New("hub recv repro", "", stat.Graph("hub repros")),
 		statRecvReproDrop: stat.New("hub recv repro drop", "", stat.NoGraph),
 	}
-	if mgr.cfg.Reproduce && mgr.dash != nil {
+	if mgr.cfg.Reproduce && mgr.impl.dash != nil {
 		// Request reproducers from hub only if there is nothing else to reproduce.
-		hc.needMoreRepros = mgr.reproMgr.Empty
+		hc.needMoreRepros = mgr.impl.reproMgr.Empty
 	}
 	hc.loop()
 }

--- a/syz-manager/manager_test.go
+++ b/syz-manager/manager_test.go
@@ -1,0 +1,191 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/google/syzkaller/pkg/asset"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/google/syzkaller/vm/vmimpl"
+	"github.com/google/syzkaller/vm/vmtest"
+)
+
+func Test_Crash_FullTitle(t *testing.T) {
+	crash := &Crash{}
+
+	tests := []struct {
+		name          string
+		report        *report.Report
+		fromDashboard bool
+		fromHub       bool
+		expected      string
+	}{
+		{
+			name:     "report title is filled",
+			report:   &report.Report{Title: "foo"},
+			expected: "foo",
+		},
+		{
+			name:          "report title fromDashboard",
+			report:        &report.Report{},
+			fromDashboard: true,
+			expected:      fmt.Sprintf("dashboard crash %p", crash),
+		},
+		{
+			name:     "report title fromHub",
+			report:   &report.Report{},
+			fromHub:  true,
+			expected: fmt.Sprintf("crash from hub %p", crash),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.report.Title == "" && !tt.fromDashboard && !tt.fromHub {
+				assert.Panics(t, func() { crash.FullTitle() })
+			} else {
+				crash.Report = tt.report
+				crash.fromDashboard = tt.fromDashboard
+				crash.fromHub = tt.fromHub
+
+				title := crash.FullTitle()
+				assert.Equal(t, tt.expected, title)
+			}
+		})
+	}
+}
+
+func TestNewManagerService(t *testing.T) {
+	initVM()
+
+	reproMgr := &reproMgrMock{
+		run: make(chan runCallback),
+	}
+	defaultCfg := mgrconfig.Config{
+		Type:    targets.TestOS,
+		Sandbox: "none",
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.TestOS,
+			TargetArch:   targets.TestArch64,
+			TargetVMArch: targets.TestArch64,
+			SysTarget:    targets.Get(targets.TestOS, targets.TestArch64),
+			Target:       &prog.Target{OS: targets.TestOS, Arch: targets.TestArch64},
+			Timeouts:     targets.Timeouts{Slowdown: 1},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mode           Mode
+		modifyCfg      func() *mgrconfig.Config
+		isFlagBenchSet bool
+		expectedErr    error
+		assertService  func(*service)
+	}{
+		{
+			name: "err - invalid config",
+			modifyCfg: func() *mgrconfig.Config {
+				return &mgrconfig.Config{}
+			},
+			assertService: func(s *service) {
+				assert.Nil(t, s)
+			},
+			expectedErr: fmt.Errorf("unknown instance type ''"),
+		},
+		{
+			name: "ok - w/o dashboard, assetStorage",
+			modifyCfg: func() *mgrconfig.Config {
+				return &defaultCfg
+			},
+			assertService: func(s *service) {
+				assert.Nil(t, s.assetStorage)
+				assert.Nil(t, s.dash)
+				assert.Nil(t, s.dashRepro)
+			},
+		},
+		{
+			name: "ok - w/o dashboard",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.AssetStorage = &asset.Config{UploadTo: "dummy://"}
+				return &cfg
+			},
+			assertService: func(s *service) {
+				assert.Nil(t, s.dash)
+				assert.Nil(t, s.dashRepro)
+			},
+		},
+		{
+			name: "ok - w/o dashboard, vmPool",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.AssetStorage = &asset.Config{UploadTo: "dummy://"}
+				cfg.VMLess = true
+				return &cfg
+			},
+			assertService: func(s *service) {
+				assert.Nil(t, s.dash)
+				assert.Nil(t, s.dashRepro)
+				assert.Nil(t, s.vmPool)
+				assert.Nil(t, s.reproMgr)
+			},
+		},
+		{
+			name: "ok - all deps are set except dash",
+			modifyCfg: func() *mgrconfig.Config {
+				// Intentionally modify defaultCfg for the last test case.
+				cfg := &defaultCfg
+				cfg.AssetStorage = &asset.Config{UploadTo: "dummy://"}
+				cfg.DashboardAddr = "addr"
+				cfg.DashboardKey = "key"
+				cfg.DashboardOnlyRepro = true
+				return cfg
+			},
+			assertService: func(s *service) {
+				assert.Nil(t, s.dash)
+			},
+		},
+		{
+			name: "ok - all deps are set",
+			modifyCfg: func() *mgrconfig.Config {
+				cfg := defaultCfg
+				cfg.DashboardOnlyRepro = false
+				return &cfg
+			},
+			assertService: func(s *service) {
+				assert.NotNil(t, s.dash)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.modifyCfg()
+			mgr := newManager(cfg, ModeRunTests)
+			service, err := newManagerService(cfg, mgr, reproMgr)
+			assert.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr != nil {
+				return
+			}
+			tt.assertService(service)
+		})
+	}
+}
+
+func initVM() {
+	ctor := func(env *vmimpl.Env) (vmimpl.Pool, error) {
+		return &vmtest.TestPool{}, nil
+	}
+	vmimpl.Register(targets.TestOS, vmimpl.Type{
+		Ctor:        ctor,
+		Preemptible: true,
+	})
+}

--- a/syz-manager/snapshot.go
+++ b/syz-manager/snapshot.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/flatbuffers/go"
+	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
 	"github.com/google/syzkaller/pkg/log"
@@ -40,7 +40,7 @@ func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
 	// All network connections (including ssh) will break once we start restoring snapshots.
 	// So we start a background process and log to /dev/kmsg.
 	cmd := fmt.Sprintf("nohup %v exec snapshot 1>/dev/null 2>/dev/kmsg </dev/null &", executor)
-	if _, _, err := inst.Run(time.Hour, mgr.reporter, cmd); err != nil {
+	if _, _, err := inst.Run(time.Hour, mgr.impl.reporter, cmd); err != nil {
 		return err
 	}
 
@@ -67,9 +67,9 @@ func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
 			return err
 		}
 
-		if mgr.reporter.ContainsCrash(output) {
+		if mgr.impl.reporter.ContainsCrash(output) {
 			res.Status = queue.Crashed
-			rep := mgr.reporter.Parse(output)
+			rep := mgr.impl.reporter.Parse(output)
 			buf := new(bytes.Buffer)
 			fmt.Fprintf(buf, "program:\n%s\n", req.Prog.Serialize())
 			buf.Write(rep.Output)

--- a/vm/vmtest/testPool.go
+++ b/vm/vmtest/testPool.go
@@ -1,0 +1,70 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vmtest
+
+import (
+	"time"
+
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/vm/vmimpl"
+)
+
+// TestPool is a mock struct for vmPool unit tests.
+type TestPool struct {
+}
+
+func (pool *TestPool) Count() int {
+	return 1
+}
+
+func (pool *TestPool) Create(workdir string, index int) (vmimpl.Instance, error) {
+	return &TestInstance{
+		Outc: make(chan []byte, 10),
+		Errc: make(chan error, 1),
+	}, nil
+}
+
+func (pool *TestPool) Close() error {
+	return nil
+}
+
+type TestInstance struct {
+	Outc           chan []byte
+	Errc           chan error
+	DiagnoseBug    bool
+	DiagnoseNoWait bool
+}
+
+func (inst *TestInstance) Copy(hostSrc string) (string, error) {
+	return "", nil
+}
+
+func (inst *TestInstance) Forward(port int) (string, error) {
+	return "", nil
+}
+
+func (inst *TestInstance) Run(timeout time.Duration, stop <-chan bool, command string) (
+	Outc <-chan []byte, Errc <-chan error, err error) {
+	return inst.Outc, inst.Errc, nil
+}
+
+func (inst *TestInstance) Diagnose(rep *report.Report) ([]byte, bool) {
+	var diag []byte
+	if inst.DiagnoseBug {
+		diag = []byte("BUG: DIAGNOSE\n")
+	} else {
+		diag = []byte("DIAGNOSE\n")
+	}
+
+	if inst.DiagnoseNoWait {
+		return diag, false
+	}
+
+	inst.Outc <- diag
+	return nil, true
+}
+
+func (inst *TestInstance) Close() error {
+	return nil
+}


### PR DESCRIPTION
syz-manager/manager.go has crucial logic to run and manage reproducers.
This patch is an initial attempt to restructure Manager dependencies,
so we can replace them with interfaces, one by one per patch.

No new logic has been added, except extra parameter validation,
mostly due to mgrconfig.Config fields being nil, so tests could pass.

In syz-manager/manager.go a new struct `type service struct` acts like
a container of dependencies. Currently, during manager_test.go testing
the actual RPC server is spawned etc., e.g. no mocking of these deps
are in this patch, though it's better to create interface per
dependency's service (or common "impl" field) and mock them via mockery.

Once we can mock Manager (btw it's exported - can be renamed with
lowercase as we have newManager() constructor), we can cover the main run()
method if we eventually will need these tests, not just to increase
coverage %. Like fs operations are likely to be ok (?) during tests.