### PR TITLE
lint: fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,6 +107,7 @@ issues:
     # This check gives false positives related to the standard log.Fatalf
     # (which is strange, standard log package should be supported).#
     - "SA5011: possible nil pointer dereference"
+    - "this check suggests that the pointer can be nil"
   exclude-rules:
     - path: (pkg/csource/generated.go|pkg/build/linux_generated.go)
       linters:

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -177,10 +177,8 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 			}
 			if module.Name == "" && len(result.CoverPoints[0]) == 0 {
 				err = fmt.Errorf("%v doesn't contain coverage callbacks (set CONFIG_KCOV=y on linux)", module.Path)
-				if err != nil {
-					binC <- binResult{err: err}
-					return
-				}
+				binC <- binResult{err: err}
+				return
 			}
 			ranges, units, err := params.readTextRanges(module)
 			if err != nil {


### PR DESCRIPTION
Fix linter reported issue with "err != nil" is always true and add "this check suggests that the pointer can be nil" to the exclusion rules as the false-positives due to non-standard/standard package's Fatalf() exiting.

```
$ make lint
bin/golangci-lint run  ./...
pkg/cover/backend/dwarf.go:180:8: SA4023: this comparison is always true
				if err != nil {
				   ^

sys/fuchsia/fidlgen/main.go:24:5: SA5011(related information): this check suggests that the pointer can be nil
	if target == nil {

tools/syz-declextract/run.go:95:6: SA5011(related information): this check suggests that the pointer can be nil
		if parse == nil {
		   ^
tools/syz-declextract/run.go:234:5: SA5011(related information): this check suggests that the pointer can be nil
	if netlinkUnionParsed == nil {
	   ^
prog/encodingexec_test.go:60:6: SA5011(related information): this check suggests that the pointer can be nil
		if c == nil {
		   ^
sys/fuchsia/fidlgen/main.go:24:5: SA5011(related information): this check suggests that the pointer can be nil
	if target == nil {
	   ^
pkg/compiler/compiler_test.go:339:5: SA5011(related information): this check suggests that the pointer can be nil
	if p == nil {
	   ^
pkg/compiler/compiler_test.go:379:5: SA5011(related information): this check suggests that the pointer can be nil
	if p == nil {
	   ^
pkg/ast/parser_test.go:32:7: SA5011(related information): this check suggests that the pointer can be nil
			if desc == nil {
			   ^
pkg/ast/parser_test.go:37:7: SA5011(related information): this check suggests that the pointer can be nil
			if desc2 == nil {
			   ^
pkg/report/report_test.go:308:5: SA5011(related information): this check suggests that the pointer can be nil
	if rep == nil {
	   ^
pkg/bisect/bisect_test.go:205:5: SA5011(related information): this check suggests that the pointer can be nil
	if sc == nil {
	   ^
make: *** [Makefile:293: lint] Error 1
```