### PR TITLE
pkg/manager: fix a NeedRepro check

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -323,23 +323,23 @@ func (dc *diffContext) monitorPatchedCoverage(ctx context.Context) error {
 // TODO: instead of this limit, consider expotentially growing delays between reproduction attempts.
 const maxReproAttempts = 6
 
-func skipDiffRepro(title string) bool {
+func needReproForTitle(title string) bool {
 	if strings.Contains(title, "no output") ||
 		strings.Contains(title, "lost connection") ||
 		strings.Contains(title, "detected stall") ||
 		strings.Contains(title, "SYZ") {
 		// Don't waste time reproducing these.
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 func (dc *diffContext) NeedRepro(crash *Crash) bool {
 	if crash.FullRepro {
 		return true
 	}
-	if skipDiffRepro(crash.Title) {
-		return true
+	if !needReproForTitle(crash.Title) {
+		return false
 	}
 	dc.mu.Lock()
 	defer dc.mu.Unlock()

--- a/pkg/manager/diff_test.go
+++ b/pkg/manager/diff_test.go
@@ -108,15 +108,15 @@ func TestModifiedSymbols(t *testing.T) {
 	})
 }
 
-func TestSkipDiffRepro(t *testing.T) {
+func TestNeedReproForTitle(t *testing.T) {
 	for title, skip := range map[string]bool{
-		"no output from test machine":                          true,
-		"SYZFAIL: read failed":                                 true,
-		"lost connection to test machine":                      true,
-		"INFO: rcu detected stall in clone":                    true,
-		"WARNING in arch_install_hw_breakpoint":                false,
-		"KASAN: slab-out-of-bounds Write in __bpf_get_stackid": false,
+		"no output from test machine":                          false,
+		"SYZFAIL: read failed":                                 false,
+		"lost connection to test machine":                      false,
+		"INFO: rcu detected stall in clone":                    false,
+		"WARNING in arch_install_hw_breakpoint":                true,
+		"KASAN: slab-out-of-bounds Write in __bpf_get_stackid": true,
 	} {
-		assert.Equal(t, skip, skipDiffRepro(title), "title=%q", title)
+		assert.Equal(t, skip, needReproForTitle(title), "title=%q", title)
 	}
 }


### PR DESCRIPTION
We've been checking the inverse.
Rename the helper function to reduce confusion in the future.