### PR TITLE
[WIP] sys/linux, tools: add ksmbd (SMB3 server) stateful fuzzing

### DIFF
--- a/sys/linux/ksmbd.txt
+++ b/sys/linux/ksmbd.txt
@@ -1,0 +1,552 @@
+include <linux/ip.h>
+include <linux/ipv6.h>
+include <linux/route.h>
+include <uapi/linux/if_arp.h>
+include <uapi/linux/netfilter_ipv6/ip6_tables.h>
+include <uapi/linux/wireless.h>
+include <uapi/linux/in.h>
+
+# =================================
+# Stateful fuzzing model (read first)
+# =================================
+# ksmbd keeps per-CONNECTION state (negotiated dialect, authenticated session,
+# opened FIDs, granted oplocks/leases) across PDUs sent on the same TCP socket.
+# So a syzkaller program that issues several sendto$ksmbd() on the SAME
+# sock_ksmbd resource, in order, IS a stateful session:
+#
+#   r0 = socket$ksmbd(...); connect$ksmbd(r0, ...)
+#   sendto$ksmbd(r0, <NEGOTIATE>)      # -> ksmbd: conn negotiated
+#   sendto$ksmbd(r0, <SESSION_SETUP>)  # -> ksmbd: session authenticated
+#   sendto$ksmbd(r0, <TREE_CONNECT>)   # -> ksmbd: tree connected
+#   sendto$ksmbd(r0, <CREATE>)         # -> ksmbd: FID opened
+#   sendto$ksmbd(r0, <WRITE/CLOSE>)    # -> uses that FID
+#
+# The gap: ksmbd assigns SessionId (in SESSION_SETUP resp), TreeId (TREE_CONNECT
+# resp) and Persistent/VolatileFileId (CREATE resp) in the RESPONSE PDUs, and
+# syzkaller does not parse responses, so it cannot thread the real server-side
+# ids into later PDUs. Two consequences the descriptions below work with:
+#  1. SessionId/TreeId/FileId are left as plain integers seeded with the special
+#     value 0xffffffffffffffff (SMB2 "compound-related / unsolicited" sentinel)
+#     plus small values, so brute/dataflow can still land valid ids.
+#  2. True id threading needs parsing the response PDUs and feeding the
+#     server-assigned ids back as syzkaller resources. That is left for a
+#     follow-up; until it lands, sequencing gives connection state but not id
+#     threading.
+
+# =================================
+# SMB2 constant / flag sets
+# =================================
+smb2_dialects = 0x202, 0x210, 0x300, 0x302, 0x311, 0x2ff
+smb2_security_mode = 0x1, 0x2
+smb2_negotiate_caps = 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40
+smb2_hdr_flags = 0x1, 0x2, 0x4, 0x8, 0x10000000, 0x20000000, 0x40000000, 0x80000000
+# DesiredAccess (file/dir access mask)
+smb2_access_mask = 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x80, 0x100, 0x10000, 0x20000, 0x40000, 0x80000, 0x100000, 0x1000000, 0x2000000, 0x10000000, 0x20000000, 0x40000000, 0x80000000
+smb2_share_access = 0x1, 0x2, 0x4
+smb2_create_disposition = 0, 1, 2, 3, 4, 5
+smb2_create_options = 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x100000
+smb2_oplock_level = 0x0, 0x1, 0x8, 0x9, 0xff
+smb2_impersonation = 0, 1, 2, 3
+smb2_file_attributes = 0x1, 0x2, 0x4, 0x10, 0x20, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000
+# InfoType (SMB2_QUERY_INFO / SET_INFO)
+smb2_info_type = 0x1, 0x2, 0x3, 0x4
+# FileInformationClass (subset ksmbd handles)
+smb2_file_info_class = 4, 5, 6, 7, 10, 13, 14, 18, 19, 20, 21, 22, 34, 35, 60
+# FSCTL / IOCTL control codes ksmbd dispatches
+smb2_fsctl_code = 0x60194, 0x110018, 0x11c017, 0x140078, 0x1401fc, 0x140204, 0x900a4, 0x900a8, 0x900ac, 0x900c4, 0x980c8, 0x940cf, 0x1440f2, 0x1480f2, 0x98344
+# Server-assigned id sentinels (see stateful note): 0 and the SMB2 all-ones id.
+smb2_ids = 0, 0xffffffffffffffff
+# SMB2 command opcodes
+smb2_commands = 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10, 0x11, 0x12
+
+# =================================
+# Common Definitions
+# =================================
+
+sync_id {
+	ProcessId	int32
+	TreeId		int32
+} [packed]
+
+union_smb_req_id [
+	sync_id		sync_id
+	async_id	int64
+] [varlen]
+
+# SMB2
+smb2_hdr {
+	ProtocolId	const[0xfe534d42, int32be]
+	StructureSize	const[0x40, int16]
+	CreditCharge	int16
+	Status		int32
+	Command		flags[smb2_commands, int16]
+	CreditRequest	int16
+	Flags		flags[smb2_hdr_flags, int32]
+	NextCommand	int32
+	MessageId	int64
+	Id		union_smb_req_id
+	SessionId	int64
+	Signature	array[int8, 16]
+} [packed]
+
+# =================================
+# SMB2 Request Definitions
+# =================================
+
+# SMB2_NEGOTIATE (0x0000)
+smb2_negotiate_req_body {
+	StructureSize		const[36, int16]
+	DialectCount		len[Dialects, int16]
+	SecurityMode		flags[smb2_security_mode, int16]
+	Reserved		int16
+	Capabilities		flags[smb2_negotiate_caps, int32]
+	ClientGUID		array[int8, 16]
+# In SMB3.02 and earlier next three were MBZ le64 ClientStartTime
+	NegotiateContextOffset	int32
+# SMB3.1.1 only. MBZ earlier
+	NegotiateContextCount	int16
+# SMB3.1.1 only. MBZ earlier
+	Reserved2		int16
+	Dialects		array[flags[smb2_dialects, int16]]
+} [packed]
+
+negotiate_message {
+	Signature			array[int8, 8]
+#  NtLmNegotiate = 1
+	MessageType			int32
+	NegotiateFlags			int32
+# MBZ unless SMB3.02 or later
+	DomainName_Length		len[DomainString, int16]
+	DomainName_MaximumLength	len[DomainString, int16]
+	DomainName_Offset		offsetof[DomainString, int32]
+# RFC 1001 and ASCII
+	WorkstationName_Length		len[Workstationname_Buffer, int16]
+	WorkstationName_MaximumLength	len[Workstationname_Buffer, int16]
+	WorkstationName_Offset		offsetof[Workstationname_Buffer, int32]
+# struct security_buffer for version info not present since we
+# do not set the version is present flag
+	DomainString			string
+# followed by WorkstationString
+	Workstationname_Buffer		string
+} [packed]
+
+smbd_buffer_descriptor_v1 {
+	offset			int64
+	token			int32
+	length			int32
+# followed by Smbd_Buffer
+	smb2_read_req_buffer	string
+} [packed]
+
+# SMB2_READ (0x0008)
+smb2_read_req_body {
+# Must be 49
+	StructureSize		const[49, int16]
+# offset from start of SMB2 header to place read
+	Padding			int8
+# MBZ unless SMB3.02 or later
+	Flags			int8
+	Length			int32
+	Offset			int64
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	MinimumCount		int32
+# MBZ except for SMB3 or later
+	Channel			int32
+	RemainingBytes		int32
+	ReadChannelInfoOffset	offsetof[Buffer, int16]
+	ReadChannelInfoLength	len[Buffer, int16]
+	Buffer			smbd_buffer_descriptor_v1
+} [packed]
+
+# SMB2_SESSION_SETUP (0x0001)
+# Header(64) + Fixed(24) = 88 bytes.
+smb2_sess_setup_req_body {
+	StructureSize		const[25, int16]
+	Flags			int8
+	SecurityMode		int8
+	Capabilities		int32
+	Channel			int32
+	SecurityBufferOffset	offsetof[Buffer, int16]
+	SecurityBufferLength	len[Buffer, int16]
+	PreviousSessionId	int64
+# variable length GSS security buffer
+	Buffer			negotiate_message
+} [packed]
+
+# SMB2_TREE_CONNECT (0x0003)
+smb2_tree_connect_req_body {
+	StructureSize	const[9, int16]
+	Reserved	int16
+	PathOffset	offsetof[Path, int16]
+	PathLength	len[Path, int16]
+	Path		string
+} [packed]
+
+# SMB2_CREATE create contexts (chained; ksmbd parses these by 4-byte tag).
+# Each context: Next | NameOffset/Len | DataOffset/Len | tag name | data.
+smb2_create_ctx_dhnq {
+	Next		const[0, int32]
+	NameOffset	const[16, int16]
+	NameLength	const[4, int16]
+	Reserved	int16
+	DataOffset	const[24, int16]
+	DataLength	const[16, int32]
+	Name		stringnoz["DHnQ"]
+	Pad		array[int8, 4]
+	Data		array[int8, 16]
+} [packed]
+
+smb2_create_ctx_dh2q {
+	Next		const[0, int32]
+	NameOffset	const[16, int16]
+	NameLength	const[4, int16]
+	Reserved	int16
+	DataOffset	const[24, int16]
+	DataLength	const[32, int32]
+	Name		stringnoz["DH2Q"]
+	Pad		array[int8, 4]
+	Timeout		int32
+	Flags		int32
+	Reserved2	int64
+	CreateGuid	array[int8, 16]
+} [packed]
+
+smb2_create_ctx_rqls {
+	Next		const[0, int32]
+	NameOffset	const[16, int16]
+	NameLength	const[4, int16]
+	Reserved	int16
+	DataOffset	const[24, int16]
+	DataLength	const[52, int32]
+	Name		stringnoz["RqLs"]
+	Pad		array[int8, 4]
+	LeaseKey	array[int8, 16]
+	LeaseState	int32
+	LeaseFlags	int32
+	LeaseDuration	int64
+	ParentLeaseKey	array[int8, 16]
+	Epoch		int16
+	Reserved2	int16
+} [packed]
+
+smb2_create_ctx_generic {
+	Next		int32
+	NameOffset	const[16, int16]
+	NameLength	len[Name, int16]
+	Reserved	int16
+	DataOffset	int16
+	DataLength	len[Data, int32]
+	Name		stringnoz
+	Data		buffer[in]
+} [packed]
+
+smb2_create_ctx [
+	dhnq	smb2_create_ctx_dhnq
+	dh2q	smb2_create_ctx_dh2q
+	rqls	smb2_create_ctx_rqls
+	mxac	smb2_create_ctx_generic
+	qfid	smb2_create_ctx_generic
+	secd	smb2_create_ctx_generic
+	alsi	smb2_create_ctx_generic
+	exta	smb2_create_ctx_generic
+] [varlen]
+
+smb2_create_buffer {
+	Name		stringnoz
+	Contexts	array[smb2_create_ctx]
+} [packed]
+
+# SMB2_CREATE (0x0005)
+# Header(64) + Fixed(56) = 120 bytes.
+smb2_create_req_body {
+	StructureSize		const[57, int16]
+	SecurityFlags		int8
+	RequestedOplockLevel	flags[smb2_oplock_level, int8]
+	ImpersonationLevel	flags[smb2_impersonation, int32]
+	SmbCreateFlags		int64
+	Reserved		int64
+	DesiredAccess		flags[smb2_access_mask, int32]
+	FileAttributes		flags[smb2_file_attributes, int32]
+	ShareAccess		flags[smb2_share_access, int32]
+	CreateDisposition	flags[smb2_create_disposition, int32]
+	CreateOptions		flags[smb2_create_options, int32]
+	NameOffset		int16
+	NameLength		int16
+	CreateContextsOffset	int32
+	CreateContextsLength	int32
+	Buffer			smb2_create_buffer
+} [packed]
+
+# SMB2_CLOSE (0x0006)
+smb2_close_req_body {
+	StructureSize		const[24, int16]
+	Flags			int16
+	Reserved		int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+} [packed]
+
+# SMB2_FLUSH (0x0007)
+smb2_flush_req_body {
+	StructureSize		const[24, int16]
+	Reserved1		int16
+	Reserved2		int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+} [packed]
+
+# SMB2_CANCEL (0x000C)
+smb2_cancel_req_body {
+	StructureSize	const[4, int16]
+	Reserved	int16
+} [packed]
+
+# SMB2_CHANGE_NOTIFY (0x000F)
+smb2_change_notify_req_body {
+	StructureSize		const[32, int16]
+	Flags			int16
+	OutputBufferLength	int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	CompletionFilter	int32
+	Reserved		int32
+} [packed]
+
+# SMB2_OPLOCK_BREAK (0x0012) — client ack of a server-initiated break
+smb2_oplock_break_req_body {
+	StructureSize		const[24, int16]
+	OplockLevel		flags[smb2_oplock_level, int8]
+	Reserved		int8
+	Reserved2		int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+} [packed]
+
+# SMB2_WRITE (0x0009)
+# Header(64) + Fixed(48) = 112 bytes.
+smb2_write_req_body {
+	StructureSize		const[49, int16]
+	DataOffset		int16
+	Length			len[Buffer, int32]
+	Offset			int64
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	Channel			int32
+	RemainingBytes		int32
+	WriteChannelInfoOffset	int16
+	WriteChannelInfoLength	int16
+	Flags			int32
+	Buffer			buffer[in]
+} [packed]
+
+# SMB2_LOCK (0x000A)
+smb2_lock_element {
+	Offset		int64
+	Length		int64
+	Flags		int32
+	Reserved	int32
+} [packed]
+
+# SMB2_LOCK (0x000A)
+smb2_lock_req_body {
+	StructureSize		const[48, int16]
+	LockCount		len[locks, int16]
+	LockSequenceNumber	int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	locks			array[smb2_lock_element]
+} [packed]
+
+# FSCTL input payloads (ksmbd fsctl dispatch)
+smb2_fsctl_copychunk {
+	SourceKey	array[int8, 24]
+	ChunkCount	len[Chunks, int32]
+	Reserved	int32
+	Chunks		array[smb2_copychunk]
+} [packed]
+
+smb2_copychunk {
+	SourceOffset	int64
+	TargetOffset	int64
+	Length		int32
+	Reserved	int32
+} [packed]
+
+smb2_fsctl_validate_negotiate {
+	Capabilities	int32
+	Guid		array[int8, 16]
+	SecurityMode	int16
+	DialectCount	len[Dialects, int16]
+	Dialects	array[int16]
+} [packed]
+
+smb2_fsctl_input [
+	copychunk	smb2_fsctl_copychunk
+	validate_neg	smb2_fsctl_validate_negotiate
+	raw		buffer[in]
+] [varlen]
+
+# SMB2_IOCTL (0x000B)
+# Header(64) + Fixed(56) = 120 bytes.
+smb2_ioctl_req_body {
+	StructureSize		const[57, int16]
+	Reserved		int16
+	CtlCode			flags[smb2_fsctl_code, int32]
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	InputOffset		int32
+	InputCount		int32
+	MaxInputResponse	int32
+	OutputOffset		int32
+	OutputCount		int32
+	MaxOutputResponse	int32
+	Flags			int32
+	Reserved2		int32
+	Buffer			smb2_fsctl_input
+} [packed]
+
+smb2_echo_req_body {
+	StructureSize	const[4, int16]
+	Reserved	int16
+} [packed]
+
+# SMB2_QUERY_DIRECTORY (0x000E)
+# Header(64) + Fixed(32) = 96 bytes.
+smb2_query_directory_req_body {
+	StructureSize		const[33, int16]
+	FileInformationClass	flags[smb2_file_info_class, int8]
+	Flags			int8
+	FileIndex		int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	FileNameOffset		int16
+	FileNameLength		len[Buffer, int16]
+	OutputBufferLength	int32
+	Buffer			buffer[in]
+} [packed]
+
+# SMB2_QUERY_INFO (0x0010)
+# Header(64) + Fixed(40) = 104 bytes.
+smb2_query_info_req_body {
+	StructureSize		const[41, int16]
+	InfoType		flags[smb2_info_type, int8]
+	FileInfoClass		flags[smb2_file_info_class, int8]
+	OutputBufferLength	int32
+	InputBufferOffset	int16
+	Reserved		int16
+	InputBufferLength	len[Buffer, int32]
+	AdditionalInformation	int32
+	Flags			int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	Buffer			buffer[in]
+} [packed]
+
+# SET_INFO file-information payloads (ksmbd smb2_set_info handlers)
+smb2_setinfo_rename {
+	ReplaceIfExists	int8
+	Reserved	array[int8, 7]
+	RootDirectory	int64
+	FileNameLength	len[FileName, int32]
+	FileName	stringnoz
+} [packed]
+
+smb2_setinfo_disposition {
+	DeletePending	int8
+} [packed]
+
+smb2_setinfo_eof {
+	EndOfFile	int64
+} [packed]
+
+smb2_setinfo_allocation {
+	AllocationSize	int64
+} [packed]
+
+smb2_setinfo_basic {
+	CreationTime	int64
+	LastAccessTime	int64
+	LastWriteTime	int64
+	ChangeTime	int64
+	FileAttributes	flags[smb2_file_attributes, int32]
+	Reserved	int32
+} [packed]
+
+smb2_setinfo_buffer [
+	rename		smb2_setinfo_rename
+	disposition	smb2_setinfo_disposition
+	eof		smb2_setinfo_eof
+	allocation	smb2_setinfo_allocation
+	basic		smb2_setinfo_basic
+	raw		buffer[in]
+] [varlen]
+
+# SMB2_SET_INFO (0x0011)
+# Header(64) + Fixed(32) = 96 bytes.
+smb2_set_info_req_body {
+	StructureSize		const[33, int16]
+	InfoType		flags[smb2_info_type, int8]
+	FileInfoClass		flags[smb2_file_info_class, int8]
+	BufferLength		len[Buffer, int32]
+	BufferOffset		int16
+	Reserved		int16
+	AdditionalInformation	int32
+	PersistentFileId	flags[smb2_ids, int64]
+	VolatileFileId		flags[smb2_ids, int64]
+	Buffer			smb2_setinfo_buffer
+} [packed]
+
+# =================================
+# PDU Definition and Syscall
+# =================================
+
+# Union of all supported SMB2 requests
+union_smb2_req_body [
+	smb2_negotiate_req_body		smb2_negotiate_req_body	(if[value[smb2_req:hdr:Command] == 0x0])
+	smb2_read_req_body		smb2_read_req_body	(if[value[smb2_req:hdr:Command] == 0x8])
+	smb2_sess_setup_req_body	smb2_sess_setup_req_body	(if[value[smb2_req:hdr:Command] == 0x1])
+	smb2_tree_connect_req_body	smb2_tree_connect_req_body	(if[value[smb2_req:hdr:Command] == 0x3])
+	smb2_create_req_body		smb2_create_req_body	(if[value[smb2_req:hdr:Command] == 0x5])
+	smb2_close_req_body		smb2_close_req_body	(if[value[smb2_req:hdr:Command] == 0x6])
+	smb2_flush_req_body		smb2_flush_req_body	(if[value[smb2_req:hdr:Command] == 0x7])
+	smb2_write_req_body		smb2_write_req_body	(if[value[smb2_req:hdr:Command] == 0x9])
+	smb2_lock_req_body		smb2_lock_req_body	(if[value[smb2_req:hdr:Command] == 0xa])
+	smb2_ioctl_req_body		smb2_ioctl_req_body	(if[value[smb2_req:hdr:Command] == 0xb])
+	smb2_cancel_req_body		smb2_cancel_req_body	(if[value[smb2_req:hdr:Command] == 0xc])
+	smb2_echo_req_body		smb2_echo_req_body	(if[value[smb2_req:hdr:Command] == 0xd])
+	smb2_query_directory_req_body	smb2_query_directory_req_body	(if[value[smb2_req:hdr:Command] == 0xe])
+	smb2_change_notify_req_body	smb2_change_notify_req_body	(if[value[smb2_req:hdr:Command] == 0xf])
+	smb2_query_info_req_body	smb2_query_info_req_body	(if[value[smb2_req:hdr:Command] == 0x10])
+	smb2_set_info_req_body		smb2_set_info_req_body	(if[value[smb2_req:hdr:Command] == 0x11])
+	smb2_oplock_break_req_body	smb2_oplock_break_req_body	(if[value[smb2_req:hdr:Command] == 0x12])
+	default				array[int8]
+] [varlen]
+
+smb2_req {
+	hdr	smb2_hdr
+	body	union_smb2_req_body
+} [packed]
+
+smb2_message {
+	req		smb2_req
+	req_andx1	smb2_req	(if[value[smb2_message:req:hdr:NextCommand] != 0])
+} [packed]
+
+smb2_req_pdu {
+	pdu_size	len[msg, int32be]
+	msg		smb2_message
+} [packed]
+
+resource sock_ksmbd[sock]
+socket$ksmbd(domain const[AF_INET], type const[SOCK_STREAM], proto const[IPPROTO_TCP]) sock_ksmbd
+
+sockaddr_in_ksmbd {
+	family	const[AF_INET, int16]
+	port	const[445, int16be]
+	addr	ipv4_addr
+	zero	array[int8, 8]
+} [packed]
+
+connect$ksmbd(fd sock_ksmbd, addr ptr[in, sockaddr_in_ksmbd], addrlen len[addr])
+sendto$ksmbd(fd sock_ksmbd, buf ptr[in, smb2_req_pdu], len len[buf], f flags[send_flags], addr const[0], addrlen const[0])

