### PR TITLE
pkg/instance: fix error extraction during smoke test

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -565,7 +565,7 @@ func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			var verboseErr *osutil.VerboseError
-			if errors.As(err, &verboseErr) {
+			if errors.As(retErr, &verboseErr) {
 				// Include more details into the report.
 				prefix := fmt.Sprintf("%s, exit code %d\n\n", verboseErr.Title, verboseErr.ExitCode)
 				output = append([]byte(prefix), output...)


### PR DESCRIPTION
The err variable is from the open call, it cannot be VerboseError. Use retErr instead.