### PR TITLE
dashboard/app: use day long aggregations not week long

### DIFF
--- a/pkg/coveragedb/time_period.go
+++ b/pkg/coveragedb/time_period.go
@@ -17,6 +17,7 @@ type TimePeriod struct {
 }
 
 const (
+	DayPeriod     = "day"
 	MonthPeriod   = "month"
 	QuarterPeriod = "quarter"
 )
@@ -25,6 +26,8 @@ var errUnknownTimePeriodType = errors.New("unknown time period type")
 
 func MinMaxDays(periodType string) (int, int, error) {
 	switch periodType {
+	case DayPeriod:
+		return 1, 1, nil
 	case MonthPeriod:
 		return 28, 31, nil
 	case QuarterPeriod:
@@ -36,6 +39,8 @@ func MinMaxDays(periodType string) (int, int, error) {
 
 func PeriodOps(periodType string) (periodOps, error) {
 	switch periodType {
+	case DayPeriod:
+		return &DayPeriodOps{}, nil
 	case MonthPeriod:
 		return &MonthPeriodOps{}, nil
 	case QuarterPeriod:
@@ -51,11 +56,11 @@ type periodOps interface {
 	pointedPeriodDays(d civil.Date) int
 }
 
-func GenNPeriodEndDatesTill(n int, d civil.Date, po periodOps) []civil.Date {
-	var res []civil.Date
+func GenNPeriodsTill(n int, d civil.Date, po periodOps) []TimePeriod {
+	var res []TimePeriod
 	for i := 0; i < n; i++ {
 		d = po.lastPeriodDate(d)
-		res = append(res, d)
+		res = append(res, TimePeriod{DateTo: d, Days: po.pointedPeriodDays(d)})
 		d = d.AddDays(-po.pointedPeriodDays(d))
 	}
 	slices.Reverse(res)

--- a/pkg/coveragedb/time_period_test.go
+++ b/pkg/coveragedb/time_period_test.go
@@ -25,8 +25,10 @@ func TestDayPeriodOps(t *testing.T) {
 	assert.Equal(t, 1, ops.pointedPeriodDays(d))
 
 	assert.Equal(t,
-		[]civil.Date{{Year: 2024, Month: time.February, Day: 19}, {Year: 2024, Month: time.February, Day: 20}},
-		GenNPeriodEndDatesTill(2, d, ops))
+		[]TimePeriod{
+			{DateTo: civil.Date{Year: 2024, Month: time.February, Day: 19}, Days: 1},
+			{DateTo: civil.Date{Year: 2024, Month: time.February, Day: 20}, Days: 1}},
+		GenNPeriodsTill(2, d, ops))
 }
 
 func TestMonthPeriodOps(t *testing.T) {
@@ -48,8 +50,10 @@ func TestMonthPeriodOps(t *testing.T) {
 	assert.Equal(t, 29, ops.pointedPeriodDays(midMonthDate))
 
 	assert.Equal(t,
-		[]civil.Date{{Year: 2024, Month: time.January, Day: 31}, {Year: 2024, Month: time.February, Day: 29}},
-		GenNPeriodEndDatesTill(2, goodPeriod.DateTo, ops))
+		[]TimePeriod{
+			{DateTo: civil.Date{Year: 2024, Month: time.January, Day: 31}, Days: 31},
+			{DateTo: civil.Date{Year: 2024, Month: time.February, Day: 29}, Days: 29}},
+		GenNPeriodsTill(2, goodPeriod.DateTo, ops))
 }
 
 func TestQuarterPeriodOps(t *testing.T) {
@@ -72,8 +76,10 @@ func TestQuarterPeriodOps(t *testing.T) {
 	assert.Equal(t, 31+29+31, ops.pointedPeriodDays(midQuarterDate))
 
 	assert.Equal(t,
-		[]civil.Date{{Year: 2023, Month: time.December, Day: 31}, {Year: 2024, Month: time.March, Day: 31}},
-		GenNPeriodEndDatesTill(2, goodPeriod.DateTo, ops))
+		[]TimePeriod{
+			{DateTo: civil.Date{Year: 2023, Month: time.December, Day: 31}, Days: 31 + 30 + 31},
+			{DateTo: civil.Date{Year: 2024, Month: time.March, Day: 31}, Days: 31 + 29 + 31}},
+		GenNPeriodsTill(2, goodPeriod.DateTo, ops))
 }
 
 func TestPeriodsToMerge(t *testing.T) {


### PR DESCRIPTION
Current coverage is a week long data merge for every day.
The goal is to show a monthly data by default and make daily data available for &period=day requests.
This commit makes the first two steps:
1. Make the day a day long, not a week long aggregation.
2. Enable the month long merges available for &period=month.


