### PR TITLE
sys/targets: add a kernel address range for FreeBSD/amd64 kernels

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -357,6 +357,12 @@ var List = map[string]map[string]*Target{
 				// freebsd_12_shm_open, shm_open2, shm_rename, __realpathat, close_range, copy_file_range
 				return nr == 482 || nr >= 569
 			},
+			KernelAddresses: KernelAddresses{
+				// On amd64 the kernel and KLDs are loaded into the top
+				// 2GB of the kernel address space.
+				TextStart: 0xffffffff80000000,
+				TextEnd:   0xffffffffffffffff,
+			},
 		},
 		ARM64: {
 			PtrSize:   8,


### PR DESCRIPTION
After some time, my FreeBSD fuzzing runs start to hit frequent "coverage filter is full" SYZFAILs, caused by garbage PC values.  Some assertions in kcov convinced me that PC values exported by the kernel are in the expected range, so it appears that the executor is corrupting them somehow.  In particular, we leave the first page of each kcov mapping writeable since the interface to clear the trace buffer involves overwriting the first quadword.

Sanitize kernel PC values so that we don't fill up the coverage filter with bogus values.
