### PR TITLE
syz-cluster: improve series triage

### DIFF
--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -57,6 +57,7 @@ var staticFs embed.FS
 func (h *dashboardHandler) Mux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sessions/{id}/log", errToStatus(h.sessionLog))
+	mux.HandleFunc("/sessions/{id}/triage_log", errToStatus(h.sessionTriageLog))
 	mux.HandleFunc("/sessions/{id}/test_logs", errToStatus(h.sessionTestLog))
 	mux.HandleFunc("/series/{id}", errToStatus(h.seriesInfo))
 	mux.HandleFunc("/patches/{id}", errToStatus(h.patchContent))
@@ -219,6 +220,17 @@ func (h *dashboardHandler) sessionLog(w http.ResponseWriter, r *http.Request) er
 		return fmt.Errorf("%w: session", errNotFound)
 	}
 	return h.streamBlob(w, session.LogURI)
+}
+
+// nolint:dupl
+func (h *dashboardHandler) sessionTriageLog(w http.ResponseWriter, r *http.Request) error {
+	session, err := h.sessionRepo.GetByID(r.Context(), r.PathValue("id"))
+	if err != nil {
+		return err
+	} else if session == nil {
+		return fmt.Errorf("%w: session", errNotFound)
+	}
+	return h.streamBlob(w, session.TriageLogURI)
 }
 
 // nolint:dupl

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -99,7 +99,12 @@
                 {{if not .SkipReason.IsNull}}
                 <tr>
                     <th>Skipped</th>
-                    <td>{{.SkipReason.StringVal}}</td>
+                    <td>
+                        {{.SkipReason.StringVal}}
+                        {{if .TriageLogURI}}
+                            <a href="/sessions/{{.ID}}/triage_log">[Log]</a>
+                        {{end}}
+                    </td>
                 </tr>
                 {{end}}
                 {{if .LogURI}}

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -13,7 +13,8 @@ type TriageResult struct {
 }
 
 type SkipRequest struct {
-	Reason string `json:"reason"`
+	Reason    string `json:"reason"`
+	TriageLog []byte `json:"log"`
 }
 
 // The data layout faclitates the simplicity of the workflow definition.

--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -60,14 +60,15 @@ const (
 )
 
 type Session struct {
-	ID         string             `spanner:"ID"`
-	SeriesID   string             `spanner:"SeriesID"`
-	CreatedAt  time.Time          `spanner:"CreatedAt"`
-	StartedAt  spanner.NullTime   `spanner:"StartedAt"`
-	FinishedAt spanner.NullTime   `spanner:"FinishedAt"`
-	SkipReason spanner.NullString `spanner:"SkipReason"`
-	LogURI     string             `spanner:"LogURI"`
-	Tags       []string           `spanner:"Tags"`
+	ID           string             `spanner:"ID"`
+	SeriesID     string             `spanner:"SeriesID"`
+	CreatedAt    time.Time          `spanner:"CreatedAt"`
+	StartedAt    spanner.NullTime   `spanner:"StartedAt"`
+	FinishedAt   spanner.NullTime   `spanner:"FinishedAt"`
+	SkipReason   spanner.NullString `spanner:"SkipReason"`
+	LogURI       string             `spanner:"LogURI"`
+	TriageLogURI string             `spanner:"TriageLogURI"`
+	Tags         []string           `spanner:"Tags"`
 	// TODO: to accept more specific fuzzing assignment,
 	// add Triager, BaseRepo, BaseCommit, Config fields.
 }

--- a/syz-cluster/pkg/db/migrations/1_initialize.up.sql
+++ b/syz-cluster/pkg/db/migrations/1_initialize.up.sql
@@ -56,6 +56,7 @@ CREATE TABLE Sessions (
     FinishedAt TIMESTAMP,
     SkipReason STRING(1024),
     LogURI STRING(512) NOT NULL,
+    TriageLogURI STRING(512) NOT NULL,
     Tags ARRAY<STRING(256)>,
     CONSTRAINT FK_SeriesSessions FOREIGN KEY (SeriesID) REFERENCES Series (ID),
 ) PRIMARY KEY(ID);

--- a/syz-cluster/pkg/triage/tree.go
+++ b/syz-cluster/pkg/triage/tree.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 )
 
-// TODO: add tests.
 func SelectTree(series *api.Series, trees []*api.Tree) *api.Tree {
 	seriesCc := map[string]bool{}
 	for _, cc := range series.Cc {

--- a/syz-cluster/workflow/triage-step/main.go
+++ b/syz-cluster/workflow/triage-step/main.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
@@ -65,7 +67,7 @@ func getVerdict(ctx context.Context, client *api.Client, ops triage.TreeOps) (*a
 	if tree == nil {
 		return &api.TriageResult{
 			Skip: &api.SkipRequest{
-				Reason: "no suitable kernel tree found",
+				Reason: "no suitable base kernel tree found",
 			},
 		}, nil
 	}
@@ -80,22 +82,24 @@ func getVerdict(ctx context.Context, client *api.Client, ops triage.TreeOps) (*a
 		// TODO: the workflow step must be retried.
 		return nil, fmt.Errorf("failed to query the last build: %w", err)
 	}
-	selector := triage.NewCommitSelector(ops)
-	commit, err := selector.Select(series, tree, lastBuild)
+	selector := triage.NewCommitSelector(ops, &debugtracer.GenericTracer{
+		TraceWriter: os.Stderr,
+	})
+	result, err := selector.Select(series, tree, lastBuild)
 	if err != nil {
 		// TODO: the workflow step must be retried.
 		return nil, fmt.Errorf("failed to run the commit selector: %w", err)
-	} else if commit == "" {
+	} else if result.Commit == "" {
 		return &api.TriageResult{
 			Skip: &api.SkipRequest{
-				Reason: "no suitable commits found",
+				Reason: "failed to find the base commit: " + result.Reason,
 			},
 		}, nil
 	}
 	base := api.BuildRequest{
 		TreeName:   tree.Name,
 		ConfigName: tree.KernelConfig,
-		CommitHash: commit,
+		CommitHash: result.Commit,
 		Arch:       arch,
 	}
 	ret := &api.TriageResult{


### PR DESCRIPTION
* Be more explicit about the exact reason for skipping a series.
* Ignore the series that do not modify any `.h` or `.c` files.