### PR TITLE
pkg/report: start using crash.KMSAN

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1443,6 +1443,7 @@ var linuxOopses = append([]*oops{
 					skip: []string{"alloc_skb", "usb_submit_urb", "usb_start_wait_urb", "usb_bulk_msg", "usb_interrupt_msg", "usb_control_msg"},
 				},
 				noStackTrace: true,
+				reportType:   crash.KMSAN,
 			},
 			{
 				title:  compile("BUG: KMSAN:"),
@@ -1460,6 +1461,7 @@ var linuxOopses = append([]*oops{
 					skip: []string{"alloc_skb", "netlink_ack", "netlink_rcv_skb"},
 				},
 				noStackTrace: true,
+				reportType:   crash.KMSAN,
 			},
 			{
 				title:        compile("BUG: KCSAN: data-race"),

--- a/pkg/report/testdata/linux/report/626
+++ b/pkg/report/testdata/linux/report/626
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in prepare_task_switch
 ALT: bad-access in prepare_task_switch
+TYPE: KMSAN
 
 [  567.476354][    T1] =====================================================
 [  567.483452][    T1] BUG: KMSAN: uninit-value in prepare_task_switch+0x284/0xd00

--- a/pkg/report/testdata/linux/report/632
+++ b/pkg/report/testdata/linux/report/632
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in __perf_event_task_sched_in
 ALT: bad-access in __perf_event_task_sched_in
+TYPE: KMSAN
 CORRUPTED: Y
 
 [ 1307.507727][    T0] =====================================================

--- a/pkg/report/testdata/linux/report/633
+++ b/pkg/report/testdata/linux/report/633
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in prepend_path
 ALT: bad-access in prepend_path
+TYPE: KMSAN
 CORRUPTED: Y
 
 [  370.741346][ T8537] =====================================================

--- a/pkg/report/testdata/linux/report/634
+++ b/pkg/report/testdata/linux/report/634
@@ -1,5 +1,6 @@
 TITLE: KMSAN: kernel-infoleak in urandom_read_nowarn
 ALT: bad-access in urandom_read_nowarn
+TYPE: KMSAN
 
 [  600.161674][ T9046] =====================================================
 [  600.168788][ T9046] BUG: KMSAN: kernel-infoleak in _copy_to_user+0x1c9/0x270

--- a/pkg/report/testdata/linux/report/635
+++ b/pkg/report/testdata/linux/report/635
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in sctp_epaddr_lookup_transport
 ALT: bad-access in sctp_epaddr_lookup_transport
+TYPE: KMSAN
 
 [  701.063465][    C1] =====================================================
 [  701.070594][    C1] BUG: KMSAN: uninit-value in sctp_epaddr_lookup_transport+0x9bc/0xd10

--- a/pkg/report/testdata/linux/report/636
+++ b/pkg/report/testdata/linux/report/636
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in ppp_send_frame
 ALT: bad-access in ppp_send_frame
+TYPE: KMSAN
 
 [   87.733076][ T3479] =====================================================
 [   87.740069][ T3479] BUG: KMSAN: uninit-value in ppp_send_frame+0x28d/0x27c0

--- a/pkg/report/testdata/linux/report/637
+++ b/pkg/report/testdata/linux/report/637
@@ -1,5 +1,6 @@
 TITLE: KMSAN: kernel-usb-infoleak in hif_usb_send
 ALT: KMSAN origin in htc_connect_service
+TYPE: KMSAN
 
 [  180.463142][ T3569] =====================================================
 [  180.470227][ T3569] BUG: KMSAN: kernel-usb-infoleak in usb_submit_urb+0x6c1/0x2aa0

--- a/pkg/report/testdata/linux/report/670
+++ b/pkg/report/testdata/linux/report/670
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in native_apic_mem_write
 ALT: bad-access in native_apic_mem_write
+TYPE: KMSAN
 
 [  663.629383][    C1] =====================================================
 [  663.636461][    C1] BUG: KMSAN: uninit-value in native_apic_mem_write+0x6e/0x90

--- a/pkg/report/testdata/linux/report/671
+++ b/pkg/report/testdata/linux/report/671
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in flush_to_ldisc
 ALT: bad-access in flush_to_ldisc
+TYPE: KMSAN
 
 [ 1725.922949][   T52] =====================================================
 [ 1725.930075][   T52] BUG: KMSAN: uninit-value in flush_to_ldisc+0x95d/0xdf0

--- a/pkg/report/testdata/linux/report/672
+++ b/pkg/report/testdata/linux/report/672
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in ext4_evict_inode
 ALT: bad-access in ext4_evict_inode
+TYPE: KMSAN
 
 [  345.516988][ T3516] =====================================================
 [  345.524532][ T3516] BUG: KMSAN: uninit-value in ext4_evict_inode+0xdd/0x26b0

--- a/pkg/report/testdata/linux/report/673
+++ b/pkg/report/testdata/linux/report/673
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in nilfs_bmap_lookup_at_level
 ALT: bad-access in nilfs_bmap_lookup_at_level
+TYPE: KMSAN
 
 [  231.715107][ T3795] =====================================================
 [  231.723837][ T3795] BUG: KMSAN: uninit-value in nilfs_bmap_lookup_at_level+0x22e/0x4c0

--- a/pkg/report/testdata/linux/report/674
+++ b/pkg/report/testdata/linux/report/674
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in ntfs_iget5
 ALT: bad-access in ntfs_iget5
+TYPE: KMSAN
 
 [  493.519926][ T7865] =====================================================
 [  493.527002][ T7865] BUG: KMSAN: uninit-value in ntfs_iget5+0x6cf/0x6510

--- a/pkg/report/testdata/linux/report/681
+++ b/pkg/report/testdata/linux/report/681
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in net_tx_action
 ALT: bad-access in net_tx_action
+TYPE: KMSAN
 
 [  142.141483][    C0] =====================================================
 [  142.148660][    C0] BUG: KMSAN: uninit-value in net_tx_action+0x77c/0x9a0

--- a/pkg/report/testdata/linux/report/682
+++ b/pkg/report/testdata/linux/report/682
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in ieee80211_rx_list
 ALT: bad-access in ieee80211_rx_list
+TYPE: KMSAN
 
 [  338.587187][    C0] BUG: KMSAN: uninit-value in ieee80211_rx_list+0x1839/0x5860
 [  338.594871][    C0]  ieee80211_rx_list+0x1839/0x5860

--- a/pkg/report/testdata/linux/report/689
+++ b/pkg/report/testdata/linux/report/689
@@ -1,5 +1,6 @@
 TITLE: KMSAN: kernel-infoleak in kernfs_fop_read_iter
 ALT: bad-access in kernfs_fop_read_iter
+TYPE: KMSAN
 
 [  160.663319][ T5029] =====================================================
 [  160.670618][ T5029] BUG: KMSAN: kernel-infoleak in _copy_to_iter+0x870/0x1fd0

--- a/pkg/report/testdata/linux/report/690
+++ b/pkg/report/testdata/linux/report/690
@@ -1,5 +1,6 @@
 TITLE: KMSAN: kernel-infoleak in __skb_datagram_iter
 ALT: bad-access in __skb_datagram_iter
+TYPE: KMSAN
 
 [ 2104.495854][ T4311] =====================================================
 [ 2104.503364][ T4311] BUG: KMSAN: kernel-infoleak in _copy_to_iter+0x870/0x1fd0

--- a/pkg/report/testdata/linux/report/699
+++ b/pkg/report/testdata/linux/report/699
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in aes_encrypt
 ALT: bad-access in aes_encrypt
+TYPE: KMSAN
 
 [  311.903743][ T5388] =====================================================
 [  311.910990][ T5388] BUG: KMSAN: uninit-value in aes_encrypt+0x15cc/0x1db0

--- a/pkg/report/testdata/linux/report/700
+++ b/pkg/report/testdata/linux/report/700
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in virtqueue_add
 ALT: bad-access in virtqueue_add
+TYPE: KMSAN
 
 [  897.203644][ T1083] =====================================================
 [  897.210960][ T1083] BUG: KMSAN: uninit-value in virtqueue_add+0x20e2/0x60f0

--- a/pkg/report/testdata/linux/report/701
+++ b/pkg/report/testdata/linux/report/701
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in btrfs_bin_search
 ALT: bad-access in btrfs_bin_search
+TYPE: KMSAN
 
 [  343.493742][ T5647] =====================================================
 [  343.504878][ T5647] BUG: KMSAN: uninit-value in btrfs_bin_search+0x74c/0xb30

--- a/pkg/report/testdata/linux/report/702
+++ b/pkg/report/testdata/linux/report/702
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in post_read_mst_fixup
 ALT: bad-access in post_read_mst_fixup
+TYPE: KMSAN
 
 [  355.605345][ T5697] =====================================================
 [  355.612721][ T5697] BUG: KMSAN: uninit-value in post_read_mst_fixup+0xab8/0xb70

--- a/pkg/report/testdata/linux/report/703
+++ b/pkg/report/testdata/linux/report/703
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in nilfs_add_checksums_on_logs
 ALT: bad-access in nilfs_add_checksums_on_logs
+TYPE: KMSAN
 
 [  417.716144][ T7542] =====================================================
 [  417.723574][ T7542] BUG: KMSAN: uninit-value in crc32_le_base+0x43c/0xd80

--- a/pkg/report/testdata/linux/report/708
+++ b/pkg/report/testdata/linux/report/708
@@ -1,5 +1,6 @@
 TITLE: KMSAN: kernel-infoleak in filemap_read
 ALT: bad-access in filemap_read
+TYPE: KMSAN
 
 [  410.433138][ T5348] =====================================================
 [  410.440506][ T5348] BUG: KMSAN: kernel-infoleak in _copy_to_iter+0x376/0x1c60

--- a/pkg/report/testdata/linux/report/709
+++ b/pkg/report/testdata/linux/report/709
@@ -1,5 +1,6 @@
 TITLE: KMSAN: uninit-value in tipc_nl_node_reset_link_stats
 ALT: bad-access in tipc_nl_node_reset_link_stats
+TYPE: KMSAN
 
 [ 1414.295772][T23431] =====================================================
 [ 1414.303512][T23431] BUG: KMSAN: uninit-value in strstr+0xb8/0x2f0


### PR DESCRIPTION
We have crash.KMSAN definition that is not used.