### PR TITLE
prog: use consistent default values for conditional unions

### DIFF
--- a/prog/expr.go
+++ b/prog/expr.go
@@ -205,8 +205,11 @@ func (c *Call) setDefaultConditions(target *Target, transientOnly bool) bool {
 				if transientOnly && !unionArg.transient {
 					return
 				}
-				// If several union options match, take the first one.
 				idx := okIndices[0]
+				if defIdx, ok := unionType.defaultField(); ok {
+					// If there's a default value available, use it.
+					idx = defIdx
+				}
 				field := unionType.Fields[idx]
 				replace[unionArg] = MakeUnionArg(unionType,
 					unionArg.Dir(),

--- a/prog/expr_test.go
+++ b/prog/expr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateConditionalFields(t *testing.T) {
@@ -308,4 +309,17 @@ func TestNestedConditionalCall(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDefaultConditionalSerialize(t *testing.T) {
+	// Serialize() omits default-valued fields for a more compact representation,
+	// but that shouldn't mess with the selected option (see #6105).
+	const rawProg = "test$parent_conditions(&(0x7f0000000000)={0xa3})\n"
+	target := initTargetTest(t, "test", "64")
+	prog, err := target.Deserialize([]byte(rawProg), NonStrict)
+	require.NoError(t, err)
+	serialized := prog.Serialize()
+	prog2, err := target.Deserialize(serialized, NonStrict)
+	require.NoError(t, err)
+	assert.Equal(t, rawProg, string(prog2.Serialize()))
 }

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -261,6 +261,10 @@ func (arg *UnionArg) validate(ctx *validCtx, dir Dir) error {
 	if arg.Index < 0 || arg.Index >= len(typ.Fields) {
 		return fmt.Errorf("union arg %v has bad index %v/%v", arg, arg.Index, len(typ.Fields))
 	}
+	if arg.transient && !ctx.opts.ignoreTransient {
+		// The union must have been patched via Call.setDefaultConditions.
+		return fmt.Errorf("union arg %v is transient (incomplete)", arg)
+	}
 	opt := typ.Fields[arg.Index]
 	return ctx.validateArg(arg.Option, opt.Type, opt.Dir(dir))
 }


### PR DESCRIPTION
We used to assume that the default value was the last, yet when it was not specified in the serialized program, the first union option whose condition is satisfied was chosen. Let's be consistent and use the last value in both cases.

Also, remember that there's a case when there's no valid default value - this happens when pkg/compiler wraps a conditional field into a union with two conditional fields. Explicitly check for this case and assume that, whatever value is set, is the correct default because in this particular case the conditions of the two union options must be exclusive.

Fixes #6105.
