### PR TITLE
syz-cluster: add nci syscalls to the net config

### DIFF
--- a/syz-cluster/workflow/configs/net/base.cfg
+++ b/syz-cluster/workflow/configs/net/base.cfg
@@ -20,7 +20,8 @@
 	    "syz_genetlink_get_family_id", "syz_init_net_socket",
 	    "mkdirat$cgroup*", "openat$cgroup*", "write$cgroup*",
 	    "clock_gettime", "bpf", "openat$tun", "openat$ppp",
-	    "syz_open_procfs$namespace", "syz_80211_*", "nanosleep"
+	    "syz_open_procfs$namespace", "syz_80211_*", "nanosleep",
+	    "openat$nci", "ioctl$IOCTL_GET_NCIDEV_IDX"
     ],
     "procs": 3,
     "sandbox": "none",


### PR DESCRIPTION
This prevents bind() and connect() from being disabled. See #6171.