### PR TITLE
sys/linux: remove bind's and connect's dependency on nfc

### DIFF
--- a/sys/linux/socket.txt
+++ b/sys/linux/socket.txt
@@ -81,6 +81,7 @@ sockaddr [
 ] [size[SOCKADDR_SIZE]]
 
 # This sockaddr type corresponds to the sockaddr_storage type and is 128 bytes size.
+# Note: nfc is not included here to avoid making everything dependent on it (see #6171).
 sockaddr_storage [
 	un		sockaddr_un
 	in		sockaddr_in
@@ -104,8 +105,6 @@ sockaddr_storage [
 	hci		sockaddr_hci
 	rc		sockaddr_rc
 	alg		sockaddr_alg
-	nfc		sockaddr_nfc
-	nfc_llcp	sockaddr_nfc_llcp
 	vsock		sockaddr_vm
 	xdp		sockaddr_xdp
 	tipc		sockaddr_tipc

--- a/sys/linux/socket_nfc.txt
+++ b/sys/linux/socket_nfc.txt
@@ -14,6 +14,7 @@ resource sock_nfc_llcp[sock]
 
 syz_init_net_socket$nfc_llcp(domain const[AF_NFC], type flags[nfc_llcp_type], proto const[NFC_SOCKPROTO_LLCP]) sock_nfc_llcp
 bind$nfc_llcp(fd sock_nfc_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])
+bind$nfc(fd sock, addr ptr[in, sockaddr_nfc], addrlen len[addr])
 connect$nfc_llcp(fd sock_nfc_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])
 accept$nfc_llcp(fd sock_nfc_llcp, peer ptr[out, sockaddr_nfc_llcp, opt], peerlen ptr[inout, len[peer, int32]]) sock_nfc_llcp
 accept4$nfc_llcp(fd sock_nfc_llcp, peer ptr[out, sockaddr_nfc_llcp, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_nfc_llcp


### PR DESCRIPTION
Currently it leads to these calls being auto-disabled on our net instances. See #6171.

While a more generic solution would be better here, let's at least resolve this particular situation.