### PR TITLE
.github/workflows: use upload-artifacts v4 in oss-fuzz workflow

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -20,7 +20,7 @@ jobs:
         language: go
         output-sarif: true
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
Closes #5664 .