### PR TITLE
pkg/manager: prevent deadlock on ReproLoop cancellation

### DIFF
--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -230,7 +230,11 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 			r.mu.Unlock()
 
 			r.parallel <- struct{}{}
-			r.pingQueue <- struct{}{}
+			// If the context is cancelled, no one is listening on pingQueue.
+			select {
+			case r.pingQueue <- struct{}{}:
+			default:
+			}
 		}()
 	}
 }


### PR DESCRIPTION
When the context is cancelled, no one may be polling the pingQueue, yet we write to it synchronously.

Wrap it in a select{} statement and add a test to ensure that the loop reacts properly to the context cancellation.
