### PR TITLE
.golangci.yml: remove deprecated gomnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ linters:
     - gochecknoinits
     - godox
     - goimports
-    - gomnd
     - gomodguard
     - gosec
     - rowserrcheck


### PR DESCRIPTION
In order to remove warning:
The linter \"gomnd\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
