### PR TITLE
pkg/rpcserver, pkg/vminfo: fix Context cancellation processing bugs

### DIFF
--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -173,14 +173,13 @@ func (f *testFuzzer) run() {
 		},
 		Executor:     f.executor,
 		Dir:          f.t.TempDir(),
-		Context:      ctx,
 		OutputWriter: &output,
 	}
 	cfg.MachineChecked = func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {
 		cfg.Cover = true
 		return f
 	}
-	if err := rpcserver.RunLocal(cfg); err != nil {
+	if err := rpcserver.RunLocal(ctx, cfg); err != nil {
 		f.t.Logf("executor output:\n%s", output.String())
 		f.t.Fatal(err)
 	}

--- a/pkg/fuzzer/queue/queue.go
+++ b/pkg/fuzzer/queue/queue.go
@@ -100,14 +100,14 @@ func (r *Request) Done(res *Result) {
 	close(r.done)
 }
 
-var errContextAborted = errors.New("context closed while waiting the result")
+var ErrRequestAborted = errors.New("context closed while waiting the result")
 
 // Wait() blocks until we have the result.
 func (r *Request) Wait(ctx context.Context) *Result {
 	r.initChannel()
 	select {
 	case <-ctx.Done():
-		return &Result{Status: ExecFailure, Err: errContextAborted}
+		return &Result{Status: ExecFailure, Err: ErrRequestAborted}
 	case <-r.done:
 		return r.result
 	}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -420,6 +420,10 @@ func (serv *server) runCheck(ctx context.Context, info *handshakeResult) error {
 		close(serv.cfg.machineCheckStarted)
 	}
 	enabledCalls, disabledCalls, features, checkErr := serv.checker.Run(ctx, info.Files, info.Features)
+	if checkErr == vminfo.ErrAborted {
+		return nil
+	}
+
 	enabledCalls, transitivelyDisabled := serv.target.TransitivelyEnabledCalls(enabledCalls)
 	// Note: need to print disbled syscalls before failing due to an error.
 	// This helps to debug "all system calls are disabled".

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/flatrpc"
@@ -217,9 +216,8 @@ func TestHandleConn(t *testing.T) {
 			serv.CreateInstance(1, injectExec, nil)
 
 			go flatrpc.Send(clientConn, tt.req)
-			var eg errgroup.Group
-			serv.handleConn(context.Background(), &eg, serverConn)
-			if err := eg.Wait(); err != nil {
+			err = serv.handleConn(context.Background(), serverConn)
+			if err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -502,7 +502,6 @@ func startRPCServer(t *testing.T, target *prog.Target, executor string,
 		},
 		Executor:    executor,
 		Dir:         dir,
-		Context:     ctx,
 		GDB:         *flagGDB,
 		MaxSignal:   extra.maxSignal,
 		CoverFilter: extra.coverFilter,
@@ -515,7 +514,7 @@ func startRPCServer(t *testing.T, target *prog.Target, executor string,
 	}
 	errc := make(chan error)
 	go func() {
-		err := rpcserver.RunLocal(cfg)
+		err := rpcserver.RunLocal(ctx, cfg)
 		done()
 		errc <- err
 	}()

--- a/pkg/vminfo/syscalls.go
+++ b/pkg/vminfo/syscalls.go
@@ -115,7 +115,10 @@ func (ctx *checkContext) do(fileInfos []*flatrpc.FileInfo, featureInfos []*flatr
 	globs := make(map[string][]string)
 	for _, req := range globReqs {
 		res := req.Wait(ctx.ctx)
-		if res.Status != queue.Success {
+		if res.Err == queue.ErrRequestAborted {
+			// Don't return an error on context cancellation.
+			return nil, nil, nil, nil
+		} else if res.Status != queue.Success {
 			return nil, nil, nil, fmt.Errorf("failed to execute glob: %w (%v)\n%s\n%s",
 				res.Err, res.Status, req.GlobPattern, res.Output)
 		}

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -101,10 +101,16 @@ func (checker *Checker) MachineInfo(fileInfos []*flatrpc.FileInfo) ([]*KernelMod
 	return modules, info.Bytes(), nil
 }
 
+var ErrAborted = errors.New("aborted through the context")
+
 func (checker *Checker) Run(ctx context.Context, files []*flatrpc.FileInfo, featureInfos []*flatrpc.FeatureInfo) (
 	map[*prog.Syscall]bool, map[*prog.Syscall]string, Features, error) {
 	cc := newCheckContext(ctx, checker.cfg, checker.checker, checker.executor)
-	return cc.do(files, featureInfos)
+	enabled, disabled, features, err := cc.do(files, featureInfos)
+	if ctx.Err() != nil {
+		return nil, nil, nil, ErrAborted
+	}
+	return enabled, disabled, features, err
 }
 
 // Implementation of the queue.Source interface.

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -181,10 +181,9 @@ func main() {
 		Executor:         *flagExecutor,
 		HandleInterrupts: true,
 		GDB:              *flagGDB,
-		Context:          rpcCtx,
 		MachineChecked:   ctx.machineChecked,
 	}
-	if err := rpcserver.RunLocal(cfg); err != nil {
+	if err := rpcserver.RunLocal(rpcCtx, cfg); err != nil {
 		tool.Fail(err)
 	}
 }


### PR DESCRIPTION
It should address the current spike in ` SYZFATAL: image testing failed w/o kernel bug`