### PR TITLE
syz-manager: pkg: skip seeds with mismatching requirements in fuzzing…

### DIFF
--- a/pkg/manager/seeds_test.go
+++ b/pkg/manager/seeds_test.go
@@ -1,0 +1,29 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package manager
+
+import (
+	"testing"
+)
+
+func TestRequires(t *testing.T) {
+	{
+		requires := parseRequires([]byte("# requires: manual arch=amd64"))
+		if !checkArch(requires, "amd64") {
+			t.Fatalf("amd64 does not pass check")
+		}
+		if checkArch(requires, "riscv64") {
+			t.Fatalf("riscv64 passes check")
+		}
+	}
+	{
+		requires := parseRequires([]byte("# requires: -arch=arm64 manual -arch=riscv64"))
+		if !checkArch(requires, "amd64") {
+			t.Fatalf("amd64 does not pass check")
+		}
+		if checkArch(requires, "riscv64") {
+			t.Fatalf("riscv64 passes check")
+		}
+	}
+}

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -589,24 +589,3 @@ func TestParsing(t *testing.T) {
 		}
 	}
 }
-
-func TestRequires(t *testing.T) {
-	{
-		requires := parseRequires([]byte("# requires: manual arch=amd64"))
-		if !checkArch(requires, "amd64") {
-			t.Fatalf("amd64 does not pass check")
-		}
-		if checkArch(requires, "riscv64") {
-			t.Fatalf("riscv64 passes check")
-		}
-	}
-	{
-		requires := parseRequires([]byte("# requires: -arch=arm64 manual -arch=riscv64"))
-		if !checkArch(requires, "amd64") {
-			t.Fatalf("amd64 does not pass check")
-		}
-		if checkArch(requires, "riscv64") {
-			t.Fatalf("riscv64 passes check")
-		}
-	}
-}


### PR DESCRIPTION
… mode

When running in the test mode, syz-manager already ignores tests that have arch requirements mismatching the target arch.
Because the same tests are also used as seeds in the fuzzing mode, skip them likewise, instead of reporting errors if they contain arch-specific syscalls.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
