### PR TITLE
pkg/manager: export programs with coverage

### DIFF
--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -271,6 +271,7 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 			{
 				FileCoverageWithDetails: coveragedb.FileCoverageWithDetails{
 					Filepath: "/file",
+					Commit:   "test-commit",
 				},
 				LinesInstrumented: []int64{1, 2, 3},
 				HitCounts:         []int64{10, 20, 30},
@@ -283,7 +284,7 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{
 	"repo": "test-repo",
-	"commit": "",
+	"commit": "test-commit",
 	"file_path": "/file",
 	"functions": [
 		{

--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -14,8 +14,8 @@ import (
 type Impl struct {
 	Units           []*CompileUnit
 	Symbols         []*Symbol
-	Frames          []Frame
-	Symbolize       func(pcs map[*vminfo.KernelModule][]uint64) ([]Frame, error)
+	Frames          []*Frame
+	Symbolize       func(pcs map[*vminfo.KernelModule][]uint64) ([]*Frame, error)
 	CallbackPoints  []uint64
 	PreciseCoverage bool
 }

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -81,7 +81,7 @@ type line struct {
 type fileMap map[string]*file
 
 func (rg *ReportGenerator) prepareFileMap(progs []Prog, force, debug bool) (fileMap, error) {
-	if err := rg.symbolizePCs(uniquePCs(progs)); err != nil {
+	if err := rg.symbolizePCs(uniquePCs(progs...)); err != nil {
 		return nil, err
 	}
 	files := make(fileMap)
@@ -187,7 +187,7 @@ func coverageCallbackMismatch(debug bool, numPCs int, unmatchedPCs map[uint64]bo
 		len(unmatchedPCs), numPCs, debugStr)
 }
 
-func uniquePCs(progs []Prog) []uint64 {
+func uniquePCs(progs ...Prog) []uint64 {
 	PCs := make(map[uint64]bool)
 	for _, p := range progs {
 		for _, pc := range p.PCs {

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -108,7 +108,7 @@ func (rg *ReportGenerator) prepareFileMap(progs []Prog, force, debug bool) (file
 	}
 	matchedPC := false
 	for _, frame := range rg.Frames {
-		f := fileByFrame(files, &frame)
+		f := fileByFrame(files, frame)
 		ln := f.lines[frame.StartLine]
 		coveredBy := pcToProgs[frame.PC]
 		if len(coveredBy) == 0 {

--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -86,6 +86,7 @@ func (serv *HTTPServer) Serve(ctx context.Context) error {
 	handle("/corpus", serv.httpCorpus)
 	handle("/corpus.db", serv.httpDownloadCorpus)
 	handle("/cover", serv.httpCover)
+	handle("/coverprogs", serv.httpPrograms)
 	handle("/debuginput", serv.httpDebugInput)
 	handle("/file", serv.httpFile)
 	handle("/filecover", serv.httpFileCover)
@@ -444,6 +445,7 @@ const (
 	DoRawCover
 	DoFilterPCs
 	DoCoverJSONL
+	DoCoverPrograms
 )
 
 func (serv *HTTPServer) httpCover(w http.ResponseWriter, r *http.Request) {
@@ -456,6 +458,18 @@ func (serv *HTTPServer) httpCover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	serv.httpCoverCover(w, r, DoHTML)
+}
+
+func (serv *HTTPServer) httpPrograms(w http.ResponseWriter, r *http.Request) {
+	if !serv.Cfg.Cover {
+		http.Error(w, "coverage is not enabled", http.StatusInternalServerError)
+		return
+	}
+	if r.FormValue("jsonl") != "1" {
+		http.Error(w, "only ?jsonl=1 param is supported", http.StatusBadRequest)
+		return
+	}
+	serv.httpCoverCover(w, r, DoCoverPrograms)
 }
 
 func (serv *HTTPServer) httpSubsystemCover(w http.ResponseWriter, r *http.Request) {
@@ -577,6 +591,7 @@ func (serv *HTTPServer) httpCoverCover(w http.ResponseWriter, r *http.Request, f
 		DoRawCover:       {rg.DoRawCover, ctTextPlain},
 		DoFilterPCs:      {rg.DoFilterPCs, ctTextPlain},
 		DoCoverJSONL:     {rg.DoCoverJSONL, ctApplicationJSON},
+		DoCoverPrograms:  {rg.DoCoverPrograms, ctApplicationJSON},
 	}
 
 	if ct := flagToFunc[funcFlag].contentType; ct != "" {


### PR DESCRIPTION
#5668 for the wider context

- [x] add tests
- [x] check the resulting report size

**The exported jsonl lines len statistics**
Average: 155514
Max: 1220378
Min: 556
25th percentile: 18392
50th percentile: 58633
75th percentile: 166546

200KB is the average json line.
Every jsonl line has the program and information about all the visited frames.