### PR TITLE
pkg/mgrconfig: increase the timeouts for arm64 QEMU hosts running arm…

### DIFF
--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -4,6 +4,7 @@
 package mgrconfig
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -237,6 +238,11 @@ func (cfg *Config) completeServices() error {
 func (cfg *Config) initTimeouts() {
 	slowdown := 1
 	switch {
+	case cfg.Type == "qemu" && (runtime.GOARCH == cfg.SysTarget.Arch || runtime.GOARCH == cfg.SysTarget.VMArch):
+		// If TCG is enabled for QEMU, increase the slowdown.
+		if bytes.Contains(cfg.VM, []byte("-accel tcg")) {
+			slowdown = 10
+		}
 	case cfg.Type == "qemu" && runtime.GOARCH != cfg.SysTarget.Arch && runtime.GOARCH != cfg.SysTarget.VMArch:
 		// Assuming qemu emulation.
 		// Quick tests of mmap syscall on arm64 show ~9x slowdown.

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -153,7 +153,7 @@ var archConfigs = map[string]*archConfig{
 		// Disable SVE and pointer authentication for now, they significantly slow down
 		// the emulation and are unlikely to bring a lot of new coverage.
 		QemuArgs: strings.Join([]string{"-machine virt,virtualization=on,gic-version=max ",
-			"-cpu max,sve128=on,pauth=off -accel tcg,thread=multi"}, ""),
+			"-cpu max,sve128=on,pauth=off"}, ""),
 		NetDev: "virtio-net-pci",
 		RngDev: "virtio-rng-pci",
 		CmdLine: []string{


### PR DESCRIPTION
…64 guests

Previously we were assuming that QEMU with matching host/guest architectures was using -enable-kvm, but for arm64 that's not always the case.
Set the timeout multiplier to 5 (carefully picked arbitrary number less than 10, which is the multiplier for emulating arm64 on x86)

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
