### PR TITLE
pkg/bisect: ignore irrelevant lost connection crashes 

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -992,6 +992,11 @@ func mostFrequentReports(reports []*report.Report) (*report.Report, []crash.Type
 			// bisecting this kind of a bug.
 			continue
 		}
+		if info.t == crash.LostConnection && len(perType) > 1 {
+			// This crash type is much more often unrelated than not.
+			// Take it only if it's the only crash type.
+			continue
+		}
 		// Take further crash types until we have considered 2/3 of all crashes, but
 		// no more than 3.
 		needTaken := (crashes + 2) * 2 / 3

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -958,6 +958,34 @@ func TestMostFrequentReport(t *testing.T) {
 			report: "A",
 			other:  true,
 		},
+		{
+			name: "do not take lost connection",
+			reports: []*report.Report{
+				{Title: "A", Type: crash.LostConnection},
+				{Title: "B", Type: crash.Warning},
+				{Title: "C", Type: crash.LostConnection},
+				{Title: "D", Type: crash.Warning},
+				{Title: "E", Type: crash.LostConnection},
+				{Title: "F", Type: crash.Warning},
+			},
+			types:  []crash.Type{crash.Warning},
+			report: "B",
+			other:  true,
+		},
+		{
+			name: "only lost connection",
+			reports: []*report.Report{
+				{Title: "A", Type: crash.LostConnection},
+				{Title: "B", Type: crash.LostConnection},
+				{Title: "C", Type: crash.LostConnection},
+				{Title: "D", Type: crash.LostConnection},
+				{Title: "E", Type: crash.LostConnection},
+				{Title: "F", Type: crash.LostConnection},
+			},
+			types:  []crash.Type{crash.LostConnection},
+			report: "A",
+			other:  false,
+		},
 	}
 	for _, test := range tests {
 		test := test

--- a/pkg/report/crash/types.go
+++ b/pkg/report/crash/types.go
@@ -19,6 +19,7 @@ const (
 	AtomicSleep      = Type("ATOMIC_SLEEP")
 	KMSAN            = Type("KMSAN")
 	SyzFailure       = Type("SYZ_FAILURE")
+	LostConnection   = Type("LOST_CONNECTION")
 )
 
 func (t Type) String() string {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/stat"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/dispatcher"
@@ -498,10 +499,15 @@ func (mon *monitor) createReport(defaultError string) *report.Report {
 		if defaultError == "" {
 			return nil
 		}
+		typ := crash.UnknownType
+		if defaultError == lostConnectionCrash {
+			typ = crash.LostConnection
+		}
 		return &report.Report{
 			Title:      defaultError,
 			Output:     mon.output,
 			Suppressed: report.IsSuppressed(mon.reporter, mon.output),
+			Type:       typ,
 		}
 	}
 	start := rep.StartPos - mon.beforeContext

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
 )
@@ -115,6 +116,7 @@ var tests = []*Test{
 		},
 		Report: &report.Report{
 			Title: lostConnectionCrash,
+			Type:  crash.LostConnection,
 		},
 	},
 	{
@@ -135,6 +137,7 @@ var tests = []*Test{
 			Output: []byte(
 				"DIAGNOSE\n",
 			),
+			Type: crash.LostConnection,
 		},
 	},
 	{
@@ -150,6 +153,7 @@ var tests = []*Test{
 					"VM DIAGNOSIS:\n" +
 					"DIAGNOSE\n",
 			),
+			Type: crash.LostConnection,
 		},
 	},
 	{
@@ -237,6 +241,7 @@ var tests = []*Test{
 		},
 		Report: &report.Report{
 			Title: lostConnectionCrash,
+			Type:  crash.LostConnection,
 		},
 	},
 	{
@@ -416,6 +421,9 @@ func testMonitorExecution(t *testing.T, test *Test) {
 	}
 	if test.Report.Output != nil && !bytes.Equal(test.Report.Output, rep.Output) {
 		t.Fatalf("want output:\n%s\n\ngot output:\n%s", test.Report.Output, rep.Output)
+	}
+	if test.Report.Type != rep.Type {
+		t.Fatalf("want type %q, got type %q", test.Report.Type, rep.Type)
 	}
 }
 


### PR DESCRIPTION
These have been the cause of too many invalid bisection results recently.

This is the first step towards the more universal approach of https://github.com/google/syzkaller/issues/5414.