### PR TITLE
executor: pull in errno.h on BSD systems

### DIFF
--- a/executor/common_bsd.h
+++ b/executor/common_bsd.h
@@ -387,6 +387,7 @@ static long syz_extract_tcp_res(volatile long a0, volatile long a1, volatile lon
 
 #if SYZ_EXECUTOR || SYZ_SANDBOX_SETUID || SYZ_SANDBOX_NONE
 
+#include <errno.h>
 #include <sys/resource.h>
 #include <unistd.h>
 


### PR DESCRIPTION
The error handling for the setsid() call in sandbox_common() requires it.  Without it, some csource builds fail.