### PR TITLE
ci.yml: use self hosted x86 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
           .github/workflows/run.sh make presubmit_aux
 
   build:
-    runs-on: ubuntu-24.04-8core
-    container: gcr.io/syzkaller/env:latest
+    runs-on: syz-env-x86
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
@@ -80,8 +79,7 @@ jobs:
           verbose: true
 
   dashboard:
-    runs-on: ubuntu-24.04-8core
-    container: gcr.io/syzkaller/env:latest
+    runs-on: syz-env-x86
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
@@ -136,9 +134,8 @@ jobs:
           .github/workflows/run.sh make ${{ matrix.target }}
 
   race:
-    runs-on: ubuntu-24.04-8core
+    runs-on: syz-env-x86
     timeout-minutes: 15 # Q1 2024 experiments may affect timeout, let's relax it
-    container: gcr.io/syzkaller/env:latest
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
@@ -162,8 +159,7 @@ jobs:
           .github/workflows/run.sh make presubmit_race
 
   race_dashboard:
-    runs-on: ubuntu-24.04-8core
-    container: gcr.io/syzkaller/env:latest
+    runs-on: syz-env-x86
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true


### PR DESCRIPTION
Every workflow job is executed on the fresh GCE instance.
4 machines are used to check every PR.

Every PR starts its own machines. 5 parallel tests means 20 machines.
The autoscaling was perfect during testing.

We need 1 minute to get the machines and 1 minute to run syz-env docker.
Every job real execution time is what you see on Github + 2 minutes.