### PR TITLE
syz-cluster: share .tar.gz of diff fuzzing artifacts

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -37,8 +37,9 @@ import (
 )
 
 type DiffFuzzerConfig struct {
-	Debug       bool
-	PatchedOnly chan *UniqueBug
+	Debug        bool
+	PatchedOnly  chan *UniqueBug
+	ArtifactsDir string // Where to store the artifacts that supplement the logs.
 }
 
 type UniqueBug struct {
@@ -73,7 +74,7 @@ func RunDiffFuzzer(ctx context.Context, baseCfg, newCfg *mgrconfig.Config, cfg D
 	base.source = stream
 	new.duplicateInto = stream
 
-	store := &DiffFuzzerStore{BasePath: new.cfg.Workdir}
+	store := &DiffFuzzerStore{BasePath: cfg.ArtifactsDir}
 	diffCtx := &diffContext{
 		doneRepro:     make(chan *ReproResult),
 		base:          base,

--- a/pkg/osutil/tar.go
+++ b/pkg/osutil/tar.go
@@ -1,0 +1,67 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package osutil
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func TarGzDirectory(dir string, writer io.Writer) error {
+	gzw := gzip.NewWriter(writer)
+	defer gzw.Close()
+	return tarDirectory(dir, gzw)
+}
+
+func tarDirectory(dir string, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || path == dir {
+			return err
+		}
+		typ := d.Type()
+		if !typ.IsDir() && !typ.IsRegular() {
+			// Only folders and regular files.
+			return nil
+		}
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.ToSlash(relPath)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = relPath
+		if typ.IsDir() && !strings.HasSuffix(header.Name, "/") {
+			header.Name += "/"
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if typ.IsDir() {
+			return nil
+		}
+		// Write the file content.
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, f)
+		f.Close()
+		return err
+	})
+}

--- a/pkg/osutil/tar_test.go
+++ b/pkg/osutil/tar_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package osutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTarDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	items := map[string]string{
+		"file1.txt":     "first file content",
+		"dir/file2.txt": "second file content",
+		"empty.txt":     "",
+	}
+
+	for path, content := range items {
+		fullPath := filepath.Join(dir, path)
+		dirPath := filepath.Dir(fullPath)
+		if err := MkdirAll(dirPath); err != nil {
+			t.Fatalf("mkdir %q failed: %v", dirPath, err)
+		}
+		if err := WriteFile(fullPath, []byte(content)); err != nil {
+			t.Fatalf("write file failed: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	err := tarDirectory(dir, &buf)
+	assert.NoError(t, err)
+
+	tr := tar.NewReader(&buf)
+	found := make(map[string]string)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			contentBytes, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found[hdr.Name] = string(contentBytes)
+		}
+	}
+
+	assert.Equal(t, items, found)
+}

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -130,6 +130,9 @@
                         {{if .LogURI}}
                             <a href="/sessions/{{.SessionID}}/test_logs?name={{.TestName}}" class="modal-link-raw">[Log]</a>
                         {{end}}
+                        {{if .ArtifactsArchiveURI}}
+                            <a href="/sessions/{{.SessionID}}/test_artifacts?name={{.TestName}}">[Artifacts]</a>
+                        {{end}}
                     </th>
                 </tr>
                 {{if .Findings}}

--- a/syz-cluster/pkg/api/client.go
+++ b/syz-cluster/pkg/api/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -72,6 +73,16 @@ func (client Client) UploadBuild(ctx context.Context, req *UploadBuildReq) (*Upl
 
 func (client Client) UploadTestResult(ctx context.Context, req *TestResult) error {
 	_, err := postJSON[TestResult, any](ctx, client.baseURL+"/tests/upload", req)
+	return err
+}
+
+func (client Client) UploadTestArtifacts(ctx context.Context, sessionID, testName string,
+	tarGzContent io.Reader) error {
+	v := url.Values{}
+	v.Add("session", sessionID)
+	v.Add("test", testName)
+	url := client.baseURL + "/tests/upload_artifacts?" + v.Encode()
+	_, err := postMultiPartFile[any](ctx, url, tarGzContent)
 	return err
 }
 

--- a/syz-cluster/pkg/controller/api_test.go
+++ b/syz-cluster/pkg/controller/api_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -78,6 +79,24 @@ func TestAPISaveFinding(t *testing.T) {
 		err = client.UploadFinding(ctx, finding)
 		assert.NoError(t, err)
 	})
+}
+
+func TestAPIUploadTestArtifacts(t *testing.T) {
+	env, ctx := app.TestEnvironment(t)
+	client := TestServer(t, env)
+
+	_, sessionID := UploadTestSeries(t, ctx, client, testSeries)
+	buildResp := UploadTestBuild(t, ctx, client, testBuild)
+	err := client.UploadTestResult(ctx, &api.TestResult{
+		SessionID:   sessionID,
+		BaseBuildID: buildResp.ID,
+		TestName:    "test",
+		Result:      api.TestRunning,
+		Log:         []byte("some log"),
+	})
+	assert.NoError(t, err)
+	err = client.UploadTestArtifacts(ctx, sessionID, "test", bytes.NewReader([]byte("artifacts content")))
+	assert.NoError(t, err)
 }
 
 var testSeries = &api.Series{

--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -106,13 +106,14 @@ func (s *Session) SetSkipReason(reason string) {
 }
 
 type SessionTest struct {
-	SessionID      string             `spanner:"SessionID"`
-	BaseBuildID    spanner.NullString `spanner:"BaseBuildID"`
-	PatchedBuildID spanner.NullString `spanner:"PatchedBuildID"`
-	UpdatedAt      time.Time          `spanner:"UpdatedAt"`
-	TestName       string             `spanner:"TestName"`
-	Result         string             `spanner:"Result"`
-	LogURI         string             `spanner:"LogURI"`
+	SessionID           string             `spanner:"SessionID"`
+	BaseBuildID         spanner.NullString `spanner:"BaseBuildID"`
+	PatchedBuildID      spanner.NullString `spanner:"PatchedBuildID"`
+	UpdatedAt           time.Time          `spanner:"UpdatedAt"`
+	TestName            string             `spanner:"TestName"`
+	Result              string             `spanner:"Result"`
+	LogURI              string             `spanner:"LogURI"`
+	ArtifactsArchiveURI string             `spanner:"ArtifactsArchiveURI"`
 }
 
 type Finding struct {

--- a/syz-cluster/pkg/db/migrations/1_initialize.up.sql
+++ b/syz-cluster/pkg/db/migrations/1_initialize.up.sql
@@ -72,6 +72,7 @@ CREATE TABLE SessionTests (
     BaseBuildID STRING(36),
     PatchedBuildID STRING(36),
     LogURI STRING(256) NOT NULL,
+    ArtifactsArchiveURI STRING(256) NOT NULL,
     CONSTRAINT FK_SessionResults FOREIGN KEY (SessionID) REFERENCES Sessions (ID),
     CONSTRAINT ResultEnum CHECK (Result IN ('passed', 'failed', 'error', 'running')),
     CONSTRAINT FK_BaseBuild FOREIGN KEY (BaseBuildID) REFERENCES Builds (ID),

--- a/tools/syz-diff/diff.go
+++ b/tools/syz-diff/diff.go
@@ -48,7 +48,8 @@ func main() {
 
 	ctx := vm.ShutdownCtx()
 	err = manager.RunDiffFuzzer(ctx, baseCfg, newCfg, manager.DiffFuzzerConfig{
-		Debug: *flagDebug,
+		ArtifactsDir: newCfg.Workdir,
+		Debug:        *flagDebug,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Compress the diff fuzzing artifacts (crash logs, various reproducers found during the process, etc) that are mentioned in the fuzzer's log and share the archive via the web dashboard. It will help debug the false positives.