### PR TITLE
pkg/manager: query a crash when ready to reproduce

### DIFF
--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -197,6 +197,12 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 	defer wg.Wait()
 
 	for {
+		select {
+		case <-r.parallel:
+		case <-ctx.Done():
+			return
+		}
+
 		crash := r.popCrash()
 		for crash == nil {
 			select {
@@ -212,13 +218,6 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 				r.adjustPoolSizeLocked()
 				r.mu.Unlock()
 			}
-		}
-
-		// Now wait until we can schedule another runner.
-		select {
-		case <-r.parallel:
-		case <-ctx.Done():
-			return
 		}
 
 		title := crash.FullTitle()


### PR DESCRIPTION
The current algorithm first queries a crash from the queue and then starts waiting for a chance to reproduce it.

Let's do the opposite -- first wait for a chance to reproduce, then query a crash. This has two benefits:
1) The time between the last NeedRepro() and the actual reproduction is
   minimal.
2) The repro tests are more reliable since we start picking crashes only
   after StartReproduction(). Earlier Enqueue() and Loop() were racing
   in TestReproOrder().

```
2024-09-10T07:10:57.7674420Z --- FAIL: TestReproOrder (0.00s)
2024-09-10T07:10:57.7674932Z     repro_test.go:100: 
2024-09-10T07:10:57.7675904Z         	Error Trace:	/__w/syzkaller/syzkaller/gopath/src/github.com/google/syzkaller/pkg/manager/repro_test.go:100
2024-09-10T07:10:57.7677254Z         	Error:      	Not equal: 
2024-09-10T07:10:57.7678412Z         	            	expected: &manager.Crash{InstanceIndex:0, FromHub:false, FromDashboard:true, Manual:true, Report:(*report.Report)(0xc001c38100)}
2024-09-10T07:10:57.7680246Z         	            	actual  : &manager.Crash{InstanceIndex:0, FromHub:true, FromDashboard:false, Manual:false, Report:(*report.Report)(0xc001c38300)}
2024-09-10T07:10:57.7681607Z         	            	
2024-09-10T07:10:57.7682023Z         	            	Diff:
2024-09-10T07:10:57.7682542Z         	            	--- Expected
2024-09-10T07:10:57.7683005Z         	            	+++ Actual
2024-09-10T07:10:57.7683596Z         	            	@@ -2,7 +2,7 @@
2024-09-10T07:10:57.7684147Z         	            	  InstanceIndex: (int) 0,
2024-09-10T07:10:57.7684794Z         	            	- FromHub: (bool) false,
2024-09-10T07:10:57.7685467Z         	            	- FromDashboard: (bool) true,
2024-09-10T07:10:57.7686141Z         	            	- Manual: (bool) true,
2024-09-10T07:10:57.7686709Z         	            	+ FromHub: (bool) true,
2024-09-10T07:10:57.7687326Z         	            	+ FromDashboard: (bool) false,
2024-09-10T07:10:57.7687946Z         	            	+ Manual: (bool) false,
2024-09-10T07:10:57.7688535Z         	            	  Report: (*report.Report)({
2024-09-10T07:10:57.7689242Z         	            	-  Title: (string) (len=1) "A",
2024-09-10T07:10:57.7689877Z         	            	+  Title: (string) (len=1) "C",
2024-09-10T07:10:57.7690492Z         	            	   AltTitles: ([]string) <nil>,
2024-09-10T07:10:57.7691114Z         	Test:       	TestReproOrder
2024-09-10T07:10:57.7692062Z     repro_test.go:100: 
2024-09-10T07:10:57.7693049Z         	Error Trace:	/__w/syzkaller/syzkaller/gopath/src/github.com/google/syzkaller/pkg/manager/repro_test.go:100
2024-09-10T07:10:57.7694192Z         	Error:      	Not equal: 
2024-09-10T07:10:57.7695357Z         	            	expected: &manager.Crash{InstanceIndex:0, FromHub:false, FromDashboard:true, Manual:false, Report:(*report.Report)(0xc001c38200)}
2024-09-10T07:10:57.7697188Z         	            	actual  : &manager.Crash{InstanceIndex:0, FromHub:false, FromDashboard:true, Manual:true, Report:(*report.Report)(0xc001c38100)}
2024-09-10T07:10:57.7698311Z         	            	
2024-09-10T07:10:57.7698712Z         	            	Diff:
2024-09-10T07:10:57.7699233Z         	            	--- Expected
2024-09-10T07:10:57.7699698Z         	            	+++ Actual
2024-09-10T07:10:57.7700230Z         	            	@@ -4,5 +4,5 @@
2024-09-10T07:10:57.7700794Z         	            	  FromDashboard: (bool) true,
2024-09-10T07:10:57.7701593Z         	            	- Manual: (bool) false,
2024-09-10T07:10:57.7702201Z         	            	+ Manual: (bool) true,
2024-09-10T07:10:57.7702808Z         	            	  Report: (*report.Report)({
2024-09-10T07:10:57.7703545Z         	            	-  Title: (string) (len=1) "B",
2024-09-10T07:10:57.7704186Z         	            	+  Title: (string) (len=1) "A",
2024-09-10T07:10:57.7704832Z         	            	   AltTitles: ([]string) <nil>,
2024-09-10T07:10:57.7705405Z         	Test:       	TestReproOrder
2024-09-10T07:12:36.8421500Z     repro_test.go:100: 
2024-09-10T07:12:36.8423277Z         	Error Trace:	/__w/syzkaller/syzkaller/gopath/src/github.com/google/syzkaller/pkg/manager/repro_test.go:100
2024-09-10T07:12:36.8430849Z         	Error:      	Not equal: 
2024-09-10T07:12:36.8433425Z         	            	expected: &manager.Crash{InstanceIndex:0, FromHub:true, FromDashboard:false, Manual:false, Report:(*report.Report)(0xc001c38300)}
2024-09-10T07:12:36.8436469Z         	            	actual  : &manager.Crash{InstanceIndex:0, FromHub:false, FromDashboard:true, Manual:false, Report:(*report.Report)(0xc001c38200)}
2024-09-10T07:12:36.8437664Z         	            	
2024-09-10T07:12:36.8438057Z         	            	Diff:
2024-09-10T07:12:36.8438934Z         	            	--- Expected
2024-09-10T07:12:36.8439426Z         	            	+++ Actual
2024-09-10T07:12:36.8440523Z         	            	@@ -2,7 +2,7 @@
2024-09-10T07:12:36.8441163Z         	            	  InstanceIndex: (int) 0,
2024-09-10T07:12:36.8442063Z         	            	- FromHub: (bool) true,
2024-09-10T07:12:36.8442728Z         	            	- FromDashboard: (bool) false,
2024-09-10T07:12:36.8443426Z         	            	+ FromHub: (bool) false,
2024-09-10T07:12:36.8444043Z         	            	+ FromDashboard: (bool) true,
2024-09-10T07:12:36.8444671Z         	            	  Manual: (bool) false,
2024-09-10T07:12:36.8446013Z         	            	  Report: (*report.Report)({
2024-09-10T07:12:36.8446938Z         	            	-  Title: (string) (len=1) "C",
2024-09-10T07:12:36.8447594Z         	            	+  Title: (string) (len=1) "B",
2024-09-10T07:12:36.8457415Z         	            	   AltTitles: ([]string) <nil>,
2024-09-10T07:12:36.8458095Z         	Test:       	TestReproOrder
```