### PR TITLE
syz-cluster: use a separate service account for email reporter

### DIFF
--- a/syz-cluster/email-reporter/deployment.yaml
+++ b/syz-cluster/email-reporter/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: email-reporter
     spec:
-      serviceAccountName: gke-service-ksa
+      serviceAccountName: gke-email-reporter-ksa
       containers:
       - name: email-reporter
         image: ${IMAGE_PREFIX}email-reporter:${IMAGE_TAG}

--- a/syz-cluster/overlays/minikube/service-accounts.yaml
+++ b/syz-cluster/overlays/minikube/service-accounts.yaml
@@ -30,3 +30,11 @@ kind: ServiceAccount
 metadata:
   name: gke-db-admin-ksa
   namespace: default
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gke-email-reporter-ksa
+  namespace: default


### PR DESCRIPTION
This will allow us to granularly configure its access to GCP's Secret Manager. Also, it doesn't need Spanner access like controller or web-dashboard.