### PR TITLE
pkg/manager: show number of times coverage for each call has overflowed

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -180,14 +180,22 @@ static void cover_reset(cover_t* cov)
 	cover_unprotect(cov);
 	*(uint64*)cov->data = 0;
 	cover_protect(cov);
+	cov->overflow = false;
+}
+
+template <typename cover_data_t>
+static void cover_collect_impl(cover_t* cov)
+{
+	cov->size = *(cover_data_t*)cov->data;
+	cov->overflow = (cov->data + (cov->size + 2) * sizeof(cover_data_t)) > cov->data_end;
 }
 
 static void cover_collect(cover_t* cov)
 {
 	if (is_kernel_64_bit)
-		cov->size = *(uint64*)cov->data;
+		cover_collect_impl<uint64>(cov);
 	else
-		cov->size = *(uint32*)cov->data;
+		cover_collect_impl<uint32>(cov);
 }
 
 // One does not simply exit.

--- a/executor/snapshot.h
+++ b/executor/snapshot.h
@@ -147,7 +147,7 @@ constexpr size_t kOutputPopulate = 256 << 10;
 constexpr size_t kInputPopulate = 64 << 10;
 constexpr size_t kGlobalsPopulate = 4 << 10;
 constexpr size_t kDataPopulate = 8 << 10;
-constexpr size_t kCoveragePopulate = 32 << 10;
+constexpr size_t kCoveragePopulate = 64 << 10;
 constexpr size_t kThreadsPopulate = 2;
 
 static void SnapshotSetState(rpc::SnapshotState state)

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -202,6 +202,7 @@ enum CallFlag : uint8 (bit_flags) {
 	Finished,		// finished executing (rather than blocked forever)
 	Blocked,		// finished but blocked during execution
 	FaultInjected,		// fault was injected into this call
+	CoverageOverflow,	// coverage buffer has overflowed so we have truncated coverage
 }
 
 table CallInfoRaw {

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -392,24 +392,27 @@ func (v ExecFlag) String() string {
 type CallFlag byte
 
 const (
-	CallFlagExecuted      CallFlag = 1
-	CallFlagFinished      CallFlag = 2
-	CallFlagBlocked       CallFlag = 4
-	CallFlagFaultInjected CallFlag = 8
+	CallFlagExecuted         CallFlag = 1
+	CallFlagFinished         CallFlag = 2
+	CallFlagBlocked          CallFlag = 4
+	CallFlagFaultInjected    CallFlag = 8
+	CallFlagCoverageOverflow CallFlag = 16
 )
 
 var EnumNamesCallFlag = map[CallFlag]string{
-	CallFlagExecuted:      "Executed",
-	CallFlagFinished:      "Finished",
-	CallFlagBlocked:       "Blocked",
-	CallFlagFaultInjected: "FaultInjected",
+	CallFlagExecuted:         "Executed",
+	CallFlagFinished:         "Finished",
+	CallFlagBlocked:          "Blocked",
+	CallFlagFaultInjected:    "FaultInjected",
+	CallFlagCoverageOverflow: "CoverageOverflow",
 }
 
 var EnumValuesCallFlag = map[string]CallFlag{
-	"Executed":      CallFlagExecuted,
-	"Finished":      CallFlagFinished,
-	"Blocked":       CallFlagBlocked,
-	"FaultInjected": CallFlagFaultInjected,
+	"Executed":         CallFlagExecuted,
+	"Finished":         CallFlagFinished,
+	"Blocked":          CallFlagBlocked,
+	"FaultInjected":    CallFlagFaultInjected,
+	"CoverageOverflow": CallFlagCoverageOverflow,
 }
 
 func (v CallFlag) String() string {

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -649,23 +649,25 @@ enum class CallFlag : uint8_t {
   Finished = 2,
   Blocked = 4,
   FaultInjected = 8,
+  CoverageOverflow = 16,
   NONE = 0,
-  ANY = 15
+  ANY = 31
 };
 FLATBUFFERS_DEFINE_BITMASK_OPERATORS(CallFlag, uint8_t)
 
-inline const CallFlag (&EnumValuesCallFlag())[4] {
+inline const CallFlag (&EnumValuesCallFlag())[5] {
   static const CallFlag values[] = {
     CallFlag::Executed,
     CallFlag::Finished,
     CallFlag::Blocked,
-    CallFlag::FaultInjected
+    CallFlag::FaultInjected,
+    CallFlag::CoverageOverflow
   };
   return values;
 }
 
 inline const char * const *EnumNamesCallFlag() {
-  static const char * const names[9] = {
+  static const char * const names[17] = {
     "Executed",
     "Finished",
     "",
@@ -674,13 +676,21 @@ inline const char * const *EnumNamesCallFlag() {
     "",
     "",
     "FaultInjected",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "CoverageOverflow",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameCallFlag(CallFlag e) {
-  if (flatbuffers::IsOutRange(e, CallFlag::Executed, CallFlag::FaultInjected)) return "";
+  if (flatbuffers::IsOutRange(e, CallFlag::Executed, CallFlag::CoverageOverflow)) return "";
   const size_t index = static_cast<size_t>(e) - static_cast<size_t>(CallFlag::Executed);
   return EnumNamesCallFlag()[index];
 }

--- a/pkg/manager/html/syscalls.html
+++ b/pkg/manager/html/syscalls.html
@@ -9,7 +9,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Syscall', textSort)" href="#">Syscall</a></th>
 		<th><a onclick="return sortTable(this, 'Inputs', numSort)" href="#" title="Number of inputs in the corpus added because of this syscall">Inputs</a></th>
 		<th><a onclick="return sortTable(this, 'Total', numSort)" href="#" title="Total number of inputs in the corpus that contain this syscall">Total</a></th>
-		<th><a onclick="return sortTable(this, 'Coverage', numSort)" href="#">Coverage</a></th>
+		<th><a onclick="return sortTable(this, 'Coverage', numSort)" href="#" title="Coverage achieved by this syscall">Coverage</a></th>
+		<th><a onclick="return sortTable(this, 'Cover overflows', numSort)" href="#" title="Number of times coverage buffer has overflowed on this syscall">Cover overflows</a></th>
+		<th><a onclick="return sortTable(this, 'Comps overflows', numSort)" href="#" title="Number of times comparisons buffer has overflowed on this syscall">Comps overflows</a></th>
 		<th>Prio</th>
 	</tr>
 	{{range $c := $.Calls}}
@@ -18,6 +20,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td><a href='/corpus?call={{$c.Name}}'>{{$c.Inputs}}</a></td>
 		<td>{{$c.Total}}</td>
 		<td><a href='/cover?call={{$c.Name}}'>{{$c.Cover}}</a></td>
+		<td>{{$c.CoverOverflows}}</td>
+		<td>{{$c.CompsOverflows}}</td>
 		<td><a href='/prio?call={{$c.Name}}'>prio</a></td>
 	</tr>
 	{{end}}

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -17,12 +17,14 @@ type Prog struct {
 	isUnsafe bool
 }
 
+const ExtraCallName = ".extra"
+
 func (p *Prog) CallName(call int) string {
 	if call >= len(p.Calls) || call < -1 {
 		panic(fmt.Sprintf("bad call index %v/%v", call, len(p.Calls)))
 	}
 	if call == -1 {
-		return ".extra"
+		return ExtraCallName
 	}
 	return p.Calls[call].Meta.Name
 }


### PR DESCRIPTION
If the overflows happen often, it's bad.
Add visibility into this.
