### PR TITLE
syz-cluster: use unique names for migrate jobs

### DIFF
--- a/syz-cluster/README.md
+++ b/syz-cluster/README.md
@@ -24,6 +24,7 @@ $ kubectl create namespace argo
 $ make k8s-config-argo | kubectl apply -f -
 $ make k8s-config-argo-wait
 $ make k8s-config-dev | kubectl apply -f -
+$ make migrate-job.yaml | kubectl create -f -
 ```
 5. (Optional) Pre-fetch the kernel git repository:
 ```

--- a/syz-cluster/db-mgmt/migrate-job.yaml
+++ b/syz-cluster/db-mgmt/migrate-job.yaml
@@ -4,8 +4,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: db-migrate-job
+  generateName: db-migrate-job-
 spec:
+  ttlSecondsAfterFinished: 86400
   template:
     spec:
       serviceAccountName: gke-db-admin-ksa


### PR DESCRIPTION
Make k8s generate unique names for migrate jobs to facilitate their run by CI/CD pipelines. Also set job expiration time.