### PR TITLE
executor: fix cover_protect() on FreeBSD

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -521,11 +521,13 @@ public:
 		if (used_)
 			fail("recursion in CoverAccessScope");
 		used_ = true;
-		cover_unprotect(cov_);
+		if (flag_coverage)
+			cover_unprotect(cov_);
 	}
 	~CoverAccessScope()
 	{
-		cover_protect(cov_);
+		if (flag_coverage)
+			cover_protect(cov_);
 		used_ = false;
 	}
 

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -120,6 +120,8 @@ static void cover_mmap(cover_t* cov)
 
 static void cover_protect(cover_t* cov)
 {
+	if (cov->data == NULL)
+		fail("cover_protect invoked on an unmapped cover_t object");
 #if GOOS_freebsd
 	size_t mmap_alloc_size = kCoverSize * KCOV_ENTRY_SIZE;
 	long page_size = sysconf(_SC_PAGESIZE);
@@ -139,6 +141,8 @@ static void cover_protect(cover_t* cov)
 
 static void cover_unprotect(cover_t* cov)
 {
+	if (cov->data == NULL)
+		fail("cover_unprotect invoked on an unmapped cover_t object");
 #if GOOS_freebsd
 	size_t mmap_alloc_size = kCoverSize * KCOV_ENTRY_SIZE;
 	mprotect(cov->data, mmap_alloc_size, PROT_READ | PROT_WRITE);


### PR DESCRIPTION
I think the OpenBSD version has the same problem, but didn't want to modify it as I'm not set up to test. Perhaps @blackgnezdo can confirm?