### PR TITLE
pkg/report: add "BUG on" oops entry for gVisor

### DIFF
--- a/pkg/report/gvisor.go
+++ b/pkg/report/gvisor.go
@@ -173,4 +173,15 @@ var gvisorOopses = append([]*oops{
 		},
 		[]*regexp.Regexp{},
 	},
+	{
+		[]byte("WARNING: BUG on"),
+		[]oopsFormat{
+			{
+				title:        compile("WARNING: BUG on (.*)"),
+				fmt:          "WARNING: BUG on %[1]v",
+				noStackTrace: true,
+			},
+		},
+		[]*regexp.Regexp{},
+	},
 }, commonOopses...)


### PR DESCRIPTION
Following
https://github.com/google/gvisor/commit/b47d21ef21a6f59b8f574eebf83c7936880c1c0d syzkaller should look for this message type.
