### PR TITLE
vm/proxyapp: introduce proxyAppParams.CreateInstanceDelay

### DIFF
--- a/vm/proxyapp/init.go
+++ b/vm/proxyapp/init.go
@@ -20,9 +20,10 @@ import (
 
 func makeDefaultParams() *proxyAppParams {
 	return &proxyAppParams{
-		CommandRunner:  osutilCommandContext,
-		InitRetryDelay: 10 * time.Second,
-		LogOutput:      os.Stdout,
+		CommandRunner:       osutilCommandContext,
+		InitRetryDelay:      10 * time.Second,
+		CreateInstanceDelay: 1 * time.Second,
+		LogOutput:           os.Stdout,
 	}
 }
 
@@ -36,9 +37,10 @@ func init() {
 
 // Package configuration VARs are mostly needed for tests.
 type proxyAppParams struct {
-	CommandRunner  func(context.Context, string, ...string) subProcessCmd
-	InitRetryDelay time.Duration
-	LogOutput      io.Writer
+	CommandRunner       func(context.Context, string, ...string) subProcessCmd
+	InitRetryDelay      time.Duration
+	CreateInstanceDelay time.Duration
+	LogOutput           io.Writer
 }
 
 func osutilCommandContext(ctx context.Context, bin string, args ...string) subProcessCmd {

--- a/vm/proxyapp/proxyappclient.go
+++ b/vm/proxyapp/proxyappclient.go
@@ -181,6 +181,7 @@ type ProxyApp struct {
 	onLostConnection    chan bool
 	stopLogPooling      chan bool
 	logPoolingDone      chan bool
+	params              *proxyAppParams
 }
 
 func initPipedRPCClient(cmd subProcessCmd) (*rpc.Client, []io.Closer, error) {
@@ -290,6 +291,7 @@ func runProxyApp(params *proxyAppParams, cmd string, initRPClient bool) (*ProxyA
 		Client:       client,
 		terminate:    cancelContext,
 		onTerminated: onTerminated,
+		params:       params,
 	}, nil
 }
 
@@ -406,6 +408,7 @@ func (proxy *ProxyApp) CreateInstance(workdir, image string, index int) (vmimpl.
 		params.WorkdirData = workdirData
 	}
 
+	time.Sleep(proxy.params.CreateInstanceDelay)
 	err := proxy.Call("ProxyVM.CreateInstance", params, &reply)
 	if err != nil {
 		return nil, fmt.Errorf("failed to proxy.Call(\"ProxyVM.CreateInstance\"): %w", err)

--- a/vm/proxyapp/proxyappclient_test.go
+++ b/vm/proxyapp/proxyappclient_test.go
@@ -33,9 +33,10 @@ var testEnv = &vmimpl.Env{
 
 func makeTestParams() *proxyAppParams {
 	return &proxyAppParams{
-		CommandRunner:  osutilCommandContext,
-		InitRetryDelay: 0,
-		LogOutput:      io.Discard,
+		CommandRunner:       osutilCommandContext,
+		InitRetryDelay:      0,
+		CreateInstanceDelay: 0,
+		LogOutput:           io.Discard,
 	}
 }
 


### PR DESCRIPTION
When there are no available machines, proxyapp is sending thousands of RPC calls per second to request a new one.

Add a parameter to allow throttling the requests.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
