### PR TITLE
migrate to mockery config

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+dir: "{{.InterfaceDir}}/mocks"
+outpkg: "mocks"
+mockname: "{{.InterfaceName}}"
+filename: "{{.InterfaceName}}.go"
+resolve-type-alias: False # TODO: remove in mockery 3
+issue-845-fix: True       # TODO: remove in mockery 3
+packages:
+  github.com/google/syzkaller/pkg/gcs:
+    interfaces:
+      Client:
+  github.com/google/syzkaller/pkg/covermerger:
+    interfaces:
+      FileVersProvider:
+  github.com/google/syzkaller/pkg/coveragedb/spannerclient:
+    config:
+      dir: "{{.InterfaceDir}}/../mocks"
+    interfaces:
+      SpannerClient:
+      ReadOnlyTransaction:
+      RowIterator:
+      Row:
+  github.com/google/syzkaller/pkg/rpcserver:
+    interfaces:
+      Manager:
+  github.com/google/syzkaller/vm/proxyapp/proxyrpc:
+    config:
+      dir: "{{.InterfaceDir}}/../mocks"
+    interfaces:
+      ProxyAppInterface:
+  github.com/google/syzkaller/vm/proxyapp:
+    config:
+      mockname: "SubProcessCmd"
+    interfaces:
+      subProcessCmd:

--- a/Makefile
+++ b/Makefile
@@ -237,10 +237,7 @@ generate:
 
 generate_go: format_cpp
 	$(GO) generate ./executor ./pkg/ifuzz ./pkg/build ./pkg/rpcserver
-	$(GO) generate ./vm/proxyapp
-	$(GO) generate ./pkg/coveragedb
-	$(GO) generate ./pkg/covermerger
-	$(GO) generate ./pkg/gcs
+	$(GO) run github.com/vektra/mockery/v2@v2.52.1 --log-level="error"
 
 generate_rpc:
 	flatc -o pkg/flatrpc --warnings-as-errors --gen-object-api --filename-suffix "" --go --gen-onefile --go-namespace flatrpc pkg/flatrpc/flatrpc.fbs

--- a/pkg/coveragedb/coveragedb_mock_test.go
+++ b/pkg/coveragedb/coveragedb_mock_test.go
@@ -18,11 +18,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-//go:generate ../../tools/mockery.sh --name SpannerClient -r
-//go:generate ../../tools/mockery.sh --name ReadOnlyTransaction -r
-//go:generate ../../tools/mockery.sh --name RowIterator -r
-//go:generate ../../tools/mockery.sh --name Row -r
-
 type spannerMockTune func(*testing.T, *mocks.SpannerClient)
 
 func TestSaveMergeResult(t *testing.T) {

--- a/pkg/coveragedb/mocks/ReadOnlyTransaction.go
+++ b/pkg/coveragedb/mocks/ReadOnlyTransaction.go
@@ -16,6 +16,14 @@ type ReadOnlyTransaction struct {
 	mock.Mock
 }
 
+type ReadOnlyTransaction_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *ReadOnlyTransaction) EXPECT() *ReadOnlyTransaction_Expecter {
+	return &ReadOnlyTransaction_Expecter{mock: &_m.Mock}
+}
+
 // Query provides a mock function with given fields: ctx, statement
 func (_m *ReadOnlyTransaction) Query(ctx context.Context, statement spanner.Statement) spannerclient.RowIterator {
 	ret := _m.Called(ctx, statement)
@@ -34,6 +42,35 @@ func (_m *ReadOnlyTransaction) Query(ctx context.Context, statement spanner.Stat
 	}
 
 	return r0
+}
+
+// ReadOnlyTransaction_Query_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Query'
+type ReadOnlyTransaction_Query_Call struct {
+	*mock.Call
+}
+
+// Query is a helper method to define mock.On call
+//   - ctx context.Context
+//   - statement spanner.Statement
+func (_e *ReadOnlyTransaction_Expecter) Query(ctx interface{}, statement interface{}) *ReadOnlyTransaction_Query_Call {
+	return &ReadOnlyTransaction_Query_Call{Call: _e.mock.On("Query", ctx, statement)}
+}
+
+func (_c *ReadOnlyTransaction_Query_Call) Run(run func(ctx context.Context, statement spanner.Statement)) *ReadOnlyTransaction_Query_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(spanner.Statement))
+	})
+	return _c
+}
+
+func (_c *ReadOnlyTransaction_Query_Call) Return(_a0 spannerclient.RowIterator) *ReadOnlyTransaction_Query_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReadOnlyTransaction_Query_Call) RunAndReturn(run func(context.Context, spanner.Statement) spannerclient.RowIterator) *ReadOnlyTransaction_Query_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewReadOnlyTransaction creates a new instance of ReadOnlyTransaction. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/coveragedb/mocks/Row.go
+++ b/pkg/coveragedb/mocks/Row.go
@@ -9,6 +9,14 @@ type Row struct {
 	mock.Mock
 }
 
+type Row_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Row) EXPECT() *Row_Expecter {
+	return &Row_Expecter{mock: &_m.Mock}
+}
+
 // ToStruct provides a mock function with given fields: p
 func (_m *Row) ToStruct(p interface{}) error {
 	ret := _m.Called(p)
@@ -25,6 +33,34 @@ func (_m *Row) ToStruct(p interface{}) error {
 	}
 
 	return r0
+}
+
+// Row_ToStruct_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ToStruct'
+type Row_ToStruct_Call struct {
+	*mock.Call
+}
+
+// ToStruct is a helper method to define mock.On call
+//   - p interface{}
+func (_e *Row_Expecter) ToStruct(p interface{}) *Row_ToStruct_Call {
+	return &Row_ToStruct_Call{Call: _e.mock.On("ToStruct", p)}
+}
+
+func (_c *Row_ToStruct_Call) Run(run func(p interface{})) *Row_ToStruct_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(interface{}))
+	})
+	return _c
+}
+
+func (_c *Row_ToStruct_Call) Return(_a0 error) *Row_ToStruct_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Row_ToStruct_Call) RunAndReturn(run func(interface{}) error) *Row_ToStruct_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewRow creates a new instance of Row. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/coveragedb/mocks/RowIterator.go
+++ b/pkg/coveragedb/mocks/RowIterator.go
@@ -12,6 +12,14 @@ type RowIterator struct {
 	mock.Mock
 }
 
