### PR TITLE
pkg/rpcserver: move executor restart to named stats

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -111,10 +111,11 @@ type server struct {
 }
 
 type Stats struct {
-	StatExecs      *stat.Val
-	StatNumFuzzing *stat.Val
-	StatVMRestarts *stat.Val
-	StatModules    *stat.Val
+	StatExecs            *stat.Val
+	StatNumFuzzing       *stat.Val
+	StatVMRestarts       *stat.Val
+	StatModules          *stat.Val
+	StatExecutorRestarts *stat.Val
 }
 
 func NewStats() Stats {
@@ -139,6 +140,8 @@ func NewNamedStats(name string) Stats {
 			stat.Rate{}, stat.NoGraph),
 		StatModules: stat.New("modules"+suffix, "Number of loaded kernel modules",
 			stat.NoGraph, stat.Link("/modules"+linkSuffix)),
+		StatExecutorRestarts: stat.New("executor restarts",
+			"Number of times executor process was restarted", stat.Rate{}, stat.Graph("executor")),
 	}
 }
 
@@ -209,8 +212,7 @@ func newImpl(cfg *Config, mgr Manager) *server {
 			statExecRetries: stat.New("exec retries",
 				"Number of times a test program was restarted because the first run failed",
 				stat.Rate{}, stat.Graph("executor")),
-			statExecutorRestarts: stat.New("executor restarts",
-				"Number of times executor process was restarted", stat.Rate{}, stat.Graph("executor")),
+			statExecutorRestarts:   cfg.Stats.StatExecutorRestarts,
 			statExecBufferTooSmall: queue.StatExecBufferTooSmall,
 			statExecs:              cfg.Stats.StatExecs,
 			statNoExecRequests:     queue.StatNoExecRequests,


### PR DESCRIPTION
This will let us see executor restart statistics per VM pool (relevant for diff fuzzing).