### PR TITLE
pkg/build, syz-ci: control the `make -j N` value

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -37,6 +37,7 @@ type Config struct {
 	Manager         *mgrconfig.Config
 	BuildSemaphore  *instance.Semaphore
 	TestSemaphore   *instance.Semaphore
+	BuildJobs       int
 	// CrossTree specifies whether a cross tree bisection is to take place, i.e.
 	// Kernel.Commit is not reachable from Kernel.Branch.
 	// In this case, bisection starts from their merge base.
@@ -625,6 +626,7 @@ func (env *env) build() (*vcs.Commit, string, error) {
 		CmdlineFile:  kern.Cmdline,
 		SysctlFile:   kern.Sysctl,
 		KernelConfig: bisectEnv.KernelConfig,
+		BuildJobs:    env.cfg.BuildJobs,
 	})
 	if imageDetails.CompilerID != "" {
 		env.log("compiler: %v", imageDetails.CompilerID)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type Params struct {
 	SysctlFile   string
 	Config       []byte
 	Tracer       debugtracer.DebugTracer
+	BuildJobs    int // If 0, all CPUs will be used.
 	Build        json.RawMessage
 }
 
@@ -70,6 +72,9 @@ type ImageDetails struct {
 func Image(params Params) (details ImageDetails, err error) {
 	if params.Tracer == nil {
 		params.Tracer = &debugtracer.NullTracer{}
+	}
+	if params.BuildJobs == 0 {
+		params.BuildJobs = runtime.NumCPU()
 	}
 	var builder builder
 	builder, err = getBuilder(params.TargetOS, params.TargetArch, params.VMType)

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -44,25 +44,25 @@ func (ctx netbsd) build(params Params) (ImageDetails, error) {
 	if strings.HasSuffix(params.Compiler, "clang++") {
 		// Build tools before building kernel.
 		if _, err := osutil.RunCmd(60*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
+			"-U", "-j"+strconv.Itoa(params.BuildJobs), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "tools"); err != nil {
 			return ImageDetails{}, err
 		}
 
 		// Build kernel.
 		if _, err := osutil.RunCmd(20*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no",
+			"-U", "-j"+strconv.Itoa(params.BuildJobs), "-V", "MKCTF=no",
 			"-V", "MKLLVM=yes", "-V", "MKGCC=no", "-V", "HAVE_LLVM=yes", "kernel="+kernelName); err != nil {
 			return ImageDetails{}, err
 		}
 	} else if strings.HasSuffix(params.Compiler, "g++") {
 		if _, err := osutil.RunCmd(30*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "tools"); err != nil {
+			"-U", "-j"+strconv.Itoa(params.BuildJobs), "-V", "MKCTF=no", "tools"); err != nil {
 			return ImageDetails{}, err
 		}
 
 		if _, err := osutil.RunCmd(20*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-			"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "-V", "MKCTF=no", "kernel="+kernelName); err != nil {
+			"-U", "-j"+strconv.Itoa(params.BuildJobs), "-V", "MKCTF=no", "kernel="+kernelName); err != nil {
 			return ImageDetails{}, err
 		}
 	}

--- a/pkg/build/openbsd.go
+++ b/pkg/build/openbsd.go
@@ -6,7 +6,6 @@ package build
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -32,7 +31,7 @@ func (ctx openbsd) build(params Params) (ImageDetails, error) {
 		return ImageDetails{}, err
 	}
 	for _, tgt := range []string{"clean", "obj", "config", "all"} {
-		if err := ctx.make(compileDir, tgt); err != nil {
+		if err := ctx.make(compileDir, params.BuildJobs, tgt); err != nil {
 			return ImageDetails{}, err
 		}
 	}
@@ -63,8 +62,8 @@ func (ctx openbsd) clean(kernelDir, targetArch string) error {
 	return nil
 }
 
-func (ctx openbsd) make(kernelDir string, args ...string) error {
-	args = append([]string{"-j", strconv.Itoa(runtime.NumCPU())}, args...)
+func (ctx openbsd) make(kernelDir string, jobs int, args ...string) error {
+	args = append([]string{"-j", strconv.Itoa(jobs)}, args...)
 	_, err := osutil.RunCmd(10*time.Minute, kernelDir, "make", args...)
 	return err
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -49,6 +49,7 @@ type BuildKernelConfig struct {
 	CmdlineFile  string
 	SysctlFile   string
 	KernelConfig []byte
+	BuildJobs    int
 }
 
 func NewEnv(cfg *mgrconfig.Config, buildSem, testSem *Semaphore) (Env, error) {
@@ -153,6 +154,7 @@ func (env *env) BuildKernel(buildCfg *BuildKernelConfig) (
 		CmdlineFile:  buildCfg.CmdlineFile,
 		SysctlFile:   buildCfg.SysctlFile,
 		Config:       buildCfg.KernelConfig,
+		BuildJobs:    buildCfg.BuildJobs,
 	}
 	details, err := build.Image(params)
 	if err != nil {

--- a/sys/syz-extract/linux.go
+++ b/sys/syz-extract/linux.go
@@ -79,7 +79,7 @@ func (*linux) prepareArch(arch *Arch) error {
 		return nil
 	}
 	kernelDir := arch.sourceDir
-	makeArgs := build.LinuxMakeArgs(arch.target, "", "", "", arch.buildDir)
+	makeArgs := build.LinuxMakeArgs(arch.target, "", "", "", arch.buildDir, runtime.NumCPU())
 	if arch.configFile != "" {
 		err := osutil.CopyFile(arch.configFile, filepath.Join(arch.buildDir, ".config"))
 		if err != nil {

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -493,6 +493,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 		BinDir:          jp.cfg.BisectBinDir,
 		Linker:          mgr.mgrcfg.Linker,
 		Ccache:          jp.cfg.Ccache,
+		BuildJobs:       jp.cfg.BuildJobs,
 		Kernel: bisect.KernelConfig{
 			Repo:           req.KernelRepo,
 			Branch:         req.KernelBranch,

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -356,6 +356,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 		SysctlFile:   mgr.mgrcfg.KernelSysctl,
 		Config:       mgr.configData,
 		Build:        mgr.mgrcfg.Build,
+		BuildJobs:    mgr.cfg.BuildJobs,
 	}
 	details, err := build.Image(params)
 	info := mgr.createBuildInfo(kernelCommit, details.CompilerID)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -126,7 +126,9 @@ type Config struct {
 	// The list is concatenated with the similar parameter from ManagerConfig.
 	BisectBackports []vcs.BackportCommit `json:"bisect_backports"`
 	Ccache          string               `json:"ccache"`
-	Managers        []*ManagerConfig     `json:"managers"`
+	// BuildJobs defines the maximum number of parallel kernel build threads.
+	BuildJobs int              `json:"build_jobs"`
+	Managers  []*ManagerConfig `json:"managers"`
 	// Poll period for jobs in seconds (optional, defaults to 10 seconds)
 	JobPollPeriod int `json:"job_poll_period"`
 	// Set up a second (parallel) job processor to speed up processing.


### PR DESCRIPTION
On syz-ci instances that fuzz on qemu VMs, we already have a substantial CPU load. If there happens a background kernel build, which gets parallelized to all (=a lot of) CPUs, it affects the execution speed of all fuzzing VMs. As all prog timeouts remain the same, we may well see the temporary fuzzing efficiency reduction.

Let's control the number of cores dedicated to the kernel build process on such VMs.