### PR TITLE
tools/docker: golang toolchain is autoupdated since 1.21

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -80,6 +80,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
+# Since go 1.21 the toolchain required by go.mod is automatically downloaded.
+# There is no need to version up golang here after go.mod changes.
 RUN curl https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath

--- a/tools/docker/old-env/Dockerfile
+++ b/tools/docker/old-env/Dockerfile
@@ -30,6 +30,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
 RUN DEBIAN_FRONTEND=noninteractive apt-get clean autoclean
 RUN DEBIAN_FRONTEND=noninteractive rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
+# Since go 1.21 the toolchain required by go.mod is automatically downloaded.
+# There is no need to version up golang here after go.mod changes.
 RUN curl https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:/gopath/bin:$PATH
 ENV GOPATH /gopath

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -32,6 +32,8 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 	  g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
 	  g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu
 
+# Since go 1.21 the toolchain required by go.mod is automatically downloaded.
+# There is no need to version up golang here after go.mod changes.
 RUN curl https://dl.google.com/go/go1.22.7.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 


### PR DESCRIPTION
"go mod go@1.23" updates go.mod to the latest 1.23.*.

Syz-ci containers are auto updating the go version now. It is cheap.
The only concern is the github actions ability to cache the new toolchain. We'll know it tomorrow.
