### PR TITLE
pkg/report: factor out type definitions

### DIFF
--- a/pkg/report/crash/types.go
+++ b/pkg/report/crash/types.go
@@ -15,6 +15,7 @@ const (
 	Bug              = Type("BUG")
 	Warning          = Type("WARNING")
 	KASAN            = Type("KASAN")
+	KFENCE           = Type("KFENCE")
 	LockdepBug       = Type("LOCKDEP")
 	AtomicSleep      = Type("ATOMIC_SLEEP")
 	KMSAN            = Type("KMSAN")

--- a/pkg/report/darwin.go
+++ b/pkg/report/darwin.go
@@ -5,8 +5,6 @@ package report
 
 import (
 	"regexp"
-
-	"github.com/google/syzkaller/pkg/report/crash"
 )
 
 func ctorDarwin(cfg *config) (reporterImpl, []string, error) {
@@ -45,7 +43,6 @@ var darwinOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("Debugger: Unexpected kernel trap number:"),
@@ -56,7 +53,6 @@ var darwinOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	&groupGoRuntimeErrors,
 }, commonOopses...)

--- a/pkg/report/freebsd.go
+++ b/pkg/report/freebsd.go
@@ -5,8 +5,6 @@ package report
 
 import (
 	"regexp"
-
-	"github.com/google/syzkaller/pkg/report/crash"
 )
 
 type freebsd struct {
@@ -57,7 +55,6 @@ var freebsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("panic:"),
@@ -105,7 +102,6 @@ var freebsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	&groupGoRuntimeErrors,
 }, commonOopses...)

--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/ianlancetaylor/demangle"
 )
@@ -324,7 +323,6 @@ var zirconOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("recursion in interrupt handler"),
@@ -345,7 +343,6 @@ var zirconOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	// We should detect just "stopping other cpus" as some kernel crash rather then as "lost connection",
 	// but if we add oops for "stopping other cpus", then it will interfere with other formats,
@@ -360,11 +357,9 @@ var zirconOopses = []*oops{
 				title:        compile("welcome to Zircon"),
 				fmt:          "unexpected kernel reboot",
 				noStackTrace: true,
-				reportType:   crash.UnexpectedReboot,
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("KVM internal error"),
@@ -376,7 +371,6 @@ var zirconOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("<== fatal exception"),
@@ -391,7 +385,6 @@ var zirconOopses = []*oops{
 		[]*regexp.Regexp{
 			compile("<== fatal exception: process .+?syz.+?\\["),
 		},
-		crash.UnknownType,
 	},
 }
 
@@ -412,7 +405,6 @@ var starnixOopses = []*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 }
 

--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -6,8 +6,6 @@ package report
 import (
 	"bytes"
 	"regexp"
-
-	"github.com/google/syzkaller/pkg/report/crash"
 )
 
 type gvisor struct {
@@ -106,7 +104,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("SIGSEGV:"),
@@ -118,7 +115,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("SIGBUS:"),
@@ -130,7 +126,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("FATAL ERROR:"),
@@ -142,7 +137,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("WARNING: DATA RACE"),
@@ -155,7 +149,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("Invalid request partialResult"),
@@ -168,7 +161,6 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("fatal error:"),
@@ -180,6 +172,5 @@ var gvisorOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 }, commonOopses...)

