### PR TITLE
executor: fix MAP_FIXED_NOREPLACE dependency

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -484,6 +484,9 @@ static void parse_handshake(const handshake_req& req);
 #include "syscalls.h"
 
 #if GOOS_linux
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
 #define MAP_FIXED_EXCLUSIVE MAP_FIXED_NOREPLACE
 #elif GOOS_freebsd
 #define MAP_FIXED_EXCLUSIVE (MAP_FIXED | MAP_EXCL)


### PR DESCRIPTION
Some environments don't define MAP_FIXED_NOREPLACE.
