### PR TITLE
syz-cluster, dashboard: assorted email sending improvements

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1349,7 +1349,7 @@ func TestSingleListForward(t *testing.T) {
 		EmailOptCC([]string{"some@list.com"}), EmailOptSubject("fix bug title"))
 
 	forwarded := c.pollEmailBug()
-	c.expectEQ(forwarded.Subject, "fix bug title")
+	c.expectEQ(forwarded.Subject, "Forwarded: fix bug title")
 	c.expectEQ(forwarded.Sender, sender)
 	c.expectEQ(forwarded.To, []string{"test@syzkaller.com"})
 	c.expectEQ(len(forwarded.Cc), 0)
@@ -1388,7 +1388,7 @@ func TestTwoListsForward(t *testing.T) {
 		EmailOptCC(nil), EmailOptSubject("fix bug title"))
 
 	forwarded := c.pollEmailBug()
-	c.expectEQ(forwarded.Subject, "fix bug title")
+	c.expectEQ(forwarded.Subject, "Forwarded: fix bug title")
 	c.expectEQ(forwarded.Sender, sender)
 	c.expectEQ(forwarded.To, []string{"some@list.com", "test@syzkaller.com"})
 	c.expectEQ(len(forwarded.Cc), 0)
@@ -1423,12 +1423,14 @@ func TestForwardEmailInbox(t *testing.T) {
 		from := "syzbot+prefixABCD@testapp.appspotmail.com"
 		c.incomingEmail(from,
 			"#syz invalid",
+			EmailOptSubject("test subject"),
 			EmailOptMessageID(1),
 			EmailOptFrom("someone@mail.com"),
 			EmailOptCC([]string{"some@list.com"}))
 		msg := c.pollEmailBug()
 		require.NotNil(t, msg)
 		assert.Equal(t, `"syzbot" <syzbot@testapp.appspotmail.com>`, msg.Sender)
+		assert.Equal(t, "Forwarded: test subject", msg.Subject)
 		assert.ElementsMatch(t, []string{"forward@a.com", "forward@b.com"},
 			msg.To, "must be sent to the author and the missing lists")
 		assert.ElementsMatch(t, []string{"\"syzbot\" <" + from + ">", "someone@mail.com"}, msg.Cc)
@@ -1438,7 +1440,7 @@ forward@a.com, forward@b.com.
 
 ***
 
-Subject: crash1
+Subject: test subject
 Author: someone@mail.com
 
 #syz invalid

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1447,9 +1447,9 @@ Author: someone@mail.com
 `, msg.Body)
 
 		t.Run("no-loop", func(t *testing.T) {
-			// Ensure that we don't react to our own reply.
-			c.incomingEmail(from, msg.Body,
-				EmailOptFrom(msg.Sender),
+			// Ensure that we don't react to replies.
+			c.incomingEmail("syzbot@testapp.appspotmail.com", msg.Body,
+				EmailOptFrom("syzbot@testapp.appspotmail.com"),
 				EmailOptCC(append(append([]string{}, msg.Cc...), msg.To...)))
 			c.expectNoEmail()
 		})

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -1442,7 +1442,7 @@ Author: %s
 		Sender:  from,
 		To:      mailingLists,
 		Cc:      cc,
-		Subject: msg.Subject,
+		Subject: email.ForwardedPrefix + msg.Subject,
 		Body:    body,
 		Headers: mail.Header{"In-Reply-To": []string{inReplyTo}},
 	})

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -220,6 +220,7 @@ Bug report`,
 			t.Fatal(err)
 		}
 		msg.Body = ""
+		msg.RawCc = nil
 		emails = append(emails, msg)
 	}
 

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -60,6 +60,8 @@ const (
 	cmdTest5
 )
 
+const ForwardedPrefix = "Forwarded: "
+
 var groupsLinkRe = regexp.MustCompile(`(?m)\nTo view this discussion (?:on the web )?visit` +
 	` (https://groups\.google\.com/.*?)\.(:?$|\n|\r)`)
 

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -442,6 +442,7 @@ For more options, visit https://groups.google.com/d/optout.`,
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com"},
+			RawCc:     []string{"bob@example.com", "foo+4564456@bar.com"},
 			Body: `text body
 second line
 #syz fix: 	 arg1 arg2 arg3 	
@@ -482,6 +483,7 @@ To view this discussion visit https://groups.google.com/d/msgid/syzkaller-bugs/6
 			Subject:   "new footer",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com"},
+			RawCc:     []string{"bob@example.com", "foo+4564456@bar.com"},
 			Body: `some title
 
 -- 
@@ -508,6 +510,7 @@ last line`,
 			Author:    "foo@bar.com",
 			OwnEmail:  true,
 			Cc:        []string{"bob@example.com"},
+			RawCc:     []string{"bob@example.com", "foo+4564456@bar.com"},
 			Body: `text body
 last line`,
 			Patch: "",
@@ -529,6 +532,7 @@ last line`,
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
+			RawCc:     []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `#syz  invalid   	 
 text body
 second line
@@ -560,6 +564,7 @@ last line
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"alice@example.com", "bob@example.com", "bot@example.com"},
+			RawCc:     []string{"alice@example.com", "bob@example.com", "bot@example.com"},
 			Body: `text body
 second line
 last line
