### PR TITLE
pkg/manager: better handle the reproduction queue

### DIFF
--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -187,6 +187,7 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 		crash := r.popCrash()
 		for {
 			if crash != nil && !r.mgr.NeedRepro(crash) {
+				log.Logf(1, "reproduction of %q aborted: it's no longer needed", crash.FullTitle())
 				crash = nil
 				// Now we might not need that many VMs.
 				r.mu.Lock()

--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -188,11 +188,15 @@ func (r *ReproLoop) Loop(ctx context.Context) {
 		for {
 			if crash != nil && !r.mgr.NeedRepro(crash) {
 				log.Logf(1, "reproduction of %q aborted: it's no longer needed", crash.FullTitle())
-				crash = nil
 				// Now we might not need that many VMs.
 				r.mu.Lock()
 				r.adjustPoolSizeLocked()
 				r.mu.Unlock()
+
+				// Immediately check if there was any other crash in the queue, so that we fall back
+				// to waiting on pingQueue only if there were really no other crashes in the queue.
+				crash = r.popCrash()
+				continue
 			}
 			if crash != nil {
 				break


### PR DESCRIPTION
As pingQueue holds maximum 1 element, it's not a very good indicator of
whether there are more elements in the reproduction queue. If the first
few crashes happen to be no longer needed (which is quite likely when
reproduction loop is started long after we have begun to collect the
crashes), the loop becomes reactive - new reproductions will be started
only once new bugs are submitted to the queue.

Fix it by polling the queue until it returns nil. Add a test that
exposes the previously existing bug.