### PR TITLE
docs/linux: update debug info kernel config

### DIFF
--- a/docs/linux/kernel_configs.md
+++ b/docs/linux/kernel_configs.md
@@ -25,8 +25,14 @@ CONFIG_DEBUG_KMEMLEAK=y
 ```
 
 To show code coverage in web interface:
+
+For Linux < 5.12
 ```
 CONFIG_DEBUG_INFO=y
+```
+For Linux >= 5.12
+```
+CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
 ```
 
 For detection of enabled syscalls and kernel bitness:


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************

After Linux 5.12, the `CONFIG_DEBUG_INFO` is replaced by `CONFIG_DEBUG_INFO_{NONE, DWARF4, DWARF5, DWARF_TOOLCHAIN_DEFAULT}`.

If a user simply adds `CONFIG_DEBUG_INFO=y` to the configuration and run `make olddefconfig`, the configuration will fallback to `CONFID_DEBUG_INFO_NONE`, causing syzkaller's failure in obtaining coverage.

This patch solves this by adding the *safe* configuration `CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT`, so the kernel will be compiled based on what the user has.

This is my first commit to syzkaller, let me know if there is any issue.

Best.