@@ -605,6 +610,7 @@ IHQpKSB7CiAJCXNwaW5fdW5sb2NrKCZrY292LT5sb2NrKTsKIAkJcmV0dXJuOwo=
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
+			RawCc:     []string{"bob@example.com", "bot@example.com"},
 			Body: `body text
 >#syz test
 `,
@@ -692,6 +698,7 @@ or)</div></div></div>
 			Subject:   "test subject",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com", "bot@example.com"},
+			RawCc:     []string{"bob@example.com", "bot@example.com"},
 			Body: `On Mon, May 8, 2017 at 6:47 PM, Bob wrote:
 > body text
 
@@ -774,6 +781,7 @@ d
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		RawCc:     []string{"bar@foo.com", "syzbot+344bb0f46d7719cd9483@syzkaller.appspotmail.com"},
 		Body: `On 2018/06/10 4:57, syzbot wrote:
 > Hello,
 > 
@@ -804,6 +812,7 @@ BUG: unable to handle kernel NULL pointer dereference in corrupted
 `, Email{
 		Author: "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		RawCc:  []string{"bar@foo.com", "syzbot+6dd701dc797b23b8c761@syzkaller.appspotmail.com"},
 		Body: `#syz dup:
 BUG: unable to handle kernel NULL pointer dereference in corrupted
 `,
@@ -825,6 +834,7 @@ When freeing a lockf struct that already is part of a linked list, make sure to
 `, Email{
 		Author: "bar@foo.com",
 		Cc:     []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		RawCc:  []string{"bar@foo.com", "syzbot+6dd701dc797b23b8c761@syzkaller.appspotmail.com"},
 		Body: `#syz fix:
 When freeing a lockf struct that already is part of a linked list, make sure to
 `,
@@ -850,6 +860,7 @@ nothing to see here`,
 			Subject:   "#syz test: git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git master",
 			Author:    "bob@example.com",
 			Cc:        []string{"bob@example.com"},
+			RawCc:     []string{"bob@example.com", "foo+4564456@bar.com"},
 			Body:      `nothing to see here`,
 			Commands: []*SingleCommand{
 				{
@@ -874,6 +885,7 @@ nothing to see here`,
 			Author:      "user@mail.com",
 			MailingList: "list@googlegroups.com",
 			Cc:          []string{"list@googlegroups.com", "user@mail.com"},
+			RawCc:       []string{"list@googlegroups.com", "user@mail.com"},
 			Body:        `nothing to see here`,
 		}},
 	{`Date: Sun, 7 May 2017 19:54:00 -0700
@@ -891,6 +903,7 @@ nothing to see here`,
 			Author:      "user@mail.com",
 			MailingList: "list@googlegroups.com",
 			Cc:          []string{"list@googlegroups.com", "user2@mail.com", "user@mail.com"},
+			RawCc:       []string{"list@googlegroups.com", "user2@mail.com", "user@mail.com"},
 			Body:        `nothing to see here`,
 		}},
 	// A faulty case, just check we handle it normally.
@@ -908,6 +921,7 @@ nothing to see here`,
 			Author:      "list@googlegroups.com",
 			MailingList: "list@googlegroups.com",
 			Cc:          []string{"list@googlegroups.com", "user2@mail.com"},
+			RawCc:       []string{"list@googlegroups.com", "user2@mail.com"},
 			Body:        `nothing to see here`,
 		}},
 	{`Sender: syzkaller-bugs@googlegroups.com
@@ -931,6 +945,7 @@ f950fddb9ea6bdb5e39
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		RawCc:     []string{"bar@foo.com", "syzbot+344bb0f46d7719cd9483@syzkaller.appspotmail.com"},
 		Body: `#syz 
 test: https://github.com/torvalds/linux.git 7b5bb460defa107dd2e82f950fddb9ea6bdb5e39
 `,
@@ -961,6 +976,7 @@ Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
 		Subject:   "[PATCH] Some patch",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		RawCc:     []string{"bar@foo.com", "someone@foo.com"},
 		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
 `,
 	}},
@@ -982,6 +998,7 @@ Link: https://bar.com/bug?extid=223c7461c58c58a4cb10@bar.com
 		Subject:   "[PATCH] Some patch",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		RawCc:     []string{"bar@foo.com", "someone@foo.com"},
 		Body: `Link: https://bar.com/bug?extid=223c7461c58c58a4cb10@bar.com
 `,
 	}},
@@ -1006,6 +1023,7 @@ Reported-by: syzbot <foo+9909090909090909@bar.com>
 		Subject:   "[PATCH] Some patch",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		RawCc:     []string{"bar@foo.com", "someone@foo.com"},
 		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
 Reported-by: syzbot <foo+9909090909090909@bar.com>
 `,
