### PR TITLE
[experiment] tools/covermerger: save kernel sources to gcs

### DIFF
--- a/pkg/covermerger/covermerger.go
+++ b/pkg/covermerger/covermerger.go
@@ -42,6 +42,7 @@ type MergeResult struct {
 	HitCounts   map[int]int
 	FileExists  bool
 	LineDetails map[int][]*FileRecord
+	RepoCommits []RepoCommit
 }
 
 type FileCoverageMerger interface {
@@ -51,13 +52,13 @@ type FileCoverageMerger interface {
 
 func batchFileData(c *Config, targetFilePath string, records []*FileRecord) (*MergeResult, error) {
 	log.Logf(1, "processing %d records for %s", len(records), targetFilePath)
-	repoBranchCommitsMap := make(map[RepoCommit]bool)
+	repoCommitsMap := make(map[RepoCommit]bool)
 	for _, record := range records {
-		repoBranchCommitsMap[record.RepoCommit] = true
+		repoCommitsMap[record.RepoCommit] = true
 	}
-	repoBranchCommitsMap[c.Base] = true
-	repoBranchCommits := maps.Keys(repoBranchCommitsMap)
-	fvs, err := c.FileVersProvider.GetFileVersions(c, targetFilePath, repoBranchCommits)
+	repoCommitsMap[c.Base] = true
+	repoCommits := maps.Keys(repoCommitsMap)
+	fvs, err := c.FileVersProvider.GetFileVersions(targetFilePath, repoCommits...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to getFileVersions: %w", err)
 	}
@@ -65,7 +66,9 @@ func batchFileData(c *Config, targetFilePath string, records []*FileRecord) (*Me
 	for _, record := range records {
 		merger.Add(record)
 	}
-	return merger.Result(), nil
+	res := merger.Result()
+	res.RepoCommits = repoCommits
+	return res, nil
 }
 
 func makeRecord(fields, schema []string) (*FileRecord, error) {

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -115,13 +115,12 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 			aggregation, err := MergeCSVData(
 				&Config{
 					Jobs:          2,
-					Workdir:       test.workdir,
 					skipRepoClone: true,
 					Base: RepoCommit{
 						Repo:   test.baseRepo,
 						Commit: test.baseCommit,
 					},
-					FileVersProvider: &fileVersProviderMock{},
+					FileVersProvider: &fileVersProviderMock{Workdir: test.workdir},
 				},
 				strings.NewReader(test.bqTable),
 			)
@@ -133,13 +132,15 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 	}
 }
 
-type fileVersProviderMock struct{}
+type fileVersProviderMock struct {
+	Workdir string
+}
 
-func (m *fileVersProviderMock) GetFileVersions(c *Config, targetFilePath string, repoCommits []RepoCommit,
+func (m *fileVersProviderMock) GetFileVersions(targetFilePath string, repoCommits ...RepoCommit,
 ) (fileVersions, error) {
 	res := make(fileVersions)
 	for _, repoCommit := range repoCommits {
-		filePath := filepath.Join(c.Workdir, "repos", repoCommit.Commit, targetFilePath)
+		filePath := filepath.Join(m.Workdir, "repos", repoCommit.Commit, targetFilePath)
 		if bytes, err := os.ReadFile(filePath); err == nil {
 			res[repoCommit] = string(bytes)
 		}

--- a/pkg/covermerger/provider_monorepo.go
+++ b/pkg/covermerger/provider_monorepo.go
@@ -14,7 +14,7 @@ import (
 )
 
 type FileVersProvider interface {
-	GetFileVersions(c *Config, targetFilePath string, repoCommits []RepoCommit,
+	GetFileVersions(targetFilePath string, repoCommits ...RepoCommit,
 	) (fileVersions, error)
 }
 
@@ -26,7 +26,7 @@ type monoRepo struct {
 
 type fileVersions map[RepoCommit]string
 
-func (mr *monoRepo) GetFileVersions(c *Config, targetFilePath string, repoCommits []RepoCommit,
+func (mr *monoRepo) GetFileVersions(targetFilePath string, repoCommits ...RepoCommit,
 ) (fileVersions, error) {
 	mr.mu.RLock()
 	if !mr.allRepoCommitsPresent(repoCommits) {

--- a/pkg/covermerger/provider_web.go
+++ b/pkg/covermerger/provider_web.go
@@ -14,7 +14,7 @@ import (
 type webGit struct {
 }
 
-func (mr *webGit) GetFileVersions(c *Config, targetFilePath string, repoCommits []RepoCommit,
+func (mr *webGit) GetFileVersions(targetFilePath string, repoCommits ...RepoCommit,
 ) (fileVersions, error) {
 	res := make(fileVersions)
 	for _, repoCommit := range repoCommits {
@@ -69,9 +69,7 @@ func MakeWebGit() FileVersProvider {
 
 func GetFileVersion(filePath, repo, commit string) (string, error) {
 	repoCommit := RepoCommit{repo, commit}
-	files, err := MakeWebGit().GetFileVersions(nil,
-		filePath,
-		[]RepoCommit{repoCommit})
+	files, err := MakeWebGit().GetFileVersions(filePath, repoCommit)
 	if err != nil {
 		return "", fmt.Errorf("failed to GetFileVersions: %w", err)
 	}


### PR DESCRIPTION
To enable file level coverage visualization, the files content is needed.
AppEngine can't get files from git:// and not every git has web interface.
GCS looks better.
Unblocks #5239 .

Problems:
1. It will be too slow...
