### PR TITLE
prog: make TestRotationCoverage faster

### DIFF
--- a/prog/rotation_test.go
+++ b/prog/rotation_test.go
@@ -59,7 +59,7 @@ func TestRotationCoverage(t *testing.T) {
 	calls := make(map[*Syscall]bool)
 	counters := make(map[string]int)
 	for _, call := range target.Syscalls {
-		if call.Attrs.Disabled {
+		if call.Attrs.Disabled || call.Attrs.Automatic {
 			continue
 		}
 		calls[call] = true


### PR DESCRIPTION
Now that we added automatically generated syscalls to the Linux corpus, we added a lot of work to the TestRotationCoverage test. We can make it faster by skipping all automatically generated syscalls.