### PR TITLE
pkg/rpcserver: pkg/flatrpc: executor: add handshake stage 0

### DIFF
--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -34,8 +34,13 @@ enum Feature : uint64 (bit_flags) {
 	BinFmtMisc,
 	Swap,
 }
+
+table ConnectHelloRaw {
+	cookie			:uint64;
+}
  
 table ConnectRequestRaw {
+	cookie			:uint64;
 	id			:int64;
 	arch			:string;
 	git_revision		:string;

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -485,7 +485,83 @@ func (v SnapshotState) String() string {
 	return "SnapshotState(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
+type ConnectHelloRawT struct {
+	Cookie uint64 `json:"cookie"`
+}
+
+func (t *ConnectHelloRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil {
+		return 0
+	}
+	ConnectHelloRawStart(builder)
+	ConnectHelloRawAddCookie(builder, t.Cookie)
+	return ConnectHelloRawEnd(builder)
+}
+
+func (rcv *ConnectHelloRaw) UnPackTo(t *ConnectHelloRawT) {
+	t.Cookie = rcv.Cookie()
+}
+
+func (rcv *ConnectHelloRaw) UnPack() *ConnectHelloRawT {
+	if rcv == nil {
+		return nil
+	}
+	t := &ConnectHelloRawT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
+type ConnectHelloRaw struct {
+	_tab flatbuffers.Table
+}
+
+func GetRootAsConnectHelloRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectHelloRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset:])
+	x := &ConnectHelloRaw{}
+	x.Init(buf, n+offset)
+	return x
+}
+
+func GetSizePrefixedRootAsConnectHelloRaw(buf []byte, offset flatbuffers.UOffsetT) *ConnectHelloRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
+	x := &ConnectHelloRaw{}
+	x.Init(buf, n+offset+flatbuffers.SizeUint32)
+	return x
+}
+
+func (rcv *ConnectHelloRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *ConnectHelloRaw) Table() flatbuffers.Table {
+	return rcv._tab
+}
+
+func (rcv *ConnectHelloRaw) Cookie() uint64 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectHelloRaw) MutateCookie(n uint64) bool {
+	return rcv._tab.MutateUint64Slot(4, n)
+}
+
+func ConnectHelloRawStart(builder *flatbuffers.Builder) {
+	builder.StartObject(1)
+}
+func ConnectHelloRawAddCookie(builder *flatbuffers.Builder, cookie uint64) {
+	builder.PrependUint64Slot(0, cookie, 0)
+}
+func ConnectHelloRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	return builder.EndObject()
+}
+
 type ConnectRequestRawT struct {
+	Cookie      uint64 `json:"cookie"`
 	Id          int64  `json:"id"`
 	Arch        string `json:"arch"`
 	GitRevision string `json:"git_revision"`
@@ -500,6 +576,7 @@ func (t *ConnectRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOff
 	gitRevisionOffset := builder.CreateString(t.GitRevision)
 	syzRevisionOffset := builder.CreateString(t.SyzRevision)
 	ConnectRequestRawStart(builder)
+	ConnectRequestRawAddCookie(builder, t.Cookie)
 	ConnectRequestRawAddId(builder, t.Id)
 	ConnectRequestRawAddArch(builder, archOffset)
 	ConnectRequestRawAddGitRevision(builder, gitRevisionOffset)
@@ -508,6 +585,7 @@ func (t *ConnectRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOff
 }
 
 func (rcv *ConnectRequestRaw) UnPackTo(t *ConnectRequestRawT) {
+	t.Cookie = rcv.Cookie()
 	t.Id = rcv.Id()
 	t.Arch = string(rcv.Arch())
 	t.GitRevision = string(rcv.GitRevision())
@@ -550,8 +628,20 @@ func (rcv *ConnectRequestRaw) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *ConnectRequestRaw) Id() int64 {
+func (rcv *ConnectRequestRaw) Cookie() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *ConnectRequestRaw) MutateCookie(n uint64) bool {
+	return rcv._tab.MutateUint64Slot(4, n)
+}
+
+func (rcv *ConnectRequestRaw) Id() int64 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
@@ -559,18 +649,10 @@ func (rcv *ConnectRequestRaw) Id() int64 {
 }
 
 func (rcv *ConnectRequestRaw) MutateId(n int64) bool {
-	return rcv._tab.MutateInt64Slot(4, n)
+	return rcv._tab.MutateInt64Slot(6, n)
 }
 
 func (rcv *ConnectRequestRaw) Arch() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
-	}
-	return nil
-}
-
-func (rcv *ConnectRequestRaw) GitRevision() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -578,7 +660,7 @@ func (rcv *ConnectRequestRaw) GitRevision() []byte {
 	return nil
 }
 
