### PR TITLE
dependabot.yml: limit to max 5 PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   commit-message:
     prefix: "mod:"
   assignees:


### PR DESCRIPTION
Merging the dependency update we trigger rebase and retest for other PRs.
Reducing the amount of PRs we reduce ARC pressure.
