### PR TITLE
syz-cluster: minor triage improvements

### DIFF
--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -96,11 +96,11 @@
                     <th>Status</th>
                     <td>{{.Status}}</td>
                 </tr>
-                {{if not .SkipReason.IsNull}}
+                {{if or (not .SkipReason.IsNull) .TriageLogURI}}
                 <tr>
-                    <th>Skipped</th>
+                    <th>Triaged</th>
                     <td>
-                        {{.SkipReason.StringVal}}
+                        {{if not .SkipReason.IsNull}}Skipped: {{.SkipReason.StringVal}}{{else}}OK{{end}}
                         {{if .TriageLogURI}}
                             <a href="/sessions/{{.ID}}/triage_log">[Log]</a>
                         {{end}}

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -5,16 +5,12 @@ package api
 
 import "time"
 
+// The output passed to other workflow steps.
 type TriageResult struct {
 	// If set, ignore the patch series completely.
-	Skip *SkipRequest `json:"skip"`
+	SkipReason string `json:"skip_reason"`
 	// Fuzzing configuration to try (NULL if nothing).
 	Fuzz *FuzzConfig `json:"fuzz"`
-}
-
-type SkipRequest struct {
-	Reason    string `json:"reason"`
-	TriageLog []byte `json:"log"`
 }
 
 // The data layout faclitates the simplicity of the workflow definition.

--- a/syz-cluster/pkg/api/client.go
+++ b/syz-cluster/pkg/api/client.go
@@ -30,8 +30,13 @@ func (client Client) GetSeries(ctx context.Context, seriesID string) (*Series, e
 	return getJSON[Series](ctx, client.baseURL+"/series/"+seriesID)
 }
 
