### PR TITLE
Revert "vm/qemu: use -machine virt and -cpu max for arm32"

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -161,8 +161,8 @@ var archConfigs = map[string]*archConfig{
 	},
 	"linux/arm": {
 		Qemu: "qemu-system-arm",
-		// The buildroot image we use does not boot with vexpress-a15/cortex-a15.
-		QemuArgs:               "-machine virt -cpu max -accel tcg,thread=multi",
+		// For some reason, new qemu-system-arm versions complain that "The only valid type is: cortex-a15".
+		QemuArgs:               "-machine vexpress-a15 -cpu cortex-a15 -accel tcg,thread=multi",
 		NetDev:                 "virtio-net-device",
 		RngDev:                 "virtio-rng-device",
 		UseNewQemuImageOptions: true,


### PR DESCRIPTION
We want to keep on using `vexpress-v2p-ca15-tc1.dtb`, so let's keep on using `-machine vexpress-a15`.