### PR TITLE
tools: add a syz-diff tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,9 @@ repro: descriptions
 mutate: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-mutate github.com/google/syzkaller/tools/syz-mutate
 
+diff: descriptions target
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-diff github.com/google/syzkaller/tools/syz-diff
+
 prog2c: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-prog2c github.com/google/syzkaller/tools/syz-prog2c
 

--- a/pkg/corpus/prio_test.go
+++ b/pkg/corpus/prio_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChooseProgram(t *testing.T) {
@@ -31,13 +32,13 @@ func TestChooseProgram(t *testing.T) {
 		if sizeSig%250 == 0 {
 			sizeSig = 0
 		}
-		inp := generateInput(target, rs, 10, sizeSig)
+		inp := generateInput(target, rs, sizeSig)
 		corpus.Save(inp)
 		priorities[inp.Prog] = int64(len(inp.Signal))
 	}
 	counters := make(map[*prog.Prog]int)
 	for it := 0; it < maxIters; it++ {
-		counters[corpus.ChooseProgram(r)]++
+		counters[corpus.chooseProgram(r)]++
 	}
 	for p, prio := range priorities {
 		prob := float64(prio) / float64(corpus.sumPrios)
@@ -46,4 +47,74 @@ func TestChooseProgram(t *testing.T) {
 			t.Fatalf("the difference (%f) is higher than %f%%", diff, eps*100)
 		}
 	}
+}
+
+func TestFocusAreas(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewCorpus(context.Background())
+	corpus.SetFocusAreas([]FocusArea{
+		{
+			CoverPCs: map[uint64]struct{}{
+				0: {},
+				1: {},
+				2: {},
+			},
+			Weight: 10,
+		},
+		{
+			CoverPCs: map[uint64]struct{}{
+				2: {},
+				3: {},
+			},
+			Weight: 30,
+		},
+		{
+			CoverPCs: map[uint64]struct{}{
+				4: {},
+				5: {},
+			},
+			Weight: 60,
+		},
+	})
+
+	rs := rand.NewSource(0)
+
+	fillGroup := func(from, to, count int) map[*prog.Prog]bool {
+		ret := map[*prog.Prog]bool{}
+		for i := 0; i < count; i++ {
+			a := from + i%(to-from+1)
+			b := a + i%(to-a+1)
+			inp := generateRangedInput(target, rs, a, b)
+			ret[inp.Prog] = true
+			corpus.Save(inp)
+		}
+		return ret
+	}
+
+	first := fillGroup(0, 1, 10)
+	second := fillGroup(2, 3, 10)
+	third := fillGroup(4, 5, 10)
+
+	rnd := rand.New(rs)
+	different := map[*prog.Prog]bool{}
+	firstCount, secondCount, thirdCount := 0, 0, 0
+	const TOTAL = 10000
+	for i := 0; i < TOTAL; i++ {
+		p := corpus.ChooseProgram(rnd)
+		different[p] = true
+
+		if first[p] {
+			firstCount++
+		} else if second[p] {
+			secondCount++
+		} else if third[p] {
+			thirdCount++
+		}
+	}
+
+	assert.Greater(t, len(different), 25)
+	// These must be proportional to the focus area weight distribution.
+	assert.InDelta(t, firstCount, TOTAL*0.1, TOTAL/25)
+	assert.InDelta(t, secondCount, TOTAL*0.3, TOTAL/25)
+	assert.InDelta(t, thirdCount, TOTAL*0.6, TOTAL/25)
 }