-func (rcv *ConnectRequestRaw) SyzRevision() []byte {
+func (rcv *ConnectRequestRaw) GitRevision() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -586,20 +668,31 @@ func (rcv *ConnectRequestRaw) SyzRevision() []byte {
 	return nil
 }
 
+func (rcv *ConnectRequestRaw) SyzRevision() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func ConnectRequestRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(4)
+	builder.StartObject(5)
+}
+func ConnectRequestRawAddCookie(builder *flatbuffers.Builder, cookie uint64) {
+	builder.PrependUint64Slot(0, cookie, 0)
 }
 func ConnectRequestRawAddId(builder *flatbuffers.Builder, id int64) {
-	builder.PrependInt64Slot(0, id, 0)
+	builder.PrependInt64Slot(1, id, 0)
 }
 func ConnectRequestRawAddArch(builder *flatbuffers.Builder, arch flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(arch), 0)
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(arch), 0)
 }
 func ConnectRequestRawAddGitRevision(builder *flatbuffers.Builder, gitRevision flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(gitRevision), 0)
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(gitRevision), 0)
 }
 func ConnectRequestRawAddSyzRevision(builder *flatbuffers.Builder, syzRevision flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(syzRevision), 0)
+	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(syzRevision), 0)
 }
 func ConnectRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -15,6 +15,10 @@ static_assert(FLATBUFFERS_VERSION_MAJOR == 2 &&
 
 namespace rpc {
 
+struct ConnectHelloRaw;
+struct ConnectHelloRawBuilder;
+struct ConnectHelloRawT;
+
 struct ConnectRequestRaw;
 struct ConnectRequestRawBuilder;
 struct ConnectRequestRawT;
@@ -846,8 +850,61 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) ComparisonRaw FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(ComparisonRaw, 32);
 
+struct ConnectHelloRawT : public flatbuffers::NativeTable {
+  typedef ConnectHelloRaw TableType;
+  uint64_t cookie = 0;
+};
+
+struct ConnectHelloRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ConnectHelloRawT NativeTableType;
+  typedef ConnectHelloRawBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_COOKIE = 4
+  };
+  uint64_t cookie() const {
+    return GetField<uint64_t>(VT_COOKIE, 0);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint64_t>(verifier, VT_COOKIE, 8) &&
+           verifier.EndTable();
+  }
+  ConnectHelloRawT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ConnectHelloRawT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ConnectHelloRaw> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectHelloRawT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct ConnectHelloRawBuilder {
+  typedef ConnectHelloRaw Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_cookie(uint64_t cookie) {
+    fbb_.AddElement<uint64_t>(ConnectHelloRaw::VT_COOKIE, cookie, 0);
+  }
+  explicit ConnectHelloRawBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<ConnectHelloRaw> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<ConnectHelloRaw>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<ConnectHelloRaw> CreateConnectHelloRaw(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    uint64_t cookie = 0) {
+  ConnectHelloRawBuilder builder_(_fbb);
+  builder_.add_cookie(cookie);
+  return builder_.Finish();
+}
+
+flatbuffers::Offset<ConnectHelloRaw> CreateConnectHelloRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectHelloRawT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
 struct ConnectRequestRawT : public flatbuffers::NativeTable {
   typedef ConnectRequestRaw TableType;
+  uint64_t cookie = 0;
   int64_t id = 0;
   std::string arch{};
   std::string git_revision{};
@@ -858,11 +915,15 @@ struct ConnectRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ConnectRequestRawT NativeTableType;
   typedef ConnectRequestRawBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_ID = 4,
-    VT_ARCH = 6,
-    VT_GIT_REVISION = 8,
-    VT_SYZ_REVISION = 10
+    VT_COOKIE = 4,
+    VT_ID = 6,
+    VT_ARCH = 8,
+    VT_GIT_REVISION = 10,
+    VT_SYZ_REVISION = 12
   };
+  uint64_t cookie() const {
+    return GetField<uint64_t>(VT_COOKIE, 0);
+  }
   int64_t id() const {
     return GetField<int64_t>(VT_ID, 0);
   }
@@ -877,6 +938,7 @@ struct ConnectRequestRaw FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
+           VerifyField<uint64_t>(verifier, VT_COOKIE, 8) &&
            VerifyField<int64_t>(verifier, VT_ID, 8) &&
            VerifyOffset(verifier, VT_ARCH) &&
            verifier.VerifyString(arch()) &&
@@ -895,6 +957,9 @@ struct ConnectRequestRawBuilder {
   typedef ConnectRequestRaw Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
+  void add_cookie(uint64_t cookie) {
+    fbb_.AddElement<uint64_t>(ConnectRequestRaw::VT_COOKIE, cookie, 0);
+  }
   void add_id(int64_t id) {
     fbb_.AddElement<int64_t>(ConnectRequestRaw::VT_ID, id, 0);
   }
@@ -920,12 +985,14 @@ struct ConnectRequestRawBuilder {
 
 inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(
     flatbuffers::FlatBufferBuilder &_fbb,
+    uint64_t cookie = 0,
     int64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> arch = 0,
     flatbuffers::Offset<flatbuffers::String> git_revision = 0,
     flatbuffers::Offset<flatbuffers::String> syz_revision = 0) {
   ConnectRequestRawBuilder builder_(_fbb);
   builder_.add_id(id);
+  builder_.add_cookie(cookie);
   builder_.add_syz_revision(syz_revision);
   builder_.add_git_revision(git_revision);
   builder_.add_arch(arch);
@@ -934,6 +1001,7 @@ inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(
 
 inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRawDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
+    uint64_t cookie = 0,
     int64_t id = 0,
     const char *arch = nullptr,
     const char *git_revision = nullptr,
@@ -943,6 +1011,7 @@ inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRawDirect(
   auto syz_revision__ = syz_revision ? _fbb.CreateString(syz_revision) : 0;
   return rpc::CreateConnectRequestRaw(
       _fbb,
+      cookie,
       id,
       arch__,
       git_revision__,
@@ -2896,6 +2965,32 @@ inline flatbuffers::Offset<SnapshotRequest> CreateSnapshotRequestDirect(
 
 flatbuffers::Offset<SnapshotRequest> CreateSnapshotRequest(flatbuffers::FlatBufferBuilder &_fbb, const SnapshotRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
+inline ConnectHelloRawT *ConnectHelloRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<ConnectHelloRawT>(new ConnectHelloRawT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void ConnectHelloRaw::UnPackTo(ConnectHelloRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = cookie(); _o->cookie = _e; }
+}
+
+inline flatbuffers::Offset<ConnectHelloRaw> ConnectHelloRaw::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ConnectHelloRawT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateConnectHelloRaw(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<ConnectHelloRaw> CreateConnectHelloRaw(flatbuffers::FlatBufferBuilder &_fbb, const ConnectHelloRawT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectHelloRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _cookie = _o->cookie;
+  return rpc::CreateConnectHelloRaw(
+      _fbb,
+      _cookie);
+}
+
 inline ConnectRequestRawT *ConnectRequestRaw::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<ConnectRequestRawT>(new ConnectRequestRawT());
   UnPackTo(_o.get(), _resolver);
@@ -2905,6 +3000,7 @@ inline ConnectRequestRawT *ConnectRequestRaw::UnPack(const flatbuffers::resolver
 inline void ConnectRequestRaw::UnPackTo(ConnectRequestRawT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
+  { auto _e = cookie(); _o->cookie = _e; }
   { auto _e = id(); _o->id = _e; }
   { auto _e = arch(); if (_e) _o->arch = _e->str(); }
   { auto _e = git_revision(); if (_e) _o->git_revision = _e->str(); }
@@ -2919,12 +3015,14 @@ inline flatbuffers::Offset<ConnectRequestRaw> CreateConnectRequestRaw(flatbuffer
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ConnectRequestRawT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _cookie = _o->cookie;
   auto _id = _o->id;
   auto _arch = _o->arch.empty() ? 0 : _fbb.CreateString(_o->arch);
   auto _git_revision = _o->git_revision.empty() ? 0 : _fbb.CreateString(_o->git_revision);
   auto _syz_revision = _o->syz_revision.empty() ? 0 : _fbb.CreateString(_o->syz_revision);
   return rpc::CreateConnectRequestRaw(
       _fbb,
+      _cookie,
       _id,
       _arch,
       _git_revision,

--- a/pkg/flatrpc/helpers.go
+++ b/pkg/flatrpc/helpers.go
@@ -18,6 +18,7 @@ const AllFeatures = ^Feature(0)
 // Flatbuffers compiler adds T suffix to object API types, which are actual structs representing types.
 // This leads to non-idiomatic Go code, e.g. we would have to use []FileInfoT in Go code.
 // So we use Raw suffix for all flatbuffers tables and rename object API types here to idiomatic names.
+type ConnectHello = ConnectHelloRawT
 type ConnectRequest = ConnectRequestRawT
 type ConnectReply = ConnectReplyRawT
 type InfoRequest = InfoRequestRawT


### PR DESCRIPTION
As we figured out in #5805, syz-manager treats random incoming RPC connections as trusted, and will crash if a non-executor client sends an invalid packet to it.

To address this issue, we introduce another stage of handshake, which includes a cookie exchange:
 - upon connection, the executor sends a ConnectHelloRequest containing its ID assigned to it at startup;
 - the manager responds with a ConnectHelloResponse containing a random 64-bit cookie;
 - the executor calculates a hash of that cookie and includes it into its ConnectRequest together with the other information;
 - before checking the validity of ConnectRequest, the manager ensures client sanity (passed ID didn't change, hashed cookie has the expected value)

We deliberately pick a random cookie instead of a magic number: if the fuzzer somehow learns to send packets to the manager, we don't want it to crash multiple managers on the same machine.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
