### PR TITLE
pkg/report: introduce null ptr crash types

### DIFF
--- a/pkg/report/README.md
+++ b/pkg/report/README.md
@@ -1,79 +1,72 @@
 # Bugs scoring
 
-Until triaged we don't really know the bug impact.
-But we can learn a lot from the bug title.
+Until triaged we don't really know the bug impact. But we can learn a lot from the bug title.
 
-Syzbot scoring is based on our understanding of what bug class
-looks historically more impactful.
-It allows to prioritize the triaging queue.
+Syzbot scoring is based on our understanding of what bug class looks historically more impactful. It allows to
+prioritize the triaging queue.
 
 ## Heuristics
 
 ### KASAN > KMSAN > KCSAN
-KASAN detected bugs are typically more dangerous than KMSAN detected bugs.
-And KMSAN detected bugs are typically more dangerous than KCSAN detected bugs.
+KASAN detected bugs are typically more dangerous than KMSAN detected bugs. And KMSAN detected bugs are typically more
+dangerous than KCSAN detected bugs.
 
 ### Use-after-free write > invalid-free(double-free) > use-after-free read.
 
 ### KASAN write > KASAN read
-KASAN write indicates an out-of-bounds or use-after-free write operation.
-Any uncontrolled write to kernel memory is extremely dangerous
-because it can corrupt data or code pointers, making it a
-high-value target for exploitation leading to system compromise.
-KASAN read indicates an out-of-bounds or use-after-free read.
-This is generally less critical. It can crash the system (DoS)
-or leak sensitive data, but it doesn't provide a direct path for an
+KASAN write indicates an out-of-bounds or use-after-free write operation. Any uncontrolled write to kernel memory is
+extremely dangerous because it can corrupt data or code pointers, making it a high-value target for exploitation
+and leading to system compromise. KASAN read indicates an out-of-bounds or use-after-free read. This is generally
+less critical. It can crash the system (DoS) or leak sensitive data, but it doesn't provide a direct path for an
 attacker to execute their own code.
 
 ### Memory Safety bugs > DoS bugs.
 This heuristic establishes a broad priority between two major classes of bugs based on their ultimate impact.
 
-Memory Safety bugs: This category includes all the issues mentioned above—use-after-free, double-free, out-of-bounds reads/writes, etc. These are considered more severe because they represent a potential system compromise. A successful exploit can allow an attacker to escalate privileges and gain complete control over the kernel and the entire system.
+Memory Safety bugs: This category includes all the issues mentioned above—use-after-free, double-free, out-of-bounds
+reads/writes, etc. These are considered more severe because they represent a potential system compromise. A successful
+exploit can allow an attacker to escalate privileges and gain complete control over the kernel and the entire system.
 
-DoS bugs (Denial of Service): This category includes bugs like kernel hangs, crashes, or resource exhaustion (e.g., memory leaks). While they are serious because they disrupt system availability, they typically do not allow an attacker to execute code or steal data. The impact is usually temporary and can be resolved by rebooting the system. They disrupt the service but don't compromise its integrity.
+DoS bugs (Denial of Service): This category includes bugs like kernel hangs, crashes, or resource exhaustion
+(e.g., memory leaks). While they are serious because they disrupt system availability, they typically do not allow an
+attacker to execute code or steal data. The impact is usually temporary and can be resolved by rebooting the system.
+They disrupt the service but don't compromise its integrity.
 
 ### Information Leaks > Denial of Service (DoS)
-Kmsan infoleak and other bugs that leak kernel memory are generally
-more severe than a typical DoS. These leaks can be used to bypass
-security mitigations like Kernel Address Space Layout Randomization (KASLR),
-which makes exploiting other vulnerabilities easier.
+Kmsan infoleak and other bugs that leak kernel memory are generally more severe than a typical DoS. These leaks can be
+used to bypass security mitigations like Kernel Address Space Layout Randomization (KASLR), which makes exploiting
+other vulnerabilities easier.
 
 ### Concurrency Issues > Simple DoS
-Bugs like DataRace and LockdepBug can be more critical than a standard DoS.
-Data races can lead to unpredictable behavior, including memory corruption,
-which might be exploitable.
+Bugs like DataRace and LockdepBug can be more critical than a standard DoS. Data races can lead to unpredictable
+behavior, including memory corruption, which might be exploitable.
 
-LockdepBug indicates potential deadlocks,
-which can cause a more severe system Hang than a resource-exhaustion DoS.
+LockdepBug indicates potential deadlocks, which can cause a more severe system Hang than a resource-exhaustion DoS.
 
 ### KFENCE reports are high priority