--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -20,6 +20,7 @@ RELEASE=trixie
 FEATURE=minimal
 SEEK=2047
 PERF=false
+KSMBD=false
 
 # Display help function
 display_help() {
@@ -31,6 +32,7 @@ display_help() {
     echo "   -h, --help                 Display help message"
     echo "   -o, --output               Set output prefix (default: value of --distribution)"
     echo "   -p, --add-perf             Add perf support. Requires environment variable \$KERNEL pointing to kernel source tree"
+    echo "   -k, --add-ksmbd            Add ksmbd (SMB3 server) fuzzing support: install ksmbd-tools + deps and the self-contained ksmbd_setup.sh, started on every boot via a systemd service."
     echo "   -s, --seek                 Image size in MB (default: $(($SEEK + 1)))"
     echo
     echo "The chroot will be created in ./<output>, the final image will be created in ./<output>.img, and SSH keys will be named"
@@ -70,6 +72,10 @@ while true; do
             ;;
         -p | --add-perf)
             PERF=true
+            shift 1
+            ;;
+        -k | --add-ksmbd)
+            KSMBD=true
             shift 1
             ;;
         -s | --seek)
@@ -200,6 +206,44 @@ if [ $PERF = "true" ]; then
     sudo chroot $DIR /bin/bash -c "cd /tmp/$BASENAME/tools/perf/; make"
     sudo chroot $DIR /bin/bash -c "cp /tmp/$BASENAME/tools/perf/perf /usr/bin/"
     rm -r $DIR/tmp/$BASENAME
