### PR TITLE
syz-manager: check that coverage is enabled in ifaceprobe mode

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -168,6 +168,9 @@ var (
 			if cfg.Sandbox != "none" {
 				return fmt.Errorf("sandbox \"%v\" is not supported (only \"none\")", cfg.Sandbox)
 			}
+			if !cfg.Cover {
+				return fmt.Errorf("coverage is required")
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
Check coverage early.
Otherwise we do machine check w/o coverage, but then it's enabled by ifaceprobe package for all programs anyway.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
