### PR TITLE
sys/linux: use syz_init_net_socket for bluetooth

### DIFF
--- a/sys/linux/socket_bluetooth.txt
+++ b/sys/linux/socket_bluetooth.txt
@@ -56,7 +56,7 @@ getsockopt$bt_l2cap_L2CAP_CONNINFO(fd sock_bt_l2cap, level const[SOL_L2CAP], opt
 
 resource sock_bt_rfcomm[sock_bt]
 
-socket$bt_rfcomm(fam const[AF_BLUETOOTH], type flags[bt_rfcomm_type], proto const[BTPROTO_RFCOMM]) sock_bt_rfcomm
+syz_init_net_socket$bt_rfcomm(fam const[AF_BLUETOOTH], type flags[bt_rfcomm_type], proto const[BTPROTO_RFCOMM]) sock_bt_rfcomm
 bind$bt_rfcomm(fd sock_bt_rfcomm, addr ptr[in, sockaddr_rc], addrlen len[addr])
 connect$bt_rfcomm(fd sock_bt_rfcomm, addr ptr[in, sockaddr_rc], addrlen len[addr])
 setsockopt$bt_rfcomm_RFCOMM_LM(fd sock_bt_rfcomm, level const[SOL_RFCOMM], opt const[RFCOMM_LM], arg ptr[in, flags[bt_l2cap_lm, int32]], arglen len[arg])
@@ -65,7 +65,7 @@ getsockopt$bt_rfcomm_RFCOMM_CONNINFO(fd sock_bt_rfcomm, level const[SOL_RFCOMM],
 
 resource sock_bt_hidp[sock_bt]
 
-socket$bt_hidp(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_HIDP]) sock_bt_hidp
+syz_init_net_socket$bt_hidp(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_HIDP]) sock_bt_hidp
 ioctl$sock_bt_hidp_HIDPCONNADD(fd sock_bt_hidp, cmd const[HIDPCONNADD], arg ptr[in, hidp_connadd_req])
 ioctl$sock_bt_hidp_HIDPCONNDEL(fd sock_bt_hidp, cmd const[HIDPCONNDEL], arg ptr[in, hidp_conndel_req])
 ioctl$sock_bt_hidp_HIDPGETCONNLIST(fd sock_bt_hidp, cmd const[HIDPGETCONNLIST], arg ptr[in, hidp_connlist_req])
@@ -73,7 +73,7 @@ ioctl$sock_bt_hidp_HIDPGETCONNINFO(fd sock_bt_hidp, cmd const[HIDPGETCONNINFO], 
 
 resource sock_bt_cmtp[sock_bt]
 
-socket$bt_cmtp(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_CMTP]) sock_bt_cmtp
+syz_init_net_socket$bt_cmtp(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_CMTP]) sock_bt_cmtp
 ioctl$sock_bt_cmtp_CMTPCONNADD(fd sock_bt_cmtp, cmd const[CMTPCONNADD], arg ptr[in, cmtp_connadd_req])
 ioctl$sock_bt_cmtp_CMTPCONNDEL(fd sock_bt_cmtp, cmd const[CMTPCONNDEL], arg ptr[in, cmtp_conndel_req])
 ioctl$sock_bt_cmtp_CMTPGETCONNLIST(fd sock_bt_cmtp, cmd const[CMTPGETCONNLIST], arg ptr[in, cmtp_connlist_req])
@@ -81,7 +81,7 @@ ioctl$sock_bt_cmtp_CMTPGETCONNINFO(fd sock_bt_cmtp, cmd const[CMTPGETCONNINFO], 
 
 resource sock_bt_bnep[sock_bt]
 
-socket$bt_bnep(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_BNEP]) sock_bt_bnep
+syz_init_net_socket$bt_bnep(fam const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[BTPROTO_BNEP]) sock_bt_bnep
 ioctl$sock_bt_bnep_BNEPCONNADD(fd sock_bt_bnep, cmd const[BNEPCONNADD], arg ptr[in, bnep_connadd_req])
 ioctl$sock_bt_bnep_BNEPCONNDEL(fd sock_bt_bnep, cmd const[BNEPCONNDEL], arg ptr[in, bnep_conndel_req])
 ioctl$sock_bt_bnep_BNEPGETCONNLIST(fd sock_bt_bnep, cmd const[BNEPGETCONNLIST], arg ptr[in, bnep_connlist_req])


### PR DESCRIPTION
Replace socket_$bt_{bnep, cmtp, hidp, rfcomm} to syz_init_net_socket.

Fixes: https://github.com/google/syzkaller/issues/4729