### PR TITLE
pkg/covermerger: skip record without target line

### DIFF
--- a/pkg/covermerger/file_line_merger.go
+++ b/pkg/covermerger/file_line_merger.go
@@ -42,6 +42,11 @@ type FileLineCoverMerger struct {
 }
 
 func (a *FileLineCoverMerger) Add(record *FileRecord) {
+	if record.StartLine < 0 {
+		// This record doesn't have information about line coverage.
+		// The best we sometimes have is the function name.
+		return
+	}
 	if a.matchers[record.RepoCommit] == nil {
 		if record.HitCount > 0 {
 			a.lostFrames[record.RepoCommit]++


### PR DESCRIPTION
```
panic: runtime error: index out of range [-1]

goroutine 1952 [running]:
github.com/google/syzkaller/pkg/covermerger.(*LineToLineMatcher).SameLinePos(...)
... 
```
It is a side effect of #5850.

Some records have only information about the function covered.
Let's skip them.
~2% of the records in BigQuery don't have information about line. (checked data for yesterday)


