### PR TITLE
docs: update docker instructions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -135,20 +135,10 @@ Or you may run the shell inside of the container with just `syz-env` and look ar
 To update `syz-env` container to the latest version do:
 
 ``` bash
+sudo apt install google-cloud-cli
+gcloud auth login
+gcloud auth configure-docker
 docker pull gcr.io/syzkaller/env
-```
-
-If you do not have access to the `gcr.io` registry, there is also a mirror in `docker.pkg.github.com` registry.
-In order to use it, you need to
-[authenticate Docker](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages)
-with your Github account with:
-```
-docker login https://docker.pkg.github.com
-```
-and then pull the image and retag it to the name expected by `syz-env`:
-```
-docker pull docker.pkg.github.com/google/syzkaller/env
-docker tag docker.pkg.github.com/google/syzkaller/env gcr.io/syzkaller/env
 ```
 
 You can also build the container from the respective `Dockerfile` by setting the `SYZ_ENV_BUILD` environment variable, i.e.:

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -10,6 +10,9 @@ These images are available as `gcr.io/syzkaller/{env,old-env}`, respectively.
 
 To download and run locally:
 ```
+sudo apt install google-cloud-cli
+gcloud auth login
+gcloud auth configure-docker
 docker pull gcr.io/syzkaller/env
 docker run -it gcr.io/syzkaller/env
 ```


### PR DESCRIPTION
Mention that one needs to install gcloud and login with a google account now.
Delete mentions of github registry, we don't update it nowadays.
