### PR TITLE
syz-cluster: enforce pod to node assignment

### DIFF
--- a/syz-cluster/overlays/gke/kustomization.yaml
+++ b/syz-cluster/overlays/gke/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 patches:
   - target:
       kind: WorkflowTemplate
-      name: boot-step-template
+      name: (boot|fuzz)-step-template
     patch: |-
       - op: replace
         path: /spec/templates/0/tolerations
@@ -24,12 +24,9 @@ patches:
               effect: "NoSchedule"
   - target:
       kind: WorkflowTemplate
-      name: fuzz-step-template
+      name: (boot|fuzz)-step-template
     patch: |-
       - op: replace
-        path: /spec/templates/0/tolerations
+        path: /spec/templates/0/nodeSelector
         value:
-            - key: "workload"
-              operator: "Equal"
-              value: "nested-vm"
-              effect: "NoSchedule"
+          cloud.google.com/gke-nodepool: nested-vm-pool


### PR DESCRIPTION
On GKE, we use a separate node pool that supports nested virtualization. Taints and tolerations (that were used before) only make sure that no other pods are scheduled there, but are not enough to make sure that the pods that do need nested virtualization will end up there.

Use nodeSelector to force the affinity.