### PR TITLE
dependabot.yml: remove mockery from ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  ignore:
-    # Mockery update requires manual changes in ./tools/mockery.sh.
-    - dependency-name: "mockery"
   open-pull-requests-limit: 5
   commit-message:
     prefix: "mod:"


### PR DESCRIPTION
For some reason dependabot stopped to create PRs again.
I think it happened after this change. Let's check this assumption.
