### PR TITLE
vm/starnix: switch to new ffx command for vm ssh address

### DIFF
--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -320,13 +320,18 @@ func (inst *instance) connect() error {
 	if inst.debug {
 		log.Logf(1, "instance %s: attempting to connect to starnix container over ssh", inst.name)
 	}
+	// Even though the formatting option is called `addresses`, it is guaranteed
+	// to return at most 1 address per target.
 	address, err := inst.runFfx(
 		30*time.Second,
 		true,
 		"--target",
 		inst.name,
 		"target",
-		"get-ssh-address")
+		"list",
+		"--format",
+		"addresses",
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of:
ffx --target <target> target get-ssh-address

Use:
ffx --target <target> target list --format addresses
