### PR TITLE
syz-cluster: better handle SeriesProcessor restarts

### DIFF
--- a/syz-cluster/controller/processor_test.go
+++ b/syz-cluster/controller/processor_test.go
@@ -52,7 +52,9 @@ func TestProcessor(t *testing.T) {
 
 	awaitFinishedSessions(t, processor.seriesRepo, 2)
 
-	// Restart the loop.
+	// Emulate the service restart by aborting the loop.
+	// This may break the execution in arbitrary places, which actually resembles the environment in which the code
+	// will actually work. The bugs it triggers may be difficult to reproduce though.
 	cancel()
 	wg.Wait()
 


### PR DESCRIPTION
If the Loop() was restarted in between the moment we marked the session as started in the DB and the moment we actually started the workflow, there was no way back to the normal operation.

That was the reason of the sporadic TestProcessor failures we've seen in the presubmit tests.

Handle this case in the code by just continuing the non-finished calls.

Closes #5776.
