### PR TITLE
dashboard: include revoked reproducers in reports

### DIFF
--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -570,18 +570,17 @@ func crashBugReport(c context.Context, bug *Bug, crash *Crash, crashKey *db.Key,
 		Manager:         crash.Manager,
 		Assets:          assetList,
 		ReportElements:  &dashapi.ReportElements{GuiltyFiles: crash.ReportElements.GuiltyFiles},
+		ReproIsRevoked:  crash.ReproIsRevoked,
 	}
-	if !crash.ReproIsRevoked {
-		rep.ReproCLink = externalLink(c, textReproC, crash.ReproC)
-		rep.ReproC, _, err = getText(c, textReproC, crash.ReproC)
-		if err != nil {
-			return nil, err
-		}
-		rep.ReproSyzLink = externalLink(c, textReproSyz, crash.ReproSyz)
-		rep.ReproSyz, err = loadReproSyz(c, crash)
-		if err != nil {
-			return nil, err
-		}
+	rep.ReproCLink = externalLink(c, textReproC, crash.ReproC)
+	rep.ReproC, _, err = getText(c, textReproC, crash.ReproC)
+	if err != nil {
+		return nil, err
+	}
+	rep.ReproSyzLink = externalLink(c, textReproSyz, crash.ReproSyz)
+	rep.ReproSyz, err = loadReproSyz(c, crash)
+	if err != nil {
+		return nil, err
 	}
 	if bugReporting.CC != "" {
 		rep.CC = append(rep.CC, strings.Split(bugReporting.CC, "|")...)

--- a/dashboard/app/templates/mail_bug.txt
+++ b/dashboard/app/templates/mail_bug.txt
@@ -11,8 +11,8 @@ git tree:       {{.KernelRepoAlias}}
 {{end}}dashboard link: {{.Link}}
 {{if .CompilerID}}compiler:       {{.CompilerID}}
 {{end}}{{if .UserSpaceArch}}userspace arch: {{.UserSpaceArch}}
-{{end}}{{if .ReproSyzLink}}syz repro:      {{.ReproSyzLink}}
-{{end}}{{if .ReproCLink}}C reproducer:   {{.ReproCLink}}
+{{end}}{{if .ReproSyzLink}}syz repro:      {{if .ReproIsRevoked}}[OBSOLETE] {{end}}{{.ReproSyzLink}}
+{{end}}{{if .ReproCLink}}C reproducer:   {{if .ReproIsRevoked}}[OBSOLETE] {{end}}{{.ReproCLink}}
 {{end}}{{if and .Moderation .Maintainers}}CC:             {{.Maintainers}}
 {{end}}{{if and (not .NoRepro) (not .ReproCLink) (not .ReproSyzLink)}}
 Unfortunately, I don't have any reproducer for this issue yet.

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -459,6 +459,7 @@ type BugReport struct {
 	ReproCLink        string
 	ReproSyz          []byte
 	ReproSyzLink      string
+	ReproIsRevoked    bool
 	ReproOpts         []byte
 	MachineInfo       []byte
 	MachineInfoLink   string


### PR DESCRIPTION
Context: #5829.

Let's not pretend that the revoked reproducer never existed and still report it. It will avoid unexpected side-effects for the higher-level logic.

There may be better ways to resolve the bug, but let's first just get it fixed to prevent syzbot from spamming the mailing lists.

Add a test to verify the new behavior.