### PR TITLE
pkg/rpsever, syz-manager: always include the program from Comm

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -518,7 +518,11 @@ func (mgr *Manager) fuzzerInstance(ctx context.Context, inst *vm.Instance, updIn
 		// This litters the log and we want to prevent it.
 		serv.StopFuzzing(inst.Index())
 	}))
-	lastExec, machineInfo := serv.ShutdownInstance(inst.Index(), rep != nil)
+	var extraExecs []report.ExecutorInfo
+	if rep != nil && rep.Executor != nil {
+		extraExecs = []report.ExecutorInfo{*rep.Executor}
+	}
+	lastExec, machineInfo := serv.ShutdownInstance(inst.Index(), rep != nil, extraExecs...)
 	if rep != nil {
 		rpcserver.PrependExecuting(rep, lastExec)
 		if len(vmInfo) != 0 {


### PR DESCRIPTION
It does sometimes happen that the kernel is crashed so fast that syz-manager is not notified that the syz-executor has started running the faulty input.

In cases when the exact program is known from Comm, let's make sure it's always present in the log of the last executed programs.
