### PR TITLE
pkg/coveragedb: fix schema in order to support multiple managers

### DIFF
--- a/pkg/coveragedb/init_db.sh
+++ b/pkg/coveragedb/init_db.sh
@@ -21,12 +21,9 @@ CREATE TABLE
     "hitcounts" bigint[],
     "manager" text,
   PRIMARY KEY
-    (session, filepath) );')
+    (session, manager, filepath) );')
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
  --ddl="$create_table"
-echo "creating 'files' index"
-gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
- --ddl="CREATE INDEX files_session_manager ON files (session, manager);"
 
 echo "drop table 'merge_history' if exists"
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \


### PR DESCRIPTION
Current schema makes session+filepath a primary key (it is unique).
Manager as a part of primary key makes session+filepath+manager a unique combination.
New schema allows us to store information from different managers.
