### PR TITLE
syz-cluster: configure a Cc list for reported bugs

### DIFF
--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -89,6 +89,7 @@ func (h *Handler) report(ctx context.Context, rep *api.SessionReport) error {
 		// We assume that email reporting is used for series received over emails.
 		toSend.InReplyTo = rep.Series.ExtID
 		toSend.To = rep.Series.Cc
+		toSend.Cc = append(toSend.Cc, h.emailConfig.ReportCC...)
 	}
 	msgID, err := h.sender(ctx, toSend)
 	if err != nil {

--- a/syz-cluster/email-reporter/handler_test.go
+++ b/syz-cluster/email-reporter/handler_test.go
@@ -57,7 +57,7 @@ func TestModerationReportFlow(t *testing.T) {
 	receivedEmail.Body = nil
 	assert.Equal(t, &emailclient.Email{
 		To:        testSeries.Cc,
-		Cc:        []string{testEmailConfig.ArchiveList},
+		Cc:        append([]string{testEmailConfig.ArchiveList}, testEmailConfig.ReportCC...),
 		Subject:   "[name] Re: " + testSeries.Title,
 		InReplyTo: testSeries.ExtID,
 		BugID:     report.ID,

--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -18,6 +18,8 @@ data:
       supportEmail: syzkaller@googlegroups.com
       archiveList: syzbot@lists.linux.dev
       moderationList: syzkaller-upstream-moderation@googlegroups.com
+      reportCc:
+        - syzkaller-bugs@googlegroups.com
       loreArchiveURL: https://lore.kernel.org/syzbot/0
       dashapiConfig:
         addr: https://syzkaller.appspot.com

--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -46,8 +46,10 @@ type EmailConfig struct {
 	Dashapi *DashapiConfig `yaml:"dashapiConfig"`
 	// Moderation requests will be sent there.
 	ModerationList string `yaml:"moderationList"`
-	// The list we listen on.
+	// The list email-reporter listens on.
 	ArchiveList string `yaml:"archiveList"`
+	// The lists/emails to be Cc'd for actual reports (not moderation).
+	ReportCC []string `yaml:"reportCc"`
 	// Lore git archive to poll for incoming messages.
 	LoreArchiveURL string `yaml:"loreArchiveURL"`
 	// The prefix which will be added to all reports' titles.

--- a/syz-cluster/pkg/emailclient/sender.go
+++ b/syz-cluster/pkg/emailclient/sender.go
@@ -60,6 +60,7 @@ func TestEmailConfig() *app.EmailConfig {
 		Name:           "name",
 		DocsLink:       "docs",
 		ModerationList: "moderation@list.com",
+		ReportCC:       []string{"reported@list.com"},
 		ArchiveList:    "archive@list.com",
 		Sender:         app.SenderSMTP,
 		SMTP: &app.SMTPConfig{


### PR DESCRIPTION
Cc syzkaller-bugs@googlegroups.com in all upstreamed syzbot ci findings.
