### PR TITLE
syz-cluster: fetch linux-next

### DIFF
--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -205,7 +205,13 @@ var DefaultTrees = []*Tree{
 		Name:       `torvalds`,
 		URL:        `https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux`,
 		Branch:     `master`,
-		EmailLists: nil, // A fallback tree.
+		EmailLists: nil, // First fallback tree.
+	},
+	{
+		Name:       `linux-next`,
+		URL:        `https://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next`,
+		Branch:     `master`,
+		EmailLists: nil, // Second fallback tree. It's less stable, but more series can be applied.
 	},
 }
 


### PR DESCRIPTION
There are a number of patch series that don't apply to torvalds, but do apply to linux-next.

Since we don't fetch all maintainer trees, use linux-next as the last resort.