+type RowIterator_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *RowIterator) EXPECT() *RowIterator_Expecter {
+	return &RowIterator_Expecter{mock: &_m.Mock}
+}
+
 // Next provides a mock function with no fields
 func (_m *RowIterator) Next() (spannerclient.Row, error) {
 	ret := _m.Called()
@@ -42,9 +50,63 @@ func (_m *RowIterator) Next() (spannerclient.Row, error) {
 	return r0, r1
 }
 
+// RowIterator_Next_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Next'
+type RowIterator_Next_Call struct {
+	*mock.Call
+}
+
+// Next is a helper method to define mock.On call
+func (_e *RowIterator_Expecter) Next() *RowIterator_Next_Call {
+	return &RowIterator_Next_Call{Call: _e.mock.On("Next")}
+}
+
+func (_c *RowIterator_Next_Call) Run(run func()) *RowIterator_Next_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RowIterator_Next_Call) Return(_a0 spannerclient.Row, _a1 error) *RowIterator_Next_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *RowIterator_Next_Call) RunAndReturn(run func() (spannerclient.Row, error)) *RowIterator_Next_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Stop provides a mock function with no fields
 func (_m *RowIterator) Stop() {
 	_m.Called()
+}
+
+// RowIterator_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
+type RowIterator_Stop_Call struct {
+	*mock.Call
+}
+
+// Stop is a helper method to define mock.On call
+func (_e *RowIterator_Expecter) Stop() *RowIterator_Stop_Call {
+	return &RowIterator_Stop_Call{Call: _e.mock.On("Stop")}
+}
+
+func (_c *RowIterator_Stop_Call) Run(run func()) *RowIterator_Stop_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RowIterator_Stop_Call) Return() *RowIterator_Stop_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *RowIterator_Stop_Call) RunAndReturn(run func()) *RowIterator_Stop_Call {
+	_c.Run(run)
+	return _c
 }
 
 // NewRowIterator creates a new instance of RowIterator. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/coveragedb/mocks/SpannerClient.go
+++ b/pkg/coveragedb/mocks/SpannerClient.go
@@ -18,6 +18,14 @@ type SpannerClient struct {
 	mock.Mock
 }
 
+type SpannerClient_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *SpannerClient) EXPECT() *SpannerClient_Expecter {
+	return &SpannerClient_Expecter{mock: &_m.Mock}
+}
+
 // Apply provides a mock function with given fields: ctx, ms, opts
 func (_m *SpannerClient) Apply(ctx context.Context, ms []*spanner.Mutation, opts ...spanner.ApplyOption) (time.Time, error) {
 	_va := make([]interface{}, len(opts))
@@ -53,9 +61,73 @@ func (_m *SpannerClient) Apply(ctx context.Context, ms []*spanner.Mutation, opts
 	return r0, r1
 }
 
+// SpannerClient_Apply_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Apply'
+type SpannerClient_Apply_Call struct {
+	*mock.Call
+}
+
+// Apply is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ms []*spanner.Mutation
+//   - opts ...spanner.ApplyOption
+func (_e *SpannerClient_Expecter) Apply(ctx interface{}, ms interface{}, opts ...interface{}) *SpannerClient_Apply_Call {
+	return &SpannerClient_Apply_Call{Call: _e.mock.On("Apply",
+		append([]interface{}{ctx, ms}, opts...)...)}
+}
+
+func (_c *SpannerClient_Apply_Call) Run(run func(ctx context.Context, ms []*spanner.Mutation, opts ...spanner.ApplyOption)) *SpannerClient_Apply_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]spanner.ApplyOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(spanner.ApplyOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].([]*spanner.Mutation), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SpannerClient_Apply_Call) Return(commitTimestamp time.Time, err error) *SpannerClient_Apply_Call {
+	_c.Call.Return(commitTimestamp, err)
+	return _c
+}
+
+func (_c *SpannerClient_Apply_Call) RunAndReturn(run func(context.Context, []*spanner.Mutation, ...spanner.ApplyOption) (time.Time, error)) *SpannerClient_Apply_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function with no fields
 func (_m *SpannerClient) Close() {
 	_m.Called()
+}
+
+// SpannerClient_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type SpannerClient_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *SpannerClient_Expecter) Close() *SpannerClient_Close_Call {
+	return &SpannerClient_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *SpannerClient_Close_Call) Run(run func()) *SpannerClient_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SpannerClient_Close_Call) Return() *SpannerClient_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SpannerClient_Close_Call) RunAndReturn(run func()) *SpannerClient_Close_Call {
+	_c.Run(run)
+	return _c
 }
 
 // Single provides a mock function with no fields
@@ -76,6 +148,33 @@ func (_m *SpannerClient) Single() spannerclient.ReadOnlyTransaction {
 	}
 
 	return r0
+}
+
+// SpannerClient_Single_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Single'
+type SpannerClient_Single_Call struct {
+	*mock.Call
+}
+
+// Single is a helper method to define mock.On call
+func (_e *SpannerClient_Expecter) Single() *SpannerClient_Single_Call {
+	return &SpannerClient_Single_Call{Call: _e.mock.On("Single")}
+}
+
+func (_c *SpannerClient_Single_Call) Run(run func()) *SpannerClient_Single_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SpannerClient_Single_Call) Return(_a0 spannerclient.ReadOnlyTransaction) *SpannerClient_Single_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SpannerClient_Single_Call) RunAndReturn(run func() spannerclient.ReadOnlyTransaction) *SpannerClient_Single_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewSpannerClient creates a new instance of SpannerClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/covermerger/mocks/FileVersProvider.go
+++ b/pkg/covermerger/mocks/FileVersProvider.go
@@ -12,6 +12,14 @@ type FileVersProvider struct {
 	mock.Mock
 }
 
