### PR TITLE
dashboard: adapt to the new Googe Groups footer

### DIFF
--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"mime/quotedprintable"
 	"net/mail"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -59,8 +60,8 @@ const (
 	cmdTest5
 )
 
-var groupsLinkRe = regexp.MustCompile("\nTo view this discussion on the web visit" +
-	" (https://groups\\.google\\.com/.*?)\\.(?:\r)?\n")
+var groupsLinkRe = regexp.MustCompile(`(?m)\nTo view this discussion (?:on the web )?visit` +
+	` (https://groups\.google\.com/.*?)\.(:?$|\n|\r)`)
 
 func prepareEmails(list []string) map[string]bool {
 	ret := make(map[string]bool)
@@ -153,6 +154,9 @@ func Parse(r io.Reader, ownEmails, goodLists, domains []string) (*Email, error) 
 	link := ""
 	if match := groupsLinkRe.FindStringSubmatchIndex(bodyStr); match != nil {
 		link = bodyStr[match[2]:match[3]]
+		if unescaped, err := url.QueryUnescape(link); err == nil {
+			link = unescaped
+		}
 	}
 
 	author := CanonicalEmail(from[0].Address)

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -461,6 +461,35 @@ For more options, visit https://groups.google.com/d/optout.`,
 				},
 			},
 		}},
+	{`Date: Sun, 7 May 2017 19:54:00 -0700
+Message-ID: <123>
+Subject: new footer
+From: Bob <bob@example.com>
+To: syzbot <foo+4564456@bar.com>
+Content-Type: text/plain; charset="UTF-8"
+
+some title
+
+-- 
+You received this message because you are subscribed to the Google Groups "syzkaller-bugs" group.
+To unsubscribe from this group and stop receiving emails from it, send an email to syzkaller-bugs+unsubscribe@googlegroups.com.
+To view this discussion visit https://groups.google.com/d/msgid/syzkaller-bugs/671b7fb2.050a0220.2e773.0000.GAE%40google.com.`,
+		Email{
+			BugIDs:    []string{"4564456"},
+			MessageID: "<123>",
+			Date:      time.Date(2017, time.May, 7, 19, 54, 0, 0, parseTestZone),
+			Link:      "https://groups.google.com/d/msgid/syzkaller-bugs/671b7fb2.050a0220.2e773.0000.GAE@google.com",
+			Subject:   "new footer",
+			Author:    "bob@example.com",
+			Cc:        []string{"bob@example.com"},
+			Body: `some title
+
+-- 
+You received this message because you are subscribed to the Google Groups "syzkaller-bugs" group.
+To unsubscribe from this group and stop receiving emails from it, send an email to syzkaller-bugs+unsubscribe@googlegroups.com.
+To view this discussion visit https://groups.google.com/d/msgid/syzkaller-bugs/671b7fb2.050a0220.2e773.0000.GAE%40google.com.`,
+			Patch: "",
+		}},
 
 	{`Date: Sun, 7 May 2017 19:54:00 -0700
 Message-ID: <123>


### PR DESCRIPTION
It changed recently and it broke our email discussion link extraction.

Closes #5431.