### PR TITLE
syz-cluster: select nested vm pool by label

### DIFF
--- a/syz-cluster/overlays/gke/common/kustomization.yaml
+++ b/syz-cluster/overlays/gke/common/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
       - op: replace
         path: /spec/templates/0/nodeSelector
         value:
-          cloud.google.com/gke-nodepool: nested-vm-pool
+          amd64-nested-virtualization: "true"
   - target:
       kind: Service
       name: web-dashboard-service


### PR DESCRIPTION
Selecting it by a label instead of an exact vm pool name makes it possible to implement a blue/greed node pool update strategy (since pool names would be different in this case).