+type FileVersProvider_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *FileVersProvider) EXPECT() *FileVersProvider_Expecter {
+	return &FileVersProvider_Expecter{mock: &_m.Mock}
+}
+
 // GetFileVersions provides a mock function with given fields: targetFilePath, repoCommits
 func (_m *FileVersProvider) GetFileVersions(targetFilePath string, repoCommits ...covermerger.RepoCommit) (covermerger.FileVersions, error) {
 	_va := make([]interface{}, len(repoCommits))
@@ -47,6 +55,42 @@ func (_m *FileVersProvider) GetFileVersions(targetFilePath string, repoCommits .
 	}
 
 	return r0, r1
+}
+
+// FileVersProvider_GetFileVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFileVersions'
+type FileVersProvider_GetFileVersions_Call struct {
+	*mock.Call
+}
+
+// GetFileVersions is a helper method to define mock.On call
+//   - targetFilePath string
+//   - repoCommits ...covermerger.RepoCommit
+func (_e *FileVersProvider_Expecter) GetFileVersions(targetFilePath interface{}, repoCommits ...interface{}) *FileVersProvider_GetFileVersions_Call {
+	return &FileVersProvider_GetFileVersions_Call{Call: _e.mock.On("GetFileVersions",
+		append([]interface{}{targetFilePath}, repoCommits...)...)}
+}
+
+func (_c *FileVersProvider_GetFileVersions_Call) Run(run func(targetFilePath string, repoCommits ...covermerger.RepoCommit)) *FileVersProvider_GetFileVersions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]covermerger.RepoCommit, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(covermerger.RepoCommit)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *FileVersProvider_GetFileVersions_Call) Return(_a0 covermerger.FileVersions, _a1 error) *FileVersProvider_GetFileVersions_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *FileVersProvider_GetFileVersions_Call) RunAndReturn(run func(string, ...covermerger.RepoCommit) (covermerger.FileVersions, error)) *FileVersProvider_GetFileVersions_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewFileVersProvider creates a new instance of FileVersProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/covermerger/provider_monorepo.go
+++ b/pkg/covermerger/provider_monorepo.go
@@ -3,8 +3,6 @@
 
 package covermerger
 
-//go:generate ../../tools/mockery.sh --name FileVersProvider -r
-
 import (
 	"fmt"
 	"path/filepath"

--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -8,8 +8,6 @@
 // https://cloud.google.com/go/getting-started/using-cloud-storage
 // https://godoc.org/cloud.google.com/go/storage
 
-//go:generate ../../tools/mockery.sh --name Client -r
-
 package gcs
 
 import (

--- a/pkg/gcs/mocks/Client.go
+++ b/pkg/gcs/mocks/Client.go
@@ -15,6 +15,14 @@ type Client struct {
 	mock.Mock
 }
 
+type Client_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Client) EXPECT() *Client_Expecter {
+	return &Client_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with no fields
 func (_m *Client) Close() error {
 	ret := _m.Called()
@@ -33,6 +41,33 @@ func (_m *Client) Close() error {
 	return r0
 }
 
+// Client_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type Client_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *Client_Expecter) Close() *Client_Close_Call {
+	return &Client_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *Client_Close_Call) Run(run func()) *Client_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_Close_Call) Return(_a0 error) *Client_Close_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_Close_Call) RunAndReturn(run func() error) *Client_Close_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteFile provides a mock function with given fields: path
 func (_m *Client) DeleteFile(path string) error {
 	ret := _m.Called(path)
@@ -49,6 +84,34 @@ func (_m *Client) DeleteFile(path string) error {
 	}
 
 	return r0
+}
+
+// Client_DeleteFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteFile'
+type Client_DeleteFile_Call struct {
+	*mock.Call
+}
+
+// DeleteFile is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) DeleteFile(path interface{}) *Client_DeleteFile_Call {
+	return &Client_DeleteFile_Call{Call: _e.mock.On("DeleteFile", path)}
+}
+
+func (_c *Client_DeleteFile_Call) Run(run func(path string)) *Client_DeleteFile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Client_DeleteFile_Call) Return(_a0 error) *Client_DeleteFile_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_DeleteFile_Call) RunAndReturn(run func(string) error) *Client_DeleteFile_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // FileExists provides a mock function with given fields: path
@@ -77,6 +140,34 @@ func (_m *Client) FileExists(path string) (bool, error) {
 	}
 
 	return r0, r1
+}
+
+// Client_FileExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FileExists'
+type Client_FileExists_Call struct {
+	*mock.Call
+}
+
+// FileExists is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) FileExists(path interface{}) *Client_FileExists_Call {
+	return &Client_FileExists_Call{Call: _e.mock.On("FileExists", path)}
+}
+
+func (_c *Client_FileExists_Call) Run(run func(path string)) *Client_FileExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Client_FileExists_Call) Return(_a0 bool, _a1 error) *Client_FileExists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_FileExists_Call) RunAndReturn(run func(string) (bool, error)) *Client_FileExists_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // FileWriter provides a mock function with given fields: path, contentType, contentEncoding
@@ -109,6 +200,36 @@ func (_m *Client) FileWriter(path string, contentType string, contentEncoding st
 	return r0, r1
 }
 
