### PR TITLE
pkg/vminfo: remove Context from the constructor

### DIFF
--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -48,7 +48,7 @@ func RunLocal(cfg *LocalConfig) error {
 		cfg:       cfg,
 		setupDone: make(chan bool),
 	}
-	serv := newImpl(cfg.Context, &cfg.Config, ctx)
+	serv := newImpl(&cfg.Config, ctx)
 	if err := serv.Listen(); err != nil {
 		return err
 	}

--- a/pkg/vminfo/linux_test.go
+++ b/pkg/vminfo/linux_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestLinuxSyscalls(t *testing.T) {
 	cfg := testConfig(t, targets.Linux, targets.AMD64)
-	checker := New(context.Background(), cfg)
+	checker := New(cfg)
 	filesystems := []string{
 		// Without sysfs, the checks would also disable mount().
 		"", "sysfs", "ext4", "binder", "",
@@ -40,7 +40,7 @@ func TestLinuxSyscalls(t *testing.T) {
 	}
 	stop := make(chan struct{})
 	go createSuccessfulResults(checker, stop)
-	enabled, disabled, features, err := checker.Run(files, allFeatures())
+	enabled, disabled, features, err := checker.Run(context.Background(), files, allFeatures())
 	close(stop)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -37,8 +37,9 @@ type KernelModule struct {
 
 type Checker struct {
 	checker
-	source       queue.Source
-	checkContext *checkContext
+	cfg      *Config
+	source   queue.Source
+	executor queue.Executor
 }
 
 type Config struct {
@@ -54,7 +55,7 @@ type Config struct {
 	SandboxArg int64
 }
 
-func New(ctx context.Context, cfg *Config) *Checker {
+func New(cfg *Config) *Checker {
 	var impl checker
 	switch cfg.Target.OS {
 	case targets.Linux:
@@ -68,9 +69,10 @@ func New(ctx context.Context, cfg *Config) *Checker {
 	}
 	executor := queue.Plain()
 	return &Checker{
-		checker:      impl,
-		source:       queue.Deduplicate(executor),
-		checkContext: newCheckContext(ctx, cfg, impl, executor),
+		cfg:      cfg,
+		checker:  impl,
+		executor: executor,
+		source:   queue.Deduplicate(executor),
 	}
 }
 
@@ -99,11 +101,10 @@ func (checker *Checker) MachineInfo(fileInfos []*flatrpc.FileInfo) ([]*KernelMod
 	return modules, info.Bytes(), nil
 }
 
-func (checker *Checker) Run(files []*flatrpc.FileInfo, featureInfos []*flatrpc.FeatureInfo) (
+func (checker *Checker) Run(ctx context.Context, files []*flatrpc.FileInfo, featureInfos []*flatrpc.FeatureInfo) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, Features, error) {
-	ctx := checker.checkContext
-	checker.checkContext = nil
-	return ctx.do(files, featureInfos)
+	cc := newCheckContext(ctx, checker.cfg, checker.checker, checker.executor)
+	return cc.do(files, featureInfos)
 }
 
 // Implementation of the queue.Source interface.

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -56,10 +56,10 @@ func TestSyscalls(t *testing.T) {
 			t.Run(target.OS+"/"+target.Arch, func(t *testing.T) {
 				t.Parallel()
 				cfg := testConfig(t, target.OS, target.Arch)
-				checker := New(context.Background(), cfg)
+				checker := New(cfg)
 				stop := make(chan struct{})
 				go createSuccessfulResults(checker, stop)
-				enabled, disabled, _, err := checker.Run(nil, allFeatures())
+				enabled, disabled, _, err := checker.Run(context.Background(), nil, allFeatures())
 				close(stop)
 				if err != nil {
 					t.Fatal(err)
@@ -126,7 +126,7 @@ func createSuccessfulResults(source queue.Source, stop chan struct{}) {
 
 func hostChecker(t *testing.T) (*Checker, []*flatrpc.FileInfo) {
 	cfg := testConfig(t, runtime.GOOS, runtime.GOARCH)
-	checker := New(context.Background(), cfg)
+	checker := New(cfg)
 	files := readFiles(checker.RequiredFiles())
 	return checker, files
 }


### PR DESCRIPTION
The context is assumed to be passed into the function doing the actual processing. Refactor vminfo to follow this approach.

This will help refactor pkg/rpcserver later.
