### PR TITLE
tools/syz-declextract/clangtool: fix getBitWidthValue for LLVM>=21

### DIFF
--- a/tools/syz-declextract/clangtool/declextract.cpp
+++ b/tools/syz-declextract/clangtool/declextract.cpp
@@ -281,13 +281,7 @@ FieldType Extractor::extractRecord(QualType QT, const RecordType* Typ, const std
       IsAnonymous = true;
     }
     FieldType FieldType = genType(F->getType(), BackupFieldName);
-    int BitWidth = F->isBitField()
-#if LLVM_VERSION_MAJOR >= 21
-	    ? F->getBitWidthValue()
-#else
-	    ? F->getBitWidthValue(*Context)
-#endif
-	    : 0;
+    int BitWidth = F->isBitField() ? F->getBitWidthValue() : 0;
     int CountedBy = F->getType()->isCountAttributedType()
                         ? llvm::dyn_cast<FieldDecl>(
                               F->getType()->getAs<CountAttributedType>()->getCountExpr()->getReferencedDeclOfCallee())

--- a/tools/syz-declextract/clangtool/declextract.cpp
+++ b/tools/syz-declextract/clangtool/declextract.cpp
@@ -281,7 +281,13 @@ FieldType Extractor::extractRecord(QualType QT, const RecordType* Typ, const std
       IsAnonymous = true;
     }
     FieldType FieldType = genType(F->getType(), BackupFieldName);
-    int BitWidth = F->isBitField() ? F->getBitWidthValue(*Context) : 0;
+    int BitWidth = F->isBitField()
+#if LLVM_VERSION_MAJOR >= 21
+	    ? F->getBitWidthValue()
+#else
+	    ? F->getBitWidthValue(*Context)
+#endif
+	    : 0;
     int CountedBy = F->getType()->isCountAttributedType()
                         ? llvm::dyn_cast<FieldDecl>(
                               F->getType()->getAs<CountAttributedType>()->getCountExpr()->getReferencedDeclOfCallee())


### PR DESCRIPTION
The signature oif `getBitWidthValue` changed in https://github.com/llvm/llvm-project/commit/81fc3add1e627c23b7270fe2739cdacc09063e54