### PR TITLE
syz-cluster/dashboard: html escape modal content

### DIFF
--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -27,7 +27,7 @@
               body.html("")
               body.load(url, function(response, status, xhr){
                   if (status == "success") {
-                      body.html("<pre>" + response + "</pre>")
+                      body.html($('<pre></pre>').text(response))
                   }
                   $('#contentModal').modal('show');
               });


### PR DESCRIPTION
Otherwise we sometimes display broken data.