### PR TITLE
syz-manager: enable pprof for occasional usage

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -209,6 +211,9 @@ const (
 )
 
 func main() {
+	go func() {
+		http.ListenAndServe("0.0.0.0:6060", nil)
+	}()
 	flag.Parse()
 	if !prog.GitRevisionKnown() {
 		log.Fatalf("bad syz-manager build: build with make, run bin/syz-manager")


### PR DESCRIPTION
The CPU/memory on enabling pprof in production env is negligible if no actively fetching profiles or CPU profiling

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
