### PR TITLE
syz-cluster: refactor blob storage

### DIFF
--- a/syz-cluster/pkg/blob/storage_test.go
+++ b/syz-cluster/pkg/blob/storage_test.go
@@ -9,20 +9,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalStorage(t *testing.T) {
 	storage := NewLocalStorage(t.TempDir())
 	var uris []string
 	for i := 0; i < 2; i++ {
+		uri, err := storage.NewURI()
+		require.NoError(t, err)
 		content := fmt.Sprintf("object #%d", i)
-		uri, err := storage.Store(bytes.NewReader([]byte(content)))
-		assert.NoError(t, err)
+		err = storage.Write(uri, bytes.NewReader([]byte(content)))
+		require.NoError(t, err)
 		uris = append(uris, uri)
 	}
 	for i, uri := range uris {
 		readBytes, err := ReadAllBytes(storage, uri)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.EqualValues(t, fmt.Sprintf("object #%d", i), readBytes)
 	}
 	_, err := storage.Read(localStoragePrefix + "abcdef")

--- a/syz-cluster/pkg/db/session_test_repo.go
+++ b/syz-cluster/pkg/db/session_test_repo.go
@@ -22,7 +22,7 @@ func NewSessionTestRepository(client *spanner.Client) *SessionTestRepository {
 
 // If the beforeSave callback is specified, it will be called before saving the entity.
 func (repo *SessionTestRepository) InsertOrUpdate(ctx context.Context, test *SessionTest,
-	beforeSave func(*SessionTest)) error {
+	beforeSave func(*SessionTest) error) error {
 	_, err := repo.client.ReadWriteTransaction(ctx,
 		func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			// Check if the test already exists.
@@ -41,7 +41,10 @@ func (repo *SessionTestRepository) InsertOrUpdate(ctx context.Context, test *Ses
 			_, iterErr := iter.Next()
 			if iterErr == nil {
 				if beforeSave != nil {
-					beforeSave(test)
+					err := beforeSave(test)
+					if err != nil {
+						return err
+					}
 				}
 				m, err := spanner.UpdateStruct("SessionTests", test)
 				if err != nil {
@@ -52,7 +55,10 @@ func (repo *SessionTestRepository) InsertOrUpdate(ctx context.Context, test *Ses
 				return iterErr
 			} else {
 				if beforeSave != nil {
-					beforeSave(test)
+					err := beforeSave(test)
+					if err != nil {
+						return err
+					}
 				}
 				m, err := spanner.InsertStruct("SessionTests", test)
 				if err != nil {

--- a/syz-cluster/pkg/service/finding.go
+++ b/syz-cluster/pkg/service/finding.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -30,13 +29,13 @@ func (s *FindingService) Save(ctx context.Context, req *api.NewFinding) error {
 	var reportURI, logURI string
 	var err error
 	if len(req.Log) > 0 {
-		logURI, err = s.blobStorage.Store(bytes.NewReader(req.Log))
+		logURI, err = blob.StoreBytes(s.blobStorage, req.Log)
 		if err != nil {
 			return fmt.Errorf("failed to save the log: %w", err)
 		}
 	}
 	if len(req.Report) > 0 {
-		reportURI, err = s.blobStorage.Store(bytes.NewReader(req.Report))
+		reportURI, err = blob.StoreBytes(s.blobStorage, req.Report)
 		if err != nil {
 			return fmt.Errorf("failed to save the report: %w", err)
 		}

--- a/syz-cluster/pkg/service/series.go
+++ b/syz-cluster/pkg/service/series.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -66,7 +65,7 @@ func (s *SeriesService) UploadSeries(ctx context.Context, series *api.Series) (*
 		for _, patch := range series.Patches {
 			// In case of errors, we will waste some space, but let's ignore it for simplicity.
 			// Patches are not super big.
-			uri, err := s.blobStorage.Store(bytes.NewReader(patch.Body))
+			uri, err := blob.StoreBytes(s.blobStorage, patch.Body)
 			if err != nil {
 				return nil, fmt.Errorf("failed to upload patch body: %w", err)
 			}


### PR DESCRIPTION
Split URI generation and write operation of the blob storage.

This allows to do quick "if URI does not exist, generate and save it" operation within DB transactions and do the actual write at a later point.

Since we don't use two-stage commits here, there's a risk of inconsistency between the blob storage and the DB, and we can only pick one that'd be more affected.

In the current scheme:
1) For crash artifacts, we store artifacts before saving an entry to the
   DB, so we risk having garbage in the blob storage.
2) For logs/debugging info, we first update the DB and then write the
   logs. We risk not serving the latest logs from the dashboard.

These choices can be changed any time.
