### PR TITLE
tools/syz-env: add local build option and consider HTTP proxy environment variables

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -151,6 +151,12 @@ docker pull docker.pkg.github.com/google/syzkaller/env
 docker tag docker.pkg.github.com/google/syzkaller/env gcr.io/syzkaller/env
 ```
 
+You can also build the container from the respective `Dockerfile` by setting the `SYZ_ENV_BUILD` environment variable, i.e.:
+```
+SYZ_ENV_BUILD=1 syz-env
+```
+This can be useful to test local changes that have not been pushed to the registry yet.
+
 ### Using [act](https://github.com/nektos/act)
 .github/workflows has more tests compared to `syz-env make presubmit`. To have the same tests as the workflow, we can run these workflow jobs locally.
 ```

--- a/tools/syz-env
+++ b/tools/syz-env
@@ -25,8 +25,21 @@
 # (Googlers see go/docker).
 
 COMMAND=""
+BUILDARGS=()
 DOCKERARGS=()
-[ -n $https_proxy ] && DOCKERARGS+=" --env https_proxy=$https_proxy"
+if [ -n $http_proxy ]; then
+	BUILDARGS+=" --build-arg http_proxy=$http_proxy"
+	DOCKERARGS+=" --env http_proxy=$http_proxy"
+fi
+if [ -n $https_proxy ]; then
+	BUILDARGS+=" --build-arg https_proxy=$https_proxy"
+	DOCKERARGS+=" --env https_proxy=$https_proxy"
+fi
+if [ -n $no_proxy ]; then
+	BUILDARGS+=" --build-arg no_proxy=$no_proxy"
+	DOCKERARGS+=" --env no_proxy=$no_proxy"
+fi
+
 for ARG in "$@"; do
 	while IFS='=' read KEY VAL; do
 		# If we have a kernel path passed in, we mount it in the container

--- a/tools/syz-env
+++ b/tools/syz-env
@@ -62,8 +62,15 @@ if [ ! "$(docker info -f "{{println .SecurityOptions}}" | grep rootless)" ]; the
 	DOCKERARGS+=" --user $(id -u ${USER}):$(id -g ${USER})"
 fi
 
-# Update docker image
-docker pull -q gcr.io/syzkaller/${IMAGE}
+
+# Build or update docker image
+if [ ! -z "$SYZ_ENV_BUILD" ]; then
+	IMAGE_NAME="syz-$IMAGE"
+	docker build "$SCRIPT_DIR/docker/$IMAGE" --tag "$IMAGE_NAME" ${BUILDARGS[@]}
+else
+	IMAGE_NAME="gcr.io/syzkaller/$IMAGE"
+	docker pull -q "$IMAGE_NAME"
+fi
 
 # Run everything as the host user, this is important for created/modified files.
 docker run \
@@ -82,4 +89,4 @@ docker run \
 	--env GITHUB_PR_COMMITS \
 	--env CI \
 	${DOCKERARGS[@]} \
-	gcr.io/syzkaller/${IMAGE} -c "$COMMAND"
+	"$IMAGE_NAME" -c "$COMMAND"


### PR DESCRIPTION
Useful for testing local Dockerfile changes that have not been pushed yet.

In extension of commit 326f9c5a1cae ("tools/syz-env: export https_proxy to docker in case behind proxy"), cover further HTTP proxy environment variables and the Docker build process.