### PR TITLE
tools/syz-build: expose ccache as cli flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -134,3 +134,4 @@ Amazon
  Bjoern Doebel
 Viacheslav Sablin
 Davide Ornaghi
+Ramneet Singh

--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -23,6 +23,7 @@ var (
 	flagMake          = flag.String("make", "", "non-default make")
 	flagCompiler      = flag.String("compiler", "", "non-default compiler")
 	flagLinker        = flag.String("linker", "", "non-default linker")
+	flagCcache        = flag.String("ccache", "", "ccache executable")
 	flagKernelConfig  = flag.String("config", "", "kernel config file")
 	flagKernelSysctl  = flag.String("sysctl", "", "kernel sysctl file")
 	flagKernelCmdline = flag.String("cmdline", "", "kernel cmdline file")
@@ -57,7 +58,7 @@ func main() {
 		Make:         *flagMake,
 		Compiler:     *flagCompiler,
 		Linker:       *flagLinker,
-		Ccache:       "",
+		Ccache:       *flagCcache,
 		UserspaceDir: *flagUserspace,
 		CmdlineFile:  *flagKernelCmdline,
 		SysctlFile:   *flagKernelSysctl,


### PR DESCRIPTION
While `Ccache` is a field in `build.Params`, a user of `syz-build` does not have the option to set it via the CLI. This PR exposes a CLI flag for `ccache` and passes it to `build.Params`.