+// Client_FileWriter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FileWriter'
+type Client_FileWriter_Call struct {
+	*mock.Call
+}
+
+// FileWriter is a helper method to define mock.On call
+//   - path string
+//   - contentType string
+//   - contentEncoding string
+func (_e *Client_Expecter) FileWriter(path interface{}, contentType interface{}, contentEncoding interface{}) *Client_FileWriter_Call {
+	return &Client_FileWriter_Call{Call: _e.mock.On("FileWriter", path, contentType, contentEncoding)}
+}
+
+func (_c *Client_FileWriter_Call) Run(run func(path string, contentType string, contentEncoding string)) *Client_FileWriter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *Client_FileWriter_Call) Return(_a0 io.WriteCloser, _a1 error) *Client_FileWriter_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_FileWriter_Call) RunAndReturn(run func(string, string, string) (io.WriteCloser, error)) *Client_FileWriter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListObjects provides a mock function with given fields: path
 func (_m *Client) ListObjects(path string) ([]*gcs.Object, error) {
 	ret := _m.Called(path)
@@ -139,6 +260,34 @@ func (_m *Client) ListObjects(path string) ([]*gcs.Object, error) {
 	return r0, r1
 }
 
+// Client_ListObjects_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListObjects'
+type Client_ListObjects_Call struct {
+	*mock.Call
+}
+
+// ListObjects is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) ListObjects(path interface{}) *Client_ListObjects_Call {
+	return &Client_ListObjects_Call{Call: _e.mock.On("ListObjects", path)}
+}
+
+func (_c *Client_ListObjects_Call) Run(run func(path string)) *Client_ListObjects_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Client_ListObjects_Call) Return(_a0 []*gcs.Object, _a1 error) *Client_ListObjects_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_ListObjects_Call) RunAndReturn(run func(string) ([]*gcs.Object, error)) *Client_ListObjects_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Publish provides a mock function with given fields: path
 func (_m *Client) Publish(path string) error {
 	ret := _m.Called(path)
@@ -155,6 +304,34 @@ func (_m *Client) Publish(path string) error {
 	}
 
 	return r0
+}
+
+// Client_Publish_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Publish'
+type Client_Publish_Call struct {
+	*mock.Call
+}
+
+// Publish is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) Publish(path interface{}) *Client_Publish_Call {
+	return &Client_Publish_Call{Call: _e.mock.On("Publish", path)}
+}
+
+func (_c *Client_Publish_Call) Run(run func(path string)) *Client_Publish_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Client_Publish_Call) Return(_a0 error) *Client_Publish_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_Publish_Call) RunAndReturn(run func(string) error) *Client_Publish_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Read provides a mock function with given fields: path
@@ -185,6 +362,34 @@ func (_m *Client) Read(path string) (*gcs.File, error) {
 	}
 
 	return r0, r1
+}
+
+// Client_Read_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Read'
+type Client_Read_Call struct {
+	*mock.Call
+}
+
+// Read is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) Read(path interface{}) *Client_Read_Call {
+	return &Client_Read_Call{Call: _e.mock.On("Read", path)}
+}
+
+func (_c *Client_Read_Call) Run(run func(path string)) *Client_Read_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Client_Read_Call) Return(_a0 *gcs.File, _a1 error) *Client_Read_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_Read_Call) RunAndReturn(run func(string) (*gcs.File, error)) *Client_Read_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/rpcserver/mocks/Manager.go
+++ b/pkg/rpcserver/mocks/Manager.go
@@ -20,6 +20,14 @@ type Manager struct {
 	mock.Mock
 }
 
+type Manager_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Manager) EXPECT() *Manager_Expecter {
+	return &Manager_Expecter{mock: &_m.Mock}
+}
+
 // BugFrames provides a mock function with no fields
 func (_m *Manager) BugFrames() ([]string, []string) {
 	ret := _m.Called()
@@ -52,6 +60,33 @@ func (_m *Manager) BugFrames() ([]string, []string) {
 	return r0, r1
 }
 
+// Manager_BugFrames_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BugFrames'
+type Manager_BugFrames_Call struct {
+	*mock.Call
+}
+
+// BugFrames is a helper method to define mock.On call
+func (_e *Manager_Expecter) BugFrames() *Manager_BugFrames_Call {
+	return &Manager_BugFrames_Call{Call: _e.mock.On("BugFrames")}
+}
+
+func (_c *Manager_BugFrames_Call) Run(run func()) *Manager_BugFrames_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Manager_BugFrames_Call) Return(leaks []string, races []string) *Manager_BugFrames_Call {
+	_c.Call.Return(leaks, races)
+	return _c
+}
+
+func (_c *Manager_BugFrames_Call) RunAndReturn(run func() ([]string, []string)) *Manager_BugFrames_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CoverageFilter provides a mock function with given fields: modules
 func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) ([]uint64, error) {
 	ret := _m.Called(modules)
@@ -80,6 +115,34 @@ func (_m *Manager) CoverageFilter(modules []*vminfo.KernelModule) ([]uint64, err
 	}
 
 	return r0, r1
+}
+
+// Manager_CoverageFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CoverageFilter'
+type Manager_CoverageFilter_Call struct {
+	*mock.Call
+}
+
+// CoverageFilter is a helper method to define mock.On call
+//   - modules []*vminfo.KernelModule
+func (_e *Manager_Expecter) CoverageFilter(modules interface{}) *Manager_CoverageFilter_Call {
+	return &Manager_CoverageFilter_Call{Call: _e.mock.On("CoverageFilter", modules)}
+}
+
+func (_c *Manager_CoverageFilter_Call) Run(run func(modules []*vminfo.KernelModule)) *Manager_CoverageFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]*vminfo.KernelModule))
+	})
+	return _c
+}
+
+func (_c *Manager_CoverageFilter_Call) Return(_a0 []uint64, _a1 error) *Manager_CoverageFilter_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Manager_CoverageFilter_Call) RunAndReturn(run func([]*vminfo.KernelModule) ([]uint64, error)) *Manager_CoverageFilter_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // MachineChecked provides a mock function with given fields: features, syscalls
@@ -112,6 +175,35 @@ func (_m *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.S
 	return r0, r1
 }
 
