### PR TITLE
Revert "executor: change input/output area mapping rules"

### DIFF
--- a/sys/targets/targets.go
+++ b/sys/targets/targets.go
@@ -209,10 +209,8 @@ var List = map[string]map[string]*Target{
 		TestArch64Fuzz: {
 			PtrSize:  8,
 			PageSize: 8 << 10,
-			CFlags: []string{
-				"-fsanitize=address",
-				"-no-pie",
-			},
+			// -fsanitize=address causes SIGSEGV.
+			CFlags: []string{"-no-pie"},
 			osCommon: osCommon{
 				SyscallNumbers:         true,
 				SyscallPrefix:          "SYS_",


### PR DESCRIPTION
Reverts google/syzkaller#6251

***

The change apparently breaks syzkaller's normal operation. We should figure out why it still passed tests, but for now let's just revert.