### PR TITLE
fsck: fix permissions of the temp fs image when a sandbox is used

### DIFF
--- a/pkg/image/fsck.go
+++ b/pkg/image/fsck.go
@@ -35,6 +35,8 @@ func Fsck(r io.Reader, fsckCmd string) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
+	osutil.SandboxChown(tempFile.Name())
+
 	// And run the provided fsck command on it.
 	fsck := append(strings.Fields(fsckCmd), tempFile.Name())
 	cmd := osutil.Command(fsck[0], fsck[1:]...)


### PR DESCRIPTION
My dev environment skips the osutil_linux sandbox because it doesn't have a "syzkaller" user and group. The CI environment also skips the sandbox because it sets the "CI" environment variable.

Therefore, nothing caught that, when run in the syzbot docker container, (which has a "syzkaller" user) the sandbox actually starts to be used and breaks fsck commands.

Syz-manager, which is run as root, writes the image to /tmp/1234.img with permissions 0600 and then tries to run fsck under the "syzkaller" user which doesn't have read permissions on the file, so fsck fails:

    fsck.ext4 -n exited with status code 8
    e2fsck 1.47.0 (5-Feb-2023)
    fsck.ext4: Permission denied while trying to open /tmp/1234.img
    You must have r/o access to the filesystem or be root

Changing the owner of the file to the "syzkaller" user before attempting to run fsck under that user fixes the problem.
