### PR TITLE
pkg/cover: allow paths to be excluded from stats

### DIFF
--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -535,8 +535,12 @@ func groupCoverByFilePrefixes(datas []fileStats, subsystems []mgrconfig.Subsyste
 		var percentCoveredFunc float64
 
 		for _, path := range subsystem.Paths {
+			if strings.HasPrefix(path, "-") {
+				continue
+			}
+			excludes := buildExcludePaths(path, subsystem.Paths)
 			for _, data := range datas {
-				if !strings.HasPrefix(data.Name, path) {
+				if !strings.HasPrefix(data.Name, path) || isExcluded(data.Name, excludes) {
 					continue
 				}
 				coveredLines += data.CoveredLines
@@ -578,6 +582,25 @@ func groupCoverByFilePrefixes(datas []fileStats, subsystems []mgrconfig.Subsyste
 	}
 
 	return d
+}
+
+func buildExcludePaths(prefix string, paths []string) []string {
+	var excludes []string
+	for _, path := range paths {
+		if strings.HasPrefix(path, "-") && strings.HasPrefix(path[1:], prefix) {
+			excludes = append(excludes, path[1:])
+		}
+	}
+	return excludes
+}
+
+func isExcluded(path string, excludes []string) bool {
+	for _, exclude := range excludes {
+		if strings.HasPrefix(path, exclude) {
+			return true
+		}
+	}
+	return false
 }
 
 func (rg *ReportGenerator) DoSubsystemCover(w io.Writer, params HandlerParams) error {

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -460,3 +460,46 @@ var sampleJSONLlProgs = []byte(`{
 		}
 	]
 }`)
+
+func makeFileStat(name string) fileStats {
+	return fileStats{
+		Name:                       name,
+		CoveredLines:               1,
+		TotalLines:                 8,
+		CoveredPCs:                 1,
+		TotalPCs:                   4,
+		TotalFunctions:             2,
+		CoveredFunctions:           1,
+		CoveredPCsInFunctions:      1,
+		TotalPCsInCoveredFunctions: 2,
+		TotalPCsInFunctions:        2,
+	}
+}
+
+func TestCoverByFilePrefixes(t *testing.T) {
+	datas := []fileStats{
+		makeFileStat("a"),
+		makeFileStat("a/1"),
+		makeFileStat("a/2"),
+		makeFileStat("a/2/A"),
+		makeFileStat("a/3"),
+	}
+	subsystems := []mgrconfig.Subsystem{
+		{
+			Name: "test",
+			Paths: []string{
+				"a",
+				"-a/2",
+			},
+		},
+	}
+	d := groupCoverByFilePrefixes(datas, subsystems)
+	assert.Equal(t, d["test"], map[string]string{
+		"name":              "test",
+		"lines":             "3 / 24 / 12.50%",
+		"PCsInFiles":        "3 / 12 / 25.00%",
+		"Funcs":             "3 / 6 / 50.00%",
+		"PCsInFuncs":        "3 / 6 / 50.00%",
+		"PCsInCoveredFuncs": "3 / 6 / 50.00%",
+	})
+}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -51,9 +51,9 @@ type Config struct {
 	KernelBuildSrc string `json:"kernel_build_src,omitempty"`
 	// Is the kernel built separately from the modules? (Specific to Android builds)
 	AndroidSplitBuild bool `json:"android_split_build"`
-	// Kernel subsystem with paths to each subsystem
+	// Kernel subsystem with paths to each subsystem, paths starting with "-" will be excluded
 	//	"kernel_subsystem": [
-	//		{ "name": "sound", "path": ["sound", "techpack/audio"]},
+	//		{ "name": "sound", "path": ["sound", "techpack/audio", "-techpack/audio/dsp"]},
 	//		{ "name": "mydriver": "path": ["mydriver_path"]}
 	//	]
 	KernelSubsystem []Subsystem `json:"kernel_subsystem,omitempty"`


### PR DESCRIPTION
Some sub paths may not be covered due to hardware configuration, or lack of interest. This patch allows them to be excluded from the stats. This can be convenient if the excluded paths are deep in the hierarchy:
```
{
    "name": "sound",
    "path": [
	"techpack/audio",
	"-techpack/audio/asoc/aaa/bbb"
	"-techpack/audio/asoc/aaa/ccc"
    ]
}
```
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
