### PR TITLE
pkg/coveragedb: update file to subsystem info periodically

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1963,12 +1963,7 @@ func apiSaveCoverage(c context.Context, payload io.Reader) (interface{}, error) 
 	if err := jsonDec.Decode(descr); err != nil {
 		return 0, fmt.Errorf("json.NewDecoder(coveragedb.HistoryRecord).Decode: %w", err)
 	}
-	var sss []*subsystem.Subsystem
-	if service := getNsConfig(c, descr.Namespace).Subsystems.Service; service != nil {
-		sss = service.List()
-		log.Infof(c, "found %d subsystems for %s namespace", len(sss), descr.Namespace)
-	}
-	rowsCreated, err := coveragedb.SaveMergeResult(c, getCoverageDBClient(c), descr, jsonDec, sss)
+	rowsCreated, err := coveragedb.SaveMergeResult(c, getCoverageDBClient(c), descr, jsonDec)
 	if err != nil {
 		log.Errorf(c, "error storing coverage for ns %s, date %s: %v",
 			descr.Namespace, descr.DateTo.String(), err)

--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -36,3 +36,6 @@ cron:
 # We use 15 for convenience here.
 - url: /cron/email_coverage_reports
   schedule: 15 of month 00:00
+# Weekly update the kernel-file -> subsystems relationship
+- url: /cron/update_coverdb_subsystems
+  schedule: every monday

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -88,6 +88,7 @@ func initHTTPHandlers() {
 	http.HandleFunc("/cron/deprecate_assets", handleDeprecateAssets)
 	http.HandleFunc("/cron/refresh_subsystems", handleRefreshSubsystems)
 	http.HandleFunc("/cron/subsystem_reports", handleSubsystemReports)
+	http.HandleFunc("/cron/update_coverdb_subsystems", handleUpdateCoverDBSubsystems)
 }
 
 func handleMovedPermanently(dest string) http.HandlerFunc {

--- a/pkg/covermerger/covermerger_test.go
+++ b/pkg/covermerger/covermerger_test.go
@@ -55,8 +55,8 @@ func TestMergeCSVWriteJSONL_and_coveragedb_SaveMergeResult(t *testing.T) {
 		spannerMock := mocks.NewSpannerClient(t)
 		spannerMock.
 			On("Apply", mock.Anything, mock.MatchedBy(func(ms []*spanner.Mutation) bool {
-				// 1 file * (5 managers + 1 manager total) x 2 (to update files and subsystems) + 1 merge_history + 18 functions
-				return len(ms) == 13+18
+				// 1 file * (5 managers + 1 manager total) x 1 (to update files) + 1 merge_history + 18 functions
+				return len(ms) == 1*(5+1)*1+1+18
 			})).
 			Return(time.Now(), nil).
 			Once()
@@ -67,7 +67,7 @@ func TestMergeCSVWriteJSONL_and_coveragedb_SaveMergeResult(t *testing.T) {
 		descr := new(coveragedb.HistoryRecord)
 		assert.NoError(t, decoder.Decode(descr))
 
-		_, err = coveragedb.SaveMergeResult(context.Background(), spannerMock, descr, decoder, nil)
+		_, err = coveragedb.SaveMergeResult(context.Background(), spannerMock, descr, decoder)
 		return err
 	})
 	assert.NoError(t, eg.Wait())


### PR DESCRIPTION
#6070 explains the problem of data propagation.
1. Add /cron/update_coverdb_subsystems.
2. Stop updating subsystems from coverage receiver API.

Closes #6070