### PR TITLE
syz-cluster/dashboard: don't smooth stats graphs

### DIFF
--- a/syz-cluster/dashboard/templates/graphs.html
+++ b/syz-cluster/dashboard/templates/graphs.html
@@ -77,7 +77,6 @@
           hAxis: { title: 'Date', format: 'MMM dd, yyyy', gridlines: { color: 'transparent' } },
           vAxis: { title: 'Count', minValue: 0 },
           colors: [chartColor],
-          curveType: 'function',
           explorer: {
             actions: ['dragToZoom', 'rightClickToReset'],
             axis: 'horizontal',


### PR DESCRIPTION
They look more natural without it.