### PR TITLE
Fix kernel clean tasks

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -49,6 +49,15 @@ type ImageDetails struct {
 	CompilerID string
 }
 
+func sanitize(params *Params) {
+	if params.Tracer == nil {
+		params.Tracer = &debugtracer.NullTracer{}
+	}
+	if params.BuildCPUs == 0 {
+		params.BuildCPUs = runtime.NumCPU()
+	}
+}
+
 // Image creates a disk image for the specified OS/ARCH/VM.
 // Kernel is taken from KernelDir, userspace system is taken from UserspaceDir.
 // If CmdlineFile is not empty, contents of the file are appended to the kernel command line.
@@ -71,12 +80,7 @@ type ImageDetails struct {
 // the version of the compiler/toolchain that was used to build the kernel.
 // The CompilerID field is not guaranteed to be non-empty.
 func Image(params Params) (details ImageDetails, err error) {
-	if params.Tracer == nil {
-		params.Tracer = &debugtracer.NullTracer{}
-	}
-	if params.BuildCPUs == 0 {
-		params.BuildCPUs = runtime.NumCPU()
-	}
+	sanitize(&params)
 	var builder builder
 	builder, err = getBuilder(params.TargetOS, params.TargetArch, params.VMType)
 	if err != nil {
@@ -114,6 +118,7 @@ func Image(params Params) (details ImageDetails, err error) {
 }
 
 func Clean(params Params) error {
+	sanitize(&params)
 	builder, err := getBuilder(params.TargetOS, params.TargetArch, params.VMType)
 	if err != nil {
 		return err

--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -6,7 +6,6 @@ package build
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -121,7 +120,7 @@ sudo mdconfig -d -u ${md#md}
 
 func (ctx freebsd) clean(params Params) error {
 	objPrefix := filepath.Join(params.KernelDir, "obj")
-	_, err := ctx.make(params.KernelDir, objPrefix, runtime.NumCPU(), "cleanworld")
+	_, err := ctx.make(params.KernelDir, objPrefix, params.BuildCPUs, "cleanworld")
 	return err
 }
 

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -88,7 +87,7 @@ func (ctx netbsd) build(params Params) (ImageDetails, error) {
 
 func (ctx netbsd) clean(params Params) error {
 	_, err := osutil.RunCmd(10*time.Minute, params.KernelDir, "./build.sh", "-m", params.TargetArch,
-		"-U", "-j"+strconv.Itoa(runtime.NumCPU()), "cleandir")
+		"-U", "-j"+strconv.Itoa(params.BuildCPUs), "cleandir")
 	return err
 }
 


### PR DESCRIPTION
It was reported in https://groups.google.com/g/syzkaller/c/GV3JjN6RrPk that linux kernel clean tasks call make with "-j0" this is because the clean function wasn't replicating the build function's default number of CPUs.

While I was at it, I also rationalised a couple of OS-specific implementations of the clean function that were extracting the number of CPUs themselves.