### PR TITLE
dashboard/app: switch to go124

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -1,7 +1,7 @@
 # Copyright 2017 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-runtime: go123
+runtime: go124
 app_engine_apis: true
 
 # With the f2 setting, the app episodically crashes with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/syzkaller
 
-go 1.23.7
+go 1.24.4
 
 require (
 	cloud.google.com/go v0.121.3


### PR DESCRIPTION
It works. Waiting for the AppEngine go124 support.

TODO:
1. #6147 
2. #6149 