### PR TITLE
sys/targets: increase DataOffset for 64bit builds

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -777,7 +777,10 @@ func initTarget(target *Target, OS, arch string) {
 func (target *Target) defaultDataOffset() uint64 {
 	if target.PtrSize == 8 {
 		// An address from ASAN's 64-bit HighMem area.
-		return 0x200000000000
+		// 0x400000000000 works both for arm64 and amd64. We don't run syzkaller tests on any other platform.
+		// During real fuzzing, we don't build with ASAN, so the address should not matter much as long as
+		// it's far enough from the area allocated by malloc().
+		return 0x400000000000
 	}
 	// From 32-bit HighMem area.
 	return 0x80000000


### PR DESCRIPTION
It turned out that the currently used value hit the high shadow area on arm64 machines.

Closes #5762.
