### PR TITLE
dashboard/app: move coverage to /coverage link

### DIFF
--- a/dashboard/app/coverage_test.go
+++ b/dashboard/app/coverage_test.go
@@ -29,7 +29,7 @@ func TestFileCoverage(t *testing.T) {
 			name:     "empty db",
 			covDB:    func(t *testing.T) spannerclient.SpannerClient { return emptyCoverageDBFixture(t, 1) },
 			fileProv: func(t *testing.T) covermerger.FileVersProvider { return staticFileProvider(t) },
-			url: "/test2/graph/coverage/file?dateto=2025-01-31&period=month" +
+			url: "/test2/coverage/file?dateto=2025-01-31&period=month" +
 				"&commit=c0e75905caf368e19aab585d20151500e750de89&filepath=virt/kvm/kvm_main.c",
 			wantInRes: []string{"1 line1"},
 		},
@@ -37,7 +37,7 @@ func TestFileCoverage(t *testing.T) {
 			name:     "regular db",
 			covDB:    func(t *testing.T) spannerclient.SpannerClient { return coverageDBFixture(t) },
 			fileProv: func(t *testing.T) covermerger.FileVersProvider { return staticFileProvider(t) },
-			url: "/test2/graph/coverage/file?dateto=2025-01-31&period=month" +
+			url: "/test2/coverage/file?dateto=2025-01-31&period=month" +
 				"&commit=c0e75905caf368e19aab585d20151500e750de89&filepath=virt/kvm/kvm_main.c",
 			wantInRes: []string{
 				"4      1 line1",
@@ -48,7 +48,7 @@ func TestFileCoverage(t *testing.T) {
 			name:     "multimanager db",
 			covDB:    func(t *testing.T) spannerclient.SpannerClient { return multiManagerCovDBFixture(t) },
 			fileProv: func(t *testing.T) covermerger.FileVersProvider { return staticFileProvider(t) },
-			url: "/test2/graph/coverage/file?dateto=2025-01-31&period=month" +
+			url: "/test2/coverage/file?dateto=2025-01-31&period=month" +
 				"&commit=c0e75905caf368e19aab585d20151500e750de89&filepath=virt/kvm/kvm_main.c" +
 				"&manager=special-cc-manager&unique-only=1",
 			wantInRes: []string{

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -65,11 +65,14 @@ func initHTTPHandlers() {
 		http.Handle("/"+ns+"/graph/fuzzing", handlerWrapper(handleGraphFuzzing))
 		http.Handle("/"+ns+"/graph/crashes", handlerWrapper(handleGraphCrashes))
 		http.Handle("/"+ns+"/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
-		http.Handle("/"+ns+"/graph/coverage/file", handlerWrapper(handleFileCoverage))
 		http.Handle("/"+ns+"/graph/coverage", handlerWrapper(handleCoverageGraph))
-		http.Handle("/"+ns+"/graph/coverage_heatmap", handlerWrapper(handleCoverageHeatmap))
+		http.Handle("/"+ns+"/coverage/file", handlerWrapper(handleFileCoverage))
+		http.Handle("/"+ns+"/coverage", handlerWrapper(handleCoverageHeatmap))
+		http.Handle("/"+ns+"/graph/coverage_heatmap", handleMovedPermanently("/"+ns+"/coverage"))
 		if nsConfig.Subsystems.Service != nil {
-			http.Handle("/"+ns+"/graph/coverage_subsystems_heatmap", handlerWrapper(handleSubsystemsCoverageHeatmap))
+			http.Handle("/"+ns+"/graph/coverage_subsystems_heatmap",
+				handleMovedPermanently("/"+ns+"/coverage/subsystems"))
+			http.Handle("/"+ns+"/coverage/subsystems", handlerWrapper(handleSubsystemsCoverageHeatmap))
 		}
 		http.Handle("/"+ns+"/repos", handlerWrapper(handleRepos))
 		http.Handle("/"+ns+"/bug-summaries", handlerWrapper(handleBugSummaries))
@@ -83,6 +86,12 @@ func initHTTPHandlers() {
 	http.HandleFunc("/cron/deprecate_assets", handleDeprecateAssets)
 	http.HandleFunc("/cron/refresh_subsystems", handleRefreshSubsystems)
 	http.HandleFunc("/cron/subsystem_reports", handleSubsystemReports)
+}
+
+func handleMovedPermanently(dest string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest, http.StatusMovedPermanently)
+	}
 }
 
 type uiMainPage struct {

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -106,11 +106,11 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				<div class="dropdown-content">
 					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/coverage" $.Namespace)}}_selected{{end}}"
 						href="/{{$.Namespace}}/graph/coverage?period=quarter">Total</a>
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/coverage_heatmap" $.Namespace)}}_selected{{end}}"
-						href="/{{$.Namespace}}/graph/coverage_heatmap?period=month">Repo&nbsp;Heatmap</a>
+					<a class="navigation_tab{{if eq .URLPath (printf "/%v/coverage" $.Namespace)}}_selected{{end}}"
+						href="/{{$.Namespace}}/coverage?period=month">Repo&nbsp;Heatmap</a>
 					{{if .ShowSubsystems}}
-						<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/coverage_subsystems_heatmap" $.Namespace)}}_selected{{end}}"
-							href="/{{$.Namespace}}/graph/coverage_subsystems_heatmap?period=month">Subsystems&nbsp;Heatmap</a>
+						<a class="navigation_tab{{if eq .URLPath (printf "/%v/coverage/subsystems" $.Namespace)}}_selected{{end}}"
+							href="/{{$.Namespace}}/coverage/subsystems?period=month">Subsystems&nbsp;Heatmap</a>
 					{{end}}
 				</div>
 			</div>

--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -101,7 +101,7 @@ func (thm *templateHeatmapRow) prepareDataFor(pageColumns []pageColumnTarget, sk
 			thm.instrumented[tp], thm.covered[tp]))
 		if !thm.IsDir {
 			thm.FileCoverageLink = append(thm.FileCoverageLink,
-				fmt.Sprintf("/graph/coverage/file?dateto=%s&period=%s&commit=%s&filepath=%s",
+				fmt.Sprintf("/coverage/file?dateto=%s&period=%s&commit=%s&filepath=%s",
 					tp.DateTo.String(),
 					tp.Type,
 					pageColumn.Commit,

--- a/pkg/cover/heatmap_test.go
+++ b/pkg/cover/heatmap_test.go
@@ -292,7 +292,7 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 								"Instrumented:\t1 blocks\nCovered:\t1 blocks",
 							},
 							FileCoverageLink: []string{
-								"/graph/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=file1"},
+								"/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=file1"},
 						},
 					},
 					Name:                "",
@@ -341,8 +341,8 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 										"Instrumented:\t0 blocks\nCovered:\t0 blocks",
 									},
 									FileCoverageLink: []string{
-										"/graph/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=dir/file1",
-										"/graph/coverage/file?dateto=2024-07-02&period=day&commit=commit2&filepath=dir/file1"},
+										"/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=dir/file1",
+										"/coverage/file?dateto=2024-07-02&period=day&commit=commit2&filepath=dir/file1"},
 								},
 								{
 									Name:                "file2",
@@ -355,8 +355,8 @@ func TestFilesCoverageToTemplateData(t *testing.T) {
 										"Instrumented:\t1 blocks\nCovered:\t0 blocks",
 									},
 									FileCoverageLink: []string{
-										"/graph/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=dir/file2",
-										"/graph/coverage/file?dateto=2024-07-02&period=day&commit=commit2&filepath=dir/file2"},
+										"/coverage/file?dateto=2024-07-01&period=day&commit=commit1&filepath=dir/file2",
+										"/coverage/file?dateto=2024-07-02&period=day&commit=commit2&filepath=dir/file2"},
 								},
 							},
 							Name:                "dir",


### PR DESCRIPTION
Current links look too complex. I'd like to change naming before we introduce coverage json API.