### PR TITLE
syz-ci: don't report context.Canceled errors

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -1082,6 +1082,16 @@ func uploadFileHTTPPut(ctx context.Context, URL string, file io.Reader) error {
 
 // Errorf logs non-fatal error and sends it to dashboard.
 func (mgr *Manager) Errorf(msg string, args ...interface{}) {
+	for _, arg := range args {
+		err, _ := arg.(error)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, context.Canceled) {
+			// Context cancelation-related errors only create unnecessary noise.
+			return
+		}
+	}
 	log.Errorf(mgr.name+": "+msg, args...)
 	if mgr.dash != nil {
 		mgr.dash.LogError(mgr.name, msg, args...)


### PR DESCRIPTION
After #6066, we have started to see a number of log messages about bench/corpus uploads aborted due to context cancelation. These messages are not of any value.

Ignore Errorf() calls where one of the arguments encloses a context.Canceled error. This is probably a bit hacky, but at least prevents repeating `errors.Is(err, context.Canceled)` for every call that may be canceled.