### PR TITLE
fallback to .init.text or .init.plt section address in case .text not exist or 0 sized

### DIFF
--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -223,8 +223,8 @@ func elfGetCompilerVersion(path string) string {
 	return string(data[:])
 }
 
-func elfReadTextSecRange(module *vminfo.KernelModule) (*SecRange, error) {
-	text, err := elfReadTextSec(module)
+func elfReadSecRange(module *vminfo.KernelModule, sec string) (*SecRange, error) {
+	text, err := elfReadSec(module, sec)
 	if err != nil {
 		return nil, err
 	}
@@ -235,13 +235,13 @@ func elfReadTextSecRange(module *vminfo.KernelModule) (*SecRange, error) {
 	return r, nil
 }
 
-func elfReadTextSec(module *vminfo.KernelModule) (*elf.Section, error) {
+func elfReadSec(module *vminfo.KernelModule, sec string) (*elf.Section, error) {
 	file, err := elf.Open(module.Path)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
-	text := file.Section(".text")
+	text := file.Section(sec)
 	if text == nil {
 		return nil, fmt.Errorf("no .text section in the object file")
 	}

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -64,6 +64,14 @@ func discoverModulesLinux(dirs []string) ([]*vminfo.KernelModule, error) {
 			return nil, err
 		}
 		module.Size = textRange.End - textRange.Start
+		if module.Size == 0 {
+			textRange, err := elfReadSecRange(module, ".init.text")
+			if err != nil {
+				module.Size = 0
+			} else {
+				module.Size = textRange.End - textRange.Start
+			}
+		}
 		modules = append(modules, module)
 	}
 	return modules, nil

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -21,7 +21,7 @@ func DiscoverModules(target *targets.Target, objDir string, moduleObj []string) 
 	module := &vminfo.KernelModule{
 		Path: filepath.Join(objDir, target.KernelObject),
 	}
-	textRange, err := elfReadTextSecRange(module)
+	textRange, err := elfReadSecRange(module, ".text")
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func discoverModulesLinux(dirs []string) ([]*vminfo.KernelModule, error) {
 			Name: name,
 			Path: path,
 		}
-		textRange, err := elfReadTextSecRange(module)
+		textRange, err := elfReadSecRange(module, ".text")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Current KernelModule is generated from .text section for modules,
for some module, there is no .text section.
This results in size field in KernelModule set to 0 when we check
/modules?raw=true.
When we use the modules info to decide which module the pc belongs in
findModule function, it might gives wrong info.

To make the findModule work properly, we need pc from .init.text
discard correctly and pc from .text find correct module.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
