### PR TITLE
dashboard/app: export info about uncovered blocks as well

### DIFF
--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -264,7 +264,7 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 			{
 				FilePath: "/file",
 				FuncName: "func_name",
-				Lines:    []int64{1, 2, 3},
+				Lines:    []int64{1, 2, 3, 4},
 			},
 		},
 		[]*coveragedb.FileCoverageWithLineInfo{
@@ -273,8 +273,8 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 					Filepath: "/file",
 					Commit:   "test-commit",
 				},
-				LinesInstrumented: []int64{1, 2, 3},
-				HitCounts:         []int64{10, 20, 30},
+				LinesInstrumented: []int64{1, 2, 3, 4},
+				HitCounts:         []int64{10, 20, 30, 0},
 			},
 		},
 	))
@@ -289,24 +289,32 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 	"functions": [
 		{
 			"func_name": "func_name",
-			"total_blocks": 3,
-			"covered_blocks": [
+			"blocks": [
 				{
+					"hit_count": 10,
 					"from_line": 1,
 					"from_column": 0,
 					"to_line": 1,
 					"to_column": -1
 				},
 				{
+					"hit_count": 20,
 					"from_line": 2,
 					"from_column": 0,
 					"to_line": 2,
 					"to_column": -1
 				},
 				{
+					"hit_count": 30,
 					"from_line": 3,
 					"from_column": 0,
 					"to_line": 3,
+					"to_column": -1
+				},
+				{
+					"from_line": 4,
+					"from_column": 0,
+					"to_line": 4,
 					"to_column": -1
 				}
 			]

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -264,19 +264,19 @@ type ProgramCoverage struct {
 }
 
 type FileCoverage struct {
-	Repo      string              `json:"repo,omitempty"`
-	Commit    string              `json:"commit,omitempty"`
-	FilePath  string              `json:"file_path"`
-	Functions []*FunctionCoverage `json:"functions"`
+	Repo      string          `json:"repo,omitempty"`
+	Commit    string          `json:"commit,omitempty"`
+	FilePath  string          `json:"file_path"`
+	Functions []*FuncCoverage `json:"functions"`
 }
 
-type FunctionCoverage struct {
-	FuncName     string          `json:"func_name"`
-	Instrumented int             `json:"total_blocks,omitempty"`
-	Blocks       []*CoveredBlock `json:"covered_blocks"`
+type FuncCoverage struct {
+	FuncName string   `json:"func_name"`
+	Blocks   []*Block `json:"blocks"`
 }
 
-type CoveredBlock struct {
+type Block struct {
+	HitCount int `json:"hit_count,omitempty"`
 	FromLine int `json:"from_line"`
 	FromCol  int `json:"from_column"`
 	ToLine   int `json:"to_line"`
@@ -312,22 +312,23 @@ func (rg *ReportGenerator) DoCoverPrograms(w io.Writer, params HandlerParams) er
 
 		var progCoverage []*FileCoverage
 		for filePath, functions := range fileFuncFrames {
-			var expFuncs []*FunctionCoverage
+			var expFuncs []*FuncCoverage
 			for funcName, frames := range functions {
-				var expCoveredBlocks []*CoveredBlock
+				var expCoveredBlocks []*Block
 				for _, frame := range frames {
 					endCol := frame.EndCol
 					if endCol == backend.LineEnd {
 						endCol = -1
 					}
-					expCoveredBlocks = append(expCoveredBlocks, &CoveredBlock{
+					expCoveredBlocks = append(expCoveredBlocks, &Block{
+						HitCount: 1,
 						FromCol:  frame.StartCol,
 						FromLine: frame.StartLine,
 						ToCol:    endCol,
 						ToLine:   frame.EndLine,
 					})
 				}
-				expFuncs = append(expFuncs, &FunctionCoverage{
+				expFuncs = append(expFuncs, &FuncCoverage{
 					FuncName: funcName,
 					Blocks:   expCoveredBlocks,
 				})

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -256,17 +256,11 @@ func (rg *ReportGenerator) DoCoverJSONL(w io.Writer, params HandlerParams) error
 	return nil
 }
 
-type CoveredBlock struct {
-	FromLine int `json:"from_line"`
-	FromCol  int `json:"from_column"`
-	ToLine   int `json:"to_line"`
-	ToCol    int `json:"to_column"`
-}
-
-type FunctionCoverage struct {
-	FuncName     string          `json:"func_name"`
-	Instrumented int             `json:"total_blocks,omitempty"`
-	Blocks       []*CoveredBlock `json:"covered_blocks"`
+type ProgramCoverage struct {
+	Repo         string          `json:"repo,omitempty"`
+	Commit       string          `json:"commit,omitempty"`
+	Program      string          `json:"program"`
+	CoveredFiles []*FileCoverage `json:"coverage"`
 }
 
 type FileCoverage struct {
@@ -276,11 +270,17 @@ type FileCoverage struct {
 	Functions []*FunctionCoverage `json:"functions"`
 }
 
-type ProgramCoverage struct {
-	Repo         string          `json:"repo,omitempty"`
-	Commit       string          `json:"commit,omitempty"`
-	Program      string          `json:"program"`
-	CoveredFiles []*FileCoverage `json:"coverage"`
+type FunctionCoverage struct {
+	FuncName     string          `json:"func_name"`
+	Instrumented int             `json:"total_blocks,omitempty"`
+	Blocks       []*CoveredBlock `json:"covered_blocks"`
+}
+
+type CoveredBlock struct {
+	FromLine int `json:"from_line"`
+	FromCol  int `json:"from_column"`
+	ToLine   int `json:"to_line"`
+	ToCol    int `json:"to_column"`
 }
 
 // DoCoverPrograms returns the corpus programs with the associated coverage.

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -424,7 +424,6 @@ func checkCSVReport(t *testing.T, CSVReport []byte) {
 	}
 }
 
-// nolint:lll
 func checkJSONLReport(t *testing.T, gotBytes, wantBytes []byte) {
 	compacted := new(bytes.Buffer)
 	if err := json.Compact(compacted, wantBytes); err != nil {
@@ -446,8 +445,9 @@ var sampleJSONLlProgs = []byte(`{
 			"functions": [
 				{
 					"func_name": "main",
-					"covered_blocks": [
+					"blocks": [
 						{
+							"hit_count": 1,
 							"from_line": 1,
 							"from_column": 0,
 							"to_line": 1,


### PR DESCRIPTION
 - pkg/cover: reorder types for natural reading order
 - dashboard/app: export info about uncovered blocks as well
