### PR TITLE
pkg/covermerger: optimize checkouts

### DIFF
--- a/pkg/covermerger/provider_monorepo.go
+++ b/pkg/covermerger/provider_monorepo.go
@@ -93,6 +93,15 @@ func (mr *monoRepo) cloneCommits(rbcs []RepoCommit) {
 		if mr.repoCommitPresent(rbc) {
 			continue
 		}
+		commitExistsInRepo, err := mr.repo.CommitExists(rbc.Commit)
+		if err != nil {
+			log.Logf(0, "can't check CommitExists: %s", err.Error())
+		}
+		if commitExistsInRepo {
+			log.Logf(0, "commit %s exists in local repo, no need to clone", rbc.Commit)
+			mr.repoCommits[rbc] = struct{}{}
+			continue
+		}
 		mr.addRepoCommit(rbc)
 	}
 }

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -103,3 +103,7 @@ func (ctx *fuchsia) Object(name, commit string) ([]byte, error) {
 func (ctx *fuchsia) MergeBases(firstCommit, secondCommit string) ([]*Commit, error) {
 	return ctx.repo.MergeBases(firstCommit, secondCommit)
 }
+
+func (ctx *fuchsia) CommitExists(string) (bool, error) {
+	return false, fmt.Errorf("not implemented for fuchsia")
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -619,3 +619,19 @@ func (git *git) MergeBases(firstCommit, secondCommit string) ([]*Commit, error) 
 	}
 	return ret, nil
 }
+
+// CommitExists relies on 'git cat-file -e'.
+// If object exists its exit status is 0.
+// If object doesn't exist its exit status is 1 (not documented).
+// Otherwise, the exit status is 128 (not documented).
+func (git *git) CommitExists(commit string) (bool, error) {
+	_, err := git.git("cat-file", "-e", commit)
+	var vErr *osutil.VerboseError
+	if errors.As(err, &vErr) && vErr.ExitCode == 1 {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -69,6 +69,9 @@ type Repo interface {
 
 	// MergeBases returns good common ancestors of the two commits.
 	MergeBases(firstCommit, secondCommit string) ([]*Commit, error)
+
+	// CommitExists check for the commit presence in local checkout.
+	CommitExists(commit string) (bool, error)
 }
 
 // Bisecter may be optionally implemented by Repo.


### PR DESCRIPTION
We currently checkout commits only.
It results in git origins w/o branch information.
Adding the branch names we simplify the repo reuse.

It also checks for the commit presence in local repo.
The alternative to CommitExists() function was a ListCommitHashes().
ListCommitHashes() takes apx. 5 seconds which is too slow.

