### PR TITLE
Yocto build compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ ifneq ("$(NO_CROSS_COMPILER)", "")
 else
 	mkdir -p ./bin/$(TARGETOS)_$(TARGETARCH)
 	$(CXX) -o ./bin/$(TARGETOS)_$(TARGETARCH)/syz-executor$(EXE) executor/executor.cc \
-		$(ADDCXXFLAGS) $(CFLAGS) -DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1 \
+		$(ADDCXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -DGOOS_$(TARGETOS)=1 -DGOARCH_$(TARGETARCH)=1 \
 		-DHOSTGOOS_$(HOSTOS)=1 -DGIT_REVISION=\"$(REV)\"
 endif
 endif

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -715,6 +715,16 @@ func initTarget(target *Target, OS, arch string) {
 	for i := range target.CFlags {
 		target.replaceSourceDir(&target.CFlags[i], sourceDir)
 	}
+
+	if cc := os.Getenv("SYZ_CC_" + OS + "_" + arch); cc != "" {
+		target.CCompiler = strings.Fields(cc)[0]
+		target.CFlags = append(target.CFlags, strings.Fields(cc)[1:]...)
+	}
+	if cxx := os.Getenv("SYZ_CXX_" + OS + "_" + arch); cxx != "" {
+		target.CxxCompiler = strings.Fields(cxx)[0]
+		target.CxxFlags = append(target.CxxFlags, strings.Fields(cxx)[1:]...)
+	}
+
 	if OS == Linux && arch == runtime.GOARCH {
 		// Don't use cross-compiler for native compilation, there are cases when this does not work:
 		// https://github.com/google/syzkaller/pull/619

--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -302,7 +302,6 @@ var List = map[string]map[string]*Target{
 			VMArch:           ARM64,
 			PtrSize:          4,
 			PageSize:         4 << 10,
-			CFlags:           []string{"-D__LINUX_ARM_ARCH__=6", "-march=armv6"},
 			Triple:           "arm-linux-gnueabi",
 			KernelArch:       "arm",
 			KernelHeaderArch: "arm",


### PR DESCRIPTION
See [this line in the Yocto recipe](https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-test/syzkaller/syzkaller_git.bb#n57) on why we need [Makefile: rename CFLAGS to CXXFLAGS and add LDFLAGS](https://github.com/google/syzkaller/commit/692168c54dcc33576aa8a89d0ebbce65c53bf341). [sys/targets: allow users to override hardcoded cross-compilers](https://github.com/google/syzkaller/commit/09e73637366462a14da0dfabc1eec4e672543f3c) and [sys/targets: remove hardcoded CFlags for ARM](https://github.com/google/syzkaller/pull/5627/commits/9c029f8f5fc7d129c76750b79fb2ca7585aeab76) are based upon a [Yocto recipe patch](https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-test/syzkaller/syzkaller/0001-sys-targets-targets.go-allow-users-to-override-hardc.patch). Note that there might be reasons why we need to force emitting ARMv6 code, but I could not find any hint in the history; so please let me know if we need to approach this issue in a different way.