### PR TITLE
pkg/mgrconfig: properly convert cover_filter

### DIFF
--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -358,6 +358,7 @@ func (cfg *Config) completeFocusAreas() error {
 				Weight: 1.0,
 			},
 		}
+		cfg.CovFilter = CovFilterCfg{}
 	}
 	return nil
 }


### PR DESCRIPTION
If we have converted one way of configuration into another, we should reset the old one.

Otherwise after the processing in syz-ci both will be set and the instance no longer starts due to
"you cannot use both cov_filter and focus_areas".
