### PR TITLE
tools/docker/syzbot: use LLVM archive instead apt

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -29,25 +29,20 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 RUN curl https://dl.google.com/go/go1.22.7.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
-# The default clang-14 is too old, install the latest one.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
+# The default clang-14 is too old, install the latest one.
+# See https://kernel.org/pub/tools/llvm.
+ARG LLVM_VERSION=llvm-15.0.7-x86_64
+COPY provision-llvm.sh /tmp/provision-llvm.sh
+RUN /tmp/provision-llvm.sh $LLVM_VERSION
+
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main"
 RUN apt-get update --allow-releaseinfo-change
-RUN apt-get install -y -q --no-install-recommends llvm-15 clang-15 clang-format-15 clang-tidy-15 lld-15
+RUN apt-get install -y -q --no-install-recommends clang-format-15 clang-tidy-15
 RUN apt autoremove -y -q
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
-RUN sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
 RUN sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
 RUN sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
-RUN sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-objdump llvm-objdump /usr/bin/llvm-objdump-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-addr2line llvm-addr2line /usr/bin/llvm-addr2line-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-readelf llvm-readelf /usr/bin/llvm-readelf-15 100
-RUN sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-15 100
 
 # Not really GRTE, but it's enough to run some scripts that hardcode the path.
 RUN mkdir -p /usr/grte/v5/bin && ln -s /usr/bin/python3 /usr/grte/v5/bin/python2.7

--- a/tools/docker/syzbot/provision-llvm.sh
+++ b/tools/docker/syzbot/provision-llvm.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2024 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+# Exit on any problem.
+set -e
+set -o pipefail
+
+if [ -z "$1" ];then
+    echo "Pass LLVM version in the argument."
+    exit 1
+fi
+
+LLVM_VERSION=$1
+
+url="https://mirrors.edge.kernel.org/pub/tools/llvm/files"
+tmp=$(mktemp -d)
+cd $tmp
+
+# Download the archive.
+curl -L $url/$LLVM_VERSION.tar.gz -o $LLVM_VERSION.tar.gz
+
+# LLVM archive intergrity check.
+curl -L -s $url/sha256sums.asc | grep $LLVM_VERSION.tar.gz > $LLVM_VERSION.asc
+sha256sum -c $LLVM_VERSION.asc
+
+# GPG signature import.
+curl -L -s $url/$LLVM_VERSION.tar.sign -o $LLVM_VERSION.tar.sign
+keyid=$(gpg --list-packets $LLVM_VERSION.tar.sign | grep -oE "keyid .*$" | awk '{print $2}')
+gpg --keyserver keyserver.ubuntu.com --recv-keys $keyid
+# See https://www.kernel.org/signature.html
+gpg --tofu-policy good $keyid
+
+# Decompress & gpg signature verification.
+gunzip -d $LLVM_VERSION.tar
+gpg --trust-model tofu --verify $LLVM_VERSION.tar.sign $LLVM_VERSION.tar
+
+# Untar binaries to the output.
+tar -xf $LLVM_VERSION.tar --strip-components=2 -C /usr/bin $LLVM_VERSION/bin
+
+cd -
+rm -rf $tmp


### PR DESCRIPTION
Replace clang, llvm apt packages in syzbot Dockerfile with the stable kernel version. Reduce Dockerfile code (less RUN layers).

Use stable LLVM version that Linux kernel doc suggests [1].

These 2 binaries are missing in the archive: "clang-format, clang-tidy", hence install them as the current apt package.

This patch increases syzbot docker image size by 230MB, see the comparison between "syz_master" (current master branch built image), and with the applied patch "syz_master_diff".

$ docker images
REPOSITORY        TAG        IMAGE ID       CREATED        SIZE
syz_master_diff   latest     40b209ef582e   6 hours ago    5.54GB
syz_master        latest     292faad84de9   13 hours ago   5.31GB

