### PR TITLE
docs/linux: update go version

### DIFF
--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -26,13 +26,13 @@ If you encounter any troubles, check the [troubleshooting](/docs/troubleshooting
 
 ### Go and syzkaller
 
-`syzkaller` is written in [Go](https://golang.org), and `Go 1.22+` toolchain is required for build.
+`syzkaller` is written in [Go](https://golang.org), and `Go 1.23+` toolchain is required for build.
 Generally we aim at supporting 2 latest releases of Go.
 The toolchain can be installed with:
 
 ```
-wget https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz
-tar -xf go1.22.1.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.23.6.linux-amd64.tar.gz
+tar -xf go1.23.6.linux-amd64.tar.gz
 export GOROOT=`pwd`/go
 export PATH=$GOROOT/bin:$PATH
 ```


### PR DESCRIPTION
Update the go version in docs/linux/setup.md from go1.22.1 to go1.23.6 to ensure consistency with go.mod.