### PR TITLE
syz-cluster: keep only one Cc list in SessionReport

### DIFF
--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -71,7 +71,7 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 	}
 	toSend := &emailclient.Email{
 		Subject: "Re: " + rep.Series.Title, // TODO: use the original rather than the stripped title.
-		To:      rep.Cc,
+		To:      rep.Series.Cc,
 		Body:    body,
 		Cc:      []string{h.emailConfig.ArchiveList},
 		BugID:   rep.ID,
@@ -85,7 +85,7 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 		}
 		// We assume that email reporting is used for series received over emails.
 		toSend.InReplyTo = rep.Series.ExtID
-		toSend.To = rep.Cc
+		toSend.To = rep.Series.Cc
 	}
 	msgID, err := h.sender(ctx, toSend)
 	if err != nil {

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -129,7 +129,6 @@ type NewSession struct {
 
 type SessionReport struct {
 	ID         string     `json:"id"`
-	Cc         []string   `json:"cc"`
 	Moderation bool       `json:"moderation"`
 	Series     *Series    `json:"series"`
 	Findings   []*Finding `json:"findings"`

--- a/syz-cluster/pkg/controller/testutil.go
+++ b/syz-cluster/pkg/controller/testutil.go
@@ -6,13 +6,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/db"
 	"github.com/stretchr/testify/assert"
-	"net/http/httptest"
-	"testing"
-	"time"
 )
 
 type EntityIDs struct {
@@ -59,6 +60,7 @@ func DummySeries() *api.Series {
 		ExtID: "ext-id",
 		Title: "test series name",
 		Link:  "http://link/to/series",
+		Cc:    []string{"first@user.com", "second@user.com"},
 		Patches: []api.SeriesPatch{
 			{
 				Seq:   1,

--- a/syz-cluster/pkg/report/template.txt
+++ b/syz-cluster/pkg/report/template.txt
@@ -63,7 +63,7 @@ See {{.Config.DocsLink}} for more information about {{.Config.Name}}.
 {{- if .Report.Moderation}}
 
 The email will later be sent to:
-{{.Report.Cc}}
+{{.Report.Series.Cc}}
 
 If the report looks fine to you, reply with:
 #syz upstream

--- a/syz-cluster/pkg/report/testdata/1.in.json
+++ b/syz-cluster/pkg/report/testdata/1.in.json
@@ -4,6 +4,7 @@
     "title": "Series title''",
     "version": 2,
     "link": "http://link/to/series",
+    "cc": ["a@a.com", "b@b.com"],
     "patches": [
       {
 	"title": "first patch"
@@ -42,6 +43,5 @@
       }
     }
   ],
-  "cc": ["a@a.com", "b@b.com"],
   "link": "http://some/link/to/report"
 }

--- a/syz-cluster/pkg/report/testdata/2.in.json
+++ b/syz-cluster/pkg/report/testdata/2.in.json
@@ -4,6 +4,7 @@
     "title": "Series title",
     "version": 2,
     "link": "http://link/to/series",
+    "cc": ["a@a.com", "b@b.com"],
     "patches": [
       {
 	"title": "first patch"
@@ -29,6 +30,5 @@
       }
     }
   ],
-  "cc": ["a@a.com", "b@b.com"],
   "link": "http://some/link/to/report"
 }

--- a/syz-cluster/pkg/reporter/api_test.go
+++ b/syz-cluster/pkg/reporter/api_test.go
@@ -4,12 +4,13 @@
 package reporter
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/controller"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestAPIReportFlow(t *testing.T) {
@@ -53,6 +54,7 @@ func TestAPIReportFlow(t *testing.T) {
 			ExtID: testSeries.ExtID,
 			Title: testSeries.Title,
 			Link:  "http://link/to/series",
+			Cc:    []string{"first@user.com", "second@user.com"},
 			Patches: []api.SeriesPatch{
 				{
 					Seq:   1,


### PR DESCRIPTION
Currently, the list was both within the Series object and within the SessionReport object that also encloses Series. And, since only was was actually filled, we were unable to actually Cc the people from the series.

Keep only the Cc list in the Series object and adjust the tests.