+// Manager_MachineChecked_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MachineChecked'
+type Manager_MachineChecked_Call struct {
+	*mock.Call
+}
+
+// MachineChecked is a helper method to define mock.On call
+//   - features flatrpc.Feature
+//   - syscalls map[*prog.Syscall]bool
+func (_e *Manager_Expecter) MachineChecked(features interface{}, syscalls interface{}) *Manager_MachineChecked_Call {
+	return &Manager_MachineChecked_Call{Call: _e.mock.On("MachineChecked", features, syscalls)}
+}
+
+func (_c *Manager_MachineChecked_Call) Run(run func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool)) *Manager_MachineChecked_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(flatrpc.Feature), args[1].(map[*prog.Syscall]bool))
+	})
+	return _c
+}
+
+func (_c *Manager_MachineChecked_Call) Return(_a0 queue.Source, _a1 error) *Manager_MachineChecked_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Manager_MachineChecked_Call) RunAndReturn(run func(flatrpc.Feature, map[*prog.Syscall]bool) (queue.Source, error)) *Manager_MachineChecked_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MaxSignal provides a mock function with no fields
 func (_m *Manager) MaxSignal() signal.Signal {
 	ret := _m.Called()
@@ -130,6 +222,33 @@ func (_m *Manager) MaxSignal() signal.Signal {
 	}
 
 	return r0
+}
+
+// Manager_MaxSignal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MaxSignal'
+type Manager_MaxSignal_Call struct {
+	*mock.Call
+}
+
+// MaxSignal is a helper method to define mock.On call
+func (_e *Manager_Expecter) MaxSignal() *Manager_MaxSignal_Call {
+	return &Manager_MaxSignal_Call{Call: _e.mock.On("MaxSignal")}
+}
+
+func (_c *Manager_MaxSignal_Call) Run(run func()) *Manager_MaxSignal_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Manager_MaxSignal_Call) Return(_a0 signal.Signal) *Manager_MaxSignal_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Manager_MaxSignal_Call) RunAndReturn(run func() signal.Signal) *Manager_MaxSignal_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewManager creates a new instance of Manager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -64,7 +64,6 @@ type RemoteConfig struct {
 	Debug   bool
 }
 
-//go:generate ../../tools/mockery.sh --name Manager --output ./mocks
 type Manager interface {
 	MaxSignal() signal.Signal
 	BugFrames() (leaks []string, races []string)

--- a/tools/mockery.sh
+++ b/tools/mockery.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Copyright 2022 syzkaller project authors. All rights reserved.
-# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-
-go run github.com/vektra/mockery/v2@v2.52.1 --log-level=error "$@"

--- a/vm/proxyapp/mocks/ProxyAppInterface.go
+++ b/vm/proxyapp/mocks/ProxyAppInterface.go
@@ -12,6 +12,14 @@ type ProxyAppInterface struct {
 	mock.Mock
 }
 
+type ProxyAppInterface_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *ProxyAppInterface) EXPECT() *ProxyAppInterface_Expecter {
+	return &ProxyAppInterface_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) Close(in proxyrpc.CloseParams, out *proxyrpc.CloseReply) error {
 	ret := _m.Called(in, out)
@@ -28,6 +36,35 @@ func (_m *ProxyAppInterface) Close(in proxyrpc.CloseParams, out *proxyrpc.CloseR
 	}
 
 	return r0
+}
+
+// ProxyAppInterface_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type ProxyAppInterface_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+//   - in proxyrpc.CloseParams
+//   - out *proxyrpc.CloseReply
+func (_e *ProxyAppInterface_Expecter) Close(in interface{}, out interface{}) *ProxyAppInterface_Close_Call {
+	return &ProxyAppInterface_Close_Call{Call: _e.mock.On("Close", in, out)}
+}
+
+func (_c *ProxyAppInterface_Close_Call) Run(run func(in proxyrpc.CloseParams, out *proxyrpc.CloseReply)) *ProxyAppInterface_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.CloseParams), args[1].(*proxyrpc.CloseReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_Close_Call) Return(_a0 error) *ProxyAppInterface_Close_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_Close_Call) RunAndReturn(run func(proxyrpc.CloseParams, *proxyrpc.CloseReply) error) *ProxyAppInterface_Close_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Copy provides a mock function with given fields: in, out
@@ -48,6 +85,35 @@ func (_m *ProxyAppInterface) Copy(in proxyrpc.CopyParams, out *proxyrpc.CopyResu
 	return r0
 }
 
+// ProxyAppInterface_Copy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Copy'
+type ProxyAppInterface_Copy_Call struct {
+	*mock.Call
+}
+
+// Copy is a helper method to define mock.On call
+//   - in proxyrpc.CopyParams
+//   - out *proxyrpc.CopyResult
+func (_e *ProxyAppInterface_Expecter) Copy(in interface{}, out interface{}) *ProxyAppInterface_Copy_Call {
+	return &ProxyAppInterface_Copy_Call{Call: _e.mock.On("Copy", in, out)}
+}
+
+func (_c *ProxyAppInterface_Copy_Call) Run(run func(in proxyrpc.CopyParams, out *proxyrpc.CopyResult)) *ProxyAppInterface_Copy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.CopyParams), args[1].(*proxyrpc.CopyResult))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_Copy_Call) Return(_a0 error) *ProxyAppInterface_Copy_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_Copy_Call) RunAndReturn(run func(proxyrpc.CopyParams, *proxyrpc.CopyResult) error) *ProxyAppInterface_Copy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateInstance provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) CreateInstance(in proxyrpc.CreateInstanceParams, out *proxyrpc.CreateInstanceResult) error {
 	ret := _m.Called(in, out)
@@ -64,6 +130,35 @@ func (_m *ProxyAppInterface) CreateInstance(in proxyrpc.CreateInstanceParams, ou
 	}
 
 	return r0
+}
+
+// ProxyAppInterface_CreateInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateInstance'
+type ProxyAppInterface_CreateInstance_Call struct {
+	*mock.Call
+}
+
+// CreateInstance is a helper method to define mock.On call
+//   - in proxyrpc.CreateInstanceParams
+//   - out *proxyrpc.CreateInstanceResult
+func (_e *ProxyAppInterface_Expecter) CreateInstance(in interface{}, out interface{}) *ProxyAppInterface_CreateInstance_Call {
+	return &ProxyAppInterface_CreateInstance_Call{Call: _e.mock.On("CreateInstance", in, out)}
+}
+
+func (_c *ProxyAppInterface_CreateInstance_Call) Run(run func(in proxyrpc.CreateInstanceParams, out *proxyrpc.CreateInstanceResult)) *ProxyAppInterface_CreateInstance_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.CreateInstanceParams), args[1].(*proxyrpc.CreateInstanceResult))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_CreateInstance_Call) Return(_a0 error) *ProxyAppInterface_CreateInstance_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_CreateInstance_Call) RunAndReturn(run func(proxyrpc.CreateInstanceParams, *proxyrpc.CreateInstanceResult) error) *ProxyAppInterface_CreateInstance_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CreatePool provides a mock function with given fields: in, out
@@ -84,6 +179,35 @@ func (_m *ProxyAppInterface) CreatePool(in proxyrpc.CreatePoolParams, out *proxy
 	return r0
 }
 
