### PR TITLE
pkg/report: typo fix

### DIFF
--- a/pkg/report/title_to_type.go
+++ b/pkg/report/title_to_type.go
@@ -233,7 +233,7 @@ var titleToType = []struct {
 			"WARNING: corrupted",
 			"WARNING: kernel stack frame pointer has bad value",
 			"WARNING: kernel stack regs has bad",
-			// keep-sorter end
+			// keep-sorted end
 		},
 		crashType: crash.UnknownType, // This is printk().
 	},


### PR DESCRIPTION
Replace "keep-sorter" with "keep-sorted" to fix the following warning:

2025-07-14T10:01:57Z WRN This instruction doesn't have matching
'keep-sorted end' line. keep-sorted will not attempt to sort anything until this is addressed.
file=./pkg/report/title_to_type.go line=231

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
