### PR TITLE
vm: dedup VM count restriction in debug mode

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -115,9 +115,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 			return nil, fmt.Errorf("invalid adb device id '%v'", device.Serial)
 		}
 	}
-	if env.Debug {
-		cfg.Devices = cfg.Devices[:1]
-	}
 	pool := &Pool{
 		cfg: cfg,
 		env: env,

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -74,10 +74,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1-128]", cfg.Count)
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	pool := &Pool{
 		cfg: cfg,
 		env: env,

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -105,10 +105,6 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 1000 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 1000]", cfg.Count)
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	if cfg.MachineType == "" {
 		return nil, fmt.Errorf("machine_type parameter is empty")
 	}

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -71,10 +71,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 		return nil, fmt.Errorf("invalid config param memory_total_bytes: %v, want [%d,%d]",
 			minMemory, cfg.MemoryTotalBytes, hostTotalMemory)
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	if !osutil.IsExist(env.Image) {
 		return nil, fmt.Errorf("image file %q does not exist", env.Image)
 	}

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -83,13 +83,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 			return nil, fmt.Errorf("the number of Targets and the number of USBDevNums should be same")
 		}
 	}
-	if env.Debug && len(cfg.Targets) > 1 {
-		log.Logf(0, "limiting number of targets from %v to 1 in debug mode", len(cfg.Targets))
-		cfg.Targets = cfg.Targets[:1]
-		if len(cfg.USBDevNums) > 1 {
-			cfg.USBDevNums = cfg.USBDevNums[:1]
-		}
-	}
 	pool := &Pool{
 		cfg: cfg,
 		env: env,

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -280,10 +280,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 1024 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1, 1024]", cfg.Count)
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	if _, err := exec.LookPath(cfg.Qemu); err != nil {
 		return nil, err
 	}

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -74,10 +74,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if cfg.Count < 1 || cfg.Count > 128 {
 		return nil, fmt.Errorf("invalid config param count: %v, want [1-128]", cfg.Count)
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	if cfg.Mem < 128 || cfg.Mem > 1048576 {
 		return nil, fmt.Errorf("invalid config param mem: %v, want [128-1048576]", cfg.Mem)
 	}

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -65,10 +65,6 @@ func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	if _, err := exec.LookPath("vmrun"); err != nil {
 		return nil, fmt.Errorf("cannot find vmrun")
 	}
-	if env.Debug && cfg.Count > 1 {
-		log.Logf(0, "limiting number of VMs from %v to 1 in debug mode", cfg.Count)
-		cfg.Count = 1
-	}
 	pool := &Pool{
 		cfg: cfg,
 		env: env,


### PR DESCRIPTION
Move the VM count restriction logic info vm package.
This avoids lots of duplication, makes it supported
for VM types that failed to do this, and allows
to unify more VM count logic in future.