+// ProxyAppInterface_CreatePool_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePool'
+type ProxyAppInterface_CreatePool_Call struct {
+	*mock.Call
+}
+
+// CreatePool is a helper method to define mock.On call
+//   - in proxyrpc.CreatePoolParams
+//   - out *proxyrpc.CreatePoolResult
+func (_e *ProxyAppInterface_Expecter) CreatePool(in interface{}, out interface{}) *ProxyAppInterface_CreatePool_Call {
+	return &ProxyAppInterface_CreatePool_Call{Call: _e.mock.On("CreatePool", in, out)}
+}
+
+func (_c *ProxyAppInterface_CreatePool_Call) Run(run func(in proxyrpc.CreatePoolParams, out *proxyrpc.CreatePoolResult)) *ProxyAppInterface_CreatePool_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.CreatePoolParams), args[1].(*proxyrpc.CreatePoolResult))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_CreatePool_Call) Return(_a0 error) *ProxyAppInterface_CreatePool_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_CreatePool_Call) RunAndReturn(run func(proxyrpc.CreatePoolParams, *proxyrpc.CreatePoolResult) error) *ProxyAppInterface_CreatePool_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Diagnose provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) Diagnose(in proxyrpc.DiagnoseParams, out *proxyrpc.DiagnoseReply) error {
 	ret := _m.Called(in, out)
@@ -100,6 +224,35 @@ func (_m *ProxyAppInterface) Diagnose(in proxyrpc.DiagnoseParams, out *proxyrpc.
 	}
 
 	return r0
+}
+
+// ProxyAppInterface_Diagnose_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Diagnose'
+type ProxyAppInterface_Diagnose_Call struct {
+	*mock.Call
+}
+
+// Diagnose is a helper method to define mock.On call
+//   - in proxyrpc.DiagnoseParams
+//   - out *proxyrpc.DiagnoseReply
+func (_e *ProxyAppInterface_Expecter) Diagnose(in interface{}, out interface{}) *ProxyAppInterface_Diagnose_Call {
+	return &ProxyAppInterface_Diagnose_Call{Call: _e.mock.On("Diagnose", in, out)}
+}
+
+func (_c *ProxyAppInterface_Diagnose_Call) Run(run func(in proxyrpc.DiagnoseParams, out *proxyrpc.DiagnoseReply)) *ProxyAppInterface_Diagnose_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.DiagnoseParams), args[1].(*proxyrpc.DiagnoseReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_Diagnose_Call) Return(_a0 error) *ProxyAppInterface_Diagnose_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_Diagnose_Call) RunAndReturn(run func(proxyrpc.DiagnoseParams, *proxyrpc.DiagnoseReply) error) *ProxyAppInterface_Diagnose_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Forward provides a mock function with given fields: in, out
@@ -120,6 +273,35 @@ func (_m *ProxyAppInterface) Forward(in proxyrpc.ForwardParams, out *proxyrpc.Fo
 	return r0
 }
 
+// ProxyAppInterface_Forward_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Forward'
+type ProxyAppInterface_Forward_Call struct {
+	*mock.Call
+}
+
+// Forward is a helper method to define mock.On call
+//   - in proxyrpc.ForwardParams
+//   - out *proxyrpc.ForwardResult
+func (_e *ProxyAppInterface_Expecter) Forward(in interface{}, out interface{}) *ProxyAppInterface_Forward_Call {
+	return &ProxyAppInterface_Forward_Call{Call: _e.mock.On("Forward", in, out)}
+}
+
+func (_c *ProxyAppInterface_Forward_Call) Run(run func(in proxyrpc.ForwardParams, out *proxyrpc.ForwardResult)) *ProxyAppInterface_Forward_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.ForwardParams), args[1].(*proxyrpc.ForwardResult))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_Forward_Call) Return(_a0 error) *ProxyAppInterface_Forward_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_Forward_Call) RunAndReturn(run func(proxyrpc.ForwardParams, *proxyrpc.ForwardResult) error) *ProxyAppInterface_Forward_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PoolLogs provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) PoolLogs(in proxyrpc.PoolLogsParam, out *proxyrpc.PoolLogsReply) error {
 	ret := _m.Called(in, out)
@@ -136,6 +318,35 @@ func (_m *ProxyAppInterface) PoolLogs(in proxyrpc.PoolLogsParam, out *proxyrpc.P
 	}
 
 	return r0
+}
+
+// ProxyAppInterface_PoolLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PoolLogs'
+type ProxyAppInterface_PoolLogs_Call struct {
+	*mock.Call
+}
+
+// PoolLogs is a helper method to define mock.On call
+//   - in proxyrpc.PoolLogsParam
+//   - out *proxyrpc.PoolLogsReply
+func (_e *ProxyAppInterface_Expecter) PoolLogs(in interface{}, out interface{}) *ProxyAppInterface_PoolLogs_Call {
+	return &ProxyAppInterface_PoolLogs_Call{Call: _e.mock.On("PoolLogs", in, out)}
+}
+
+func (_c *ProxyAppInterface_PoolLogs_Call) Run(run func(in proxyrpc.PoolLogsParam, out *proxyrpc.PoolLogsReply)) *ProxyAppInterface_PoolLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.PoolLogsParam), args[1].(*proxyrpc.PoolLogsReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_PoolLogs_Call) Return(_a0 error) *ProxyAppInterface_PoolLogs_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_PoolLogs_Call) RunAndReturn(run func(proxyrpc.PoolLogsParam, *proxyrpc.PoolLogsReply) error) *ProxyAppInterface_PoolLogs_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // RunReadProgress provides a mock function with given fields: in, out
@@ -156,6 +367,35 @@ func (_m *ProxyAppInterface) RunReadProgress(in proxyrpc.RunReadProgressParams, 
 	return r0
 }
 
