### PR TITLE
vm/qemu: use virtio-net-ccw as virtual netdev on s390x arch

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -201,8 +201,8 @@ var archConfigs = map[string]*archConfig{
 	},
 	"linux/s390x": {
 		Qemu:     "qemu-system-s390x",
-		QemuArgs: "-M s390-ccw-virtio -cpu max,zpci=on",
-		NetDev:   "virtio-net-pci",
+		QemuArgs: "-M s390-ccw-virtio -cpu max",
+		NetDev:   "virtio-net-ccw",
 		RngDev:   "virtio-rng-ccw",
 		CmdLine: []string{
 			"root=/dev/vda",


### PR DESCRIPTION
virtio-net-ccw is a preferred way to set up a virtual network interface on s390x at the moment because it is faster than virtio-net-pci (eventfd and irqfd is missing). This also allows disabling of zPCI in QEMU which was required only because virtio-net-pci was used as a network interface. PCI is special on s390x and, for instance, does not use MMIO or expose topology [1,2,3]. Furthermore, any features like PXE are not supported with virtio-net-pci on s390x.

[1] https://people.redhat.com/~cohuck/2018/02/19/notes-on-pci-on-s390x.html
[2] https://wiki.qemu.org/Documentation/Platforms/S390X#A_note_on_PCI_support
[3] https://www.qemu.org/docs/master/system/s390x/pcidevices.html
