### PR TITLE
executor: better support for globs

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -3953,6 +3953,16 @@ static void sandbox_common_mount_tmpfs(void)
 		fail("mount(smackfs) failed");
 	if (mount("/proc/sys/fs/binfmt_misc", "./syz-tmp/newroot/proc/sys/fs/binfmt_misc", NULL, bind_mount_flags, NULL) && errno != ENOENT)
 		fail("mount(binfmt_misc) failed");
+
+	// If user wants to supply custom inputs, those can be placed to /syz-inputs
+	// That folder will be mounted to fuzzer sandbox
+	// https://groups.google.com/g/syzkaller/c/U-DISFjKLzg
+	if (mkdir("./syz-tmp/newroot/syz-inputs", 0700))
+		fail("mkdir(/syz-inputs) failed");
+
+	if (mount("/syz-inputs", "./syz-tmp/newroot/syz-inputs", NULL, bind_mount_flags | MS_RDONLY, NULL) && errno != ENOENT)
+		fail("mount(syz-inputs) failed");
+
 #if SYZ_EXECUTOR || SYZ_CGROUPS
 	initialize_cgroups();
 #endif


### PR DESCRIPTION
* Linux executor now mounts /syz-inputs folder to sandbox, so user can pass their own files for fuzzing with globs. Folder is mounted as RO, so this shouldn't make sandoxing less effective. (See https://groups.google.com/g/syzkaller/c/U-DISFjKLzg for specific usecase)

* Timeouts for globs are disabled. They can be quite slow (with default settings, in my tests, globs started timing out on thousands of files), and right now, if glob resolution timeouts, nothing happens. If you are running debug, you can see the timeout error, but in any case, it is ignored and fuzzer runs with less inputs then user expected without any notification. I think that it is reasonable to wait for those longer then default program timeout.