### PR TITLE
pkg/manager: lower the broken seed error message

### DIFF
--- a/pkg/manager/seeds.go
+++ b/pkg/manager/seeds.go
@@ -100,7 +100,7 @@ func LoadSeeds(cfg *mgrconfig.Config, immutable bool) Seeds {
 		if inp.Prog == nil {
 			if inp.IsSeed {
 				brokenSeeds++
-				log.Errorf("seed %s is broken: %s", inp.Path, inp.Err)
+				log.Logf(0, "seed %s is broken: %s", inp.Path, inp.Err)
 			} else {
 				brokenCorpus = append(brokenCorpus, inp.Key)
 			}


### PR DESCRIPTION
Some seeds are arch-dependent, so it's to be expected that we do not take them.

Ideally we should have been parsing the conditions in pkg/manager as well, but for now it does not seem to be worth the refactoring effort.
