### PR TITLE
pkg/vminfo: refactor few things

### DIFF
--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -13,9 +13,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/google/syzkaller/sys/targets"
 )
 
-type linux int
+type linux struct {
+	vmType string
+}
 
 func (linux) RequiredFiles() []string {
 	return []string{
@@ -27,7 +31,7 @@ func (linux) RequiredFiles() []string {
 	}
 }
 
-func (linux) checkFiles() []string {
+func (linux) CheckFiles() []string {
 	return []string{
 		"/proc/version",
 		"/proc/filesystems",
@@ -42,7 +46,10 @@ func (linux) machineInfos() []machineInfoFunc {
 	}
 }
 
-func (linux) parseModules(files filesystem) ([]*KernelModule, error) {
+func (linux linux) parseModules(files filesystem) ([]*KernelModule, error) {
+	if linux.vmType == targets.GVisor || linux.vmType == targets.Starnix {
+		return nil, nil
+	}
 	var modules []*KernelModule
 	re := regexp.MustCompile(`(\w+) ([0-9]+) .*(0[x|X][a-fA-F0-9]+)[^\n]*`)
 	modulesText, _ := files.ReadFile("/proc/modules")

--- a/pkg/vminfo/netbsd.go
+++ b/pkg/vminfo/netbsd.go
@@ -7,22 +7,8 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-type netbsd int
-
-func (netbsd) RequiredFiles() []string {
-	return nil
-}
-
-func (netbsd) checkFiles() []string {
-	return nil
-}
-
-func (netbsd) parseModules(files filesystem) ([]*KernelModule, error) {
-	return nil, nil
-}
-
-func (netbsd) machineInfos() []machineInfoFunc {
-	return nil
+type netbsd struct {
+	nopChecker
 }
 
 func (netbsd) syscallCheck(ctx *checkContext, call *prog.Syscall) string {

--- a/pkg/vminfo/openbsd.go
+++ b/pkg/vminfo/openbsd.go
@@ -7,22 +7,8 @@ import (
 	"github.com/google/syzkaller/prog"
 )
 
-type openbsd int
-
-func (openbsd) RequiredFiles() []string {
-	return nil
-}
-
-func (openbsd) checkFiles() []string {
-	return nil
-}
-
-func (openbsd) parseModules(files filesystem) ([]*KernelModule, error) {
-	return nil, nil
-}
-
-func (openbsd) machineInfos() []machineInfoFunc {
-	return nil
+type openbsd struct {
+	nopChecker
 }
 
 func (openbsd) syscallCheck(ctx *checkContext, call *prog.Syscall) string {


### PR DESCRIPTION
Use default nop implementation for most openbsd/netbsd methods.
Move linux-specific vm type checks to linux code.
Remove indirection for CheckFiles as we have for RequiredFiles.
