### PR TITLE
pkg/report: ignore the __alloc_frozen_pages_noprof frame

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1138,6 +1138,7 @@ var linuxStackParams = &stackParams{
 		"krealloc",
 		"kmem_cache",
 		"allocate_slab",
+		"__alloc_frozen_pages_noprof",
 		"folio_(?:alloc|unlock)",
 		"filemap_alloc_folio",
 		"__filemap_get_folio",

--- a/pkg/report/testdata/linux/report/745
+++ b/pkg/report/testdata/linux/report/745
@@ -1,0 +1,67 @@
+TITLE: WARNING in v9fs_fid_get_acl
+TYPE: WARNING
+
+[   60.880086][ T5830] ------------[ cut here ]------------
+[   60.885827][ T5830] WARNING: CPU: 0 PID: 5830 at mm/page_alloc.c:4728 __alloc_frozen_pages_noprof+0x3c5/0x710
+[   60.896011][ T5830] Modules linked in:
+[   60.899938][ T5830] CPU: 0 UID: 0 PID: 5830 Comm: syz-executor405 Not tainted 6.13.0-rc1-next-20241205-syzkaller #0
+[   60.910593][ T5830] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/13/2024
+[   60.920724][ T5830] RIP: 0010:__alloc_frozen_pages_noprof+0x3c5/0x710
+[   60.927394][ T5830] Code: ff df 0f 85 09 01 00 00 44 89 e9 81 e1 7f ff ff ff a9 00 00 04 00 41 0f 44 cd 41 89 cd e9 f9 00 00 00 c6 05 87 3a 0c 0e 01 90 <0f> 0b 90 41 83 fc 0a 0f 86 13 fd ff ff 45 31 e4 48 c7 44 24 20 0e
+[   60.947123][ T5830] RSP: 0018:ffffc90003e8f940 EFLAGS: 00010246
+[   60.953230][ T5830] RAX: 0000000000000000 RBX: dffffc0000000000 RCX: 0000000000000000
+[   60.961263][ T5830] RDX: 0000000000000000 RSI: 0000000000000000 RDI: ffffc90003e8f9c8
+[   60.969284][ T5830] RBP: ffffc90003e8fa50 R08: ffffc90003e8f9c7 R09: 0000000000000000
+[   60.977298][ T5830] R10: ffffc90003e8f9a0 R11: fffff520007d1f39 R12: 0000000000000020
+[   60.985322][ T5830] R13: 0000000000040d40 R14: 1ffff920007d1f30 R15: 1ffff920007d1f2c
+[   60.993289][ T5830] FS:  0000555587715480(0000) GS:ffff8880b8600000(0000) knlGS:0000000000000000
+[   61.002261][ T5830] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[   61.009019][ T5830] CR2: 0000000020001000 CR3: 000000003352e000 CR4: 00000000003526f0
+[   61.017077][ T5830] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[   61.025105][ T5830] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[   61.033117][ T5830] Call Trace:
+[   61.036440][ T5830]  <TASK>
+[   61.039379][ T5830]  ? __warn+0x165/0x4d0
+[   61.043542][ T5830]  ? __alloc_frozen_pages_noprof+0x3c5/0x710
+[   61.049580][ T5830]  ? report_bug+0x2b3/0x500
+[   61.054104][ T5830]  ? __alloc_frozen_pages_noprof+0x3c5/0x710
+[   61.060146][ T5830]  ? handle_bug+0x60/0x90
+[   61.064534][ T5830]  ? exc_invalid_op+0x1a/0x50
+[   61.069322][ T5830]  ? asm_exc_invalid_op+0x1a/0x20
+[   61.074418][ T5830]  ? __alloc_frozen_pages_noprof+0x3c5/0x710
+[   61.080417][ T5830]  ? kfree+0x196/0x430
+[   61.084557][ T5830]  ? __pfx___alloc_frozen_pages_noprof+0x10/0x10
+[   61.090903][ T5830]  ? v9fs_fid_xattr_get+0x327/0x450
+[   61.096205][ T5830]  __alloc_pages_noprof+0xa/0x30
+[   61.101416][ T5830]  ___kmalloc_large_node+0x8b/0x1d0
+[   61.106668][ T5830]  __kmalloc_large_node_noprof+0x1a/0x80
+[   61.112316][ T5830]  __kmalloc_noprof+0x339/0x4c0
+[   61.117205][ T5830]  ? v9fs_fid_get_acl+0x4f/0x100
+[   61.122163][ T5830]  v9fs_fid_get_acl+0x4f/0x100
+[   61.126987][ T5830]  v9fs_get_acl+0x96/0x350
+[   61.131476][ T5830]  v9fs_inode_from_fid_dotl+0x22d/0x2c0
+[   61.137060][ T5830]  v9fs_mount+0x718/0xa90
+[   61.141401][ T5830]  ? __pfx_v9fs_mount+0x10/0x10
+[   61.146322][ T5830]  ? __kmalloc_cache_noprof+0x243/0x390
+[   61.151879][ T5830]  ? rcu_is_watching+0x15/0xb0
+[   61.156693][ T5830]  legacy_get_tree+0xee/0x190
+[   61.161379][ T5830]  ? __pfx_v9fs_mount+0x10/0x10
+[   61.166287][ T5830]  vfs_get_tree+0x90/0x2b0
+[   61.170719][ T5830]  do_new_mount+0x2be/0xb40
+[   61.175271][ T5830]  ? __pfx_do_new_mount+0x10/0x10
+[   61.180310][ T5830]  __se_sys_mount+0x2d6/0x3c0
+[   61.185041][ T5830]  ? __pfx___se_sys_mount+0x10/0x10
+[   61.190252][ T5830]  ? exc_page_fault+0x590/0x8b0
+[   61.195157][ T5830]  ? __x64_sys_mount+0x20/0xc0
+[   61.199952][ T5830]  do_syscall_64+0xf3/0x230
+[   61.204535][ T5830]  ? clear_bhb_loop+0x35/0x90
+[   61.209314][ T5830]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   61.215249][ T5830] RIP: 0033:0x7f05fcd17de9
+[   61.219683][ T5830] Code: 28 00 00 00 75 05 48 83 c4 28 c3 e8 f1 17 00 00 90 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 b8 ff ff ff f7 d8 64 89 01 48
+[   61.239354][ T5830] RSP: 002b:00007ffc85e9b418 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+[   61.247813][ T5830] RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007f05fcd17de9
+[   61.255862][ T5830] RDX: 0000000020000b80 RSI: 00000000200003c0 RDI: 0000000000000000
+[   61.263925][ T5830] RBP: 000000000000ec55 R08: 0000000020000580 R09: 00007ffc85e9b450
+[   61.271936][ T5830] R10: 0000000000000000 R11: 0000000000000246 R12: 00007ffc85e9b450
+[   61.279966][ T5830] R13: 00007ffc85e9b43c R14: 431bde82d7b634db R15: 00007f05fcd60087
+[   61.287987][ T5830]  </TASK>

