### PR TITLE
syz-cluster: log possible findings at the end of fuzzing

### DIFF
--- a/syz-cluster/workflow/fuzz-step/main.go
+++ b/syz-cluster/workflow/fuzz-step/main.go
@@ -75,9 +75,23 @@ func main() {
 		status = api.TestError
 	}
 	log.Logf(0, "fuzzing is finished")
-	log.Logf(0, "status at the end:\n%s", store.PlainTextDump())
+	logFinalState(store)
 	if err := reportStatus(ctx, client, status, store); err != nil {
 		app.Fatalf("failed to update the test: %v", err)
+	}
+}
+
+func logFinalState(store *manager.DiffFuzzerStore) {
+	log.Logf(0, "status at the end:\n%s", store.PlainTextDump())
+
+	// There can be findings that we did not report only because we failed
+	// to come up with a reproducer.
+	// Let's log such cases so that it's easier to find and manually review them.
+	const countCutOff = 10
+	for _, bug := range store.List() {
+		if bug.Base.Crashes == 0 && bug.Patched.Crashes >= countCutOff {
+			log.Logf(0, "possibly patched-only: %s", bug.Title)
+		}
 	}
 }
 


### PR DESCRIPTION
It does happen that we detect a bug that was introduced in the patch series, but we don't report it becase no reliable reproducer was found.

Let's at least log such cases to better understand the scale of the problem.

10 is an arbitrary cut-off value.
