### PR TITLE
syz-cluster: refactor triage + add a kvm fuzz config

### DIFF
--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -14,6 +14,7 @@ data:
       - bpf
       - linux-ext4
       - netfilter-devel
+      - kvm
     emailReporting:
       name: "syzbot ci"
       sender: dashapi

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -210,6 +210,12 @@ const (
 // The list is ordered by decreasing importance.
 var FuzzConfigs = []*FuzzConfig{
 	{
+		Name:         `kvm`,
+		EmailLists:   []string{`kvm@vger.kernel.org`},
+		KernelConfig: `upstream-apparmor-kasan.config`,
+		CorpusURL:    allCorpusURL,
+	},
+	{
 		Name:         `bpf`,
 		EmailLists:   []string{`bpf@vger.kernel.org`},
 		KernelConfig: `upstream-apparmor-kasan.config`,

--- a/syz-cluster/pkg/api/client.go
+++ b/syz-cluster/pkg/api/client.go
@@ -41,7 +41,8 @@ func (client Client) UploadTriageResult(ctx context.Context, sessionID string, r
 }
 
 type TreesResp struct {
-	Trees []*Tree `json:"trees"`
+	Trees       []*Tree       `json:"trees"`
+	FuzzConfigs []*FuzzConfig `json:"fuzz_configs"`
 }
 
 func (client Client) GetTrees(ctx context.Context) (*TreesResp, error) {

--- a/syz-cluster/pkg/controller/api.go
+++ b/syz-cluster/pkg/controller/api.go
@@ -202,6 +202,7 @@ func (c APIServer) uploadSession(w http.ResponseWriter, r *http.Request) {
 
 func (c APIServer) getTrees(w http.ResponseWriter, r *http.Request) {
 	api.ReplyJSON(w, &api.TreesResp{
-		Trees: api.DefaultTrees,
+		Trees:       api.DefaultTrees,
+		FuzzConfigs: api.FuzzConfigs,
 	})
 }

--- a/syz-cluster/pkg/triage/fuzz_config.go
+++ b/syz-cluster/pkg/triage/fuzz_config.go
@@ -1,0 +1,28 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package triage
+
+import (
+	"strings"
+
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
+)
+
+func SelectFuzzConfig(series *api.Series, fuzzConfigs []*api.FuzzConfig) *api.FuzzConfig {
+	seriesCc := map[string]bool{}
+	for _, cc := range series.Cc {
+		seriesCc[strings.ToLower(cc)] = true
+	}
+	for _, config := range fuzzConfigs {
+		intersects := false
+		for _, cc := range config.EmailLists {
+			intersects = intersects || seriesCc[cc]
+		}
+		if len(config.EmailLists) != 0 && !intersects {
+			continue
+		}
+		return config
+	}
+	return nil
+}

--- a/syz-cluster/pkg/triage/fuzz_config_test.go
+++ b/syz-cluster/pkg/triage/fuzz_config_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package triage
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectFuzzConfig(t *testing.T) {
+	configs := []*api.FuzzConfig{
+		{
+			Name:       "bpf",
+			EmailLists: []string{"bpf@list"},
+		},
+		{
+			Name:       "net",
+			EmailLists: []string{"net@list"},
+		},
+		{
+			Name:       "mainline",
+			EmailLists: nil,
+		},
+	}
+	tests := []struct {
+		testName string
+		result   string
+		series   *api.Series
+	}{
+		{
+			testName: "select-first",
+			result:   "bpf",
+			series:   &api.Series{Cc: []string{"bpf@list", "net@list"}},
+		},
+		{
+			testName: "fallback",
+			result:   "mainline",
+			series:   &api.Series{Cc: []string{"unknown@list"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			ret := SelectFuzzConfig(test.series, configs)
+			assert.Equal(t, test.result, ret.Name)
+		})
+	}
+}

--- a/syz-cluster/pkg/triage/tree.go
+++ b/syz-cluster/pkg/triage/tree.go
@@ -40,11 +40,8 @@ func SelectTrees(series *api.Series, trees []*api.Tree) []*api.Tree {
 		result = append(result, tree)
 	}
 	sort.SliceStable(result, func(i, j int) bool {
-		a, b := result[i], result[j]
-		if tagsMap[a.Name] != tagsMap[b.Name] {
-			return tagsMap[a.Name]
-		}
-		return a.Priority > b.Priority
+		// First the trees from the patch subject, then everything else.
+		return tagsMap[result[i].Name] && !tagsMap[result[j].Name]
 	})
 	return result
 }

--- a/syz-cluster/pkg/triage/tree_test.go
+++ b/syz-cluster/pkg/triage/tree_test.go
@@ -13,29 +13,24 @@ import (
 func TestSelectTrees(t *testing.T) {
 	trees := []*api.Tree{
 		{
-			Name:       "mainline",
-			EmailLists: nil,
-			Priority:   0,
-		},
-		{
-			Name:       "net",
-			EmailLists: []string{"net@list"},
-			Priority:   1,
+			Name:       "bpf",
+			EmailLists: []string{"bpf@list"},
 		},
 		{
 			Name:       "wireless",
 			EmailLists: []string{"wireless@list"},
-			Priority:   2,
 		},
 		{
-			Name:       "bpf",
-			EmailLists: []string{"bpf@list"},
-			Priority:   3,
+			Name:       "net",
+			EmailLists: []string{"net@list"},
 		},
 		{
 			Name:       "test",
-			Priority:   api.TreePriorityNever,
 			EmailLists: []string{"test@list"},
+		},
+		{
+			Name:       "mainline",
+			EmailLists: nil,
 		},
 	}
 	tests := []struct {

--- a/syz-cluster/workflow/configs/kvm/base.cfg
+++ b/syz-cluster/workflow/configs/kvm/base.cfg
@@ -1,0 +1,34 @@
+{
+    "name": "base",
+    "target": "linux/amd64",
+    "kernel_obj": "/base/obj",
+    "kernel_build_src": "/workdir",
+    "image": "/base/image",
+    "syzkaller": "/syzkaller",
+    "workdir": "/workdir",
+    "type": "qemu",
+    "enable_syscalls": [
+	"openat$kvm",
+	"openat$sev",
+	"close",
+	"ioctl$KVM*",
+	"syz_kvm*",
+	"mmap$KVM_VCPU",
+	"munmap",
+	"syz_memcpy_off$KVM_EXIT_MMIO",
+	"syz_memcpy_off$KVM_EXIT_HYPERCALL",
+	"eventfd2",
+	"write$eventfd"
+    ],
+    "procs": 3,
+    "sandbox": "none",
+    "experimental": {"cover_edges": false},
+    "vm": {
+      "count": 4,
+      "cmdline": "root=/dev/sda1 kvm-intel.nested=1",
+      "kernel": "/base/kernel",
+      "cpu": 2,
+      "mem": 3072,
+      "qemu_args": "-machine q35,nvdimm=on,accel=kvm,kernel-irqchip=split -cpu max,migratable=off -enable-kvm -smp 2,sockets=2,cores=1"
+    }
+}

--- a/syz-cluster/workflow/configs/kvm/patched.cfg
+++ b/syz-cluster/workflow/configs/kvm/patched.cfg
@@ -1,0 +1,10 @@
+{
+    "name": "patched",
+    "target": "linux/amd64",
+    "kernel_obj": "/patched/obj",
+    "image": "/patched/image",
+    "vm": {
+      "count": 10,
+      "kernel": "/patched/kernel"
+    }
+}


### PR DESCRIPTION
Not always are fuzzing targets well represented by their own kernel
trees, so let's select a kernel tree and a fuzzing config separately.

Drop explicit priorities and instead just sort the lists of trees and
configs.

***
Add a config to fuzz kvm patches.
Listen on the kvm mailing list.
