### PR TITLE
dashboard: add missing access check for fsck logs

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -145,6 +145,8 @@ func checkTextAccess(c context.Context, r *http.Request, tag string, id int64) (
 		// But since machine info is usually the same for all bugs and is not secret,
 		// it's fine to check based on the namespace.
 		return nil, nil, nil
+	case textFsckLog:
+		return checkCrashTextAccess(c, r, "Assets.FsckLog", id)
 	}
 }
 


### PR DESCRIPTION
To make them accessible for non-admins, we need explicit checks in access.go.

Extend TestAccess to cover fsck logs.

Cc @FlorentRevest 