### PR TITLE
test coverage upload dashapi

### DIFF
--- a/dashboard/app/api_test.go
+++ b/dashboard/app/api_test.go
@@ -302,3 +302,18 @@ func TestUpdateReportingPriority(t *testing.T) {
 	// "0-3", "4-5" have the same priority (repro revoked as no repro).
 	assert.Equal(t, len(slices.Compact(prios)), len(prios)-4)
 }
+
+func TestCreateUploadURL(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	c.transformContext = func(c context.Context) context.Context {
+		newConfig := *getConfig(c)
+		newConfig.UploadBucket = "blobstorage"
+		return contextWithConfig(c, &newConfig)
+	}
+
+	url, err := c.client.CreateUploadURL()
+	assert.NoError(t, err)
+	assert.Regexp(t, "blobstorage/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.upload", url)
+}


### PR DESCRIPTION
It tests the Dashboard.CreateUploadURL.
It internally calls "create_upload_url" method of the dashboard "/api" interface.
This dashboard API requires GlobalConfig.UploadBucket option to specify the bucket.
Dashboard generates the $bucket/$uuid.upload URL and returns it to the client.