+// ProxyAppInterface_RunReadProgress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunReadProgress'
+type ProxyAppInterface_RunReadProgress_Call struct {
+	*mock.Call
+}
+
+// RunReadProgress is a helper method to define mock.On call
+//   - in proxyrpc.RunReadProgressParams
+//   - out *proxyrpc.RunReadProgressReply
+func (_e *ProxyAppInterface_Expecter) RunReadProgress(in interface{}, out interface{}) *ProxyAppInterface_RunReadProgress_Call {
+	return &ProxyAppInterface_RunReadProgress_Call{Call: _e.mock.On("RunReadProgress", in, out)}
+}
+
+func (_c *ProxyAppInterface_RunReadProgress_Call) Run(run func(in proxyrpc.RunReadProgressParams, out *proxyrpc.RunReadProgressReply)) *ProxyAppInterface_RunReadProgress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.RunReadProgressParams), args[1].(*proxyrpc.RunReadProgressReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunReadProgress_Call) Return(_a0 error) *ProxyAppInterface_RunReadProgress_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunReadProgress_Call) RunAndReturn(run func(proxyrpc.RunReadProgressParams, *proxyrpc.RunReadProgressReply) error) *ProxyAppInterface_RunReadProgress_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RunStart provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) RunStart(in proxyrpc.RunStartParams, out *proxyrpc.RunStartReply) error {
 	ret := _m.Called(in, out)
@@ -174,6 +414,35 @@ func (_m *ProxyAppInterface) RunStart(in proxyrpc.RunStartParams, out *proxyrpc.
 	return r0
 }
 
+// ProxyAppInterface_RunStart_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunStart'
+type ProxyAppInterface_RunStart_Call struct {
+	*mock.Call
+}
+
+// RunStart is a helper method to define mock.On call
+//   - in proxyrpc.RunStartParams
+//   - out *proxyrpc.RunStartReply
+func (_e *ProxyAppInterface_Expecter) RunStart(in interface{}, out interface{}) *ProxyAppInterface_RunStart_Call {
+	return &ProxyAppInterface_RunStart_Call{Call: _e.mock.On("RunStart", in, out)}
+}
+
+func (_c *ProxyAppInterface_RunStart_Call) Run(run func(in proxyrpc.RunStartParams, out *proxyrpc.RunStartReply)) *ProxyAppInterface_RunStart_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.RunStartParams), args[1].(*proxyrpc.RunStartReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunStart_Call) Return(_a0 error) *ProxyAppInterface_RunStart_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunStart_Call) RunAndReturn(run func(proxyrpc.RunStartParams, *proxyrpc.RunStartReply) error) *ProxyAppInterface_RunStart_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RunStop provides a mock function with given fields: in, out
 func (_m *ProxyAppInterface) RunStop(in proxyrpc.RunStopParams, out *proxyrpc.RunStopReply) error {
 	ret := _m.Called(in, out)
@@ -190,6 +459,35 @@ func (_m *ProxyAppInterface) RunStop(in proxyrpc.RunStopParams, out *proxyrpc.Ru
 	}
 
 	return r0
+}
+
+// ProxyAppInterface_RunStop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunStop'
+type ProxyAppInterface_RunStop_Call struct {
+	*mock.Call
+}
+
+// RunStop is a helper method to define mock.On call
+//   - in proxyrpc.RunStopParams
+//   - out *proxyrpc.RunStopReply
+func (_e *ProxyAppInterface_Expecter) RunStop(in interface{}, out interface{}) *ProxyAppInterface_RunStop_Call {
+	return &ProxyAppInterface_RunStop_Call{Call: _e.mock.On("RunStop", in, out)}
+}
+
+func (_c *ProxyAppInterface_RunStop_Call) Run(run func(in proxyrpc.RunStopParams, out *proxyrpc.RunStopReply)) *ProxyAppInterface_RunStop_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(proxyrpc.RunStopParams), args[1].(*proxyrpc.RunStopReply))
+	})
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunStop_Call) Return(_a0 error) *ProxyAppInterface_RunStop_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ProxyAppInterface_RunStop_Call) RunAndReturn(run func(proxyrpc.RunStopParams, *proxyrpc.RunStopReply) error) *ProxyAppInterface_RunStop_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewProxyAppInterface creates a new instance of ProxyAppInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/vm/proxyapp/mocks/subProcessCmd.go
+++ b/vm/proxyapp/mocks/subProcessCmd.go
@@ -13,6 +13,14 @@ type SubProcessCmd struct {
 	mock.Mock
 }
 
