### PR TITLE
syz-cluster: include bot's name into the sender email

### DIFF
--- a/syz-cluster/pkg/emailclient/dashapi_sender.go
+++ b/syz-cluster/pkg/emailclient/dashapi_sender.go
@@ -5,10 +5,10 @@ package emailclient
 
 import (
 	"context"
-
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
+	"net/mail"
 )
 
 func makeDashapiSender(cfg *app.EmailConfig) (Sender, error) {
@@ -17,7 +17,10 @@ func makeDashapiSender(cfg *app.EmailConfig) (Sender, error) {
 		return nil, err
 	}
 	return func(_ context.Context, item *Email) (string, error) {
-		sender := cfg.Dashapi.From
+		sender := (&mail.Address{
+			Name:    cfg.Name,
+			Address: cfg.Dashapi.From,
+		}).String()
 		if item.BugID != "" {
 			var err error
 			sender, err = email.AddAddrContext(sender, cfg.Dashapi.ContextPrefix+item.BugID)


### PR DESCRIPTION
When sending via dashapi, we used to only include the raw email address. Include the bot's name there as well.
