### PR TITLE
vm/vmimpl: show all locked tcpcbs

### DIFF
--- a/vm/vmimpl/freebsd.go
+++ b/vm/vmimpl/freebsd.go
@@ -23,6 +23,7 @@ func DiagnoseFreeBSD(w io.Writer) ([]byte, bool) {
 		"show all locks",
 		"show malloc",
 		"show uma",
+		"show all tcpcbs/l",
 	}
 	for _, c := range commands {
 		w.Write([]byte(c + "\n"))


### PR DESCRIPTION
Add a command to show all locked TCP control blocked. If a panic is related to the TCP stack, most likely the affected TCP control block is locked. Therefore, this is show. This is much less noisy than showing all TCP control blocks.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
