### PR TITLE
pkg/build/cuttlefish: copy module objects

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -107,7 +107,7 @@ func (a android) build(params Params) (ImageDetails, error) {
 	}
 	defer imageFile.Close()
 
-	if err := a.copyModuleFiles(filepath.Join(params.KernelDir, "out"), params.OutputDir); err != nil {
+	if err := copyModuleFiles(filepath.Join(params.KernelDir, "out"), params.OutputDir); err != nil {
 		return details, fmt.Errorf("failed copying module files: %w", err)
 	}
 
@@ -124,7 +124,7 @@ func (a android) build(params Params) (ImageDetails, error) {
 	return details, nil
 }
 
-func (a android) copyModuleFiles(srcDir, dstDir string) error {
+func copyModuleFiles(srcDir, dstDir string) error {
 	err := filepath.Walk(srcDir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/pkg/build/cuttlefish.go
+++ b/pkg/build/cuttlefish.go
@@ -153,6 +153,9 @@ func (c cuttlefish) build(params Params) (ImageDetails, error) {
 	if err := osutil.CopyFile(config, filepath.Join(params.OutputDir, "kernel.config")); err != nil {
 		return details, err
 	}
+	if err := copyModuleFiles(filepath.Join(params.KernelDir, "out"), params.OutputDir); err != nil {
+		return details, err
+	}
 
 	details.Signature, err = elfBinarySignature(vmlinux, params.Tracer)
 	if err != nil {


### PR DESCRIPTION
Copy Cuttlefish module objects to be used
in coverage report generation.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
