### PR TITLE
pkg/covermerger: aggregate data per-manager

### DIFF
--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -695,7 +695,7 @@ type MergedCoverage struct {
 	Duration  int64
 	DateTo    civil.Date
 	TotalRows int64
-	FileData  map[string]*coveragedb.Coverage
+	FileData  coveragedb.ManagersCoverage
 }
 
 type SaveCoverageReq struct {

--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -169,7 +169,7 @@ from merge_history
   join file_subsystems
     on merge_history.namespace = file_subsystems.namespace and files.filepath = file_subsystems.filepath
 where
-  merge_history.namespace=$1 and dateto=$2 and duration=$3`,
+  merge_history.namespace=$1 and dateto=$2 and duration=$3 and manager='*'`,
 		Params: map[string]interface{}{
 			"p1": ns,
 			"p2": timePeriod.DateTo,

--- a/pkg/covermerger/bq_csv_reader.go
+++ b/pkg/covermerger/bq_csv_reader.go
@@ -64,15 +64,15 @@ func (r *bqCSVReader) InitNsRecords(ctx context.Context, ns, filePath, commit st
 				compression = "GZIP")
 			AS (
 				SELECT
-					kernel_repo, kernel_branch, kernel_commit, file_path, sl, SUM(hit_count) as hit_count
+					kernel_repo, kernel_branch, kernel_commit, file_path, manager, sl, SUM(hit_count) as hit_count
 				FROM syzkaller.syzbot_coverage.`+"`%s`"+`
 				WHERE
 					TIMESTAMP_TRUNC(timestamp, DAY) >= "%s" AND
 					TIMESTAMP_TRUNC(timestamp, DAY) <= "%s" AND
 					version = 1 AND
 					starts_with(file_path, "%s") %s
-				GROUP BY file_path, kernel_commit, kernel_repo, kernel_branch, sl
-				ORDER BY file_path
+				GROUP BY file_path, manager, kernel_commit, kernel_repo, kernel_branch, sl
+				ORDER BY file_path, manager
 			);
 	`, gsURI, ns, from.String(), to.String(), filePath, selectCommit))
 	job, err := q.Run(ctx)

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -125,7 +125,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 				strings.NewReader(test.bqTable),
 			)
 			assert.Nil(t, err)
-			var expectedAggregation map[string]*MergeResult
+			var expectedAggregation FilesMergeResults
 			assert.Nil(t, json.Unmarshal([]byte(test.simpleAggregation), &expectedAggregation))
 			assert.Equal(t, expectedAggregation, aggregation)
 		})

--- a/tools/syz-covermerger/init_db.sh
+++ b/tools/syz-covermerger/init_db.sh
@@ -19,6 +19,7 @@ CREATE TABLE
     "covered" bigint,
     "linesinstrumented" bigint[],
     "hitcounts" bigint[],
+    "manager" text,
   PRIMARY KEY
     (session, filepath) );')
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \


### PR DESCRIPTION
This PR starts to collect the per-manager data.
It eventually enables us to see the per-manager and manager unique coverage.

Manager unique coverage will require additional processing on the AE side but we'll be able to see unique coverage from any combination of the namespace managers.
