### PR TITLE
pkg/manager: add column and missing html tags

### DIFF
--- a/pkg/manager/html/corpus.html
+++ b/pkg/manager/html/corpus.html
@@ -5,10 +5,13 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>Corpus{{if $.Call}} for {{$.Call}}{{end}}:</caption>
+	<thead>
 	<tr>
 		<th>Coverage</th>
 		<th>Program</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $inp := $.Inputs}}
 	<tr>
 		<td>
@@ -20,4 +23,5 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td><a href="/input?sig={{$inp.Sig}}">{{$inp.Short}}</a></td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/crash.html
+++ b/pkg/manager/html/crash.html
@@ -10,6 +10,7 @@ Report: <a href="/report?id={{.ID}}">{{.Triaged}}</a>
 {{end}}
 
 <table class="list_table">
+	<thead>
 	<tr>
 		<th>#</th>
 		<th>Log</th>
@@ -17,6 +18,8 @@ Report: <a href="/report?id={{.ID}}">{{.Triaged}}</a>
 		<th>Time</th>
 		<th>Tag</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $c := $.Crashes}}
 	<tr>
 		<td>{{$c.Index}}</td>
@@ -30,4 +33,5 @@ Report: <a href="/report?id={{.ID}}">{{.Triaged}}</a>
 		<td class="tag {{if not $c.Active}}inactive{{end}}" title="{{$c.Tag}}">{{formatTagHash $c.Tag}}</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/fallback_cover.html
+++ b/pkg/manager/html/fallback_cover.html
@@ -4,11 +4,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 */}}
 
 <table class="list_table">
+	<thead>
 	<tr>
 		<th>Call</th>
 		<th>Successful</th>
 		<th>Errnos</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $c := $.Calls}}
 	<tr>
 		<td>{{$c.Name}}</td>
@@ -16,4 +19,5 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{range $e := $c.Errnos}}{{$e}}&nbsp;{{end}}</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/job_list.html
+++ b/pkg/manager/html/job_list.html
@@ -5,11 +5,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>{{.PageTitle}} ({{len .Jobs}}):</caption>
+	<thead>
 	<tr>
 		<th>Program</th>
 		<th>Calls</th>
 		<th>Execs</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $job := $.Jobs}}
 	<tr>
 		<td class="job_description"><a href='/jobs?id={{$job.ID}}'>{{$job.Short}}</a></td>
@@ -17,4 +20,5 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td class="job_description">{{$job.Execs}}</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/main.html
+++ b/pkg/manager/html/main.html
@@ -27,6 +27,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'First Time', textSort, true)" href="#">First Time</a></th>
 		<th><a onclick="return sortTable(this, 'Last Time', textSort, true)" href="#">Last Time</a></th>
 		<th><a onclick="return sortTable(this, 'Report', textSort)" href="#">Report</a></th>
+		<th><a onclick="return sortTable(this, 'Repro Attempt Count', numSort)" href="#">Repro Attempt Count</a></th>
 	</tr>
 	{{range $c := $.Crashes}}
 	<tr>
@@ -35,7 +36,6 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td class="time {{if not $c.New}}inactive{{end}}">{{formatTime $c.FirstTime}}</td>
 		<td class="time {{if not $c.Active}}inactive{{end}}">{{formatTime $c.LastTime}}</td>
 		<td>
-			{{if $c.ReproAttempts}}[{{$c.ReproAttempts}} repro attempts]{{end}}
 			{{if $c.Triaged}}
 				<a href="/report?id={{$c.ID}}">{{$c.Triaged}}</a>
 			{{end}}
@@ -43,6 +43,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				<a href="/file?name={{$c.StraceFile}}">Strace</a>
 			{{end}}
 		</td>
+		<td class="stat">{{if $c.ReproAttempts}}{{$c.ReproAttempts}}{{end}}</td>
 	</tr>
 	{{end}}
 </table>

--- a/pkg/manager/html/main.html
+++ b/pkg/manager/html/main.html
@@ -4,6 +4,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 */}}
 
 <table class="list_table">
+	<tbody>
 	{{range $s := $.Stats}}
 	<tr>
 		<td class="stat_name" title="{{$s.Hint}}">{{$s.Name}}</td>
@@ -16,11 +17,13 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>
 
 {{if .Crashes}}
 <table class="list_table">
 	<caption>Crashes:</caption>
+	<thead>
 	<tr>
 		<th><a onclick="return sortTable(this, 'Description', textSort)" href="#">Description</a></th>
 		<th><a onclick="return sortTable(this, 'Count', numSort)" href="#">Count</a></th>