-KFENCE is a lighter-weight memory safety detector compared to KASAN.
-While it may have a lower performance overhead, the bugs it finds
-(use-after-free, out-of-bounds) are of the same high-impact nature
-as those found by KASAN.
-Therefore, KFENCE detected bugs should be treated with a similar level
-of urgency as KASAN reports.
+KFENCE is a lighter-weight memory safety detector compared to KASAN. While it may have a lower performance overhead,
+the bugs it finds (use-after-free, out-of-bounds) are of the same high-impact nature as those found by KASAN.
+Therefore, KFENCE detected bugs should be treated with a similar level of urgency as KASAN reports.
 
 ### UBSAN reports require careful evaluation
-The Undefined Behavior Sanitizer (UBSAN) can detect a wide range
-of issues. Their severity can vary greatly:
+The Undefined Behavior Sanitizer (UBSAN) can detect a wide range of issues. Their severity can vary greatly:
 
-1. A shift-out-of-bounds or array-index-out-of-bounds issue
-can be very severe if it leads to memory corruption.
-2. An integer-overflow can also be critical if it results in bypassing
-security checks and leads to a buffer overflow.
-3. Other UBSAN issues might be less critical but still indicate latent
-bugs that could become problematic.
+1. A shift-out-of-bounds or array-index-out-of-bounds issue can be very severe if it leads to memory corruption.
+2. An integer-overflow can also be critical if it results in bypassing security checks and leads to a buffer overflow.
+3. Other UBSAN issues might be less critical but still indicate latent bugs that could become problematic.
 
 ### LockdepSleeping in Atomic Context is a critical flaw
-AtomicSleep is a serious bug that can lead to system-wide hangs
-and instability. This is because holding a spinlock or being in
-another atomic context while sleeping can cause deadlocks.
+AtomicSleep is a serious bug that can lead to system-wide hangs and instability. This is because holding a spinlock
+or being in another atomic context while sleeping can cause deadlocks.
 
 These are generally more severe than a typical DoS.
 
 ### Memory Leaks are a form of DoS
