### PR TITLE
syz-cluster: fix db-mgmt job problems

### DIFF
--- a/syz-cluster/db-mgmt/migrate-job.yaml
+++ b/syz-cluster/db-mgmt/migrate-job.yaml
@@ -7,6 +7,7 @@ metadata:
   generateName: db-migrate-job-
 spec:
   ttlSecondsAfterFinished: 86400
+  backoffLimit: 0
   template:
     spec:
       serviceAccountName: gke-db-admin-ksa

--- a/syz-cluster/pkg/db/spanner.go
+++ b/syz-cluster/pkg/db/spanner.go
@@ -109,7 +109,12 @@ func RunMigrations(uri string) error {
 	if err != nil {
 		return err
 	}
-	return m.Up()
+	err = m.Up()
+	if err == migrate.ErrNoChange {
+		// Not really an error.
+		return nil
+	}
+	return err
 }
 
 func getMigrateInstance(uri string) (*migrate.Migrate, error) {


### PR DESCRIPTION
Don't restart the job if it returned a non-zero exit code. Don't treat the ErrNoChange error as a failure.
