### PR TITLE
dashboard/app: integrate tail reports

### DIFF
--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -206,7 +206,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					<span class="bug-label">{{link .Link .Name}}</span>
 				{{- end}}
 			</td>
-			<td class="stat">{{$b.ImpactScore}}</td>
+			<td class="rank">
+				{{if $b.RankTooltip}}
+					<b>{{$b.ImpactScore}}</b>
+					<pre class="tooltiptext">{{$b.RankTooltip}}</pre>
+				{{else}}
+					{{$b.ImpactScore}}
+				{{end}}
+			</td>
 			<td class="stat">{{formatReproLevel $b.ReproLevel}}</td>
 			<td class="bisect_status">{{print $b.BisectCause}}</td>
 			<td class="bisect_status">{{print $b.BisectFix}}</td>
@@ -456,7 +463,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<td class="tag">{{link $b.SyzkallerCommitLink (formatShortHash $b.SyzkallerCommit)}}</td>
 			<td class="config">{{if $b.KernelConfigLink}}<a href="{{$b.KernelConfigLink}}">.config</a>{{end}}</td>
 			<td class="repro">{{if $b.LogLink}}<a href="{{$b.LogLink}}">{{if $b.LogHasStrace}}strace{{else}}console{{end}} log</a>{{end}}</td>
-			<td class="repro">{{if $b.ReportLink}}<a href="{{$b.ReportLink}}">report</a>{{end}}</td>
+			<td class="repro">
+				{{- if $b.ReportLink -}}
+					<a href="{{$b.ReportLink}}">report</a>
+				{{- end -}}
+				{{- range $i, $trl := $b.TailReportsLinks -}}
+					<br><a href="{{$trl}}">tail report {{add $i 1}}</a>
+				{{- end -}}
+			</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproSyzLink}}<a href="{{$b.ReproSyzLink}}">syz</a>{{end}}{{if $b.ReproLogLink}} / <a href="{{$b.ReproLogLink}}">log</a>{{end}}</td>
 			<td class="repro{{if $b.ReproIsRevoked}} stale_repro{{end}}">{{if $b.ReproCLink}}<a href="{{$b.ReproCLink}}">C</a>{{end}}</td>
 			<td class="repro">{{if $b.MachineInfoLink}}<a href="{{$b.MachineInfoLink}}">info</a>{{end}}</td>
@@ -464,7 +478,12 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				<span class="no-break">[<a href="{{$asset.DownloadURL}}">{{$asset.Title}}</a>{{if $asset.FsckLogURL}} (<a href="{{$asset.FsckLogURL}}">{{if $asset.FsIsClean}}clean{{else}}corrupt{{end}} fs</a>){{end}}]</span>
 			{{end}}</td>
 			<td class="manager">{{$b.Manager}}</td>
