### PR TITLE
pkg/instance: fix sandbox_arg passing

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -483,7 +483,7 @@ func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Optio
 	if optionalFlags {
 		optionalArg += " " + tool.OptionalFlags([]tool.Flag{
 			{Name: "slowdown", Value: fmt.Sprint(slowdown)},
-			{Name: "sandboxArg", Value: fmt.Sprint(opts.SandboxArg)},
+			{Name: "sandbox_arg", Value: fmt.Sprint(opts.SandboxArg)},
 			{Name: "type", Value: fmt.Sprint(vmType)},
 		})
 	}

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -36,6 +36,7 @@ func TestExecprogCmd(t *testing.T) {
 	flagSignal := flags.Bool("cover", false, "collect feedback signals (coverage)")
 	flagSandbox := flags.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace/android)")
 	flagSlowdown := flags.Int("slowdown", 1, "")
+	flagSandboxArg := flags.Int("sandbox_arg", 0, "argument for sandbox runner to adjust it via config")
 	cmdLine := ExecprogCmd(os.Args[0], "/myexecutor", targets.FreeBSD, targets.I386, "vmtype",
 		csource.Options{
 			Sandbox:    "namespace",
@@ -80,6 +81,9 @@ func TestExecprogCmd(t *testing.T) {
 	}
 	if *flagSandbox != "namespace" {
 		t.Errorf("bad sandbox: %q, want: %q", *flagSandbox, "namespace")
+	}
+	if *flagSandboxArg != 3 {
+		t.Errorf("bad sandbox_arg: %q, want: %q", *flagSandboxArg, 3)
 	}
 	if *flagSignal {
 		t.Errorf("bad signal: %v, want: %v", *flagSignal, false)


### PR DESCRIPTION
We used the wrong name for the optional argument.