### PR TITLE
executor/kvm: add SYZOS support for CPUID

### DIFF
--- a/sys/linux/dev_kvm_amd64.txt
+++ b/sys/linux/dev_kvm_amd64.txt
@@ -43,9 +43,15 @@ type syzos_api$x86[NUM, PAYLOAD] {
 	payload	PAYLOAD
 }
 
+syzos_api_cpuid {
+	eax	int32
+	ecx	int32
+}
+
 syzos_api_call$x86 [
 	uexit	syzos_api$x86[0, intptr]
 	code	syzos_api$x86[1, syzos_api_code$x86]
+	cpuid	syzos_api$x86[2, syzos_api_cpuid]
 ] [varlen]
 
 kvm_text_x86 [

--- a/sys/linux/test/amd64-syz_kvm_setup_syzos_vm-cpuid
+++ b/sys/linux/test/amd64-syz_kvm_setup_syzos_vm-cpuid
@@ -1,0 +1,17 @@
+#
+# requires: arch=amd64 -threaded
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm$x86(r1, &(0x7f0000c00000/0x400000)=nil)
+#
+# 0x2 queries Cache and TLB information
+#
+r3 = syz_kvm_add_vcpu$x86(r2, &AUTO={0x0, &AUTO=[@cpuid={AUTO, AUTO, {0x1, 0x0}}], AUTO})
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till the end of guest_main(). 0xffffffffffffffff is UEXIT_END.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit$x86(r5, 0xffffffffffffffff)


### PR DESCRIPTION
This commit adds support for CPUID instructions on AMD64. It also adds a relevant test.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
