### PR TITLE
pkg/bisect: document zero-value env test results

### DIFF
--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -119,6 +119,7 @@ func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collect
 		}
 		return ret, nil
 	}
+	// Zero-value results represent VMs where the test completed without a crash.
 	ret = make([]instance.EnvTestResult, numVMs)
 	if env.test.injectSyzFailure {
 		ret[0] = instance.EnvTestResult{


### PR DESCRIPTION
~~The intention here should be to initialize a slice with a capacity of numVMs-1 rather than initializing the length of this slice.~~



Clarify that prefilled zero-value EnvTestResult entries represent VMs
that completed without a crash.