### PR TITLE
tools: mount devtmpfs in Buildroot images explicitly

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -161,6 +161,9 @@ esac
 cat >rootfs_script.sh <<'EOFEOF'
 set -eux
 
+# Mount /dev right after / is mounted.
+sed -Ei '/\/dev\/pts/i ::sysinit:/bin/mount -t devtmpfs devtmpfs /dev' $1/etc/inittab
+
 # Mount debugfs for KCOV and other filesystems.
 cat >>$1/etc/fstab <<EOF
 debugfs /sys/kernel/debug debugfs defaults 0 0


### PR DESCRIPTION
It will enable Buildroot image usage also for the kenrels that don't enable CONFIG_DEVTMPFS_MOUNT.

On the kernels with `CONFIG_DEVTMPFS_MOUNT` enabled, the kernel prints `mount: mounting devtmpfs on /dev failed: Device or resource busy` to the serial output, but otherwise everything works fine.