### PR TITLE
dashboard/app: add targeting controls to the coverage page

### DIFF
--- a/dashboard/app/static/coverage.js
+++ b/dashboard/app/static/coverage.js
@@ -1,7 +1,8 @@
 // Copyright 2024 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-initTogglers();
+$(document).ready(initTogglers());
+$(document).ready(initUpdateForm);
 
 // Initializes the file tree onClick collapse logic.
 function initTogglers(){
@@ -9,6 +10,14 @@ function initTogglers(){
     $(this).toggleClass("caret-down");
     $(this).closest("li").find(".nested").first().toggleClass("active");
   });
+}
+
+function initUpdateForm(){
+  var curUrlParams = new URLSearchParams(window.location.search);
+  $('#target-period').val(curUrlParams.get('period'));
+  $('#target-subsystem').val(curUrlParams.get('subsystem'));
+  $('#target-manager').val(curUrlParams.get('manager'));
+  $("#only-unique").prop("checked", curUrlParams.get('subsystem') == "1");
 }
 
 // This handler is called when user clicks on the coverage percentage.

--- a/pkg/cover/templates/heatmap.html
+++ b/pkg/cover/templates/heatmap.html
@@ -104,6 +104,44 @@
 {{ end }}
 
 {{ define "body" }}
+  <div style="display:inline-block">
+    <form method="get">
+      <div style="display:inline-block; vertical-align: top">
+        <label for="target-period">Periods:</label>
+        <br>
+        <label for="target-subsystem">Subsystem:</label>
+        <br>
+        <label for="target-manager">Manager:</label>
+        <br>
+        <label for="only-unique">Only unique:</label>
+      </div>
+      <div style="display:inline-block; vertical-align: top">
+        <select id="target-period" name="period">
+          <option value="month">Month</option>
+          <option value="day">Day</option>
+        </select>
+        <br>
+        <select id="target-subsystem" name="subsystem">
+          <option value="">*</option>
+          {{ range $ss := .Subsystems }}
+            <option value="{{ $ss }}">{{ $ss }}</option>
+          {{ end }}
+        </select>
+        <br>
+        <select id="target-manager" name="manager">
+          <option value="">*</option>
+          {{ range $manager := .Managers }}
+            <option value="{{ $manager }}">{{ $manager }}</option>
+          {{ end }}
+        </select>
+        <br>
+        <input type="checkbox" id="only-unique" name="unique-only" disabled>
+      </div>
+      <br>
+      <button id="updateButton">Update</button>
+    </form>
+  </div>
+  <hr>
   <div style="white-space: nowrap">
     <div style="display:inline-block">
       <ul id="collapsible-list">


### PR DESCRIPTION
It allows to control known parameters:
1. Period (months or days).
2. Target subsystem.
3. Target manager.

And adds the disabled "Only unique" checkbox.