### PR TITLE
dashboard/app: support gerrit servers as a webgit source

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -165,6 +165,7 @@ type CoverageConfig struct {
 	DashboardClientName string
 
 	// WebGitURI specifies where can we get the kernel file source code directly from AppEngine.
+	// It may be the Git or Gerrit compatible repo.
 	WebGitURI string
 }
 

--- a/dashboard/app/coverage.go
+++ b/dashboard/app/coverage.go
@@ -146,7 +146,10 @@ func handleHeatmap(c context.Context, w http.ResponseWriter, r *http.Request, f 
 
 func makeProxyURIProvider(url string) covermerger.FuncProxyURI {
 	return func(filePath, commit string) string {
-		return fmt.Sprintf("%s/%s/%s", url, commit, filePath)
+		// Parameter format=TEXT is ignored by git servers but is processed by gerrit servers.
+		// Gerrit returns base64 encoded data.
+		// Git return the plain text data.
+		return fmt.Sprintf("%s/%s/%s?format=TEXT", url, commit, filePath)
 	}
 }
 


### PR DESCRIPTION
Gerrit servers return base64 encoded file content. To get the raw data, &format=TEXT request param is needed.
This PR closes #5592.