### PR TITLE
executor: use any executor if the avoid mask included all of them

### DIFF
--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -321,9 +321,6 @@ func (runner *Runner) sendRequest(req *queue.Request) error {
 			avoid |= uint64(1 << id.Proc)
 		}
 	}
-	if avoid == (uint64(1)<<runner.procs)-1 {
-		avoid = 0
-	}
 	msg := &flatrpc.HostMessage{
 		Msg: &flatrpc.HostMessages{
 			Type: flatrpc.HostMessagesRawExecRequest,


### PR DESCRIPTION
After 9fc8fe026baa ("executor: better handling for hanged test processes"), syz-executor's responses may reference procids outside of the [0;procs] range.

If procids are no longer dense on the syz-executor side, we cannot rely on this check in pkg/rpcserver:
```
	if avoid == (uint64(1)<<runner.procs)-1 {
		avoid = 0
	}
```
