### PR TITLE
executor: sys/linux: arm64: implement SYZOS_API_MEMWRITE

### DIFF
--- a/sys/linux/dev_kvm.txt
+++ b/sys/linux/dev_kvm.txt
@@ -288,6 +288,15 @@ syzos_api_irq_setup {
 	nr_spis	int32[0:987]
 }
 
+syzos_memwrite_len = 1, 2, 4, 8
+
+syzos_api_memwrite {
+	base	flags[kvm_guest_addrs, int64]
+	offset	int64[0:4096]
+	value	int64
+	len	flags[syzos_memwrite_len, int64]
+}
+
 type syzos_api[NUM, PAYLOAD] {
 	call	const[NUM, int64]
 	size	bytesize[parent, int64]
@@ -301,6 +310,7 @@ syzos_api_call [
 	smc		syzos_api[3, syzos_api_smccc]
 	hvc		syzos_api[4, syzos_api_smccc]
 	irq_setup	syzos_api[5, syzos_api_irq_setup]
+	memwrite	syzos_api[6, syzos_api_memwrite]
 ] [varlen]
 
 kvm_text_ppc64 {

--- a/sys/linux/test/syz_kvm_setup_cpu_arm64-memwrite
+++ b/sys/linux/test/syz_kvm_setup_cpu_arm64-memwrite
@@ -1,0 +1,14 @@
+#
+# requires: arch=arm64
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = ioctl$KVM_CREATE_VCPU(r1, AUTO, 0x0)
+r3 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r4 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r3, 0x3, 0x1, r2, 0x0)
+# Emulate a uexit with the memwrite API command: write 0 at address ARM64_ADDR_UEXIT.
+#
+syz_kvm_setup_cpu$arm64(r1, r2, &(0x7f0000e8a000/0x18000), &AUTO=[{0x0, &AUTO=[@memwrite={AUTO, AUTO, {0xdddd0000, 0x100, 0x0, 0x8}}], AUTO}], 0x1, 0x0, 0x0, 0x0)
+# Run till uexit.
+#
+ioctl$KVM_RUN(r2, AUTO, 0x0)


### PR DESCRIPTION
The new API call will be used to write values to guest memory specified by base+offset.

Writing to e.g. MMIO registers for VGIC (or any other MMIO ranges) may result in new coverage.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
