### PR TITLE
pkg/coveragedb: fix data unpacking bug

### DIFF
--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -81,8 +81,8 @@ func SaveMergeResult(ctx context.Context, client spannerclient.SpannerClient, de
 	session := uuid.New().String()
 	mutations := []*spanner.Mutation{}
 
-	var mcr MergedCoverageRecord
 	for {
+		var mcr MergedCoverageRecord
 		err := dec.Decode(&mcr)
 		if err == io.EOF {
 			break


### PR DESCRIPTION
Current tests check the amount of data transfered to the mock.
But they didn't check the data correctness.

Because of this bug every batch have the same coverage which is nonsense.