### PR TITLE
dashboard/app: use go122

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -1,7 +1,7 @@
 # Copyright 2017 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-runtime: go121
+runtime: go122
 app_engine_apis: true
 
 # With the f2 setting, the app episodically crashes with:


### PR DESCRIPTION
go122 is the latest supported. Let's update.
https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#go