### PR TITLE
syz-cluster: add gcc to fuzz-step container

### DIFF
--- a/syz-cluster/workflow/fuzz-step/Dockerfile
+++ b/syz-cluster/workflow/fuzz-step/Dockerfile
@@ -16,7 +16,7 @@ RUN GO_FLAGS=$(make go-flags 2>/dev/null) && go build "$GO_FLAGS" -o /bin/fuzz-s
 FROM debian:bookworm
 
 RUN apt-get update && \
-    apt-get install -y qemu-system openssh-client curl cpp
+    apt-get install -y qemu-system openssh-client curl cpp gcc
 
 # Install clang tools.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https


### PR DESCRIPTION
We use it for C repros by default.