### PR TITLE
dashboard/app: disable old datastore backup

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -16,9 +16,6 @@ cron:
   schedule: every 5 minutes
 - url: /cron/subsystem_reports
   schedule: every 8 hours
-- url: /_ah/datastore_admin/backup.create?name=backup&filesystem=gs&gs_bucket_name=syzkaller-backups&kind=Bug&kind=Build&kind=Crash&kind=CrashLog&kind=CrashReport&kind=Error&kind=Job&kind=KernelConfig&kind=Manager&kind=ManagerStats&kind=Patch&kind=ReportingState&kind=ReproC&kind=ReproSyz
-  schedule: every monday 00:00
-  target: ah-builtin-python-bundle
 # Update quarter coverage numbers every week.
 - url: /cron/batch_coverage?quarters=true&steps=2
   schedule: every sunday 00:00


### PR DESCRIPTION
We're currently using alternative solution:
https://cloud.google.com/datastore/docs/backups
