### PR TITLE
Added flag to enforce syscall dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ Tudor Ambarus
 Elektrobit Automotive GmbH
 Rivos Inc.
 Jeongjun Park
+Qualcomm, Inc

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -141,3 +141,5 @@ Rivos Inc.
 Jeongjun Park
 Nikita Zhandarovich
 Jiacheng Xu
+Qualcomm, Inc
+ Nilo Redini

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -284,7 +284,7 @@ func (fuzzer *Fuzzer) genFuzz() *queue.Request {
 	if req == nil {
 		req = genProgRequest(fuzzer, rnd)
 	}
-	if fuzzer.Config.Collide && rnd.Intn(3) == 0 {
+	if !req.Prog.EnforceDeps && fuzzer.Config.Collide && rnd.Intn(3) == 0 {
 		req = &queue.Request{
 			Prog: randomCollide(req.Prog, rnd),
 			Stat: fuzzer.statExecCollide,

--- a/pkg/fuzzer/job.go
+++ b/pkg/fuzzer/job.go
@@ -44,7 +44,8 @@ func (ji *JobInfo) ID() string {
 func genProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *queue.Request {
 	p := fuzzer.target.Generate(rnd,
 		prog.RecommendedCalls,
-		fuzzer.ChoiceTable())
+		fuzzer.ChoiceTable(),
+	)
 	return &queue.Request{
 		Prog:     p,
 		ExecOpts: setFlags(flatrpc.ExecFlagCollectSignal),
@@ -64,6 +65,9 @@ func mutateProgRequest(fuzzer *Fuzzer, rnd *rand.Rand) *queue.Request {
 		fuzzer.Config.NoMutateCalls,
 		fuzzer.Config.Corpus.Programs(),
 	)
+	if !newP.ValidateDeps() {
+		return nil
+	}
 	return &queue.Request{
 		Prog:     newP,
 		ExecOpts: setFlags(flatrpc.ExecFlagCollectSignal),
@@ -456,6 +460,9 @@ func (job *smashJob) run(fuzzer *Fuzzer) {
 			fuzzer.ChoiceTable(),
 			fuzzer.Config.NoMutateCalls,
 			fuzzer.Config.Corpus.Programs())
+		if !p.ValidateDeps() {
+			continue
+		}
 		result := fuzzer.execute(job.exec, &queue.Request{
 			Prog:     p,
 			ExecOpts: setFlags(flatrpc.ExecFlagCollectSignal),

--- a/prog/clone.go
+++ b/prog/clone.go
@@ -21,8 +21,9 @@ func (p *Prog) cloneWithMap(newargs map[*ResultArg]*ResultArg) *Prog {
 		panic("cloning of unsafe programs is not supposed to be done")
 	}
 	p1 := &Prog{
-		Target: p.Target,
-		Calls:  cloneCalls(p.Calls, newargs),
+		Target:      p.Target,
+		Calls:       cloneCalls(p.Calls, newargs),
+		EnforceDeps: p.EnforceDeps,
 	}
 	p1.debugValidate()
 	return p1

--- a/prog/expr.go
+++ b/prog/expr.go
@@ -72,7 +72,7 @@ func makeArgFinder(t *Target, c *Call, unionArg *UnionArg, parents parentStack) 
 }
 
 func (r *randGen) patchConditionalFields(c *Call, s *state) (extra []*Call, changed bool) {
-	if r.patchConditionalDepth > 1 {
+	if r.patchConditionalDepth > 1 && !r.EnforceDeps {
 		// Some nested patchConditionalFields() calls are fine as we could trigger a resource
 		// constructor via generateArg(). But since nested createResource() calls are prohibited,
 		// patchConditionalFields() should never be nested more than 2 times.

--- a/prog/minimization.go
+++ b/prog/minimization.go
@@ -62,7 +62,7 @@ func Minimize(p0 *Prog, callIndex0 int, mode MinimizeMode, pred0 func(*Prog, int
 		p.debugValidate()
 		id := hash.String(p.Serialize())
 		if _, ok := dedup[id]; !ok {
-			dedup[id] = pred0(p, callIndex)
+			dedup[id] = p.ValidateDeps() && pred0(p, callIndex)
 		}
 		return dedup[id]
 	}

--- a/prog/prog.go
+++ b/prog/prog.go
@@ -9,15 +9,20 @@ import (
 )
 
 type Prog struct {
-	Target   *Target
-	Calls    []*Call
-	Comments []string
+	Target      *Target
+	Calls       []*Call
+	Comments    []string
+	EnforceDeps bool
 
 	// Was deserialized using Unsafe mode, so can do unsafe things.
 	isUnsafe bool
 }
 
 const ExtraCallName = ".extra"
+
+func (p *Prog) ValidateDeps() bool {
+	return p.doValidateDeps()
+}
 
 func (p *Prog) CallName(call int) string {
 	if call >= len(p.Calls) || call < -1 {

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -21,6 +21,10 @@ const (
 	// "Recommended" max number of calls in programs.
 	// If we receive longer programs from hub/corpus we discard them.
 	MaxCalls = 40
+	// Maximum number of times we can call the same IOCTL while resolving/creating a resource.
+	MaxResSameSyscall = 3
+	// Number of times we try to avoid reusing an IOCTL that's already in the stack while resolving/creating a resource.
+	AvoidSameSyscallAttempts = 20
 )
 
 type randGen struct {
@@ -29,6 +33,7 @@ type randGen struct {
 	inGenerateResource    bool
 	patchConditionalDepth int
 	recDepth              map[string]int
+	EnforceDeps           bool
 }
 
 func newRand(target *Target, rs rand.Source) *randGen {
@@ -426,17 +431,26 @@ func (r *randGen) createResource(s *state, res *ResourceType, dir Dir) (Arg, []*
 	var precise []*Syscall
 	for _, info := range ctors {
 		if info.Precise {
+			if r.EnforceDeps && isSyscallInStack(s, info.Call.Name) {
+				continue
+			}
 			precise = append(precise, info.Call)
 		}
 	}
-	if len(precise) > 0 {
-		// If the argument is optional, it's not guaranteed that there'd be a
-		// precise constructor.
-		meta = precise[r.Intn(len(precise))]
-	}
-	if meta == nil || r.oneOf(3) {
-		// Sometimes just take a random one.
-		meta = ctors[r.Intn(len(ctors))].Call
+	for i := 0; i < AvoidSameSyscallAttempts; i++ {
+		if len(precise) > 0 {
+			// If the argument is optional, it's not guaranteed that there'd be a
+			// precise constructor.
+			meta = precise[r.Intn(len(precise))]
+		}
+		if meta == nil || r.oneOf(3) {
+			// Sometimes just take a random one.
+			meta = ctors[r.Intn(len(ctors))].Call
+		}
+
+		if !r.EnforceDeps || !isSyscallInStack(s, meta.Name) {
+			break
+		}
 	}
 
 	calls := r.generateParticularCall(s, meta)
@@ -457,6 +471,11 @@ func (r *randGen) createResource(s *state, res *ResourceType, dir Dir) (Arg, []*
 			res.Desc.Kind[0], kind, meta.Name))
 	}
 	arg := MakeResultArg(res, dir, allres[r.Intn(len(allres))], 0)
+	for _, rRes := range allres {
+		if rRes.Dir() != DirIn {
+			s.resources[kind] = append(s.resources[kind], rRes)
+		}
+	}
 	return arg, calls
 }
 
@@ -609,7 +628,9 @@ func (r *randGen) generateParticularCall(s *state, meta *Syscall) (calls []*Call
 		panic(fmt.Sprintf("generating no_generate call: %v", meta.Name))
 	}
 	c := MakeCall(meta, nil)
+	pushSyscallToStack(s, meta.Name)
 	c.Args, calls = r.generateArgs(s, meta.Args, DirIn)
+	popSyscallFromStack(s)
 	moreCalls, _ := r.patchConditionalFields(c, s)
 	r.target.assignSizesCall(c)
 	return append(append(calls, moreCalls...), c)
@@ -685,10 +706,12 @@ func (r *randGen) generateArgs(s *state, fields []Field, dir Dir) ([]Arg, []*Cal
 
 	// Generate all args. Size args have the default value 0 for now.
 	for i, field := range fields {
+		pushFieldToStack(s, field.Name)
 		arg, calls1 := r.generateArg(s, field.Type, field.Dir(dir))
 		if arg == nil {
 			panic(fmt.Sprintf("generated arg is nil for field '%v', fields: %+v", field.Type.Name(), fields))
 		}
+		popFieldFromStack(s)
 		args[i] = arg
 		calls = append(calls, calls1...)
 	}
@@ -742,12 +765,17 @@ func (a *ResourceType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls [
 		defer func() { r.inGenerateResource = false }()
 		canRecurse = true
 	}
-	if canRecurse && r.nOutOf(8, 10) ||
-		!canRecurse && r.nOutOf(19, 20) {
+	if (canRecurse && r.nOutOf(8, 10)) ||
+		(!canRecurse && r.nOutOf(19, 20)) ||
+		r.EnforceDeps {
 		arg = r.existingResource(s, a, dir)
 		if arg != nil {
 			return
 		}
+	}
+	if r.EnforceDeps && !canRecurse {
+		recCounter := getSyscallFieldLoopIterations(s)
+		canRecurse = (recCounter < MaxResSameSyscall)
 	}
 	if canRecurse {
 		if r.oneOf(4) {
@@ -756,7 +784,7 @@ func (a *ResourceType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls [
 				return
 			}
 		}
-		if r.nOutOf(4, 5) {
+		if r.nOutOf(4, 5) || r.EnforceDeps {
 			// If we could not reuse a resource, let's prefer resource creation over
 			// random int substitution.
 			arg, calls = r.createResource(s, a, dir)
@@ -911,7 +939,7 @@ func (a *PtrType) generate(r *randGen, s *state, dir Dir) (arg Arg, calls []*Cal
 	}
 	// The resource we are trying to generate may be in the pointer,
 	// so don't try to create an empty special pointer during resource generation.
-	if !r.inGenerateResource && r.oneOf(1000) {
+	if !r.EnforceDeps && !r.inGenerateResource && r.oneOf(1000) {
 		index := r.rand(len(r.target.SpecialPointers))
 		return MakeSpecialPointerArg(a, dir, index), nil
 	}

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -18,6 +18,32 @@ func init() {
 	}
 }
 
+func (p *Prog) doValidateDeps() bool {
+	toRet := true
+	if p.EnforceDeps {
+		for _, c := range p.Calls {
+			ForeachArg(c, func(arg Arg, _ *ArgCtx) {
+				if a, ok := arg.(*ResultArg); ok {
+					if a.Dir() == DirIn && a.Res == nil {
+						toRet = false
+						return
+					}
+				}
+
+				if p, ok := arg.(*PointerArg); ok {
+					if _, okPtr := p.Type().(*PtrType); okPtr {
+						if p.Res == nil {
+							toRet = false
+							return
+						}
+					}
+				}
+			})
+		}
+	}
+	return toRet
+}
+
 func (p *Prog) debugValidate() {
 	if debug {
 		if err := p.validate(); err != nil {


### PR DESCRIPTION
**Issue**
Syzkaller often breaks dependencies across syscalls (expressed through the use of resources in Syzkaller programs). And because of this, Syzkaller struggles to build fuzzing inputs (i.e., programs) that would exercise deeper paths in the drivers. Syzkaller breaks syscalls dependencies because: 1) fuzzing mutation might remove random calls (and resources), 2) the resource generation itself is stochastic -- with a certain probability P, Syzkaller purposefully disregards syscall dependencies in an attempt to increase randomness, and 3) program minimization -- Syzkaller minimizes the programs that it generates, as they are initially quite big.

**Patch**
The patch addresses all these issues by adding a Boolean (called PromoteDep) in the validation module of Syzkaller. If the Boolean is set to true, certain measures are taken to enforce that IOCTL dependencies are respected in any generated program. In particular, Mutation does not break dependencies, Resource generation is no longer stochastic, and dependencies across syscalls are never disregarded, If a minimized program has broken dependencies, it gets discarded. The patch allows for different ways to enable the PromoteDep flag: 1) The configuration flag promote_syscalls_dependency. If enabled Syzkaller is instructed to not break dependencies, and 2) The flag dynamic_promote_syscalls_dependency. This flag contains a time expressed in minutes (e.g, 30). Once the manager starts it sets a timer with the value contained in this flag. Once the timer reaches the 0, the Boolean PromoteDep is switched (i.e., if it contained false it now contains true, and vice versa), and the timer starts again. This switch allows us to introduce more randomness in the generated programs. 

All flags are optional, and they don't have to be set.