### PR TITLE
dashboard/app/templates: fix to display repro type incorrectly

### DIFF
--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -631,7 +631,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="stat">{{link $item.KernelCommitLink (formatTagHash $item.KernelCommit)}}</td>
 			<td>
 				{{if $item.ReproCLink}}<a href="{{$item.ReproCLink}}">C</a>
-				{{else if $item.ReproSyzLink}}<a href="{{$item.ReproSyzLink}}">C</a>{{end}}
+				{{else if $item.ReproSyzLink}}<a href="{{$item.ReproSyzLink}}">syz</a>{{end}}
 			</td>
 			{{if ne $item.CrashTitle ""}}
 			<td class="status-crashed">


### PR DESCRIPTION
This pull request include one commit that fixes a minor issue where the bug page incorrectly shows syz repro as c repro.