### PR TITLE
executor: remove a tempnam() call from test.h

### DIFF
--- a/executor/test.h
+++ b/executor/test.h
@@ -208,10 +208,8 @@ static int test_csum_inet_acc()
 
 static int test_cover_filter()
 {
-	char* tmp = tempnam(nullptr, "syz-test-cover-filter");
 	CoverFilter filter;
 	CoverFilter child(filter.FD());
-	free(tmp);
 
 	std::vector<uint64> pcs = {
 	    100,


### PR DESCRIPTION
It's no longer needed.
