### PR TITLE
syz-cluster: assorted fixes for regular kernel rebuilds

### DIFF
--- a/syz-cluster/pkg/triage/git.go
+++ b/syz-cluster/pkg/triage/git.go
@@ -30,7 +30,15 @@ func NewGitTreeOps(dir string, sandbox bool) (*GitTreeOps, error) {
 
 func (ops *GitTreeOps) HeadCommit(tree *api.Tree) (*vcs.Commit, error) {
 	// See kernel-disk/cron.yaml.
-	return ops.Commit(tree.Name + "-head")
+	return ops.Git.Commit(tree.Name + "-head")
+}
+
+func (ops *GitTreeOps) Commit(treeName, commitOrBranch string) (*vcs.Commit, error) {
+	// See kernel-disk/cron.yaml.
+	if vcs.CheckCommitHash(commitOrBranch) {
+		return ops.Git.Commit(commitOrBranch)
+	}
+	return ops.Git.Commit(treeName + "/" + commitOrBranch)
 }
 
 func (ops *GitTreeOps) ApplySeries(commit string, patches [][]byte) error {

--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -186,7 +186,7 @@ func checkoutKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest, serie
 	if err != nil {
 		return nil, err
 	}
-	commit, err := ops.Commit(req.CommitHash)
+	commit, err := ops.Commit(req.TreeName, req.CommitHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit info: %w", err)
 	}
@@ -197,7 +197,7 @@ func checkoutKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest, serie
 	if len(patches) > 0 {
 		tracer.Log("applying %d patches", len(patches))
 	}
-	err = ops.ApplySeries(req.CommitHash, patches)
+	err = ops.ApplySeries(commit.Hash, patches)
 	return commit, err
 }
 

--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -78,20 +78,20 @@ func main() {
 		uploadReq.CommitHash = commit.Hash
 		uploadReq.CommitDate = commit.CommitDate
 	}
-	if *flagSmokeBuild {
-		skip, err := alreadyBuilt(ctx, client, uploadReq)
-		if err != nil {
-			app.Fatalf("failed to query known builds: %v", err)
-		} else if skip {
-			log.Printf("%s already built, skipping", uploadReq.CommitHash)
-			return
-		}
-	}
 	ret := &BuildResult{}
 	if err != nil {
 		log.Printf("failed to checkout: %v", err)
 		uploadReq.Log = []byte(err.Error())
 	} else {
+		if *flagSmokeBuild {
+			skip, err := alreadyBuilt(ctx, client, uploadReq)
+			if err != nil {
+				app.Fatalf("failed to query known builds: %v", err)
+			} else if skip {
+				log.Printf("%s already built, skipping", uploadReq.CommitHash)
+				return
+			}
+		}
 		ret, err = buildKernel(tracer, req)
 		if err != nil {
 			log.Printf("build process failed: %v", err)

--- a/syz-cluster/workflow/rebuild-kernels-cron.yaml
+++ b/syz-cluster/workflow/rebuild-kernels-cron.yaml
@@ -24,32 +24,66 @@ spec:
     - name: main
       parallelism: 1
       steps:
-        - - name: query-trees
-            template: query-trees-template
-        - - name: iterate-trees
-            template: process-tree
+        - - name: query-data
+            template: query-data-template
+        - - name: prepare-build-requests
+            template: prepare-build-requests-template
             arguments:
               parameters:
-                - name: tree
+              - name: response
+                value: "{{steps.query-data.outputs.result}}"
+        - - name: iterate-builds
+            template: process-build-request
+            arguments:
+              parameters:
+                - name: request-json
                   value: "{{item}}"
-            withParam: "{{=jsonpath(steps['query-trees'].outputs.result, '$.trees')}}"
+            withParam: "{{steps.prepare-build-requests.outputs.result}}"
             continueOn:
               failed: true
-    - name: query-trees-template
+    - name: query-data-template
       http:
         url: "http://controller-service:8080/trees"
         method: "GET"
-    - name: process-tree
+    - name: prepare-build-requests-template
       inputs:
         parameters:
-          - name: tree
+          - name: response
+      script:
+        image: python:3.9
+        command: [python]
+        source: |
+          import json
+          import sys
+
+          data = json.loads('''{{inputs.parameters.response}}''')
+          unique_kernel_configs = sorted(list(set(
+              config["kernel_config"] for config in data.get("fuzz_configs", [])
+          )))
+          build_requests = []
+          for tree in data.get("trees", []):
+              for config_name in unique_kernel_configs:
+                  build_request = {
+                      "arch": "amd64", # TODO: consider others as well.
+                      "tree_name": tree["name"],
+                      "tree_url": tree["URL"],
+                      "commit_hash": tree["branch"],
+                      "config_name": config_name
+                  }
+                  build_requests.append(build_request)
+          print(json.dumps(build_requests))
+
+    - name: process-build-request
+      inputs:
+        parameters:
+          - name: request-json
       steps:
-        - - name: convert-json
-            template: convert-to-request
+        - - name: create-request-artifact
+            template: request-to-artifact
             arguments:
               parameters:
-                - name: tree
-                  value: "{{inputs.parameters.tree}}"
+                - name: data
+                  value: "{{inputs.parameters.request-json}}"
         - - name: run-build
             templateRef:
               name: build-step-template
@@ -60,35 +94,17 @@ spec:
                   value: "true"
               artifacts:
                 - name: request
-                  from: "{{steps.convert-json.outputs.artifacts.request}}"
-    - name: convert-to-request
+                  from: "{{steps.create-request-artifact.outputs.artifacts.request}}"
+    - name: request-to-artifact
       inputs:
         parameters:
-          - name: tree
+          - name: data
       outputs:
         artifacts:
           - name: request
-            path: /output/request.json
-      volumes:
-      - name: output-volume
-        emptyDir: {}
+            path: /tmp/request.json
       script:
-        image: python:3.9
-        command: [python]
-        volumeMounts:
-          - name: output-volume
-            mountPath: /output
+        image: alpine:latest
+        command: [sh, -c]
         source: |
-          import json
-          import sys
-
-          input = {{inputs.parameters.tree}}
-          output = {
-            "arch": "amd64", # TODO: consider others as well.
-            "tree_name": input["name"],
-            "tree_url": input["URL"],
-            "commit_hash": input["branch"],
-            "config_name": input["kernel_config"]
-          }
-          with open('/output/request.json', 'w') as f:
-            json.dump(output, f)
+          printf '%s' '{{inputs.parameters.data}}' > /tmp/request.json

--- a/syz-cluster/workflow/rebuild-kernels-cron.yaml
+++ b/syz-cluster/workflow/rebuild-kernels-cron.yaml
@@ -20,6 +20,11 @@ spec:
     podMetadata:
       labels:
         tier: workflow
+    podGC:
+      strategy: OnPodCompletion
+      deleteDelayDuration: 12h
+    ttlStrategy:
+      secondsAfterCompletion: 86400
     templates:
     - name: main
       parallelism: 1


### PR DESCRIPTION
The functionality that checks if latest base kernel revisions are not build-broken (we use this information to determine to which base commit to apply a series) has gotten broken itself. This PR includes a number of fixes that bring it back.