### PR TITLE
pkg/cover: use space for alignment, not underscore

### DIFF
--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -294,7 +294,7 @@ func FormatResult(thm *templateHeatmap, format Format) {
 }
 
 func approximateInstrumented(points int64) string {
-	dim := "_"
+	dim := " "
 	if abs(points) > 10000 {
 		dim = "K"
 		points /= 1000

--- a/pkg/cover/templates/heatmap.html
+++ b/pkg/cover/templates/heatmap.html
@@ -33,6 +33,9 @@
     width: 50px;
     text-align: right;
   }
+  .instrumented_column > pre {
+    margin: 0
+  }
   .tree_depth_0 {width: 0px;}
   .tree_depth_1 {width: 20px;}
   .tree_depth_2 {width: 40px;}
@@ -100,6 +103,9 @@
   }
   .cover_percent:hover .tooltiptext {
     visibility: visible;
+  }
+  #collapsible-list {
+    font-family: monospace;
   }
 {{ end }}
 
@@ -215,7 +221,7 @@
           </div>
         {{ end }}
         <div class="instrumented_column">
-          {{ approxInstr $child.Summary }}
+          <pre>{{ approxInstr $child.Summary }}</pre>
         </div>
       </div>
       {{ if $child.IsDir }}


### PR DESCRIPTION
The new look:
<img width=400 src="https://github.com/user-attachments/assets/7b411102-d032-4ff5-a9f4-7201e7e86397">
