### PR TITLE
pkg/manager: properly handle NeedRepro() == false

### DIFF
--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -197,8 +197,12 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			}
-			if crash == nil || !r.mgr.NeedRepro(crash) {
-				continue
+			if crash != nil && !r.mgr.NeedRepro(crash) {
+				crash = nil
+				// Now we might not need that many VMs.
+				r.mu.Lock()
+				r.adjustPoolSizeLocked()
+				r.mu.Unlock()
 			}
 		}
 

--- a/pkg/manager/repro_test.go
+++ b/pkg/manager/repro_test.go
@@ -119,19 +119,14 @@ func TestReproRWRace(t *testing.T) {
 
 	assert.True(t, mock.NeedRepro(nil))
 	called := <-mock.run
-	called.ret <- &ReproResult{}
 	// Pretend that processRepro() is finished and
 	// we've written "repro.prog" to the disk.
 	mock.reproProgExist.Store(true)
 	assert.False(t, mock.NeedRepro(nil))
+	called.ret <- &ReproResult{}
 	assert.True(t, obj.CanReproMore())
 
-	called2 := <-mock.run
-	called2.ret <- &ReproResult{}
-	assert.False(t, mock.NeedRepro(nil))
-	assert.True(t, obj.CanReproMore())
-
-	// Reproducers may be still running.
+	// The second repro process will never be started.
 	mock.onVMShutdown(t, obj)
 }
 


### PR DESCRIPTION
It was processed incorrectly in the repro loop - we should have skipped that crash and looked for another one, but we actually ignored its return value.
