### PR TITLE
dependabot.yml: let's ignore mockery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    # Mockery update requires manual changes in ./tools/mockery.sh.
+    - dependency-name: "mockery"
   open-pull-requests-limit: 5
   commit-message:
     prefix: "mod:"


### PR DESCRIPTION
Mockery and golangci-lint updates typically require more efforts.
I don't see any value in mockery updates now.
