### PR TITLE
pkg/manager: improve patched crash skip rules

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -323,16 +323,23 @@ func (dc *diffContext) monitorPatchedCoverage(ctx context.Context) error {
 // TODO: instead of this limit, consider expotentially growing delays between reproduction attempts.
 const maxReproAttempts = 6
 
+func skipDiffRepro(title string) bool {
+	if strings.Contains(title, "no output") ||
+		strings.Contains(title, "lost connection") ||
+		strings.Contains(title, "detected stall") ||
+		strings.Contains(title, "SYZ") {
+		// Don't waste time reproducing these.
+		return true
+	}
+	return false
+}
+
 func (dc *diffContext) NeedRepro(crash *Crash) bool {
 	if crash.FullRepro {
 		return true
 	}
-	if strings.Contains(crash.Title, "no output") ||
-		strings.Contains(crash.Title, "lost connection") ||
-		strings.Contains(crash.Title, "stall") ||
-		strings.Contains(crash.Title, "SYZ") {
-		// Don't waste time reproducing these.
-		return false
+	if skipDiffRepro(crash.Title) {
+		return true
 	}
 	dc.mu.Lock()
 	defer dc.mu.Unlock()

--- a/pkg/manager/diff_test.go
+++ b/pkg/manager/diff_test.go
@@ -107,3 +107,16 @@ func TestModifiedSymbols(t *testing.T) {
 		assert.Equal(t, []string{"function", "function2"}, modifiedSymbols(base, patched))
 	})
 }
+
+func TestSkipDiffRepro(t *testing.T) {
+	for title, skip := range map[string]bool{
+		"no output from test machine":                          true,
+		"SYZFAIL: read failed":                                 true,
+		"lost connection to test machine":                      true,
+		"INFO: rcu detected stall in clone":                    true,
+		"WARNING in arch_install_hw_breakpoint":                false,
+		"KASAN: slab-out-of-bounds Write in __bpf_get_stackid": false,
+	} {
+		assert.Equal(t, skip, skipDiffRepro(title), "title=%q", title)
+	}
+}


### PR DESCRIPTION
The rules were too generic - there are plenty of functions that have "stall" as substring, yet they do not relate to rcu stall bugs.

Improve the rules list and add a unit test.