+type SubProcessCmd_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *SubProcessCmd) EXPECT() *SubProcessCmd_Expecter {
+	return &SubProcessCmd_Expecter{mock: &_m.Mock}
+}
+
 // Start provides a mock function with no fields
 func (_m *SubProcessCmd) Start() error {
 	ret := _m.Called()
@@ -29,6 +37,33 @@ func (_m *SubProcessCmd) Start() error {
 	}
 
 	return r0
+}
+
+// SubProcessCmd_Start_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Start'
+type SubProcessCmd_Start_Call struct {
+	*mock.Call
+}
+
+// Start is a helper method to define mock.On call
+func (_e *SubProcessCmd_Expecter) Start() *SubProcessCmd_Start_Call {
+	return &SubProcessCmd_Start_Call{Call: _e.mock.On("Start")}
+}
+
+func (_c *SubProcessCmd_Start_Call) Run(run func()) *SubProcessCmd_Start_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SubProcessCmd_Start_Call) Return(_a0 error) *SubProcessCmd_Start_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SubProcessCmd_Start_Call) RunAndReturn(run func() error) *SubProcessCmd_Start_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // StderrPipe provides a mock function with no fields
@@ -61,6 +96,33 @@ func (_m *SubProcessCmd) StderrPipe() (io.ReadCloser, error) {
 	return r0, r1
 }
 
+// SubProcessCmd_StderrPipe_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StderrPipe'
+type SubProcessCmd_StderrPipe_Call struct {
+	*mock.Call
+}
+
+// StderrPipe is a helper method to define mock.On call
+func (_e *SubProcessCmd_Expecter) StderrPipe() *SubProcessCmd_StderrPipe_Call {
+	return &SubProcessCmd_StderrPipe_Call{Call: _e.mock.On("StderrPipe")}
+}
+
+func (_c *SubProcessCmd_StderrPipe_Call) Run(run func()) *SubProcessCmd_StderrPipe_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SubProcessCmd_StderrPipe_Call) Return(_a0 io.ReadCloser, _a1 error) *SubProcessCmd_StderrPipe_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SubProcessCmd_StderrPipe_Call) RunAndReturn(run func() (io.ReadCloser, error)) *SubProcessCmd_StderrPipe_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StdinPipe provides a mock function with no fields
 func (_m *SubProcessCmd) StdinPipe() (io.WriteCloser, error) {
 	ret := _m.Called()
@@ -89,6 +151,33 @@ func (_m *SubProcessCmd) StdinPipe() (io.WriteCloser, error) {
 	}
 
 	return r0, r1
+}
+
+// SubProcessCmd_StdinPipe_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StdinPipe'
+type SubProcessCmd_StdinPipe_Call struct {
+	*mock.Call
+}
+
+// StdinPipe is a helper method to define mock.On call
+func (_e *SubProcessCmd_Expecter) StdinPipe() *SubProcessCmd_StdinPipe_Call {
+	return &SubProcessCmd_StdinPipe_Call{Call: _e.mock.On("StdinPipe")}
+}
+
+func (_c *SubProcessCmd_StdinPipe_Call) Run(run func()) *SubProcessCmd_StdinPipe_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SubProcessCmd_StdinPipe_Call) Return(_a0 io.WriteCloser, _a1 error) *SubProcessCmd_StdinPipe_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SubProcessCmd_StdinPipe_Call) RunAndReturn(run func() (io.WriteCloser, error)) *SubProcessCmd_StdinPipe_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // StdoutPipe provides a mock function with no fields
@@ -121,6 +210,33 @@ func (_m *SubProcessCmd) StdoutPipe() (io.ReadCloser, error) {
 	return r0, r1
 }
 
+// SubProcessCmd_StdoutPipe_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StdoutPipe'
+type SubProcessCmd_StdoutPipe_Call struct {
+	*mock.Call
+}
+
+// StdoutPipe is a helper method to define mock.On call
+func (_e *SubProcessCmd_Expecter) StdoutPipe() *SubProcessCmd_StdoutPipe_Call {
+	return &SubProcessCmd_StdoutPipe_Call{Call: _e.mock.On("StdoutPipe")}
+}
+
+func (_c *SubProcessCmd_StdoutPipe_Call) Run(run func()) *SubProcessCmd_StdoutPipe_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SubProcessCmd_StdoutPipe_Call) Return(_a0 io.ReadCloser, _a1 error) *SubProcessCmd_StdoutPipe_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SubProcessCmd_StdoutPipe_Call) RunAndReturn(run func() (io.ReadCloser, error)) *SubProcessCmd_StdoutPipe_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Wait provides a mock function with no fields
 func (_m *SubProcessCmd) Wait() error {
 	ret := _m.Called()
@@ -137,6 +253,33 @@ func (_m *SubProcessCmd) Wait() error {
 	}
 
 	return r0
+}
+
+// SubProcessCmd_Wait_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Wait'
+type SubProcessCmd_Wait_Call struct {
+	*mock.Call
+}
+
+// Wait is a helper method to define mock.On call
+func (_e *SubProcessCmd_Expecter) Wait() *SubProcessCmd_Wait_Call {
+	return &SubProcessCmd_Wait_Call{Call: _e.mock.On("Wait")}
+}
+
+func (_c *SubProcessCmd_Wait_Call) Run(run func()) *SubProcessCmd_Wait_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SubProcessCmd_Wait_Call) Return(_a0 error) *SubProcessCmd_Wait_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SubProcessCmd_Wait_Call) RunAndReturn(run func() error) *SubProcessCmd_Wait_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewSubProcessCmd creates a new instance of SubProcessCmd. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/vm/proxyapp/proxyappclient_mocks_test.go
+++ b/vm/proxyapp/proxyappclient_mocks_test.go
@@ -3,9 +3,6 @@
 
 package proxyapp
 
-//go:generate ../../tools/mockery.sh --name subProcessCmd --exported
-//go:generate ../../tools/mockery.sh --name ProxyAppInterface -r
-
 import (
 	"context"
 	"testing"


### PR DESCRIPTION
Changes
1. //go:generate is not recommended. Removed.
2. Mockery `packages` is the new default way to configure it. Added config with `packages` (see yaml file).
3. Fixes ~3 warnings.