### PR TITLE
sys/targets: determine DataOffset by Arch

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -782,7 +782,7 @@ func initTarget(target *Target, OS, arch string) {
 
 func (target *Target) defaultDataOffset() uint64 {
 	if target.PtrSize == 8 {
-		if target.VMArch == ARM64 {
+		if target.Arch == ARM64 {
 			// On ARM64, in many cases we can't use many enough bits of the address space.
 			// Let's use the old value for now. It's also problematic (see #5770), but it's
 			// lesser of the two evils.


### PR DESCRIPTION
It is incorrect to consider VMArch here - if we are running a 32 bit app on a 64 bit kernel, the 64 bit arch is not of interest here.

Also, VMArch is not set for every Target, what led to problems when running arm64 fuzzing on an arm64 host.