### PR TITLE
doc: bisect: add `compiler_type` entry

### DIFF
--- a/docs/bisect.md
+++ b/docs/bisect.md
@@ -22,6 +22,7 @@ Create a config file with following lines adjusted for your environment:
 {
 	"bin_dir": "/home/syzkaller/bisect_bin",
 	"ccache": "/usr/bin/ccache",
+	"compiler_type": "gcc",
 	"kernel_repo": "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git",
 	"kernel_branch": "master",
 	"syzkaller_repo": "https://github.com/google/syzkaller",


### PR DESCRIPTION
It looks like `compiler_type` entry is mandatory to avoid this error:

    unsupported bisect compiler:

It can be `gcc` or `clang`.

(Note that I had to install `grub-pc-bin` and apply the following extra patch because apparently, `create-gce-image.sh` is called and `nbd` doesn't seem to work on Ubuntu 25.04, but even after that, `syz-bisect` couldn't reproduce the issue on the current kernel, I need to investigate why)

```diff
diff --git a/pkg/build/linux_generated.go b/pkg/build/linux_generated.go
index a084684d3..c7cb0b87c 100644
--- a/pkg/build/linux_generated.go
+++ b/pkg/build/linux_generated.go
@@ -33,7 +33,7 @@ fi
 
 BLOCK_DEVICE="loop"
 if [ "$(uname -a | grep Ubuntu)" != "" ]; then
-       BLOCK_DEVICE="nbd"
+       : # BLOCK_DEVICE="nbd"
 fi
 
 sudo umount disk.mnt || true
diff --git a/tools/create-gce-image.sh b/tools/create-gce-image.sh
index 39d01c2e3..6cf6b5bdf 100755
--- a/tools/create-gce-image.sh
+++ b/tools/create-gce-image.sh
@@ -69,7 +69,7 @@ fi
 # Try to figure out what will work.
 BLOCK_DEVICE="loop"
 if [ "$(uname -a | grep Ubuntu)" != "" ]; then
-       BLOCK_DEVICE="nbd"
+       : # BLOCK_DEVICE="nbd"
 fi
 
 # Clean up after previous unsuccessful run.
```