### PR TITLE
dashboard/app: tune repro export

### DIFF
--- a/dashboard/app/batch_reproexport.go
+++ b/dashboard/app/batch_reproexport.go
@@ -27,10 +27,11 @@ func handleBatchReproExport(w http.ResponseWriter, r *http.Request) {
 
 func exportReproScript(srcNamespace, archivePath string) string {
 	return "\n" +
-		"git clone --depth 1 --branch master --single-branch https://github.com/google/syzkaller\n" +
+		"git clone -q --depth 1 --branch master --single-branch https://github.com/google/syzkaller\n" +
 		"cd syzkaller\n" +
-		"./tools/syz-env \"" +
-		"go run ./tools/syz-reprolist/... -namespace " + srcNamespace + " && " +
+		"token=$(gcloud auth print-access-token)\n" +
+		"CI=1 ./tools/syz-env \"" + // CI=1 to suppress "The input device is not a TTY".
+		"go run ./tools/syz-reprolist/... -namespace " + srcNamespace + " -token $token -j 10 && " +
 		"tar -czvf reproducers.tar.gz ./repros/ && " +
 		"gsutil -m cp reproducers.tar.gz " + archivePath +
 		"\""


### PR DESCRIPTION
1. Silent git clone to not write "Cloning syzkaller..." into stderr.
2. Download in 10 threads to speed up testing.
3. Use gcloud token to bypass throttling.
4. CI=1 to stop writing warnings into stderr.

