### PR TITLE
pkg/build: enable BBLog for FreeBSD

### DIFF
--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -105,6 +105,9 @@ __EOF__
 cat | sudo tee -a ${tmpdir}/etc/sysctl.conf <<__EOF__
 net.inet.sctp.udp_tunneling_port=9899
 net.inet.tcp.udp_tunneling_port=9811
+net.inet.tcp.bb.log_auto_all=1
+net.inet.tcp.bb.log_auto_ratio=1
+net.inet.tcp.bb.log_auto_mode=1
 vm.redzone.panic=1
 __EOF__
 


### PR DESCRIPTION
This enables BBLog for all TCP endpoints using the CONTINUAL mode. This stores the most recent events at each TCP endpoint.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
