### PR TITLE
Fix errno for Landlock

### DIFF
--- a/sys/linux/test/landlock_fs_ioctl
+++ b/sys/linux/test/landlock_fs_ioctl
@@ -1,6 +1,6 @@
-# Makes a regular file.
+# Makes a character device /dev/null
 
-mknodat(0xffffffffffffff9c, &AUTO='./file0\x00', 0x81c0, 0x0)
+mknodat(0xffffffffffffff9c, &AUTO='./file0\x00', 0x21c0, 0x103)
 
 # Creates a ruleset to restrict most filesystem IOCTLs: LANDLOCK_ACCESS_FS_IOCTL_DEV.
 
@@ -17,9 +17,9 @@ landlock_restrict_self(r0, 0x0)
 
 r1 = openat$dir(0xffffffffffffff9c, &AUTO='./file0\x00', 0x2, 0x0)
 
-# Denied FIOQSIZE IOCTL.
+# Denied FIONREAD (not really but same value) IOCTL.
 
-ioctl(r1, 0x5460, 0x0) # EACCES
+ioctl(r1, 0x541b, 0x0) # EACCES
 
 # Allowed FIOCLEX IOCTL.
 

--- a/sys/linux/test/landlock_ptrace
+++ b/sys/linux/test/landlock_ptrace
@@ -1,5 +1,8 @@
 # Creates independent Landlock hierarchies and try different tracer/tracee
 # schemas (without scheduling control).
+#
+# In this test, some ptrace(2) calls return different code according to the
+# calling thread.
 
 capset(&AUTO={0x20080522, 0x0}, &AUTO={0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 prctl$PR_SET_NO_NEW_PRIVS(0x26, 0x1)
@@ -16,7 +19,7 @@ landlock_restrict_self(r1, 0x0)
 
 r2 = syz_clone(0x11, 0x0, 0x0, 0x0, 0x0, 0x0)
 
-ptrace(0x10, r0)
+ptrace(0x10, r0) # EPERM
 ptrace(0x11, r0)
 
 ptrace(0x10, r2)
@@ -25,10 +28,10 @@ ptrace(0x11, r2)
 r3 = landlock_create_ruleset(&AUTO={0x100, 0x0, 0x0}, AUTO, 0x0)
 landlock_restrict_self(r3, 0x0)
 
-ptrace(0x10, r0)
+ptrace(0x10, r0) # EPERM
 ptrace(0x11, r0)
 
-ptrace(0x10, r2)
+ptrace(0x10, r2) # EPERM
 ptrace(0x11, r2)
 
 # For now, PTRACE_TRACEME is transformed to -1, which returns an error:


### PR DESCRIPTION
When testing with the test mode (see #6164), I found that some Landlock tests are not correct.

This PR improves them as much as possible and document why it may not be possible.

Filtered output of `syz-manager` with `-mode run-tests --tests landlock_ -debug`:

```
landlock_fs_accesses none             : OK
landlock_fs_accesses none/cover       : OK
landlock_fs_accesses none/cover C     : OK
landlock_fs_accesses none/cover C/repeat C: OK
landlock_fs_accesses none/cover C/repeat C/thr: OK
landlock_fs_accesses none/cover C/repeat C/thr/cover: OK
landlock_fs_accesses none/cover C/repeat C/thr/cover C: OK
landlock_fs_accesses none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_fs_forbidden none            : OK
landlock_fs_forbidden none/cover      : OK
landlock_fs_forbidden none/cover C    : OK
landlock_fs_forbidden none/cover C/repeat C: OK
landlock_fs_forbidden none/cover C/repeat C/thr: OK
landlock_fs_forbidden none/cover C/repeat C/thr/cover: OK
landlock_fs_forbidden none/cover C/repeat C/thr/cover C: OK
landlock_fs_forbidden none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_fs_ioctl none                : OK
landlock_fs_ioctl none/cover          : OK
landlock_fs_ioctl none/cover C        : OK
landlock_fs_ioctl none/cover C/repeat C: OK
landlock_fs_ioctl none/cover C/repeat C/thr: OK
landlock_fs_ioctl none/cover C/repeat C/thr/cover: OK
landlock_fs_ioctl none/cover C/repeat C/thr/cover C: OK
landlock_fs_ioctl none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_fs_reparent none             : OK
landlock_fs_reparent none/cover       : OK
landlock_fs_reparent none/cover C     : OK
landlock_fs_reparent none/cover C/repeat C: OK
landlock_fs_reparent none/cover C/repeat C/thr: OK
landlock_fs_reparent none/cover C/repeat C/thr/cover: OK
landlock_fs_reparent none/cover C/repeat C/thr/cover C: OK
landlock_fs_reparent none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_fs_truncate none             : OK
landlock_fs_truncate none/cover       : OK
landlock_fs_truncate none/cover C     : OK
landlock_fs_truncate none/cover C/repeat C: OK
landlock_fs_truncate none/cover C/repeat C/thr: OK
landlock_fs_truncate none/cover C/repeat C/thr/cover: OK
landlock_fs_truncate none/cover C/repeat C/thr/cover C: OK
landlock_fs_truncate none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_layers none                  : OK
landlock_layers none/cover            : OK
landlock_layers none/cover C          : OK
landlock_layers none/cover C/repeat C : OK
landlock_layers none/cover C/repeat C/thr: OK
landlock_layers none/cover C/repeat C/thr/cover: OK
landlock_layers none/cover C/repeat C/thr/cover C: OK
landlock_layers none/cover C/repeat C/thr/cover C/repeat C: OK
landlock_sb_delete none               : OK
landlock_sb_delete none/cover         : OK
landlock_sb_delete none/cover C       : OK
landlock_sb_delete none/cover C/repeat C: OK
landlock_sb_delete none/cover C/repeat C/thr: OK
landlock_sb_delete none/cover C/repeat C/thr/cover: OK
landlock_sb_delete none/cover C/repeat C/thr/cover C: OK
landlock_sb_delete none/cover C/repeat C/thr/cover C/repeat C: OK
```

Only the `landlock_ptrace` test cannot be fully fixed, but that's OK, it is still run and helps improve coverage:
 
```
landlock_ptrace none                  : FAIL: run 0: wrong call 4 result 3, want 0
landlock_ptrace none/cover            : FAIL: run 0: wrong call 9 result 3, want 0
landlock_ptrace none/cover C          : FAIL: run 0: wrong call 4 result 3, want 0
landlock_ptrace none/cover C/repeat C : FAIL: run 0: wrong call 9 result 3, want 0
landlock_ptrace none/cover C/repeat C/thr: FAIL: run 0: wrong call 9 result 3, want 0
landlock_ptrace none/cover C/repeat C/thr/cover: FAIL: run 0: wrong call 9 result 3, want 0
landlock_ptrace none/cover C/repeat C/thr/cover C: FAIL: run 0: wrong call 9 result 3, want 0
landlock_ptrace none/cover C/repeat C/thr/cover C/repeat C: FAIL: run 0: wrong call 9 result 3, want 0
```