The archive is 123M size and I've built the image 3 times with removing the images as the fresh install, and curl downloading for my 500Mbit/s Ethernet downlink took:

1st build: 0 hour 0 min 50 sec
2nd build: 1 hour 3 min 5 sec
3rd build: 0 hour 1 min 5 sec

Hereby, I'm concerned if the archive can be mirrored from "mirrors.edge.kernel.org" to more stable/reliable storage with more distributed CDN like dl.google.com, or it's something local with my downlink.

Per the 3rd build, the patch also speeds up (~1 min faster) the docker image build time:
	...
	Step 7/27 : RUN curl -L <redacted>
 ---> Running in ae2853dfc0fc
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  123M  100  123M    0     0  1916k      0  0:01:05  0:01:05 --:--:-- 2513k
	...
	Successfully built 387ae7e06dfa
	Successfully tagged syz_master_diff:latest

	real    6m23.013s
	user    0m0.145s
	sys     0m0.094s

and the original "syz_master" fresh build:
	...
	Successfully built 843592c9ce1b
	Successfully tagged syz_master:latest

	real    7m18.333s
	user    0m0.152s
	sys     0m0.090s

Verified the binaries' versions in the container as well:

	$ docker run --rm --name syz_master_diff -it syz_master_diff bash

	/🤖 for e in {clang,clang++,clang-tidy,clang-format,ld.lld,llvm-nm,\
	> llvm-ar,llvm-objcopy,llvm-objdump,llvm-addr2line,llvm-readelf,\
	> llvm-strip}; do echo; $e --version; done

	Debian clang version 15.0.6
	Target: x86_64-pc-linux-gnu
	Thread model: posix
	InstalledDir: /usr/bin

	Debian clang version 15.0.6
	Target: x86_64-pc-linux-gnu
	Thread model: posix
	InstalledDir: /usr/bin

	Debian LLVM version 15.0.6
	  Optimized build.
	  Default target: x86_64-pc-linux-gnu
	  Host CPU: skylake

	Debian clang-format version 15.0.6

	ClangBuiltLinux LLD 15.0.7 (compatible with GNU linkers)

	llvm-nm, compatible with GNU nm
	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	llvm-objcopy, compatible with GNU objcopy
	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	  Registered Targets:
	    aarch64    - AArch64 (little endian)
	    aarch64_32 - AArch64 (little endian ILP32)
	    aarch64_be - AArch64 (big endian)
	    arm        - ARM
	    arm64      - ARM64 (little endian)
	    arm64_32   - ARM64 (little endian ILP32)
	    armeb      - ARM (big endian)
	    bpf        - BPF (host endian)
	    bpfeb      - BPF (big endian)
	    bpfel      - BPF (little endian)
	    hexagon    - Hexagon
	    mips       - MIPS (32-bit big endian)
	    mips64     - MIPS (64-bit big endian)
	    mips64el   - MIPS (64-bit little endian)
	    mipsel     - MIPS (32-bit little endian)
	    ppc32      - PowerPC 32
	    ppc32le    - PowerPC 32 LE
	    ppc64      - PowerPC 64
	    ppc64le    - PowerPC 64 LE
	    riscv32    - 32-bit RISC-V
	    riscv64    - 64-bit RISC-V
	    systemz    - SystemZ
	    thumb      - Thumb
	    thumbeb    - Thumb (big endian)
	    x86        - 32-bit X86: Pentium-Pro and above
	    x86-64     - 64-bit X86: EM64T and AMD64

	llvm-addr2line
	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

	llvm-strip, compatible with GNU strip
	LLVM (http://llvm.org/):
	  LLVM version 15.0.7
	  Optimized build.
	  Default target: x86_64-unknown-linux-gnu
	  Host CPU: skylake

[1] https://mirrors.edge.kernel.org/pub/tools/llvm/

Fixes: https://github.com/google/syzkaller/issues/5385