@@ -29,6 +32,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Report', textSort)" href="#">Report</a></th>
 		<th><a onclick="return sortTable(this, 'Repro Attempt Count', numSort)" href="#">Repro Attempt Count</a></th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $c := $.Crashes}}
 	<tr>
 		<td class="title"><a href="/crash?id={{$c.ID}}">{{$c.Title}}</a></td>
@@ -46,17 +51,21 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td class="stat">{{if $c.ReproAttempts}}{{$c.ReproAttempts}}{{end}}</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>
 {{end}}
 
 {{define "diff_crashes"}}
 <table class="list_table">
 	<caption>{{.Title}}:</caption>
+	<thead>
 	<tr>
 		<th>Description</th>
 		<th>Base</th>
 		<th>Patched</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $bug := .List}}
 	<tr>
 		<td class="title">{{$bug.Title}}</td>
@@ -90,6 +99,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>
 {{end}}
 

--- a/pkg/manager/html/prio.html
+++ b/pkg/manager/html/prio.html
@@ -5,14 +5,18 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>Priorities for {{$.Call}}:</caption>
+	<thead>
 	<tr>
 		<th><a onclick="return sortTable(this, 'Prio', floatSort)" href="#">Prio</a></th>
 		<th><a onclick="return sortTable(this, 'Call', textSort)" href="#">Call</a></th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $p := $.Prios}}
 	<tr>
 		<td>{{printf "%5v" $p.Prio}}</td>
 		<td><a href='/prio?call={{$p.Call}}'>{{$p.Call}}</a></td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/raw_cover.html
+++ b/pkg/manager/html/raw_cover.html
@@ -5,18 +5,22 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>Raw cover</caption>
+	<thead>
 	<tr>
 		<th>Line</th>
 		<th>Links</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $line := .Calls}}
 	<tr>
 		<td>{{$line.Call}}</td>
 		<td>
-		{{range $id := $line.UpdateIDs}}
-		<a href="/rawcover?input={{$line.Sig}}&update_id={{$id}}">[{{$id}}]</a>
-		{{end}}
-</td>
+			{{range $id := $line.UpdateIDs}}
+			<a href="/rawcover?input={{$line.Sig}}&update_id={{$id}}">[{{$id}}]</a>
+			{{end}}
+		</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/syscalls.html
+++ b/pkg/manager/html/syscalls.html
@@ -5,6 +5,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>Per-syscall coverage:</caption>
+	<thead>
 	<tr>
 		<th><a onclick="return sortTable(this, 'Syscall', textSort)" href="#">Syscall</a></th>
 		<th><a onclick="return sortTable(this, 'Inputs', numSort)" href="#" title="Number of inputs in the corpus added because of this syscall">Inputs</a></th>
@@ -14,6 +15,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Comps overflows', numSort)" href="#" title="Number of times comparisons buffer has overflowed on this syscall">Comps overflows</a></th>
 		<th>Prio</th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $c := $.Calls}}
 	<tr>
 		<td>{{$c.Name}}{{if $c.ID }} [{{$c.ID}}]{{end}}</td>
@@ -25,4 +28,5 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td><a href='/prio?call={{$c.Name}}'>prio</a></td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>

--- a/pkg/manager/html/vms.html
+++ b/pkg/manager/html/vms.html
@@ -5,6 +5,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <table class="list_table">
 	<caption>VM Info:</caption>
+	<thead>
 	<tr>
 		<th><a onclick="return sortTable(this, 'Name', textSort)" href="#">Name</a></th>
 		<th><a onclick="return sortTable(this, 'State', textSort)" href="#">State</a></th>
@@ -12,6 +13,8 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Machine Info', timeSort)" href="#">Machine Info</a></th>
 		<th><a onclick="return sortTable(this, 'Status', timeSort)" href="#">Status</a></th>
 	</tr>
+	</thead>
+	<tbody>
 	{{range $vm := $.VMs}}
 	<tr>
 		<td>{{$vm.Name}}</td>
@@ -21,4 +24,5 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{optlink $vm.DetailedStatus "status"}}</td>
 	</tr>
 	{{end}}
+	</tbody>
 </table>


### PR DESCRIPTION
We need to modify the table so that you can sort it using the values ​​of Report and Repro Attempt Count by creating a separate column for Repro Attempt Count.

Also, the thead and tbody HTML tags are missing throughout the syz-manager HTML, causing a minor issue where the background color of the header section matches the background color of the first line of the body. Therefore, you need to add the missing HTML tags.