### PR TITLE
pkg/vcs: implement remaining Repo methods for fuchsia

### DIFF
--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -11,12 +11,18 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 )
 
+// TODO: Check out branches and commits from Fuchsia's global integration repo
+// rather than fuchsia.git.
 type fuchsia struct {
 	dir  string
 	repo *git
 }
 
 func newFuchsia(dir string, opts []RepoOpt) *fuchsia {
+	// For now, don't clean up the Fuchsia repo when checking out new commits or branches.
+	// Otherwise, subsequent builds will fail due to missing GN args and other build configuration.
+	// TODO: Implement selective cleanup with `fx clean`.
+	opts = append(opts, OptPrecious)
 	return &fuchsia{
 		dir:  dir,
 		repo: newGit(dir, nil, opts),
@@ -60,19 +66,19 @@ func (ctx *fuchsia) initRepo() error {
 }
 
 func (ctx *fuchsia) CheckoutBranch(repo, branch string) (*Commit, error) {
-	return nil, fmt.Errorf("not implemented for fuchsia: CheckoutBranch")
+	return ctx.repo.CheckoutBranch(repo, branch)
 }
 
 func (ctx *fuchsia) CheckoutCommit(repo, commit string) (*Commit, error) {
-	return nil, fmt.Errorf("not implemented for fuchsia: CheckoutCommit")
+	return ctx.repo.CheckoutCommit(repo, commit)
 }
 
 func (ctx *fuchsia) SwitchCommit(commit string) (*Commit, error) {
-	return nil, fmt.Errorf("not implemented for fuchsia: SwitchCommit")
+	return ctx.repo.SwitchCommit(commit)
 }
 
-func (ctx *fuchsia) Commit(com string) (*Commit, error) {
-	return nil, fmt.Errorf("not implemented for fuchsia: Commit")
+func (ctx *fuchsia) Commit(commit string) (*Commit, error) {
+	return ctx.repo.Commit(commit)
 }
 
 func (ctx *fuchsia) GetCommitByTitle(title string) (*Commit, error) {
@@ -88,11 +94,11 @@ func (ctx *fuchsia) ExtractFixTagsFromCommits(baseCommit, email string) ([]*Comm
 }
 
 func (ctx *fuchsia) ReleaseTag(commit string) (string, error) {
-	return "", fmt.Errorf("not implemented for fuchsia: ReleaseTag")
+	return ctx.repo.ReleaseTag(commit)
 }
 
 func (ctx *fuchsia) Contains(commit string) (bool, error) {
-	return false, fmt.Errorf("not implemented for fuchsia: Contains")
+	return ctx.repo.Contains(commit)
 }
 
 func (ctx *fuchsia) ListCommitHashes(base string) ([]string, error) {
@@ -107,10 +113,11 @@ func (ctx *fuchsia) MergeBases(firstCommit, secondCommit string) ([]*Commit, err
 	return ctx.repo.MergeBases(firstCommit, secondCommit)
 }
 
-func (ctx *fuchsia) CommitExists(string) (bool, error) {
-	return false, fmt.Errorf("not implemented for fuchsia: CommitExists")
+func (ctx *fuchsia) CommitExists(commit string) (bool, error) {
+	return ctx.repo.CommitExists(commit)
 }
 
 func (ctx *fuchsia) PushCommit(repo, commit string) error {
+	// Fuchsia repo doesn't accept unauthenticated pushes.
 	return fmt.Errorf("not implemented for fuchsia: PushCommit")
 }


### PR DESCRIPTION
This is a temporary workaround for managing a fuchsia checkout:
- Mark the repo as "precious" so that checkout operations don't delete GN args and other build configuration state. In a follow-up, this will be replaced by a fuchsia-specific `repair` method using `fx clean`.
- Checkout operations apply only to fuchsia.git, which has a chance of creating inconsistencies between versions of fuchsia and its dependencies. The main poll workflow (using `jiri`) is not affected by this problem, but bisection workflows may fail. This will be fixed in a follow-up by checking out branches and commits from fuchsia's global integration repo.
