### PR TITLE
dashboard/app: truncate console output log

### DIFF
--- a/pkg/osutil/fileutil.go
+++ b/pkg/osutil/fileutil.go
@@ -4,6 +4,7 @@
 package osutil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -64,4 +65,25 @@ func WriteTempFile(data []byte) (string, error) {
 	}
 	f.Close()
 	return f.Name(), nil
+}
+
+// Truncate leaves up to `begin` bytes at the beginning of log and
+// up to `end` bytes at the end of the log.
+func Truncate(log []byte, begin, end int) []byte {
+	if begin+end >= len(log) {
+		return log
+	}
+	var b bytes.Buffer
+	b.Write(log[:begin])
+	if begin > 0 {
+		b.WriteString("\n\n")
+	}
+	fmt.Fprintf(&b, "<<cut %d bytes out>>",
+		len(log)-begin-end,
+	)
+	if end > 0 {
+		b.WriteString("\n\n")
+	}
+	b.Write(log[len(log)-end:])
+	return b.Bytes()
 }

--- a/pkg/osutil/fileutil_test.go
+++ b/pkg/osutil/fileutil_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessTempDir(t *testing.T) {
@@ -59,4 +61,18 @@ func TestProcessTempDir(t *testing.T) {
 			}
 		}()
 	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, []byte(`01234
+
+<<cut 11 bytes out>>`), Truncate([]byte(`0123456789ABCDEF`), 5, 0))
+	assert.Equal(t, []byte(`<<cut 11 bytes out>>
+
+BCDEF`), Truncate([]byte(`0123456789ABCDEF`), 0, 5))
+	assert.Equal(t, []byte(`0123
+
+<<cut 9 bytes out>>
+
+DEF`), Truncate([]byte(`0123456789ABCDEF`), 4, 3))
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -768,27 +768,6 @@ func replace(where []byte, start, end int, what []byte) []byte {
 	return where
 }
 
-// Truncate leaves up to `begin` bytes at the beginning of log and
-// up to `end` bytes at the end of the log.
-func Truncate(log []byte, begin, end int) []byte {
-	if begin+end >= len(log) {
-		return log
-	}
-	var b bytes.Buffer
-	b.Write(log[:begin])
-	if begin > 0 {
-		b.WriteString("\n\n")
-	}
-	fmt.Fprintf(&b, "<<cut %d bytes out>>",
-		len(log)-begin-end,
-	)
-	if end > 0 {
-		b.WriteString("\n\n")
-	}
-	b.Write(log[len(log)-end:])
-	return b.Bytes()
-}
-
 var (
 	filenameRe    = regexp.MustCompile(`([a-zA-Z0-9_\-\./]*[a-zA-Z0-9_\-]+\.(c|h)):[0-9]+`)
 	reportFrameRe = regexp.MustCompile(`.* in ([a-zA-Z0-9_]+)`)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/sys/targets"
-	"github.com/stretchr/testify/assert"
 )
 
 var flagUpdate = flag.Bool("update", false, "update test files accordingly to current results")
@@ -459,18 +458,4 @@ func TestFuzz(t *testing.T) {
 	} {
 		Fuzz([]byte(data)[:len(data):len(data)])
 	}
-}
-
-func TestTruncate(t *testing.T) {
-	assert.Equal(t, []byte(`01234
-
-<<cut 11 bytes out>>`), Truncate([]byte(`0123456789ABCDEF`), 5, 0))
-	assert.Equal(t, []byte(`<<cut 11 bytes out>>
-
-BCDEF`), Truncate([]byte(`0123456789ABCDEF`), 0, 5))
-	assert.Equal(t, []byte(`0123
-
-<<cut 9 bytes out>>
-
-DEF`), Truncate([]byte(`0123456789ABCDEF`), 4, 3))
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -761,7 +761,7 @@ func (mgr *Manager) NeedRepro(crash *manager.Crash) bool {
 func truncateReproLog(log []byte) []byte {
 	// Repro logs can get quite large and we have trouble sending large API requests (see #4495).
 	// Let's truncate the log to a 512KB prefix and 512KB suffix.
-	return report.Truncate(log, 512000, 512000)
+	return osutil.Truncate(log, 512000, 512000)
 }
 
 func (mgr *Manager) saveFailedRepro(rep *report.Report, stats *repro.Stats) {


### PR DESCRIPTION
For fs related crashes, the console output log is trimmed if exceeds 1MB [1] losing kernel logs at the end. Truncating strategy wit prefix and postfix of output log should reserve this significant data.

This fix doesn't solve gzip compression problem addressed in issue [2].

[1] https://lore.kernel.org/all/CANp29Y5edqzjYyXEgeU8i9mrrfOkPBMWYd8yMnhrozePFuWhkA@mail.gmail.com/
[2] https://github.com/google/syzkaller/issues/5250