### PR TITLE
tools/syz-bq: make sure branch information is available locally

### DIFF
--- a/tools/syz-bq.sh
+++ b/tools/syz-bq.sh
@@ -52,6 +52,7 @@ if [ ! -d $base_dir ]; then
 fi
 cd $base_dir
 remote=$(git remote -v | grep $repo | head -n1 | awk '{print $1;}')
+git fetch --tags $remote
 git checkout $remote/$branch
 cd -
 


### PR DESCRIPTION
tools/syz-covermerger uses CheckoutCommit() now.
CheckoutCommit calls "git fetch --tags origin commit".
The tags are not available in this case.
