### PR TITLE
syz-cluster: add vsock to the enabled syscalls for net

### DIFF
--- a/syz-cluster/workflow/configs/net/base.cfg
+++ b/syz-cluster/workflow/configs/net/base.cfg
@@ -23,7 +23,7 @@
 	    "clock_gettime", "bpf", "openat$tun", "openat$ppp",
 	    "syz_open_procfs$namespace", "syz_80211_*", "nanosleep",
 	    "openat$nci", "ioctl$IOCTL_GET_NCIDEV_IDX", "openat$rfkill",
-	    "openat$6lowpan*", "openat$pidfd", "openat$tcp*"
+	    "openat$6lowpan*", "openat$pidfd", "openat$tcp*", "openat$vhost_vsock"
     ],
     "procs": 3,
     "sandbox": "none",


### PR DESCRIPTION
vsock patches are sent to the net mailing lists.