### PR TITLE
syz-cluster/controller: handle a channel closure

### DIFF
--- a/syz-cluster/controller/processor.go
+++ b/syz-cluster/controller/processor.go
@@ -120,6 +120,9 @@ func (sp *SeriesProcessor) seriesRunner(ctx context.Context, ch <-chan *db.Sessi
 		var session *db.Session
 		select {
 		case session = <-ch:
+			if session == nil {
+				return
+			}
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
If we don't consider the possibility, we risk getting a nil pointer dereference in the case it's closed:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2d648de]

goroutine 1103 [running]:
github.com/google/syzkaller/syz-cluster/controller.(*SeriesProcessor).seriesRunner(0xc000d96f80, {0x37681e0, 0xc000e37c70}, 0xc000e3d5c0)
	/__w/syzkaller/syzkaller/gopath/src/github.com/google/syzkaller/syz-cluster/controller/processor.go:126 +0x21e
github.com/google/syzkaller/syz-cluster/controller.(*SeriesProcessor).Loop.func1()