-			<td class="manager">{{$b.Title}}</td>
+			<td class="manager">
+				{{- $b.Title}}
+				{{- range $tt := $b.TailTitles -}}
+				<br>{{$tt}}
+				{{- end -}}
+			</td>
 		</tr>
 		{{end}}
 		</tbody>

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -322,6 +322,7 @@ type Crash struct {
 	BuildID     string // refers to Build.ID
 	Title       string
 	AltTitles   []string // alternative titles, used for better deduplication
+	TailTitles  []string // titles of the tail reports, see TailReports field
 	Corrupted   bool     // report is corrupted (corrupted title, no stacks, etc)
 	Suppressed  bool
 	Maintainers []string // deprecated in favor of Recipients
@@ -329,6 +330,9 @@ type Crash struct {
 	Log         []byte
 	Flags       CrashFlags
 	Report      []byte
+	// Crashing machine may generate report chain like WARNING -> WARNING -> KASAN -> GPF.
+	// These additional reports are used to better understand the bug nature and impact.
+	TailReports [][]byte
 	MachineInfo []byte
 	Assets      []NewAsset
 	GuiltyFiles []string

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -52,24 +52,27 @@ func CreateTextGlob(glob string) *texttemplate.Template {
 }
 
 var Funcs = template.FuncMap{
+	// keep-sorted start
+	"add":                    func(a, b int) int { return a + b },
+	"commitLink":             commitLink,
+	"dereference":            dereferencePointer,
+	"formatClock":            formatClock,
+	"formatCommitTableTitle": formatCommitTableTitle,
+	"formatDate":             FormatDate,
+	"formatDuration":         formatDuration,
+	"formatJSTime":           formatJSTime,
+	"formatKernelTime":       formatKernelTime,
+	"formatLateness":         formatLateness,
+	"formatList":             formatStringList,
+	"formatReproLevel":       formatReproLevel,
+	"formatShortHash":        formatShortHash,
+	"formatStat":             formatStat,
+	"formatTagHash":          formatTagHash,
+	"formatTime":             FormatTime,
 	"link":                   link,
 	"optlink":                optlink,
-	"formatTime":             FormatTime,
-	"formatDate":             FormatDate,
-	"formatKernelTime":       formatKernelTime,
-	"formatJSTime":           formatJSTime,
-	"formatClock":            formatClock,
-	"formatDuration":         formatDuration,
-	"formatLateness":         formatLateness,
-	"formatReproLevel":       formatReproLevel,
-	"formatStat":             formatStat,
-	"formatShortHash":        formatShortHash,
-	"formatTagHash":          formatTagHash,
-	"formatCommitTableTitle": formatCommitTableTitle,
-	"formatList":             formatStringList,
 	"selectBisect":           selectBisect,
-	"dereference":            dereferencePointer,
-	"commitLink":             commitLink,
+	// keep-sorted end
 }
 
 func selectBisect(rep *dashapi.BugReport) *dashapi.BisectResult {

--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -357,32 +357,12 @@ func makeUICrashType(info *BugInfo, startTime time.Time, repros map[string]bool)
 		info.ReproAttempts >= MaxReproAttempts)
 	return UICrashType{
 		BugInfo:     *info,
-		RankTooltip: higherRankTooltip(info.Title, info.TailTitles),
+		RankTooltip: report.HigherRankTooltip(info.Title, info.TailTitles),
 		New:         info.FirstTime.After(startTime),
 		Active:      info.LastTime.After(startTime),
 		Triaged:     triaged,
 		Crashes:     crashes,
 	}
-}
-
-// higherRankTooltip generates the prioritized list of the titles with higher Rank
-// than the firstTitle has.
-func higherRankTooltip(firstTitle string, titlesInfo []*report.TitleFreqRank) string {
-	baseRank := report.TitlesToImpact(firstTitle)
-	res := ""
-	for _, ti := range titlesInfo {
-		if ti.Rank <= baseRank {
-			continue
-		}
-		res += fmt.Sprintf("[rank %2v, freq %5.1f%%] %s\n",
-			ti.Rank,
-			100*float32(ti.Count)/float32(ti.Total),
-			ti.Title)
-	}
-	if res != "" {
-		return fmt.Sprintf("[rank %2v,  originally] %s\n%s", baseRank, firstTitle, res)
-	}
-	return res
 }
 
 var crashIDRe = regexp.MustCompile(`^\w+$`)

--- a/pkg/manager/repro.go
+++ b/pkg/manager/repro.go
@@ -51,6 +51,22 @@ func (c *Crash) FullTitle() string {
 	panic("the crash is expected to have a report")
 }
 
+func (c *Crash) TailTitles() []string {
+	res := make([]string, len(c.TailReports))
+	for i, r := range c.TailReports {
+		res[i] = r.Title
+	}
+	return res
+}
+
+func (c *Crash) TailReportsBytes() [][]byte {
+	res := make([][]byte, len(c.TailReports))
+	for i, r := range c.TailReports {
+		res[i] = r.Report
+	}
+	return res
+}
+
 type ReproManagerView interface {
 	RunRepro(ctx context.Context, crash *Crash) *ReproResult
 	NeedRepro(crash *Crash) bool

--- a/pkg/report/impact_score.go
+++ b/pkg/report/impact_score.go
@@ -4,8 +4,6 @@
 package report
 
 import (
-	"sort"
-
 	"github.com/google/syzkaller/pkg/report/crash"
 )
 
@@ -63,46 +61,4 @@ func TitlesToImpact(title string, otherTitles ...string) int {
 		}
 	}
 	return maxImpact
-}
-
-type TitleFreqRank struct {
-	Title string
-	Count int
-	Total int
-	Rank  int
-}
-
-func ExplainTitleStat(ts *titleStat) []*TitleFreqRank {
-	titleCount := map[string]int{}
-	var totalCount int
-	ts.visit(func(count int, titles ...string) {
-		uniq := map[string]bool{}
-		for _, title := range titles {
-			uniq[title] = true
-		}
-		for title := range uniq {
-			titleCount[title] += count
-		}
-		totalCount += count
-	})
-	var res []*TitleFreqRank
-	for title, count := range titleCount {
-		res = append(res, &TitleFreqRank{
-			Title: title,
-			Count: count,
-			Total: totalCount,
-			Rank:  TitlesToImpact(title),
-		})
-	}
-	sort.Slice(res, func(l, r int) bool {
-		if res[l].Rank != res[r].Rank {
-			return res[l].Rank > res[r].Rank
-		}
-		lTitle, rTitle := res[l].Title, res[r].Title
-		if titleCount[lTitle] != titleCount[rTitle] {
-			return titleCount[lTitle] > titleCount[rTitle]
-		}
-		return lTitle < rTitle
-	})
-	return res
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -955,6 +955,10 @@ func MergeReportBytes(reps []*Report) []byte {
 	return res
 }
 
-func SplitReportBytes(data []byte) [][]byte {
-	return bytes.Split(data, []byte(reportSeparator))
+func firstReportBytes(data []byte) []byte {
+	reps := bytes.Split(data, []byte(reportSeparator))
+	if len(reps) == 0 {
+		return nil
+	}
+	return reps[0]
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -511,37 +511,37 @@ BCDEF`), Truncate([]byte(`0123456789ABCDEF`), 0, 5))
 DEF`), Truncate([]byte(`0123456789ABCDEF`), 4, 3))
 }
 
