### PR TITLE
pkg/coveragedb: store hitcount instead of coveredlines

### DIFF
--- a/pkg/coveragedb/spanner.go
+++ b/pkg/coveragedb/spanner.go
@@ -22,7 +22,7 @@ type FilesRecord struct {
 	Instrumented      int64
 	Covered           int64
 	LinesInstrumented []int64
-	LinesCovered      []int64
+	HitCounts         []int64
 }
 
 type FileSubsystems struct {
@@ -51,7 +51,7 @@ type Coverage struct {
 	Instrumented      int64
 	Covered           int64
 	LinesInstrumented []int64
-	LinesCovered      []int64
+	HitCounts         []int64
 }
 
 func SaveMergeResult(ctx context.Context, projectID string, covMap map[string]*Coverage,
@@ -113,10 +113,10 @@ func fileRecordMutation(session, filePath string, record *Coverage) *spanner.Mut
 		Instrumented:      record.Instrumented,
 		Covered:           record.Covered,
 		LinesInstrumented: record.LinesInstrumented,
-		LinesCovered:      record.LinesCovered,
+		HitCounts:         record.HitCounts,
 	})
 	if err != nil {
-		panic(fmt.Sprintf("failed to fileRecordMutation(): %s", err.Error()))
+		panic(fmt.Sprintf("failed to fileRecordMutation: %v", err))
 	}
 	return insert
 }

--- a/tools/syz-covermerger/init_db.sh
+++ b/tools/syz-covermerger/init_db.sh
@@ -18,7 +18,7 @@ CREATE TABLE
     "instrumented" bigint,
     "covered" bigint,
     "linesinstrumented" bigint[],
-    "linescovered" bigint[],
+    "hitcounts" bigint[],
   PRIMARY KEY
     (session, filepath) );')
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \

--- a/tools/syz-covermerger/syz_covermerger.go
+++ b/tools/syz-covermerger/syz_covermerger.go
@@ -140,22 +140,26 @@ func mergeResultsToCoverage(mergedCoverage map[string]*covermerger.MergeResult,
 		if !lineStat.FileExists {
 			continue
 		}
-		var linesInstrumented, linesCovered []int64
-		for lineNum, lineHitCount := range lineStat.HitCounts {
-			linesInstrumented = append(linesInstrumented, int64(lineNum))
-			if lineHitCount > 0 {
-				linesCovered = append(linesCovered, int64(lineNum))
+
+		lines := maps.Keys(lineStat.HitCounts)
+		slices.Sort(lines)
+
+		var linesInstrumented, hitCounts []int64
+		var instrumented, covered int64
+		for _, line := range lines {
+			instrumented++
+			linesInstrumented = append(linesInstrumented, int64(line))
+			hitCount := lineStat.HitCounts[line]
+			hitCounts = append(hitCounts, int64(hitCount))
+			if hitCount > 0 {
+				covered++
 			}
 		}
-		slices.Sort(linesInstrumented)
-		slices.Sort(linesCovered)
-		instrumented := int64(len(linesInstrumented))
-		covered := int64(len(linesCovered))
 		res[fileName] = &coveragedb.Coverage{
 			Instrumented:      instrumented,
 			Covered:           covered,
 			LinesInstrumented: linesInstrumented,
-			LinesCovered:      linesCovered,
+			HitCounts:         hitCounts,
 		}
 		totalInstrumented += instrumented
 		totalCovered += covered


### PR DESCRIPTION
Instrumented lines + hit count gives more information than instrumented + covered lines.
Expected storage cost is at the same level.
