### PR TITLE
sys/linux: add rnullb descriptions

### DIFF
--- a/sys/linux/dev_block.txt
+++ b/sys/linux/dev_block.txt
@@ -12,6 +12,7 @@ resource fd_block_trace[fd]
 resource fd_block[fd_block_trace]
 
 openat$nullb(fd const[AT_FDCWD], file ptr[in, string["/dev/nullb0"]], flags flags[open_flags], mode const[0]) fd_block
+openat$rnullb(fd const[AT_FDCWD], file ptr[in, string["/dev/rnullb0"]], flags flags[open_flags], mode const[0]) fd_block
 openat$md(fd const[AT_FDCWD], file ptr[in, string["/dev/md0"]], flags flags[open_flags], mode const[0]) fd_block
 openat$pmem0(fd const[AT_FDCWD], file ptr[in, string["/dev/pmem0"]], flags flags[open_flags], mode const[0]) fd_block
 

--- a/sys/linux/filesystem.txt
+++ b/sys/linux/filesystem.txt
@@ -86,6 +86,7 @@ blockdev_filename [
 	nbd		nbd_filename
 	loop		loop_filename
 	nullb		string["/dev/nullb0"]
+	rnullb		string["/dev/rnullb0"]
 	md0		string["/dev/md0"]
 	sg0		string["/dev/sg0"]
 	sr0		string["/dev/sr0"]


### PR DESCRIPTION
/dev/rnullb{} is the Rust implementation of the null block driver.
