### PR TITLE
dashboard/config: restore CMDLINE_FROM_BOOTLOADER on arm64

### DIFF
--- a/dashboard/config/linux/bits/arm64.yml
+++ b/dashboard/config/linux/bits/arm64.yml
@@ -9,6 +9,8 @@ config:
  - CMDLINE: [append, "root=/dev/vda console=ttyAMA0"]
  # Was dropped in "arm64: Drop support for CMDLINE_EXTEND".
  - CMDLINE_EXTEND: [-v5.10]
+ - CMDLINE_FROM_BOOTLOADER: [v5.11]
+ - CMDLINE_FORCE: n
 
  - ARM64_TAGGED_ADDR_ABI
  - ARM64_PMEM

--- a/dashboard/config/linux/upstream-arm64-full-base.config
+++ b/dashboard/config/linux/upstream-arm64-full-base.config
@@ -214,7 +214,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -553,8 +552,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=100000 watchdog_thresh=55 workqueue.watchdog_thresh=140 sysctl.net.core.netdev_unregister_timeout_secs=140 dummy_hcd.num=8 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-full.config
+++ b/dashboard/config/linux/upstream-arm64-full.config
@@ -215,7 +215,6 @@ CONFIG_SCHED_AUTOGROUP=y
 CONFIG_RELAY=y
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -555,8 +554,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=100000 watchdog_thresh=55 workqueue.watchdog_thresh=140 sysctl.net.core.netdev_unregister_timeout_secs=140 dummy_hcd.num=8 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-kasan-base.config
+++ b/dashboard/config/linux/upstream-arm64-kasan-base.config
@@ -212,7 +212,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -550,8 +549,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-kasan.config
+++ b/dashboard/config/linux/upstream-arm64-kasan.config
@@ -213,7 +213,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -552,8 +551,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-kasan_sw-kcov-base.config
+++ b/dashboard/config/linux/upstream-arm64-kasan_sw-kcov-base.config
@@ -212,7 +212,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -550,8 +549,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-kasan_sw-kcov.config
+++ b/dashboard/config/linux/upstream-arm64-kasan_sw-kcov.config
@@ -213,7 +213,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -552,8 +551,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2 panic_on_warn=1"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-mte-base.config
+++ b/dashboard/config/linux/upstream-arm64-mte-base.config
@@ -208,7 +208,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -544,8 +543,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set

--- a/dashboard/config/linux/upstream-arm64-mte.config
+++ b/dashboard/config/linux/upstream-arm64-mte.config
@@ -209,7 +209,6 @@ CONFIG_SCHED_AUTOGROUP=y
 # CONFIG_RELAY is not set
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_INITRAMFS_SOURCE=""
-# CONFIG_INITRAMFS_FORCE is not set
 CONFIG_RD_GZIP=y
 CONFIG_RD_BZIP2=y
 CONFIG_RD_LZMA=y
@@ -546,8 +545,8 @@ CONFIG_ARM64_CONTPTE=y
 #
 # CONFIG_ARM64_ACPI_PARKING_PROTOCOL is not set
 CONFIG_CMDLINE="earlyprintk=serial net.ifnames=0 sysctl.kernel.hung_task_all_cpu_backtrace=1 ima_policy=tcb nf-conntrack-ftp.ports=20000 nf-conntrack-tftp.ports=20000 nf-conntrack-sip.ports=20000 nf-conntrack-irc.ports=20000 nf-conntrack-sane.ports=20000 binder.debug_mask=0 rcupdate.rcu_expedited=1 rcupdate.rcu_cpu_stall_cputime=1 no_hash_pointers page_owner=on sysctl.vm.nr_hugepages=4 sysctl.vm.nr_overcommit_hugepages=4 secretmem.enable=1 sysctl.max_rcu_stall_to_panic=1 msr.allow_writes=off coredump_filter=0xffff root=/dev/vda console=ttyAMA0 smp.csd_lock_timeout=300000 watchdog_thresh=165 workqueue.watchdog_thresh=420 sysctl.net.core.netdev_unregister_timeout_secs=420 dummy_hcd.num=2"
-# CONFIG_CMDLINE_FROM_BOOTLOADER is not set
-CONFIG_CMDLINE_FORCE=y
+CONFIG_CMDLINE_FROM_BOOTLOADER=y
+# CONFIG_CMDLINE_FORCE is not set
 CONFIG_EFI_STUB=y
 CONFIG_EFI=y
 # CONFIG_COMPRESSED_INSTALL is not set


### PR DESCRIPTION
It seems to have caused boot problems on ci-upstream-gce-arm64 (see #5303).

Reported-by: Sabyrzhan Tasbolatov <snovitoll@gmail.com>
