### PR TITLE
vm/qemu: use -machine virt and -cpu max for arm32

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -161,8 +161,8 @@ var archConfigs = map[string]*archConfig{
 	},
 	"linux/arm": {
 		Qemu: "qemu-system-arm",
-		// For some reason, new qemu-system-arm versions complain that "The only valid type is: cortex-a15".
-		QemuArgs:               "-machine vexpress-a15 -cpu cortex-a15 -accel tcg,thread=multi",
+		// The buildroot image we use does not boot with vexpress-a15/cortex-a15.
+		QemuArgs:               "-machine virt -cpu max -accel tcg,thread=multi",
 		NetDev:                 "virtio-net-device",
 		RngDev:                 "virtio-rng-device",
 		UseNewQemuImageOptions: true,


### PR DESCRIPTION
The previously used combination does not boot our buildroot image:

```
[    6.334727][    T1] Run /sbin/init as init process
[    6.668200][    T1] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000004
```