### PR TITLE
pkg/fuzzer: remove an unnecessary clone

### DIFF
--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -166,7 +166,7 @@ func (job *triageJob) handleCall(call int, info *triageCall) {
 		return
 	}
 
-	p := job.p.Clone()
+	p := job.p
 	if job.flags&ProgMinimized == 0 {
 		p, call = job.minimize(call, info)
 		if p == nil {


### PR DESCRIPTION
The Clone() we do at the beginning of the handleCall() function is unnecessary and may even confuse the people wo read and modify the code (see #5878).

For all the jobs we start below, we anyway do another Clone() of the program. The corpus also does not assume that the programs in it will be modified elsewhere.
