### PR TITLE
dashboard/app: fix cron schedule

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -21,7 +21,7 @@ cron:
   target: ah-builtin-python-bundle
 # Update quarter coverage numbers every week.
 - url: /cron/batch_coverage?quarters=true&steps=2
-  schedule: every sunday
+  schedule: every sunday 00:00
 # Update other coverage numbers every day.
 - url: /cron/batch_coverage?days=true&months=true&steps=10
   schedule: every 24 hours


### PR DESCRIPTION
It fixes the "INVALID_ARGUMENT: Cron jobs only support Groc format for schedule." error.