### PR TITLE
dashboard/app/app.yaml: go122 -> go123

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -1,7 +1,7 @@
 # Copyright 2017 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-runtime: go122
+runtime: go123
 app_engine_apis: true
 
 # With the f2 setting, the app episodically crashes with:


### PR DESCRIPTION
It is available in preview since Nov. 19 2024.
Tested the AppEngine manually. Looks good.