### PR TITLE
pkg/rpcserver: improve the mismatching arches error message

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -419,7 +419,7 @@ func (serv *server) connectionLoop(baseCtx context.Context, runner *Runner) erro
 
 func checkRevisions(a *flatrpc.ConnectRequest, target *prog.Target) error {
 	if target.Arch != a.Arch {
-		return fmt.Errorf("mismatching manager/executor arches: %v vs %v", target.Arch, a.Arch)
+		return fmt.Errorf("mismatching manager/executor arches: %v vs %v (full request: `%#v`)", target.Arch, a.Arch, a)
 	}
 	if prog.GitRevision != a.GitRevision {
 		return fmt.Errorf("mismatching manager/executor git revisions: %v vs %v",


### PR DESCRIPTION
Dump the whole flatrpc.ConnectRequest to the logs, so that we can better understand the cause of #5805

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
