### PR TITLE
syz-cluster: fix a possible nil ptr deref

### DIFF
--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -143,10 +143,12 @@ func reportResults(ctx context.Context, client *api.Client,
 		Result:    status,
 		Log:       output,
 	}
-	if uploadReq.SeriesID != "" {
-		testResult.PatchedBuildID = buildID
-	} else {
-		testResult.BaseBuildID = buildID
+	if uploadReq != nil {
+		if uploadReq.SeriesID != "" {
+			testResult.PatchedBuildID = buildID
+		} else {
+			testResult.BaseBuildID = buildID
+		}
 	}
 	err := client.UploadTestResult(ctx, testResult)
 	if err != nil {


### PR DESCRIPTION
Fix the following error:

```
runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x16e3c5e]

at main.reportResults ( /syz-cluster/workflow/build-step/main.go:146 )
at main.main ( /syz-cluster/workflow/build-step/main.go:84 )
```
