### PR TITLE
sys/linux/test: Add tests for ARM QEMU emulation

### DIFF
--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-0
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-0
@@ -1,0 +1,48 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the PMU registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x603000000013c4f1 is PMINTENSET_EL1.
+# 0x603000000013c4f2 is PMINTENCLR_EL1.
+# 0x603000000013dce0 is PMCR_EL0.
+# 0x603000000013dce1 is PMCNTENSET_EL0.
+# 0x603000000013dce2 is PMCNTENCLR_EL0.
+# 0x603000000013dce3 is PMOVSCLR_EL0.
+# 0x603000000013dce4 is PMSWINC_EL0.
+# 0x603000000013dce5 is PMSELR_EL0.
+# 0x603000000013dce8 is PMCCNTR_EL0.
+# 0x603000000013dce9 is PMXEVTYPER_EL0.
+# Writes to these registers will trigger kvm_handle_sys_reg in arch/arm64/kvm/sys_regs.c
+# This is done to illustrate that PMU is accessible.
+# 0x8 corresponds to the KVM_ARM_VCPU_PMU_V3 feature bit and is required to enable PMU.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x603000000013c4f1, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c4f2, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce0, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce1, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce2, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce3, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce4, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce5, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce8, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dce9, 0x8000}}], AUTO}, &AUTO=[@featur1={0x1, 0x8}], 0x1)
+#
+# Call ioctl(KVM_SET_DEVICE_ATTR) with group=KVM_ARM_VCPU_PMU_V3_CTRL and attr=KVM_ARM_VCPU_PMU_V3_INIT,
+# as per https://www.kernel.org/doc/Documentation/virt/kvm/devices/vcpu.rst.
+#
+ioctl$KVM_SET_DEVICE_ATTR_vcpu(r3, AUTO, &AUTO=@attr_pmu_init)
+
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+#
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x603000000013c4f1, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c4f2, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce0, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce1, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce2, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce3, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce4, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce5, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce8, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dce9, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-1
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-1
@@ -1,0 +1,48 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the PMU registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x603000000013dcea is PMXEVCNTR_EL0.
+# 0x603000000013dcf0 is PMUSERENR_EL0.
+# 0x603000000013dcf3 is PMOVSSET_EL0.
+# 0x603000000013df40 is PMEVCNTRn_EL0(0).
+# 0x603000000013df41 is PMEVCNTRn_EL0(1).
+# 0x603000000013df42 is PMEVCNTRn_EL0(2).
+# 0x603000000013df43 is PMEVCNTRn_EL0(3).
+# 0x603000000013df44 is PMEVCNTRn_EL0(4).
+# 0x603000000013df45 is PMEVCNTRn_EL0(5).
+# 0x603000000013df7f is PMCCFILTR_EL0.
+# Writes to these registers will trigger kvm_handle_sys_reg in arch/arm64/kvm/sys_regs.c
+# This is done to illustrate that PMU is accessible.
+# 0x8 corresponds to the KVM_ARM_VCPU_PMU_V3 feature bit and is required to enable PMU.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x603000000013dcea, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dcf0, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013dcf3, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df40, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df41, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df42, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df43, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df44, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df45, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df7f, 0x8000}}], AUTO}, &AUTO=[@featur1={0x1, 0x8}], 0x1)
+#
+# Call ioctl(KVM_SET_DEVICE_ATTR) with group=KVM_ARM_VCPU_PMU_V3_CTRL and attr=KVM_ARM_VCPU_PMU_V3_INIT,
+# as per https://www.kernel.org/doc/Documentation/virt/kvm/devices/vcpu.rst.
+#
+ioctl$KVM_SET_DEVICE_ATTR_vcpu(r3, AUTO, &AUTO=@attr_pmu_init)
+
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+#
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x603000000013dcea, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dcf0, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013dcf3, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df40, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df41, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df42, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df43, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df44, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df45, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df7f, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-2
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-enable-pmu-msr-emul-2
@@ -1,0 +1,42 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the PMU registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x603000000013df60 is PMEVTYPERn_EL0(0).
+# 0x603000000013df61 is PMEVTYPERn_EL0(1).
+# 0x603000000013df62 is PMEVTYPERn_EL0(2).
+# 0x603000000013df63 is PMEVTYPERn_EL0(3).
+# 0x603000000013df64 is PMEVTYPERn_EL0(4).
+# 0x603000000013df65 is PMEVTYPERn_EL0(5).
+# 0x603000000013df7f is PMCCFILTR_EL0.
+# Writes to these registers will trigger kvm_handle_sys_reg in arch/arm64/kvm/sys_regs.c
+# This is done to illustrate that PMU is accessible.
+# 0x8 corresponds to the KVM_ARM_VCPU_PMU_V3 feature bit and is required to enable PMU.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x603000000013df60, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df61, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df62, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df63, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df64, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df65, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013df7f, 0x8000}}, ], AUTO}, &AUTO=[@featur1={0x1, 0x8}], 0x1)
+#
+# Call ioctl(KVM_SET_DEVICE_ATTR) with group=KVM_ARM_VCPU_PMU_V3_CTRL and attr=KVM_ARM_VCPU_PMU_V3_INIT,
+# as per https://www.kernel.org/doc/Documentation/virt/kvm/devices/vcpu.rst.
+#
+ioctl$KVM_SET_DEVICE_ATTR_vcpu(r3, AUTO, &AUTO=@attr_pmu_init)
+
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+#
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x603000000013df60, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df61, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df62, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df63, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df64, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df65, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013df7f, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-0
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-0
@@ -1,0 +1,39 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the system registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x6030000000138010 is MDCCINT_EL1.
+# 0x6030000000138012 is MDSCR_EL1.
+# 0x6030000000138004 is DBGBVRn_EL1(0).
+# 0x603000000013800c is DBGBVRn_EL1(1).
+# 0x6030000000138014 is DBGBVRn_EL1(2).
+# 0x603000000013801c is DBGBVRn_EL1(3).
+# 0x6030000000138024 is DBGBVRn_EL1(4).
+# 0x603000000013802c is DBGBVRn_EL1(5).
+# 0x6030000000138005 is DBGBCRn_EL1(0).
+# 0x603000000013800d is DBGBCRn_EL1(1).
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x6030000000138010, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138012, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138004, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013800c, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138014, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013801c, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138024, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013802c, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138005, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013800d, 0x8000}}], AUTO}, 0x0, 0x0)
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x6030000000138010, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138012, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138004, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013800c, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138014, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013801c, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138024, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013802c, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138005, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013800d, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-1
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-1
@@ -1,0 +1,39 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the system registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x6030000000138015 is DBGBCRn_EL1(2).
+# 0x603000000013801d is DBGBCRn_EL1(3).
+# 0x6030000000138025 is DBGBCRn_EL1(4).
+# 0x603000000013802d is DBGBCRn_EL1(5).
+# 0x6030000000138006 is DBGWVRn_EL1(0).
+# 0x603000000013800e is DBGWVRn_EL1(1).
+# 0x6030000000138016 is DBGWVRn_EL1(2).
+# 0x603000000013801e is DBGWVRn_EL1(3).
+# 0x6030000000138007 is DBGWCRn_EL1(0).
+# 0x603000000013800f is DBGWCRn_EL1(1).
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x6030000000138015, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013801d, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138025, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013802d, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138006, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013800e, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138016, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013801e, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138007, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013800f, 0x8000}}], AUTO}, 0x0, 0x0)
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x6030000000138015, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013801d, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138025, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013802d, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138006, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013800e, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138016, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013801e, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138007, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013800f, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-2
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-2
@@ -1,0 +1,39 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the system registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x6030000000138017 is DBGWCRn_EL1(2).
+# 0x603000000013801f is DBGWCRn_EL1(3).
+# 0x6030000000138084 is OSLAR_EL1.
+# 0x603000000013809c is OSDLR_EL1.
+# 0x60300000001383c6 is DBGCLAIMSET_EL1.
+# 0x60300000001383ce is DBGCLAIMCLR_EL1.
+# 0x6030000000139828 is DBGDTRTX_EL0.
+# 0x6030000000139828 is DBGDTRTX_EL0.
+# 0x603000000013c081 is ACTLR_EL1.
+# 0x603000000013c230 is ICC_PMR_EL1.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x6030000000138017, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013801f, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000138084, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013809c, 0x8000}}, @msr={AUTO, AUTO, {0x60300000001383c6, 0x8000}}, @msr={AUTO, AUTO, {0x60300000001383ce, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000139828, 0x8000}}, @msr={AUTO, AUTO, {0x6030000000139828, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c081, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c230, 0x8000}}], AUTO}, 0x0, 0x0)
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x6030000000138017, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013801f, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000138084, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013809c, 0x8000)
+syz_kvm_assert_reg(r3, 0x60300000001383c6, 0x8000)
+syz_kvm_assert_reg(r3, 0x60300000001383ce, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000139828, 0x8000)
+syz_kvm_assert_reg(r3, 0x6030000000139828, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c081, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c230, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-3
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-3
@@ -1,0 +1,39 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the system registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x603000000013c520 is LORSA_EL1.
+# 0x603000000013c521 is LOREA_EL1.
+# 0x603000000013c522 is LORN_EL1.
+# 0x603000000013c523 is LORC_EL1.
+# 0x603000000013c641 is ICC_EOIR0_EL1.
+# 0x603000000013c643 is ICC_BPR0_EL1.
+# 0x603000000013c644 is ICC_AP0R0_EL1.
+# 0x603000000013c648 is ICC_AP1R0_EL1.
+# 0x603000000013c659 is ICC_DIR_EL1.
+# 0x603000000013c65d is ICC_SGI1R_EL1.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x603000000013c520, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c521, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c522, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c523, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c641, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c643, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c644, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c648, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c659, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c65d, 0x8000}}], AUTO}, 0x0, 0x0)
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x603000000013c520, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c521, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c522, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c523, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c641, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c643, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c644, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c648, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c659, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c65d, 0x8000)

