### PR TITLE
pkg/runtest: make cross-arch failures fatal on CI

### DIFF
--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -45,7 +46,7 @@ func TestExecutor(t *testing.T) {
 				if sysTarget.Arch == runtime.GOARCH || sysTarget.VMArch == runtime.GOARCH {
 					t.Fatal(err)
 				}
-				if strings.Contains(err.Error(), "SYZFAIL:") {
+				if os.Getenv("CI") != "" || strings.Contains(err.Error(), "SYZFAIL:") {
 					t.Fatal(err)
 				} else {
 					t.Skipf("skipping, cross-arch binary failed: %v", err)

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -17,7 +17,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	# These are needed to build Linux kernel:
 	flex bison bc libelf-dev libssl-dev \
 	# qemu-user is required to run alien arch binaries in pkg/cover tests.
-	qemu-user qemu-user-binfmt \
+	qemu-user \
 	# These are various fsck-like commands needed for prog/fsck:
 	dosfstools e2fsprogs btrfs-progs util-linux f2fs-tools jfsutils \
 	util-linux dosfstools ocfs2-tools reiserfsprogs xfsprogs erofs-utils \


### PR DESCRIPTION
When running on Github CI, turn every failure to start a cross-arch binary (e.g. due to missing qemu-user) into a fatal error.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
