### PR TITLE
tools: openbsd workarounds to use clang-19

### DIFF
--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -42,9 +42,9 @@ echo 'permit keepenv nopass syzkaller as root' > /etc/doas.conf
 mkdir /syzkaller
 echo '/dev/sd1a /syzkaller ffs rw,noauto 1 0' >> /etc/fstab
 
-mkdir -p /usr/lib/clang/16/lib/openbsd
-ln -s /usr/lib/clang/16/lib/libclang_rt.ubsan_minimal.a /usr/lib/clang/16/lib/openbsd/libclang_rt.ubsan_standalone-x86_64.a
-touch /usr/lib/clang/16/lib/openbsd/libclang_rt.ubsan_standalone_cxx-x86_64.a
+mkdir -p /usr/lib/clang/19/lib/openbsd
+ln -s /usr/lib/clang/19/lib/libclang_rt.ubsan_minimal.a /usr/lib/clang/19/lib/openbsd/libclang_rt.ubsan_standalone-x86_64.a
+touch /usr/lib/clang/19/lib/openbsd/libclang_rt.ubsan_standalone_cxx-x86_64.a
 EOF
 
 cat >etc/installurl <<EOF

--- a/tools/create-openbsd-gce-ci.sh
+++ b/tools/create-openbsd-gce-ci.sh
@@ -32,6 +32,7 @@ cat >install.site <<EOF
 PKGS="bash gcc%8 git gmake go llvm%19 nano wget"
 PKG_PATH=${SNAPSHOTS}packages/${ARCH}/ pkg_add -I \$PKGS
 PKG_PATH= pkg_info -I \$PKGS && echo pkg_add OK
+ln -s /usr/local/bin/clang-format{-19,}
 
 echo 'set tty com0' > boot.conf
 echo 'PasswordAuthentication no' >> /etc/ssh/sshd_config


### PR DESCRIPTION
- **tools: put clang-format into PATH on openbsd GCE image**
- **tools: openbsd workarounds to use clang-19**
