### PR TITLE
pkg/manager: don't symbolize reports

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -197,7 +197,6 @@ loop:
 				// Report it as error so that we could at least find it in the logs.
 				log.Errorf("repro didn't crash base, but base itself crashed: %s", ret.origReport.Title)
 			} else if ret.crashReport == nil {
-				dc.new.symbolize(ret.origReport)
 				dc.store.BaseNotCrashed(ret.origReport.Title)
 				select {
 				case <-ctx.Done():
@@ -718,13 +717,6 @@ func (rr *reproRunner) Run(ctx context.Context, r *repro.Result) {
 	select {
 	case rr.done <- ret:
 	case <-ctx.Done():
-	}
-}
-
-func (kc *kernelContext) symbolize(rep *report.Report) {
-	err := kc.reporter.Symbolize(rep)
-	if err != nil {
-		log.Logf(0, "failed to symbolize: %v", err)
 	}
 }
 


### PR DESCRIPTION
These are already symbolized in pkg/repro.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
