### PR TITLE
syz-ci: rename bench file on all syz-manager restarts

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -472,13 +472,12 @@ func (mgr *Manager) restartManager() {
 	bin := filepath.FromSlash("syzkaller/current/bin/syz-manager")
 	logFile := filepath.Join(mgr.currentDir, "manager.log")
 	benchFile := filepath.Join(mgr.currentDir, benchFileName)
-	os.Remove(benchFile) // or else syz-manager will complain
 
 	args := []string{"-config", cfgFile, "-vv", "1", "-bench", benchFile}
 	if mgr.debug {
 		args = append(args, "-debug")
 	}
-	mgr.cmd = NewManagerCmd(mgr.name, logFile, mgr.Errorf, bin, args...)
+	mgr.cmd = NewManagerCmd(mgr.name, logFile, benchFile, mgr.Errorf, bin, args...)
 	mgr.lastRestarted = time.Now()
 }
 

--- a/syz-ci/managercmd.go
+++ b/syz-ci/managercmd.go
@@ -19,6 +19,7 @@ import (
 type ManagerCmd struct {
 	name    string
 	log     string
+	bench   string
 	errorf  Errorf
 	bin     string
 	args    []string
@@ -31,10 +32,11 @@ type Errorf func(msg string, args ...interface{})
 // name - name for logging.
 // log - manager log file with stdout/stderr.
 // bin/args - process binary/args.
-func NewManagerCmd(name, log string, errorf Errorf, bin string, args ...string) *ManagerCmd {
+func NewManagerCmd(name, log, bench string, errorf Errorf, bin string, args ...string) *ManagerCmd {
 	mc := &ManagerCmd{
 		name:    name,
 		log:     log,
+		bench:   bench,
 		errorf:  errorf,
 		bin:     bin,
 		args:    args,
@@ -75,6 +77,7 @@ func (mc *ManagerCmd) loop() {
 			if time.Since(started) > restartPeriod {
 				started = time.Now()
 				osutil.Rename(mc.log, mc.log+".old")
+				osutil.Rename(mc.bench, mc.bench+".old") // or else syz-manager will complain
 				logfile, err := os.Create(mc.log)
 				if err != nil {
 					mc.errorf("failed to create manager log: %v", err)


### PR DESCRIPTION
ManagerCmd transparently restarts the instance in case of crashes, so we should better be cleaning up the bench file within its loop, rather than in manager.go.