### PR TITLE
syz-cluster: display statistics

### DIFF
--- a/syz-cluster/dashboard/templates/base.html
+++ b/syz-cluster/dashboard/templates/base.html
@@ -9,12 +9,15 @@
     <title>{{.Title}}</title>
   </head>
   <body>
-    <nav class="navbar navbar-light bg-light justify-content-start">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light justify-content-start">
       <a class="navbar-brand px-3" href="#">{{.Title}}</a>
-      <div class="">
+      <div class="collapse navbar-collapse">
         <ul class="navbar-nav">
-          <li class="nav-item active">
+          <li class="nav-item{{if eq .Template "index.html"}} active{{end}}">
             <a class="nav-link" href="/">All Series</a>
+          </li>
+          <li class="nav-item{{if eq .Template "graphs.html"}} active{{end}}">
+            <a class="nav-link" href="/stats">Statistics</a>
           </li>
         </ul>
       </div>

--- a/syz-cluster/dashboard/templates/graphs.html
+++ b/syz-cluster/dashboard/templates/graphs.html
@@ -1,0 +1,114 @@
+{{define "content"}}
+    <main class="container-fluid my-4">
+      <div class="chart-wrapper mb-5">
+        <h2 class="h4">Processed Series (weekly)</h2>
+        <p class="text-muted small">Click and drag to zoom into a time range. Right-click to reset.</p>
+        <div id="processed_chart_div" style="width: 100%; height: 400px;"></div>
+      </div>
+
+      <hr class="my-4">
+
+      <div class="chart-wrapper mb-4">
+        <h2 class="h4">Findings (weekly)</h2>
+        <p class="text-muted small">Click and drag to zoom into a time range. Right-click to reset.</p>
+        <div id="findings_chart_div" style="width: 100%; height: 400px;"></div>
+      </div>
+
+      <hr class="my-4">
+
+      <div class="chart-wrapper mb-4">
+        <h2 class="h4">Wait Time before Fuzzing (avg hours, weekly)</h2>
+        <p class="text-muted small">How many hours have passed since the moment the series was published and the moment we started fuzzing it.</p>
+        <p class="text-muted small">Click and drag to zoom into a time range. Right-click to reset.</p>
+        <div id="avg_wait_chart_div" style="width: 100%; height: 400px;"></div>
+      </div>
+
+      <hr class="my-4">
+
+      <div class="chart-wrapper mb-4">
+        <h2 class="h4">Status Distribution (weekly)</h2>
+        <p class="text-muted small">Click and drag to zoom into a time range. Right-click to reset.</p>
+        <div id="distribution_chart_div" style="width: 100%; height: 400px;"></div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript">
+      google.charts.load('current', {'packages':['corechart']});
+      google.charts.setOnLoadCallback(drawAllCharts);
+
+      const processedData = [
+        {{range .Processed}}
+          [new Date({{.Date.Format "2006-01-02"}}), {{.Count}}],
+        {{end}}
+      ];
+
+      const findingsData = [
+        {{range .Findings}}
+          [new Date({{.Date.Format "2006-01-02"}}), {{.Count}}],
+        {{end}}
+      ];
+
+      const delayData = [
+        {{range .Delay}}
+          [new Date({{.Date.Format "2006-01-02"}}), {{.DelayHours}}],
+        {{end}}
+      ];
+
+      const distributionData = [
+        {{range .Distribution}}
+          [new Date({{.Date.Format "2006-01-02"}}), {{.Finished}}, {{.Skipped}}],
+        {{end}}
+      ];
+
+      function drawAllCharts() {
+        drawChart('processed_chart_div', processedData, '#007bff');
+        drawChart('findings_chart_div', findingsData, '#dc3545');
+        drawChart('avg_wait_chart_div', delayData, 'black');
+        drawDistributionChart();
+      }
+
+      function drawChart(chartDivId, chartData, chartColor) {
+        const data = new google.visualization.DataTable();
+        data.addColumn('date', 'Date');
+        data.addColumn('number', 'Count');
+        data.addRows(chartData);
+        const options = {
+          legend: { position: 'none' },
+          hAxis: { title: 'Date', format: 'MMM dd, yyyy', gridlines: { color: 'transparent' } },
+          vAxis: { title: 'Count', minValue: 0 },
+          colors: [chartColor],
+          curveType: 'function',
+          explorer: {
+            actions: ['dragToZoom', 'rightClickToReset'],
+            axis: 'horizontal',
+            keepInBounds: true,
+            maxZoomIn: 4.0
+          }
+        };
+
+        const chart = new google.visualization.LineChart(document.getElementById(chartDivId));
+        chart.draw(data, options);
+      }
+
+      function drawDistributionChart() {
+        const data = new google.visualization.DataTable();
+        data.addColumn('date', 'Date');
+        data.addColumn('number', 'Processed');
+        data.addColumn('number', 'Skipped');
+        data.addRows(distributionData);
+        const options = {
+          isStacked: 'percent',
+          legend: { position: 'top', maxLines: 2 },
+          hAxis: { title: 'Date', format: 'MMM dd, yyyy', gridlines: { color: 'transparent' } },
+          vAxis: {
+            minValue: 0,
+            format: '#%'
+          },
+          colors: ['#28a745', '#ffc107'],
+          areaOpacity: 0.8
+        };
+        const chart = new google.visualization.AreaChart(document.getElementById('distribution_chart_div'));
+        chart.draw(data, options);
+    }
+    </script>
+{{end}}

