### PR TITLE
pkg/covermerger: add debug tooltips

### DIFF
--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -28,6 +28,7 @@ type templateHeatmapRow struct {
 	IsDir               bool
 	Depth               int
 	LastDayInstrumented int64
+	Tooltips            []string
 
 	builder      map[string]*templateHeatmapRow
 	instrumented map[civil.Date]int64
@@ -74,6 +75,8 @@ func (thm *templateHeatmapRow) prepareDataFor(dates []civil.Date) {
 			dateCoverage = 100 * thm.covered[d] / thm.instrumented[d]
 		}
 		thm.Coverage = append(thm.Coverage, dateCoverage)
+		thm.Tooltips = append(thm.Tooltips, fmt.Sprintf("Instrumented:\t%d blocks\nCovered:\t%d blocks",
+			thm.instrumented[d], thm.covered[d]))
 	}
 	if len(dates) > 0 {
 		lastDate := dates[len(dates)-1]

--- a/pkg/cover/heatmap_test.go
+++ b/pkg/cover/heatmap_test.go
@@ -46,6 +46,9 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 							IsDir:               false,
 							Depth:               0,
 							LastDayInstrumented: 1,
+							Tooltips: []string{
+								"Instrumented:\t1 blocks\nCovered:\t1 blocks",
+							},
 						},
 					},
 					Name:                "",
@@ -53,6 +56,9 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 					IsDir:               false,
 					Depth:               0,
 					LastDayInstrumented: 1,
+					Tooltips: []string{
+						"Instrumented:\t1 blocks\nCovered:\t1 blocks",
+					},
 				},
 				Dates: []string{"2024-07-01"},
 			},
@@ -85,6 +91,10 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 									IsDir:               false,
 									Depth:               1,
 									LastDayInstrumented: 0,
+									Tooltips: []string{
+										"Instrumented:\t1 blocks\nCovered:\t1 blocks",
+										"Instrumented:\t0 blocks\nCovered:\t0 blocks",
+									},
 								},
 								{
 									Items:               []*templateHeatmapRow{},
@@ -93,6 +103,10 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 									IsDir:               false,
 									Depth:               1,
 									LastDayInstrumented: 1,
+									Tooltips: []string{
+										"Instrumented:\t0 blocks\nCovered:\t0 blocks",
+										"Instrumented:\t1 blocks\nCovered:\t0 blocks",
+									},
 								},
 							},
 							Name:                "dir",
@@ -100,11 +114,19 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 							IsDir:               true,
 							Depth:               0,
 							LastDayInstrumented: 1,
+							Tooltips: []string{
+								"Instrumented:\t1 blocks\nCovered:\t1 blocks",
+								"Instrumented:\t1 blocks\nCovered:\t0 blocks",
+							},
 						},
 					},
 					Name:                "",
 					Coverage:            []int64{100, 0},
 					LastDayInstrumented: 1,
+					Tooltips: []string{
+						"Instrumented:\t1 blocks\nCovered:\t1 blocks",
+						"Instrumented:\t1 blocks\nCovered:\t0 blocks",
+					},
 				},
 				Dates: []string{"2024-07-01", "2024-07-02"},
 			},

--- a/pkg/cover/templates/heatmap.html
+++ b/pkg/cover/templates/heatmap.html
@@ -91,6 +91,25 @@
   .data_row:hover {
     background-color: #ffff99 !important;
   }
+  .cover_percent {
+    position: relative;
+    display: inline-block;
+  }
+  .cover_percent .tooltiptext {
+    visibility: hidden;
+    background-color: black;
+    color: #fff;
+    text-align: left;
+    border-radius: 6px;
+    padding: 5px 0;
+
+    /* Position the tooltip */
+    position: absolute;
+    z-index: 1;
+  }
+  .cover_percent:hover .tooltiptext {
+    visibility: visible;
+  }
 {{ end }}
 
 {{ define "body" }}
@@ -137,9 +156,10 @@
             {{$child.Name}}
           </div>
         </div>
-        {{ range $cov := $child.Coverage }}
-          <div class="date_column">
-            {{ $cov }}%
+        {{ range $i, $cov := $child.Coverage }}
+          <div class="date_column cover_percent">
+            {{$cov}}%
+            <pre class="tooltiptext">{{ index $child.Tooltips $i }}</pre>
           </div>
         {{ end }}
         <div class="instrumented_column">


### PR DESCRIPTION
Hover mouse onto the percent value to see details.
It enables hover details for both, command line tool and dashboard.
To test:
$ go run ./tools/syz-cover -heatmap upstream -from 2024-08-23 -to 2024-08-23
$ google-chrome upstream.html