### PR TITLE
syz-manager: add a check for 'localhost'

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -242,6 +242,11 @@ func main() {
 }
 
 func RunManager(mode *Mode, cfg *mgrconfig.Config) {
+	// localhost is going to be used later, notify users
+	if _, err := net.LookupHost("localhost"); err != nil {
+		log.Fatalf("'localhost' is not resolving on this system, configure your DNS resolver")
+	}
+
 	var vmPool *vm.Pool
 	if !cfg.VMLess {
 		var err error


### PR DESCRIPTION
If localhost is not resolvable on a system, we might hang without any logging (for example in vm/vmimpl/UnusedTCPPort) or fail later. Since syzkaller uses localhost (and not something like 127.0.0.1) it's way better to notify user earlier if their localhost is not configured correctly.

----
P.S. I was running syzkaller on a system with empty /etc/hosts, so I've stuck inside [UnusedTCPPort](https://github.com/google/syzkaller/blob/d3ccff6372e07c6aabd02b5da419aa6492b5f0ad/vm/vmimpl/vmimpl.go#L236-L245), because of unsolvable 'localhost'.

I guess fixing this ONLY inside the problematic function is not enough, so I've added a top-level check. However, I'm not familiar with the codebase, so please tell me if I need to add this check to more locations or somewhere else.
