### PR TITLE
pkg/covermerger: always store details

### DIFF
--- a/pkg/cover/file.go
+++ b/pkg/cover/file.go
@@ -59,7 +59,6 @@ func GetMergeResult(c context.Context, ns, repo, forCommit, sourceCommit, filePa
 			Commit: forCommit,
 		},
 		FileVersProvider: covermerger.MakeWebGit(proxy),
-		StoreDetails:     true,
 	}
 
 	fromDate, toDate := tp.DatesFromTo()

--- a/pkg/covermerger/covermerger.go
+++ b/pkg/covermerger/covermerger.go
@@ -63,7 +63,7 @@ func batchFileData(c *Config, targetFilePath string, records []*FileRecord) (*Me
 	if err != nil {
 		return nil, fmt.Errorf("failed to getFileVersions: %w", err)
 	}
-	merger := makeFileLineCoverMerger(fvs, c.Base, c.StoreDetails)
+	merger := makeFileLineCoverMerger(fvs, c.Base)
 	for _, record := range records {
 		merger.Add(record)
 	}
@@ -113,7 +113,6 @@ type Config struct {
 	skipRepoClone    bool
 	Base             RepoCommit
 	FileVersProvider FileVersProvider
-	StoreDetails     bool
 }
 
 func isSchema(fields, schema []string) bool {

--- a/pkg/covermerger/file_line_merger.go
+++ b/pkg/covermerger/file_line_merger.go
@@ -5,8 +5,7 @@ package covermerger
 
 import "github.com/google/syzkaller/pkg/log"
 
-func makeFileLineCoverMerger(
-	fvs fileVersions, base RepoCommit, storeDetails bool) FileCoverageMerger {
+func makeFileLineCoverMerger(fvs fileVersions, base RepoCommit) FileCoverageMerger {
 	baseFile := ""
 	baseFileExists := false
 	for repoCommit, fv := range fvs {
@@ -21,15 +20,13 @@ func makeFileLineCoverMerger(
 	}
 	a := &FileLineCoverMerger{
 		MergeResult: &MergeResult{
-			HitCounts:  make(map[int]int),
-			FileExists: true,
+			HitCounts:   make(map[int]int),
+			FileExists:  true,
+			LineDetails: make(map[int][]*FileRecord),
 		},
 		baseFile:   baseFile,
 		matchers:   make(map[RepoCommit]*LineToLineMatcher),
 		lostFrames: map[RepoCommit]int64{},
-	}
-	if storeDetails {
-		a.MergeResult.LineDetails = make(map[int][]*FileRecord)
 	}
 	for repoBranch, fv := range fvs {
 		a.matchers[repoBranch] = makeLineToLineMatcher(fv, baseFile)
@@ -53,9 +50,7 @@ func (a *FileLineCoverMerger) Add(record *FileRecord) {
 	}
 	if targetLine := a.matchers[record.RepoCommit].SameLinePos(record.StartLine); targetLine != -1 {
 		a.HitCounts[targetLine] += record.HitCount
-		if a.LineDetails != nil {
-			a.LineDetails[targetLine] = append(a.LineDetails[targetLine], record)
-		}
+		a.LineDetails[targetLine] = append(a.LineDetails[targetLine], record)
 	}
 }
 

--- a/tools/syz-covermerger/syz_covermerger.go
+++ b/tools/syz-covermerger/syz_covermerger.go
@@ -56,7 +56,6 @@ func main() {
 			Commit: *flagCommit,
 		},
 		FileVersProvider: makeProvider(),
-		StoreDetails:     true,
 	}
 	var dateFrom, dateTo civil.Date
 	var err error


### PR DESCRIPTION
We need coverage details for all usage scenarios.
It makes sense to remove this option.