### PR TITLE
pkg/manager: accept multiple patches in PatchFocusAreas

### DIFF
--- a/tools/syz-diff/diff.go
+++ b/tools/syz-diff/diff.go
@@ -43,7 +43,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		manager.PatchFocusAreas(newCfg, data)
+		manager.PatchFocusAreas(newCfg, [][]byte{data})
 	}
 
 	ctx := vm.ShutdownCtx()


### PR DESCRIPTION
Make the method more flexible.
Rename the variables to better reflect what is being done.