### PR TITLE
pkg/covermerger: propagate context cancellation

### DIFF
--- a/pkg/cover/file.go
+++ b/pkg/cover/file.go
@@ -79,7 +79,7 @@ func GetMergeResult(c context.Context, ns, repo, forCommit, sourceCommit, filePa
 	}
 
 	ch := make(chan *covermerger.FileMergeResult, 1)
-	if err := covermerger.MergeCSVData(config, csvReader, ch); err != nil {
+	if err := covermerger.MergeCSVData(c, config, csvReader, ch); err != nil {
 		return nil, fmt.Errorf("error merging coverage: %w", err)
 	}
 

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -246,6 +246,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 				doneCh <- true
 			}()
 			assert.NoError(t, MergeCSVData(
+				context.Background(),
 				testConfig(test.baseRepo, test.baseCommit, test.workdir),
 				strings.NewReader(test.bqTable),
 				mergeResultsCh))


### PR DESCRIPTION
The problem is the deadlock happening on GCS storage error.

GCS client establishes the connection when it has enough data to write. It is approximately 16M.
The error happens on io.Writer access in the middle of the merge.
This error terminates errgroup goroutine. Other goroutines remain blocked.
This commit propagates termination signal to other goroutines.