+fi
+
+# Add ksmbd (in-kernel SMB3 server) fuzzing support: install ksmbd-tools, drop
+# in the config, and enable a boot service that runs tools/ksmbd_setup.sh so the
+# server is up and configured before syzkaller connects. The kernel itself must
+# be built with CONFIG_SMB_SERVER for `modprobe ksmbd` to succeed.
+if [ $KSMBD = "true" ]; then
+    SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+    if [ ! -r "$SCRIPT_DIR/ksmbd_setup.sh" ]; then
+        echo "Error: $SCRIPT_DIR/ksmbd_setup.sh not found"
+        exit 1
+    fi
+    # ksmbd-tools: the mountd/adduser userspace. rdma-core + iproute2: SMB Direct
+    # transport setup (SIW/RXE). krb5-*: the Kerberos session-setup auth path.
+    # DEBIAN_FRONTEND=noninteractive: krb5-* otherwise prompt for a realm and
+    # hang the non-interactive image build.
+    sudo chroot $DIR /bin/bash -c "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install -y ksmbd-tools rdma-core iproute2 krb5-kdc krb5-admin-server krb5-user"
+    # ksmbd_setup.sh is self-contained -- it writes the config itself, so there is
+    # no separate config file to install. Stage it and bring it up on every boot
+    # via a systemd oneshot, enabled with systemctl inside the chroot the same way
+    # create-ec2-rootfs.sh enables its boot services. The mountd daemon it starts
+    # then persists independently of syzkaller's executor restarts.
+    sudo cp "$SCRIPT_DIR/ksmbd_setup.sh" $DIR/usr/bin/ksmbd_setup.sh
+    sudo chmod 0755 $DIR/usr/bin/ksmbd_setup.sh
+    cat <<'EOF' | sudo tee $DIR/etc/systemd/system/ksmbd-for-fuzzing.service >/dev/null
+[Unit]
+Description=Bring up ksmbd for syzkaller fuzzing
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ksmbd_setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo chroot $DIR systemctl enable ksmbd-for-fuzzing.service
 fi
 
 # Add udev rules for custom drivers.

