### PR TITLE
all: support empty HTTP config

### DIFF
--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -68,6 +68,9 @@ type HTTPServer struct {
 }
 
 func (serv *HTTPServer) Serve() {
+	if serv.Cfg.HTTP == "" {
+		log.Fatalf("starting a disabled HTTP server")
+	}
 	if serv.Pool != nil {
 		serv.Pools = map[string]*vm.Dispatcher{"": serv.Pool}
 	}

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -145,7 +145,6 @@ func Complete(cfg *Config) error {
 		cfg.TargetArch, "target",
 		cfg.Workdir, "workdir",
 		cfg.Syzkaller, "syzkaller",
-		cfg.HTTP, "http",
 		cfg.Type, "type",
 		cfg.SSHUser, "ssh_user",
 	); err != nil {

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -591,8 +591,7 @@ func (mgr *Manager) createTestConfig(imageDir string, info *BuildInfo) (*mgrconf
 	*mgrcfg = *mgr.managercfg
 	mgrcfg.Name += "-test"
 	mgrcfg.Tag = info.KernelCommit
-	// Use designated ports not to collide with the ports of other managers.
-	mgrcfg.HTTP = fmt.Sprintf("localhost:%v", mgr.mgrcfg.testHTTPPort)
+	mgrcfg.HTTP = "" // Don't start the HTTP server.
 	// For GCE VMs, we need to bind to a real networking interface, so no localhost.
 	mgrcfg.RPC = fmt.Sprintf(":%v", mgr.mgrcfg.testRPCPort)
 	mgrcfg.Workdir = filepath.Join(imageDir, "workdir")

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -225,8 +225,7 @@ type ManagerConfig struct {
 	managercfg       *mgrconfig.Config
 
 	// Auto-assigned ports used by test instances.
-	testHTTPPort int
-	testRPCPort  int
+	testRPCPort int
 }
 
 type ManagerJobs struct {
@@ -461,8 +460,6 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 		managercfg.RPC = fmt.Sprintf(":%v", cfg.RPCPort)
 		cfg.RPCPort++
 	}
-	mgr.testHTTPPort = cfg.ManagerPort
-	cfg.ManagerPort++
 	mgr.testRPCPort = cfg.RPCPort
 	cfg.RPCPort++
 	// Note: we don't change Compiler/Ccache because it may be just "gcc" referring


### PR DESCRIPTION
We don't really need an HTTP server when running syz-manager during kernel image testing and when running syz-diff automatically.

Don't require the config to be set and don't start the HTTP server in this case.