### PR TITLE
dashboard/app: generate fewer logs exporting reproducers

### DIFF
--- a/dashboard/app/batch_reproexport.go
+++ b/dashboard/app/batch_reproexport.go
@@ -36,7 +36,7 @@ func exportReproScript(srcNamespace, archivePath string) string {
 		"token=$(gcloud auth print-access-token)\n" +
 		"CI=1 ./tools/syz-env \"" + // CI=1 to suppress "The input device is not a TTY".
 		"go run ./tools/syz-reprolist/... -namespace " + srcNamespace + " -token $token -j 10 && " +
-		"tar -czvf reproducers.tar.gz ./repros/ && " +
-		"gsutil -m cp reproducers.tar.gz " + archivePath +
+		"tar -czf reproducers.tar.gz ./repros/ && " +
+		"gsutil -q -m cp reproducers.tar.gz " + archivePath +
 		"\""
 }

--- a/tools/syz-reprolist/reprolist.go
+++ b/tools/syz-reprolist/reprolist.go
@@ -23,6 +23,7 @@ var (
 	flagToken     = flag.String("token", "", "gcp bearer token to disable throttling (contact syzbot first)\n"+
 		"usage example: ./tools/syz-reprolist -namespace upstream -token $(gcloud auth print-access-token)")
 	flagParallel = flag.Int("j", 2, "number of parallel threads")
+	flagVerbose  = flag.Bool("v", false, "verbose output")
 )
 
 func main() {
@@ -61,8 +62,10 @@ func exportNamespace() error {
 					continue
 				}
 				reproID := reproIDFromURL(cReproURL)
-				fmt.Printf("[%v](%v/%v)saving c-repro %v for bug %v\n",
-					i, iBug, len(bugs), reproID, bug.ID)
+				if *flagVerbose {
+					fmt.Printf("[%v](%v/%v)saving c-repro %v for bug %v\n",
+						i, iBug, len(bugs), reproID, bug.ID)
+				}
 				cReproBody, err := cli.Text(cReproURL)
 				if err != nil {
 					return err


### PR DESCRIPTION
1. Don't print per-file log by tool.
2. Disable tar verbosity.
3. Make gsutil quiet.
