### PR TITLE
syz-manager: fix panic in debug mode

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -359,7 +359,8 @@ func RunManager(mode *Mode, cfg *mgrconfig.Config) {
 	}
 	mgr.pool = vm.NewDispatcher(mgr.vmPool, mgr.fuzzerInstance)
 	mgr.http.Pool = mgr.pool
-	mgr.reproLoop = manager.NewReproLoop(mgr, mgr.vmPool.Count()-mgr.cfg.FuzzingVMs, mgr.cfg.DashboardOnlyRepro)
+	reproVMs := max(0, mgr.vmPool.Count()-mgr.cfg.FuzzingVMs)
+	mgr.reproLoop = manager.NewReproLoop(mgr, reproVMs, mgr.cfg.DashboardOnlyRepro)
 	mgr.http.ReproLoop = mgr.reproLoop
 	mgr.http.TogglePause = mgr.pool.TogglePause
 


### PR DESCRIPTION
When running in debug mode, mgr.vmPool.Count()-mgr.cfg.FuzzingVMs can become negative even for a valid config since we reduce number of VMs to 1.
NewReproLoop panics when VM count argument is negative since it passes it to make chan.
Cap number of repro VMs at 0.
