### PR TITLE
all: add support for binaries shipped with target

### DIFF
--- a/executor/subprocess.h
+++ b/executor/subprocess.h
@@ -56,9 +56,9 @@ public:
 		    "GLIBC_TUNABLES=glibc.pthread.rseq=0",
 		    nullptr};
 
-		if (posix_spawn(&pid_, argv[0], &actions, &attr,
-				const_cast<char**>(argv), const_cast<char**>(child_envp)))
-			fail("posix_spawn failed");
+		if (posix_spawnp(&pid_, argv[0], &actions, &attr,
+				 const_cast<char**>(argv), const_cast<char**>(child_envp)))
+			fail("posix_spawnp failed");
 
 		if (posix_spawn_file_actions_destroy(&actions))
 			fail("posix_spawn_file_actions_destroy failed");

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -50,9 +50,13 @@ const (
 
 func SetupExecProg(vmInst *vm.Instance, mgrCfg *mgrconfig.Config, reporter *report.Reporter,
 	opt *OptionalConfig) (*ExecProgInstance, error) {
-	execprogBin, err := vmInst.Copy(mgrCfg.ExecprogBin)
-	if err != nil {
-		return nil, &TestError{Title: fmt.Sprintf("failed to copy syz-execprog to VM: %v", err)}
+	var err error
+	execprogBin := mgrCfg.SysTarget.ExecprogBin
+	if execprogBin == "" {
+		execprogBin, err = vmInst.Copy(mgrCfg.ExecprogBin)
+		if err != nil {
+			return nil, &TestError{Title: fmt.Sprintf("failed to copy syz-execprog to VM: %v", err)}
+		}
 	}
 	executorBin := mgrCfg.SysTarget.ExecutorBin
 	if executorBin == "" {
@@ -70,7 +74,7 @@ func SetupExecProg(vmInst *vm.Instance, mgrCfg *mgrconfig.Config, reporter *repo
 	}
 	if opt != nil {
 		ret.OptionalConfig = *opt
-		if ret.StraceBin != "" {
+		if !mgrCfg.StraceBinOnTarget && ret.StraceBin != "" {
 			var err error
 			ret.StraceBin, err = vmInst.Copy(ret.StraceBin)
 			if err != nil {

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -191,6 +191,15 @@ type Config struct {
 	// If set, for each reproducer syzkaller will run it once more under strace and save
 	// the output.
 	StraceBin string `json:"strace_bin"`
+	// If true, syzkaller will expect strace_bin to be part of the target
+	// image instead of copying it from the host (default: false).
+	StraceBinOnTarget bool `json:"strace_bin_on_target"`
+
+	// File in PATH to syz-execprog/executor on the target. If set,
+	// syzkaller will expect the execprog/executor binaries to be part of
+	// the target image instead of copying them from the host.
+	ExecprogBinOnTarget string `json:"execprog_bin_on_target"`
+	ExecutorBinOnTarget string `json:"executor_bin_on_target"`
 
 	// Whether to run fsck commands on file system images found in new crash
 	// reproducers. The fsck logs get reported as assets in the dashboard.

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -308,17 +308,31 @@ func (cfg *Config) completeBinaries() error {
 	}
 	cfg.ExecprogBin = targetBin("syz-execprog", cfg.TargetVMArch)
 	cfg.ExecutorBin = targetBin("syz-executor", cfg.TargetArch)
-	// If the target already provides an executor binary, we don't need to copy it.
+
+	if cfg.ExecprogBinOnTarget != "" {
+		cfg.SysTarget.ExecprogBin = cfg.ExecprogBinOnTarget
+	}
+	if cfg.ExecutorBinOnTarget != "" {
+		cfg.SysTarget.ExecutorBin = cfg.ExecutorBinOnTarget
+	}
+	if cfg.StraceBinOnTarget && cfg.StraceBin == "" {
+		cfg.StraceBin = "strace"
+	}
+
+	// If the target already provides binaries, we don't need to copy them.
+	if cfg.SysTarget.ExecprogBin != "" {
+		cfg.ExecprogBin = ""
+	}
 	if cfg.SysTarget.ExecutorBin != "" {
 		cfg.ExecutorBin = ""
 	}
-	if !osutil.IsExist(cfg.ExecprogBin) {
+	if cfg.ExecprogBin != "" && !osutil.IsExist(cfg.ExecprogBin) {
 		return fmt.Errorf("bad config syzkaller param: can't find %v", cfg.ExecprogBin)
 	}
 	if cfg.ExecutorBin != "" && !osutil.IsExist(cfg.ExecutorBin) {
 		return fmt.Errorf("bad config syzkaller param: can't find %v", cfg.ExecutorBin)
 	}
-	if cfg.StraceBin != "" {
+	if !cfg.StraceBinOnTarget && cfg.StraceBin != "" {
 		if !osutil.IsExist(cfg.StraceBin) {
 			return fmt.Errorf("bad config param strace_bin: can't find %v", cfg.StraceBin)
 		}

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -82,10 +82,11 @@ type osCommon struct {
 	// Special mode for OSes that do not have support for building Go binaries.
 	// In this mode we run Go binaries on the host machine, only executor runs on target.
 	HostFuzzer bool
-	// How to run syz-executor directly.
-	// Some systems build syz-executor into their images.
-	// If this flag is not empty, syz-executor will not be copied to the machine, and will be run using
+	// How to run syz-execprog/executor directly.
+	// Some systems build syz-execprog/executor into their images.
+	// If this flag is not empty, syz-execprog/executor will not be copied to the machine, and will be run using
 	// this command instead.
+	ExecprogBin string
 	ExecutorBin string
 	// Extension of executable files (notably, .exe for windows).
 	ExeExtension string


### PR DESCRIPTION
In some build environments (notably Yocto), syzkaller host and target binaries end up in separate packages for each built architecture, which are then shipped with the respective image/SDK.

Add the `Execprog`/`ExecutorBinOnTarget` and `StraceBinOnTarget` options to the manager config, which when set expects the respective binaries to be shipped with the target image and does not attempt to copy them from the host.