### PR TITLE
executor: disable /dev/[k]?mem access through CAP_SYS_RAWIO

### DIFF
--- a/dashboard/config/linux/bits/base.yml
+++ b/dashboard/config/linux/bits/base.yml
@@ -190,14 +190,6 @@ config:
  # We use GVNIC on Google Cloud.
  - GVE: [-arm, -riscv, -s390, -timeouts_emu]
 
- # If syzkaller gets to /dev/{mem,kmem,ioport}, it will destroy the machine.
- # It managed to do so with some mount's, chdir's and bogus file names.
- # These are not needed for fuzzing, so completely disabling them is
- # the simplest and the most reliable option.
- - DEVMEM: n
- - DEVKMEM: n
- - DEVPORT: n
-
  # Disable magic SysRq completely, as it can be reached over USB and through tty.
  - MAGIC_SYSRQ: n
  # We don't need it and it enables MAGIC_SYSRQ and KPROBES.

--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4166,7 +4166,12 @@ static void drop_caps(void)
 	// which could be used to enfore safe limits without droppping CAP_SYS_NICE, but we don't have it yet.
 	// See the following bug for details:
 	// https://groups.google.com/forum/#!topic/syzkaller-bugs/G6Wl_PKPIWI
-	const int drop = (1 << CAP_SYS_PTRACE) | (1 << CAP_SYS_NICE);
+	//
+	// CAP_SYS_RAWIO gives direct access to various low level interfaces
+	// like iopl, ioperm, /proc/kcore, FIBMAP, MSRs, mmap_min_addr, pci,
+	// /dev/mem, /dev/kmem, low level SCSI operations, or various other
+	// interfaces that can directly corrupt low level kernel states.
+	const int drop = (1 << CAP_SYS_PTRACE) | (1 << CAP_SYS_NICE) | (1 << CAP_SYS_RAWIO);
 	cap_data[0].effective &= ~drop;
 	cap_data[0].permitted &= ~drop;
 	cap_data[0].inheritable &= ~drop;


### PR DESCRIPTION
Currently, syz-kconf disables CONFIG_DEVMEM and CONFIG_DEVKMEM but on some setups, these nodes might be needed by various system daemons. To allow these daemons to work while fuzzing, we need to re-enable those CONFIGs.

On the other hand, we really don't want fuzzing to break the machine by accessing these nodes. Since their access is guarded by a capability, we can have syz-executor drop that capability as part of the shared "drop_caps()" logic. That capability has a slightly larger scope than /dev/mem and /dev/kmem but it seems to me that these are all equally risky low level operations which could break the system in all sorts of unexpected way and dropping the capability seems safer.