### PR TITLE
executor: handle zero length in syz_compare_zlib

### DIFF
--- a/executor/common_test.h
+++ b/executor/common_test.h
@@ -118,9 +118,13 @@ static long syz_compare_zlib(volatile long data, volatile long size, volatile lo
 	struct stat statbuf;
 	if (fstat(fd, &statbuf))
 		return -1;
-	void* uncompressed = mmap(0, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-	if (uncompressed == MAP_FAILED)
-		return -1;
+	void* uncompressed = NULL;
+	if (statbuf.st_size > 0) {
+		// We cannot mmap 0 bytes.
+		uncompressed = mmap(0, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+		if (uncompressed == MAP_FAILED)
+			return -1;
+	}
 	return syz_compare(data, size, (long)uncompressed, statbuf.st_size);
 }
 #endif


### PR DESCRIPTION
It used to fail because we cannot mmap 0 bytes.

Closes #6148.