### PR TITLE
tools/syz-linter: detect loop variables scoping

### DIFF
--- a/dashboard/app/access_test.go
+++ b/dashboard/app/access_test.go
@@ -421,7 +421,6 @@ func TestAccess(t *testing.T) {
 				// In the short mode, only test that there's no public access to non-public URLs.
 				continue
 			}
-			ent := ent
 			t.Run(fmt.Sprintf("level%d_%d", requestLevel, i), func(t *testing.T) {
 				reply := checkPage(t, requestLevel, ent.level, ent.url)
 				checkReferences(t, ent.url, requestLevel, reply)

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -473,7 +473,6 @@ func TestEmailDup(t *testing.T) {
 
 func TestEmailDup2(t *testing.T) {
 	for i := 0; i < 4; i++ {
-		i := i
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			c := NewCtx(t)
 			defer c.Close()

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1855,7 +1855,6 @@ func (j *bugJob) loadBuild(c context.Context) error {
 func fullBackportInfo(c context.Context, list []*backportInfo) error {
 	crashLoader := &dependencyLoader[Crash]{}
 	for _, info := range list {
-		info := info
 		if info.job.CrashID == 0 {
 			continue
 		}
@@ -1869,7 +1868,6 @@ func fullBackportInfo(c context.Context, list []*backportInfo) error {
 	}
 	buildLoader := &dependencyLoader[Build]{}
 	for _, info := range list {
-		info := info
 		if info.crash == nil {
 			continue
 		}

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1213,7 +1213,6 @@ func TestObsoletePeriod(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			ret := test.bug.obsoletePeriod(c)
 			assert.Equal(t, test.period, ret)

--- a/dashboard/app/stats.go
+++ b/dashboard/app/stats.go
@@ -84,7 +84,6 @@ func allBugInputs(c context.Context, ns string) ([]*bugInput, error) {
 	}
 	buildLoader := &dependencyLoader[Build]{}
 	for _, input := range inputs {
-		input := input
 		if input.reportedCrash == nil {
 			continue
 		}

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -732,7 +732,6 @@ func TestBisectionResults(t *testing.T) {
 	repoCache := make(chan string, len(bisectionTests))
 	t.Run("group", func(tt *testing.T) {
 		for _, test := range bisectionTests {
-			test := test
 			tt.Run(test.name, func(t *testing.T) {
 				t.Parallel()
 				checkTest(t, test)
@@ -889,7 +888,6 @@ func TestBisectVerdict(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sum := test.good + test.bad + test.infra + test.skip
 			assert.Equal(t, test.total, sum)
@@ -1008,7 +1006,6 @@ func TestMostFrequentReport(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			rep, types, other := mostFrequentReports(test.reports)
 			assert.ElementsMatch(t, types, test.types)
@@ -1066,7 +1063,6 @@ func TestPickReleaseTags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			ret := pickReleaseTags(append([]string{}, test.tags...))
 			assert.Equal(t, test.ret, ret)

--- a/pkg/bisect/minimize/slice_test.go
+++ b/pkg/bisect/minimize/slice_test.go
@@ -112,7 +112,6 @@ func TestBisectRandomSlice(t *testing.T) {
 
 func BenchmarkSplits(b *testing.B) {
 	for _, guilty := range []int{1, 2, 3, 4} {
-		guilty := guilty
 		b.Run(fmt.Sprintf("%d_guilty", guilty), func(b *testing.B) {
 			var sum int
 			for i := 0; i < b.N; i++ {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -17,7 +17,6 @@ import (
 func TestCompilerIdentity(t *testing.T) {
 	t.Parallel()
 	for _, compiler := range []string{"gcc", "clang", "bazel"} {
-		compiler := compiler
 		t.Run(compiler, func(t *testing.T) {
 			t.Parallel()
 			if _, err := exec.LookPath(compiler); err != nil {
@@ -42,7 +41,6 @@ func TestCompilerIdentity(t *testing.T) {
 
 func TestExtractCauseInner(t *testing.T) {
 	for i, test := range rootCauseTests {
-		test := test
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			reason, file := extractCauseInner([]byte(test.e), test.src)
 			if test.reason != string(reason) {

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -23,7 +23,6 @@ var flagUpdate = flag.Bool("update", false, "reformat all.txt")
 
 func TestCompileAll(t *testing.T) {
 	for os, arches := range targets.List {
-		os, arches := os, arches
 		t.Run(os, func(t *testing.T) {
 			t.Parallel()
 			eh := func(pos ast.Pos, msg string) {
@@ -35,7 +34,6 @@ func TestCompileAll(t *testing.T) {
 				t.Fatalf("parsing failed")
 			}
 			for arch, target := range arches {
-				arch, target := arch, target
 				t.Run(arch, func(t *testing.T) {
 					t.Parallel()
 					errors := new(bytes.Buffer)
@@ -68,7 +66,6 @@ func TestData(t *testing.T) {
 	// Because of this we have one file per phase.
 	for _, name := range []string{"errors.txt", "errors2.txt", "errors3.txt", "warnings.txt", "all.txt"} {
 		for _, arch := range []string{targets.TestArch32, targets.TestArch64} {
-			name, arch := name, arch
 			t.Run(fmt.Sprintf("%v/%v", name, arch), func(t *testing.T) {
 				t.Parallel()
 				target := targets.List[targets.TestOS][arch]

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -161,8 +161,6 @@ func makeDWARFUnsafe(params *dwarfParams) (*Impl, error) {
 	}
 	binC := make(chan binResult, len(modules))
 	for _, module := range modules {
-		// check https://go.dev/blog/loopvar-preview for loopvar bug
-		module := module
 		go func() {
 			info := &symbolInfo{
 				tracePC:     make(map[uint64]bool),

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -148,7 +148,6 @@ func TestReportGenerator(t *testing.T) {
 					t.Skip("skipping the test due to broken cross-compiler:\n" + target.BrokenCompiler)
 				}
 				for _, test := range tests {
-					test := test
 					t.Run(test.Name, func(t *testing.T) {
 						if test.Supports != nil && !test.Supports(target) {
 							t.Skip("unsupported target")

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -38,7 +38,6 @@ func TestGenerate(t *testing.T) {
 	t.Parallel()
 	checked := make(map[string]bool)
 	for _, target := range prog.AllTargets() {
-		target := target
 		sysTarget := targets.Get(target.OS, target.Arch)
 		if runtime.GOOS != sysTarget.BuildOS {
 			continue
@@ -114,7 +113,6 @@ func testTarget(t *testing.T, target *prog.Target, full bool) {
 			// compilation time from 1.94s to 104.73s and memory consumption from 136MB to 8116MB.
 			continue
 		}
-		opts := opts
 		t.Run(fmt.Sprintf("%v", opti), func(t *testing.T) {
 			t.Parallel()
 			testOne(t, p, opts)

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -301,7 +301,6 @@ func TestParsePatchSubject(t *testing.T) {
 		},
 	}
 	for id, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(id), func(t *testing.T) {
 			ret, ok := parsePatchSubject(test.subj)
 			assert.True(t, ok)

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -152,7 +152,6 @@ func (job *triageJob) run(fuzzer *Fuzzer) {
 	}
 	var wg sync.WaitGroup
 	for call, info := range job.calls {
-		call, info := call, info
 		wg.Add(1)
 		go func() {
 			job.handleCall(call, info)

--- a/pkg/report/linux_test.go
+++ b/pkg/report/linux_test.go
@@ -430,7 +430,6 @@ func TestParseLinuxOpcodes(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		test := test // Capturing the value.
 		t.Run(fmt.Sprintf("%s/%v", test.arch, idx), func(t *testing.T) {
 			t.Parallel()
 			_, linuxReporter := prepareLinuxReporter(t, test.arch)

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -241,7 +241,6 @@ nextSandbox:
 			"arch=" + ctx.Target.Arch: true,
 		}
 		for _, threaded := range []bool{false, true} {
-			name := name
 			if threaded {
 				name += "/thr"
 			}
@@ -259,7 +258,6 @@ nextSandbox:
 					if times != 1 {
 						break
 					}
-					name := name
 					if cov {
 						name += "/cover"
 					}
@@ -277,7 +275,6 @@ nextSandbox:
 					// and copy the binary to the target system.
 					continue
 				}
-				name := name
 				properties["C"] = true
 				properties["executor"] = false
 				name += " C"

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -370,7 +370,6 @@ func testCover(t *testing.T, target *prog.Target) {
 	}
 	executor := csource.BuildExecutor(t, target, "../../")
 	for i, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			t.Parallel()
 			source := queue.Plain()

--- a/pkg/stat/set_test.go
+++ b/pkg/stat/set_test.go
@@ -190,7 +190,6 @@ func TestSetStress(t *testing.T) {
 	}
 	for p := 0; p < 2; p++ {
 		for _, opt := range []any{Link(""), NoGraph, Rate{}, Distribution{}} {
-			opt := opt
 			go func() {
 				v := set.New(fmt.Sprintf("v%v", seq.Add(1)), "desc", opt)
 				for p1 := 0; p1 < 2; p1++ {

--- a/pkg/vcs/linux_configs_test.go
+++ b/pkg/vcs/linux_configs_test.go
@@ -71,7 +71,6 @@ CONFIG_DEBUG_ATOMIC_SLEEP=y
 CONFIG_PROVE_LOCKING=y
 `
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			conf, err := kconfig.ParseConfigData([]byte(base), "base")
 			if err != nil {

--- a/pkg/vminfo/features.go
+++ b/pkg/vminfo/features.go
@@ -48,7 +48,6 @@ type featureResult struct {
 func (ctx *checkContext) startFeaturesCheck() {
 	testProg := ctx.target.DataMmapProg()
 	for feat := range flatrpc.EnumNamesFeature {
-		feat := feat
 		if ctx.cfg.Features&feat == 0 {
 			ctx.features <- featureResult{feat, "disabled by user"}
 			continue

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -49,7 +49,6 @@ func TestSyscalls(t *testing.T) {
 	t.Parallel()
 	for _, arches := range targets.List {
 		for _, target := range arches {
-			target := target
 			if target.OS == targets.Linux {
 				continue // linux has own TestLinuxSyscalls test
 			}

--- a/prog/alloc_test.go
+++ b/prog/alloc_test.go
@@ -62,7 +62,6 @@ func TestMemAlloc(t *testing.T) {
 		},
 	}
 	for ti, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(ti), func(t *testing.T) {
 			ma := newMemAlloc(16 << 20)
 			for i, op := range test {

--- a/prog/encodingexec_test.go
+++ b/prog/encodingexec_test.go
@@ -655,7 +655,6 @@ test$res1(r0)
 	}
 
 	for i, test := range tests {
-		i, test := i, test
 		t.Run(fmt.Sprintf("%v:%v", i, test.prog), func(t *testing.T) {
 			p, err := target.Deserialize([]byte(test.prog), Strict)
 			if err != nil {

--- a/prog/export_test.go
+++ b/prog/export_test.go
@@ -35,7 +35,6 @@ func initTest(t *testing.T) (*Target, rand.Source, int) {
 func testEachTarget(t *testing.T, fn func(t *testing.T, target *Target)) {
 	t.Parallel()
 	for _, target := range AllTargets() {
-		target := target
 		t.Run(fmt.Sprintf("%v/%v", target.OS, target.Arch), func(t *testing.T) {
 			skipTargetRace(t, target)
 			t.Parallel()
@@ -50,7 +49,6 @@ func testEachTargetRandom(t *testing.T, fn func(t *testing.T, target *Target, rs
 	iters := max(testutil.IterCount()/len(targets), 3)
 	rs0 := testutil.RandSource(t)
 	for _, target := range targets {
-		target := target
 		rs := rand.NewSource(rs0.Int63())
 		t.Run(fmt.Sprintf("%v/%v", target.OS, target.Arch), func(t *testing.T) {
 			skipTargetRace(t, target)

--- a/prog/mutation_test.go
+++ b/prog/mutation_test.go
@@ -136,7 +136,6 @@ func TestMutateArgument(t *testing.T) {
 
 	target := initTargetTest(t, "test", "64")
 	for ti, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(ti), func(t *testing.T) {
 			t.Parallel()
 			rs, ct, p, goal, err := buildTestContext(test, target)
@@ -410,7 +409,6 @@ func runMutationTests(t *testing.T, tests [][2]string, valid bool) {
 	}
 	target := initTargetTest(t, "test", "64")
 	for ti, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(ti), func(t *testing.T) {
 			t.Parallel()
 			rs, ct, p, goal, err := buildTestContext(test, target)

--- a/prog/rotation_test.go
+++ b/prog/rotation_test.go
@@ -27,7 +27,6 @@ func TestRotationResourceless(t *testing.T) {
 func TestRotationRandom(t *testing.T) {
 	target, rs, _ := initTest(t)
 	for _, ncalls := range []int{10, 100, 1000, 1e9} {
-		ncalls := ncalls
 		rnd := rand.New(rand.NewSource(rs.Int63()))
 		t.Run(fmt.Sprint(ncalls), func(t *testing.T) {
 			t.Parallel()

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -139,7 +139,6 @@ func main() {
 		wg.Add(len(jobs))
 
 		for _, job := range jobs {
-			job := job
 			go func() {
 				defer wg.Done()
 				processJob(job, descriptions, constFile)

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -295,7 +295,6 @@ func main() {
 	var wg sync.WaitGroup
 	if *flagManagers {
 		for _, mgr := range managers {
-			mgr := mgr
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/syz-cluster/pkg/triage/commit_test.go
+++ b/syz-cluster/pkg/triage/commit_test.go
@@ -77,7 +77,6 @@ func TestCommitSelector(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			selector := NewCommitSelector(test.ops)
 			commits, err := selector.Select(test.series, testTree, test.last)

--- a/syz-cluster/pkg/triage/tree_test.go
+++ b/syz-cluster/pkg/triage/tree_test.go
@@ -51,7 +51,6 @@ func TestSelectTree(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.testName, func(t *testing.T) {
 			ret := SelectTree(test.series, trees)
 			assert.NotNil(t, ret)

--- a/syz-verifier/execresult_test.go
+++ b/syz-verifier/execresult_test.go
@@ -166,7 +166,6 @@ func TestCompareResults(t *testing.T) {
 		}}
 
 	for _, test := range tests {
-		test := test // TODO: remove for gover >= 1.22
 		t.Run(test.name, func(t *testing.T) {
 			target := prog.InitTargetTest(t, "test", "64")
 			prog, err := target.Deserialize([]byte(p), prog.Strict)

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -177,7 +177,6 @@ func (vrf *Verifier) Run(prog *prog.Prog, env EnvDescr) (result []*ExecResult, e
 	wg := sync.WaitGroup{}
 	wg.Add(totalKernels)
 	for i := 0; i < totalKernels; i++ {
-		i := i
 		q := vrf.kernelEnvTasks[i][env]
 
 		go func() {

--- a/tools/syz-db-export/reprolist.go
+++ b/tools/syz-db-export/reprolist.go
@@ -51,7 +51,6 @@ func exportNamespace() error {
 	iBugChan := make(chan int)
 	g, _ := errgroup.WithContext(context.Background())
 	for i := 0; i < *flagParallel; i++ {
-		i := i
 		g.Go(func() error {
 			for iBug := range iBugChan {
 				bug, err := cli.Bug(bugs[iBug].Link)

--- a/tools/syz-declextract/declextract_test.go
+++ b/tools/syz-declextract/declextract_test.go
@@ -132,7 +132,6 @@ func testEachFile(t *testing.T, fn func(t *testing.T, cfg *clangtool.Config, fil
 		t.Fatal("found no source files")
 	}
 	for _, file := range files {
-		file := file
 		t.Run(filepath.Base(file), func(t *testing.T) {
 			t.Parallel()
 			buildDir := t.TempDir()

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -136,3 +136,11 @@ func minmax() {
 		x = 10
 	}
 }
+
+func loopvar() {
+	s := []int{1, 2, 3}
+	for i, v := range s {
+		i, v := i, v // want "Don't duplicate loop variables.*"
+		_, _ = i, v
+	}
+}

--- a/vm/dispatcher/pool.go
+++ b/vm/dispatcher/pool.go
@@ -101,7 +101,6 @@ func (p *Pool[T]) Loop(ctx context.Context) {
 	var wg sync.WaitGroup
 	wg.Add(len(p.instances))
 	for _, inst := range p.instances {
-		inst := inst
 		go func() {
 			for ctx.Err() == nil {
 				p.runInstance(ctx, inst)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -337,7 +337,6 @@ var tests = []*Test{
 
 func TestMonitorExecution(t *testing.T) {
 	for _, test := range tests {
-		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 			testMonitorExecution(t, test)


### PR DESCRIPTION
Loop variables are per-iteration, not per loop since go122.
https://go.dev/blog/loopvar-preview