### PR TITLE
sys/linux/dev_kvm.txt: fix the description of kvm_coalesced_mmio_zone

### DIFF
--- a/sys/linux/dev_kvm.txt
+++ b/sys/linux/dev_kvm.txt
@@ -1085,9 +1085,9 @@ kvm_reinject_control {
 }
 
 kvm_coalesced_mmio_zone {
-	addr	flags[kvm_guest_addrs, int64]
-	size	flags[kvm_guest_addr_size, int32]
-	pad	const[0, int32]
+	addr		flags[kvm_guest_addrs, int64]
+	size		flags[kvm_guest_addr_size, int32]
+	pio_or_pad	int32[0:1]
 }
 
 kvm_vcpu_init {


### PR DESCRIPTION
According to
https://elixir.bootlin.com/linux/v6.10.9/source/include/uapi/linux/kvm.h, the third member of `struct kvm_coalesced_mmio_zone` is a union of `__u32 pad` and `__u32 pio`, where `pio` can be 0 or 1, depending on whether the user wants to use KVM_MMIO_BUS or KVM_PIO_BUS (see also https://elixir.bootlin.com/linux/v6.10.9/source/virt/kvm/coalesced_mmio.c#L137)

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
