### PR TITLE
executor: don't revert coverage order

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1169,8 +1169,9 @@ uint32 write_cover(flatbuffers::FlatBufferBuilder& fbb, cover_t* cov)
 		cover_size = std::unique(cover_data, end) - cover_data;
 	}
 	fbb.StartVector(cover_size, sizeof(uint64));
+	// Flatbuffer arrays are written backwards, so reverse the order on our side as well.
 	for (uint32 i = 0; i < cover_size; i++)
-		fbb.PushElement(uint64(cover_data[i] + cov->pc_offset));
+		fbb.PushElement(uint64(cover_data[cover_size - i - 1] + cov->pc_offset));
 	return fbb.EndVector(cover_size);
 }
 

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -219,15 +219,15 @@ func testCover(t *testing.T, target *prog.Target) {
 			Input: makeCover64(0xc0dec0dec0000033, 0xc0dec0dec0000022, 0xc0dec0dec0000011,
 				0xc0dec0dec0000011, 0xc0dec0dec0000022, 0xc0dec0dec0000033, 0xc0dec0dec0000011),
 			Flags: flatrpc.ExecFlagCollectCover,
-			Cover: []uint64{0xc0dec0dec0000011, 0xc0dec0dec0000033, 0xc0dec0dec0000022,
-				0xc0dec0dec0000011, 0xc0dec0dec0000011, 0xc0dec0dec0000022, 0xc0dec0dec0000033},
+			Cover: []uint64{0xc0dec0dec0000033, 0xc0dec0dec0000022, 0xc0dec0dec0000011,
+				0xc0dec0dec0000011, 0xc0dec0dec0000022, 0xc0dec0dec0000033, 0xc0dec0dec0000011},
 		},
 		{
 			Is64Bit: true,
 			Input: makeCover64(0xc0dec0dec0000033, 0xc0dec0dec0000022, 0xc0dec0dec0000011,
 				0xc0dec0dec0000011, 0xc0dec0dec0000022, 0xc0dec0dec0000033, 0xc0dec0dec0000011),
 			Flags: flatrpc.ExecFlagCollectCover | flatrpc.ExecFlagDedupCover,
-			Cover: []uint64{0xc0dec0dec0000033, 0xc0dec0dec0000022, 0xc0dec0dec0000011},
+			Cover: []uint64{0xc0dec0dec0000011, 0xc0dec0dec0000022, 0xc0dec0dec0000033},
 		},
 		// Signal hashing.
 		{
@@ -315,8 +315,8 @@ func testCover(t *testing.T, target *prog.Target) {
 				0xc0dec0dec0000100, 0xc0dec0dec0001000),
 			MaxSignal: []uint64{0xc0dec0dec0000001, 0xc0dec0dec0000013, 0xc0dec0dec0000abc},
 			Flags:     flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover,
-			Cover: []uint64{0xc0dec0dec0001000, 0xc0dec0dec0000100, 0xc0dec0dec0000002,
-				0xc0dec0dec0000010, 0xc0dec0dec0000001},
+			Cover: []uint64{0xc0dec0dec0000001, 0xc0dec0dec0000010, 0xc0dec0dec0000002,
+				0xc0dec0dec0000100, 0xc0dec0dec0001000},
 			Signal: []uint64{0xc0dec0dec0001100, 0xc0dec0dec0000102},
 		},
 		{
@@ -324,7 +324,7 @@ func testCover(t *testing.T, target *prog.Target) {
 			Input:     makeCover32(0xc0000001, 0xc0000010, 0xc0000002, 0xc0000100, 0xc0001000),
 			MaxSignal: []uint64{0xc0000001, 0xc0000013, 0xc0000abc},
 			Flags:     flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover,
-			Cover:     []uint64{0xc0001000, 0xc0000100, 0xc0000002, 0xc0000010, 0xc0000001},
+			Cover:     []uint64{0xc0000001, 0xc0000010, 0xc0000002, 0xc0000100, 0xc0001000},
 			Signal:    []uint64{0xc0001100, 0xc0000102},
 		},
 		{
@@ -344,8 +344,8 @@ func testCover(t *testing.T, target *prog.Target) {
 				0xc0dec0dec0000040, 0xc0dec0dec0000100, 0xc0dec0dec0001000, 0xc0dec0dec0002000),
 			CoverFilter: []uint64{0xc0dec0dec0000002, 0xc0dec0dec0000100},
 			Flags:       flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover,
-			Cover: []uint64{0xc0dec0dec0002000, 0xc0dec0dec0001000, 0xc0dec0dec0000100, 0xc0dec0dec0000040,
-				0xc0dec0dec0000020, 0xc0dec0dec0000010, 0xc0dec0dec0000001},
+			Cover: []uint64{0xc0dec0dec0000001, 0xc0dec0dec0000010, 0xc0dec0dec0000020, 0xc0dec0dec0000040,
+				0xc0dec0dec0000100, 0xc0dec0dec0001000, 0xc0dec0dec0002000},
 			Signal: []uint64{0xc0dec0dec0001100, 0xc0dec0dec0000140, 0xc0dec0dec0000011, 0xc0dec0dec0000001},
 		},
 		{
@@ -354,8 +354,8 @@ func testCover(t *testing.T, target *prog.Target) {
 				0xc0000100, 0xc0001000, 0xc0002000),
 			CoverFilter: []uint64{0xc0000002, 0xc0000100},
 			Flags:       flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover,
-			Cover: []uint64{0xc0002000, 0xc0001000, 0xc0000100, 0xc0000040,
-				0xc0000020, 0xc0000010, 0xc0000001},
+			Cover: []uint64{0xc0000001, 0xc0000010, 0xc0000020, 0xc0000040,
+				0xc0000100, 0xc0001000, 0xc0002000},
 			Signal: []uint64{0xc0001100, 0xc0000140, 0xc0000011, 0xc0000001},
 		},
 		// Extra coverage.
@@ -364,7 +364,7 @@ func testCover(t *testing.T, target *prog.Target) {
 			ExtraCoverage: true,
 			Input:         makeCover64(0xc0dec0dec0000001, 0xc0dec0dec0000010),
 			Flags:         flatrpc.ExecFlagCollectSignal | flatrpc.ExecFlagCollectCover,
-			Cover:         []uint64{0xc0dec0dec0000010, 0xc0dec0dec0000001},
+			Cover:         []uint64{0xc0dec0dec0000001, 0xc0dec0dec0000010},
 			Signal:        []uint64{0xc0dec0dec0000011, 0xc0dec0dec0000001},
 		},
 	}


### PR DESCRIPTION
Currently we write coverage backwards.
This is visible e.g. when running syz-execprog -coverfile.
Write it in the right order.
