### PR TITLE
pkg/vminfo: re-enable SYZOS for arm64

### DIFF
--- a/pkg/vminfo/linux_syscalls.go
+++ b/pkg/vminfo/linux_syscalls.go
@@ -184,8 +184,8 @@ func linuxSyzKvmSupported(ctx *checkContext, call *prog.Syscall) string {
 		if ctx.target.Arch == targets.AMD64 {
 			return ""
 		}
-	case "syz_kvm_setup_cpu$arm64", "syz_kvm_setup_syzos_vm$arm64", "syz_kvm_add_vcpu$arm64":
-	case "syz_kvm_assert_syzos_uexit$arm64":
+	case "syz_kvm_setup_cpu$arm64", "syz_kvm_setup_syzos_vm$arm64", "syz_kvm_add_vcpu$arm64",
+		"syz_kvm_assert_syzos_uexit$arm64":
 		if ctx.target.Arch == targets.ARM64 {
 			return ""
 		}


### PR DESCRIPTION
"executor/kvm: add x86-64 SYZOS fuzzer" accidentally disabled pseudo-syscalls that manipulate SYZOS VMs, by adding an empty case to a switch statement.

Merge the two cases together to fix the problem.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
