### PR TITLE
pkg/vcs: backport a fix for devm_drm_of_get_bridge link error

### DIFF
--- a/pkg/vcs/linux_patches.go
+++ b/pkg/vcs/linux_patches.go
@@ -114,4 +114,16 @@ var pickLinuxCommits = []BackportCommit{
 		FixHash:    `10a77965760c6e2b3eef483be33ae407004df894`,
 		FixTitle:   `batman-adv: Fix double-hold of meshif when getting enabled`,
 	},
+	{
+		// Fixes `ld.lld: error: undefined symbol: devm_drm_of_get_bridge`.
+		GuiltyHash: `2a04739139b2b2761571e18937e2400e71eff664`,
+		FixHash:    `b12fa5e76e1463fc5a196f2717040e4564e184b6`,
+		FixTitle:   `drm/bridge: select DRM_KMS_HELPER for AUX_BRIDGE`,
+	},
+	{
+		// Fixes `undefined symbol: devm_drm_of_get_bridge referenced by nb7vpq904m.c`.
+		GuiltyHash: `2a04739139b2b2761571e18937e2400e71eff664`,
+		FixHash:    `c5d296bad640b190c52ef7508114d70e971a4bba`,
+		FixTitle:   `usb: typec: nb7vpq904m: switch to DRM_AUX_BRIDGE`,
+	},
 }


### PR DESCRIPTION
This should fix our broken bisections.

Closes #6136.