### PR TITLE
dashboard/app: add file coverage page

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -65,6 +65,7 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/graph/crashes", handlerWrapper(handleGraphCrashes))
 		http.Handle("/"+ns+"/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
 		if nsConfig.Coverage != nil {
+			http.Handle("/"+ns+"/graph/coverage/file", handlerWrapper(handleFileCoverage))
 			http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
 			http.Handle("/"+ns+"/graph/coverage_heatmap", handlerWrapper(handleCoverageHeatmap))
 			if nsConfig.Subsystems.Service != nil {

--- a/pkg/coveragedb/time_period_test.go
+++ b/pkg/coveragedb/time_period_test.go
@@ -22,7 +22,7 @@ func TestDayPeriodOps(t *testing.T) {
 	assert.True(t, ops.IsValidPeriod(goodPeriod))
 	assert.False(t, ops.IsValidPeriod(badPeriod))
 
-	assert.Equal(t, 1, ops.pointedPeriodDays(d))
+	assert.Equal(t, 1, ops.PointedPeriodDays(d))
 
 	assert.Equal(t,
 		[]TimePeriod{
@@ -47,7 +47,7 @@ func TestMonthPeriodOps(t *testing.T) {
 	assert.False(t, ops.IsValidPeriod(badPeriod1))
 	assert.False(t, ops.IsValidPeriod(badPeriod2))
 
-	assert.Equal(t, 29, ops.pointedPeriodDays(midMonthDate))
+	assert.Equal(t, 29, ops.PointedPeriodDays(midMonthDate))
 
 	assert.Equal(t,
 		[]TimePeriod{
@@ -73,7 +73,7 @@ func TestQuarterPeriodOps(t *testing.T) {
 	assert.False(t, ops.IsValidPeriod(badPeriod1))
 	assert.False(t, ops.IsValidPeriod(badPeriod2))
 
-	assert.Equal(t, 31+29+31, ops.pointedPeriodDays(midQuarterDate))
+	assert.Equal(t, 31+29+31, ops.PointedPeriodDays(midQuarterDate))
 
 	assert.Equal(t,
 		[]TimePeriod{
@@ -278,4 +278,14 @@ func TestAtMostNLatestPeriods(t *testing.T) {
 	}
 	assert.Equal(t, []TimePeriod{makeTimePeriod("2024-06-06", 1)}, AtMostNLatestPeriods(sampleDays, 1))
 	assert.Equal(t, sampleDays, AtMostNLatestPeriods(sampleDays, 100))
+}
+
+func TestMakeTimePeriod(t *testing.T) {
+	tp, err := MakeTimePeriod(civil.Date{Year: 2024, Month: time.March, Day: 31}, QuarterPeriod)
+	assert.NoError(t, err)
+	assert.NotEqual(t, TimePeriod{}, tp)
+
+	tp, err = MakeTimePeriod(civil.Date{Year: 2024, Month: time.March, Day: 30}, QuarterPeriod)
+	assert.Error(t, err)
+	assert.Equal(t, TimePeriod{}, tp)
 }

--- a/pkg/covermerger/provider_web.go
+++ b/pkg/covermerger/provider_web.go
@@ -11,14 +11,17 @@ import (
 	"net/url"
 )
 
+type FuncProxyURI func(filePath string, rc RepoCommit) string
+
 type webGit struct {
+	funcProxy FuncProxyURI
 }
 
 func (mr *webGit) GetFileVersions(targetFilePath string, repoCommits ...RepoCommit,
 ) (fileVersions, error) {
 	res := make(fileVersions)
 	for _, repoCommit := range repoCommits {
-		fileBytes, err := loadFile(targetFilePath, repoCommit.Repo, repoCommit.Commit)
+		fileBytes, err := mr.loadFile(targetFilePath, repoCommit.Repo, repoCommit.Commit)
 		// It is ok if some file doesn't exist. It means we have repo FS diff.
 		if err == errFileNotFound {
 			continue
@@ -33,10 +36,15 @@ func (mr *webGit) GetFileVersions(targetFilePath string, repoCommits ...RepoComm
 
 var errFileNotFound = errors.New("file not found")
 
-func loadFile(filePath, repo, commit string) ([]byte, error) {
-	uri := fmt.Sprintf("%s/plain/%s", repo, filePath)
-	if commit != "latest" {
-		uri += "?id=" + commit
+func (mr *webGit) loadFile(filePath, repo, commit string) ([]byte, error) {
+	var uri string
+	if mr.funcProxy != nil {
+		uri = mr.funcProxy(filePath, RepoCommit{Repo: repo, Commit: commit})
+	} else {
+		uri = fmt.Sprintf("%s/plain/%s", repo, filePath)
+		if commit != "latest" {
+			uri += "?id=" + commit
+		}
 	}
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -54,7 +62,7 @@ func loadFile(filePath, repo, commit string) ([]byte, error) {
 		return nil, errFileNotFound
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("error: status %d getting %s", res.StatusCode, uri)
+		return nil, fmt.Errorf("error: status %d getting '%s'", res.StatusCode, uri)
 	}
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -63,13 +71,15 @@ func loadFile(filePath, repo, commit string) ([]byte, error) {
 	return body, nil
 }
 
-func MakeWebGit() FileVersProvider {
-	return &webGit{}
+func MakeWebGit(funcProxy FuncProxyURI) FileVersProvider {
+	return &webGit{
+		funcProxy: funcProxy,
+	}
 }
 
 func GetFileVersion(filePath, repo, commit string) (string, error) {
 	repoCommit := RepoCommit{repo, commit}
-	files, err := MakeWebGit().GetFileVersions(filePath, repoCommit)
+	files, err := MakeWebGit(nil).GetFileVersions(filePath, repoCommit)
 	if err != nil {
 		return "", fmt.Errorf("failed to GetFileVersions: %w", err)
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	"github.com/google/syzkaller/pkg/auth"
+	"github.com/google/syzkaller/pkg/coveragedb"
 )
 
 type Result struct {
@@ -50,11 +51,14 @@ var (
 	EmptyStr       = makeStrLenFunc("not empty", 0)
 	AlphaNumeric   = makeStrReFunc("not an alphanum", "^[a-zA-Z0-9]*$")
 	CommitHash     = makeCombinedStrFunc("not a hash", AlphaNumeric, makeStrLenFunc("len is not 40", 40))
-	KernelFilePath = makeStrReFunc("not a kernel file path", "^[./_a-zA-Z0-9]*$")
+	KernelFilePath = makeStrReFunc("not a kernel file path", "^[./-_a-zA-Z0-9]*$")
 	NamespaceName  = makeStrReFunc("not a namespace name", "^[a-zA-Z0-9-_.]{4,32}$")
 	DashClientName = makeStrReFunc("not a dashboard client name", "^[a-zA-Z0-9-_.]{4,100}$")
 	DashClientKey  = makeStrReFunc("not a dashboard client key",
 		"^([a-zA-Z0-9]{16,128})|("+regexp.QuoteMeta(auth.OauthMagic)+".*)$")
+	TimePeriodType = makeStrReFunc(fmt.Sprintf("bad time period, use (%s|%s|%s)",
+		coveragedb.DayPeriod, coveragedb.MonthPeriod, coveragedb.QuarterPeriod),
+		fmt.Sprintf("^(%s|%s|%s)$", coveragedb.DayPeriod, coveragedb.MonthPeriod, coveragedb.QuarterPeriod))
 )
 
 type strValidationFunc func(string, ...string) Result

--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -125,6 +125,7 @@ func toolFileCover() {
 		*flagCommit,
 		*flagSourceCommit,
 		*flagForFile,
+		nil, // no proxy - get files directly from WebGits
 		dateFrom,
 		dateTo,
 		config,

--- a/tools/syz-covermerger/syz_covermerger.go
+++ b/tools/syz-covermerger/syz_covermerger.go
@@ -39,7 +39,7 @@ func makeProvider() covermerger.FileVersProvider {
 	case "git-clone":
 		return covermerger.MakeMonoRepo(*flagWorkdir)
 	case "web-git":
-		return covermerger.MakeWebGit()
+		return covermerger.MakeWebGit(nil)
 	default:
 		panic(fmt.Sprintf("unknown provider %v", *flagSrcProvider))
 	}


### PR DESCRIPTION
It directly uses the coverage signals from BigQuery.
There is no need to wait for the coverage_batch cron jobs.
Looks good for debugging.

Limitations:
1. It is slow on large periods. I know how to speed up but want to stabilize the UI first.
2. It is expensive because of the direct BQ requests. Limited to admin mostly because of it.
3. It merges only the commits reachable on github because of the gitweb throttling.

After the UI stabilization I'll save all the required artifacts to spanner and make this page publicly available.
To merge all the commits, not the github reachable only, http git caching instance is needed.

To test:
/upstream/graph/coverage/file?dateto=2024-08-31&period=day&commit=20371ba120635d9ab7fc7670497105af8f33eb08&filepath=virt/kvm/kvm_main.c