--- a/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-4
+++ b/sys/linux/test/arm64-syz_kvm_setup_syzos_vm-msr-emul-4
@@ -1,0 +1,39 @@
+#
+# requires: arch=arm64 -threaded
+#
+# This series of tests exercise the system registers that are exposed in the QEMU emulation mode.
+# They should not be used in the corpus when running on real HW.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x603000000013c65e is ICC_ASGI1R_EL1.
+# 0x603000000013c65f is ICC_SGI0R_EL1.
+# 0x603000000013c661 is ICC_EOIR1_EL1.
+# 0x603000000013c663 is ICC_BPR1_EL1.
+# 0x603000000013c664 is ICC_CTLR_EL1.
+# 0x603000000013c666 is ICC_IGRPEN0_EL1.
+# 0x603000000013c667 is ICC_IGRPEN1_EL1.
+# 0x603000000013c687 is SCXTNUM_EL1.
+# 0x603000000013d000 is CSSELR_EL1.
+# 0x603000000013de87 is SCXTNUM_EL0.
+#
+r3 = syz_kvm_add_vcpu(r2, &AUTO={0x0, &AUTO=[@msr={AUTO, AUTO, {0x603000000013c65e, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c65f, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c661, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c663, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c664, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c666, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c667, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013c687, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013d000, 0x8000}}, @msr={AUTO, AUTO, {0x603000000013de87, 0x8000}}], AUTO}, 0x0, 0x0)
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit(r5, 0xffffffffffffffff)
+syz_kvm_assert_reg(r3, 0x603000000013c65e, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c65f, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c661, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c663, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c664, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c666, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c667, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013c687, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013d000, 0x8000)
+syz_kvm_assert_reg(r3, 0x603000000013de87, 0x8000)


### PR DESCRIPTION
When using QEMU full emulation mode, the majority of the system registers (as defined in sys/linux/dev_kvm.txt:kvm_regs_arm64_sys) are not accessible (i.e. only 77/592 trigger kvm_handle_sys_reg()). This series of tests perform MSR accesses to the accessible registers.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
