### PR TITLE
dashboard/app: use more cores for coverage merging

### DIFF
--- a/dashboard/app/batch_main.go
+++ b/dashboard/app/batch_main.go
@@ -63,7 +63,7 @@ func createScriptJob(ctx context.Context, projectID, jobNamePrefix, script strin
 			PolicyTemplate: &batchpb.AllocationPolicy_InstancePolicyOrTemplate_Policy{
 				Policy: &batchpb.AllocationPolicy_InstancePolicy{
 					ProvisioningModel: batchpb.AllocationPolicy_SPOT,
-					MachineType:       "c3-standard-4",
+					MachineType:       "c3-highcpu-8",
 				},
 			},
 		}},


### PR DESCRIPTION
Coverage merging often costs more than 1 hour.
