### PR TITLE
all: add clean_rules config to help CleanPath for specific targets

### DIFF
--- a/pkg/cover/backend/backend.go
+++ b/pkg/cover/backend/backend.go
@@ -67,7 +67,7 @@ type SecRange struct {
 const LineEnd = 1 << 30
 
 func Make(target *targets.Target, vm string, kernelDirs *mgrconfig.KernelDirs, splitBuild bool,
-	moduleObj []string, modules []*vminfo.KernelModule) (*Impl, error) {
+	moduleObj []string, modules []*vminfo.KernelModule, cleanRules []string) (*Impl, error) {
 	if kernelDirs.Obj == "" {
 		return nil, fmt.Errorf("kernel obj directory is not specified")
 	}
@@ -84,7 +84,7 @@ func Make(target *targets.Target, vm string, kernelDirs *mgrconfig.KernelDirs, s
 		// details.
 		delimiters = []string{"/aosp/", "/private/"}
 	}
-	return makeELF(target, kernelDirs, delimiters, moduleObj, modules)
+	return makeELF(target, kernelDirs, delimiters, moduleObj, modules, cleanRules)
 }
 
 func GetPCBase(cfg *mgrconfig.Config) (uint64, error) {

--- a/pkg/cover/backend/elf.go
+++ b/pkg/cover/backend/elf.go
@@ -18,7 +18,7 @@ import (
 )
 
 func makeELF(target *targets.Target, kernelDirs *mgrconfig.KernelDirs, splitBuildDelimiters, moduleObj []string,
-	hostModules []*vminfo.KernelModule) (*Impl, error) {
+	hostModules []*vminfo.KernelModule, cleanRules []string) (*Impl, error) {
 	return makeDWARF(&dwarfParams{
 		target:                target,
 		kernelDirs:            kernelDirs,
@@ -30,6 +30,7 @@ func makeELF(target *targets.Target, kernelDirs *mgrconfig.KernelDirs, splitBuil
 		readModuleCoverPoints: elfReadModuleCoverPoints,
 		readTextRanges:        elfReadTextRanges,
 		getCompilerVersion:    elfGetCompilerVersion,
+		cleanRules:            cleanRules,
 	})
 }
 

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -34,7 +34,8 @@ func GetPCBase(cfg *mgrconfig.Config) (uint64, error) {
 }
 
 func MakeReportGenerator(cfg *mgrconfig.Config, modules []*vminfo.KernelModule) (*ReportGenerator, error) {
-	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelDirs(), cfg.AndroidSplitBuild, cfg.ModuleObj, modules)
+	impl, err := backend.Make(cfg.SysTarget, cfg.Type, cfg.KernelDirs(), cfg.AndroidSplitBuild, cfg.ModuleObj,
+		modules, cfg.CleanRules)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -230,6 +230,17 @@ type Config struct {
 
 	// Implementation details beyond this point. Filled after parsing.
 	Derived `json:"-"`
+
+	// cleanPath rules like "old_path:new_path" which replaces old_path by new_path
+	// it's especially useful for out-of-tree kernel modules symbol path
+	// old_path is relative path to kernel_src, for example in Android S
+	// "clean_rules" : [
+	//   "/proc/self/cwd/common:kernel_platform/common"
+	// ]
+	// in cleanPath function, if path in elf is /proc/self/cwd/common/drivers/something.c
+	// then path will be changed to kernel_platform/common/drivers/something.c,
+	// and filename will be kernel_src + /kernel_platform/common/drivers/something.c
+	CleanRules []string `json:"clean_rules,omitempty"`
 }
 
 // These options are not guaranteed to be backward/forward compatible and

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -487,7 +487,7 @@ func symbolizeLine(symbFunc func(bin string, pc uint64) ([]symbolizer.Frame, err
 	}
 	var symbolized []byte
 	for _, frame := range frames {
-		path, _ := backend.CleanPath(frame.File, &ctx.kernelDirs, nil)
+		path, _ := backend.CleanPath(frame.File, &ctx.kernelDirs, nil, ctx.config.cleanRules)
 		info := fmt.Sprintf(" %v:%v", path, frame.Line)
 		modified := append([]byte{}, line...)
 		if buildID != "" {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -122,6 +122,7 @@ func NewReporter(cfg *mgrconfig.Config) (*Reporter, error) {
 		kernelDirs:    *cfg.KernelDirs(),
 		ignores:       ignores,
 		kernelModules: localModules,
+		cleanRules:    cfg.CleanRules,
 	}
 	rep, suppressions, err := ctor(config)
 	if err != nil {
@@ -172,6 +173,7 @@ type config struct {
 	kernelDirs    mgrconfig.KernelDirs
 	ignores       []*regexp.Regexp
 	kernelModules []*vminfo.KernelModule
+	cleanRules    []string
 }
 
 type fn func(cfg *config) (reporterImpl, []string, error)


### PR DESCRIPTION
In some targets like android, we got addr2line info like: /proc/self/cwd/common/kernel/kcov.c:852
To cleanup the path, we need to remove /proc/self/cwd/ prefix, and add relative path to common directory,
so we can have clean_rules like:
"/proc/self/cwd/common:kernel_platform/common"

More examples:
"clean_rules" : [
	"/proc/self/cwd/common/../vendor:vendor",
	"/proc/self/cwd/common/../soc-repo:kernel_platform/soc-repo",
	"/proc/self/cwd/vendor:vendor",
	"/proc/self/cwd/common:kernel_platform/common"
]

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
