### PR TITLE
dashboard/app: allow to fetch coverage from multiple managers

### DIFF
--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -328,11 +328,11 @@ func fileFuncLinesDBFixture(t *testing.T, funcLines []*coveragedb.FuncLines,
 	fileCovWithLineInfo []*coveragedb.FileCoverageWithLineInfo) spannerclient.SpannerClient {
 	mPartialTran := mocks.NewReadOnlyTransaction(t)
 	mPartialTran.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, funcLines)).Once()
+		Return(coveragedb.NewRowIteratorMock(t, funcLines)).Once()
 
 	mFullTran := mocks.NewReadOnlyTransaction(t)
 	mFullTran.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, fileCovWithLineInfo)).Once()
+		Return(coveragedb.NewRowIteratorMock(t, fileCovWithLineInfo)).Once()
 
 	m := mocks.NewSpannerClient(t)
 	m.On("Single").

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1375,7 +1375,7 @@ func TestCoverageRegression(t *testing.T) {
 
 	mTran1 := mocks.NewReadOnlyTransaction(t)
 	mTran1.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, []*coveragedb.FileCoverageWithDetails{
+		Return(coveragedb.NewRowIteratorMock(t, []*coveragedb.FileCoverageWithDetails{
 			{
 				Filepath:     "file_name.c",
 				Instrumented: 100,
@@ -1385,7 +1385,7 @@ func TestCoverageRegression(t *testing.T) {
 
 	mTran2 := mocks.NewReadOnlyTransaction(t)
 	mTran2.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, []*coveragedb.FileCoverageWithDetails{
+		Return(coveragedb.NewRowIteratorMock(t, []*coveragedb.FileCoverageWithDetails{
 			{
 				Filepath:     "file_name.c",
 				Instrumented: 0,

--- a/dashboard/app/static/coverage.js
+++ b/dashboard/app/static/coverage.js
@@ -40,7 +40,11 @@ function initUpdateForm(){
 function onShowFileContent(url) {
   var curUrlParams = new URLSearchParams(window.location.search);
   url += '&subsystem=' + (curUrlParams.get('subsystem') || "")
-  url += '&manager=' + (curUrlParams.get('manager') || "")
+   // Get all 'manager' parameters.
+  var managerParams = curUrlParams.getAll('manager');
+  managerParams.forEach(function(managerValue) {
+    url += '&manager=' + (managerValue || "");
+  });
   url += '&unique-only=' + (curUrlParams.get('unique-only') || "")
 
   $.get(url, function(response) {

--- a/pkg/coveragedb/coveragedb_test.go
+++ b/pkg/coveragedb/coveragedb_test.go
@@ -214,38 +214,16 @@ func fullCoverageDBFixture(
 ) spannerclient.SpannerClient {
 	mPartialTran := mocks.NewReadOnlyTransaction(t)
 	mPartialTran.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, partial)).Once()
+		Return(NewRowIteratorMock(t, partial)).Once()
 
 	mFullTran := mocks.NewReadOnlyTransaction(t)
 	mFullTran.On("Query", mock.Anything, mock.Anything).
-		Return(newRowIteratorMock(t, full)).Once()
+		Return(NewRowIteratorMock(t, full)).Once()
 
 	m := mocks.NewSpannerClient(t)
 	m.On("Single").
 		Return(mPartialTran).Once()
 	m.On("Single").
 		Return(mFullTran).Once()
-	return m
-}
-
-func newRowIteratorMock(t *testing.T, events []*FileCoverageWithLineInfo,
-) *mocks.RowIterator {
-	m := mocks.NewRowIterator(t)
-	m.On("Stop").Once().Return()
-	for _, item := range events {
-		mRow := mocks.NewRow(t)
-		mRow.On("ToStruct", mock.Anything).
-			Run(func(args mock.Arguments) {
-				arg := args.Get(0).(*FileCoverageWithLineInfo)
-				*arg = *item
-			}).
-			Return(nil).Once()
-
-		m.On("Next").
-			Return(mRow, nil).Once()
-	}
-
-	m.On("Next").
-		Return(nil, iterator.Done).Once()
 	return m
 }

--- a/pkg/coveragedb/test_util.go
+++ b/pkg/coveragedb/test_util.go
@@ -1,0 +1,34 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package coveragedb
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/coveragedb/mocks"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/api/iterator"
+)
+
+func NewRowIteratorMock[K any](t *testing.T, cov []*K,
+) *mocks.RowIterator {
+	m := mocks.NewRowIterator(t)
+	m.On("Stop").Once().Return()
+	for _, item := range cov {
+		mRow := mocks.NewRow(t)
+		mRow.On("ToStruct", mock.Anything).
+			Run(func(args mock.Arguments) {
+				arg := args.Get(0).(*K)
+				*arg = *item
+			}).
+			Return(nil).Once()
+
+		m.On("Next").
+			Return(mRow, nil).Once()
+	}
+
+	m.On("Next").
+		Return(nil, iterator.Done).Once()
+	return m
+}


### PR DESCRIPTION
It allows to manually specify multiple target managers as a `&manager=...&manager=...` GET params.
Closes #6044 

Clang only managers are `&manager=ci-qemu-native-arm64-kvm&manager=ci-snapshot-upstream-root&manager=ci-upstream-bpf-next-kasan-gce&manager=ci-upstream-gce-arm64&manager=ci-upstream-kasan-gce-root&manager=ci-upstream-kasan-gce-smack-root&manager=ci-upstream-kmsan-gce-root&manager=ci-upstream-linux-next-kasan-gce-root&manager=ci-upstream-net-kasan-gce&manager=ci-upstream-net-this-kasan-gce&manager=ci2-upstream-fs&manager=ci2-upstream-kcsan-gce`.