### PR TITLE
syz-ci: reset to the build commit at restart

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -430,6 +430,13 @@ func (mgr *Manager) restartManager() {
 		mgr.Errorf("failed to load build info: %v", err)
 		return
 	}
+	// HEAD might be pointing to a different commit now e.g. due to a recent failed kernel
+	// build attempt, so let's always reset it to the commit the current kernel was built at.
+	_, err = mgr.repo.CheckoutCommit(mgr.mgrcfg.Repo, info.KernelCommit)
+	if err != nil {
+		mgr.Errorf("failed to check out the last kernel commit %q: %v", info.KernelCommit, err)
+		return
+	}
 	buildTag, err := mgr.uploadBuild(info, mgr.currentDir)
 	if err != nil {
 		mgr.Errorf("failed to upload build: %v", err)


### PR DESCRIPTION
If we failed to build/test the current tip of the tree, it seems that we still stay on that commit, which may lead to problems in fix commit collection, coverage report generation and in determining the right people to Cc.

Always reset to the last successfully built kernel commit before restarting a syz-manager instance.

Closes #5333.

