### PR TITLE
syz-cluster/wokflow/fuzz-step: don't mount /output

### DIFF
--- a/syz-cluster/workflow/fuzz-step/workflow-template.yaml
+++ b/syz-cluster/workflow/fuzz-step/workflow-template.yaml
@@ -48,8 +48,6 @@ spec:
         volumeMounts:
         - name: workdir
           mountPath: /workdir
-        - name: output
-          mountPath: /output
         - name: dev-kvm
           mountPath: /dev/kvm
         # Needed for /dev/kvm.
@@ -65,8 +63,3 @@ spec:
           hostPath:
             path: /dev/kvm
             type: CharDevice
-      outputs:
-        parameters:
-          - name: result
-            valueFrom:
-              path: /output/result.json


### PR DESCRIPTION
The fuzzing step only takes inputs and communicates via API. This will reduce the number of `Error: open /mainctrfs/output/result.json: no such file or directory` errors in our logs.