### PR TITLE
vm: func Run accepts context

### DIFF
--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -4,6 +4,7 @@
 package build
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -155,7 +156,9 @@ func (ctx netbsd) copyKernelToDisk(targetArch, vmType, outputDir, kernel string)
 	}
 	commands = append(commands, "mknod /dev/vhci c 355 0")
 	commands = append(commands, "sync") // Run sync so that the copied image is stored properly.
-	_, rep, err := inst.Run(time.Minute, reporter, strings.Join(commands, ";"))
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	_, rep, err := inst.Run(ctxTimeout, reporter, strings.Join(commands, ";"))
 	if err != nil {
 		return fmt.Errorf("error syncing the instance %w", err)
 	}

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -4,6 +4,7 @@
 package instance
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -123,7 +124,9 @@ func (inst *ExecProgInstance) runCommand(command string, duration time.Duration,
 	if inst.BeforeContextLen != 0 {
 		opts = append(opts, vm.OutputSize(inst.BeforeContextLen))
 	}
-	output, rep, err := inst.VMInstance.Run(duration, inst.reporter, command, opts...)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	output, rep, err := inst.VMInstance.Run(ctxTimeout, inst.reporter, command, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run command in VM: %w", err)
 	}

--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -535,8 +535,10 @@ func (kc *kernelContext) runInstance(ctx context.Context, inst *vm.Instance,
 		return nil, fmt.Errorf("failed to parse manager's address")
 	}
 	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
-	_, rep, err := inst.Run(kc.cfg.Timeouts.VMRunningTime, kc.reporter, cmd,
-		vm.ExitTimeout, vm.StopContext(ctx), vm.InjectExecuting(injectExec),
+	ctxTimeout, cancel := context.WithTimeout(ctx, kc.cfg.Timeouts.VMRunningTime)
+	defer cancel()
+	_, rep, err := inst.Run(ctxTimeout, kc.reporter, cmd, vm.ExitTimeout,
+		vm.InjectExecuting(injectExec),
 		vm.EarlyFinishCb(func() {
 			// Depending on the crash type and kernel config, fuzzing may continue
 			// running for several seconds even after kernel has printed a crash report.

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -652,8 +652,10 @@ func (mgr *Manager) runInstanceInner(ctx context.Context, inst *vm.Instance, inj
 		return nil, nil, fmt.Errorf("failed to parse manager's address")
 	}
 	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
-	_, rep, err := inst.Run(mgr.cfg.Timeouts.VMRunningTime, mgr.reporter, cmd,
-		vm.ExitTimeout, vm.StopContext(ctx), vm.InjectExecuting(injectExec),
+	ctxTimeout, cancel := context.WithTimeout(ctx, mgr.cfg.Timeouts.VMRunningTime)
+	defer cancel()
+	_, rep, err := inst.Run(ctxTimeout, mgr.reporter, cmd,
+		vm.ExitTimeout, vm.InjectExecuting(injectExec),
 		finishCb,
 	)
 	if err != nil {

--- a/syz-manager/snapshot.go
+++ b/syz-manager/snapshot.go
@@ -41,7 +41,9 @@ func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
 	// All network connections (including ssh) will break once we start restoring snapshots.
 	// So we start a background process and log to /dev/kmsg.
 	cmd := fmt.Sprintf("nohup %v exec snapshot 1>/dev/null 2>/dev/kmsg </dev/null &", executor)
-	if _, _, err := inst.Run(time.Hour, mgr.reporter, cmd); err != nil {
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Hour)
+	defer cancel()
+	if _, _, err := inst.Run(ctxTimeout, mgr.reporter, cmd); err != nil {
 		return err
 	}
 

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -7,6 +7,7 @@ package adb
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -521,7 +522,7 @@ func isRemoteCuttlefish(dev string) (bool, string) {
 	return true, ip
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	var tty io.ReadCloser
 	var err error
@@ -566,9 +567,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	merger.Add("console", tty)
 	merger.Add("adb", adbRpipe)
 
-	return vmimpl.Multiplex(adb, merger, timeout, vmimpl.MultiplexConfig{
+	return vmimpl.Multiplex(ctx, adb, merger, vmimpl.MultiplexConfig{
 		Console: tty,
-		Stop:    stop,
 		Close:   inst.closed,
 		Debug:   inst.debug,
 		Scale:   inst.timeouts.Scale,

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -11,6 +11,7 @@
 package cuttlefish
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -167,9 +168,9 @@ func (inst *instance) Close() error {
 	return inst.gceInst.Close()
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
-	return inst.gceInst.Run(timeout, stop, fmt.Sprintf("adb shell 'cd %s; %s'", deviceRoot, command))
+	return inst.gceInst.Run(ctx, fmt.Sprintf("adb shell 'cd %s; %s'", deviceRoot, command))
 }
 
 func (inst *instance) Diagnose(rep *report.Report) ([]byte, bool) {

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -271,7 +271,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, nil
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	conRpipe, conWpipe, err := osutil.LongPipe()
 	if err != nil {
@@ -340,9 +340,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	sshWpipe.Close()
 	merger.Add("ssh", sshRpipe)
 
-	return vmimpl.Multiplex(ssh, merger, timeout, vmimpl.MultiplexConfig{
+	return vmimpl.Multiplex(ctx, ssh, merger, vmimpl.MultiplexConfig{
 		Console: vmimpl.CmdCloser{Cmd: con},
-		Stop:    stop,
 		Close:   inst.closed,
 		Debug:   inst.debug,
 		Scale:   inst.timeouts.Scale,

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -5,6 +5,7 @@ package isolated
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -311,7 +312,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, nil
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	args := append(vmimpl.SSHArgs(inst.debug, inst.Key, inst.Port, inst.cfg.SystemSSHCfg),
 		inst.User+"@"+inst.Addr)
@@ -354,9 +355,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	merger.Add("dmesg", dmesg)
 	merger.Add("ssh", rpipe)
 
-	return vmimpl.Multiplex(cmd, merger, timeout, vmimpl.MultiplexConfig{
+	return vmimpl.Multiplex(ctx, cmd, merger, vmimpl.MultiplexConfig{
 		Console: dmesg,
-		Stop:    stop,
 		Close:   inst.closed,
 		Debug:   inst.debug,
 		Scale:   inst.timeouts.Scale,

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -5,6 +5,7 @@ package qemu
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -667,7 +668,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, nil
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	rpipe, wpipe, err := osutil.LongPipe()
 	if err != nil {
@@ -707,8 +708,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 		return nil, nil, err
 	}
 	wpipe.Close()
-	return vmimpl.Multiplex(cmd, inst.merger, timeout, vmimpl.MultiplexConfig{
-		Stop:  stop,
+	return vmimpl.Multiplex(ctx, cmd, inst.merger, vmimpl.MultiplexConfig{
 		Debug: inst.debug,
 		Scale: inst.timeouts.Scale,
 	})

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -5,6 +5,7 @@ package starnix
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -403,7 +404,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, fmt.Errorf("instance %s: can't push binary %s to instance over scp", inst.name, base)
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	rpipe, wpipe, err := osutil.LongPipe()
 	if err != nil {
@@ -430,8 +431,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 		return nil, nil, err
 	}
 	wpipe.Close()
-	return vmimpl.Multiplex(cmd, inst.merger, timeout, vmimpl.MultiplexConfig{
-		Stop:  stop,
+	return vmimpl.Multiplex(ctx, cmd, inst.merger, vmimpl.MultiplexConfig{
 		Debug: inst.debug,
 		Scale: inst.timeouts.Scale,
 	})

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -5,6 +5,7 @@ package vm
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -49,7 +50,7 @@ func (inst *testInstance) Forward(port int) (string, error) {
 	return "", nil
 }
 
-func (inst *testInstance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *testInstance) Run(ctx context.Context, command string) (
 	outc <-chan []byte, errc <-chan error, err error) {
 	return inst.outc, inst.errc, nil
 }
@@ -395,7 +396,7 @@ func testMonitorExecution(t *testing.T, test *Test) {
 		test.BodyExecuting(testInst.outc, testInst.errc, inject)
 		done <- true
 	}()
-	_, rep, err := inst.Run(time.Second, reporter, "", opts...)
+	_, rep, err := inst.Run(context.Background(), reporter, "", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -5,6 +5,7 @@
 package vmm
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -250,7 +251,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, nil
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	rpipe, wpipe, err := osutil.LongPipe()
 	if err != nil {
@@ -281,9 +282,7 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 
 	go func() {
 		select {
-		case <-time.After(timeout):
-			signal(vmimpl.ErrTimeout)
-		case <-stop:
+		case <-ctx.Done():
 			signal(vmimpl.ErrTimeout)
 		case err := <-inst.merger.Err:
 			cmd.Process.Kill()

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -4,6 +4,7 @@
 package vmware
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -173,7 +174,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	return vmDst, nil
 }
 
-func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command string) (
+func (inst *instance) Run(ctx context.Context, command string) (
 	<-chan []byte, <-chan error, error) {
 	vmxDir := filepath.Dir(inst.vmx)
 	serial := filepath.Join(vmxDir, "serial")
@@ -217,9 +218,8 @@ func (inst *instance) Run(timeout time.Duration, stop <-chan bool, command strin
 	merger.Add("dmesg", dmesg)
 	merger.Add("ssh", rpipe)
 
-	return vmimpl.Multiplex(cmd, merger, timeout, vmimpl.MultiplexConfig{
+	return vmimpl.Multiplex(ctx, cmd, merger, vmimpl.MultiplexConfig{
 		Console: dmesg,
-		Stop:    stop,
 		Close:   inst.closed,
 		Debug:   inst.debug,
 		Scale:   inst.timeouts.Scale,


### PR DESCRIPTION
There are a few reasons for these changes:
1. vm.Run behavior is the same for the termination event and timeout event. Implementation duplicates logic.
2. Termination events  sometimes are channels and sometimes are contexts. It requires double conversion.

This change allows to use context as a single termination signal source.
