### PR TITLE
dashboard/app: fix create_upload_url bug

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1937,7 +1937,7 @@ func apiCreateUploadURL(c context.Context, payload io.Reader) (interface{}, erro
 	if bucket == "" {
 		return nil, errors.New("not configured")
 	}
-	return fmt.Printf("%s/%s.upload", bucket, uuid.New().String())
+	return fmt.Sprintf("%s/%s.upload", bucket, uuid.New().String()), nil
 }
 
 // apiSaveCoverage reads jsonl data from payload and stores it to coveragedb.


### PR DESCRIPTION
Fixing the error from logs:
```
create_upload_url: failed to unmarshal response: json: cannot unmarshal number into Go value of type string
```

