### PR TITLE
tooks/docker/syzbot: git config --system not --global

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get install -y -q ca-certificates \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update && apt-get install -y google-cloud-cli
-RUN git config --global credential.'https://*.*.sourcemanager.dev'.helper gcloud.sh
+RUN git config --system credential.'https://*.*.sourcemanager.dev'.helper gcloud.sh
 
 # pkg/osutil uses syzkaller user for sandboxing.
 RUN useradd --create-home syzkaller


### PR DESCRIPTION
We need these changes to make "git config" available for "syzkaller" user.
Let's make it a --system wide config to also enable it for root.
It'll be easier to copy-paste it later to syz-env (just in case).
