### PR TITLE
pkg/repro: accept a cancellable context

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -388,7 +388,12 @@ func (inst *inst) testInstance() error {
 		return err
 	}
 	opts.Repeat = false
-	out, err := execProg.RunSyzProg(testProg, inst.cfg.Timeouts.NoOutputRunningTime, opts, vm.ExitNormal)
+	out, err := execProg.RunSyzProg(ExecParams{
+		SyzProg:        testProg,
+		Duration:       inst.cfg.Timeouts.NoOutputRunningTime,
+		Opts:           opts,
+		ExitConditions: vm.ExitNormal,
+	})
 	if err != nil {
 		return &TestError{Title: err.Error()}
 	}
@@ -420,8 +425,11 @@ func (inst *inst) testRepro() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		out, err = transformError(execProg.RunSyzProg(inst.reproSyz,
-			inst.cfg.Timeouts.NoOutputRunningTime, opts, SyzExitConditions))
+		out, err = transformError(execProg.RunSyzProg(ExecParams{
+			SyzProg:  inst.reproSyz,
+			Duration: inst.cfg.Timeouts.NoOutputRunningTime,
+			Opts:     opts,
+		}))
 		if err != nil {
 			return out, err
 		}

--- a/pkg/repro/strace.go
+++ b/pkg/repro/strace.go
@@ -44,13 +44,18 @@ func RunStrace(result *Result, cfg *mgrconfig.Config, reporter *report.Reporter,
 			err = fmt.Errorf("failed to set up instance: %w", setupErr)
 			return
 		}
+		params := instance.ExecParams{
+			Opts:     result.Opts,
+			Duration: result.Duration,
+		}
 		if result.CRepro {
 			log.Logf(1, "running C repro under strace")
-			runRes, err = ret.RunCProg(result.Prog, result.Duration, result.Opts)
+			params.CProg = result.Prog
+			runRes, err = ret.RunCProg(params)
 		} else {
 			log.Logf(1, "running syz repro under strace")
-			runRes, err = ret.RunSyzProg(result.Prog.Serialize(), result.Duration,
-				result.Opts, instance.SyzExitConditions)
+			params.SyzProg = result.Prog.Serialize()
+			runRes, err = ret.RunSyzProg(params)
 		}
 	})
 	if err != nil {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -430,7 +430,12 @@ func reportReproError(err error) {
 }
 
 func (mgr *Manager) RunRepro(crash *manager.Crash) *manager.ReproResult {
-	res, stats, err := repro.Run(crash.Output, mgr.cfg, mgr.enabledFeatures, mgr.reporter, mgr.pool)
+	res, stats, err := repro.Run(context.Background(), crash.Output, repro.Environment{
+		Config:   mgr.cfg,
+		Features: mgr.enabledFeatures,
+		Reporter: mgr.reporter,
+		Pool:     mgr.pool,
+	})
 	ret := &manager.ReproResult{
 		Crash: crash,
 		Repro: res,

--- a/tools/syz-repro/repro.go
+++ b/tools/syz-repro/repro.go
@@ -67,7 +67,12 @@ func main() {
 	go func() {
 		defer done()
 
-		res, stats, err := repro.Run(data, cfg, flatrpc.AllFeatures, reporter, pool)
+		res, stats, err := repro.Run(ctx, data, repro.Environment{
+			Config:   cfg,
+			Features: flatrpc.AllFeatures,
+			Reporter: reporter,
+			Pool:     pool,
+		})
 		if err != nil {
 			log.Logf(0, "reproduction failed: %v", err)
 		}


### PR DESCRIPTION
Refactor pkg/repro to accept a context.Context object. This will make it look more similar to other package interfaces and will eventually let us abort currently running repro jobs without having to shut down the whole application.

Simplify the code by factoring out the parameters common both to RunSyzRepro() and RunCRepro().