### PR TITLE
pkg/report: better suppress ALSA-caused go runtime error

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -864,6 +864,7 @@ var groupGoRuntimeErrors = oops{
 	},
 	[]*regexp.Regexp{
 		compile("ALSA"),
+		compile("fatal error: cannot create timer"),
 	},
 	crash.UnknownType,
 }

--- a/pkg/report/testdata/linux/report/706
+++ b/pkg/report/testdata/linux/report/706
@@ -1,2 +1,7 @@
 
-[  471.848871][T11685] ALSA: seq fatal error: cannot create timer (-22)
+Sep 23 02:31[   69.295771][ T2742] ALSA: seq fatal error: cannot create timer (-22)
+:17 syzkaller ke[   69.303665][ T2742] ALSA: seq fatal error: cannot create timer (-22)
+rn.err kernel: [[   69.311910][ T2742] ALSA: seq fatal error: cannot create timer (-22)
+   68.938106][ T[   69.319571][ T2742] ALSA: seq fatal error: cannot create timer (-22)
+2742] ALSA: seq [   69.327618][ T2742] ALSA: seq fatal error: cannot create timer (-22)
+fatal error: cannot create timer (-22)


### PR DESCRIPTION
Sometimes it may happen that we only get part of the string. Let's suppress the report both for the specific error message and for ALSA in general.