### PR TITLE
tools/docker: add various fsck-like commands to the environment

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -18,6 +18,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	flex bison bc libelf-dev libssl-dev \
 	# qemu-user is required to run alien arch binaries in pkg/cover tests.
 	qemu-user \
+	# These are various fsck-like commands needed for prog/fsck:
+	dosfstools e2fsprogs btrfs-progs util-linux f2fs-tools jfsutils \
+	util-linux dosfstools ocfs2-tools reiserfsprogs xfsprogs erofs-utils \
+	exfatprogs gfs2-utils \
 	&& \
 	apt-get -y autoremove && \
 	apt-get clean autoclean && \

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -17,6 +17,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	apt-transport-https curl gnupg python-is-python3 \
 	# Needed for building Cuttlefish images.
 	rsync libarchive-tools \
+	# These are various fsck-like commands needed for prog/fsck:
+	dosfstools e2fsprogs btrfs-progs util-linux f2fs-tools jfsutils \
+	util-linux dosfstools ocfs2-tools reiserfsprogs xfsprogs erofs-utils \
+	exfatprogs gfs2-utils \
 	# Needed for buiding gVisor.
 	crossbuild-essential-amd64 crossbuild-essential-arm64 libbpf-dev
 RUN test "$(uname -m)" != x86_64 && exit 0 || \


### PR DESCRIPTION
As part of #5518, I'm adding fsck logs as annotation to the mounted file system assets. For this, I need a variety of fsck-like commands in the ci environment as well as eventually in the production environment.
