### PR TITLE
tools: adjust EC2 rootfs network configuration

### DIFF
--- a/tools/create-ec2-rootfs.sh
+++ b/tools/create-ec2-rootfs.sh
@@ -135,6 +135,9 @@ dnf install -y \
 systemctl enable systemd-networkd
 
 cat << EOF > /etc/systemd/network/ether.network
+[Match]
+Name=*
+
 [Network]
 DHCP=yes
 EOF


### PR DESCRIPTION
In a previous change (https://github.com/google/syzkaller/pull/6023) we made a simplification, assuming that a non-existent Match section in systemd networkd's config would allow DHCP for any network interface. After more testing this turns out to be incorrect and we really only get an IP via DHCP with an explicit broad Name regex.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