-func TestSplitReportBytes(t *testing.T) {
+func TestFirstReportBytes(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     []byte
-		wantFirst string
+		name  string
+		input []byte
+		want  string
 	}{
 		{
-			name:      "empty",
-			input:     nil,
-			wantFirst: "",
+			name:  "empty",
+			input: nil,
+			want:  "",
 		},
 		{
-			name:      "single",
-			input:     []byte("report1"),
-			wantFirst: "report1",
+			name:  "single",
+			input: []byte("report1"),
+			want:  "report1",
 		},
 		{
-			name:      "split in the middle",
-			input:     []byte("report1" + reportSeparator + "report2"),
-			wantFirst: "report1",
+			name:  "split in the middle",
+			input: []byte("report1" + reportSeparator + "report2"),
+			want:  "report1",
 		},
 		{
-			name:      "split in the middle, save new line",
-			input:     []byte("report1\n" + reportSeparator + "report2"),
-			wantFirst: "report1\n",
+			name:  "split in the middle, save new line",
+			input: []byte("report1\n" + reportSeparator + "report2"),
+			want:  "report1\n",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			splitted := SplitReportBytes(test.input)
-			assert.Equal(t, test.wantFirst, string(splitted[0]))
+			first := firstReportBytes(test.input)
+			assert.Equal(t, test.want, string(first))
 		})
 	}
 }

--- a/pkg/report/title_stat.go
+++ b/pkg/report/title_stat.go
@@ -9,61 +9,54 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"sort"
 )
 
