### PR TITLE
pkg/validator: target value is not empty by default

### DIFF
--- a/pkg/covermerger/bq_csv_reader.go
+++ b/pkg/covermerger/bq_csv_reader.go
@@ -34,7 +34,7 @@ func MakeBQCSVReader() *bqCSVReader {
 func (r *bqCSVReader) InitNsRecords(ctx context.Context, ns, filePath, commit string, from, to civil.Date) error {
 	if err := validator.AnyError("input validation failed",
 		validator.NamespaceName(ns),
-		validator.KernelFilePath(filePath),
+		validator.AnyOk(validator.EmptyStr(filePath), validator.KernelFilePath(filePath)),
 		validator.AnyOk(validator.EmptyStr(commit), validator.CommitHash(commit)),
 	); err != nil {
 		return err

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -66,6 +66,9 @@ type strValidationFunc func(string, ...string) Result
 func makeStrReFunc(errStr, reStr string) strValidationFunc {
 	matchRe := regexp.MustCompile(reStr)
 	return func(s string, objName ...string) Result {
+		if s == "" {
+			return Result{false, wrapError(errStr + ": can't be empty")}
+		}
 		if !matchRe.MatchString(s) {
 			return Result{false, wrapError(errStr, objName...)}
 		}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -24,6 +24,7 @@ func TestIsCommitHash(t *testing.T) {
 		validator.CommitHash("!311c1b497e51a628aa89e7cb954481e5f9dced2", "valName").Err.Error())
 }
 
+// nolint: dupl
 func TestIsNamespaceName(t *testing.T) {
 	assert.True(t, validator.NamespaceName("upstream").Ok)
 	assert.False(t, validator.NamespaceName("up").Ok)
@@ -58,6 +59,7 @@ func TestIsDashboardClientKey(t *testing.T) {
 func TestIsKernelFilePath(t *testing.T) {
 	assert.True(t, validator.KernelFilePath("io_uring/advise.c").Ok)
 	assert.False(t, validator.KernelFilePath("io-uring/advise.c").Ok)
+	assert.False(t, validator.KernelFilePath("").Ok)
 
 	assert.Equal(t, "not a kernel file path", validator.KernelFilePath("io-uring").Err.Error())
 	assert.Equal(t, "kernelPath: not a kernel file path",


### PR DESCRIPTION
The consistency make the code more predictable.
We want all the values to be non-empty (commit, kernelPath, etc.).
If "empty" is an option - use validator.AnyOk(validator.EmptyStr(target), otherCheck(target)).