-func (client Client) SkipSession(ctx context.Context, sessionID string, req *SkipRequest) error {
-	_, err := postJSON[SkipRequest, any](ctx, client.baseURL+"/sessions/"+sessionID+"/skip", req)
+type UploadTriageResultReq struct {
+	SkipReason string `json:"skip_reason"`
+	Log        []byte `json:"log"`
+}
+
+func (client Client) UploadTriageResult(ctx context.Context, sessionID string, req *UploadTriageResultReq) error {
+	_, err := postJSON[UploadTriageResultReq, any](ctx, client.baseURL+"/sessions/"+sessionID+"/triage_result", req)
 	return err
 }
 

--- a/syz-cluster/pkg/controller/api.go
+++ b/syz-cluster/pkg/controller/api.go
@@ -42,7 +42,7 @@ func (c APIServer) Mux() *http.ServeMux {
 	mux.HandleFunc("/series/{series_id}", c.getSeries)
 	mux.HandleFunc("/sessions/upload", c.uploadSession)
 	mux.HandleFunc("/sessions/{session_id}/series", c.getSessionSeries)
-	mux.HandleFunc("/sessions/{session_id}/skip", c.skipSession)
+	mux.HandleFunc("/sessions/{session_id}/triage_result", c.triageResult)
 	mux.HandleFunc("/tests/upload_artifacts", c.uploadTestArtifact)
 	mux.HandleFunc("/tests/upload", c.uploadTest)
 	mux.HandleFunc("/trees", c.getTrees)
@@ -61,12 +61,12 @@ func (c APIServer) getSessionSeries(w http.ResponseWriter, r *http.Request) {
 	api.ReplyJSON(w, resp)
 }
 
-func (c APIServer) skipSession(w http.ResponseWriter, r *http.Request) {
-	req := api.ParseJSON[api.SkipRequest](w, r)
+func (c APIServer) triageResult(w http.ResponseWriter, r *http.Request) {
+	req := api.ParseJSON[api.UploadTriageResultReq](w, r)
 	if req == nil {
 		return
 	}
-	err := c.sessionService.SkipSession(r.Context(), r.PathValue("session_id"), req)
+	err := c.sessionService.TriageResult(r.Context(), r.PathValue("session_id"), req)
 	if errors.Is(err, service.ErrSessionNotFound) {
 		http.Error(w, fmt.Sprint(err), http.StatusNotFound)
 		return

--- a/syz-cluster/pkg/triage/tree.go
+++ b/syz-cluster/pkg/triage/tree.go
@@ -4,12 +4,14 @@
 package triage
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 )
 
-func SelectTree(series *api.Series, trees []*api.Tree) *api.Tree {
+// SelectTrees returns an ordered list of git trees to apply the series to.
+func SelectTrees(series *api.Series, trees []*api.Tree) []*api.Tree {
 	seriesCc := map[string]bool{}
 	for _, cc := range series.Cc {
 		seriesCc[strings.ToLower(cc)] = true
@@ -18,11 +20,12 @@ func SelectTree(series *api.Series, trees []*api.Tree) *api.Tree {
 	for _, tag := range series.SubjectTags {
 		tagsMap[tag] = true
 	}
-	var best *api.Tree
+	var result []*api.Tree
 	for _, tree := range trees {
 		if tagsMap[tree.Name] {
-			// If the tree was directly mentioned in the patch subject, just return it.
-			return tree
+			// If the tree was directly mentioned in the patch subject, always take it.
+			result = append(result, tree)
+			continue
 		}
 		intersects := false
 		for _, cc := range tree.EmailLists {
@@ -34,9 +37,14 @@ func SelectTree(series *api.Series, trees []*api.Tree) *api.Tree {
 		if len(tree.EmailLists) > 0 && !intersects {
 			continue
 		}
-		if best == nil || tree.Priority > best.Priority {
-			best = tree
-		}
+		result = append(result, tree)
 	}
-	return best
+	sort.SliceStable(result, func(i, j int) bool {
+		a, b := result[i], result[j]
+		if tagsMap[a.Name] != tagsMap[b.Name] {
+			return tagsMap[a.Name]
+		}
+		return a.Priority > b.Priority
+	})
+	return result
 }

--- a/syz-cluster/pkg/workflow/template.yaml
+++ b/syz-cluster/pkg/workflow/template.yaml
@@ -38,7 +38,7 @@ spec:
               template: triage-step
         - - name: abort-on-skip-outcome
             template: exit-workflow
-            when: "{{=jsonpath(steps['run-triage'].outputs.parameters.result, '$.skip') != nil}}"
+            when: "{{=jsonpath(steps['run-triage'].outputs.parameters.result, '$.skip_reason') != ''}}"
         - - name: run-process-fuzz
             template: process-fuzz
             arguments:

--- a/syz-cluster/workflow/triage-step/main.go
+++ b/syz-cluster/workflow/triage-step/main.go
@@ -8,13 +8,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/triage"
-	"io"
-	"os"
 )
 
 var (
@@ -35,15 +34,18 @@ func main() {
 		app.Fatalf("failed to initialize the repository: %v", err)
 	}
 	ctx := context.Background()
-	verdict, err := getVerdict(ctx, client, repo)
+	output := new(bytes.Buffer)
+	tracer := &debugtracer.GenericTracer{WithTime: true, TraceWriter: output}
+	verdict, err := getVerdict(ctx, tracer, client, repo)
 	if err != nil {
 		app.Fatalf("failed to get the verdict: %v", err)
 	}
-	if verdict.Skip != nil {
-		err := client.SkipSession(context.Background(), *flagSession, verdict.Skip)
-		if err != nil {
-			app.Fatalf("failed to upload the skip reason: %v", err)
-		}
+	err = client.UploadTriageResult(ctx, *flagSession, &api.UploadTriageResultReq{
+		SkipReason: verdict.SkipReason,
+		Log:        output.Bytes(),
+	})
+	if err != nil {
+		app.Fatalf("failed to upload triage results: %v", err)
 	}
 	if *flagVerdict != "" {
 		osutil.WriteJSON(*flagVerdict, verdict)
@@ -54,7 +56,8 @@ func main() {
 	// 2. What if controller does not reply? Let Argo just restart the step.
 }
 
-func getVerdict(ctx context.Context, client *api.Client, ops triage.TreeOps) (*api.TriageResult, error) {
+func getVerdict(ctx context.Context, tracer debugtracer.DebugTracer, client *api.Client,
+	ops triage.TreeOps) (*api.TriageResult, error) {
 	series, err := client.GetSessionSeries(ctx, *flagSession)
 	if err != nil {
 		// TODO: the workflow step must be retried.
@@ -67,11 +70,10 @@ func getVerdict(ctx context.Context, client *api.Client, ops triage.TreeOps) (*a
 	tree := triage.SelectTree(series, trees.Trees)
 	if tree == nil {
 		return &api.TriageResult{
-			Skip: &api.SkipRequest{
-				Reason: "no suitable base kernel tree found",
-			},
+			SkipReason: "no suitable base kernel tree found",
 		}, nil
 	}
+	tracer.Log("selected tree %q", tree.Name)
 	arch := "amd64"
 	lastBuild, err := client.LastBuild(ctx, &api.LastBuildReq{
 		Arch:       arch,
@@ -83,22 +85,18 @@ func getVerdict(ctx context.Context, client *api.Client, ops triage.TreeOps) (*a
 		// TODO: the workflow step must be retried.
 		return nil, fmt.Errorf("failed to query the last build: %w", err)
 	}
-	var buf bytes.Buffer
-	selector := triage.NewCommitSelector(ops, &debugtracer.GenericTracer{
-		TraceWriter: io.MultiWriter(os.Stderr, &buf),
-	})
+	tracer.Log("last build: %q", lastBuild)
+	selector := triage.NewCommitSelector(ops, tracer)
 	result, err := selector.Select(series, tree, lastBuild)
 	if err != nil {
 		// TODO: the workflow step must be retried.
 		return nil, fmt.Errorf("failed to run the commit selector: %w", err)
 	} else if result.Commit == "" {
 		return &api.TriageResult{
-			Skip: &api.SkipRequest{
-				Reason:    "failed to find the base commit: " + result.Reason,
-				TriageLog: buf.Bytes(),
-			},
+			SkipReason: "failed to find the base commit: " + result.Reason,
 		}, nil
 	}
+	tracer.Log("selected base commit: %s", result.Commit)
 	base := api.BuildRequest{
 		TreeName:   tree.Name,
 		TreeURL:    tree.URL,


### PR DESCRIPTION
* Always upload and display triage logs.
* Instead of selecting one base tree and sticking to it, generate an ordered list of trees to try out. Then, pick the first one where the patch series can be applied without issues.