### PR TITLE
pkg/report: ignore warnings printed by __ext4_msg

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1951,6 +1951,7 @@ var linuxOopses = append([]*oops{
 			compile(`WARNING: fbcon: Driver '(.*)' missed to adjust virtual screen size (\((?:\d+)x(?:\d+) vs\. (?:\d+)x(?:\d+)\))`),
 			compile(`WARNING: See https.* for mitigation options.`),
 			compile(`WARNING: kernel not compiled with CPU_SRSO`),
+			compile(`EXT4-[Ff][Ss](?: \(.*\))?:`), // printed in __ext4_msg
 		},
 		crash.Warning,
 	},

--- a/pkg/report/testdata/linux/report/728
+++ b/pkg/report/testdata/linux/report/728
@@ -1,0 +1,7 @@
+TITLE: 
+
+
+EXT4-fs: Warning: mounting with an experimental mount option 'dioread_nolock' for blocksize < PAGE_SIZE
+EXT4-fs (loop4): 1 truncate cleaned up
+EXT4-fs (loop4): mounted filesystem without journal. Quota mode: writeback.
+


### PR DESCRIPTION
These are just warnings to the system administrator. Ignore them during fuzzing.
