### PR TITLE
set default periods for coverage pages

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -65,7 +65,7 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/graph/crashes", handlerWrapper(handleGraphCrashes))
 		http.Handle("/"+ns+"/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
 		if nsConfig.Coverage != nil {
-			http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
+			http.Handle("/"+ns+"/graph/coverage?period=quarter", handlerWrapper(handleCoverageGraph))
 			http.Handle("/"+ns+"/graph/coverage_heatmap?period=month", handlerWrapper(handleCoverageHeatmap))
 			if nsConfig.Subsystems.Service != nil {
 				http.Handle("/"+ns+"/graph/coverage_subsystems_heatmap?period=month",

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -66,9 +66,10 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
 		if nsConfig.Coverage != nil {
 			http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
-			http.Handle("/"+ns+"/graph/coverage_heatmap", handlerWrapper(handleCoverageHeatmap))
+			http.Handle("/"+ns+"/graph/coverage_heatmap?period=month", handlerWrapper(handleCoverageHeatmap))
 			if nsConfig.Subsystems.Service != nil {
-				http.Handle("/"+ns+"/graph/coverage_subsystems_heatmap", handlerWrapper(handleSubsystemsCoverageHeatmap))
+				http.Handle("/"+ns+"/graph/coverage_subsystems_heatmap?period=month",
+					handlerWrapper(handleSubsystemsCoverageHeatmap))
 			}
 		}
 		http.Handle("/"+ns+"/repos", handlerWrapper(handleRepos))


### PR DESCRIPTION
This PR changes the default period for coverage details pages to 1 month.
Nothing changes for the total page. The parameter in URI is needed as a reminder.