--- a/tools/ksmbd_setup.sh
+++ b/tools/ksmbd_setup.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+# ksmbd_setup.sh brings up the in-kernel SMB3 server (ksmbd) inside the target
+# VM so that syzkaller's ksmbd descriptions (sys/linux/ksmbd.txt) reach a
+# configured, listening server. It configures three transports/paths so the
+# fuzzer can exercise the full server:
+#   - TCP on 127.0.0.1:445           (always)
+#   - SMB Direct / RDMA (SIW or RXE) (if the kernel + rdma-core support it)
+#   - Kerberos KDC for the krb5 auth path in session-setup (optional)
+#
+# Installed into the image by `create-image.sh --add-ksmbd`, and run on every
+# boot via a systemd unit. Deliberately idempotent (safe to re-run): it kills
+# any running daemon and tolerates already-provisioned state, because the guest
+# may reboot many times during a fuzzing campaign. Every optional step is
+# non-fatal -- a kernel without RDMA or a host without krb5 still gets a working
+# TCP server.
+#
+# Kernel config expected: CONFIG_SMB_SERVER (ksmbd); plus, for SMB Direct,
+# CONFIG_SMB_SERVER_SMBDIRECT and CONFIG_RDMA_RXE / CONFIG_RDMA_SIW / dummy net.
+
+set -u
+
+CONF=/etc/ksmbd/ksmbd.conf
+PWDB=/tmp/ksmbd_conf/ksmbdpwd.db
+USER=fuzz
+PASS=fuzz
+
+log() { echo "[ksmbd_setup] $*"; }
+
+# 1. Share/backing directories (paths referenced by CONF). World-writable
+#    because [aclshare] uses `force user = fuzz`: a root-owned 0755 dir would
+#    make every fuzzer write fail with EACCES.
+log "1/7 creating share/config directories"
+mkdir -p /tmp/ksmbd_share /tmp/ksmbd_acl /tmp/ksmbd_priv /tmp/ksmbd_conf
+chmod 0777 /tmp/ksmbd_share /tmp/ksmbd_acl /tmp/ksmbd_priv
+
+# 2. Write the server config. Kept in this script so the bring-up is
+#    self-contained (no separate config file to install/keep in sync). Maximum
+#    attack surface: SMB3.1.1, all features, large buffers, three shares
+#    (full-write, ACL-enforced, DesiredAccess-respecting).
+log "2/7 writing $CONF"
+mkdir -p /etc/ksmbd
+cat > "$CONF" <<'EOF'
+[global]
+	workgroup = WORKGROUP
+	netbios name = FUZZHOST
+	map to guest = Bad User
+	guest account = nobody
+	server min protocol = SMB2_10
+	server max protocol = SMB3_11
+	server string = syzkaller-ksmbd
+	smb2 max read = 8388608
+	smb2 max write = 8388608
+	smb2 max trans = 8388608
+	smb2 max credits = 8192
+	smbd max io size = 16777216
+	smb2 leases = yes
+	durable handles = yes
+	oplocks = yes
+	server multi channel support = yes
+	smb3 encryption = enabled
+	server signing = auto
+	max active sessions = 65536
+	max connections = 65536
+	max open files = 65536
+	deadtime = 0
+	ipc timeout = 0
+	restrict anonymous = 0
+
+[share]
+	path = /tmp/ksmbd_share
+	comment = Full feature write share
+	read only = no
+	guest ok = yes
+	force user = root
+	force group = root
+	create mask = 0777
+	directory mask = 0777
+	oplocks = yes
+	store dos attributes = yes
+	follow symlinks = yes
+	crossmnt = yes
+	inherit owner = yes
+	vfs objects = streams_xattr
+
+[aclshare]
+	path = /tmp/ksmbd_acl
+	comment = ACL enforced share
+	read only = no
+	guest ok = yes
+	force user = fuzz
+	valid users = fuzz
+	write list = fuzz
+	oplocks = yes
+	store dos attributes = yes
+	follow symlinks = yes
+	crossmnt = yes
+	inherit owner = yes
+	create mask = 0777
+	directory mask = 0777
+	vfs objects = streams_xattr
+
+[privtest]
+	path = /tmp/ksmbd_priv
+	comment = Privilege bypass testing (respects DesiredAccess)
+	read only = no
+	guest ok = no
+	valid users = fuzz
+	write list = fuzz
+	oplocks = yes
+	store dos attributes = yes
+	vfs objects = streams_xattr
+EOF
+
+# 3. Load the module (no-op if ksmbd is built-in).
+log "3/7 modprobe ksmbd"
+modprobe ksmbd 2>/dev/null || true
+
+# 4. POSIX user `fuzz`. ksmbd.mountd resolves `force user = fuzz` /
+#    `valid users = fuzz` via getpwnam() at load; if `fuzz` is missing from
+#    /etc/passwd, mountd drops the share and a tree-connect returns
+#    BAD_NETWORK_NAME. ksmbd.adduser only populates the SMB user DB, not
+#    /etc/passwd, so the POSIX user must exist too.
+log "4/7 provisioning POSIX user $USER"
+if ! getent passwd "$USER" >/dev/null 2>&1; then
+	useradd -m -s /bin/false "$USER" 2>/dev/null || \
+		useradd "$USER" 2>/dev/null || \
+		log "WARNING: could not create POSIX user $USER; aclshare will be dropped"
+fi
+
+# 5. SMB user in the ksmbd password DB.
+log "5/7 provisioning ksmbd SMB user $USER"
+rm -f "$PWDB"
+ksmbd.adduser -C "$CONF" -P "$PWDB" -a "$USER" -p "$PASS" 2>/dev/null || \
+	log "WARNING: ksmbd.adduser failed"
+
+# 6. Software RDMA for SMB Direct (non-fatal). Must run BEFORE ksmbd.mountd so
+#    the SMB Direct listener can bind to the IB device. Primary path is SIW
+#    (iWARP) on a real (non-loopback) interface; RXE (Soft-RoCE) on a dummy
+#    interface is the fallback, since RDMA CM needs a routable IP, not lo.
+setup_rdma() {
+	command -v rdma >/dev/null 2>&1 || { log "     rdma tool absent; SMB Direct skipped"; return; }
+	# Modules are usually built-in; modprobe is best-effort for a modular kernel.
+	modprobe siw 2>/dev/null || true
+	modprobe rdma_rxe 2>/dev/null || true
+	modprobe dummy 2>/dev/null || true
+	ip link set lo up 2>/dev/null || true
+
+	# Primary: SIW on the first non-loopback interface that is up.
+	local iface
+	iface=$(ip -o link show up 2>/dev/null | awk -F': ' \
+		'$2 != "lo" && $0 !~ /LOOPBACK/ {print $2; exit}')
+	if [ -n "${iface:-}" ]; then
+		if ! ip -4 addr show "$iface" 2>/dev/null | grep -q 'inet '; then
+			ip addr add 192.168.122.50/24 dev "$iface" 2>/dev/null || true
+			ip link set "$iface" up 2>/dev/null || true
+		fi
+		rdma link del siw0 2>/dev/null || true
+		if rdma link add siw0 type siw netdev "$iface" 2>/dev/null; then
+			log "     SMB Direct: siw0 (SIW/iWARP) on $iface"
+			return
+		fi
+	fi
+
+	# Fallback: RXE (Soft-RoCE) on a dummy interface with a routable IP.
+	ip link add dummy0 type dummy 2>/dev/null || true
+	ip addr add 10.0.99.1/24 dev dummy0 2>/dev/null || true
+	ip link set dummy0 up 2>/dev/null || true
+	rdma link del rxe0 2>/dev/null || true
+	if rdma link add rxe0 type rxe netdev dummy0 2>/dev/null; then
+		log "     SMB Direct: rxe0 (Soft-RoCE) on dummy0 (10.0.99.1)"
+	else
+		log "     SMB Direct: RDMA link setup failed; TCP only"
+	fi
+}
+log "6/7 setting up Software RDMA (SMB Direct)"
+setup_rdma
+
+# 7. Kerberos KDC for the krb5 session-setup path (non-fatal). Gives the
+#    kernel's krb5 auth parsing something to talk to; realm FUZZ.LOCAL on
+#    127.0.0.1:88.
+setup_kdc() {
+	command -v krb5kdc >/dev/null 2>&1 || { log "     krb5kdc absent; KDC skipped"; return; }
+	mkdir -p /tmp/kdc
+	cat > /etc/krb5.conf <<'EOF'
+[libdefaults]
+  default_realm = FUZZ.LOCAL
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+[realms]
+  FUZZ.LOCAL = {
+    kdc = 127.0.0.1
+    admin_server = 127.0.0.1
+  }
+[domain_realm]
+  .fuzz.local = FUZZ.LOCAL
+EOF
+	cat > /tmp/kdc/kdc.conf <<'EOF'
+[kdcdefaults]
+  kdc_listen = 88
+[realms]
+  FUZZ.LOCAL = {
+    database_name = /tmp/kdc/principal
+    key_stash_file = /tmp/kdc/.k5.FUZZ.LOCAL
+    max_life = 10h
+    max_renewable_life = 7d
+  }
+EOF
+	export KRB5_KDC_PROFILE=/tmp/kdc/kdc.conf
+	if [ ! -e /tmp/kdc/principal ]; then
+		kdb5_util create -s -r FUZZ.LOCAL -P fuzzpass 2>/dev/null || {
+			log "     KDC database creation failed; krb5 path skipped"; return; }
+		kadmin.local -q "addprinc -pw fuzz fuzz@FUZZ.LOCAL" 2>/dev/null || true
+		kadmin.local -q "addprinc -pw fuzz cifs/127.0.0.1@FUZZ.LOCAL" 2>/dev/null || true
+	fi
+	pkill -9 krb5kdc 2>/dev/null || true
+	krb5kdc -n &
+	log "     KDC running (FUZZ.LOCAL, 127.0.0.1:88)"
+}
+log "7/7 setting up Kerberos KDC (krb5 auth path)"
+setup_kdc
+
+# Finally, (re)start the mountd user daemon. Kill any prior instance first so
+# this is idempotent across reboots / re-runs.
+log "starting ksmbd.mountd"
+pkill -9 ksmbd.mountd 2>/dev/null || true
+if ! command -v ksmbd.mountd >/dev/null 2>&1; then
+	log "ERROR: ksmbd.mountd not found (install ksmbd-tools in the image)"
+	exit 1
+fi
+# No -n: let mountd daemonize (fork to background) so this script returns. With
+# -n it stays in the foreground and would block the caller forever.
+ksmbd.mountd -C "$CONF" -P "$PWDB"
+log "ksmbd.mountd started; server listening on 127.0.0.1:445 (+ SMB Direct if enabled)"


