### PR TITLE
fix perf compiling on debootstrap images

### DIFF
--- a/tools/create-image.sh
+++ b/tools/create-image.sh
@@ -183,6 +183,8 @@ if [ $PERF = "true" ]; then
     cp -r $KERNEL $DIR/tmp/
     BASENAME=$(basename $KERNEL)
     sudo chroot $DIR /bin/bash -c "apt-get update; apt-get install -y flex bison python-dev libelf-dev libunwind8-dev libaudit-dev libslang2-dev libperl-dev binutils-dev liblzma-dev libnuma-dev"
+    sudo chroot $DIR /bin/bash -c "apt-get install -y make pkg-config systemtap-sdt-dev libssl-dev libdw-dev libpfm4-dev libtraceevent-dev"
+    sudo chroot $DIR /bin/bash -c "apt-get install -y python3-setuptools python3-nitime"
     sudo chroot $DIR /bin/bash -c "cd /tmp/$BASENAME/tools/perf/; make"
     sudo chroot $DIR /bin/bash -c "cp /tmp/$BASENAME/tools/perf/perf /usr/bin/"
     rm -r $DIR/tmp/$BASENAME


### PR DESCRIPTION
compiling perf within create-image.sh on recent kernels requires a few missing debian packages
