### PR TITLE
sys/targets: change the default DataOffset value

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -702,7 +702,7 @@ func initTarget(target *Target, OS, arch string) {
 		target.NeedSyscallDefine = needSyscallDefine
 	}
 	if target.DataOffset == 0 {
-		target.DataOffset = 512 << 20
+		target.DataOffset = target.defaultDataOffset()
 	}
 	target.NumPages = (16 << 20) / target.PageSize
 	sourceDir := getSourceDir(target)
@@ -772,6 +772,15 @@ func initTarget(target *Target, OS, arch string) {
 		target.HostEndian = binary.BigEndian
 	}
 	target.initAddr2Line()
+}
+
+func (target *Target) defaultDataOffset() uint64 {
+	if target.PtrSize == 8 {
+		// An address from ASAN's 64-bit HighMem area.
+		return 0x200000000000
+	}
+	// From 32-bit HighMem area.
+	return 0x80000000
 }
 
 func (target *Target) initAddr2Line() {


### PR DESCRIPTION
The current default value sometimes intersects with the addresses used by malloc, which causes executor memory corruptions.

Closes #5674.