### PR TITLE
pkg/instance: extend image testing failed errors

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -564,6 +564,12 @@ func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
 	reportData, err := os.ReadFile(filepath.Join(cfg.Workdir, "report.json"))
 	if err != nil {
 		if os.IsNotExist(err) {
+			var verboseErr *osutil.VerboseError
+			if errors.As(err, &verboseErr) {
+				// Include more details into the report.
+				prefix := fmt.Sprintf("%s, exit code %d\n\n", verboseErr.Title, verboseErr.ExitCode)
+				output = append([]byte(prefix), output...)
+			}
 			rep := &report.Report{
 				Title:  "SYZFATAL: image testing failed w/o kernel bug",
 				Output: output,


### PR DESCRIPTION
Include a bit more info into the bug reports.

The change is motivated by inactionable "image testing failed w/o kernel bug" errors like this:
https://syzkaller.appspot.com/text?tag=CrashLog&x=17acec42580000