-MemoryLeak bugs are a type of denial of service where the kernel
-gradually runs out of memory. While generally less severe than
-memory corruption, a fast memory leak that can be triggered by
-an unprivileged user can be a high-impact DoS vector.
+MemoryLeak bugs are a type of denial of service where the kernel gradually runs out of memory. While generally less
+severe than memory corruption, a fast memory leak that can be triggered by an unprivileged user can be a high-impact
+DoS vector.
+
+### NULL pointer dereference in reads/writes
+They may be exploitable (see [proof](https://googleprojectzero.blogspot.com/2023/01/exploiting-null-dereferences-in-linux.html ))
+but the exploitation probability is not clear. Because of this uncertainty they are put to the bottom of the high
+priority bugs.

--- a/pkg/report/crash/types.go
+++ b/pkg/report/crash/types.go
@@ -15,6 +15,8 @@ const (
 	DoS                     = Type("DoS")
 	Hang                    = Type("HANG")
 	KASANInvalidFree        = Type("KASAN-INVALID-FREE")
+	KASANNullPtrDerefRead   = Type("KASAN-NULL-POINTER-DEREFERENCE-READ")
+	KASANNullPtrDerefWrite  = Type("KASAN-NULL-POINTER-DEREFERENCE-WRITE")
 	KASANRead               = Type("KASAN-READ")
 	KASANUnknown            = Type("KASAN-UNKNOWN")
 	KASANUseAfterFreeRead   = Type("KASAN-USE-AFTER-FREE-READ")
@@ -38,6 +40,7 @@ const (
 	MemoryLeak              = Type("LEAK")
 	MemorySafetyBUG         = Type("MEMORY_SAFETY_BUG")
 	MemorySafetyUBSAN       = Type("MEMORY_SAFETY_UBSAN")
+	NullPtrDerefBUG         = Type("NULL-POINTER-DEREFERENCE")
 	RefcountWARNING         = Type("REFCOUNT_WARNING")
 	UBSAN                   = Type("UBSAN")
 	Warning                 = Type("WARNING")
@@ -58,7 +61,8 @@ type TypeGroupPred func(Type) bool
 
 func (t Type) IsKASAN() bool {
 	return slices.Contains([]Type{
-		KASANRead, KASANWrite, KASANUseAfterFreeRead, KASANUseAfterFreeWrite, KASANInvalidFree, KASANUnknown}, t)
+		KASANNullPtrDerefRead, KASANNullPtrDerefWrite, KASANRead, KASANWrite,
+		KASANUseAfterFreeRead, KASANUseAfterFreeWrite, KASANInvalidFree, KASANUnknown}, t)
 }
 
 func (t Type) IsKMSAN() bool {
@@ -75,7 +79,7 @@ func (t Type) IsUBSAN() bool {
 }
 
 func (t Type) IsBUG() bool {
-	return t == Bug || t == MemorySafetyBUG
+	return slices.Contains([]Type{Bug, MemorySafetyBUG, NullPtrDerefBUG}, t)
 }
 
 func (t Type) IsWarning() bool {

--- a/pkg/report/impact_score.go
+++ b/pkg/report/impact_score.go
@@ -24,6 +24,9 @@ var impactOrder = []crash.Type{
 	crash.MemorySafetyUBSAN, // array-index-out-of-bounds, at least Read.
 	crash.KCSANAssert,
 	crash.RefcountWARNING, // we had a few UAFs in the past
+	crash.KASANNullPtrDerefWrite,
+	crash.KASANNullPtrDerefRead,
+	crash.NullPtrDerefBUG,
 	// Medium Priority (Infoleaks, Uninitialized Memory, Corruptions)
 	crash.KMSANInfoLeak,
 	crash.MemorySafetyBUG,

--- a/pkg/report/testdata/linux/report/112
+++ b/pkg/report/testdata/linux/report/112
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in process_one_work
 ALT: bad-access in process_one_work
+TYPE: NULL-POINTER-DEREFERENCE
 
 [  190.154802] BUG: unable to handle kernel NULL pointer dereference at 0000000000000286
 [  190.154802] IP: 0x286

--- a/pkg/report/testdata/linux/report/174
+++ b/pkg/report/testdata/linux/report/174
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in rtnl_dump_ifinfo
 ALT: bad-access in rtnl_dump_ifinfo
+TYPE: NULL-POINTER-DEREFERENCE
 
 [  218.951194] BUG: unable to handle kernel NULL pointer dereference at 0000000000000010
 [  218.959174] IP: strlen+0x0/0x30

--- a/pkg/report/testdata/linux/report/18
+++ b/pkg/report/testdata/linux/report/18
@@ -1,5 +1,5 @@
 TITLE: KASAN: null-ptr-deref Read
-TYPE: KASAN-READ
+TYPE: KASAN-NULL-POINTER-DEREFERENCE-READ
 CORRUPTED: Y
 
 [23818.431954] BUG: KASAN: null-ptr-deref on address           (null)

--- a/pkg/report/testdata/linux/report/20
+++ b/pkg/report/testdata/linux/report/20
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
 ALT: bad-access in corrupted
+TYPE: NULL-POINTER-DEREFERENCE
 CORRUPTED: Y
 
 [  149.188010] BUG: unable to handle kernel NULL pointer dereference at 000000000000058c

--- a/pkg/report/testdata/linux/report/21
+++ b/pkg/report/testdata/linux/report/21
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in skb_release_data
 ALT: bad-access in skb_release_data
+TYPE: NULL-POINTER-DEREFERENCE
 CORRUPTED: Y
 
 [   55.112844] BUG: unable to handle kernel NULL pointer dereference at 000000000000001a

--- a/pkg/report/testdata/linux/report/247
+++ b/pkg/report/testdata/linux/report/247
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in inet_sendmsg
 ALT: bad-access in inet_sendmsg
+TYPE: NULL-POINTER-DEREFERENCE
 
 [   61.889077] BUG: unable to handle kernel NULL pointer dereference at           (null)
 [   61.890070] IP: [<          (null)>]           (null)

--- a/pkg/report/testdata/linux/report/256
+++ b/pkg/report/testdata/linux/report/256
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in sock_poll
 ALT: bad-access in sock_poll
+TYPE: NULL-POINTER-DEREFERENCE
 
 [   27.294614] random: sshd: uninitialized urandom read (32 bytes read)
 [   27.396136] BUG: unable to handle kernel NULL pointer dereference at 0000000000000000

--- a/pkg/report/testdata/linux/report/371
+++ b/pkg/report/testdata/linux/report/371
@@ -1,6 +1,6 @@
 TITLE: KASAN: null-ptr-deref Read in zr364xx_vidioc_querycap
 ALT: bad-access in zr364xx_vidioc_querycap
-TYPE: KASAN-READ
+TYPE: KASAN-NULL-POINTER-DEREFERENCE-READ
 
 [   62.911361] ==================================================================
 [   62.919256] BUG: KASAN: null-ptr-deref in read_word_at_a_time+0xe/0x20

--- a/pkg/report/testdata/linux/report/480
+++ b/pkg/report/testdata/linux/report/480
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
 ALT: bad-access in corrupted
+TYPE: NULL-POINTER-DEREFERENCE
 CORRUPTED: Y
 
 [  202.652969][ T9969] BUG: kernel NULL pointer dereference, address: 0000000000000086

--- a/pkg/report/testdata/linux/report/481
+++ b/pkg/report/testdata/linux/report/481
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in corrupted
 ALT: bad-access in corrupted
+TYPE: NULL-POINTER-DEREFERENCE
 CORRUPTED: Y
 
 [  418.945118][T17277] BUG: kernel NULL pointer dereference, address: 0000000000000086

--- a/pkg/report/testdata/linux/report/567
+++ b/pkg/report/testdata/linux/report/567
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in vhci_shutdown_connection
 ALT: bad-access in vhci_shutdown_connection
+TYPE: NULL-POINTER-DEREFERENCE
 
 [  775.896747][ T5109] 8<--- cut here ---
 [  775.897679][ T5109] Unable to handle kernel NULL pointer dereference at virtual address 00000004

--- a/pkg/report/testdata/linux/report/676
+++ b/pkg/report/testdata/linux/report/676
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in gsmld_receive_buf
 ALT: bad-access in gsmld_receive_buf
+TYPE: NULL-POINTER-DEREFERENCE
 
 [  794.144064][ T8604] 8<--- cut here ---
 [  794.144523][ T8604] Unable to handle kernel NULL pointer dereference at virtual address 00000000

--- a/pkg/report/testdata/linux/report/677
+++ b/pkg/report/testdata/linux/report/677
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in nci_send_cmd
 ALT: bad-access in nci_send_cmd
+TYPE: NULL-POINTER-DEREFERENCE
 
 [ 9171.691128][T26146] 8<--- cut here ---
 [ 9171.691541][T26146] Unable to handle kernel NULL pointer dereference at virtual address 00000000

--- a/pkg/report/testdata/linux/report/693
+++ b/pkg/report/testdata/linux/report/693
@@ -1,5 +1,6 @@
 TITLE: BUG: unable to handle kernel NULL pointer dereference in ni_readpage_cmpr
 ALT: bad-access in ni_readpage_cmpr
+TYPE: NULL-POINTER-DEREFERENCE
 
 Unable to handle kernel NULL pointer dereference at virtual address 0000000000000008
 Mem abort info:

--- a/pkg/report/title_to_type.go
+++ b/pkg/report/title_to_type.go
@@ -78,9 +78,26 @@ var titleToType = []struct {
 	},
 	{
 		includePrefixes: []string{
+			"KASAN: null-ptr-deref Write",
+		},
+		crashType: crash.KASANNullPtrDerefWrite,
+	},
+	{
+		includePrefixes: []string{
+			"KASAN: null-ptr-deref Read",
+		},
+		crashType: crash.KASANNullPtrDerefRead,
+	},
+	{
+		includePrefixes: []string{
+			"BUG: unable to handle kernel NULL pointer dereference in",
+		},
+		crashType: crash.NullPtrDerefBUG,
+	},
+	{
+		includePrefixes: []string{
 			// keep-sorting start
 			"KASAN: global-out-of-bounds Write",
-			"KASAN: null-ptr-deref Write",
 			"KASAN: out-of-bounds Write",
 			"KASAN: slab-out-of-bounds Write",
 			"KASAN: stack-out-of-bounds Write",
@@ -96,7 +113,6 @@ var titleToType = []struct {
 			// keep-sorting start
 			"KASAN: global-out-of-bounds Read",
 			"KASAN: invalid-access Read",
-			"KASAN: null-ptr-deref Read",
 			"KASAN: out-of-bounds Read",
 			"KASAN: slab-out-of-bounds Read",
 			"KASAN: slab-out-of-bounds", // Read/Write is not clear. It is at least Read.


### PR DESCRIPTION
Null ptr derefs deserve lower priority than all other KASAN bugs because of the lower exploitation probability.
Some of the null ptr derefs are detected as a "general protection faults". Let's keep them as is and let them go to DoS category (for now).
