### PR TITLE
tools/syz-bq: session was moved to syz-covermerger

### DIFF
--- a/tools/syz-bq.sh
+++ b/tools/syz-bq.sh
@@ -106,5 +106,4 @@ go run ./tools/syz-covermerger/ -workdir $workdir \
   -date-to $to_date \
   -total-rows $total_rows
 
-echo Cleanup
-rm -rf $sessionDir
+echo Done


### PR DESCRIPTION
There is nothing to cleanup.
