### PR TITLE
syz-ci: run syz-ci without a dashboard

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -154,11 +154,14 @@ func createManager(cfg *Config, mgrcfg *ManagerConfig, stop chan struct{},
 		repo:           repo,
 		mgrcfg:         mgrcfg,
 		managercfg:     mgrcfg.managercfg,
-		dash:           dash,
 		storage:        assetStorage,
 		debugStorage:   !cfg.AssetStorage.IsEmpty() && cfg.AssetStorage.Debug,
 		stop:           stop,
 		debug:          debug,
+	}
+	// Leave the dashboard interface value as nil if it does not wrap a valid dashboard pointer.
+	if dash != nil {
+		mgr.dash = dash
 	}
 
 	os.RemoveAll(mgr.currentDir)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -180,9 +180,9 @@ type ManagerConfig struct {
 	// and rename managers/foo to managers/ci-foo. Then this instance can be moved
 	// to another ci along with managers/ci-foo dir.
 	Name            string `json:"name"`
-	Disabled        string `json:"disabled"` // If not empty, don't build/start this manager.
-	DashboardClient string `json:"dashboard_client"`
-	DashboardKey    string `json:"dashboard_key"`
+	Disabled        string `json:"disabled"`         // If not empty, don't build/start this manager.
+	DashboardClient string `json:"dashboard_client"` // Optional.
+	DashboardKey    string `json:"dashboard_key"`    // Optional.
 	Repo            string `json:"repo"`
 	// Short name of the repo (e.g. "linux-next"), used only for reporting.
 	RepoAlias string `json:"repo_alias"`


### PR DESCRIPTION
syz-ci calls several `Dashboard` methods, and the case of a nil `Dashboard` pointer receiver was not handled. This change allows syz-ci to operate with a nil dashboard. (In terms of the [syzbot setup docs](https://github.com/google/syzkaller/blob/master/docs/setup_syzbot.md), we wanted to deploy a test instance of syz-ci without deploying a dashboard.)


