### PR TITLE
pkg/instance: refactor ExecprogCmd

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -173,12 +173,7 @@ func (inst *ExecProgInstance) RunSyzProgFile(progFile string, duration time.Dura
 		return nil, &TestError{Title: fmt.Sprintf("failed to copy prog to VM: %v", err)}
 	}
 	target := inst.mgrCfg.SysTarget
-	faultCall := -1
-	if opts.Fault {
-		faultCall = opts.FaultCall
-	}
-	command := ExecprogCmd(inst.execprogBin, inst.executorBin, target.OS, target.Arch, inst.mgrCfg.Type, opts.Sandbox,
-		opts.SandboxArg, opts.Repeat, opts.Threaded, opts.Collide, opts.Procs, faultCall, opts.FaultNth,
+	command := ExecprogCmd(inst.execprogBin, inst.executorBin, target.OS, target.Arch, inst.mgrCfg.Type, opts,
 		!inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, vmProgFile)
 	return inst.runCommand(command, duration, exitCondition)
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -442,11 +442,10 @@ func (inst *inst) csourceOptions() (csource.Options, error) {
 	return opts, nil
 }
 
-func ExecprogCmd(execprog, executor, OS, arch, vmType, sandbox string, sandboxArg int, repeat,
-	threaded, collide bool, procs, faultCall, faultNth int, optionalFlags bool, slowdown int,
-	progFile string) string {
+func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Options,
+	optionalFlags bool, slowdown int, progFile string) string {
 	repeatCount := 1
-	if repeat {
+	if opts.Repeat {
 		repeatCount = 0
 	}
 	osArg := ""
@@ -454,24 +453,21 @@ func ExecprogCmd(execprog, executor, OS, arch, vmType, sandbox string, sandboxAr
 		osArg = " -os=" + OS
 	}
 	optionalArg := ""
-
-	if faultCall >= 0 {
+	if opts.Fault && opts.FaultCall >= 0 {
 		optionalArg = fmt.Sprintf(" -fault_call=%v -fault_nth=%v",
-			faultCall, faultNth)
+			opts.FaultCall, opts.FaultNth)
 	}
-
 	if optionalFlags {
 		optionalArg += " " + tool.OptionalFlags([]tool.Flag{
 			{Name: "slowdown", Value: fmt.Sprint(slowdown)},
-			{Name: "sandboxArg", Value: fmt.Sprint(sandboxArg)},
+			{Name: "sandboxArg", Value: fmt.Sprint(opts.SandboxArg)},
 			{Name: "type", Value: fmt.Sprint(vmType)},
 		})
 	}
-
 	return fmt.Sprintf("%v -executor=%v -arch=%v%v -sandbox=%v"+
 		" -procs=%v -repeat=%v -threaded=%v -collide=%v -cover=0%v %v",
-		execprog, executor, arch, osArg, sandbox,
-		procs, repeatCount, threaded, collide,
+		execprog, executor, arch, osArg, opts.Sandbox,
+		opts.Procs, repeatCount, opts.Threaded, opts.Collide,
 		optionalArg, progFile)
 }
 

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -36,7 +37,19 @@ func TestExecprogCmd(t *testing.T) {
 	flagSandbox := flags.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace/android)")
 	flagSlowdown := flags.Int("slowdown", 1, "")
 	cmdLine := ExecprogCmd(os.Args[0], "/myexecutor", targets.FreeBSD, targets.I386, "vmtype",
-		"namespace", 3, true, false, true, 7, 2, 3, true, 10, "myprog")
+		csource.Options{
+			Sandbox:    "namespace",
+			SandboxArg: 3,
+			Repeat:     true,
+			Threaded:   false,
+			Procs:      7,
+			LegacyOptions: csource.LegacyOptions{
+				Collide:   true,
+				Fault:     true,
+				FaultCall: 2,
+				FaultNth:  3,
+			},
+		}, true, 10, "myprog")
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := tool.ParseFlags(flags, args); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Reduce the number of arguments by using a csource.Options value directly.