### PR TITLE
syz-cluster: consider global/static variable values

### DIFF
--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -293,7 +293,8 @@ func saveSymbolHashes(tracer debugtracer.DebugTracer) error {
 	if err != nil {
 		return fmt.Errorf("failed to query symbol hashes: %w", err)
 	}
-	tracer.Log("extracted hashes for %d symbols", len(hashes))
+	tracer.Log("extracted hashes for %d text symbols and %d data symbols",
+		len(hashes.Text), len(hashes.Data))
 	file, err := os.Create(filepath.Join(*flagOutput, "symbol_hashes.json"))
 	if err != nil {
 		return fmt.Errorf("failed to open symbol_hashes.json: %w", err)

--- a/syz-cluster/workflow/fuzz-step/main_test.go
+++ b/syz-cluster/workflow/fuzz-step/main_test.go
@@ -4,11 +4,16 @@
 package main
 
 import (
+	"encoding/json"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigLoad(t *testing.T) {
@@ -29,26 +34,86 @@ func TestConfigLoad(t *testing.T) {
 	})
 }
 
+func TestReadSectionHashes(t *testing.T) {
+	hashes := build.SectionHashes{
+		Text: map[string]string{"A": "1"},
+		Data: map[string]string{"B": "2"},
+	}
+
+	jsonData, err := json.Marshal(hashes)
+	require.NoError(t, err)
+
+	file, err := osutil.WriteTempFile(jsonData)
+	require.NoError(t, err)
+	defer os.Remove(file)
+
+	fromFile, err := readSectionHashes(file)
+	require.NoError(t, err)
+	assert.Equal(t, hashes, fromFile)
+}
+
+// nolint: dupl
 func TestShouldSkipFuzzing(t *testing.T) {
 	t.Run("one empty", func(t *testing.T) {
-		assert.False(t, shouldSkipFuzzing(nil, map[string]string{"A": "1"}))
+		assert.False(t, shouldSkipFuzzing(
+			build.SectionHashes{},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1"},
+			},
+		))
 	})
-	t.Run("equal", func(t *testing.T) {
+	t.Run("equal symbols", func(t *testing.T) {
 		assert.True(t, shouldSkipFuzzing(
-			map[string]string{"A": "1", "B": "2"},
-			map[string]string{"A": "1", "B": "2"},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "D": "2"},
+			},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "D": "2"},
+			},
+		))
+	})
+	t.Run("ignore known variables", func(t *testing.T) {
+		assert.True(t, shouldSkipFuzzing(
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "raw_data": "A", "vermagic": "A"},
+			},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "raw_data": "B", "vermagic": "B"},
+			},
 		))
 	})
 	t.Run("same len, different hashes", func(t *testing.T) {
 		assert.False(t, shouldSkipFuzzing(
-			map[string]string{"A": "1", "B": "2"},
-			map[string]string{"A": "1", "B": "different"},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+			},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "different"},
+			},
+		))
+		assert.False(t, shouldSkipFuzzing(
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "D": "2"},
+			},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+				Data: map[string]string{"C": "1", "D": "different"},
+			},
 		))
 	})
 	t.Run("different len, same hashes", func(t *testing.T) {
 		assert.False(t, shouldSkipFuzzing(
-			map[string]string{"A": "1", "B": "2", "C": "3"},
-			map[string]string{"A": "1", "B": "2"},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2"},
+			},
+			build.SectionHashes{
+				Text: map[string]string{"A": "1", "B": "2", "C": "new"},
+			},
 		))
 	})
 }


### PR DESCRIPTION
When determining whether a patch series is worth fuzzing, consider not only the hashes of .text symbols, but also the hashes of the global (static and non-static) variables.

As before, calculate the hashes during build and process them at the beginning of the fuzz step.