### PR TITLE
pkg/build: handle OOM-killed build error

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -134,14 +134,6 @@ type Result struct {
 	Confidence float64
 }
 
-type InfraError struct {
-	Title string
-}
-
-func (e InfraError) Error() string {
-	return e.Title
-}
-
 // Run does the bisection and returns either the Result,
 // or, if the crash is not reproduced on the start commit, an error.
 func Run(cfg *Config) (*Result, error) {
@@ -158,7 +150,7 @@ func Run(cfg *Config) (*Result, error) {
 		return nil, err
 	}
 	if _, err = repo.CheckoutBranch(cfg.Kernel.Repo, cfg.Kernel.Branch); err != nil {
-		return nil, &InfraError{Title: fmt.Sprintf("%v", err)}
+		return nil, &build.InfraError{Title: fmt.Sprintf("%v", err)}
 	}
 	return runImpl(cfg, repo, inst)
 }
@@ -692,7 +684,7 @@ func (env *env) test() (*testResult, error) {
 	if err != nil {
 		problem := fmt.Sprintf("repro testing failure: %v", err)
 		env.log(problem)
-		return res, &InfraError{Title: problem}
+		return res, &build.InfraError{Title: problem}
 	}
 	bad, good, infra, rep, types := env.processResults(current, results)
 	res.verdict, err = env.bisectionDecision(len(results), bad, good, infra)
@@ -851,7 +843,7 @@ func (env *env) bisectionDecision(total, bad, good, infra int) (vcs.BisectResult
 		// We have been unable to determine a verdict mostly because of infra errors.
 		// Abort the bisection.
 		return vcs.BisectSkip,
-			&InfraError{Title: "unable to determine the verdict because of infra errors"}
+			&build.InfraError{Title: "unable to determine the verdict because of infra errors"}
 	}
 	env.logf("unable to determine the verdict: %d good runs (wanted %d), for bad wanted %d in total, got %d",
 		good, wantGoodRuns, wantTotalRuns, good+bad)

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -651,7 +651,7 @@ var bisectionTests = []BisectionTest{
 		startCommit:   905,
 		expectRep:     false,
 		expectErr:     true,
-		expectErrType: &InfraError{},
+		expectErrType: &build.InfraError{},
 		infraErrStart: 600,
 		infraErrEnd:   800,
 		introduced:    "602",

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -8,6 +8,10 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCompilerIdentity(t *testing.T) {
@@ -36,7 +40,7 @@ func TestCompilerIdentity(t *testing.T) {
 	}
 }
 
-func TestExtractRootCause(t *testing.T) {
+func TestExtractCauseInner(t *testing.T) {
 	for i, test := range rootCauseTests {
 		test := test
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
@@ -46,6 +50,36 @@ func TestExtractRootCause(t *testing.T) {
 			}
 			if test.file != file {
 				t.Errorf("expected file: %q, got: %q", test.file, file)
+			}
+		})
+	}
+}
+
+func TestExtractRootCause(t *testing.T) {
+	targetOs := targets.TestOS
+	for i, test := range rootCauseTests {
+		var expected error
+		err := &osutil.VerboseError{Output: []byte(test.e)}
+		if test.reason == "" {
+			continue
+		} else if test.reason == "Killed" {
+			err.ExitCode = 137
+			targetOs = targets.Linux
+			expected = &InfraError{
+				Title:  test.reason,
+				Output: err.Output,
+			}
+		} else {
+			expected = &KernelError{
+				Report:     []byte(test.reason),
+				Output:     err.Output,
+				guiltyFile: test.file,
+			}
+		}
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := extractRootCause(err, targetOs, test.src)
+			if got != nil {
+				assert.Equal(t, expected, got)
 			}
 		})
 	}
@@ -543,6 +577,19 @@ Caused by:
 ninja: build stopped: subcommand failed.
 `,
 		`Error: Unable to write generate doc for "/syzkaller/managers/main/kernel/out/x64/host_x64/fpublish" to "host_x64/gen/tools/docsgen/sdk-docs"`,
+		"",
+		"",
+	},
+	{`
+  AR      built-in.a
+  AR      vmlinux.a
+  LD      vmlinux.o
+Killed
+make[1]: *** [scripts/Makefile.vmlinux_o:61: vmlinux.o] Error 137
+make[1]: *** Deleting file 'vmlinux.o'
+make: *** [Makefile:1231: vmlinux_o] Error 2
+`,
+		"Killed",
 		"",
 		"",
 	},

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -68,7 +68,7 @@ func Run(timeout time.Duration, cmd *exec.Cmd) ([]byte, error) {
 		if <-timedout {
 			text = fmt.Sprintf("timedout after %v %q", timeout, cmd.Args)
 		}
-		exitCode := 0
+		exitCode := cmd.ProcessState.ExitCode()
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -524,7 +524,7 @@ func (jp *JobProcessor) bisect(job *Job, mgrcfg *mgrconfig.Config) error {
 	res, err := bisect.Run(cfg)
 	resp.Log = trace.Bytes()
 	if err != nil {
-		var infraErr *bisect.InfraError
+		var infraErr *build.InfraError
 		if errors.As(err, &infraErr) {
 			resp.Flags |= dashapi.BisectResultInfraError
 		}

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -384,6 +384,8 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 		case errors.As(err, &verboseError):
 			rep.Report = []byte(verboseError.Title)
 			rep.Output = verboseError.Output
+		case errors.As(err, &build.InfraError{}):
+			return err
 		default:
 			rep.Report = []byte(err.Error())
 		}


### PR DESCRIPTION
Handle SIGKILL (exit code = 137) on osutil.Run() during Linux kernel image
building and return build.InfraError without reporting.


Fixes: https://github.com/google/syzkaller/issues/5317