### PR TITLE
dashboard/api: better error description

### DIFF
--- a/dashboard/api/client.go
+++ b/dashboard/api/client.go
@@ -106,7 +106,8 @@ func (c *Client) Text(query string) ([]byte, error) {
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if res.StatusCode < 200 || res.StatusCode >= 300 || err != nil {
-		return nil, fmt.Errorf("api request %q failed: %v (%w)", queryURL, res.StatusCode, err)
+		return nil, fmt.Errorf("api request %q failed: status(%v) err(%w) body(%.1024s)",
+			queryURL, res.StatusCode, err, string(body))
 	}
 	return body, nil
 }

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -43,11 +43,13 @@ func handleContext(fn contextHandler) http.Handler {
 		if err := fn(c, w, r); err != nil {
 			hdr := commonHeaderRaw(c, r)
 			data := &struct {
-				Header *uiHeader
-				Error  string
+				Header  *uiHeader
+				Error   string
+				TraceID string
 			}{
-				Header: hdr,
-				Error:  err.Error(),
+				Header:  hdr,
+				Error:   err.Error(),
+				TraceID: strings.Join(r.Header["X-Cloud-Trace-Context"], " "),
 			}
 			if err == ErrAccess {
 				if hdr.LoginLink != "" {
@@ -83,7 +85,7 @@ func logErrorPrepareStatus(c context.Context, err error) int {
 		logf = log.Warningf
 		status = clientError.HTTPStatus()
 	}
-	logf(c, "%v", err)
+	logf(c, "appengine error: %v", err)
 	return status
 }
 

--- a/dashboard/app/templates/error.html
+++ b/dashboard/app/templates/error.html
@@ -5,6 +5,8 @@
 	<title>syzbot</title>
 </head>
 <body>
+	traceID: {{.TraceID}}
+	<br>
 	{{.Error}}
 	<br>
 	<a href="javascript:history.back()">back</a>


### PR DESCRIPTION
2024/10/26 00:08:09 alert: error: api request "https://syzkaller.appspot.com/text?json=1&tag=ReproC&x=11003952980000" failed: 500 (%!w(<nil>))

1. We have a 500 error w/o explanation. Let's dump some body here to better understand root-cause.
2. It is hard to filter AppEngine errors. Let's use "appengine error: " prefix.
3. Let's return traceID in body to simplify the errors analysis.
