### PR TITLE
syz-cluster: skip fuzzing if binaries are the same

### DIFF
--- a/syz-cluster/dashboard/templates/graphs.html
+++ b/syz-cluster/dashboard/templates/graphs.html
@@ -56,7 +56,7 @@
 
       const distributionData = [
         {{range .Distribution}}
-          [new Date({{.Date.Format "2006-01-02"}}), {{.Finished}}, {{.Skipped}}],
+          [new Date({{.Date.Format "2006-01-02"}}), {{.Finished}}, {{.Skipped}}, {{.WithFailedSteps}}, {{.WithSkippedSteps}}],
         {{end}}
       ];
 
@@ -94,6 +94,8 @@
         data.addColumn('date', 'Date');
         data.addColumn('number', 'Processed');
         data.addColumn('number', 'Skipped');
+        data.addColumn('number', 'Some steps failed');
+        data.addColumn('number', 'Some steps skipped');
         data.addRows(distributionData);
         const options = {
           isStacked: 'percent',
@@ -103,7 +105,7 @@
             minValue: 0,
             format: '#%'
           },
-          colors: ['#28a745', '#ffc107'],
+          colors: ['#28a745', '#ffc107', '#ffcccb', '#d5f0c0'],
           areaOpacity: 0.8
         };
         const chart = new google.visualization.AreaChart(document.getElementById('distribution_chart_div'));

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -73,6 +73,7 @@ type Build struct {
 const (
 	TestRunning string = "running"
 	TestPassed  string = "passed"
+	TestSkipped string = "skipped"
 	TestFailed  string = "failed" // TODO: drop it? only mark completion?
 	TestError   string = "error"
 )

--- a/syz-cluster/pkg/db/migrations/5_session_test_skipped.down.sql
+++ b/syz-cluster/pkg/db/migrations/5_session_test_skipped.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE SessionTests DROP CONSTRAINT ResultEnum;
+ALTER TABLE SessionTests ADD CONSTRAINT ResultEnum CHECK (Result IN ('passed', 'failed', 'error', 'running'));
+DROP INDEX SessionTestsByResult;

--- a/syz-cluster/pkg/db/migrations/5_session_test_skipped.up.sql
+++ b/syz-cluster/pkg/db/migrations/5_session_test_skipped.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE SessionTests DROP CONSTRAINT ResultEnum;
+ALTER TABLE SessionTests ADD CONSTRAINT ResultEnum CHECK (Result IN ('passed', 'failed', 'error', 'running', 'skipped'));
+CREATE INDEX SessionTestsByResult ON SessionTests(SessionID, Result);

--- a/syz-cluster/workflow/fuzz-step/main_test.go
+++ b/syz-cluster/workflow/fuzz-step/main_test.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigLoad(t *testing.T) {
@@ -24,5 +26,23 @@ func TestConfigLoad(t *testing.T) {
 			t.Fatalf("error proessing %q: %v", path, err)
 		}
 		return nil
+	})
+}
+
+func TestShouldSkipFuzzing(t *testing.T) {
+	t.Run("one empty", func(t *testing.T) {
+		assert.False(t, shouldSkipFuzzing(nil, map[string]string{"A": "1"}))
+	})
+	t.Run("equal", func(t *testing.T) {
+		assert.True(t, shouldSkipFuzzing(
+			map[string]string{"A": "1", "B": "2"},
+			map[string]string{"A": "1", "B": "2"},
+		))
+	})
+	t.Run("different", func(t *testing.T) {
+		assert.False(t, shouldSkipFuzzing(
+			map[string]string{"A": "1", "B": "2"},
+			map[string]string{"A": "1", "B": "different"},
+		))
 	})
 }


### PR DESCRIPTION
If all symbol hashes between the base and the pathed kernel match, there's no reason to spend time fuzzing the series.

Add a 'skipped' status to the enum of possible session test results and set it from the fuzz-step. Display it in the status distribution.