### PR TITLE
executor: refactor struct cover_t

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -348,18 +348,25 @@ struct cover_t {
 	int fd;
 	uint32 size;
 	uint32 mmap_alloc_size;
-	char* data;
-	char* data_end;
+	// Memory buffer shared with kcov.
+	void* alloc;
+	// Buffer used by kcov for collecting PCs.
+	char* trace;
+	uint32 trace_size;
+	char* trace_end;
+	// Offset of `trace` from the beginning of `alloc`. Should only be accessed
+	// by OS-specific code.
+	intptr_t trace_offset;
 	// Currently collecting comparisons.
 	bool collect_comps;
-	// Note: On everything but darwin the first value in data is the count of
-	// recorded PCs, followed by the PCs. We therefore set data_offset to the
+	// Note: On everything but darwin the first value in trace is the count of
+	// recorded PCs, followed by the PCs. We therefore set trace_skip to the
 	// size of one PC.
-	// On darwin data points to an instance of the ksancov_trace struct. Here we
-	// set data_offset to the offset between data and the structs 'pcs' member,
+	// On darwin trace points to an instance of the ksancov_trace struct. Here we
+	// set trace_skip to the offset between trace and the structs 'pcs' member,
 	// which contains the PCs.
-	intptr_t data_offset;
-	// Note: On everything but darwin this is 0, as the PCs contained in data
+	intptr_t trace_skip;
+	// Note: On everything but darwin this is 0, as the PCs contained in trace
 	// are already correct. XNUs KSANCOV API, however, chose to always squeeze
 	// PCs into 32 bit. To make the recorded PC fit, KSANCOV substracts a fixed
 	// offset (VM_MIN_KERNEL_ADDRESS for AMD64) and then truncates the result to
@@ -1170,8 +1177,8 @@ uint32 write_signal(flatbuffers::FlatBufferBuilder& fbb, int index, cover_t* cov
 	// Write out feedback signals.
 	// Currently it is code edges computed as xor of two subsequent basic block PCs.
 	fbb.StartVector(0, sizeof(uint64));
-	cover_data_t* cover_data = (cover_data_t*)(cov->data + cov->data_offset);
-	if ((char*)(cover_data + cov->size) > cov->data_end)
+	cover_data_t* cover_data = (cover_data_t*)(cov->trace + cov->trace_skip);
+	if ((char*)(cover_data + cov->size) > cov->trace_end)
 		failmsg("too much cover", "cov=%u", cov->size);
 	uint32 nsig = 0;
 	cover_data_t prev_pc = 0;
@@ -1204,7 +1211,7 @@ template <typename cover_data_t>
 uint32 write_cover(flatbuffers::FlatBufferBuilder& fbb, cover_t* cov)
 {
 	uint32 cover_size = cov->size;
-	cover_data_t* cover_data = (cover_data_t*)(cov->data + cov->data_offset);
+	cover_data_t* cover_data = (cover_data_t*)(cov->trace + cov->trace_skip);
 	if (flag_dedup_cover) {
 		cover_data_t* end = cover_data + cover_size;
 		std::sort(cover_data, end);
@@ -1220,11 +1227,11 @@ uint32 write_cover(flatbuffers::FlatBufferBuilder& fbb, cover_t* cov)
 uint32 write_comparisons(flatbuffers::FlatBufferBuilder& fbb, cover_t* cov)
 {
 	// Collect only the comparisons
-	uint64 ncomps = *(uint64_t*)cov->data;
-	kcov_comparison_t* cov_start = (kcov_comparison_t*)(cov->data + sizeof(uint64));
-	if ((char*)(cov_start + ncomps) > cov->data_end)
+	uint64 ncomps = *(uint64_t*)cov->trace;
+	kcov_comparison_t* cov_start = (kcov_comparison_t*)(cov->trace + sizeof(uint64));
+	if ((char*)(cov_start + ncomps) > cov->trace_end)
 		failmsg("too many comparisons", "ncomps=%llu", ncomps);
-	cov->overflow = ((char*)(cov_start + ncomps + 1) > cov->data_end);
+	cov->overflow = ((char*)(cov_start + ncomps + 1) > cov->trace_end);
 	rpc::ComparisonRaw* start = (rpc::ComparisonRaw*)cov_start;
 	rpc::ComparisonRaw* end = start;
 	// We will convert kcov_comparison_t to ComparisonRaw inplace.
@@ -1456,7 +1463,7 @@ void thread_create(thread_t* th, int id, bool need_coverage)
 
 void thread_mmap_cover(thread_t* th)
 {
-	if (th->cov.data != NULL)
+	if (th->cov.alloc != NULL)
 		return;
 	cover_mmap(&th->cov);
 	cover_protect(&th->cov);

--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -106,15 +106,18 @@ static void cover_open(cover_t* cov, bool extra)
 
 static void cover_mmap(cover_t* cov)
 {
-	if (cov->data != NULL)
+	if (cov->alloc != NULL)
 		fail("cover_mmap invoked on an already mmapped cover_t object");
 	void* mmap_ptr = mmap(NULL, cov->mmap_alloc_size, PROT_READ | PROT_WRITE,
 			      MAP_SHARED, cov->fd, 0);
 	if (mmap_ptr == MAP_FAILED)
 		fail("cover mmap failed");
-	cov->data = (char*)mmap_ptr;
-	cov->data_end = cov->data + cov->mmap_alloc_size;
-	cov->data_offset = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
+	cov->alloc = mmap_ptr;
+	cov->trace = (char*)cov->alloc;
+	cov->trace_size = cov->mmap_alloc_size;
+	cov->trace_end = cov->trace + cov->trace_size;
+	cov->trace_offset = 0;
+	cov->trace_skip = is_kernel_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
 	cov->pc_offset = 0;
 }
 
@@ -124,7 +127,7 @@ static void cover_protect(cover_t* cov)
 	size_t mmap_alloc_size = kCoverSize * KCOV_ENTRY_SIZE;
 	long page_size = sysconf(_SC_PAGESIZE);
 	if (page_size > 0)
-		mprotect(cov->data + page_size, mmap_alloc_size - page_size,
+		mprotect(cov->alloc + page_size, mmap_alloc_size - page_size,
 			 PROT_READ);
 #elif GOOS_openbsd
 	int mib[2], page_size;
@@ -133,7 +136,7 @@ static void cover_protect(cover_t* cov)
 	mib[1] = HW_PAGESIZE;
 	size_t len = sizeof(page_size);
 	if (sysctl(mib, ARRAY_SIZE(mib), &page_size, &len, NULL, 0) != -1)
-		mprotect(cov->data + page_size, mmap_alloc_size - page_size, PROT_READ);
+		mprotect(cov->alloc + page_size, mmap_alloc_size - page_size, PROT_READ);
 #endif
 }
 
@@ -141,10 +144,10 @@ static void cover_unprotect(cover_t* cov)
 {
 #if GOOS_freebsd
 	size_t mmap_alloc_size = kCoverSize * KCOV_ENTRY_SIZE;
-	mprotect(cov->data, mmap_alloc_size, PROT_READ | PROT_WRITE);
+	mprotect(cov->alloc, mmap_alloc_size, PROT_READ | PROT_WRITE);
 #elif GOOS_openbsd
 	size_t mmap_alloc_size = kCoverSize * sizeof(uintptr_t);
-	mprotect(cov->data, mmap_alloc_size, PROT_READ | PROT_WRITE);
+	mprotect(cov->alloc, mmap_alloc_size, PROT_READ | PROT_WRITE);
 #endif
 }
 
@@ -171,12 +174,12 @@ static void cover_enable(cover_t* cov, bool collect_comps, bool extra)
 
 static void cover_reset(cover_t* cov)
 {
-	*(uint64*)cov->data = 0;
+	*(uint64*)cov->trace = 0;
 }
 
 static void cover_collect(cover_t* cov)
 {
-	cov->size = *(uint64*)cov->data;
+	cov->size = *(uint64*)cov->trace;
 }
 
 #if GOOS_netbsd

--- a/executor/snapshot.h
+++ b/executor/snapshot.h
@@ -213,7 +213,7 @@ static void SnapshotStart()
 		thread_t* th = &threads[i];
 		thread_create(th, i, flag_coverage);
 		if (flag_coverage)
-			PopulateMemory(th->cov.data, kCoveragePopulate);
+			PopulateMemory(th->cov.alloc, kCoveragePopulate);
 	}
 	TouchMemory((char*)output_data + output_size - kOutputPopulate, kOutputPopulate);
 	TouchMemory(ivs.input, kInputPopulate);


### PR DESCRIPTION
Instead of having a single void *data pointer that is used to both allocate the memory and access the trace, split it into:
 - void *alloc of size mmap_alloc_size, used by mmap/munmap to manage the memory for kcov (may contain other data apart from the trace)
 - void *trace of size trace_size, used to access the collected trace

Future patches will introduce other collection modes that may relocate the trace, so *alloc and *trace won't be interchangeable anymore.

I tried my best to not break Darwin and BSD, but I didn't test them.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
