### PR TITLE
dashboard: allow multiple allowed authentication domains

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -49,6 +49,16 @@ func checkAccessLevel(c context.Context, r *http.Request, level AccessLevel) err
 // AuthDomain is broken in AppEngine tests.
 var isBrokenAuthDomainInTest = false
 
+func emailInAuthDomains(email string, authDomains []string) bool {
+	for _, authDomain := range authDomains {
+		if strings.HasSuffix(email, authDomain) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func accessLevel(c context.Context, r *http.Request) AccessLevel {
 	if user.IsAdmin(c) {
 		switch r.FormValue("access") {
@@ -63,7 +73,7 @@ func accessLevel(c context.Context, r *http.Request) AccessLevel {
 	if u == nil ||
 		// Devappserver does not pass AuthDomain.
 		u.AuthDomain != "gmail.com" && !isBrokenAuthDomainInTest ||
-		!strings.HasSuffix(u.Email, getConfig(c).AuthDomain) {
+		!emailInAuthDomains(u.Email, getConfig(c).AuthDomains) {
 		return AccessPublic
 	}
 	return AccessUser

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -42,7 +42,7 @@ func init() {
 // Config used in tests.
 var testConfig = &GlobalConfig{
 	AccessLevel: AccessPublic,
-	AuthDomain:  "@syzkaller.com",
+	AuthDomains: []string{"@syzkaller.com"},
 	Clients: map[string]string{
 		"reporting": "reportingkeyreportingkeyreportingkey",
 	},

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -26,8 +26,8 @@ import (
 type GlobalConfig struct {
 	// Min access levels specified hierarchically throughout the config.
 	AccessLevel AccessLevel
-	// Email suffix of authorized users (e.g. "@foobar.com").
-	AuthDomain string
+	// Email suffixes of authorized users (e.g. []string{"@foo.com","@bar.org"}).
+	AuthDomains []string
 	// Google Analytics Tracking ID.
 	AnalyticsTrackingID string
 	// URL prefix of source coverage reports.

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/mail"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -452,6 +453,15 @@ func checkConfig(cfg *GlobalConfig) {
 		checkNamespace(ns, cfg, namespaces, clientNames)
 	}
 	checkDiscussionEmails(cfg.DiscussionEmails)
+	checkAuthDomains(cfg.AuthDomains)
+}
+
+func checkAuthDomains(list []string) {
+	for _, domain := range list {
+		if !strings.HasPrefix(domain, "@") {
+			panic(fmt.Sprintf("authentication domain %s doesn't start with @", domain))
+		}
+	}
 }
 
 func checkDiscussionEmails(list []DiscussionEmailConfig) {

--- a/docs/setup_syzbot.md
+++ b/docs/setup_syzbot.md
@@ -247,7 +247,7 @@ func init() {
 }
 var prodConfig = &GlobalConfig{
         AccessLevel:         AccessPublic,
-        AuthDomain:          "@google.com",
+        AuthDomains:         []string{"@google.com"},
         CoverPath:           "https://storage.googleapis.com/syzkaller/cover/",
         Clients: map[string]string{
                 "$CI_HOSTNAME":     "$CI_KEY",


### PR DESCRIPTION
In some situations, it could be useful to share access to the dashboard to multiple authentication domains. The current GlobalConfig format doesn't really allow it so this deprecates the existing field and add a new slice of allowed authentication domains.