### PR TITLE
dashboard/app: install opsagent to batch processors

### DIFF
--- a/dashboard/app/batch_main.go
+++ b/dashboard/app/batch_main.go
@@ -66,6 +66,7 @@ func createScriptJob(ctx context.Context, projectID, jobNamePrefix, script strin
 					MachineType:       "c3-highcpu-8",
 				},
 			},
+			InstallOpsAgent: true,
 		}},
 		ServiceAccount: sa,
 	}


### PR DESCRIPTION
Quarter long aggregations are killed.
OpsAgent may help to understand why.
