### PR TITLE
pkg/symbolizer: Fix parser handling of small hex values

### DIFF
--- a/pkg/symbolizer/addr2line.go
+++ b/pkg/symbolizer/addr2line.go
@@ -138,7 +138,7 @@ func parse(interner *Interner, s *bufio.Scanner) ([]Frame, error) {
 	var frames []Frame
 	for s.Scan() {
 		ln := s.Text()
-		if len(ln) > 3 && ln[0] == '0' && ln[1] == 'x' {
+		if len(ln) >= 3 && ln[0] == '0' && ln[1] == 'x' {
 			break
 		}
 		fn := ln


### PR DESCRIPTION
The parser in symbolizer presently breaks out of the for loop if it receives a hex value, to indicate it has reached the next PC, or the sentinel.

The condition for breaking the loop is:
if len(ln) > 3 && ln[0] == '0' && ln[1] == 'x', this does not catch 0xc, for example

len(ln) >= 3 && ln[0] == '0' && ln[1] == 'x' is correct for such cases.

Fixes #6290

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
