### PR TITLE
syz-cluster: fix stats display for non finished sessions

### DIFF
--- a/syz-cluster/pkg/db/stats_repo.go
+++ b/syz-cluster/pkg/db/stats_repo.go
@@ -46,7 +46,7 @@ func (repo *StatsRepository) FindingsPerWeek(ctx context.Context) (
   TIMESTAMP_TRUNC(Sessions.FinishedAt, WEEK) as Date,
   COUNT(*) as Count
 FROM Findings
-JOIN Sessions ON Sessions.ID = Findings.SessionID
+JOIN Sessions ON Sessions.ID = Findings.SessionID AND Sessions.FinishedAt IS NOT NULL
 GROUP BY Date
 ORDER BY Date`,
 	})

--- a/syz-cluster/pkg/db/stats_repo_test.go
+++ b/syz-cluster/pkg/db/stats_repo_test.go
@@ -15,19 +15,26 @@ func TestStatsSQLs(t *testing.T) {
 	// That already brings a lot of value.
 	client, ctx := NewTransientDB(t)
 
-	// Add some data to test field decoding as well.
+	checkStats := func() {
+		statsRepo := NewStatsRepository(client)
+		_, err := statsRepo.ProcessedSeriesPerWeek(ctx)
+		assert.NoError(t, err)
+		_, err = statsRepo.FindingsPerWeek(ctx)
+		assert.NoError(t, err)
+		_, err = statsRepo.SessionStatusPerWeek(ctx)
+		assert.NoError(t, err)
+		_, err = statsRepo.DelayPerWeek(ctx)
+		assert.NoError(t, err)
+	}
+
 	dtd := &dummyTestData{t, ctx, client}
 	session := dtd.dummySession(dtd.dummySeries())
+	checkStats()
 	dtd.startSession(session)
+	dtd.addSessionTest(session, "test")
+	checkStats()
+	dtd.addFinding(session, "test", "test")
+	checkStats()
 	dtd.finishSession(session)
-
-	statsRepo := NewStatsRepository(client)
-	_, err := statsRepo.ProcessedSeriesPerWeek(ctx)
-	assert.NoError(t, err)
-	_, err = statsRepo.FindingsPerWeek(ctx)
-	assert.NoError(t, err)
-	_, err = statsRepo.SessionStatusPerWeek(ctx)
-	assert.NoError(t, err)
-	_, err = statsRepo.DelayPerWeek(ctx)
-	assert.NoError(t, err)
+	checkStats()
 }


### PR DESCRIPTION
We could not generate the stats page when there were findings for a not yet finished session.

Fix it and adjust the tests.