### PR TITLE
dependabot.yml: remove dash from the names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,5 @@ updates:
         - "*"
       exclude-patterns:
         - "mockery"
-        - "golangci-lint"
+        - "golangci"
         - "appengine"


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/7542#issuecomment-1664438228
Dependabot can't create the PRs for some reason. The logs don't explain why.
It may be the root cause.