### PR TITLE
tools: widen network DHCP configuration for EC2 Root FS

### DIFF
--- a/tools/create-ec2-rootfs.sh
+++ b/tools/create-ec2-rootfs.sh
@@ -135,9 +135,6 @@ dnf install -y \
 systemctl enable systemd-networkd
 
 cat << EOF > /etc/systemd/network/ether.network
-[Match]
-Driver=e1000
-
 [Network]
 DHCP=yes
 EOF


### PR DESCRIPTION
The current EC2/AL2023 root file system only works for systems using the Intel e1000 driver. Extend the configuration to cover all potential network interfaces in order to allow fuzzing with other network interfaces (such as virtio-net).

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
