### PR TITLE
tools: use lvvm-16 for OpenBSD bot as 13 is not available in 7.7

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -29,7 +29,7 @@ fi
 rm -fr etc && mkdir -p etc
 cat >install.site <<EOF
 #!/bin/sh
-PKGS="bash gcc%8 git gmake go llvm%13 nano wget"
+PKGS="bash gcc%8 git gmake go llvm%16 nano wget"
 PKG_PATH=${SNAPSHOTS}packages/${ARCH}/ pkg_add -I \$PKGS
 PKG_PATH= pkg_info -I \$PKGS && echo pkg_add OK
 


### PR DESCRIPTION
Tested locally:
```
quirks-7.103 signed on 2025-03-30T21:24:36Z
ldconfig: /var/run/ld.so.hints: No such file or directory
The following new rcscripts were installed: /etc/rc.d/gitdaemon
See rcctl(8) for details.
New and changed readme(s):
	/usr/local/share/doc/pkg-readmes/git
	/usr/local/share/doc/pkg-readmes/llvm-16
bash-5.2.37         GNU Bourne Again Shell
gcc-8.4.0p26        GNU compiler collection: core C compiler
git-2.49.0          distributed version control system
gmake-4.4.1         GNU make
go-1.24.1           Go programming language
llvm-16.0.6p32      modular, fast C/C++/ObjC compiler, static analyzer and tools
nano-8.3            simple editor, inspired by Pico
wget-1.25.0         retrieve files from the web via HTTP, HTTPS and FTP
pkg_add OK

CONGRATULATIONS! Your OpenBSD install has been successfully completed!
```