### PR TITLE
all: clarify the error in case of ExecFailure

### DIFF
--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -300,7 +300,10 @@ func (runner *Runner) sendRequest(req *queue.Request) error {
 			// but so far we don't have a better handling than counting this.
 			// This error is observed a lot on the seeded syz_mount_image calls.
 			runner.stats.statExecBufferTooSmall.Add(1)
-			req.Done(&queue.Result{Status: queue.ExecFailure})
+			req.Done(&queue.Result{
+				Status: queue.ExecFailure,
+				Err:    fmt.Errorf("program serialization failed: %w", err),
+			})
 			return nil
 		}
 		data = progData

--- a/syz-manager/snapshot.go
+++ b/syz-manager/snapshot.go
@@ -104,7 +104,10 @@ func (mgr *Manager) snapshotRun(inst *vm.Instance, builder *flatbuffers.Builder,
 	progData, err := req.Prog.SerializeForExec()
 	if err != nil {
 		queue.StatExecBufferTooSmall.Add(1)
-		return &queue.Result{Status: queue.ExecFailure}, nil, nil
+		return &queue.Result{
+			Status: queue.ExecFailure,
+			Err:    fmt.Errorf("program serialization failed: %w", err),
+		}, nil, nil
 	}
 	msg := flatrpc.SnapshotRequestT{
 		ExecFlags: req.ExecOpts.ExecFlags,


### PR DESCRIPTION
Whenever the status is set, also include the reason. It should help easier debug execution and machine check time problems.