### PR DESCRIPTION
Add ksmbd, the in-kernel SMB3 server, as a syzkaller target: the SMB2 protocol grammar, the transport syscalls (enabled in vminfo), and the image setup that brings the server up so the descriptions reach a live, configured daemon.
    
### Transport (sys/linux/ksmbd.txt):
    
`socket$ksmbd -> connect$ksmbd -> sendto$ksmbd`
    
 A sock_ksmbd resource is threaded through connect and sendto, so a  program that issues several sendto$ksmbd() on the same socket forms a stateful SMB session: ksmbd keeps per-connection state (negotiated dialect, authenticated session, opened FIDs, granted oplocks/leases) across the PDUs. The file documents this model, and its one gap: ksmbd assigns SessionId/TreeId/Persistent-VolatileFileId in the response PDUs, which syzkaller does not parse, so the server-assigned ids cannot yet be threaded into later PDUs (they are seeded with the SMB2 all-ones sentinel and 0 so brute/dataflow can still land valid ids). Closing that gap needs a send+recv pseudo-syscall that returns the ids as resources.
    
### Protocol grammar:
    
- smb2_hdr with the ProtocolId/StructureSize constants and Command/Flags as flag sets;
- request bodies for negotiate, session-setup, tree-connect, create, close, flush, read, write, lock, ioctl, cancel, echo, query-directory, change-notify, query-info, set-info and oplock-break, dispatched by a union keyed on hdr.Command;
- structured create contexts (durable-handle DHnQ/DH2Q, lease RqLs, and generic tagged contexts) instead of an opaque blob;
- an FSCTL input union for IOCTL (copychunk, validate-negotiate-info);
- a set-info file-information union (rename, disposition, end-of-file, allocation, basic);
- flag sets for the access mask, share access, create disposition and options, oplock level, impersonation, file attributes, info classes, dialects and FSCTL codes, so directed mutation lands valid values.
    
### Image setup:
    
`create-image.sh --add-ksmbd` installs ksmbd-tools plus the RDMA (rdma-core, iproute2) and Kerberos (krb5-*) userspace, stages the self-contained `tools/ksmbd_setup.sh`, and enables it as a systemd.