### PR TITLE
pkg: avoid log.Fatal calls

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -110,7 +110,11 @@ func (dc *diffContext) Loop(baseCtx context.Context) error {
 		// Let both base and patched instances somewhat progress in fuzzing before we take
 		// VMs away for bug reproduction.
 		// TODO: determine the exact moment of corpus triage.
-		time.Sleep(15 * time.Minute)
+		select {
+		case <-time.After(15 * time.Minute):
+		case <-ctx.Done():
+			return nil
+		}
 		log.Logf(0, "starting bug reproductions")
 		reproLoop.Loop(ctx)
 		return nil

--- a/pkg/rpcserver/mocks/Manager.go
+++ b/pkg/rpcserver/mocks/Manager.go
@@ -53,7 +53,7 @@ func (_m *Manager) BugFrames() ([]string, []string) {
 }
 
 // CoverageFilter provides a mock function with given fields: modules
-func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) []uint64 {
+func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) ([]uint64, error) {
 	ret := _m.Called(modules)
 
 	if len(ret) == 0 {
@@ -61,6 +61,10 @@ func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) []uint64 {
 	}
 
 	var r0 []uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]*vminfo.KernelModule) ([]uint64, error)); ok {
+		return rf(modules)
+	}
 	if rf, ok := ret.Get(0).(func([]*vminfo.KernelModule) []uint64); ok {
 		r0 = rf(modules)
 	} else {
@@ -69,11 +73,17 @@ func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) []uint64 {
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func([]*vminfo.KernelModule) error); ok {
+		r1 = rf(modules)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MachineChecked provides a mock function with given fields: features, syscalls
-func (_m *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {
+func (_m *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) (queue.Source, error) {
 	ret := _m.Called(features, syscalls)
 
 	if len(ret) == 0 {
@@ -81,6 +91,10 @@ func (_m *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.S
 	}
 
 	var r0 queue.Source
+	var r1 error
+	if rf, ok := ret.Get(0).(func(flatrpc.Feature, map[*prog.Syscall]bool) (queue.Source, error)); ok {
+		return rf(features, syscalls)
+	}
 	if rf, ok := ret.Get(0).(func(flatrpc.Feature, map[*prog.Syscall]bool) queue.Source); ok {
 		r0 = rf(features, syscalls)
 	} else {
@@ -89,7 +103,13 @@ func (_m *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.S
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(flatrpc.Feature, map[*prog.Syscall]bool) error); ok {
+		r1 = rf(features, syscalls)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MaxSignal provides a mock function with given fields:

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -4,10 +4,12 @@
 package rpcserver
 
 import (
+	"context"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -212,7 +214,11 @@ func TestHandleConn(t *testing.T) {
 			serv.CreateInstance(1, injectExec, nil)
 
 			go flatrpc.Send(clientConn, tt.req)
-			serv.handleConn(serverConn)
+			var eg errgroup.Group
+			serv.handleConn(context.Background(), &eg, serverConn)
+			if err := eg.Wait(); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -546,7 +546,10 @@ func (mgr *Manager) processRepro(res *manager.ReproResult) {
 }
 
 func (mgr *Manager) preloadCorpus() {
-	info := manager.LoadSeeds(mgr.cfg, false)
+	info, err := manager.LoadSeeds(mgr.cfg, false)
+	if err != nil {
+		log.Fatalf("failed to load corpus: %v", err)
+	}
 	mgr.fresh = info.Fresh
 	mgr.corpusDB = info.CorpusDB
 	mgr.corpusPreload <- info.Candidates


### PR DESCRIPTION
These calls prevent graceful error handling in the caller code. We should just return `error` and let individual tools decide what to do.