### PR TITLE
pkg/cover: fix handling of compile unit name

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -140,3 +140,4 @@ Rivos Inc.
  Alexandre Ghiti
 Jeongjun Park
 Nikita Zhandarovich
+Jiacheng Xu

--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -407,8 +407,11 @@ func readTextRanges(debugInfo *dwarf.Data, module *vminfo.KernelModule, pcFix pc
 		} else {
 			// Compile unit names are relative to the compilation dir,
 			// while per-line info isn't.
-			// Let's stick to the common approach.
-			unitName := filepath.Join(attrCompDir, attrName)
+			// attrName could be an absolute path for out-of-tree modules.
+			unitName := attrName
+			if !filepath.IsAbs(attrName) {
+				unitName = filepath.Join(attrCompDir, attrName)
+			}
 			ranges1, err := debugInfo.Ranges(ent)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
The `attrName` is often an absolute path for out-of-tree modules. This commit avoids redundant path concatenation when `attrName` is already absolute, enabling developers to view coverage correctly in the web UI.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
