### PR TITLE
syz-cluster/series-tracker: use simpler lore links

### DIFF
--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/email"
@@ -158,7 +159,7 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, series *lore.Series,
 		Title:       series.Subject,
 		Version:     series.Version,
 		SubjectTags: series.Tags,
-		Link:        "https://lore.kernel.org/all/" + series.MessageID,
+		Link:        loreLink(series.MessageID),
 		PublishedAt: date,
 	}
 	sp := seriesProcessor{}
@@ -196,6 +197,10 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, series *lore.Series,
 	}
 	log.Printf("series %s saved to the DB", series.MessageID)
 	return nil
+}
+
+func loreLink(messageID string) string {
+	return "https://lore.kernel.org/all/" + strings.Trim(messageID, "<>")
 }
 
 type seriesProcessor map[string]struct{}

--- a/syz-cluster/series-tracker/main_test.go
+++ b/syz-cluster/series-tracker/main_test.go
@@ -43,3 +43,12 @@ second body`,
 		"bob@example.com", "d@d.com",
 	}, sp.Emails())
 }
+
+func TestLoreLink(t *testing.T) {
+	for id, link := range map[string]string{
+		"<id@domain>": "https://lore.kernel.org/all/id@domain",
+		"id@domain":   "https://lore.kernel.org/all/id@domain",
+	} {
+		assert.Equal(t, link, loreLink(id), "id=%q", id)
+	}
+}


### PR DESCRIPTION
Trim away angle brackets because otherwise email clients do not recognize the resulting links.