### PR TITLE
syz-cluster: checkout the archive into a subfolder

### DIFF
--- a/syz-cluster/email-reporter/main.go
+++ b/syz-cluster/email-reporter/main.go
@@ -51,7 +51,7 @@ func main() {
 	msgCh := make(chan *email.Email, 16)
 	eg, loopCtx := errgroup.WithContext(ctx)
 	if cfg.EmailReporting.LoreArchiveURL != "" {
-		fetcher := NewLKMLEmailStream("/lore-repo", reporterClient, cfg.EmailReporting, msgCh)
+		fetcher := NewLKMLEmailStream("/lore-repo/checkout", reporterClient, cfg.EmailReporting, msgCh)
 		eg.Go(func() error { return fetcher.Loop(loopCtx, fetcherPollPeriod) })
 	}
 	eg.Go(func() error {


### PR DESCRIPTION
Our pkg/vcs logic attempts to first delete a target folder, which is impossible for the mount point of a k8s disk.

Instead of checking out into the mounted disk directly, use a subfolder on it.