--- a/pkg/corpus/prio_test.go
+++ b/pkg/corpus/prio_test.go
@@ -51,8 +51,7 @@ func TestChooseProgram(t *testing.T) {
 
 func TestFocusAreas(t *testing.T) {
 	target := getTarget(t, targets.TestOS, targets.TestArch64)
-	corpus := NewCorpus(context.Background())
-	corpus.SetFocusAreas([]FocusArea{
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{
 		{
 			CoverPCs: map[uint64]struct{}{
 				0: {},

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -348,7 +348,11 @@ func (job *triageJob) minimize(call int, info *triageCall) (*prog.Prog, int) {
 		minimizeAttempts = 2
 	}
 	stop := false
-	p, call := prog.Minimize(job.p, call, prog.MinimizeCorpus, func(p1 *prog.Prog, call1 int) bool {
+	mode := prog.MinimizeCorpus
+	if job.fuzzer.Config.PatchTest {
+		mode = prog.MinimizeCallsOnly
+	}
+	p, call := prog.Minimize(job.p, call, mode, func(p1 *prog.Prog, call1 int) bool {
 		if stop {
 			return false
 		}

--- a/pkg/fuzzer/queue/stats.go
+++ b/pkg/fuzzer/queue/stats.go
@@ -7,10 +7,6 @@ import "github.com/google/syzkaller/pkg/stat"
 
 // Common stats related to fuzzing that are updated/read by different parts of the system.
 var (
-	StatExecs = stat.New("exec total", "Total test program executions",
-		stat.Console, stat.Rate{}, stat.Prometheus("syz_exec_total"))
-	StatNumFuzzing = stat.New("fuzzing VMs", "Number of VMs that are currently fuzzing",
-		stat.Console, stat.Link("/vms"))
 	StatNoExecRequests = stat.New("no exec requests",
 		"Number of times fuzzer was stalled with no exec requests", stat.Rate{})
 	StatNoExecDuration = stat.New("no exec duration",

--- a/pkg/manager/covfilter.go
+++ b/pkg/manager/covfilter.go
@@ -17,7 +17,8 @@ import (
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
-func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCfg) (map[uint64]struct{}, error) {
+func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCfg,
+	strict bool) (map[uint64]struct{}, error) {
 	if covCfg.Empty() {
 		return nil, nil
 	}
@@ -31,7 +32,7 @@ func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCf
 			apply(&sym.ObjectUnit)
 		}
 	}
-	if err := covFilterAddFilter(pcs, covCfg.Functions, foreachSymbol); err != nil {
+	if err := covFilterAddFilter(pcs, covCfg.Functions, foreachSymbol, strict); err != nil {
 		return nil, err
 	}
 	foreachUnit := func(apply func(*backend.ObjectUnit)) {
@@ -39,7 +40,7 @@ func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCf
 			apply(&unit.ObjectUnit)
 		}
 	}
-	if err := covFilterAddFilter(pcs, covCfg.Files, foreachUnit); err != nil {
+	if err := covFilterAddFilter(pcs, covCfg.Files, foreachUnit, strict); err != nil {
 		return nil, err
 	}
 	if err := covFilterAddRawPCs(pcs, covCfg.RawPCs); err != nil {
@@ -49,7 +50,8 @@ func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCf
 	return pcs, nil
 }
 
-func covFilterAddFilter(pcs map[uint64]struct{}, filters []string, foreach func(func(*backend.ObjectUnit))) error {
+func covFilterAddFilter(pcs map[uint64]struct{}, filters []string, foreach func(func(*backend.ObjectUnit)),
+	strict bool) error {
 	res, err := compileRegexps(filters)
 	if err != nil {
 		return err
@@ -75,7 +77,7 @@ func covFilterAddFilter(pcs map[uint64]struct{}, filters []string, foreach func(
 		sort.Strings(used[re])
 		log.Logf(0, "coverage filter: %v: %v", re, used[re])
 	}
-	if len(res) != len(used) {
+	if strict && len(res) != len(used) {
 		return fmt.Errorf("some filters don't match anything")
 	}
 	return nil
@@ -134,11 +136,12 @@ type CoverageFilters struct {
 	ExecutorFilter map[uint64]struct{}
 }
 
-func PrepareCoverageFilters(source *ReportGeneratorWrapper, cfg *mgrconfig.Config) (CoverageFilters, error) {
+func PrepareCoverageFilters(source *ReportGeneratorWrapper, cfg *mgrconfig.Config,
+	strict bool) (CoverageFilters, error) {
 	var ret CoverageFilters
 	needExecutorFilter := len(cfg.Experimental.FocusAreas) > 0
 	for _, area := range cfg.Experimental.FocusAreas {
-		pcs, err := CoverageFilter(source, area.Filter)
+		pcs, err := CoverageFilter(source, area.Filter, strict)
 		if err != nil {
 			return ret, err
 		}

--- a/pkg/manager/covfilter.go
+++ b/pkg/manager/covfilter.go
@@ -11,19 +11,19 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/google/syzkaller/pkg/corpus"
 	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 )
 
-func CreateCoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCfg) ([]uint64,
-	map[uint64]struct{}, error) {
+func CoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFilterCfg) (map[uint64]struct{}, error) {
 	if covCfg.Empty() {
-		return nil, nil, nil
+		return nil, nil
 	}
 	rg, err := source.Get()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	pcs := make(map[uint64]struct{})
 	foreachSymbol := func(apply func(*backend.ObjectUnit)) {
@@ -32,7 +32,7 @@ func CreateCoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFi
 		}
 	}
 	if err := covFilterAddFilter(pcs, covCfg.Functions, foreachSymbol); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	foreachUnit := func(apply func(*backend.ObjectUnit)) {
 		for _, unit := range rg.Units {
@@ -40,23 +40,13 @@ func CreateCoverageFilter(source *ReportGeneratorWrapper, covCfg mgrconfig.CovFi
 		}
 	}
 	if err := covFilterAddFilter(pcs, covCfg.Files, foreachUnit); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := covFilterAddRawPCs(pcs, covCfg.RawPCs); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	// Copy pcs into execPCs. This is used to filter coverage in the executor.
-	execPCs := make([]uint64, 0, len(pcs))
-	for pc := range pcs {
-		execPCs = append(execPCs, pc)
-	}
-	// PCs from CMPs are deleted to calculate `filtered coverage` statistics.
-	for _, sym := range rg.Symbols {
-		for _, pc := range sym.CMPs {
-			delete(pcs, pc)
-		}
-	}
-	return execPCs, pcs, nil
+	// Note that pcs may include both comparison and block/edge coverage callbacks.
+	return pcs, nil
 }
 
 func covFilterAddFilter(pcs map[uint64]struct{}, filters []string, foreach func(func(*backend.ObjectUnit))) error {
@@ -137,4 +127,44 @@ func compileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
 		regexps = append(regexps, r)
 	}
 	return regexps, nil
+}
+
+type CoverageFilters struct {
+	Areas          []corpus.FocusArea
+	ExecutorFilter map[uint64]struct{}
+}
+
+func PrepareCoverageFilters(source *ReportGeneratorWrapper, cfg *mgrconfig.Config) (CoverageFilters, error) {
+	var ret CoverageFilters
+	needExecutorFilter := len(cfg.Experimental.FocusAreas) > 0
+	for _, area := range cfg.Experimental.FocusAreas {
+		pcs, err := CoverageFilter(source, area.Filter)
+		if err != nil {
+			return ret, err
+		}
+		// KCOV will point to the next instruction, so we need to adjust the map.
+		covPCs := make(map[uint64]struct{})
+		for pc := range pcs {
+			next := backend.NextInstructionPC(cfg.SysTarget, cfg.Type, pc)
+			covPCs[next] = struct{}{}
+		}
+		ret.Areas = append(ret.Areas, corpus.FocusArea{
+			Name:     area.Name,
+			CoverPCs: covPCs,
+			Weight:   area.Weight,
+		})
+		if area.Filter.Empty() {
+			// An empty cover filter indicates that the user is interested in all the coverage.
+			needExecutorFilter = false
+		}
+	}
+	if needExecutorFilter {
+		ret.ExecutorFilter = map[uint64]struct{}{}
+		for _, area := range ret.Areas {
+			for pc := range area.CoverPCs {
+				ret.ExecutorFilter[pc] = struct{}{}
+			}
+		}
+	}
+	return ret, nil
 }

--- a/pkg/manager/crash.go
+++ b/pkg/manager/crash.go
@@ -306,11 +306,11 @@ func (cs *CrashStore) BugList() ([]*BugInfo, error) {
 	return ret, nil
 }
 
-func (cs *CrashStore) titleToID(title string) string {
+func crashHash(title string) string {
 	sig := hash.Hash([]byte(title))
 	return sig.String()
 }
 
 func (cs *CrashStore) path(title string) string {
-	return filepath.Join(cs.BaseDir, "crashes", cs.titleToID(title))
+	return filepath.Join(cs.BaseDir, "crashes", crashHash(title))
 }

--- a/pkg/manager/crash_test.go
+++ b/pkg/manager/crash_test.go
@@ -76,7 +76,7 @@ func TestMaxCrashLogs(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	info, err := crashStore.BugInfo(crashStore.titleToID("Title A"), false)
+	info, err := crashStore.BugInfo(crashHash("Title A"), false)
 	assert.NoError(t, err)
 	assert.Len(t, info.Crashes, 5)
 }
@@ -105,7 +105,7 @@ func TestCrashRepro(t *testing.T) {
 	}, []byte("prog text"), []byte("c prog text"))
 	assert.NoError(t, err)
 
-	report, err := crashStore.Report(crashStore.titleToID("Some title"))
+	report, err := crashStore.Report(crashHash("Some title"))
 	assert.NoError(t, err)
 	assert.Equal(t, "Some title", report.Title)
 	assert.Equal(t, "abcd", report.Tag)

--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -1,0 +1,139 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package manager
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+type DiffBug struct {
+	Title   string
+	Base    DiffBugInfo
+	Patched DiffBugInfo
+}
+
+func (bug DiffBug) PatchedOnly() bool {
+	return bug.Base.NotCrashed && bug.Patched.Crashes > 0
+}
+
+func (bug DiffBug) AffectsBoth() bool {
+	return bug.Base.Crashes > 0 && bug.Patched.Crashes > 0
+}
+
+type DiffBugInfo struct {
+	Crashes    int  // Count of detected crashes.
+	NotCrashed bool // If were proven not to crash by running a repro.
+
+	// File paths.
+	Report   string
+	Repro    string
+	ReproLog string
+	CrashLog string
+}
+
+// DiffFuzzerStore provides the functionality of a database of the patch fuzzing.
+type DiffFuzzerStore struct {
+	BasePath string
+
+	mu   sync.Mutex
+	bugs map[string]*DiffBug
+}
+
+func (s *DiffFuzzerStore) BaseCrashed(title string, report []byte) {
+	s.patch(title, func(obj *DiffBug) {
+		obj.Base.Crashes++
+		if len(report) > 0 {
+			obj.Base.Report = s.saveFile(title, "base_report", report)
+		}
+	})
+}
+
+func (s *DiffFuzzerStore) EverCrashedBase(title string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	obj := s.bugs[title]
+	return obj != nil && obj.Base.Crashes > 0
+}
+
+func (s *DiffFuzzerStore) BaseNotCrashed(title string) {
+	s.patch(title, func(obj *DiffBug) {
+		if obj.Base.Crashes == 0 {
+			obj.Base.NotCrashed = true
+		}
+	})
+}
+
+func (s *DiffFuzzerStore) PatchedCrashed(title string, report, log []byte) {
+	s.patch(title, func(obj *DiffBug) {
+		obj.Patched.Crashes++
+		if len(report) > 0 {
+			obj.Patched.Report = s.saveFile(title, "patched_report", report)
+		}
+		if len(log) > 0 && obj.Patched.CrashLog == "" {
+			obj.Patched.CrashLog = s.saveFile(title, "patched_crash_log", log)
+		}
+	})
+}
+
+func (s *DiffFuzzerStore) SaveRepro(result *ReproResult) {
+	title := result.Crash.Report.Title
+	if result.Repro != nil {
+		// If there's a repro, save under the new title.
+		title = result.Repro.Report.Title
+	}
+
+	now := time.Now().Unix()
+	crashLog := fmt.Sprintf("%v.crash.log", now)
+	s.saveFile(title, crashLog, result.Crash.Output)
+	log.Logf(0, "%q: saved crash log into %s", title, crashLog)
+
+	s.patch(title, func(obj *DiffBug) {
+		if result.Repro != nil {
+			obj.Patched.Repro = s.saveFile(title, reproFileName, result.Repro.Prog.Serialize())
+		}
+		if result.Stats != nil {
+			reproLog := fmt.Sprintf("%v.repro.log", now)
+			obj.Patched.ReproLog = s.saveFile(title, reproLog, result.Stats.FullLog())
+			log.Logf(0, "%q: saved repro log into %s", title, reproLog)
+		}
+	})
+}
+
+func (s *DiffFuzzerStore) List() []DiffBug {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var list []DiffBug
+	for _, obj := range s.bugs {
+		list = append(list, *obj)
+	}
+	return list
+}
+
+func (s *DiffFuzzerStore) saveFile(title, name string, data []byte) string {
+	hash := crashHash(title)
+	path := filepath.Join(s.BasePath, "crashes", hash)
+	osutil.MkdirAll(path)
+	osutil.WriteFile(filepath.Join(path, name), data)
+	return filepath.Join("crashes", hash, name)
+}
+
+func (s *DiffFuzzerStore) patch(title string, cb func(*DiffBug)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bugs == nil {
+		s.bugs = map[string]*DiffBug{}
+	}
+	obj, ok := s.bugs[title]
+	if !ok {
+		obj = &DiffBug{Title: title}
+		s.bugs[title] = obj
+	}
+	cb(obj)
+}

--- a/pkg/manager/report_generator.go
+++ b/pkg/manager/report_generator.go
@@ -68,3 +68,12 @@ func CoverToPCs(cfg *mgrconfig.Config, cov []uint64) []uint64 {
 	}
 	return pcs
 }
+
+func PCsToCover(cfg *mgrconfig.Config, pcs map[uint64]struct{}) map[uint64]struct{} {
+	ret := make(map[uint64]struct{})
+	for pc := range pcs {
+		next := backend.NextInstructionPC(cfg.SysTarget, cfg.Type, pc)
+		ret[next] = struct{}{}
+	}
+	return ret
+}

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -322,7 +322,7 @@ func (ctx *reproContext) extractProg(entries []*prog.LogEntry) (*Result, error) 
 		}
 	}
 
-	ctx.reproLogf(0, "failed to extract reproducer")
+	ctx.reproLogf(2, "failed to extract reproducer")
 	return nil, nil
 }
 
@@ -417,7 +417,7 @@ func (ctx *reproContext) concatenateProgs(entries []*prog.LogEntry, dur time.Dur
 		// There's a risk of exceeding prog.MaxCalls, so let's first minimize
 		// all entries separately.
 		for i := 0; i < len(entries); i++ {
-			ctx.reproLogf(1, "minimizing program #%d before concatenation", i)
+			ctx.reproLogf(2, "minimizing program #%d before concatenation", i)
 			callsBefore := len(entries[i].P.Calls)
 			entries[i].P, _ = prog.Minimize(entries[i].P, -1, prog.MinimizeCallsOnly,
 				func(p1 *prog.Prog, _ int) bool {
@@ -438,7 +438,7 @@ func (ctx *reproContext) concatenateProgs(entries []*prog.LogEntry, dur time.Dur
 					}
 					return ret.Crashed
 				})
-			ctx.reproLogf(1, "minimized %d calls -> %d calls", callsBefore, len(entries[i].P.Calls))
+			ctx.reproLogf(2, "minimized %d calls -> %d calls", callsBefore, len(entries[i].P.Calls))
 		}
 	}
 	p := &prog.Prog{
@@ -489,7 +489,7 @@ func (ctx *reproContext) minimizeProg(res *Result) (*Result, error) {
 		}
 		ret, err := ctx.testProg(p1, res.Duration, res.Opts, false)
 		if err != nil {
-			ctx.reproLogf(0, "minimization failed with %v", err)
+			ctx.reproLogf(2, "minimization failed with %v", err)
 			return false
 		}
 		return ret.Crashed

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -43,6 +43,7 @@ func RunLocal(cfg *LocalConfig) error {
 	cfg.FilterSignal = true
 	cfg.RPC = ":0"
 	cfg.PrintMachineCheck = log.V(1)
+	cfg.Stats = NewStats()
 	ctx := &local{
 		cfg:       cfg,
 		setupDone: make(chan bool),

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -103,12 +104,27 @@ type Stats struct {
 }
 
 func NewStats() Stats {
+	return NewNamedStats("")
+}
+
+func NewNamedStats(name string) Stats {
+	suffix := name
+	if suffix != "" {
+		suffix = " [" + suffix + "]"
+	}
+	vmsLink := "/vms"
+	if name != "" {
+		vmsLink += "?pool=" + url.QueryEscape(name)
+	}
 	return Stats{
-		StatExecs: stat.New("exec total", "Total test program executions",
-			stat.Console, stat.Rate{}, stat.Prometheus("syz_exec_total")),
-		StatNumFuzzing: stat.New("fuzzing VMs",
-			"Number of VMs that are currently fuzzing", stat.Graph("fuzzing VMs")),
-		StatVMRestarts: stat.New("vm restarts", "Total number of VM starts",
+		StatExecs: stat.New("exec total"+suffix, "Total test program executions",
+			stat.Console, stat.Rate{}, stat.Prometheus("syz_exec_total"+name),
+		),
+		StatNumFuzzing: stat.New("fuzzing VMs"+suffix,
+			"Number of VMs that are currently fuzzing", stat.Graph("fuzzing VMs"),
+			stat.Link(vmsLink),
+		),
+		StatVMRestarts: stat.New("vm restarts"+suffix, "Total number of VM starts",
 			stat.Rate{}, stat.NoGraph),
 	}
 }

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -80,7 +80,7 @@ func TestNew(t *testing.T) {
 			cfg.Target, err = prog.GetTarget(cfg.TargetOS, cfg.TargetArch)
 			assert.NoError(t, err)
 
-			serv, err := New(cfg, nil, tt.debug)
+			serv, err := New(cfg, nil, NewStats(), tt.debug)
 			if tt.expectedErr != nil {
 				assert.Equal(t, tt.expectedErr, err)
 			} else if tt.expectsErr {
@@ -195,7 +195,7 @@ func TestHandleConn(t *testing.T) {
 			cfg.Target.Revision = tt.req.SyzRevision
 			assert.NoError(t, err)
 
-			s, err := New(cfg, managerMock, debug)
+			s, err := New(cfg, managerMock, NewStats(), debug)
 			assert.NoError(t, err)
 			serv := s.(*server)
 

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -654,3 +654,14 @@ func (git *git) PushCommit(repo, commit string) error {
 	}
 	return nil
 }
+
+var fileNameRe = regexp.MustCompile(`(?m)^diff.* b\/([^\s]+)`)
+
+// ParseGitDiff extracts the files modified in the git patch.
+func ParseGitDiff(patch []byte) []string {
+	var files []string
+	for _, match := range fileNameRe.FindAllStringSubmatch(string(patch), -1) {
+		files = append(files, match[1])
+	}
+	return files
+}

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -462,3 +462,25 @@ func TestGitFetchShortHash(t *testing.T) {
 	_, err := local.CheckoutCommit(remoteRepoDir, refCommit.Hash[:12])
 	assert.NoError(t, err)
 }
+
+func TestParseGitDiff(t *testing.T) {
+	files := ParseGitDiff([]byte(`diff --git a/a.txt b/a.txt
+index 4c5fd91..8fe1e32 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-First file
++First file!
+diff --git a/b.txt b/b.txt
+new file mode 100644
+index 0000000..f8a9677
+--- /dev/null
++++ b/b.txt
+@@ -0,0 +1 @@
++Second file.
+diff --git a/c/c.txt b/c/c.txt
+new file mode 100644
+index 0000000..e69de29
+`))
+	assert.ElementsMatch(t, files, []string{"a.txt", "b.txt", "c/c.txt"})
+}

--- a/prog/meta.go
+++ b/prog/meta.go
@@ -8,12 +8,18 @@ import (
 	"time"
 )
 
+const defaultGitRevision = "unknown"
+
 var (
-	GitRevision     = "unknown" // emitted by Makefile, may contain + at the end
-	GitRevisionBase string      // without +
-	gitRevisionDate string      // emitted by Makefile
-	GitRevisionDate time.Time   // parsed from gitRevisionDate
+	GitRevision     = defaultGitRevision // emitted by Makefile, may contain + at the end
+	GitRevisionBase string               // without +
+	gitRevisionDate string               // emitted by Makefile
+	GitRevisionDate time.Time            // parsed from gitRevisionDate
 )
+
+func GitRevisionKnown() bool {
+	return GitRevision != defaultGitRevision
+}
 
 func init() {
 	GitRevisionBase = strings.Replace(GitRevision, "+", "", -1)

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -299,7 +299,7 @@ func RunManager(mode Mode, cfg *mgrconfig.Config) {
 		return
 	}
 	mgr.pool = vm.NewDispatcher(mgr.vmPool, mgr.fuzzerInstance)
-	mgr.http.Pool.Store(mgr.pool)
+	mgr.http.Pools.Store(manager.DefaultPool, mgr.pool)
 	mgr.reproLoop = manager.NewReproLoop(mgr, mgr.vmPool.Count()-mgr.cfg.FuzzingVMs, mgr.cfg.DashboardOnlyRepro)
 	mgr.http.ReproLoop.Store(mgr.reproLoop)
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -151,7 +151,7 @@ const (
 )
 
 func main() {
-	if prog.GitRevision == "" {
+	if !prog.GitRevisionKnown() {
 		log.Fatalf("bad syz-manager build: build with make, run bin/syz-manager")
 	}
 	flag.Parse()

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1035,7 +1035,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map
 	statSyscalls.Add(len(enabledSyscalls))
 	corpus := mgr.loadCorpus(enabledSyscalls)
 	mgr.setPhaseLocked(phaseLoadedCorpus)
-	opts := mgr.defaultExecOpts()
+	opts := fuzzer.DefaultExecOpts(mgr.cfg, features, *flagDebug)
 
 	if mgr.mode == ModeFuzzing {
 		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -1140,34 +1140,6 @@ func (cr *corpusRunner) Next() *queue.Request {
 	return &queue.Request{
 		Prog:      p,
 		Important: true,
-	}
-}
-
-func (mgr *Manager) defaultExecOpts() flatrpc.ExecOpts {
-	env := csource.FeaturesToFlags(mgr.enabledFeatures, nil)
-	if *flagDebug {
-		env |= flatrpc.ExecEnvDebug
-	}
-	if mgr.cfg.Experimental.ResetAccState {
-		env |= flatrpc.ExecEnvResetState
-	}
-	if mgr.cfg.Cover {
-		env |= flatrpc.ExecEnvSignal
-	}
-	sandbox, err := flatrpc.SandboxToFlags(mgr.cfg.Sandbox)
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse sandbox: %v", err))
-	}
-	env |= sandbox
-
-	exec := flatrpc.ExecFlagThreaded
-	if !mgr.cfg.RawCover {
-		exec |= flatrpc.ExecFlagDedupCover
-	}
-	return flatrpc.ExecOpts{
-		EnvFlags:   env,
-		ExecFlags:  exec,
-		SandboxArg: mgr.cfg.SandboxArg,
 	}
 }
 

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1327,7 +1327,7 @@ func (mgr *Manager) dashboardReproTasks() {
 
 func (mgr *Manager) CoverageFilter(modules []*vminfo.KernelModule) []uint64 {
 	mgr.reportGenerator.Init(modules)
-	filters, err := manager.PrepareCoverageFilters(mgr.reportGenerator, mgr.cfg)
+	filters, err := manager.PrepareCoverageFilters(mgr.reportGenerator, mgr.cfg, true)
 	if err != nil {
 		log.Fatalf("failed to init coverage filter: %v", err)
 	}

--- a/syz-manager/snapshot.go
+++ b/syz-manager/snapshot.go
@@ -20,8 +20,8 @@ import (
 )
 
 func (mgr *Manager) snapshotInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
-	queue.StatNumFuzzing.Add(1)
-	defer queue.StatNumFuzzing.Add(-1)
+	mgr.servStats.StatNumFuzzing.Add(1)
+	defer mgr.servStats.StatNumFuzzing.Add(-1)
 
 	updInfo(func(info *dispatcher.Info) {
 		info.Status = "snapshot fuzzing"
@@ -48,7 +48,7 @@ func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
 	builder := flatbuffers.NewBuilder(0)
 	var envFlags flatrpc.ExecEnv
 	for first := true; ctx.Err() == nil; first = false {
-		queue.StatExecs.Add(1)
+		mgr.servStats.StatExecs.Add(1)
 		req := mgr.snapshotSource.Next(inst.Index())
 		if first {
 			envFlags = req.ExecOpts.EnvFlags

--- a/tools/syz-diff/diff.go
+++ b/tools/syz-diff/diff.go
@@ -1,0 +1,492 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/syzkaller/pkg/corpus"
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/fuzzer"
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/manager"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/repro"
+	"github.com/google/syzkaller/pkg/rpcserver"
+	"github.com/google/syzkaller/pkg/signal"
+	"github.com/google/syzkaller/pkg/stat"
+	"github.com/google/syzkaller/pkg/vminfo"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/vm"
+	"github.com/google/syzkaller/vm/dispatcher"
+)
+
+var (
+	flagBaseConfig = flag.String("base", "", "base config")
+	flagNewConfig  = flag.String("new", "", "new config (treated as the main one)")
+	flagDebug      = flag.Bool("debug", false, "dump all VM output to console")
+	flagPatch      = flag.String("patch", "", "a git patch")
+)
+
+func main() {
+	if !prog.GitRevisionKnown() {
+		log.Fatalf("bad syz-diff build: build with make, run bin/syz-diff")
+	}
+	flag.Parse()
+	log.EnableLogCaching(1000, 1<<20)
+
+	baseCfg, err := mgrconfig.LoadFile(*flagBaseConfig)
+	if err != nil {
+		log.Fatalf("base config: %v", err)
+	}
+
+	ctx := vm.ShutdownCtx()
+	base := setup(ctx, "base", baseCfg)
+
+	newCfg, err := mgrconfig.LoadFile(*flagNewConfig)
+	if err != nil {
+		log.Fatalf("new config: %v", err)
+	}
+
+	if *flagPatch != "" {
+		data, err := os.ReadFile(*flagPatch)
+		if err != nil {
+			log.Fatal(err)
+		}
+		extractModifiedFiles(newCfg, data)
+	}
+
+	new := setup(ctx, "new", newCfg)
+	go func() {
+		new.candidates <- manager.LoadSeeds(newCfg, true).Candidates
+	}()
+
+	stream := queue.NewRandomQueue(4096, rand.New(rand.NewSource(time.Now().UnixNano())))
+	base.source = stream
+	new.duplicateInto = stream
+
+	store := &manager.DiffFuzzerStore{BasePath: new.cfg.Workdir}
+	diffCtx := &diffContext{
+		doneRepro:     make(chan *manager.ReproResult),
+		base:          base,
+		new:           new,
+		store:         store,
+		reproAttempts: map[string]int{},
+		http: &manager.HTTPServer{
+			Cfg:       newCfg,
+			StartTime: time.Now(),
+			Corpus:    new.corpus,
+			DiffStore: store,
+		},
+	}
+	diffCtx.http.Pools.Store(new.name, new.pool)
+	diffCtx.http.Pools.Store(base.name, base.pool)
+	new.http = diffCtx.http
+
+	diffCtx.Loop(ctx)
+}
+
+type diffContext struct {
+	store *manager.DiffFuzzerStore
+	http  *manager.HTTPServer
+
+	doneRepro chan *manager.ReproResult
+	base      *kernelContext
+	new       *kernelContext
+
+	mu            sync.Mutex
+	reproAttempts map[string]int
+}
+
+func (dc *diffContext) Loop(ctx context.Context) {
+	reproLoop := manager.NewReproLoop(dc, dc.new.pool.Total()-dc.new.cfg.FuzzingVMs, false)
+	dc.http.ReproLoop.Store(reproLoop)
+	go func() {
+		// Let both base and patched instances somewhat progress in fuzzing before we take
+		// VMs away for bug reproduction.
+		// TODO: determine the exact moment of corpus triage.
+		time.Sleep(15 * time.Minute)
+		log.Logf(0, "starting bug reproductions")
+		reproLoop.Loop(ctx)
+	}()
+
+	go dc.base.Loop()
+	go dc.new.Loop()
+	go dc.http.Serve()
+
+	runner := &reproRunner{done: make(chan reproRunnerResult, 2), kernel: dc.base}
+
+	rareStat := time.NewTicker(5 * time.Minute)
+	for {
+		select {
+		case <-rareStat.C:
+			vals := make(map[string]int)
+			for _, stat := range stat.Collect(stat.All) {
+				vals[stat.Name] = stat.V
+			}
+			data, _ := json.MarshalIndent(vals, "", "  ")
+			log.Logf(0, "STAT %s", data)
+		case rep := <-dc.base.crashes:
+			log.Logf(1, "base crash: %v", rep.Title)
+			dc.store.BaseCrashed(rep.Title, rep.Report)
+		case ret := <-runner.done:
+			if ret.crashTitle == "" {
+				dc.store.BaseNotCrashed(ret.originalTitle)
+				log.Logf(0, "patched-only: %s", ret.originalTitle)
+			} else {
+				dc.store.BaseCrashed(ret.originalTitle, ret.report)
+				log.Logf(0, "crashes both: %s / %s", ret.originalTitle, ret.crashTitle)
+			}
+		case ret := <-dc.doneRepro:
+			if ret.Repro != nil && ret.Repro.Report != nil {
+				origTitle := ret.Crash.Report.Title
+				if ret.Repro.Report.Title == origTitle {
+					origTitle = "-SAME-"
+				}
+				log.Logf(1, "found repro for %q (orig title: %q), took %.2f minutes",
+					ret.Repro.Report.Title, origTitle, ret.Stats.TotalTime.Minutes())
+				go runner.Run(ret.Repro)
+			} else {
+				origTitle := ret.Crash.Report.Title
+				log.Logf(1, "failed repro for %q, err=%s", origTitle, ret.Err)
+			}
+			dc.store.SaveRepro(ret)
+		case rep := <-dc.new.crashes:
+			crash := &manager.Crash{Report: rep}
+			need := dc.NeedRepro(crash)
+			log.Logf(0, "patched crashed: %v [need repro = %v]",
+				rep.Title, need)
+			dc.store.PatchedCrashed(rep.Title, rep.Report, rep.Output)
+			if need {
+				reproLoop.Enqueue(crash)
+			}
+		}
+	}
+}
+
+// TODO: instead of this limit, consider expotentially growing delays between reproduction attempts.
+const maxReproAttempts = 6
+
+func (dc *diffContext) NeedRepro(crash *manager.Crash) bool {
+	if strings.Contains(crash.Title, "no output") ||
+		strings.Contains(crash.Title, "lost connection") ||
+		strings.Contains(crash.Title, "stall") ||
+		strings.Contains(crash.Title, "SYZ") {
+		// Don't waste time reproducing these.
+		return false
+	}
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.store.EverCrashedBase(crash.Title) {
+		return false
+	}
+	if dc.reproAttempts[crash.Title] > maxReproAttempts {
+		return false
+	}
+	return true
+}
+
+func (dc *diffContext) RunRepro(crash *manager.Crash) *manager.ReproResult {
+	dc.mu.Lock()
+	dc.reproAttempts[crash.Title]++
+	dc.mu.Unlock()
+
+	res, stats, err := repro.Run(crash.Output, dc.new.cfg, dc.new.features,
+		dc.new.reporter, dc.new.pool, repro.Fast)
+	if res != nil && res.Report != nil {
+		dc.mu.Lock()
+		dc.reproAttempts[res.Report.Title] = maxReproAttempts
+		dc.mu.Unlock()
+	}
+	ret := &manager.ReproResult{
+		Crash: crash,
+		Repro: res,
+		Stats: stats,
+		Err:   err,
+	}
+	dc.doneRepro <- ret
+	return ret
+}
+
+func (dc *diffContext) ResizeReproPool(size int) {
+	dc.new.pool.ReserveForRun(size)
+}
+
+type kernelContext struct {
+	name       string
+	ctx        context.Context
+	cfg        *mgrconfig.Config
+	reporter   *report.Reporter
+	corpus     *corpus.Corpus
+	fuzzer     atomic.Pointer[fuzzer.Fuzzer]
+	serv       rpcserver.Server
+	servStats  rpcserver.Stats
+	crashes    chan *report.Report
+	pool       *dispatcher.Pool[*vm.Instance]
+	features   flatrpc.Feature
+	candidates chan []fuzzer.Candidate
+
+	coverFilters    manager.CoverageFilters
+	reportGenerator *manager.ReportGeneratorWrapper
+
+	http          *manager.HTTPServer
+	source        queue.Source
+	duplicateInto queue.Executor
+}
+
+func setup(ctx context.Context, name string, cfg *mgrconfig.Config) *kernelContext {
+	osutil.MkdirAll(cfg.Workdir)
+
+	kernelCtx := &kernelContext{
+		name:            name,
+		ctx:             ctx,
+		cfg:             cfg,
+		corpus:          corpus.NewCorpus(ctx),
+		crashes:         make(chan *report.Report, 128),
+		candidates:      make(chan []fuzzer.Candidate),
+		servStats:       rpcserver.NewNamedStats(name),
+		reportGenerator: manager.ReportGeneratorCache(cfg),
+	}
+
+	var err error
+	kernelCtx.reporter, err = report.NewReporter(cfg)
+	if err != nil {
+		log.Fatalf("failed to create reporter for %q: %v", name, err)
+	}
+
+	kernelCtx.serv, err = rpcserver.New(cfg, kernelCtx, kernelCtx.servStats, *flagDebug)
+	if err != nil {
+		log.Fatalf("failed to create rpc server for %q: %v", name, err)
+	}
+
+	vmPool, err := vm.Create(cfg, *flagDebug)
+	if err != nil {
+		log.Fatalf("failed to create vm.Pool for %q: %v", name, err)
+	}
+
+	kernelCtx.pool = vm.NewDispatcher(vmPool, kernelCtx.fuzzerInstance)
+	return kernelCtx
+}
+
+func (kc *kernelContext) Loop() {
+	if err := kc.serv.Listen(); err != nil {
+		log.Fatalf("failed to start rpc server: %v", err)
+	}
+	kc.pool.Loop(kc.ctx)
+}
+
+func (kc *kernelContext) MaxSignal() signal.Signal {
+	if fuzzer := kc.fuzzer.Load(); fuzzer != nil {
+		return fuzzer.Cover.CopyMaxSignal()
+	}
+	return nil
+}
+
+func (kc *kernelContext) BugFrames() (leaks, races []string) {
+	return nil, nil
+}
+
+func (kc *kernelContext) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {
+	if len(syscalls) == 0 {
+		log.Fatalf("all system calls are disabled")
+	}
+	log.Logf(0, "%s: machine check complete", kc.name)
+	kc.features = features
+
+	var source queue.Source
+	if kc.source == nil {
+		source = queue.Tee(kc.setupFuzzer(features, syscalls), kc.duplicateInto)
+	} else {
+		source = kc.source
+	}
+	opts := fuzzer.DefaultExecOpts(kc.cfg, features, *flagDebug)
+	return queue.DefaultOpts(source, opts)
+}
+
+func (kc *kernelContext) setupFuzzer(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fuzzerObj := fuzzer.NewFuzzer(context.Background(), &fuzzer.Config{
+		Corpus:   kc.corpus,
+		Coverage: kc.cfg.Cover,
+		// TODO: it may be unstable between different revisions though.
+		// For now it's only kept true because it seems to increase repro chances in local runs (???).
+		FaultInjection: true,
+		Comparisons:    features&flatrpc.FeatureComparisons != 0,
+		Collide:        true,
+		EnabledCalls:   syscalls,
+		NoMutateCalls:  kc.cfg.NoMutateCalls,
+		PatchTest:      true,
+		Logf: func(level int, msg string, args ...interface{}) {
+			if level != 0 {
+				return
+			}
+			log.Logf(level, msg, args...)
+		},
+	}, rnd, kc.cfg.Target)
+	kc.fuzzer.Store(fuzzerObj)
+
+	if kc.http != nil {
+		kc.http.Fuzzer.Store(fuzzerObj)
+		kc.http.EnabledSyscalls.Store(syscalls)
+	}
+
+	filtered := manager.FilterCandidates(<-kc.candidates, syscalls, false).Candidates
+	log.Logf(0, "%s: adding %d seeds", kc.name, len(filtered))
+	fuzzerObj.AddCandidates(filtered)
+
+	go func() {
+		if !kc.cfg.Cover {
+			return
+		}
+		for {
+			select {
+			case <-time.After(time.Second):
+			case <-kc.ctx.Done():
+				return
+			}
+			newSignal := fuzzerObj.Cover.GrabSignalDelta()
+			if len(newSignal) == 0 {
+				continue
+			}
+			kc.serv.DistributeSignalDelta(newSignal)
+		}
+	}()
+	return fuzzerObj
+}
+
+func (kc *kernelContext) CoverageFilter(modules []*vminfo.KernelModule) []uint64 {
+	kc.reportGenerator.Init(modules)
+	filters, err := manager.PrepareCoverageFilters(kc.reportGenerator, kc.cfg, false)
+	if err != nil {
+		log.Fatalf("failed to init coverage filter: %v", err)
+	}
+	kc.coverFilters = filters
+	kc.corpus.SetFocusAreas(filters.Areas)
+	log.Logf(0, "cover filter size: %d", len(filters.ExecutorFilter))
+	if kc.http != nil {
+		kc.http.Cover.Store(&manager.CoverageInfo{
+			Modules:         modules,
+			ReportGenerator: kc.reportGenerator,
+			CoverFilter:     filters.ExecutorFilter,
+		})
+	}
+	var pcs []uint64
+	for pc := range filters.ExecutorFilter {
+		pcs = append(pcs, pc)
+	}
+	return pcs
+}
+
+func (kc *kernelContext) fuzzerInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
+	index := inst.Index()
+	injectExec := make(chan bool, 10)
+	kc.serv.CreateInstance(index, injectExec, updInfo)
+	rep, err := kc.runInstance(ctx, inst, injectExec)
+	lastExec, _ := kc.serv.ShutdownInstance(index, rep != nil)
+	if rep != nil {
+		rpcserver.PrependExecuting(rep, lastExec)
+		kc.crashes <- rep
+	}
+	if err != nil {
+		log.Errorf("#%d run failed: %s", inst.Index(), err)
+	}
+}
+
+func (kc *kernelContext) runInstance(ctx context.Context, inst *vm.Instance,
+	injectExec <-chan bool) (*report.Report, error) {
+	fwdAddr, err := inst.Forward(kc.serv.Port())
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup port forwarding: %w", err)
+	}
+	executorBin, err := inst.Copy(kc.cfg.ExecutorBin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy binary: %w", err)
+	}
+	host, port, err := net.SplitHostPort(fwdAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manager's address")
+	}
+	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
+	_, rep, err := inst.Run(kc.cfg.Timeouts.VMRunningTime, kc.reporter, cmd,
+		vm.ExitTimeout, vm.StopContext(ctx), vm.InjectExecuting(injectExec),
+		vm.EarlyFinishCb(func() {
+			// Depending on the crash type and kernel config, fuzzing may continue
+			// running for several seconds even after kernel has printed a crash report.
+			// This litters the log and we want to prevent it.
+			kc.serv.StopFuzzing(inst.Index())
+		}),
+	)
+	return rep, err
+}
+
+// reproRunner is used to run reproducers on the base kernel to determine whether it is affected.
+type reproRunner struct {
+	done    chan reproRunnerResult
+	running atomic.Int64
+	kernel  *kernelContext
+}
+
+type reproRunnerResult struct {
+	originalTitle string
+	crashTitle    string
+	report        []byte
+}
+
+func (rr *reproRunner) Run(r *repro.Result) {
+	pool := rr.kernel.pool
+	cnt := int(rr.running.Add(1))
+	pool.ReserveForRun(min(cnt, pool.Total()))
+	defer func() {
+		cnt := int(rr.running.Add(-1))
+		rr.kernel.pool.ReserveForRun(min(cnt, pool.Total()))
+	}()
+
+	ret := reproRunnerResult{originalTitle: r.Report.Title}
+
+	var result *instance.RunResult
+	var err error
+	for i := 0; i < 3; i++ {
+		opts := r.Opts
+		opts.Repeat = true
+		if i == 0 || i == 1 {
+			// Two times out of 3, test with Threaded=true.
+			// The third time we leave it as is in case it was important.
+			opts.Threaded = true
+		}
+		pool.Run(func(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
+			var ret *instance.ExecProgInstance
+			ret, err = instance.SetupExecProg(inst, rr.kernel.cfg, rr.kernel.reporter, nil)
+			if err != nil {
+				return
+			}
+			result, err = ret.RunSyzProg(r.Prog.Serialize(), max(r.Duration, time.Minute), opts,
+				instance.SyzExitConditions)
+		})
+		crashed := result != nil && result.Report != nil
+		log.Logf(1, "attempt #%d to run %q on base: crashed=%v", i, ret.originalTitle, crashed)
+		if crashed {
+			ret.crashTitle = result.Report.Title
+			break
+		}
+	}
+	if err != nil {
+		log.Errorf("failed to run repro: %v", err)
+		return
+	}
+	rr.done <- ret
+}

--- a/tools/syz-diff/patch.go
+++ b/tools/syz-diff/patch.go
@@ -1,0 +1,94 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
+)
+
+func extractModifiedFiles(cfg *mgrconfig.Config, data []byte) {
+	const maxAffectedByHeader = 50
+
+	names := map[string]bool{}
+	includedNames := map[string]bool{}
+	for _, file := range vcs.ParseGitDiff(data) {
+		names[file] = true
+
+		if strings.HasSuffix(file, ".h") && cfg.KernelSrc != "" {
+			// Ideally, we should combine this with the recompilation process - then we know
+			// exactly which files were affected by the patch.
+			out, err := osutil.RunCmd(time.Minute, cfg.KernelSrc, "/usr/bin/grep",
+				"-rl", "--include", `*.c`, `<`+strings.TrimPrefix(file, "include/")+`>`)
+			if err != nil {
+				log.Logf(0, "failed to grep for the header usages: %v", err)
+				continue
+			}
+			lines := strings.Split(string(out), "\n")
+			if len(lines) >= maxAffectedByHeader {
+				// It's too widespread. It won't help us focus on anything.
+				log.Logf(0, "the header %q is included in too many files (%d)", file, len(lines))
+				continue
+			}
+			for _, name := range lines {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				includedNames[name] = true
+			}
+		}
+	}
+
+	var namesList, includedList []string
+	for name := range names {
+		namesList = append(namesList, name)
+	}
+	for name := range includedNames {
+		if names[name] {
+			continue
+		}
+		includedList = append(includedList, name)
+	}
+
+	if len(namesList) > 0 {
+		sort.Strings(namesList)
+		log.Logf(0, "adding the following modified files to focus_order: %q", namesList)
+		cfg.Experimental.FocusAreas = append(cfg.Experimental.FocusAreas,
+			mgrconfig.FocusArea{
+				Name: "modified",
+				Filter: mgrconfig.CovFilterCfg{
+					Files: namesList,
+				},
+				Weight: 3.0,
+			})
+	}
+
+	if len(includedList) > 0 {
+		sort.Strings(includedList)
+		log.Logf(0, "adding the following included files to focus_order: %q", includedList)
+		cfg.Experimental.FocusAreas = append(cfg.Experimental.FocusAreas,
+			mgrconfig.FocusArea{
+				Name: "included",
+				Filter: mgrconfig.CovFilterCfg{
+					Files: includedList,
+				},
+				Weight: 2.0,
+			})
+	}
+
+	// Still fuzz the rest of the kernel.
+	if len(cfg.Experimental.FocusAreas) > 0 {
+		cfg.Experimental.FocusAreas = append(cfg.Experimental.FocusAreas,
+			mgrconfig.FocusArea{
+				Weight: 1.0,
+			})
+	}
+}


### PR DESCRIPTION
This is the prototype version of the patch series fuzzing functionality based on the syzkaller fuzzing engine.

The tool takes two syzkaller configs -- one for the base kernel, one for the patched kernel. The patch itself can optionally be also provided.

syz-diff will consider a bug patched-only if:
1) It happened while fuzzing the patched kernel.
2) It was never observed on the base kernel.
3) The tool found a repro on the patched kernel.
4) The repro did not crash the base kernel.
