### PR TITLE
tools/docker/env: update gcloud to 519

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/argoproj/argo-workflows/v3 v3.6.5
 	github.com/dvyukov/go-fuzz v0.0.0-20220726122315-1d375ef9f9f6
 	github.com/golang-migrate/migrate/v4 v4.18.2
+	github.com/golang/protobuf v1.5.4
 	github.com/golangci/golangci-lint v1.63.4
 	github.com/google/flatbuffers v25.1.24+incompatible
 	github.com/google/generative-ai-go v0.19.0
@@ -37,7 +38,7 @@ require (
 	golang.org/x/sys v0.31.0
 	golang.org/x/tools v0.30.0
 	google.golang.org/api v0.227.0
-	google.golang.org/appengine/v2 v2.0.5
+	google.golang.org/appengine/v2 v2.0.6
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6
@@ -134,7 +135,6 @@ require (
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20241223200906-057b0627d9b9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1976,8 +1976,8 @@ google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine/v2 v2.0.5 h1:4C+F3Cd3L2nWEfSmFEZDPjQvDwL8T0YCeZBysZifP3k=
-google.golang.org/appengine/v2 v2.0.5/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
+google.golang.org/appengine/v2 v2.0.6 h1:LvPZLGuchSBslPBp+LAhihBeGSiRh1myRoYK4NtuBIw=
+google.golang.org/appengine/v2 v2.0.6/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -3,17 +3,6 @@
 
 # See /tools/docker/README.md for details.
 
-# Build Python2 in a separate container to facilitate caching.
-FROM debian:bookworm AS python2-builder
-
-RUN apt-get update --allow-releaseinfo-change
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
-    wget gcc make openssl libffi-dev libgdbm-dev libsqlite3-dev libssl-dev zlib1g-dev ca-certificates
-RUN wget -O /tmp/Python-2.7.18.tgz 'https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz'
-RUN cd /tmp/ && tar -zxf Python-2.7.18.tgz
-RUN cd /tmp/Python-2.7.18 && ./configure --prefix=/python2/
-RUN cd /tmp/Python-2.7.18 && make -j4 && make altinstall
-
 # Construct a /syzkaller folder.
 FROM debian:bookworm as syzkaller-folder
 WORKDIR /syzkaller
@@ -117,10 +106,6 @@ RUN dpkg --add-architecture i386 && \
 	apt-get clean autoclean && \
 	rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# Install Python 2.7.
-COPY --from=python2-builder /python2/ /usr/local/
-RUN ln -s /usr/local/bin/python2.7 /usr/bin/python2
-
 # Copy the /syzkaller folder and set the toolchain environment variables.
 COPY --from=syzkaller-folder /syzkaller/ /syzkaller/
 RUN chmod 0777 /syzkaller
@@ -131,13 +116,16 @@ ENV SOURCEDIR_NETBSD /syzkaller/netbsd
 RUN apt-get install -y -q nodejs
 
 # Install gcloud sdk for dashboard/app tests.
-# The newest version (as of 07/10/23) is 437, however, it seems to expect to be run with python3
-# (but still requires python2). But Go's aetest package still runs dev_appserver.py with python2.7.
-# So let's use an older, but working sdk.
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-400.0.0-linux-x86_64.tar.gz | tar -C /usr/local -xz
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-519.0.0-linux-x86_64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/google-cloud-sdk/bin:$PATH
 RUN gcloud components install --quiet app-engine-python app-engine-go app-engine-python-extras cloud-datastore-emulator
 RUN chmod 0777 /usr/local/google-cloud-sdk
+
+# Patch gcloud app-engine-python to fix projected queries problem, see issue #4785.
+RUN sed -i "s/entity\.key\.MergeFrom(original_entity\.key())/entity\.key\.MergeFrom(original_entity\.key)/g" \
+    /usr/local/google-cloud-sdk/platform/google_appengine/google/appengine/datastore/datastore_sqlite_stub.py
+RUN sed -i "s/array\.array('B', str(value_data))))/entity_pb2\.PropertyValue, array\.array('B', value_data)))/g" \
+    /usr/local/google-cloud-sdk/platform/google_appengine/google/appengine/datastore/datastore_sqlite_stub.py
 
 # The default Docker prompt is too ugly and takes the whole line:
 # I have no name!@0f3331d2fb54:~/gopath/src/github.com/google/syzkaller$


### PR DESCRIPTION
It requires appengine dependency update to match golang versions.
gcloud-appengine-python patching is needed to fix #4785.
