### PR TITLE
dashboard/app: set coverage batching timeout to 12 hours

### DIFF
--- a/dashboard/app/coverage_batch.go
+++ b/dashboard/app/coverage_batch.go
@@ -25,10 +25,7 @@ func initCoverageBatches() {
 	http.HandleFunc("/cron/batch_coverage", handleBatchCoverage)
 }
 
-const (
-	daysToMerge         = 7
-	batchTimeoutSeconds = 60 * 60 * 6
-)
+const batchTimeoutSeconds = 60 * 60 * 12
 
 func handleBatchCoverage(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)


### PR DESCRIPTION
Sometimes 6 hours are not enough to make the quarter long aggregation.
Typically 5 hours 30 minutes are enough.
