### PR TITLE
tools/docker: add libdw-dev to the syzbot container

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -22,7 +22,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	util-linux dosfstools ocfs2-tools reiserfsprogs xfsprogs erofs-utils \
 	exfatprogs gfs2-utils \
 	# Needed for buiding gVisor.
-	crossbuild-essential-amd64 crossbuild-essential-arm64 libbpf-dev
+	crossbuild-essential-amd64 crossbuild-essential-arm64 libbpf-dev \
+	# Needed for CONFIG_GENDWARFKSYMS.
+	libdw-dev
 RUN test "$(uname -m)" != x86_64 && exit 0 || \
         DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
 	  libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-12-dev lib32stdc++-12-dev \


### PR DESCRIPTION
Linux-next now offers a choice between using `CONFIG_GENDWARFKSYMS` and `CONFIG_GENKSYMS`. See:
* Docs: https://www.kernel.org/doc/html/next/kbuild/gendwarfksyms.html
* Series: https://patchwork.kernel.org/project/linux-kbuild/list/?series=922143

It broke our builds: https://syzkaller.appspot.com/bug?extid=62ba359e1dfec1473c57

We could either enforce `CONFIG_GENKSYMS=y` and keep things as they used to be or we could add a libdw-dev dependency to the container and be more flexible.

`CONFIG_GENDWARFKSYMS` offers a slight advantage in that it will be better if/when we start fuzzing Rust code in the kernel.