--- a/pkg/report/netbsd.go
+++ b/pkg/report/netbsd.go
@@ -5,8 +5,6 @@ package report
 
 import (
 	"regexp"
-
-	"github.com/google/syzkaller/pkg/report/crash"
 )
 
 func ctorNetbsd(cfg *config) (reporterImpl, []string, error) {
@@ -33,7 +31,6 @@ var netbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("panic: "),
@@ -67,7 +64,6 @@ var netbsdOopses = append([]*oops{
 		[]*regexp.Regexp{
 			compile(`ddb\.onpanic:`),
 		},
-		crash.UnknownType,
 	},
 	{
 		[]byte("UBSan:"),
@@ -78,7 +74,6 @@ var netbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	&groupGoRuntimeErrors,
 }, commonOopses...)

--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -5,8 +5,6 @@ package report
 
 import (
 	"regexp"
-
-	"github.com/google/syzkaller/pkg/report/crash"
 )
 
 func ctorOpenbsd(cfg *config) (reporterImpl, []string, error) {
@@ -38,7 +36,6 @@ var openbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("panic:"),
@@ -93,7 +90,6 @@ var openbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("lock order reversal:"),
@@ -108,7 +104,6 @@ var openbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("witness:"),
@@ -127,7 +122,6 @@ var openbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("uvm_fault("),
@@ -149,7 +143,6 @@ var openbsdOopses = append([]*oops{
 			},
 		},
 		[]*regexp.Regexp{},
-		crash.UnknownType,
 	},
 	{
 		[]byte("kernel:"),
@@ -166,7 +159,6 @@ var openbsdOopses = append([]*oops{
 		[]*regexp.Regexp{
 			compile("reorder_kernel"),
 		},
-		crash.UnknownType,
 	},
 	&groupGoRuntimeErrors,
 }, commonOopses...)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -208,7 +208,7 @@ func testFromReport(rep *Report) *ParseTest {
 		Corrupted:       rep.Corrupted,
 		corruptedReason: rep.CorruptedReason,
 		Suppressed:      rep.Suppressed,
-		Type:            rep.Type,
+		Type:            titleToCrashType(rep.Title),
 		Frame:           rep.Frame,
 		Report:          rep.Report,
 	}
@@ -231,9 +231,6 @@ func testParseImpl(t *testing.T, reporter *Reporter, test *ParseTest) {
 	}
 	if rep != nil && rep.Title == "" {
 		t.Fatalf("found crash, but title is empty")
-	}
-	if rep != nil && rep.Type == unspecifiedType {
-		t.Fatalf("unspecifiedType leaked outside")
 	}
 	parsed := testFromReport(rep)
 	if !test.Equal(parsed) {

--- a/pkg/report/testdata/linux/report/590
+++ b/pkg/report/testdata/linux/report/590
@@ -1,5 +1,6 @@
 TITLE: KFENCE: use-after-free in find_uprobe
 ALT: bad-access in find_uprobe
+TYPE: KFENCE
 
 [  221.211609][ T9991] ==================================================================
 [  221.219706][ T9991] BUG: KFENCE: use-after-free read in memcmp+0x57/0x150

--- a/pkg/report/testdata/linux/report/591
+++ b/pkg/report/testdata/linux/report/591
@@ -1,5 +1,6 @@
 TITLE: KFENCE: out-of-bounds in test_out_of_bounds_read
 ALT: bad-access in test_out_of_bounds_read
+TYPE: KFENCE
 
 [    3.317089] ==================================================================
 [    3.317855] BUG: KFENCE: out-of-bounds read in test_out_of_bounds_read+0xa6/0x234

--- a/pkg/report/testdata/linux/report/592
+++ b/pkg/report/testdata/linux/report/592
@@ -1,5 +1,6 @@
 TITLE: KFENCE: out-of-bounds in test_out_of_bounds_write
 ALT: bad-access in test_out_of_bounds_write
+TYPE: KFENCE
 
 [    3.980910] ==================================================================
 [    3.981709] BUG: KFENCE: out-of-bounds write in test_out_of_bounds_write+0x8e/0x148

--- a/pkg/report/testdata/linux/report/593
+++ b/pkg/report/testdata/linux/report/593
@@ -1,5 +1,6 @@
 TITLE: KFENCE: use-after-free in test_use_after_free_read
 ALT: bad-access in test_use_after_free_read
+TYPE: KFENCE
 
 [    4.252938] ==================================================================
 [    4.253783] BUG: KFENCE: use-after-free read in test_use_after_free_read+0xb3/0x143

--- a/pkg/report/testdata/linux/report/594
+++ b/pkg/report/testdata/linux/report/594
@@ -1,5 +1,6 @@
 TITLE: KFENCE: invalid free in test_double_free
 ALT: invalid-free in test_double_free
+TYPE: KFENCE
 
 [    4.524933] ==================================================================
 [    4.525732] BUG: KFENCE: invalid free in test_double_free+0xdc/0x171

--- a/pkg/report/testdata/linux/report/595
+++ b/pkg/report/testdata/linux/report/595
@@ -1,5 +1,6 @@
 TITLE: KFENCE: invalid free in test_invalid_addr_free
 ALT: invalid-free in test_invalid_addr_free
+TYPE: KFENCE
 
 [    4.764967] ==================================================================
 [    4.765977] BUG: KFENCE: invalid free in test_invalid_addr_free+0xb4/0x17e

--- a/pkg/report/testdata/linux/report/596
+++ b/pkg/report/testdata/linux/report/596
@@ -1,4 +1,5 @@
 TITLE: KFENCE: memory corruption in test_corruption
+TYPE: KFENCE
 
 [    4.996949] ==================================================================
 [    4.997809] BUG: KFENCE: memory corruption in test_corruption+0xb3/0x20f

--- a/pkg/report/testdata/linux/report/597
+++ b/pkg/report/testdata/linux/report/597
@@ -1,4 +1,5 @@
 TITLE: KFENCE: memory corruption in kunit_try_run_case
+TYPE: KFENCE
 
 [   10.396949] ==================================================================
 [   10.397720] BUG: KFENCE: memory corruption in test_kmalloc_aligned_oob_write+0xef/0x184

--- a/pkg/report/testdata/linux/report/598
+++ b/pkg/report/testdata/linux/report/598
@@ -1,5 +1,6 @@
 TITLE: KFENCE: invalid read in test_invalid_access
 ALT: bad-access in test_invalid_access
+TYPE: KFENCE
 
 [   10.613348] ==================================================================
 [   10.614532] BUG: KFENCE: invalid read in test_invalid_access+0x48/0xe0

--- a/pkg/report/testdata/linux/report/599
+++ b/pkg/report/testdata/linux/report/599
@@ -1,4 +1,5 @@
 TITLE: KFENCE: memory corruption in do_check_common
+TYPE: KFENCE
 
 [   98.860898][ T9916] ==================================================================
 [   98.869076][ T9916] BUG: KFENCE: memory corruption in krealloc+0x60/0xd0

--- a/pkg/report/title_to_type.go
+++ b/pkg/report/title_to_type.go
@@ -16,10 +16,6 @@ var titleToType = []struct {
 		crashType:       crash.DataRace,
 	},
 	{
-		includePrefixes: []string{"KFENCE: "},
-		crashType:       crash.UnknownType,
-	},
-	{
 		includePrefixes: []string{
 			// keep-sorted start
 			"BUG: bad unlock balance in",
@@ -143,6 +139,10 @@ var titleToType = []struct {
 	{
 		includePrefixes: []string{"KASAN: "},
 		crashType:       crash.KASAN,
+	},
+	{
+		includePrefixes: []string{"KFENCE: "},
+		crashType:       crash.KFENCE,
 	},
 	{
 		includePrefixes: []string{"KMSAN: "},

--- a/pkg/report/title_to_type.go
+++ b/pkg/report/title_to_type.go
@@ -1,0 +1,155 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package report
+
+import (
+	"github.com/google/syzkaller/pkg/report/crash"
+)
+
+var titleToType = []struct {
+	includePrefixes []string
+	crashType       crash.Type
+}{
+	{
+		includePrefixes: []string{"KCSAN: data-race"},
+		crashType:       crash.DataRace,
+	},
+	{
+		includePrefixes: []string{"KFENCE: "},
+		crashType:       crash.UnknownType,
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"BUG: bad unlock balance in",
+			"BUG: held lock freed in",
+			"BUG: rwlock",
+			"BUG: spinlock",
+			"BUG: still has locks held in",
+			"WARNING: bad unlock balance in",
+			"WARNING: held lock freed in",
+			"WARNING: lock held",
+			"WARNING: locking bug in",
+			"WARNING: nested lock was not taken in",
+			"WARNING: still has locks held in",
+			"WARNING: suspicious RCU usage in",
+			"inconsistent lock state in",
+			"possible deadlock in",
+			// keep-sorted end
+		},
+		crashType: crash.LockdepBug,
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"BUG: scheduling while atomic in",
+			"BUG: sleeping function called from invalid context in",
+			// keep-sorted end
+		},
+		crashType: crash.AtomicSleep,
+	},
+	{
+		includePrefixes: []string{"memory leak in"},
+		crashType:       crash.MemoryLeak,
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"BUG: bad usercopy in",
+			"BUG: corrupted list in",
+			"kernel BUG ",
+			// keep-sorted end
+		},
+		crashType: crash.Bug,
+	},
+	{
+		includePrefixes: []string{"WARNING in"},
+		crashType:       crash.Warning,
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"BUG: stack guard page was hit in",
+			"WARNING: corrupted",
+			"WARNING: kernel stack frame pointer has bad value",
+			"WARNING: kernel stack regs has bad",
+			// keep-sorter end
+		},
+		crashType: crash.UnknownType, // This is printk().
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"BUG: soft lockup in",
+			"INFO: rcu detected stall in",
+			"INFO: task can't die in",
+			"INFO: task hung in",
+			// keep-sorted end
+		},
+		crashType: crash.Hang,
+	},
+	{
+		includePrefixes: []string{
+			// keep-sorted start
+			"Alignment trap in",
+			"BUG: Object already free",
+			"BUG: unable to handle kernel",
+			"Internal error in",
+			"PANIC: double fault",
+			"Unhandled fault in",
+			"VFS: Busy inodes after unmount (use-after-free)",
+			"VFS: Close: file count is zero (use-after-free)",
+			"divide error in",
+			"general protection fault in",
+			"go runtime error",
+			"invalid opcode in",
+			"kernel panic: ",
+			"kernel stack overflow",
+			"panic:",
+			"rust_kernel panicked",
+			"stack segment fault in",
+			"trusty:",
+			"unregister_netdevice: waiting for DEV to become free",
+			// keep-sorted end
+		},
+		crashType: crash.UnknownType,
+	},
+	{
+		includePrefixes: []string{"unexpected kernel reboot"},
+		crashType:       crash.UnexpectedReboot,
+	},
+	{
+		includePrefixes: []string{
+			"SYZFAIL",
+			"SYZFATAL:",
+		},
+		crashType: crash.SyzFailure,
+	},
+
+	// DEFAULTS.
+	{
+		includePrefixes: []string{"WARNING: "},
+		crashType:       crash.Warning,
+	},
+	{
+		includePrefixes: []string{"BUG: "},
+		crashType:       crash.UnknownType,
+	},
+	{
+		includePrefixes: []string{"INFO: "},
+		crashType:       crash.UnknownType,
+	},
+	{
+		includePrefixes: []string{"KASAN: "},
+		crashType:       crash.KASAN,
+	},
+	{
+		includePrefixes: []string{"KMSAN: "},
+		crashType:       crash.KMSAN,
+	},
+	{
+		includePrefixes: []string{"UBSAN: "},
+		crashType:       crash.UBSAN,
+	},
+}

--- a/pkg/report/title_to_type_test.go
+++ b/pkg/report/title_to_type_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package report
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTitleToTypeDefinitions(t *testing.T) {
+	knownPrefixes := make(map[string]bool)
+	for _, def := range titleToType {
+		if len(def.includePrefixes) == 0 {
+			t.Errorf("title definition can't be empty")
+		}
+		for _, prefix := range def.includePrefixes {
+			if prefix == "" {
+				t.Errorf("title prefix can't be empty")
+			}
+			if knownPrefixes[prefix] {
+				t.Errorf("duplicate title prefix: %q", prefix)
+			}
+			if wasMatched, byPrefix := hasPrefix(knownPrefixes, prefix); wasMatched {
+				t.Errorf("%s was matched by %s", prefix, byPrefix)
+			}
+			knownPrefixes[prefix] = true
+		}
+	}
+}
+
+func hasPrefix(prefixes map[string]bool, s string) (bool, string) {
+	for prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true, prefix
+		}
+	}
+	return false, ""
+}


### PR DESCRIPTION
Bug title uniquely identifies the bug class.
This refactoring allows to add bug subclasses that may be used by:
1. Manager.
2. Dashboard.
3. Non-Linux OSes.

We're doing it in scope #6072.