--- a/pkg/report/testdata/linux/report/746
+++ b/pkg/report/testdata/linux/report/746
@@ -1,0 +1,72 @@
+TITLE: WARNING in drm_mode_create_lease_ioctl
+TYPE: WARNING
+
+[   42.860506][ T5936] WARNING: CPU: 0 PID: 5936 at mm/page_alloc.c:4715 __alloc_frozen_pages_noprof+0x1f66/0x2470
+[   42.863402][ T5936] Modules linked in:
+[   42.865118][ T5936] CPU: 0 UID: 0 PID: 5936 Comm: syz-executor305 Not tainted 6.14.0-rc4-syzkaller-00248-g03d38806a902 #0
+[   42.869306][ T5936] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2~bpo12+1 04/01/2014
+[   42.872295][ T5936] RIP: 0010:__alloc_frozen_pages_noprof+0x1f66/0x2470
+[   42.874216][ T5936] Code: 24 38 41 89 c6 0f b6 c0 44 8b ac 24 84 00 00 00 89 44 24 18 e9 a8 f7 ff ff 90 0f 0b 90 e9 b6 f7 ff ff c6 05 2d 52 3a 0e 01 90 <0f> 0b 90 e9 d9 e4 ff ff 90 0f 0b 90 e9 4e fb ff ff 83 bc 24 80 00
+[   42.879500][ T5936] RSP: 0018:ffffc900039677c0 EFLAGS: 00010246
+[   42.881159][ T5936] RAX: 0000000000000000 RBX: 0000000000000000 RCX: 0000000000000000
+[   42.883611][ T5936] RDX: 0000000000000000 RSI: 000000000000000b RDI: 0000000000040dc0
+[   42.885830][ T5936] RBP: 00000000007a1200 R08: 0000000000000007 R09: 0000000000000000
+[   42.888010][ T5936] R10: 0000000000000000 R11: 0000000000000000 R12: 000000000000000b
+[   42.890200][ T5936] R13: 1ffff9200072cf0c R14: 00000000007a1200 R15: ffffffff855c28fd
+[   42.892470][ T5936] FS:  00005555724b6380(0000) GS:ffff88806a600000(0000) knlGS:0000000000000000
+[   42.894921][ T5936] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[   42.896753][ T5936] CR2: 00004000003d0000 CR3: 0000000025918000 CR4: 0000000000352ef0
+[   42.898895][ T5936] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[   42.901047][ T5936] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[   42.903319][ T5936] Call Trace:
+[   42.904281][ T5936]  <TASK>
+[   42.905149][ T5936]  ? __warn+0xea/0x3c0
+[   42.906348][ T5936]  ? __alloc_frozen_pages_noprof+0x1f66/0x2470
+[   42.908026][ T5936]  ? report_bug+0x3c0/0x580
+[   42.909339][ T5936]  ? handle_bug+0x54/0xa0
+[   42.910570][ T5936]  ? exc_invalid_op+0x17/0x50
+[   42.911967][ T5936]  ? asm_exc_invalid_op+0x1a/0x20
+[   42.913405][ T5936]  ? drm_mode_create_lease_ioctl+0x4bd/0x1f60
+[   42.915153][ T5936]  ? __alloc_frozen_pages_noprof+0x1f66/0x2470
+[   42.916925][ T5936]  ? count_memcg_events_mm.constprop.0+0x138/0x340
+[   42.918754][ T5936]  ? __pfx_lock_release+0x10/0x10
+[   42.920158][ T5936]  ? find_held_lock+0x2d/0x110
+[   42.921647][ T5936]  ? __pfx___alloc_frozen_pages_noprof+0x10/0x10
+[   42.923471][ T5936]  ? __pfx___up_read+0x10/0x10
+[   42.924831][ T5936]  ? do_user_addr_fault+0x83d/0x13f0
+[   42.926360][ T5936]  ? drm_mode_create_lease_ioctl+0x4bd/0x1f60
+[   42.928050][ T5936]  __alloc_pages_noprof+0xb/0x1b0
+[   42.929637][ T5936]  ___kmalloc_large_node+0x84/0x1b0
+[   42.931620][ T5936]  __kmalloc_large_node_noprof+0x1c/0x70
+[   42.933298][ T5936]  __kmalloc_noprof.cold+0xc/0x61
+[   42.934898][ T5936]  ? _copy_from_user+0x59/0xd0
+[   42.936423][ T5936]  drm_mode_create_lease_ioctl+0x4bd/0x1f60
+[   42.938212][ T5936]  ? __pfx___lock_acquire+0x10/0x10
+[   42.939700][ T5936]  ? __pfx_drm_mode_create_lease_ioctl+0x10/0x10
+[   42.941516][ T5936]  ? lock_acquire.part.0+0x11b/0x380
+[   42.943017][ T5936]  ? find_held_lock+0x2d/0x110
+[   42.944380][ T5936]  ? drm_is_current_master+0x2c/0x40
+[   42.946013][ T5936]  ? do_raw_spin_unlock+0x172/0x230
+[   42.947479][ T5936]  drm_ioctl_kernel+0x1e6/0x3d0
+[   42.948854][ T5936]  ? __pfx_drm_mode_create_lease_ioctl+0x10/0x10
+[   42.950646][ T5936]  ? __pfx___might_fault+0x1/0x10
+[   42.952142][ T5936]  ? __pfx_drm_ioctl_kernel+0x10/0x10
+[   42.953680][ T5936]  ? __might_fault+0xe3/0x190
+[   42.955049][ T5936]  drm_ioctl+0x5d6/0xc00
+[   42.956322][ T5936]  ? __pfx_drm_mode_create_lease_ioctl+0x10/0x10
+[   42.958082][ T5936]  ? __pfx_drm_ioctl+0x10/0x10
+[   42.959455][ T5936]  ? selinux_file_ioctl+0x180/0x270
+[   42.960902][ T5936]  ? selinux_file_ioctl+0xb4/0x270
+[   42.962499][ T5936]  ? __pfx_drm_ioctl+0x10/0x10
+[   42.963810][ T5936]  __x64_sys_ioctl+0x190/0x200
+[   42.965160][ T5936]  do_syscall_64+0xcd/0x250
+[   42.966472][ T5936]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   42.968134][ T5936] RIP: 0033:0x7fee89044129
+[   42.969441][ T5936] Code: 48 83 c4 28 c3 e8 37 17 00 00 0f 1f 80 00 00 00 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 b8 ff ff ff f7 d8 64 89 01 48
+[   42.975252][ T5936] RSP: 002b:00007ffe5200dad8 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
+[   42.977569][ T5936] RAX: ffffffffffffffda RBX: 0000400000000000 RCX: 00007fee89044129
+[   42.979768][ T5936] RDX: 00004000000003c0 RSI: 00000000c01864c6 RDI: 0000000000000003
+[   42.982069][ T5936] RBP: 00007fee890b7610 R08: 0023647261632f69 R09: 00007ffe5200dca8
+[   42.984285][ T5936] R10: 000000000000000f R11: 0000000000000246 R12: 0000000000000001
+[   42.986487][ T5936] R13: 00007ffe5200dc98 R14: 0000000000000001 R15: 0000000000000001
+[   42.988657][ T5936]  </TASK>


### PR DESCRIPTION
Even though __alloc_frozen_pages_noprof has the WARN_ON, the actual problem lies in how malloc was called down the stacktrace. This leads to several different bugs being merged into one:
https://syzkaller.appspot.com/bug?extid=03fb58296859d8dbab4d

Ingore the __alloc_frozen_pages_noprof frame when selecting the bug title.