### PR TITLE
dashboard: display up to 1000 last builds

### DIFF
--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -841,7 +841,7 @@ func lastManagerBuild(c context.Context, ns, manager string) (*Build, error) {
 }
 
 func loadBuilds(c context.Context, ns, manager string, typ BuildType) ([]*Build, error) {
-	const limit = 500
+	const limit = 1000
 	var builds []*Build
 	_, err := db.NewQuery("Build").
 		Filter("Namespace=", ns).


### PR DESCRIPTION
For many managers, 500 are not enough to even cover the last year.

Cc: @pchaigno 