### PR TITLE
syz-cluster: add kvm/next tree

### DIFF
--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -202,6 +202,12 @@ var DefaultTrees = []*Tree{
 		EmailLists: []string{`netdev@vger.kernel.org`},
 	},
 	{
+		Name:       `kvm-next`,
+		URL:        `https://kernel.googlesource.com/pub/scm/virt/kvm/kvm/`,
+		Branch:     `next`,
+		EmailLists: []string{`kvm@vger.kernel.org`},
+	},
+	{
 		Name:       `torvalds`,
 		URL:        `https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux`,
 		Branch:     `master`,


### PR DESCRIPTION
Some series don't apply to torvalds, see e.g.
https://ci.syzbot.org/series/f429573e-7862-4f1e-97dd-3215a235b1d3
