### PR TITLE
tools/docker/syz-env: persist GOMODCACHE

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -25,7 +25,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q curl
 # otherwise --volume will create these dirs under root and then
 # the current user won't have access to them.
 RUN mkdir -p /syzkaller/gopath/src/github.com/google/syzkaller && \
-	mkdir -p /syzkaller/.cache && \
+	mkdir -p /syzkaller/.cache/gomod && \
 	chmod -R 0777 /syzkaller
 
 # Install OS toolchains from pre-built archives.
@@ -83,6 +83,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 RUN curl https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath
+ENV GOMODCACHE /syzkaller/.cache/gomod
 
 # Install clang.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https


### PR DESCRIPTION
Prevent Go from downloading all external dependencies each time syz-env is called. It will become a problem once vendor/ is deleted.
