### PR TITLE
syz-ci: gzip programs coverage on GCS

### DIFF
--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -32,7 +32,7 @@ type Client interface {
 	FileExists(path string) (bool, error)
 	ListObjects(path string) ([]*Object, error)
 
-	publish(path string) error
+	Publish(path string) error
 }
 
 type UploadOptions struct {
@@ -63,7 +63,7 @@ func UploadFile(ctx context.Context, srcFile io.Reader, destURL string, opts Upl
 		return fmt.Errorf("gcsWriter.Close: %w", err)
 	}
 	if opts.Publish {
-		return gcsClient.publish(destURL)
+		return gcsClient.Publish(destURL)
 	}
 	return nil
 }
@@ -143,8 +143,8 @@ func (c *client) FileWriter(gcsFile, contentType, contentEncoding string) (io.Wr
 	return w, nil
 }
 
-// publish lets any user read gcsFile.
-func (c *client) publish(gcsFile string) error {
+// Publish lets any user read gcsFile.
+func (c *client) Publish(gcsFile string) error {
 	bucket, filename, err := split(gcsFile)
 	if err != nil {
 		return err

--- a/pkg/gcs/mocks/Client.go
+++ b/pkg/gcs/mocks/Client.go
@@ -139,6 +139,24 @@ func (_m *Client) ListObjects(path string) ([]*gcs.Object, error) {
 	return r0, r1
 }
 
+// Publish provides a mock function with given fields: path
+func (_m *Client) Publish(path string) error {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Publish")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Read provides a mock function with given fields: path
 func (_m *Client) Read(path string) (*gcs.File, error) {
 	ret := _m.Called(path)
@@ -167,24 +185,6 @@ func (_m *Client) Read(path string) (*gcs.File, error) {
 	}
 
 	return r0, r1
-}
-
-// publish provides a mock function with given fields: path
-func (_m *Client) publish(path string) error {
-	ret := _m.Called(path)
-
-	if len(ret) == 0 {
-		panic("no return value specified for publish")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(path)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/syz-ci/manager_test.go
+++ b/syz-ci/manager_test.go
@@ -4,10 +4,21 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/google/syzkaller/pkg/cover"
+	gcsmocks "github.com/google/syzkaller/pkg/gcs/mocks"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/vcs"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
@@ -105,4 +116,130 @@ Reported-by: foo+abcd000@bar.com`,
 	commit := fixCommits[0]
 	assert.Equal(t, commit.Title, "title with fix")
 	assert.ElementsMatch(t, commit.BugIDs, []string{"abcd000"})
+}
+
+func TestUploadCoverJSONLToGCS(t *testing.T) {
+	tests := []struct {
+		name string
+
+		inputJSONL string
+		inputTime  time.Time
+
+		inputCompress bool
+		inputPublish  bool
+
+		wantGCSFileName    string
+		wantGCSFileContent string
+		wantCompressed     bool
+		wantPublish        bool
+		wantError          string
+	}{
+		{
+			name:               "upload single object",
+			inputJSONL:         "{}",
+			inputTime:          time.Time{},
+			wantGCSFileName:    "test-bucket/test-namespace/mgr-name-0001-01-01-0-0.jsonl",
+			wantGCSFileContent: "{}\n",
+		},
+		{
+			name:               "upload single object, compress",
+			inputJSONL:         "{}",
+			inputTime:          time.Time{},
+			inputCompress:      true,
+			wantGCSFileName:    "test-bucket/test-namespace/mgr-name-0001-01-01-0-0.jsonl",
+			wantGCSFileContent: "{}\n",
+			wantCompressed:     true,
+		},
+		{
+			name:               "upload single object, publish",
+			inputJSONL:         "{}",
+			inputTime:          time.Time{},
+			inputPublish:       true,
+			wantGCSFileName:    "test-bucket/test-namespace/mgr-name-0001-01-01-0-0.jsonl",
+			wantGCSFileContent: "{}\n",
+			wantPublish:        true,
+		},
+		{
+			name:            "upload single object, error",
+			inputJSONL:      "{",
+			inputTime:       time.Time{},
+			wantGCSFileName: "test-bucket/test-namespace/mgr-name-0001-01-01-0-0.jsonl",
+			wantError:       "callback: cover.ProgramCoverage: unexpected EOF",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(test.inputJSONL))
+			}))
+			defer httpServer.Close()
+
+			testSetverAddrPort, _ := strings.CutPrefix(httpServer.URL, "http://")
+			mgr := Manager{
+				name: "mgr-name",
+				managercfg: &mgrconfig.Config{
+					HTTP:  testSetverAddrPort,
+					Cover: true,
+				},
+				mgrcfg: &ManagerConfig{
+					DashboardClient: "test-namespace",
+				},
+			}
+
+			gcsMock := gcsmocks.NewClient(t)
+			gotBytes := mockWriteCloser{}
+
+			gcsMock.On("FileWriter", test.wantGCSFileName, "", "").
+				Return(&gotBytes, nil).Once()
+			gcsMock.On("Close").Return(nil).Once()
+			if test.wantPublish {
+				gcsMock.On("Publish", test.wantGCSFileName).
+					Return(nil).Once()
+			}
+			err := mgr.uploadCoverJSONLToGCS(gcsMock,
+				"/teststream&jsonl=1",
+				"gs://test-bucket",
+				time.Time{}, test.inputPublish, test.inputCompress, func(w io.Writer, dec *json.Decoder) error {
+					var v any
+					if err := dec.Decode(&v); err != nil {
+						return fmt.Errorf("cover.ProgramCoverage: %w", err)
+					}
+					if err := cover.WriteJSLine(w, &v); err != nil {
+						return fmt.Errorf("cover.WriteJSLine: %w", err)
+					}
+					return nil
+				})
+			if test.wantError != "" {
+				assert.Equal(t, test.wantError, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, 1, gotBytes.closedTimes)
+			if test.wantCompressed {
+				gzReader, err := gzip.NewReader(&gotBytes.buf)
+				assert.NoError(t, err)
+				defer gzReader.Close()
+				plainBytes := mockWriteCloser{}
+				_, err = io.Copy(&plainBytes, gzReader)
+				assert.NoError(t, err)
+				gotBytes = plainBytes
+			}
+			assert.Equal(t, test.wantGCSFileContent, gotBytes.buf.String())
+		})
+	}
+}
+
+type mockWriteCloser struct {
+	buf         bytes.Buffer
+	closedTimes int
+}
+
+func (m *mockWriteCloser) Write(p []byte) (n int, err error) {
+	return m.buf.Write(p)
+}
+
+func (m *mockWriteCloser) Close() error {
+	m.closedTimes++
+	return nil
 }


### PR DESCRIPTION
Each fuzzing session costs 2G-13G of detailed coverage data now. It looks too much.
The data is highly redundant (jsonl) thus compression should help.

P. S. The better option is to dedup this data in some DB but it will take much more efforts.
Cloud Spanner allows to import gzipped JSONL data just in case we'll decide to use these programs for web UX.

TODO:

- [x] land #5858 