@@ -1030,6 +1048,7 @@ Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
 		Subject:   "[PATCH] Some patch",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		RawCc:     []string{"bar@foo.com", "foo+9909090909090909@bar.com", "someone@foo.com"},
 		Body: `Reported-by: syzbot <foo+223c7461c58c58a4cb10@bar.com>
 `,
 	}},
@@ -1058,6 +1077,7 @@ Some text
 		Subject:   "Some discussion",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "someone@foo.com"},
+		RawCc:     []string{"bar@foo.com", "someone@foo.com"},
 		Body:      "Some text\n",
 	}},
 	{`Sender: syzkaller-bugs@googlegroups.com
@@ -1080,6 +1100,7 @@ Content-Transfer-Encoding: quoted-printable
 		Subject:   "Re: BUG: unable to handle kernel NULL pointer dereference in sock_poll",
 		Author:    "bar@foo.com",
 		Cc:        []string{"bar@foo.com", "syzbot@syzkaller.appspotmail.com"},
+		RawCc:     []string{"bar@foo.com", "syzbot+344bb0f46d7719cd9483@syzkaller.appspotmail.com"},
 		Body: `#syz test: aaa bbb
 #syz test: ccc ddd
 `,

--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/email"
@@ -110,6 +111,10 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 func (h *Handler) IncomingEmail(ctx context.Context, msg *email.Email) error {
 	if len(msg.BugIDs) == 0 {
 		// Unrelated email.
+		return nil
+	}
+	if msg.OwnEmail && !strings.HasPrefix(msg.Subject, email.ForwardedPrefix) {
+		// We normally ignore our own emails, with the exception of the emails forwarded from the dashboard.
 		return nil
 	}
 	reportID := msg.BugIDs[0]

--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -72,6 +72,7 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 		Subject: "Re: " + rep.Series.Title, // TODO: use the original rather than the stripped title.
 		To:      rep.Cc,
 		Body:    body,
+		Cc:      []string{h.emailConfig.ArchiveList},
 	}
 	if rep.Moderation {
 		toSend.To = []string{h.emailConfig.ModerationList}
@@ -83,7 +84,6 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 		// We assume that email reporting is used for series received over emails.
 		toSend.InReplyTo = rep.Series.ExtID
 		toSend.To = rep.Cc
-		toSend.Cc = []string{h.emailConfig.ArchiveList}
 	}
 	msgID, err := h.sender(ctx, toSend)
 	if err != nil {

--- a/syz-cluster/email-reporter/handler_test.go
+++ b/syz-cluster/email-reporter/handler_test.go
@@ -118,6 +118,40 @@ Unknown command
 `),
 		}, reply)
 	})
+
+	t.Run("own email", func(t *testing.T) {
+		err = handler.IncomingEmail(ctx, &email.Email{
+			OwnEmail: true,
+			BugIDs:   []string{report.ID},
+			Commands: []*email.SingleCommand{
+				{
+					Command: email.CmdUpstream,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		_, err = handler.PollAndReport(ctx)
+		assert.NoError(t, err)
+		// No email must be sent in reply.
+		assert.Nil(t, emailServer.email())
+	})
+
+	t.Run("forwarded email", func(t *testing.T) {
+		err = handler.IncomingEmail(ctx, &email.Email{
+			Subject:  email.ForwardedPrefix + "abcd",
+			OwnEmail: true,
+			BugIDs:   []string{report.ID},
+			Commands: []*email.SingleCommand{
+				{
+					Command: email.CmdUpstream,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		_, err = handler.PollAndReport(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, emailServer.email())
+	})
 }
 
 func setupHandlerTest(t *testing.T, env *app.AppEnvironment, ctx context.Context,

--- a/syz-cluster/email-reporter/handler_test.go
+++ b/syz-cluster/email-reporter/handler_test.go
@@ -31,6 +31,7 @@ func TestModerationReportFlow(t *testing.T) {
 	receivedEmail.Body = nil // for now don't validate the body
 	assert.Equal(t, &emailclient.Email{
 		To:      []string{testEmailConfig.ModerationList},
+		Cc:      []string{testEmailConfig.ArchiveList},
 		Subject: "[moderation/CI] Re: " + testSeries.Title,
 		// Note that InReplyTo and Cc are nil.
 	}, receivedEmail)

--- a/syz-cluster/email-reporter/stream.go
+++ b/syz-cluster/email-reporter/stream.go
@@ -34,6 +34,9 @@ func NewLKMLEmailStream(repoFolder string, client *api.ReporterClient,
 	if cfg.Dashapi != nil {
 		ownEmails = append(ownEmails, cfg.Dashapi.From)
 	}
+	if cfg.SMTP != nil {
+		ownEmails = append(ownEmails, cfg.SMTP.From)
+	}
 	return &LKMLEmailStream{
 		cfg:          cfg,
 		ownEmails:    ownEmails,


### PR DESCRIPTION
Let's make sure we always recognize our patch fuzzing findings emails as our own to avoid reacting to them. At the same time, we should still react to the emails forwarded by the web dashboard. 