### PR TITLE
sys/targets: add environment variable support for ARM64 triple config…

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -294,7 +294,7 @@ var List = map[string]map[string]*Target{
 		ARM64: {
 			PtrSize:          8,
 			PageSize:         4 << 10,
-			Triple:           "aarch64-linux-gnu",
+			Triple:           getEnvOrDefault("SYZ_TRIPLE_LINUX_ARM64", "aarch64-linux-gnu"),
 			KernelArch:       "arm64",
 			KernelHeaderArch: "arm64",
 		},
@@ -1119,3 +1119,10 @@ int main() { printf("Hello, World!\n"); }
 int main() { std::vector<int> v(10); }
 `
 )
+
+func getEnvOrDefault(env, defaultVal string) string {
+	if val, exists := os.LookupEnv(env); exists {
+		return val
+	}
+	return defaultVal
+}


### PR DESCRIPTION
Instead of hard code ARM64 triple, a custom toolchain (e.g. `aarch64-buildroot-linux-gnu`) would be used sometimes

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
