### PR TITLE
syz-cluster: install addr2line in the fuzz-step container

### DIFF
--- a/syz-cluster/workflow/fuzz-step/Dockerfile
+++ b/syz-cluster/workflow/fuzz-step/Dockerfile
@@ -16,7 +16,17 @@ RUN GO_FLAGS=$(make go-flags 2>/dev/null) && go build "$GO_FLAGS" -o /bin/fuzz-s
 FROM debian:bookworm
 
 RUN apt-get update && \
-    apt-get install -y qemu-system openssh-client
+    apt-get install -y qemu-system openssh-client curl
+
+# Install clang tools.
+RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
+RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+RUN apt-get update --allow-releaseinfo-change
+RUN apt-get install -y -q --no-install-recommends llvm-20 clang-20 clang-format-20
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
+RUN update-alternatives --install /usr/bin/llvm-addr2line llvm-addr2line /usr/bin/llvm-addr2line-20 100
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
 
 # pkg/osutil uses syzkaller user for sandboxing.
 RUN useradd --create-home syzkaller


### PR DESCRIPTION
It's required for report symbolization.