### PR TITLE
pkg/gcs: check errors with errors.Is

### DIFF
--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -143,7 +143,7 @@ func (c *client) DeleteFile(gcsFile string) error {
 		return err
 	}
 	err = c.client.Bucket(bucket).Object(filename).Delete(c.ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return ErrFileNotFound
 	}
 	return err
@@ -155,7 +155,7 @@ func (c *client) FileExists(gcsFile string) (bool, error) {
 		return false, err
 	}
 	_, err = c.client.Bucket(bucket).Object(filename).Attrs(c.ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return false, nil
 	} else if err != nil {
 		return false, err


### PR DESCRIPTION
After https://github.com/googleapis/google-cloud-go/pull/11519, the cloud storage library wraps the errors which we used to check directly. This has led to multiple asset upload errors.

***

We need this PR ASAP to fix asset storage, but then it would be nice to think how we could have caught such an incompatibility.  In `syz-cluster`, I was using https://github.com/fsouza/fake-gcs-server in the dev environment, probably we could add it to our `env` container and write some tests for `pkg/gcs` against the emulated server?