### PR TITLE
sys/linux: fix error defined attributes

### DIFF
--- a/sys/linux/dev_nbd.txt
+++ b/sys/linux/dev_nbd.txt
@@ -42,7 +42,7 @@ nbd_attr_policy [
 	NBD_ATTR_TIMEOUT		nlattr[NBD_ATTR_TIMEOUT, int64]
 	NBD_ATTR_SERVER_FLAGS		nlattr[NBD_ATTR_SERVER_FLAGS, flags[nbd_server_flags, int64]]
 	NBD_ATTR_CLIENT_FLAGS		nlattr[NBD_ATTR_CLIENT_FLAGS, flags[nbd_client_flags, int64]]
-	NBD_ATTR_SOCKETS		nlnest[NBD_ATTR_SOCKETS, array[nlattr[NBD_SOCK_FD, sock_nbd_client]]]
+	NBD_ATTR_SOCKETS		nlnest[NBD_ATTR_SOCKETS, array[nlnest[NBD_SOCK_ITEM, nlattr[NBD_SOCK_FD, sock_nbd_client]]]]
 	NBD_ATTR_DEAD_CONN_TIMEOUT	nlattr[NBD_ATTR_DEAD_CONN_TIMEOUT, int64]
 	NBD_ATTR_BACKEND_IDENTIFIER	nlattr[NBD_ATTR_BACKEND_IDENTIFIER, stringnoz]
 ] [varlen]

--- a/sys/linux/dev_nbd.txt.const
+++ b/sys/linux/dev_nbd.txt.const
@@ -35,6 +35,7 @@ NBD_SET_SIZE_BLOCKS = 43783, mips64le:ppc64le:536914695
 NBD_SET_SOCK = 43776, mips64le:ppc64le:536914688
 NBD_SET_TIMEOUT = 43785, mips64le:ppc64le:536914697
 NBD_SOCK_FD = 1
+NBD_SOCK_ITEM = 1
 SOCK_STREAM = 1, mips64le:2
 __NR_ioctl = 54, amd64:16, arm64:riscv64:29, mips64le:5015
 __NR_sendmsg = 211, 386:s390x:370, amd64:46, arm:296, mips64le:5045, ppc64le:341

--- a/sys/linux/socket_netlink_generic_80211.txt
+++ b/sys/linux/socket_netlink_generic_80211.txt
@@ -73,7 +73,7 @@ sendmsg$NL80211_CMD_DISCONNECT(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wd
 sendmsg$NL80211_CMD_UNEXPECTED_FRAME(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_UNEXPECTED_FRAME, void]], f flags[send_flags])
 sendmsg$NL80211_CMD_NOTIFY_RADAR(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_NOTIFY_RADAR, nl80211_policy$chandef_params]], f flags[send_flags])
 sendmsg$NL80211_CMD_RADAR_DETECT(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_RADAR_DETECT, nl80211_policy$chandef_params]], f flags[send_flags])
-sendmsg$NL80211_CMD_PEER_MEASUREMENT_START(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_PEER_MEASUREMENT_START, nl80211_pmsr_attr_policy]], f flags[send_flags])
+sendmsg$NL80211_CMD_PEER_MEASUREMENT_START(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_PEER_MEASUREMENT_START, nl80211_policy$pmsr_measurement]], f flags[send_flags])
 sendmsg$NL80211_CMD_UPDATE_OWE_INFO(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_UPDATE_OWE_INFO, nl80211_policy$upd_owe_info]], f flags[send_flags])
 sendmsg$NL80211_CMD_GET_SURVEY(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_wdev[NL80211_CMD_GET_SURVEY, void]], f flags[send_flags])
 sendmsg$NL80211_CMD_GET_COALESCE(fd sock_nl_generic, msg ptr[in, msghdr_nl80211_rdev[NL80211_CMD_GET_COALESCE, void]], f flags[send_flags])
@@ -542,7 +542,7 @@ nl80211_policy$scan [
 	NL80211_ATTR_BSSID				nlattr[NL80211_ATTR_BSSID, ieee80211_bssid]
 	NL80211_ATTR_SCHED_SCAN_RSSI_ADJUST		nlattr[NL80211_ATTR_SCHED_SCAN_RSSI_ADJUST, nl80211_bss_select_rssi_adjust]
 	NL80211_ATTR_SCAN_SUPP_RATES			nlnest[NL80211_ATTR_SCAN_SUPP_RATES, array[nl80211_rates_policy]]
-	NL80211_ATTR_SCHED_SCAN_MATCH			nlnest[NL80211_ATTR_SCHED_SCAN_MATCH, array[nl80211_match_policy]]
+	NL80211_ATTR_SCHED_SCAN_MATCH			nlnest[NL80211_ATTR_SCHED_SCAN_MATCH, array[nlnest[0, array[nl80211_match_policy]]]]
 	NL80211_ATTR_SCAN_FLAGS				nlattr[NL80211_ATTR_SCAN_FLAGS, flags[nl80211_scan_flags, int32]]
 ] [varlen]
 