-func AddTitleStat(file string, reps []*Report) error {
-	var titles []string
-	for _, rep := range reps {
-		titles = append(titles, rep.Title)
-	}
+func AddTitlesToStatFile(file string, titles []string) error {
 	stat, err := ReadStatFile(file)
 	if err != nil {
-		return fmt.Errorf("report.ReadStatFile: %w", err)
+		return fmt.Errorf("readStatFile: %w", err)
 	}
-	stat.add(titles)
-	if err := writeStatFile(file, stat); err != nil {
-		return fmt.Errorf("writeStatFile: %w", err)
+	stat.Add(titles)
+	bytes, err := stat.ToBytes()
+	if err != nil {
+		return err
 	}
-	return nil
+	return os.WriteFile(file, bytes, 0644)
 }
 
-func ReadStatFile(file string) (*titleStat, error) {
-	stat := &titleStat{}
+func ReadStatFile(file string) (*TitleStat, error) {
+	res := &TitleStat{}
 	if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
-		return stat, nil
+		return res, nil
 	}
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
+	return TitleStatFromBytes(data)
+}
+
+func TitleStatFromBytes(data []byte) (*TitleStat, error) {
+	var ts TitleStat
 	if len(data) == 0 {
-		return stat, nil
+		return &ts, nil
 	}
-	if err := json.Unmarshal(data, stat); err != nil {
+	if err := json.Unmarshal(data, &ts); err != nil {
 		return nil, err
 	}
-	return stat, nil
+	return &ts, nil
 }
 
-func writeStatFile(file string, stat *titleStat) error {
-	data, err := json.MarshalIndent(stat, "", "\t")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(file, data, 0644); err != nil {
-		return err
-	}
-	return nil
-}
+type titleStatNodes map[string]*TitleStat
 
-type titleStatNodes map[string]*titleStat
-
-type titleStat struct {
+type TitleStat struct {
 	Count int
 	Nodes titleStatNodes
 }
 
-func (ts *titleStat) add(reps []string) {
+func (ts *TitleStat) Add(reps []string) {
+	ts.Count++
 	if len(reps) == 0 {
 		return
 	}
@@ -71,13 +64,12 @@ func (ts *titleStat) add(reps []string) {
 		ts.Nodes = make(titleStatNodes)
 	}
 	if ts.Nodes[reps[0]] == nil {
-		ts.Nodes[reps[0]] = &titleStat{}
+		ts.Nodes[reps[0]] = &TitleStat{}
 	}
-	ts.Nodes[reps[0]].Count++
-	ts.Nodes[reps[0]].add(reps[1:])
+	ts.Nodes[reps[0]].Add(reps[1:])
 }
 
-func (ts *titleStat) visit(cb func(int, ...string), titles ...string) {
+func (ts *TitleStat) visit(cb func(int, ...string), titles ...string) {
 	if len(ts.Nodes) == 0 {
 		cb(ts.Count, titles...)
 		return
@@ -85,4 +77,68 @@ func (ts *titleStat) visit(cb func(int, ...string), titles ...string) {
 	for title := range maps.Keys(ts.Nodes) {
 		ts.Nodes[title].visit(cb, append(titles, title)...)
 	}
+}
+
+func (ts *TitleStat) ToBytes() ([]byte, error) {
+	return json.MarshalIndent(ts, "", "\t")
+}
+
+type TitleFreqRank struct {
+	Title string
+	Count int
+	Total int
+	Rank  int
+}
+
+func (ts *TitleStat) Explain() []*TitleFreqRank {
+	titleCount := map[string]int{}
+
+	ts.visit(func(count int, titles ...string) {
+		uniq := map[string]bool{}
+		for _, title := range titles {
+			uniq[title] = true
+		}
+		for title := range uniq {
+			titleCount[title] += count
+		}
+	})
+	var res []*TitleFreqRank
+	for title, count := range titleCount {
+		res = append(res, &TitleFreqRank{
+			Title: title,
+			Count: count,
+			Total: ts.Count,
+			Rank:  TitlesToImpact(title),
+		})
+	}
+	sort.Slice(res, func(l, r int) bool {
+		if res[l].Rank != res[r].Rank {
+			return res[l].Rank > res[r].Rank
+		}
+		lTitle, rTitle := res[l].Title, res[r].Title
+		if titleCount[lTitle] != titleCount[rTitle] {
+			return titleCount[lTitle] > titleCount[rTitle]
+		}
+		return lTitle < rTitle
+	})
+	return res
+}
+
+// HigherRankTooltip generates a prioritized list of titles with a rank higher than firstTitle.
+func HigherRankTooltip(firstTitle string, titlesInfo []*TitleFreqRank) string {
+	baseRank := TitlesToImpact(firstTitle)
+	res := ""
+	for _, ti := range titlesInfo {
+		if ti.Rank <= baseRank {
+			continue
+		}
+		res += fmt.Sprintf("[rank %2v, freq %5.1f%%] %s\n",
+			ti.Rank,
+			100*float32(ti.Count)/float32(ti.Total),
+			ti.Title)
+	}
+	if res != "" {
+		return fmt.Sprintf("[rank %2v,  originally] %s\n%s", baseRank, firstTitle, res)
+	}
+	return res
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -714,8 +714,8 @@ func (mgr *Manager) saveCrash(crash *manager.Crash) bool {
 		flags += " [suppressed]"
 	}
 	log.Logf(0, "VM %v: crash: %v%v", crash.InstanceIndex, crash.Report.Title, flags)
-	for i, report := range crash.TailReports {
-		log.Logf(0, "VM %v: crash(tail%d): %v%v", crash.InstanceIndex, i, report.Title, flags)
+	for i, t := range crash.TailTitles() {
+		log.Logf(0, "VM %v: crash(tail%d): %v%v", crash.InstanceIndex, i, t, flags)
 	}
 
 	if mgr.mode.FailOnCrashes {
@@ -748,12 +748,14 @@ func (mgr *Manager) saveCrash(crash *manager.Crash) bool {
 		dc := &dashapi.Crash{
 			BuildID:     mgr.cfg.Tag,
 			Title:       crash.Title,
+			TailTitles:  crash.TailTitles(),
 			AltTitles:   crash.AltTitles,
 			Corrupted:   crash.Corrupted,
 			Suppressed:  crash.Suppressed,
 			Recipients:  crash.Recipients.ToDash(),
 			Log:         crash.Output,
-			Report:      report.SplitReportBytes(crash.Report.Report)[0],
+			Report:      crash.Report.Report,
+			TailReports: crash.TailReportsBytes(),
 			MachineInfo: crash.MachineInfo,
 		}
 		setGuiltyFiles(dc, crash.Report)
@@ -900,12 +902,14 @@ func (mgr *Manager) saveRepro(res *manager.ReproResult) {
 		dc := &dashapi.Crash{
 			BuildID:       mgr.cfg.Tag,
 			Title:         reproReport.Title,
+			TailTitles:    res.Crash.TailTitles(),
 			AltTitles:     reproReport.AltTitles,
 			Suppressed:    reproReport.Suppressed,
 			Recipients:    reproReport.Recipients.ToDash(),
 			Log:           output,
 			Flags:         crashFlags,
-			Report:        report.SplitReportBytes(reproReport.Report)[0],
+			Report:        reproReport.Report,
+			TailReports:   res.Crash.TailReportsBytes(),
 			ReproOpts:     repro.Opts.Serialize(),
 			ReproSyz:      progText,
 			ReproC:        cprogText,


### PR DESCRIPTION
TODO

- [x] read DB data and show tooltip as we do it in syz-manager
- [x] propagate stat data to DB and merge the stat numbers
- [x] test upload-merge-read pipeline
- [ ] rename syz-manager var name from Rank to ImpactScore to aligh with dashboard code