### PR TITLE
pkg: move gcpsecret to a separate package

### DIFF
--- a/pkg/gcpsecret/secret.go
+++ b/pkg/gcpsecret/secret.go
@@ -1,7 +1,7 @@
 // Copyright 2021 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package gce
+package gcpsecret
 
 import (
 	"context"

--- a/syz-cluster/pkg/emailclient/smtp_sender.go
+++ b/syz-cluster/pkg/emailclient/smtp_sender.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/syzkaller/pkg/gce"
+	"github.com/google/syzkaller/pkg/gcpsecret"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/uuid"
 )
@@ -22,7 +22,7 @@ type smtpSender struct {
 }
 
 func newSMTPSender(ctx context.Context, cfg *app.EmailConfig) (*smtpSender, error) {
-	project, err := gce.ProjectName(ctx)
+	project, err := gcpsecret.ProjectName(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query project name: %w", err)
 	}
@@ -117,7 +117,7 @@ func (sender *smtpSender) querySecret(ctx context.Context, key string) (string, 
 	var err error
 	for i := 0; i < retries; i++ {
 		var val []byte
-		val, err := gce.LatestGcpSecret(ctx, sender.projectName, key)
+		val, err := gcpsecret.LatestGcpSecret(ctx, sender.projectName, key)
 		if err == nil {
 			return string(val), nil
 		}

--- a/syz-cluster/tools/send-test-email/Dockerfile
+++ b/syz-cluster/tools/send-test-email/Dockerfile
@@ -8,9 +8,9 @@ COPY go.sum ./
 RUN go mod download
 COPY dashboard/dashapi/ dashboard/dashapi/
 COPY pkg/gcs/ pkg/gcs/
-COPY pkg/gce/ pkg/gce/
 COPY pkg/email/ pkg/email/
 COPY pkg/auth/ pkg/auth/
+COPY pkg/gcpsecret/ pkg/gcpsecret/
 
 # Build the tool.
 COPY syz-cluster/tools/send-test-email/*.go syz-cluster/tools/send-test-email/


### PR DESCRIPTION
It simplifies the dependency tree and fixes a build error for the send-test-email container.