### PR TITLE
dashboard/app: allow to set spanner context only from tests

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -104,7 +104,6 @@ var maxCrashes = func() int {
 func handleJSON(fn JSONHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := appengine.NewContext(r)
-		c = SetCoverageDBClient(c, coverageDBClient)
 		reply, err := fn(c, r)
 		if err != nil {
 			status := logErrorPrepareStatus(c, err)
@@ -1944,7 +1943,7 @@ func apiSaveCoverage(c context.Context, payload io.Reader) (interface{}, error) 
 		sss = service.List()
 		log.Infof(c, "found %d subsystems for %s namespace", len(sss), descr.Namespace)
 	}
-	rowsCreated, err := coveragedb.SaveMergeResult(c, GetCoverageDBClient(c), descr, jsonDec, sss)
+	rowsCreated, err := coveragedb.SaveMergeResult(c, getCoverageDBClient(c), descr, jsonDec, sss)
 	if err != nil {
 		log.Errorf(c, "error storing coverage for ns %s, date %s: %v",
 			descr.Namespace, descr.DateTo.String(), err)

--- a/dashboard/app/coverage_test.go
+++ b/dashboard/app/coverage_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -16,6 +17,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/api/iterator"
 )
+
+func setCoverageDBClient(ctx context.Context, client spannerclient.SpannerClient) context.Context {
+	return context.WithValue(ctx, &keyCoverageDBClient, client)
+}
 
 func TestFileCoverage(t *testing.T) {
 	tests := []struct {

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/html"
-	"google.golang.org/appengine/v2"
 	"google.golang.org/appengine/v2/log"
 	"google.golang.org/appengine/v2/user"
 )
@@ -33,11 +32,7 @@ func handlerWrapper(fn contextHandler) http.Handler {
 
 func handleContext(fn contextHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c := appengine.NewContext(r)
-		if coverageDBClient != nil { // Nil in prod.
-			c = SetCoverageDBClient(c, coverageDBClient)
-		}
-		c = context.WithValue(c, &currentURLKey, r.URL.RequestURI())
+		c := context.WithValue(r.Context(), &currentURLKey, r.URL.RequestURI())
 		authorizedUser, _ := userAccessLevel(currentUser(c), "", getConfig(c))
 		if !authorizedUser {
 			if !throttleRequest(c, w, r) {

--- a/dashboard/app/public_json_api.go
+++ b/dashboard/app/public_json_api.go
@@ -188,7 +188,7 @@ func writeExtAPICoverageFor(ctx context.Context, w io.Writer, ns, repo string) e
 		return fmt.Errorf("coveragedb.GenNPeriodsTill: %w", err)
 	}
 	defaultTimePeriod := tps[0]
-	covDBClient := GetCoverageDBClient(ctx)
+	covDBClient := getCoverageDBClient(ctx)
 	ff, err := coveragedb.MakeFuncFinder(ctx, covDBClient, ns, defaultTimePeriod)
 	if err != nil {
 		return fmt.Errorf("coveragedb.MakeFuncFinder: %w", err)

--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -259,7 +259,7 @@ func TestPublicJSONAPI(t *testing.T) {
 }
 
 func TestWriteExtAPICoverageFor(t *testing.T) {
-	ctx := SetCoverageDBClient(context.Background(), fileFuncLinesDBFixture(t,
+	ctx := setCoverageDBClient(context.Background(), fileFuncLinesDBFixture(t,
 		[]*coveragedb.FuncLines{
 			{
 				FilePath: "/file",

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -110,9 +110,6 @@ func (cfg *EmailConfig) Validate() error {
 // Assuming it is called June 15, the monthly report will cover April-May diff.
 func handleCoverageReports(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if coverageDBClient != nil { // initialized in prod deployment, nil in tests
-		ctx = SetCoverageDBClient(r.Context(), coverageDBClient)
-	}
 	targetDate := civil.DateOf(timeNow(ctx)).AddMonths(-1)
 	periods, err := coveragedb.GenNPeriodsTill(2, targetDate, "month")
 	if err != nil {
@@ -196,7 +193,7 @@ func sendNsCoverageReport(ctx context.Context, ns, email string,
 func coverageTable(ctx context.Context, ns string, fromTo []coveragedb.TimePeriod, minDrop int) (string, error) {
 	covAndDates, err := coveragedb.FilesCoverageWithDetails(
 		ctx,
-		GetCoverageDBClient(ctx),
+		getCoverageDBClient(ctx),
 		&coveragedb.SelectScope{
 			Ns:      ns,
 			Periods: fromTo,

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1399,7 +1399,7 @@ func TestCoverageRegression(t *testing.T) {
 		Return(mTran2).Once()
 
 	c.transformContext = func(ctx context.Context) context.Context {
-		return SetCoverageDBClient(ctx, m)
+		return setCoverageDBClient(ctx, m)
 	}
 	_, err := c.AuthGET(AccessAdmin, "/cron/email_coverage_reports")
 	assert.NoError(t, err)

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -236,7 +236,7 @@ func (c *Ctx) setCoverageMocks(ns string, dbClientMock spannerclient.SpannerClie
 			ret.Coverage = &CoverageConfig{WebGitURI: "test-git"}
 			return &ret
 		})
-		ctxWithSpanner := SetCoverageDBClient(ctx, dbClientMock)
+		ctxWithSpanner := setCoverageDBClient(ctx, dbClientMock)
 		ctxWithSpannerAndFileProvider := setWebGit(ctxWithSpanner, fileProvMock)
 		return contextWithConfig(ctxWithSpannerAndFileProvider, newConfig)
 	}


### PR DESCRIPTION
getSpannerClient returns prod client as a default.

