### PR TITLE
vm/dispatcher: make pool.Run cancellable

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -767,7 +767,7 @@ func (pw *poolWrapper) Run(ctx context.Context, params instance.ExecParams,
 
 	var result *instance.RunResult
 	var err error
-	pw.pool.Run(func(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
+	runErr := pw.pool.Run(ctx, func(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
 		updInfo(func(info *dispatcher.Info) {
 			typ := "syz"
 			if params.CProg != nil {
@@ -787,6 +787,9 @@ func (pw *poolWrapper) Run(ctx context.Context, params instance.ExecParams,
 			result, err = ret.RunSyzProg(params)
 		}
 	})
+	if runErr != nil {
+		return nil, runErr
+	}
 	return result, err
 }
 

--- a/pkg/repro/strace.go
+++ b/pkg/repro/strace.go
@@ -31,7 +31,7 @@ func RunStrace(result *Result, cfg *mgrconfig.Config, reporter *report.Reporter,
 	}
 	var runRes *instance.RunResult
 	var err error
-	pool.Run(func(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
+	runErr := pool.Run(context.Background(), func(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
 		updInfo(func(info *dispatcher.Info) {
 			info.Status = "running strace"
 		})
@@ -58,7 +58,9 @@ func RunStrace(result *Result, cfg *mgrconfig.Config, reporter *report.Reporter,
 			runRes, err = ret.RunSyzProg(params)
 		}
 	})
-	if err != nil {
+	if runErr != nil {
+		return straceFailed(runErr)
+	} else if err != nil {
 		return straceFailed(err)
 	}
 	return &StraceResult{


### PR DESCRIPTION
Make the pool.Run() function take a context.Context to be able to abort the callback passed to it or abort its scheduling if it's not yet running.

Otherwise, if the callback is not yet started and the pool's Loop is aborted, we risk waiting for pool.Run() forever. It prevents the normal shutdown of repro.Run() and, consequently, the DiffFuzzer functionality.
