### PR TITLE
doc: update go version in syzkaller setup

### DIFF
--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -26,13 +26,13 @@ If you encounter any troubles, check the [troubleshooting](/docs/troubleshooting
 
 ### Go and syzkaller
 
-`syzkaller` is written in [Go](https://golang.org), and `Go 1.21+` toolchain is required for build.
+`syzkaller` is written in [Go](https://golang.org), and `Go 1.22+` toolchain is required for build.
 Generally we aim at supporting 2 latest releases of Go.
 The toolchain can be installed with:
 
 ```
-wget https://dl.google.com/go/go1.21.4.linux-amd64.tar.gz
-tar -xf go1.21.4.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz
+tar -xf go1.22.1.linux-amd64.tar.gz
 export GOROOT=`pwd`/go
 export PATH=$GOROOT/bin:$PATH
 ```


### PR DESCRIPTION
go.mod has been bumped with go 1.22.1 version recently. So let's update the documentation as well.

https://github.com/google/syzkaller/blob/master/docs/linux/setup.md#go-and-syzkaller