### PR TITLE
workflow: don't trigger gemini pr review by pull_request

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -6,10 +6,11 @@
 name: '🧐 Gemini Pull Request Review'
 
 on:
-  pull_request:
-    types:
-      - 'opened'
-      - 'reopened'
+# Pull requests created from the forks doesn't have access to secrets. Disabling this trigger.
+#  pull_request:
+#    types:
+#      - 'opened'
+#      - 'reopened'
   issue_comment:
     types:
       - 'created'


### PR DESCRIPTION
Workers created by the forked repository triggers don't have access to github secrets.
