### PR TITLE
executor: sys/linux: arm64: implement SYZOS_API_WFI_WFE

### DIFF
--- a/sys/linux/dev_kvm_arm64.txt
+++ b/sys/linux/dev_kvm_arm64.txt
@@ -205,4 +205,5 @@ syzos_api_call [
 	memwrite	syzos_api[6, syzos_api_memwrite]
 	its_setup	syzos_api[7, syzos_api_its_setup]
 	its_send_cmd	syzos_api[8, syzos_api_its_send_cmd]
+	wfi_wfe		syzos_api[9, int64[0:1]]
 ] [varlen]

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-wfi
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-wfi
@@ -1,0 +1,21 @@
+#
+# requires: arch=arm64 -threaded
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@wfi_wfe={AUTO, AUTO, 0x1}], AUTO}, 0x0, 0x0)
+syz_kvm_vgic_v3_setup(r1, 0x1, 0x100)
+
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+
+ioctl$KVM_IRQ_LINE(r1, AUTO, &AUTO={0x1000020, 0x1}) (async)
+
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)


### PR DESCRIPTION
The new API call will be executing WFI and WFE instructions (Wait For Interrupt and Wait For Event, see
https://developer.arm.com/documentation/100453/0401/Power-management/Wait-For-Interrupt-and-Wait-For-Event).

These instructions are handled by KVM via kvm_handle_wfx().

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
