### PR TITLE
dashboard/app: make WebGitURIProvider configurable

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -159,6 +159,9 @@ type CoverageConfig struct {
 	JobInitScript       string
 	SyzEnvInitScript    string
 	DashboardClientName string
+
+	// WebGitURI specifies where can we get the kernel file source code directly from AppEngine.
+	WebGitURI string
 }
 
 // DiscussionEmailConfig defines the correspondence between an email and a DiscussionSource.

--- a/pkg/covermerger/provider_web.go
+++ b/pkg/covermerger/provider_web.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 )
 
-type FuncProxyURI func(filePath string, rc RepoCommit) string
+type FuncProxyURI func(filePath, commit string) string
 
 type webGit struct {
 	funcProxy FuncProxyURI
@@ -39,7 +39,7 @@ var errFileNotFound = errors.New("file not found")
 func (mr *webGit) loadFile(filePath, repo, commit string) ([]byte, error) {
 	var uri string
 	if mr.funcProxy != nil {
-		uri = mr.funcProxy(filePath, RepoCommit{Repo: repo, Commit: commit})
+		uri = mr.funcProxy(filePath, commit)
 	} else {
 		uri = fmt.Sprintf("%s/plain/%s", repo, filePath)
 		if commit != "latest" {


### PR DESCRIPTION
We don't want to scale the github repo usage.
Let's eventually switch to the internal service.
