### PR TITLE
pkg/coveragedb: store information about the covered functions

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1936,7 +1936,7 @@ func apiCreateUploadURL(c context.Context, payload io.Reader) (interface{}, erro
 
 // apiSaveCoverage reads jsonl data from payload and stores it to coveragedb.
 // First payload jsonl line is a coveragedb.HistoryRecord (w/o session and time).
-// Second+ records are coveragedb.MergedCoverageRecord.
+// Second+ records are coveragedb.JSONLWrapper.
 func apiSaveCoverage(c context.Context, payload io.Reader) (interface{}, error) {
 	descr := new(coveragedb.HistoryRecord)
 	jsonDec := json.NewDecoder(payload)

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -71,6 +71,19 @@ type MergedCoverageRecord struct {
 	FileData *Coverage
 }
 
+// FuncLines represents the 'functions' table records.
+// It could be used to maps 'hitcounts' from 'files' table to the function names.
+type FuncLines struct {
+	FilePath string
+	FuncName string
+	Lines    []int64 // List of lines we know belong to this function name according to the addr2line output.
+}
+
+type JSONLWrapper struct {
+	MCR *MergedCoverageRecord
+	FL  *FuncLines
+}
+
 func SaveMergeResult(ctx context.Context, client spannerclient.SpannerClient, descr *HistoryRecord, dec *json.Decoder,
 	sss []*subsystem.Subsystem) (int, error) {
 	if client == nil {

--- a/pkg/coveragedb/coveragedb_mock_test.go
+++ b/pkg/coveragedb/coveragedb_mock_test.go
@@ -45,9 +45,10 @@ func TestSaveMergeResult(t *testing.T) {
 			jsonl:   strings.NewReader(`{a}`),
 			wantErr: true,
 		},
+		// nolint: dupl
 		{
-			name:     "1 record, Ok",
-			jsonl:    strings.NewReader(`{"FileData":{}}`),
+			name:     "1 MCR record, Ok",
+			jsonl:    strings.NewReader(`{"MCR":{"FileData":{}}}`),
 			descr:    &HistoryRecord{},
 			wantRows: 3, // 1 in files, 1 in file_subsystems and 1 in merge_history
 			mockTune: func(t *testing.T, m *mocks.SpannerClient) {
@@ -57,10 +58,23 @@ func TestSaveMergeResult(t *testing.T) {
 					Once()
 			},
 		},
+		// nolint: dupl
+		{
+			name:     "1 FC record, Ok",
+			jsonl:    strings.NewReader(`{"FL":{}}`),
+			descr:    &HistoryRecord{},
+			wantRows: 2, // 1 in functions and 1 in merge_history
+			mockTune: func(t *testing.T, m *mocks.SpannerClient) {
+				m.
+					On("Apply", mock.Anything, mock.Anything).
+					Return(time.Now(), nil).
+					Once()
+			},
+		},
 		{
 			name: "2 records, Ok",
-			jsonl: strings.NewReader(`	{"FileData":{}}
-																		{"FileData":{}}`),
+			jsonl: strings.NewReader(`	{"MCR":{"FileData":{}}}
+																		{"MCR":{"FileData":{}}}`),
 			descr:    &HistoryRecord{},
 			wantRows: 5,
 			mockTune: func(t *testing.T, m *mocks.SpannerClient) {
@@ -77,7 +91,7 @@ func TestSaveMergeResult(t *testing.T) {
 		},
 		{
 			name:     "2k records, Ok",
-			jsonl:    strings.NewReader(strings.Repeat("{\"FileData\":{}}\n", 2000)),
+			jsonl:    strings.NewReader(strings.Repeat("{\"MCR\":{\"FileData\":{}}}\n", 2000)),
 			descr:    &HistoryRecord{},
 			wantRows: 4001,
 			mockTune: func(t *testing.T, m *mocks.SpannerClient) {

--- a/pkg/coveragedb/init_db.sh
+++ b/pkg/coveragedb/init_db.sh
@@ -25,6 +25,22 @@ CREATE TABLE
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
  --ddl="$create_table"
 
+echo "drop table 'functions' if exists"
+gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
+--ddl="DROP TABLE IF EXISTS functions"
+echo "create table 'functions'"
+create_table=$( echo -n '
+CREATE TABLE
+  functions (
+    "session" text,
+    "filepath" text,
+    "function" text,
+    "lines" bigint[],
+  PRIMARY KEY
+    (session, filepath, function) );')
+gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
+ --ddl="$create_table"
+
 echo "drop table 'merge_history' if exists"
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
 --ddl="DROP TABLE IF EXISTS merge_history"

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -55,8 +55,8 @@ func TestMergeCSVWriteJSONL_and_coveragedb_SaveMergeResult(t *testing.T) {
 		spannerMock := mocks.NewSpannerClient(t)
 		spannerMock.
 			On("Apply", mock.Anything, mock.MatchedBy(func(ms []*spanner.Mutation) bool {
-				// 1 file * (5 managers + 1 manager total) x 2 (to update files and subsystems) + 1 merge_history
-				return len(ms) == 13
+				// 1 file * (5 managers + 1 manager total) x 2 (to update files and subsystems) + 1 merge_history + 18 functions
+				return len(ms) == 13+18
 			})).
 			Return(time.Now(), nil).
 			Once()

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -163,11 +163,12 @@ func TestMergerdCoverageRecords(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotRecords := mergedCoverageRecords(test.input)
+			gotRecords, gotFuncs := mergedCoverageRecords(test.input)
 			sort.Slice(gotRecords, func(i, j int) bool {
 				return gotRecords[i].Manager < gotRecords[j].Manager
 			})
 			assert.Equal(t, test.wantRecords, gotRecords, "records are not equal")
+			assert.Equal(t, 0, len(gotFuncs), "no functions expected")
 		})
 	}
 }
@@ -241,6 +242,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit1,change_line.c,func1,3,
 			[
 				{
 					"FilePath":"change_line.c",
+					"FuncName":"func1",
 					"Repo":"git://repo",
 					"Commit":"commit1",
 					"StartLine":3,
@@ -271,6 +273,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit1,add_line.c,func1,2,0,2
 			[
 				{
 					"FilePath":"add_line.c",
+					"FuncName":"func1",
 					"Repo":"git://repo",
 					"Commit":"commit1",
 					"StartLine":2,
@@ -302,6 +305,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 			[
 				{
 					"FilePath":"not_changed.c",
+					"FuncName":"func1",
 					"Repo":"git://repo",
 					"Commit":"commit1",
 					"StartLine":3,
@@ -313,6 +317,7 @@ samp_time,1,360,arch,b1,ci-mock,git://repo,master,commit2,not_changed.c,func1,4,
 			[
 				{
 					"FilePath":"not_changed.c",
+					"FuncName":"func1",
 					"Repo":"git://repo",
 					"Commit":"commit2",
 					"StartLine":4,
@@ -395,5 +400,34 @@ func testConfig(repo, commit, workdir string) *Config {
 			Commit: commit,
 		},
 		FileVersProvider: &fileVersProviderMock{Workdir: workdir},
+	}
+}
+
+func TestCheckedFuncName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  string
+	}{
+		{
+			name: "empty input",
+			want: "",
+		},
+		{
+			name:  "single func",
+			input: []string{"func1", "func1"},
+			want:  "func1",
+		},
+		{
+			name:  "multi names",
+			input: []string{"", "", "", "func2", "func2", "func1", "func"},
+			want:  "func2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := bestFuncName(test.input)
+			assert.Equal(t, test.want, got)
+		})
 	}
 }


### PR DESCRIPTION
Unblocks #5591 .

Instead of the target file function name this version is using the most popular source function name.
It will generate wrong function names if the function was renamed.
The better way is to parse the actual file.