### PR TITLE
syz-cluster: fix incorrect Node toleration values

### DIFF
--- a/syz-cluster/overlays/gke/kustomization.yaml
+++ b/syz-cluster/overlays/gke/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
             - key: "workload"
               operator: "Equal"
               value: "nested-vm"
-              effect: "NO_SCHEDULE"
+              effect: "NoSchedule"
   - target:
       kind: WorkflowTemplate
       name: fuzz-step-template
@@ -32,4 +32,4 @@ patches:
             - key: "workload"
               operator: "Equal"
               value: "nested-vm"
-              effect: "NO_SCHEDULE"
+              effect: "NoSchedule"


### PR DESCRIPTION
It's NoSchedule, not NO_SCHEDULE.