--- a/syz-cluster/pkg/db/stats_repo.go
+++ b/syz-cluster/pkg/db/stats_repo.go
@@ -1,0 +1,92 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package db
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+type StatsRepository struct {
+	client *spanner.Client
+}
+
+func NewStatsRepository(client *spanner.Client) *StatsRepository {
+	return &StatsRepository{
+		client: client,
+	}
+}
+
+type CountPerWeek struct {
+	Date  time.Time `spanner:"Date"`
+	Count int64     `spanner:"Count"`
+}
+
+func (repo *StatsRepository) ProcessedSeriesPerWeek(ctx context.Context) (
+	[]*CountPerWeek, error) {
+	return readEntities[CountPerWeek](ctx, repo.client.Single(), spanner.Statement{
+		SQL: `SELECT
+  TIMESTAMP_TRUNC(Sessions.FinishedAt, WEEK) as Date,
+  COUNT(*) as Count
+FROM Series
+JOIN Sessions ON Sessions.ID = Series.LatestSessionID
+WHERE FinishedAt IS NOT NULL
+GROUP BY Date
+ORDER BY Date`,
+	})
+}
+
+func (repo *StatsRepository) FindingsPerWeek(ctx context.Context) (
+	[]*CountPerWeek, error) {
+	return readEntities[CountPerWeek](ctx, repo.client.Single(), spanner.Statement{
+		SQL: `SELECT
+  TIMESTAMP_TRUNC(Sessions.FinishedAt, WEEK) as Date,
+  COUNT(*) as Count
+FROM Findings
+JOIN Sessions ON Sessions.ID = Findings.SessionID
+GROUP BY Date
+ORDER BY Date`,
+	})
+}
+
+type StatusPerWeek struct {
+	Date     time.Time `spanner:"Date"`
+	Finished int64     `spanner:"Finished"`
+	Skipped  int64     `spanner:"Skipped"`
+}
+
+func (repo *StatsRepository) SessionStatusPerWeek(ctx context.Context) (
+	[]*StatusPerWeek, error) {
+	return readEntities[StatusPerWeek](ctx, repo.client.Single(), spanner.Statement{
+		SQL: `SELECT
+  TIMESTAMP_TRUNC(Sessions.FinishedAt, WEEK) as Date,
+  COUNTIF(Sessions.SkipReason IS NULL) as Finished,
+  COUNTIF(Sessions.SkipReason IS NOT NULL) as Skipped
+FROM Series
+JOIN Sessions ON Sessions.ID = Series.LatestSessionID
+WHERE FinishedAt IS NOT NULL
+GROUP BY Date
+ORDER BY Date`,
+	})
+}
+
+type DelayPerWeek struct {
+	Date       time.Time `spanner:"Date"`
+	DelayHours float64   `spanner:"AvgDelayHours"`
+}
+
+func (repo *StatsRepository) DelayPerWeek(ctx context.Context) (
+	[]*DelayPerWeek, error) {
+	return readEntities[DelayPerWeek](ctx, repo.client.Single(), spanner.Statement{
+		SQL: `SELECT
+  TIMESTAMP_TRUNC(Sessions.StartedAt, WEEK) as Date,
+  AVG(TIMESTAMP_DIFF(Sessions.StartedAt,Sessions.CreatedAt, HOUR)) as AvgDelayHours
+FROM Sessions
+WHERE StartedAt IS NOT NULL
+GROUP BY Date
+ORDER BY Date`,
+	})
+}

--- a/syz-cluster/pkg/db/stats_repo_test.go
+++ b/syz-cluster/pkg/db/stats_repo_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsSQLs(t *testing.T) {
+	// Ideally, there should be some proper tests, but for now let's at least
+	// check that the SQL queries themselves have no errors.
+	// That already brings a lot of value.
+	client, ctx := NewTransientDB(t)
+
+	// Add some data to test field decoding as well.
+	dtd := &dummyTestData{t, ctx, client}
+	session := dtd.dummySession(dtd.dummySeries())
+	dtd.startSession(session)
+	dtd.finishSession(session)
+
+	statsRepo := NewStatsRepository(client)
+	_, err := statsRepo.ProcessedSeriesPerWeek(ctx)
+	assert.NoError(t, err)
+	_, err = statsRepo.FindingsPerWeek(ctx)
+	assert.NoError(t, err)
+	_, err = statsRepo.SessionStatusPerWeek(ctx)
+	assert.NoError(t, err)
+	_, err = statsRepo.DelayPerWeek(ctx)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Add a web dashboard page with the main statistics concerning patch series fuzzing.

Improve the navigation bar on top of the page.
