### PR TITLE
pkg/report: parse the new WARNING format

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1837,6 +1837,11 @@ var linuxOopses = append([]*oops{
 				stack: warningStackFmt(),
 			},
 			{
+				title: compile("WARNING: {{SRC}} at {{FUNC}}"),
+				fmt:   "WARNING in %[3]v",
+				stack: warningStackFmt(),
+			},
+			{
 				title:  compile("WARNING: possible circular locking dependency detected"),
 				report: compile("WARNING: possible circular locking dependency detected(?:.*\\n)+?.*is trying to acquire lock"),
 				fmt:    "possible deadlock in %[1]v",

--- a/pkg/report/testdata/linux/report/743
+++ b/pkg/report/testdata/linux/report/743
@@ -1,0 +1,224 @@
+TITLE: WARNING in __ieee80211_beacon_get
+TYPE: WARNING
+EXECUTOR: proc=9, id=803
+
+[  456.487620][    C1] ------------[ cut here ]------------
+[  456.493487][    C1] WARNING: net/mac80211/tx.c:5024 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+[  456.504170][    C1] Modules linked in:
+[  456.508373][    C1] CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full) 
+[  456.519883][    C1] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  456.529983][    C1] RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+[  456.536355][    C1] Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+[  456.556047][    C1] RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+[  456.562128][    C1] RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+[  456.570166][    C1] RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+[  456.578202][    C1] RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+[  456.586217][    C1] R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+[  456.594216][    C1] R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+[  456.602240][    C1] FS:  0000000000000000(0000) GS:ffff888125d40000(0000) knlGS:0000000000000000
+[  456.611234][    C1] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  456.617865][    C1] CR2: 00007fd624370000 CR3: 000000000df38000 CR4: 00000000003526f0
+[  456.625879][    C1] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[  456.633857][    C1] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[  456.641894][    C1] Call Trace:
+[  456.645219][    C1]  <IRQ>
+[  456.648074][    C1]  ? __ieee80211_beacon_get+0x36/0x1630
+[  456.653659][    C1]  ieee80211_beacon_get_tim+0xb4/0x2b0
+[  456.659163][    C1]  ? __pfx_ieee80211_beacon_get_tim+0x10/0x10
+[  456.665278][    C1]  mac80211_hwsim_beacon_tx+0x3ce/0x860
+[  456.670840][    C1]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  456.678073][    C1]  __iterate_interfaces+0x2a8/0x590
+[  456.683279][    C1]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  456.689374][    C1]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  456.696631][    C1]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  456.702714][    C1]  ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+[  456.709773][    C1]  mac80211_hwsim_beacon+0xbb/0x1c0
+[  456.715007][    C1]  ? __pfx_mac80211_hwsim_beacon+0x10/0x10
+[  456.720827][    C1]  __hrtimer_run_queues+0x529/0xc60
+[  456.726075][    C1]  ? __pfx___hrtimer_run_queues+0x10/0x10
+[  456.731821][    C1]  ? read_tsc+0x9/0x20
+[  456.735918][    C1]  ? __pfx___local_bh_disable_ip+0x10/0x10
+[  456.741744][    C1]  hrtimer_run_softirq+0x187/0x2b0
+[  456.746878][    C1]  handle_softirqs+0x283/0x870
+[  456.751660][    C1]  ? __irq_exit_rcu+0xca/0x1f0
+[  456.756479][    C1]  ? __pfx_handle_softirqs+0x10/0x10
+[  456.761782][    C1]  ? irqtime_account_irq+0xb6/0x1c0
+[  456.767014][    C1]  __irq_exit_rcu+0xca/0x1f0
+[  456.771618][    C1]  ? __pfx___irq_exit_rcu+0x10/0x10
+[  456.776863][    C1]  irq_exit_rcu+0x9/0x30
+[  456.781118][    C1]  sysvec_apic_timer_interrupt+0xa6/0xc0
+[  456.786784][    C1]  </IRQ>
+[  456.789716][    C1]  <TASK>
+[  456.792650][    C1]  asm_sysvec_apic_timer_interrupt+0x1a/0x20
+[  456.798662][    C1] RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+[  456.805549][    C1] Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+[  456.825207][    C1] RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+[  456.831296][    C1] RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+[  456.839361][    C1] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+[  456.847373][    C1] RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+[  456.855378][    C1] R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+[  456.863355][    C1] R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+[  456.871366][    C1]  ? __folio_rmap_sanity_checks+0x120/0x700
+[  456.877308][    C1]  __folio_rmap_sanity_checks+0x120/0x700
+[  456.883046][    C1]  folio_remove_rmap_ptes+0x3b/0xaf0
+[  456.888367][    C1]  ? page_table_check_clear+0x187/0x700
+[  456.893919][    C1]  ? page_table_check_clear+0x4f3/0x700
+[  456.899501][    C1]  ? page_table_check_clear+0x187/0x700
+[  456.905089][    C1]  unmap_page_range+0x1e59/0x41c0
+[  456.910159][    C1]  ? __pfx_unmap_page_range+0x10/0x10
+[  456.915569][    C1]  ? mas_find+0x987/0xbc0
+[  456.919906][    C1]  ? unmap_vmas+0x144/0x580
+[  456.924420][    C1]  unmap_vmas+0x399/0x580
+[  456.928798][    C1]  ? __pfx_unmap_vmas+0x10/0x10
+[  456.933676][    C1]  exit_mmap+0x248/0xb50
+[  456.937950][    C1]  ? uprobe_clear_state+0x20f/0x290
+[  456.943161][    C1]  ? __pfx_exit_mmap+0x10/0x10
+[  456.947949][    C1]  ? __mutex_unlock_slowpath+0x1cd/0x700
+[  456.953604][    C1]  ? __pfx_exit_aio+0x10/0x10
+[  456.958321][    C1]  ? uprobe_clear_state+0x274/0x290
+[  456.963534][    C1]  __mmput+0x118/0x420
+[  456.967640][    C1]  exit_mm+0x1da/0x2c0
+[  456.971735][    C1]  ? __pfx_exit_mm+0x10/0x10
+[  456.976360][    C1]  ? rcu_is_watching+0x15/0xb0
+[  456.981142][    C1]  do_exit+0x648/0x22e0
+[  456.985330][    C1]  ? do_raw_spin_lock+0x121/0x290
+[  456.990364][    C1]  ? __pfx_do_exit+0x10/0x10
+[  456.994994][    C1]  do_group_exit+0x21c/0x2d0
+[  456.999602][    C1]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.004880][    C1]  get_signal+0x1286/0x1340
+[  457.009417][    C1]  arch_do_signal_or_restart+0x9a/0x750
+[  457.015006][    C1]  ? count_memcg_event_mm+0x21/0x260
+[  457.020330][    C1]  ? __pfx_arch_do_signal_or_restart+0x10/0x10
+[  457.026531][    C1]  ? exit_to_user_mode_loop+0x40/0x110
+[  457.032004][    C1]  exit_to_user_mode_loop+0x75/0x110
+[  457.037320][    C1]  do_syscall_64+0x2bd/0x3b0
+[  457.041925][    C1]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.047253][    C1]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.053325][    C1]  ? clear_bhb_loop+0x60/0xb0
+[  457.058030][    C1]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.063927][    C1] RIP: 0033:0x7f7ace38e929
+[  457.068361][    C1] Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+[  457.075399][    C1] RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+[  457.083837][    C1] RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+[  457.091854][    C1] RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+[  457.099854][    C1] RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+[  457.107865][    C1] R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+[  457.115864][    C1] R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+[  457.123853][    C1]  </TASK>
+[  457.126909][    C1] Kernel panic - not syncing: kernel: panic_on_warn set ...
+[  457.134192][    C1] CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full) 
+[  457.145647][    C1] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  457.155703][    C1] Call Trace:
+[  457.158994][    C1]  <IRQ>
+[  457.161841][    C1]  dump_stack_lvl+0x99/0x250
+[  457.166445][    C1]  ? __asan_memcpy+0x40/0x70
+[  457.171045][    C1]  ? __pfx_dump_stack_lvl+0x10/0x10
+[  457.176251][    C1]  ? __pfx__printk+0x10/0x10
+[  457.180858][    C1]  panic+0x2db/0x790
+[  457.184770][    C1]  ? __pfx_panic+0x10/0x10
+[  457.189276][    C1]  __warn+0x334/0x4c0
+[  457.193266][    C1]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.198990][    C1]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.204719][    C1]  report_bug+0x2be/0x4f0
+[  457.209083][    C1]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.214820][    C1]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.220556][    C1]  ? __ieee80211_beacon_get+0x125f/0x1630
+[  457.226277][    C1]  handle_bug+0x84/0x160
+[  457.230530][    C1]  exc_invalid_op+0x1a/0x50
+[  457.235043][    C1]  asm_exc_invalid_op+0x1a/0x20
+[  457.239897][    C1] RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+[  457.246228][    C1] Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+[  457.265836][    C1] RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+[  457.271906][    C1] RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+[  457.279880][    C1] RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+[  457.287854][    C1] RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+[  457.295827][    C1] R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+[  457.303796][    C1] R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+[  457.311783][    C1]  ? __ieee80211_beacon_get+0x36/0x1630
+[  457.317346][    C1]  ? __ieee80211_beacon_get+0x125c/0x1630
+[  457.323080][    C1]  ? __ieee80211_beacon_get+0x125c/0x1630
+[  457.328803][    C1]  ? __ieee80211_beacon_get+0x36/0x1630
+[  457.334382][    C1]  ieee80211_beacon_get_tim+0xb4/0x2b0
+[  457.339849][    C1]  ? __pfx_ieee80211_beacon_get_tim+0x10/0x10
+[  457.345937][    C1]  mac80211_hwsim_beacon_tx+0x3ce/0x860
+[  457.351498][    C1]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  457.358707][    C1]  __iterate_interfaces+0x2a8/0x590
+[  457.363912][    C1]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  457.369985][    C1]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  457.377189][    C1]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  457.383266][    C1]  ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+[  457.390297][    C1]  mac80211_hwsim_beacon+0xbb/0x1c0
+[  457.395513][    C1]  ? __pfx_mac80211_hwsim_beacon+0x10/0x10
+[  457.401342][    C1]  __hrtimer_run_queues+0x529/0xc60
+[  457.406570][    C1]  ? __pfx___hrtimer_run_queues+0x10/0x10
+[  457.412302][    C1]  ? read_tsc+0x9/0x20
+[  457.416387][    C1]  ? __pfx___local_bh_disable_ip+0x10/0x10
+[  457.422213][    C1]  hrtimer_run_softirq+0x187/0x2b0
+[  457.427333][    C1]  handle_softirqs+0x283/0x870
+[  457.432108][    C1]  ? __irq_exit_rcu+0xca/0x1f0
+[  457.436885][    C1]  ? __pfx_handle_softirqs+0x10/0x10
+[  457.442184][    C1]  ? irqtime_account_irq+0xb6/0x1c0
+[  457.447392][    C1]  __irq_exit_rcu+0xca/0x1f0
+[  457.451993][    C1]  ? __pfx___irq_exit_rcu+0x10/0x10
+[  457.457206][    C1]  irq_exit_rcu+0x9/0x30
+[  457.461460][    C1]  sysvec_apic_timer_interrupt+0xa6/0xc0
+[  457.467102][    C1]  </IRQ>
+[  457.470036][    C1]  <TASK>
+[  457.472966][    C1]  asm_sysvec_apic_timer_interrupt+0x1a/0x20
+[  457.478952][    C1] RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+[  457.485812][    C1] Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+[  457.505429][    C1] RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+[  457.511510][    C1] RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+[  457.519498][    C1] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+[  457.527473][    C1] RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+[  457.535453][    C1] R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+[  457.543444][    C1] R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+[  457.551441][    C1]  ? __folio_rmap_sanity_checks+0x120/0x700
+[  457.557400][    C1]  __folio_rmap_sanity_checks+0x120/0x700
+[  457.563133][    C1]  folio_remove_rmap_ptes+0x3b/0xaf0
+[  457.568437][    C1]  ? page_table_check_clear+0x187/0x700
+[  457.574019][    C1]  ? page_table_check_clear+0x4f3/0x700
+[  457.579578][    C1]  ? page_table_check_clear+0x187/0x700
+[  457.585143][    C1]  unmap_page_range+0x1e59/0x41c0
+[  457.590212][    C1]  ? __pfx_unmap_page_range+0x10/0x10
+[  457.595595][    C1]  ? mas_find+0x987/0xbc0
+[  457.599929][    C1]  ? unmap_vmas+0x144/0x580
+[  457.604438][    C1]  unmap_vmas+0x399/0x580
+[  457.608779][    C1]  ? __pfx_unmap_vmas+0x10/0x10
+[  457.613672][    C1]  exit_mmap+0x248/0xb50
+[  457.617935][    C1]  ? uprobe_clear_state+0x20f/0x290
+[  457.623144][    C1]  ? __pfx_exit_mmap+0x10/0x10
+[  457.627907][    C1]  ? __mutex_unlock_slowpath+0x1cd/0x700
+[  457.633563][    C1]  ? __pfx_exit_aio+0x10/0x10
+[  457.638254][    C1]  ? uprobe_clear_state+0x274/0x290
+[  457.643463][    C1]  __mmput+0x118/0x420
+[  457.647554][    C1]  exit_mm+0x1da/0x2c0
+[  457.651645][    C1]  ? __pfx_exit_mm+0x10/0x10
+[  457.656265][    C1]  ? rcu_is_watching+0x15/0xb0
+[  457.661066][    C1]  do_exit+0x648/0x22e0
+[  457.665252][    C1]  ? do_raw_spin_lock+0x121/0x290
+[  457.670295][    C1]  ? __pfx_do_exit+0x10/0x10
+[  457.674915][    C1]  do_group_exit+0x21c/0x2d0
+[  457.679523][    C1]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.684732][    C1]  get_signal+0x1286/0x1340
+[  457.689270][    C1]  arch_do_signal_or_restart+0x9a/0x750
+[  457.694831][    C1]  ? count_memcg_event_mm+0x21/0x260
+[  457.700146][    C1]  ? __pfx_arch_do_signal_or_restart+0x10/0x10
+[  457.706316][    C1]  ? exit_to_user_mode_loop+0x40/0x110
+[  457.711787][    C1]  exit_to_user_mode_loop+0x75/0x110
+[  457.717082][    C1]  do_syscall_64+0x2bd/0x3b0
+[  457.721684][    C1]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.726892][    C1]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.732965][    C1]  ? clear_bhb_loop+0x60/0xb0
+[  457.737651][    C1]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.743551][    C1] RIP: 0033:0x7f7ace38e929
+[  457.747963][    C1] Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+[  457.754978][    C1] RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+[  457.763401][    C1] RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+[  457.771373][    C1] RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+[  457.779344][    C1] RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+[  457.787316][    C1] R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+[  457.795296][    C1] R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+[  457.803283][    C1]  </TASK>
+[  457.806470][    C1] Kernel Offset: disabled
+[  457.810805][    C1] Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/744
+++ b/pkg/report/testdata/linux/report/744
@@ -1,0 +1,112 @@
+TITLE: WARNING in dbAdjTree
+TYPE: WARNING
+
+[  237.726449][  T112] WARNING: fs/jfs/jfs_dmap.c:2867 at dbAdjTree+0x454/0x4e0, CPU#0: jfsCommit/112
+[  237.729558][   T43] usb 1-1: config 1 interface 0 altsetting 0 has 1 endpoint descriptor, different from the interface descriptor's value: 0
+[  237.736143][  T112] Modules linked in:
+[  237.749016][   T43] usb 1-1: config 1 interface 2 altsetting 1 has 0 endpoint descriptors, different from the interface descriptor's value: 1
+[  237.755269][  T112] CPU: 0 UID: 0 PID: 112 Comm: jfsCommit Not tainted 6.16.0-rc2-next-20250617-syzkaller #0 PREEMPT(full) 
+[  237.769760][   T43] usb 1-1: New USB device found, idVendor=1d6b, idProduct=0101, bcdDevice= 0.40
+[  237.778028][  T112] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  237.797266][  T112] RIP: 0010:dbAdjTree+0x454/0x4e0
+[  237.802653][  T112] Code: 5a ff ff ff e8 6d ea 81 fe eb 05 e8 66 ea 81 fe 48 83 c4 28 5b 41 5c 41 5d 41 5e 41 5f 5d e9 83 f7 2d 08 cc e8 4d ea 81 fe 90 <0f> 0b 90 eb e1 44 89 e1 80 e1 07 80 c1 03 38 c1 0f 8c e1 fb ff ff
+[  237.823544][  T112] RSP: 0018:ffffc900026c7988 EFLAGS: 00010293
+[  237.829670][  T112] RAX: ffffffff833e8123 RBX: ffff8880701db010 RCX: ffff88801e3e5a00
+[  237.838375][  T112] RDX: 0000000000000000 RSI: 0000000000000155 RDI: 0000000000020056
+[  237.838513][   T43] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[  237.846448][  T112] RBP: 0000000000020056 R08: ffffea0001c076c7 R09: 1ffffd4000380ed8
+[  237.846473][  T112] R10: dffffc0000000000 R11: fffff94000380ed9 R12: ffff8880701db018
+[  237.846490][  T112] R13: dffffc0000000000 R14: 0000000000000004 R15: 0000000000000155
+[  237.846507][  T112] FS:  0000000000000000(0000) GS:ffff888125c40000(0000) knlGS:0000000000000000
+[  237.846526][  T112] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  237.846543][  T112] CR2: 00007fcb789f3178 CR3: 00000000731e8000 CR4: 00000000003526f0
+[  237.846563][  T112] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[  237.846577][  T112] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[  237.913066][   T43] usb 1-1: Product: syz
+[  237.919598][  T112] Call Trace:
+[  237.926755][  T112]  <TASK>
+[  237.929740][  T112]  ? __pfx_lock_metapage+0x10/0x10
+[  237.935025][  T112]  dbJoin+0x238/0x300
+[  237.939067][  T112]  ? do_read_cache_folio+0x4c6/0x590
+[  237.944500][  T112]  dbFreeBits+0x4e1/0xdb0
+[  237.948895][  T112]  dbFree+0x336/0x650
+[  237.952968][  T112]  txFreeMap+0x7ff/0xde0
+[  237.957257][  T112]  txUpdateMap+0x308/0x9c0
+[  237.961816][  T112]  jfs_lazycommit+0x43f/0xa90
+[  237.963682][   T43] usb 1-1: Manufacturer: syz
+[  237.966542][  T112]  ? __pfx_jfs_lazycommit+0x10/0x10
+[  237.976446][  T112]  ? __pfx_default_wake_function+0x10/0x10
+[  237.979918][   T43] usb 1-1: SerialNumber: syz
+[  237.982383][  T112]  ? __kthread_parkme+0x7b/0x200
+[  237.982414][  T112]  ? __kthread_parkme+0x1a1/0x200
+[  237.982443][  T112]  kthread+0x711/0x8a0
+[  238.002759][  T112]  ? __pfx_jfs_lazycommit+0x10/0x10
+[  238.008047][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.008087][  T112]  ? _raw_spin_unlock_irq+0x23/0x50
+[  238.018823][  T112]  ? lockdep_hardirqs_on+0x9c/0x150
+[  238.018861][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.018899][  T112]  ret_from_fork+0x3fc/0x770
+[  238.034089][  T112]  ? __pfx_ret_from_fork+0x10/0x10
+[  238.034134][  T112]  ? __switch_to_asm+0x39/0x70
+[  238.034154][  T112]  ? __switch_to_asm+0x33/0x70
+[  238.034172][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.034195][  T112]  ret_from_fork_asm+0x1a/0x30
+[  238.034228][  T112]  </TASK>
+[  238.034250][  T112] Kernel panic - not syncing: kernel: panic_on_warn set ...
+[  238.034264][  T112] CPU: 0 UID: 0 PID: 112 Comm: jfsCommit Not tainted 6.16.0-rc2-next-20250617-syzkaller #0 PREEMPT(full) 
+[  238.034287][  T112] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  238.034299][  T112] Call Trace:
+[  238.034309][  T112]  <TASK>
+[  238.034317][  T112]  dump_stack_lvl+0x99/0x250
+[  238.034350][  T112]  ? __asan_memcpy+0x40/0x70
+[  238.034385][  T112]  ? __pfx_dump_stack_lvl+0x10/0x10
+[  238.034425][  T112]  ? __pfx__printk+0x10/0x10
+[  238.034486][  T112]  panic+0x2db/0x790
+[  238.034532][  T112]  ? __pfx_panic+0x10/0x10
+[  238.034585][  T112]  ? ret_from_fork_asm+0x1a/0x30
+[  238.034615][  T112]  __warn+0x334/0x4c0
+[  238.034651][  T112]  ? dbAdjTree+0x454/0x4e0
+[  238.034685][  T112]  ? dbAdjTree+0x454/0x4e0
+[  238.034714][  T112]  report_bug+0x2be/0x4f0
+[  238.034744][  T112]  ? dbAdjTree+0x454/0x4e0
+[  238.034775][  T112]  ? dbAdjTree+0x454/0x4e0
+[  238.034803][  T112]  ? dbAdjTree+0x456/0x4e0
+[  238.034832][  T112]  handle_bug+0x84/0x160
+[  238.034883][  T112]  exc_invalid_op+0x1a/0x50
+[  238.034919][  T112]  asm_exc_invalid_op+0x1a/0x20
+[  238.034943][  T112] RIP: 0010:dbAdjTree+0x454/0x4e0
+[  238.034975][  T112] Code: 5a ff ff ff e8 6d ea 81 fe eb 05 e8 66 ea 81 fe 48 83 c4 28 5b 41 5c 41 5d 41 5e 41 5f 5d e9 83 f7 2d 08 cc e8 4d ea 81 fe 90 <0f> 0b 90 eb e1 44 89 e1 80 e1 07 80 c1 03 38 c1 0f 8c e1 fb ff ff
+[  238.034996][  T112] RSP: 0018:ffffc900026c7988 EFLAGS: 00010293
+[  238.035022][  T112] RAX: ffffffff833e8123 RBX: ffff8880701db010 RCX: ffff88801e3e5a00
+[  238.035041][  T112] RDX: 0000000000000000 RSI: 0000000000000155 RDI: 0000000000020056
+[  238.035058][  T112] RBP: 0000000000020056 R08: ffffea0001c076c7 R09: 1ffffd4000380ed8
+[  238.035088][  T112] R10: dffffc0000000000 R11: fffff94000380ed9 R12: ffff8880701db018
+[  238.035106][  T112] R13: dffffc0000000000 R14: 0000000000000004 R15: 0000000000000155
+[  238.035133][  T112]  ? dbAdjTree+0x453/0x4e0
+[  238.035169][  T112]  ? dbAdjTree+0x453/0x4e0
+[  238.035196][  T112]  ? __pfx_lock_metapage+0x10/0x10
+[  238.035237][  T112]  dbJoin+0x238/0x300
+[  238.035265][  T112]  ? do_read_cache_folio+0x4c6/0x590
+[  238.035302][  T112]  dbFreeBits+0x4e1/0xdb0
+[  238.035346][  T112]  dbFree+0x336/0x650
+[  238.035386][  T112]  txFreeMap+0x7ff/0xde0
+[  238.035423][  T112]  txUpdateMap+0x308/0x9c0
+[  238.035463][  T112]  jfs_lazycommit+0x43f/0xa90
+[  238.035498][  T112]  ? __pfx_jfs_lazycommit+0x10/0x10
+[  238.035525][  T112]  ? __pfx_default_wake_function+0x10/0x10
+[  238.035561][  T112]  ? __kthread_parkme+0x7b/0x200
+[  238.035586][  T112]  ? __kthread_parkme+0x1a1/0x200
+[  238.035618][  T112]  kthread+0x711/0x8a0
+[  238.035649][  T112]  ? __pfx_jfs_lazycommit+0x10/0x10
+[  238.035674][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.035705][  T112]  ? _raw_spin_unlock_irq+0x23/0x50
+[  238.035733][  T112]  ? lockdep_hardirqs_on+0x9c/0x150
+[  238.035760][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.035791][  T112]  ret_from_fork+0x3fc/0x770
+[  238.035830][  T112]  ? __pfx_ret_from_fork+0x10/0x10
+[  238.035880][  T112]  ? __switch_to_asm+0x39/0x70
+[  238.035906][  T112]  ? __switch_to_asm+0x33/0x70
+[  238.035931][  T112]  ? __pfx_kthread+0x10/0x10
+[  238.035959][  T112]  ret_from_fork_asm+0x1a/0x30
+[  238.036003][  T112]  </TASK>
+[  238.039568][  T112] Kernel Offset: disabled


### PR DESCRIPTION
The format has been slightly changed lately and we have started to get duplicates of the exiting reports, e.g.
https://syzkaller.appspot.com/bug?extid=077d9ebda84f426a6a1e

Adjust the parsing rules to keep the resulting bug titles unchanged.