@@ -650,7 +650,7 @@ nl80211_policy$connect [
 	NL80211_ATTR_VHT_CAPABILITY_MASK	nlattr[NL80211_ATTR_VHT_CAPABILITY_MASK, ieee80211_vht_cap]
 	NL80211_ATTR_USE_RRM			nlattr[NL80211_ATTR_USE_RRM, void]
 	NL80211_ATTR_PBSS			nlattr[NL80211_ATTR_PBSS, void]
-	NL80211_ATTR_BSS_SELECT			nlnest[NL80211_ATTR_BSS_SELECT, array[nl80211_bss_select_policy]]
+	NL80211_ATTR_BSS_SELECT			nlnest[NL80211_ATTR_BSS_SELECT, nlattr[0, array[nl80211_bss_select_policy]]]
 	NL80211_ATTR_EXTERNAL_AUTH_SUPPORT	nlattr[NL80211_ATTR_EXTERNAL_AUTH_SUPPORT, void]
 	NL80211_ATTR_SOCKET_OWNER		nlattr[NL80211_ATTR_SOCKET_OWNER, void]
 ] [varlen]
@@ -691,9 +691,13 @@ nl80211_pmsr_peer_attr_policy [
 	NL80211_PMSR_PEER_ATTR_REQ	nlnest[NL80211_PMSR_PEER_ATTR_REQ, array[nl80211_pmsr_req_attr_policy]]
 ] [varlen]
 
-nl80211_pmsr_attr_policy [
-	NL80211_PMSR_ATTR_PEERS	nlnest[NL80211_PMSR_ATTR_PEERS, array[nlnest[0, array[nl80211_pmsr_peer_attr_policy]]]]
+nl80211_policy$pmsr_measurement [
+	NL80211_ATTR_MAC		nlattr[NL80211_ATTR_MAC, ieee80211_mac_addr]
+	NL80211_ATTR_TIMEOUT		nlattr[NL80211_ATTR_TIMEOUT, int32]
+	NL80211_ATTR_PEER_MEASUREMENTS	nlnest[NL80211_ATTR_PEER_MEASUREMENTS, nl80211_pmsr_attr]
 ] [varlen]
+
+type nl80211_pmsr_attr nlnest[NL80211_PMSR_ATTR_PEERS, array[nlnest[0, array[nl80211_pmsr_peer_attr_policy]]]]
 
 nl80211_policy$upd_owe_info [
 	NL80211_ATTR_MAC		nlattr[NL80211_ATTR_MAC, ieee80211_mac_addr]


### PR DESCRIPTION
Definitions for attribute `NBD_ATTR_SOCKETS`, `NL80211_ATTR_BSS_SELECT`, `NL80211_ATTR_PEER_MEASUREMENTS`, and `NL80211_ATTR_SCHED_SCAN_MATCH` have some errors.

For example, the current definition of `NBD_ATTR_SOCKETS` is like

```c
NBD_ATTR_SOCKETS  nlnest[NBD_ATTR_SOCKETS, array[nlattr[NBD_SOCK_FD, sock_nbd_client]]]
```

However, according to the actual parsing code:

```c
nla_for_each_nested(attr, info->attrs[NBD_ATTR_SOCKETS],
		    rem) {
	struct nlattr *socks[NBD_SOCK_MAX+1];

	if (nla_type(attr) != NBD_SOCK_ITEM) {
		pr_err("socks must be embedded in a SOCK_ITEM attr\n");
		ret = -EINVAL;
		goto out;
	}
	ret = nla_parse_nested_deprecated(socks, NBD_SOCK_MAX,
					  attr,
					  nbd_sock_policy,
					  info->extack);
```

The attribute `NBD_ATTR_SOCKETS` actually encloses stream of `NBD_SOCK_ITEM`
attribute first, then to the nested `nbd_sock_policy` attribute.

Fix them carefully, Check related parse functions: nbd_genl_reconfigure, parse_bss_select, nl80211_pmsr_start, and nl80211_parse_sched_scan for details.