### PR TITLE
pkg/cover: several fixes

### DIFF
--- a/pkg/cover/backend/dwarf.go
+++ b/pkg/cover/backend/dwarf.go
@@ -82,6 +82,18 @@ var arches = map[string]*Arch{
 			return pc + 4*off
 		},
 	},
+	targets.S390x: {
+		scanSize:      1,
+		callLen:       6,
+		callRelocType: uint64(elf.R_390_PLT32DBL),
+		isCallInsn: func(arch *Arch, insn []byte) bool {
+			return insn[0] == 0xc0 && insn[1] == 0xe5
+		},
+		callTarget: func(arch *Arch, insn []byte, pc uint64) uint64 {
+			off := uint64(int64(int32(binary.BigEndian.Uint32(insn[2:]))))
+			return pc + 2*off
+		},
+	},
 }
 
 func makeDWARF(params *dwarfParams) (impl *Impl, err error) {
@@ -114,7 +126,7 @@ func processModule(params *dwarfParams, module *vminfo.KernelModule, info *symbo
 
 	var data []byte
 	var coverPoints [2][]uint64
-	if target.Arch != targets.AMD64 && target.Arch != targets.ARM64 {
+	if _, ok := arches[target.Arch]; !ok {
 		coverPoints, err = objdump(target, module)
 	} else if module.Name == "" {
 		data, err = params.readTextData(module)


### PR DESCRIPTION
The function CleanPath() cannot handle symbolic links within syz-manager's paths to kernel directories because the DWARF backend returns paths to kernel source files with symbolic links resolved.

objdump prints absolute addresses for coverage points of core kernel.
