### PR TITLE
syz-manager: fix empty fs images being run through fsck

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -922,14 +922,16 @@ func (mgr *Manager) uploadReproAssets(repro *repro.Result) []dashapi.NewAsset {
 		if !ok {
 			panic("unknown extracted prog asset")
 		}
-		asset, err := mgr.assetStorage.UploadCrashAsset(r, name, dashTyp, nil)
+		r2 := &bytes.Buffer{}
+		r1 := io.TeeReader(r, r2)
+		asset, err := mgr.assetStorage.UploadCrashAsset(r1, name, dashTyp, nil)
 		if err != nil {
 			log.Logf(1, "processing of the asset %v (%v) failed: %v", name, typ, err)
 			return
 		}
 		// Report file systems that fail fsck with a separate tag.
 		if mgr.cfg.RunFsck && dashTyp == dashapi.MountInRepro && c.Meta.Attrs.Fsck != "" {
-			logs, isClean, err := image.Fsck(r, c.Meta.Attrs.Fsck)
+			logs, isClean, err := image.Fsck(r2, c.Meta.Attrs.Fsck)
 			if err != nil {
 				log.Logf(1, "fsck of the asset %v failed: %v", name, err)
 			} else {


### PR DESCRIPTION
We currently read an fs image twice from an io.Reader, once to upload it to the dashboard and once to write it to disk for fsck. The first io.Reader read exhausts the stream and therefore leaves an empty image to write to disk. All fsck commands fail with

    fsck.ext4 -n exited with status code 8
    e2fsck 1.47.0 (5-Feb-2023)
    fsck.ext4: Attempt to read block from filesystem resulted in short
      read while trying to open /tmp/1234.img
    Could this be a zero-length partition?

This basically duplicates the io.Reader using a Tee. I considered refactoring the asset upload and fsck APIs to use a buffer instead of a reader but this leads to a rather far fetching refactoring. Duplicating streams here seemed to be a more self-contained change.