### PR TITLE
vm/vmimpl: explicitly indicate empty boot output

### DIFF
--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -96,6 +96,11 @@ type BootError struct {
 }
 
 func MakeBootError(err error, output []byte) error {
+	if len(output) == 0 {
+		// In reports, it may be helpful to distinguish the case when the boot output
+		// was collected, but turned out to be empty.
+		output = []byte("<empty boot output>")
+	}
 	var verboseError *osutil.VerboseError
 	if errors.As(err, &verboseError) {
 		return BootError{verboseError.Title, append(verboseError.Output, output...)}


### PR DESCRIPTION
It will help distinguish the cases when the output was collected, but lost somewhere during the reporting pipeline, or it was empty in the first place, e.g. because qemu could not start at all.

Cc #5986.
