### PR TITLE
syz-ci/manager.go: make CoverProgramsPath target public

### DIFF
--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -114,7 +114,7 @@ type Config struct {
 	// Path to upload corpus.db from managers (optional).
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).
 	CorpusUploadPath string `json:"corpus_upload_path"`
-	// Make files uploaded via CoverUploadPath and CorpusUploadPath public.
+	// Make files uploaded via CoverUploadPath, CorpusUploadPath and CoverProgramsPath public.
 	PublishGCS bool `json:"publish_gcs"`
 	// Path to upload bench data from instances (optional).
 	// Supported protocols: GCS (gs://) and HTTP PUT (http:// or https://).


### PR DESCRIPTION
PublishGCS param now controls the CoverProgramsPath targets too.
Previously it controlled only CoverUploadPath and CorpusUploadPath.

Context: gcs://syzkaller bucket doesn't allow to configure permissions per-folder.
The alternatives are - to create one more bucket for all the programs coverage export to change syzkaller code and configure ACL the same was we're doing it for other artefacts.
