### PR TITLE
pkg/manager: display repro attempts

### DIFF
--- a/pkg/manager/html/crash.html
+++ b/pkg/manager/html/crash.html
@@ -3,7 +3,7 @@ Copyright 2024 syzkaller project authors. All rights reserved.
 Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 */}}
 
-<b>{{.Description}}</b>
+<b>{{.Title}}</b>
 
 {{if .Triaged}}
 Report: <a href="/report?id={{.ID}}">{{.Triaged}}</a>

--- a/pkg/manager/html/main.html
+++ b/pkg/manager/html/main.html
@@ -35,6 +35,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td class="time {{if not $c.New}}inactive{{end}}">{{formatTime $c.FirstTime}}</td>
 		<td class="time {{if not $c.Active}}inactive{{end}}">{{formatTime $c.LastTime}}</td>
 		<td>
+			{{if $c.ReproAttempts}}[{{$c.ReproAttempts}} repro attempts]{{end}}
 			{{if $c.Triaged}}
 				<a href="/report?id={{$c.ID}}">{{$c.Triaged}}</a>
 			{{end}}

--- a/pkg/manager/html/main.html
+++ b/pkg/manager/html/main.html
@@ -30,8 +30,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	</tr>
 	{{range $c := $.Crashes}}
 	<tr>
-		<td class="title"><a href="/crash?id={{$c.ID}}">{{$c.Description}}</a></td>
-		<td class="stat {{if not $c.Active}}inactive{{end}}">{{$c.Count}}</td>
+		<td class="title"><a href="/crash?id={{$c.ID}}">{{$c.Title}}</a></td>
+		<td class="stat {{if not $c.Active}}inactive{{end}}">{{len $c.Crashes}}</td>
 		<td class="time {{if not $c.New}}inactive{{end}}">{{formatTime $c.FirstTime}}</td>
 		<td class="time {{if not $c.Active}}inactive{{end}}">{{formatTime $c.LastTime}}</td>
 		<td>
@@ -39,8 +39,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{if $c.Triaged}}
 				<a href="/report?id={{$c.ID}}">{{$c.Triaged}}</a>
 			{{end}}
-			{{if $c.Strace}}
-				<a href="/file?name={{$c.Strace}}">Strace</a>
+			{{if $c.StraceFile}}
+				<a href="/file?name={{$c.StraceFile}}">Strace</a>
 			{{end}}
 		</td>
 	</tr>

--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -355,16 +355,17 @@ func makeUICrashType(info *BugInfo, startTime time.Time, repros map[string]bool)
 	triaged := reproStatus(info.HasRepro, info.HasCRepro, repros[info.Title],
 		info.ReproAttempts >= MaxReproAttempts)
 	return UICrashType{
-		Description: info.Title,
-		FirstTime:   info.FirstTime,
-		LastTime:    info.LastTime,
-		New:         info.FirstTime.After(startTime),
-		Active:      info.LastTime.After(startTime),
-		ID:          info.ID,
-		Count:       len(info.Crashes),
-		Triaged:     triaged,
-		Strace:      info.StraceFile,
-		Crashes:     crashes,
+		Description:   info.Title,
+		FirstTime:     info.FirstTime,
+		LastTime:      info.LastTime,
+		New:           info.FirstTime.After(startTime),
+		Active:        info.LastTime.After(startTime),
+		ID:            info.ID,
+		Count:         len(info.Crashes),
+		Triaged:       triaged,
+		Strace:        info.StraceFile,
+		Crashes:       crashes,
+		ReproAttempts: info.ReproAttempts,
 	}
 }
 
@@ -1028,16 +1029,17 @@ type UICrashPage struct {
 }
 
 type UICrashType struct {
-	Description string
-	FirstTime   time.Time
-	LastTime    time.Time
-	New         bool // was first found in the current run
-	Active      bool // was found in the current run
-	ID          string
-	Count       int
-	Triaged     string
-	Strace      string
-	Crashes     []UICrash
+	Description   string
+	FirstTime     time.Time
+	LastTime      time.Time
+	New           bool // was first found in the current run
+	Active        bool // was found in the current run
+	ID            string
+	Count         int
+	Triaged       string
+	Strace        string
+	ReproAttempts int
+	Crashes       []UICrash
 }
 
 type UICrash struct {

--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -355,17 +355,11 @@ func makeUICrashType(info *BugInfo, startTime time.Time, repros map[string]bool)
 	triaged := reproStatus(info.HasRepro, info.HasCRepro, repros[info.Title],
 		info.ReproAttempts >= MaxReproAttempts)
 	return UICrashType{
-		Description:   info.Title,
-		FirstTime:     info.FirstTime,
-		LastTime:      info.LastTime,
-		New:           info.FirstTime.After(startTime),
-		Active:        info.LastTime.After(startTime),
-		ID:            info.ID,
-		Count:         len(info.Crashes),
-		Triaged:       triaged,
-		Strace:        info.StraceFile,
-		Crashes:       crashes,
-		ReproAttempts: info.ReproAttempts,
+		BugInfo: *info,
+		New:     info.FirstTime.After(startTime),
+		Active:  info.LastTime.After(startTime),
+		Triaged: triaged,
+		Crashes: crashes,
 	}
 }
 
@@ -1029,17 +1023,11 @@ type UICrashPage struct {
 }
 
 type UICrashType struct {
-	Description   string
-	FirstTime     time.Time
-	LastTime      time.Time
-	New           bool // was first found in the current run
-	Active        bool // was found in the current run
-	ID            string
-	Count         int
-	Triaged       string
-	Strace        string
-	ReproAttempts int
-	Crashes       []UICrash
+	BugInfo
+	New     bool // was first found in the current run
+	Active  bool // was found in the current run
+	Triaged string
+	Crashes []UICrash
 }
 
 type UICrash struct {


### PR DESCRIPTION
On the syz-manager's html dashboard, dispay the number of repro attempts per each bug. It will help distinguish the bugs where reproduction was attempted and failed from those that have never been reproduced yet.