### PR TITLE
tools/syz-declextract: support attributes on types

### DIFF
--- a/tools/syz-declextract/clangtool/declextract.cpp
+++ b/tools/syz-declextract/clangtool/declextract.cpp
@@ -195,11 +195,19 @@ void Extractor::run(const MatchFinder::MatchResult& Result, MatchFunc Action) {
 
 template <typename T> const T* Extractor::getResult(StringRef ID) const { return Nodes->getNodeAs<T>(ID); }
 
+std::string TypeName(QualType QT) {
+  std::string Name = QT.getAsString();
+  auto Attr = Name.find(" __attribute__");
+  if (Attr != std::string::npos)
+    Name = Name.substr(0, Attr);
+  return Name;
+}
+
 // Top function that converts any clang type QT to our output type.
 FieldType Extractor::genType(QualType QT, const std::string& BackupName) {
   const Type* T = QT.IgnoreParens().getUnqualifiedType().getDesugaredType(*Context).getTypePtr();
   if (auto* Typ = llvm::dyn_cast<BuiltinType>(T)) {
-    return IntType{.ByteSize = sizeofType(T), .Name = QT.getAsString(), .Base = QualType(T, 0).getAsString()};
+    return IntType{.ByteSize = sizeofType(T), .Name = TypeName(QT), .Base = QualType(T, 0).getAsString()};
   }
   if (auto* Typ = llvm::dyn_cast<EnumType>(T)) {
     return IntType{.ByteSize = sizeofType(T), .Enum = extractEnum(Typ->getDecl())};

--- a/tools/syz-declextract/testdata/include/types.h
+++ b/tools/syz-declextract/testdata/include/types.h
@@ -10,6 +10,8 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 typedef unsigned long long u64;
 
+#define __user __attribute__((btf_type_tag("user")))
+
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
 
 static inline u32 atomic_load32(u32* p) {

--- a/tools/syz-declextract/testdata/types.c
+++ b/tools/syz-declextract/testdata/types.c
@@ -2,6 +2,7 @@
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 #include "include/syscall.h"
+#include "include/types.h"
 
 typedef struct { float f; } anon_t;
 struct empty_struct {};
@@ -42,7 +43,7 @@ struct packed_t {
 struct various {
 	struct various* recursive;
 	struct recursive* next;
-	struct packed_t packed;	
+	struct packed_t packed;
 };
 
 struct recursive {
@@ -50,7 +51,8 @@ struct recursive {
 };
 
 SYSCALL_DEFINE1(types_syscall, struct anon_struct* p, struct empty_struct* y,
-	struct bitfields* b, int pid, fd_t f, struct various* v) {
+	struct bitfields* b, int pid, fd_t f, struct various __user* v,
+	int __user* pi, u32 __user* pu) {
 	return 0;
 }
 

--- a/tools/syz-declextract/testdata/types.c.json
+++ b/tools/syz-declextract/testdata/types.c.json
@@ -37,7 +37,7 @@
 							},
 							"dst": {
 								"field": {
-									"struct": "11253655576479126316",
+									"struct": "11253655576479126317",
 									"field": "x"
 								}
 							}
@@ -51,7 +51,7 @@
 							},
 							"dst": {
 								"field": {
-									"struct": "11253655576479126318",
+									"struct": "11253655576479126319",
 									"field": "y"
 								}
 							}
@@ -65,7 +65,7 @@
 							},
 							"dst": {
 								"field": {
-									"struct": "11253655576479126319",
+									"struct": "11253655576479126320",
 									"field": "w"
 								}
 							}
@@ -79,22 +79,8 @@
 							},
 							"dst": {
 								"field": {
-									"struct": "11253655576479126309",
+									"struct": "11253655576479126310",
 									"field": "f"
-								}
-							}
-						},
-						{
-							"src": {
-								"argument": {
-									"func": "anon_flow",
-									"arg": 0
-								}
-							},
-							"dst": {
-								"field": {
-									"struct": "11253655576479126322",
-									"field": "a"
 								}
 							}
 						},
@@ -122,11 +108,46 @@
 							"dst": {
 								"field": {
 									"struct": "11253655576479126324",
+									"field": "a"
+								}
+							}
+						},
+						{
+							"src": {
+								"argument": {
+									"func": "anon_flow",
+									"arg": 0
+								}
+							},
+							"dst": {
+								"field": {
+									"struct": "11253655576479126325",
 									"field": "b"
 								}
 							}
 						}
 					]
+				}
+			]
+		},
+		{
+			"name": "atomic_load32",
+			"file": "include/types.h",
+			"is_static": true,
+			"scopes": [
+				{
+					"arg": -1,
+					"loc": 1
+				}
+			]
+		},
+		{
+			"name": "atomic_load64",
+			"file": "include/types.h",
+			"scopes": [
+				{
+					"arg": -1,
+					"loc": 1
 				}
 			]
 		}
@@ -938,6 +959,36 @@
 						"ptr": {
 							"elem": {
 								"struct": "various"
+							}
+						}
+					}
+				},
+				{
+					"name": "pi",
+					"counted_by": -1,
+					"type": {
+						"ptr": {
+							"elem": {
+								"int": {
+									"byte_size": 4,
+									"name": "int",
+									"base": "int"
+								}
+							}
+						}
+					}
+				},
+				{
+					"name": "pu",
+					"counted_by": -1,
+					"type": {
+						"ptr": {
+							"elem": {
+								"int": {
+									"byte_size": 4,
+									"name": "u32",
+									"base": "unsigned int"
+								}
 							}
 						}
 					}

--- a/tools/syz-declextract/testdata/types.c.txt
+++ b/tools/syz-declextract/testdata/types.c.txt
@@ -11,7 +11,7 @@ type auto_aligner[N] {
 bitfield_enum$auto = a, b, c
 
 align_syscall$auto(a1 ptr[inout, align1$auto], a2 ptr[inout, align2$auto], a3 ptr[inout, align3$auto], a4 ptr[inout, align4$auto])
-types_syscall$auto(p ptr[inout, anon_struct$auto], y ptr[inout, auto_aligner[1]], b ptr[inout, bitfields$auto], pid pid, f int32, v ptr[inout, various$auto])
+types_syscall$auto(p ptr[inout, anon_struct$auto], y ptr[inout, auto_aligner[1]], b ptr[inout, bitfields$auto], pid pid, f int32, v ptr[inout, various$auto], pi ptr[inout, int32], pu ptr[inout, int32])
 
 align1$auto {
 	f1	int8


### PR DESCRIPTION
Remove __attribute__ on types.
Some kernels now use it on some syscall args as shown in the test.
The __attribute__ may contain quotes and break json.
