### PR TITLE
pkg/fuzzer/queue: copy more field in Tee

### DIFF
--- a/pkg/fuzzer/queue/queue.go
+++ b/pkg/fuzzer/queue/queue.go
@@ -566,7 +566,13 @@ func (t *tee) Next() *Request {
 		return nil
 	}
 	t.queue.Submit(&Request{
-		Prog: req.Prog.Clone(),
+		// It makes little sense to copy other fields if these requests
+		// are to be executed in a different environment.
+		Type:        req.Type,
+		ExecOpts:    req.ExecOpts,
+		Prog:        req.Prog.Clone(),
+		BinaryFile:  req.BinaryFile,
+		GlobPattern: req.GlobPattern,
 	})
 	return req
 }


### PR DESCRIPTION
Copy everything that might be important during execution on other kernels/VM pools. Add a test to verify it.

The functionality is actively used to clone requests in the diff fuzzer.