### PR TITLE
all: replace Walk with WalkDir to reduce os.Lstat calls

### DIFF
--- a/pkg/build/android.go
+++ b/pkg/build/android.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -125,8 +126,8 @@ func (a android) build(params Params) (ImageDetails, error) {
 }
 
 func copyModuleFiles(srcDir, dstDir string) error {
-	err := filepath.Walk(srcDir,
-		func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(srcDir,
+		func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return fmt.Errorf("error walking out dir: %w", err)
 			}
@@ -136,7 +137,7 @@ func copyModuleFiles(srcDir, dstDir string) error {
 			}
 
 			if filepath.Ext(path) == ".ko" {
-				if err := osutil.CopyFile(path, filepath.Join(dstDir, info.Name())); err != nil {
+				if err := osutil.CopyFile(path, filepath.Join(dstDir, d.Name())); err != nil {
 					return fmt.Errorf("error copying file: %w", err)
 				}
 			}

--- a/pkg/cover/backend/modules.go
+++ b/pkg/cover/backend/modules.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"debug/elf"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -72,7 +72,7 @@ func discoverModulesLinux(dirs []string) ([]*vminfo.KernelModule, error) {
 func locateModules(dirs []string) (map[string]string, error) {
 	paths := make(map[string]string)
 	for _, dir := range dirs {
-		err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || filepath.Ext(path) != ".ko" {
 				return err
 			}

--- a/tools/syz-declextract/declextract.go
+++ b/tools/syz-declextract/declextract.go
@@ -323,8 +323,8 @@ func parseTblFile(data []byte, arch string, syscalls map[string][]tblSyscall) {
 func findTblFiles(sourceDir string) (map[string][]string, error) {
 	files := make(map[string][]string)
 	for _, arch := range targets.List[target.OS] {
-		err := filepath.Walk(filepath.Join(sourceDir, "arch", arch.KernelHeaderArch),
-			func(file string, info fs.FileInfo, err error) error {
+		err := filepath.WalkDir(filepath.Join(sourceDir, "arch", arch.KernelHeaderArch),
+			func(file string, d fs.DirEntry, err error) error {
 				if err == nil && strings.HasSuffix(file, ".tbl") {
 					files[file] = append(files[file], arch.VMArch)
 				}

--- a/tools/syz-testbed/targets.go
+++ b/tools/syz-testbed/targets.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"math/rand"
 	"os"
@@ -41,11 +42,11 @@ var targetConstructors = map[string]func(cfg *TestbedConfig) TestbedTarget{
 		inputFiles := []string{}
 		reproConfig := cfg.ReproConfig
 		if reproConfig.InputLogs != "" {
-			err := filepath.Walk(reproConfig.InputLogs, func(path string, info os.FileInfo, err error) error {
+			err := filepath.WalkDir(reproConfig.InputLogs, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
-				if !info.IsDir() {
+				if !d.IsDir() {
 					inputFiles = append(inputFiles, path)
 				}
 				return nil


### PR DESCRIPTION
filepath.Walk calls os.Lstat for every file or directory to retrieve os.FileInfo. 

filepath.WalkDir avoids unnecessary system calls since it provides a fs.DirEntry, which includes file type information without requiring a stat call.

This improves performance by reducing redundant system calls.

