### PR TITLE
dependabot.yml: revert changes, don't use groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,3 @@ updates:
     prefix: "mod:"
   assignees:
     - "tarasmadan"
-  groups:
-    stable-enough:
-      patterns:
-        - "*"
-      exclude-patterns:
-        - "mockery"
-        - "golangci"
-        - "appengine"


### PR DESCRIPTION
For some reason dependabot doesn't create PRs for group updates.
We have a tracking issue for it #5466 .
Let's disable grouping for now.
