### PR TITLE
pkg/covermerger: never give up diffing the files

### DIFF
--- a/pkg/covermerger/lines_matcher.go
+++ b/pkg/covermerger/lines_matcher.go
@@ -11,6 +11,7 @@ import (
 
 func makeLineToLineMatcher(textFrom, textTo string) *LineToLineMatcher {
 	diffMatcher := dmp.New()
+	diffMatcher.DiffTimeout = 0
 	diffs := diffMatcher.DiffMain(textFrom, textTo, false)
 	curToLinePos := 0
 	textDestPosToLine := map[int]int{}


### PR DESCRIPTION
It hopefully fixes https://github.com/google/syzkaller/issues/4815.
The default 1 second timeout is not what we want.
To reproduce the problem, set timeout to 10 ms.
