### PR TITLE
dashboard/app: priority of revoked & no repro

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -905,14 +905,10 @@ func parseCrashAssets(c context.Context, req *dashapi.Crash) ([]Asset, error) {
 
 func (crash *Crash) UpdateReportingPriority(c context.Context, build *Build, bug *Bug) {
 	prio := int64(kernelRepoInfo(c, build).ReportingPriority) * 1e6
-	divReproPrio := int64(1)
-	if crash.ReproIsRevoked {
-		divReproPrio = 10
-	}
-	if crash.ReproC > 0 {
-		prio += 4e12 / divReproPrio
-	} else if crash.ReproSyz > 0 {
-		prio += 2e12 / divReproPrio
+	if crash.ReproC > 0 && !crash.ReproIsRevoked {
+		prio += 4e12
+	} else if crash.ReproSyz > 0 && !crash.ReproIsRevoked {
+		prio += 2e12
 	}
 	if crash.Title == bug.Title {
 		prio += 1e8 // prefer reporting crash that matches bug title


### PR DESCRIPTION
Per: https://github.com/google/syzkaller/issues/4992#issuecomment-2334090331

>If there are non-revoked reproducers, we will always prefer them to the revoked ones. And we do update the priority once we have revoked a reproducer. But if the only reproducer was revoked, we still give that crash a higher priority than other crashes, which never had a reproducer attached.
>
>If "repro revoked" should have the same priority as "no repro", then we just need to update Crash.UpdateReportingPriority.

Fixes: https://github.com/google/syzkaller/issues/4992.