### PR TITLE
tools/syz-cover: capture debug flag and add force flag

### DIFF
--- a/tools/syz-cover/syz-cover.go
+++ b/tools/syz-cover/syz-cover.go
@@ -65,6 +65,8 @@ var (
 	flagExports      = flag.String("exports", "cover",
 		"[optional] comma separated list of exports for which we want to generate coverage, "+
 			"possible values are: cover, subsystem, module, funccover, json, jsonl, rawcover, rawcoverfiles, all")
+	flagForce = flag.Bool("force", false, "[optional] create coverage report when "+
+		"there are missing coverage callbacks")
 )
 
 func parseDates() (civil.Date, civil.Date) {
@@ -159,6 +161,8 @@ func main() {
 	progs := []cover.Prog{{PCs: pcs}}
 	params := cover.HandlerParams{
 		Progs: progs,
+		Debug: *flagDebug,
+		Force: *flagForce,
 	}
 
 	if *flagExports == "all" {


### PR DESCRIPTION
This adds the force flag to syz-cover, and makes syz-cover aware of the debug flag.

I'm only uncertain about the wording on the description for the new force flag.

It also doesn't line up exactly with the error message below, but I think it's a relatively intuitive thing to try.

`x out of y PCs returned by kcov do not have matching coverage callbacks. Check the discoverModules() code. Use ?force=1 to disable this message.`

Closes #5265 