### PR TITLE
syz-cluster: clean up running steps of finished workflows 

### DIFF
--- a/syz-cluster/pkg/db/report_repo_test.go
+++ b/syz-cluster/pkg/db/report_repo_test.go
@@ -74,7 +74,7 @@ func TestSessionsWithoutReports(t *testing.T) {
 				SessionID: session.ID,
 				TestName:  "test",
 				Result:    api.TestPassed,
-			})
+			}, nil)
 			assert.NoError(t, err)
 			err = findingRepo.Save(ctx, &Finding{
 				SessionID: session.ID,

--- a/syz-cluster/pkg/db/session_test_repo.go
+++ b/syz-cluster/pkg/db/session_test_repo.go
@@ -85,14 +85,7 @@ type FullSessionTest struct {
 }
 
 func (repo *SessionTestRepository) BySession(ctx context.Context, sessionID string) ([]*FullSessionTest, error) {
-	stmt := spanner.Statement{
-		SQL: "SELECT * FROM `SessionTests` WHERE `SessionID` = @session" +
-			" ORDER BY `UpdatedAt`",
-		Params: map[string]interface{}{"session": sessionID},
-	}
-	iter := repo.client.Single().Query(ctx, stmt)
-	defer iter.Stop()
-	list, err := readEntities[SessionTest](iter)
+	list, err := repo.BySessionRaw(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -130,4 +123,15 @@ func (repo *SessionTestRepository) BySession(ctx context.Context, sessionID stri
 		}
 	}
 	return ret, nil
+}
+
+func (repo *SessionTestRepository) BySessionRaw(ctx context.Context, sessionID string) ([]*SessionTest, error) {
+	stmt := spanner.Statement{
+		SQL: "SELECT * FROM `SessionTests` WHERE `SessionID` = @session" +
+			" ORDER BY `UpdatedAt`",
+		Params: map[string]interface{}{"session": sessionID},
+	}
+	iter := repo.client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	return readEntities[SessionTest](iter)
 }

--- a/syz-cluster/pkg/db/session_test_repo_test.go
+++ b/syz-cluster/pkg/db/session_test_repo_test.go
@@ -43,7 +43,7 @@ func TestSessionTestRepository(t *testing.T) {
 			PatchedBuildID: spanner.NullString{StringVal: build2.ID, Valid: true},
 			Result:         api.TestPassed,
 		}
-		err = testsRepo.InsertOrUpdate(ctx, test)
+		err = testsRepo.InsertOrUpdate(ctx, test, nil)
 		assert.NoError(t, err)
 	}
 

--- a/syz-cluster/pkg/db/util_test.go
+++ b/syz-cluster/pkg/db/util_test.go
@@ -26,7 +26,7 @@ func (d *dummyTestData) addSessionTest(session *Session, names ...string) {
 			SessionID: session.ID,
 			TestName:  name,
 			Result:    api.TestPassed,
-		})
+		}, nil)
 		assert.NoError(d.t, err)
 	}
 }


### PR DESCRIPTION
If the workflow step crashed or timed out, we used to have Running
status for such steps even though the session itself may be long
finished.

In order to prevent this inconsistency, on finishing each session go
through all remaining running steps and update their status to Error.