### PR TITLE
dashboard/app: introduce authorized access to public resources

### DIFF
--- a/dashboard/app/access_test.go
+++ b/dashboard/app/access_test.go
@@ -468,6 +468,7 @@ func TestUserAccessLevel(t *testing.T) {
 		enforcedAccessLevel string
 		config              *GlobalConfig
 		wantAccessLevel     AccessLevel
+		wantIsAuthorized    bool
 	}{
 		{
 			name:            "wrong auth domain",
@@ -514,10 +515,11 @@ func TestUserAccessLevel(t *testing.T) {
 			wantAccessLevel:     AccessPublic,
 		},
 		{
-			name:            "authorized for AccessPublic user",
-			u:               makeUser(AuthorizedAccessPublic),
-			config:          testConfig,
-			wantAccessLevel: AccessPublic,
+			name:             "authorized for AccessPublic user",
+			u:                makeUser(AuthorizedAccessPublic),
+			config:           testConfig,
+			wantAccessLevel:  AccessPublic,
+			wantIsAuthorized: true,
 		},
 		{
 			name:                "authorized for AccessPublic user wants to be an admin",
@@ -525,6 +527,7 @@ func TestUserAccessLevel(t *testing.T) {
 			enforcedAccessLevel: "admin",
 			config:              testConfig,
 			wantAccessLevel:     AccessPublic,
+			wantIsAuthorized:    true,
 		},
 		{
 			name:                "authorized for AccessPublic user wants to be a user",
@@ -532,12 +535,14 @@ func TestUserAccessLevel(t *testing.T) {
 			enforcedAccessLevel: "user",
 			config:              testConfig,
 			wantAccessLevel:     AccessPublic,
+			wantIsAuthorized:    true,
 		},
 		{
-			name:            "authorized for AccessUser user",
-			u:               makeUser(AuthorizedUser),
-			config:          testConfig,
-			wantAccessLevel: AccessUser,
+			name:             "authorized for AccessUser user",
+			u:                makeUser(AuthorizedUser),
+			config:           testConfig,
+			wantAccessLevel:  AccessUser,
+			wantIsAuthorized: true,
 		},
 		{
 			name:                "authorized for AccessUser user wants to be an admin",
@@ -545,12 +550,14 @@ func TestUserAccessLevel(t *testing.T) {
 			enforcedAccessLevel: "admin",
 			config:              testConfig,
 			wantAccessLevel:     AccessUser,
+			wantIsAuthorized:    true,
 		},
 		{
-			name:            "authorized admin wants AccessAdmin",
-			u:               makeUser(AuthorizedAdmin),
-			config:          testConfig,
-			wantAccessLevel: AccessAdmin,
+			name:             "authorized admin wants AccessAdmin",
+			u:                makeUser(AuthorizedAdmin),
+			config:           testConfig,
+			wantAccessLevel:  AccessAdmin,
+			wantIsAuthorized: true,
 		},
 		{
 			name:                "authorized admin wants AccessPublic",
@@ -558,6 +565,7 @@ func TestUserAccessLevel(t *testing.T) {
 			enforcedAccessLevel: "public",
 			config:              testConfig,
 			wantAccessLevel:     AccessPublic,
+			wantIsAuthorized:    true,
 		},
 		{
 			name:                "authorized admin wants AccessUser",
@@ -565,11 +573,14 @@ func TestUserAccessLevel(t *testing.T) {
 			enforcedAccessLevel: "user",
 			config:              testConfig,
 			wantAccessLevel:     AccessUser,
+			wantIsAuthorized:    true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.wantAccessLevel, userAccessLevel(test.u, test.enforcedAccessLevel, test.config))
+			gotIsAuthorized, gotAccessLevel := userAccessLevel(test.u, test.enforcedAccessLevel, test.config)
+			assert.Equal(t, test.wantAccessLevel, gotAccessLevel)
+			assert.Equal(t, test.wantIsAuthorized, gotIsAuthorized)
 		})
 	}
 }

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -42,7 +42,16 @@ func init() {
 // Config used in tests.
 var testConfig = &GlobalConfig{
 	AccessLevel: AccessPublic,
-	AuthDomains: []string{"@syzkaller.com"},
+	ACL: []*ACLItem{
+		{
+			Domain: "syzkaller.com",
+			Access: AccessUser,
+		},
+		{
+			Email:  makeUser(AuthorizedAccessPublic).Email,
+			Access: AccessPublic,
+		},
+	},
 	Clients: map[string]string{
 		"reporting": "reportingkeyreportingkeyreportingkey",
 	},

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -33,7 +33,8 @@ func handleContext(fn contextHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := appengine.NewContext(r)
 		c = context.WithValue(c, &currentURLKey, r.URL.RequestURI())
-		if accessLevel(c, r) == AccessPublic {
+		authorizedUser, _ := userAccessLevel(currentUser(c), "", getConfig(c))
+		if !authorizedUser {
 			if !throttleRequest(c, w, r) {
 				return
 			}


### PR DESCRIPTION
1. This PR unit test the accessLevel function internals and
2. Introduces the authorized AccessPublic requests

We need AccessPublic authorization primarily to stop throttling our own service accounts.