### PR TITLE
syz-cluster/workflow/configs: update net and bpf configs

### DIFF
--- a/syz-cluster/workflow/configs/bpf/base.cfg
+++ b/syz-cluster/workflow/configs/bpf/base.cfg
@@ -11,10 +11,10 @@
 	"bpf", "mkdir", "mount$bpf", "unlink", "close",
 	"perf_event_open*", "ioctl$PERF*", "getpid", "gettid",
 	"socketpair", "sendmsg", "recvmsg", "setsockopt$sock_attach_bpf",
-	"socket$kcm", "ioctl$sock_kcm*", "syz_clone",
+	"socket", "ioctl$sock_kcm*", "syz_clone",
 	"mkdirat$cgroup*", "openat$cgroup*", "write$cgroup*",
 	"openat$tun", "write$tun", "ioctl$TUN*", "ioctl$SIOCSIFHWADDR",
-	"openat$ppp", "syz_open_procfs$namespace"
+	"openat$ppp", "syz_open_procfs$namespace", "openat$pidfd", "fstat"
     ],
     "procs": 3,
     "sandbox": "none",

--- a/syz-cluster/workflow/configs/net/base.cfg
+++ b/syz-cluster/workflow/configs/net/base.cfg
@@ -22,7 +22,8 @@
 	    "mkdirat$cgroup*", "openat$cgroup*", "write$cgroup*",
 	    "clock_gettime", "bpf", "openat$tun", "openat$ppp",
 	    "syz_open_procfs$namespace", "syz_80211_*", "nanosleep",
-	    "openat$nci", "ioctl$IOCTL_GET_NCIDEV_IDX"
+	    "openat$nci", "ioctl$IOCTL_GET_NCIDEV_IDX", "openat$rfkill",
+	    "openat$6lowpan*", "openat$pidfd", "openat$tcp*"
     ],
     "procs": 3,
     "sandbox": "none",


### PR DESCRIPTION
openat$6lowpan* is necessary for write$6lowpan*.
openat$tcp* is necessary for write$tcp_*.
bpf$BPF_LINK_CREATE depends on pidfd.
bpf$MAP_UPDATE_ELEM needs socket.
mount$bpf needs fstat.