### PR TITLE
pkg/report: get only the thread local reports

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -165,8 +165,9 @@ func (ctx *linux) Parse(output []byte) *Report {
 	}
 	for questionable := false; ; questionable = true {
 		rep := &Report{
-			Output:   output,
-			StartPos: startPos,
+			Output:    output,
+			StartPos:  startPos,
+			ContextID: context,
 		}
 		endPos, reportEnd, report, prefix := ctx.findReport(output, oops, startPos, context, questionable)
 		rep.EndPos = endPos

--- a/pkg/report/testdata/gvisor/report/0
+++ b/pkg/report/testdata/gvisor/report/0
@@ -122,3 +122,47 @@ runtime.goexit()
 	bazel-out/k8-fastbuild/bin/external/io_bazel_rules_go/linux_amd64_pure_stripped/stdlib~/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc4205d1fe0 sp=0xc4205d1fd8 pc=0x455f11
 created by gvisor.googlesource.com/gvisor/pkg/sentry/fs.Async
 	pkg/sentry/fs/fs.go:80 +0x58
+TAIL REPORTS:
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x811ac1]
+
+goroutine 9707990 [running]:
+panic(0xaddd00, 0x10d2b90)
+	GOROOT/src/runtime/panic.go:551 +0x3c1 fp=0xc4205d15b0 sp=0xc4205d1510 pc=0x428fa1
+runtime.panicmem()
+	GOROOT/src/runtime/panic.go:63 +0x5e fp=0xc4205d15d0 sp=0xc4205d15b0 pc=0x427e7e
+runtime.sigpanic()
+	GOROOT/src/runtime/signal_unix.go:388 +0x17a fp=0xc4205d1620 sp=0xc4205d15d0 pc=0x43e59a
+gvisor.googlesource.com/gvisor/pkg/sentry/fs/gofer.(*handleReadWriter).WriteFromBlocks(0xc420ef06e0, 0x7fe2a3453200, 0xffffffffffffffff, 0x0, 0x61, 0x0, 0x0, 0x0)
+	pkg/sentry/fs/gofer/handles.go:133 +0x41 fp=0xc4205d1698 sp=0xc4205d1620 pc=0x811ac1
+gvisor.googlesource.com/gvisor/pkg/sentry/fs/gofer.(*inodeFileState).WriteFromBlocksAt(0xc4204e24d0, 0xc94d20, 0xc4203fdcc8, 0x7fe2a3453200, 0xffffffffffffffff, 0x0, 0x61, 0x200, 0x0, 0x0, ...)
+	pkg/sentry/fs/gofer/inode.go:204 +0xfe fp=0xc4205d1710 sp=0xc4205d1698 pc=0x81239e
+gvisor.googlesource.com/gvisor/pkg/sentry/fs/fsutil.(*inodeReadWriter).WriteFromBlocks(0xc421cdcf40, 0x7fe2a3453200, 0xffffffffffffffff, 0x0, 0x61, 0x0, 0x0, 0x0)
+	pkg/sentry/fs/fsutil/inode_cached.go:605 +0x35d fp=0xc4205d1848 sp=0xc4205d1710 pc=0x660f8d
+gvisor.googlesource.com/gvisor/pkg/sentry/safemem.(Writer).WriteFromBlocks-fm(0x7fe2a3453200, 0xffffffffffffffff, 0x0, 0x61, 0x20000261, 0x7fe2a3453200, 0xffffffffffffffff)
+	pkg/sentry/mm/io.go:309 +0x57 fp=0xc4205d1898 sp=0xc4205d1848 pc=0x6bacd7
+gvisor.googlesource.com/gvisor/pkg/sentry/mm.(*MemoryManager).withInternalMappings(0xc4214a6580, 0xc94d20, 0xc4203fdcc8, 0x20000200, 0x20000261, 0x1, 0xc420ef0b40, 0x10fd8e0, 0x6e5a33137f9f62, 0xc420ef0a88)
+	pkg/sentry/mm/io.go:464 +0x72c fp=0xc4205d1998 sp=0xc4205d1898 pc=0x694c4c
+gvisor.googlesource.com/gvisor/pkg/sentry/mm.(*MemoryManager).withVecInternalMappings(0xc4214a6580, 0xc94d20, 0xc4203fdcc8, 0x0, 0x1, 0x20000200, 0x61, 0xc400000001, 0xc420ef0b40, 0x1538c53a716d7b9c, ...)
+	pkg/sentry/mm/io.go:533 +0x7f1 fp=0xc4205d1a90 sp=0xc4205d1998 pc=0x6954c1
+gvisor.googlesource.com/gvisor/pkg/sentry/mm.(*MemoryManager).CopyInTo(0xc4214a6580, 0xc94d20, 0xc4203fdcc8, 0x0, 0x1, 0x20000200, 0x61, 0xc87960, 0xc421cdcf40, 0x0, ...)
+	pkg/sentry/mm/io.go:309 +0x17c fp=0xc4205d1b68 sp=0xc4205d1a90 pc=0x69370c
+gvisor.googlesource.com/gvisor/pkg/sentry/usermem.IOSequence.CopyInTo(0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, 0x0, 0xc94d20, 0xc4203fdcc8, 0xc87960, ...)
+	pkg/sentry/usermem/usermem.go:528 +0xad fp=0xc4205d1be0 sp=0xc4205d1b68 pc=0x590a4d
+gvisor.googlesource.com/gvisor/pkg/sentry/fs/fsutil.(*CachingInodeOperations).Write(0xc4202ed800, 0xc94d20, 0xc4203fdcc8, 0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, 0x0, ...)
+	pkg/sentry/fs/fsutil/inode_cached.go:474 +0x19e fp=0xc4205d1ca0 sp=0xc4205d1be0 pc=0x66037e
+gvisor.googlesource.com/gvisor/pkg/sentry/fs/gofer.(*fileOperations).Write(0xc421fcd1d0, 0xc94d20, 0xc4203fdcc8, 0xc4205e9000, 0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, ...)
+	pkg/sentry/fs/gofer/file.go:192 +0x271 fp=0xc4205d1d78 sp=0xc4205d1ca0 pc=0x80dbf1
+gvisor.googlesource.com/gvisor/pkg/sentry/fs.(*overlayFileOperations).Write(0xc421fcd200, 0xc94d20, 0xc4203fdcc8, 0xc4205e9080, 0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, ...)
+	pkg/sentry/fs/file_overlay.go:222 +0x9b fp=0xc4205d1e00 sp=0xc4205d1d78 pc=0x61d95b
+gvisor.googlesource.com/gvisor/pkg/sentry/fs.(*File).Pwritev(0xc4205e9080, 0xc94d20, 0xc4203fdcc8, 0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, 0x0, ...)
+	pkg/sentry/fs/file.go:269 +0x1c2 fp=0xc4205d1ea8 sp=0xc4205d1e00 pc=0x61b532
+gvisor.googlesource.com/gvisor/pkg/sentry/syscalls/linux.performCallback(0xc421b91b00, 0xc4205e9080, 0x20000280, 0xc4204a8a80, 0xc93580, 0xc4214a6580, 0x0, 0x1, 0x20000200, 0x61, ...)
+	pkg/sentry/syscalls/linux/sys_aio.go:264 +0x2a4 fp=0xc4205d1f38 sp=0xc4205d1ea8 pc=0x8c2144
+gvisor.googlesource.com/gvisor/pkg/sentry/syscalls/linux.submitCallback.func1()
+	pkg/sentry/syscalls/linux/sys_aio.go:342 +0x7c fp=0xc4205d1fb0 sp=0xc4205d1f38 pc=0x8ef8bc
+gvisor.googlesource.com/gvisor/pkg/sentry/fs.Async.func1(0xc420172b60)
+	pkg/sentry/fs/fs.go:82 +0x4f fp=0xc4205d1fd8 sp=0xc4205d1fb0 pc=0x63408f
+runtime.goexit()
+	bazel-out/k8-fastbuild/bin/external/io_bazel_rules_go/linux_amd64_pure_stripped/stdlib~/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc4205d1fe0 sp=0xc4205d1fd8 pc=0x455f11
+created by gvisor.googlesource.com/gvisor/pkg/sentry/fs.Async
+	pkg/sentry/fs/fs.go:80 +0x58

--- a/pkg/report/testdata/gvisor/report/7
+++ b/pkg/report/testdata/gvisor/report/7
@@ -167,3 +167,13 @@ Previous write at 0x00c4211413e0 by goroutine 45:
       pkg/sentry/kernel/task_run.go:217 +0x157c
   gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*Task).run()
       pkg/sentry/kernel/task_run.go:95 +0x264
+TAIL REPORTS:
+W0618 15:50:34.276259  112427 x:0] FATAL ERROR: error running container: err waiting on container "syz-1": EOF
+error running container: err waiting on container "syz-1": EOF
+W0618 15:50:34.276259  112492 x:0] FATAL ERROR: error getting processes for container: error executing in sandbox: EOF
+error getting processes for container: error executing in sandbox: EOF
+
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+W0618 15:50:34.276259  112492 x:0] FATAL ERROR: error getting processes for container: error executing in sandbox: EOF
+error getting processes for container: error executing in sandbox: EOF
+

--- a/pkg/report/testdata/linux/report/345
+++ b/pkg/report/testdata/linux/report/345
@@ -1,5 +1,6 @@
 TITLE: WARNING in xfrm_state_fini
 TYPE: WARNING
+CONTEXTS: ["[ T1194]","[ T1194]"]
 
 [  560.713151][ T1194] WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
 [  560.714556][ T1194] Kernel panic - not syncing: panic_on_warn set ...
@@ -52,6 +53,38 @@ TYPE: WARNING
 
 REPORT:
 WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
+Kernel panic - not syncing: panic_on_warn set ...
+CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Workqueue: netns cleanup_net
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ panic+0x2cb/0x65c
+ __warn.cold+0x20/0x48
+ report_bug+0x263/0x2b0
+ do_error_trap+0x11b/0x200
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:xfrm_state_fini+0x440/0x5c0
+Code: c3 e8 d4 94 be fa 0f 0b e9 d5 fd ff ff e8 c8 94 be fa 0f 0b e9 9d fe ff ff e8 bc 94 be fa 0f 0b e9 65 ff ff ff e8 b0 94 be fa <0f> 0b e9 d1 fc ff ff e8 94 87 02 fb e9 f4 fc ff ff 48 89 85 08 ff
+RSP: 0018:ffff888068c37718 EFLAGS: 00010293
+RAX: ffff888068c28300 RBX: ffff88805fec4340 RCX: 0000000000000000
+RDX: 0000000000000000 RSI: ffffffff86c36c50 RDI: 1ffff1100d186ee9
+RBP: ffff888068c37810 R08: 0000000000000007 R09: ffff888068c28bf0
+R10: ffff888068c28300 R11: 0000000000000000 R12: 1ffff1100d186ee5
+R13: ffff888068c377e8 R14: ffff88805fec5e40 R15: ffff88801f9cb0e0
+ xfrm_net_exit+0x25/0x70
+ ops_exit_list.isra.0+0xb0/0x160
+ cleanup_net+0x51d/0xb10
+ process_one_work+0xd0c/0x1ce0
+ worker_thread+0x143/0x14a0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+TAIL REPORTS:
 Kernel panic - not syncing: panic_on_warn set ...
 CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014

--- a/pkg/report/testdata/linux/report/346
+++ b/pkg/report/testdata/linux/report/346
@@ -1,5 +1,6 @@
 TITLE: WARNING in xfrm_state_fini
 TYPE: WARNING
+CONTEXTS: ["[ T1194]","[ T1234]","[ T1194]"]
 
 [  560.713151][ T1194] WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
 [ 3481.239960][ T1234] INFO: rcu_sched detected stalls on CPUs/tasks:
@@ -69,6 +70,66 @@ TYPE: WARNING
 
 REPORT:
 WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
+Kernel panic - not syncing: panic_on_warn set ...
+CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Workqueue: netns cleanup_net
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ panic+0x2cb/0x65c
+ __warn.cold+0x20/0x48
+ report_bug+0x263/0x2b0
+ do_error_trap+0x11b/0x200
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:xfrm_state_fini+0x440/0x5c0
+RSP: 0018:ffff888068c37718 EFLAGS: 00010293
+RAX: ffff888068c28300 RBX: ffff88805fec4340 RCX: 0000000000000000
+RDX: 0000000000000000 RSI: ffffffff86c36c50 RDI: 1ffff1100d186ee9
+RBP: ffff888068c37810 R08: 0000000000000007 R09: ffff888068c28bf0
+R10: ffff888068c28300 R11: 0000000000000000 R12: 1ffff1100d186ee5
+R13: ffff888068c377e8 R14: ffff88805fec5e40 R15: ffff88801f9cb0e0
+ xfrm_net_exit+0x25/0x70
+ ops_exit_list.isra.0+0xb0/0x160
+ cleanup_net+0x51d/0xb10
+ process_one_work+0xd0c/0x1ce0
+ worker_thread+0x143/0x14a0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+TAIL REPORTS:
+INFO: rcu_sched detected stalls on CPUs/tasks:
+ 	(detected by 1, t=105002 jiffies, g=687946, c=687945, q=520)
+ All QSes seen, last rcu_sched kthread activity 103964 (4298143477-4298039513), jiffies_till_next_fqs=3, root ->qsmask 0x0
+ syz-executor0   R running task on cpu   1     0 315571 315308 0x0000000e 3375506638533
+ Call Trace:
+  <IRQ>  [<ffffffff816efb87>] _sched_show_task+0x31a/0x325
+  [<ffffffff816f030c>] sched_show_task+0x10/0x12
+  [<ffffffff816fabed>] rcu_check_callbacks.cold.76+0xbfa/0xc77
+  [<ffffffff814f5cdf>] update_process_times+0x3f/0x70
+  [<ffffffff8151f1ea>] tick_sched_handle.isra.16+0x5a/0x100
+  [<ffffffff8151f89a>] tick_sched_timer+0x7a/0x130
+  [<ffffffff814f8e15>] __hrtimer_run_queues+0x3a5/0xc50
+  [<ffffffff814fa03e>] hrtimer_interrupt+0x18e/0x400
+  [<ffffffff8129a744>] local_apic_timer_interrupt+0x74/0x90
+  [<ffffffff81012dff>] smp_apic_timer_interrupt+0xdf/0x130
+  [<ffffffff81011c72>] smp_apic_timer_interrupt_entry_after_kaiser_bti+0x20/0x2e
+  <EOI>  [<ffffffff815bcdb1>] ? __sanitizer_cov_trace_pc+0x21/0x60
+  [<ffffffff8152dedc>] smp_call_function_single+0x26c/0x330
+  [<ffffffff8152eaa5>] smp_cfm_core+0x6a5/0x7e0
+  [<ffffffff8152ee6b>] on_each_cpu+0x6b/0x120
+  [<ffffffff812dd836>] flush_tlb_kernel_range+0x86/0xe0
+  [<ffffffff817ea3cc>] __purge_vmap_area_lazy+0x3ec/0xf40
+  [<ffffffff817eb5df>] free_vmap_area_noflush+0x1bf/0x200
+  [<ffffffff817ee77e>] remove_vm_area+0x13e/0x1c0
+  [<ffffffff817ee849>] __vunmap+0x49/0x330
+  [<ffffffff817eebf5>] vfree+0x55/0xe0
+  [<ffffffff8177bc6b>] kvfree+0x3b/0x60
+  [<ffffffff82430b98>] uhaul_rx_release+0x268/0x5a0
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
 Kernel panic - not syncing: panic_on_warn set ...
 CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014

--- a/pkg/report/testdata/linux/report/347
+++ b/pkg/report/testdata/linux/report/347
@@ -1,5 +1,6 @@
 TITLE: WARNING in xfrm_state_fini
 TYPE: WARNING
+CONTEXTS: ["[T27130]","[T27130]"]
 
 [  602.265237][T27130] FAULT_INJECTION: forcing a failure.
 [  602.265237][T27130] name failslab, interval 1, probability 0, space 0, times 0
@@ -81,6 +82,33 @@ RBP: 00007f6d6741eca0 R08: 0000000000000000 R09: 0000000000000000
 R10: 0000000000000000 R11: 0000000000000246 R12: 00007f6d6741f6d4
 R13: 00000000004aa309 R14: 00000000006e90f0 R15: 0000000000000004
 WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
+Kernel panic - not syncing: panic_on_warn set ...
+CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Workqueue: netns cleanup_net
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:xfrm_state_fini+0x440/0x5c0
+RSP: 0018:ffff888068c37718 EFLAGS: 00010293
+RAX: ffff888068c28300 RBX: ffff88805fec4340 RCX: 0000000000000000
+RDX: 0000000000000000 RSI: ffffffff86c36c50 RDI: 1ffff1100d186ee9
+RBP: ffff888068c37810 R08: 0000000000000007 R09: ffff888068c28bf0
+R10: ffff888068c28300 R11: 0000000000000000 R12: 1ffff1100d186ee5
+R13: ffff888068c377e8 R14: ffff88805fec5e40 R15: ffff88801f9cb0e0
+ xfrm_net_exit+0x25/0x70
+ ops_exit_list.isra.0+0xb0/0x160
+ cleanup_net+0x51d/0xb10
+ process_one_work+0xd0c/0x1ce0
+ worker_thread+0x143/0x14a0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+TAIL REPORTS:
 Kernel panic - not syncing: panic_on_warn set ...
 CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014

--- a/pkg/report/testdata/linux/report/348
+++ b/pkg/report/testdata/linux/report/348
@@ -1,5 +1,6 @@
 TITLE: WARNING in xfrm_state_fini
 TYPE: WARNING
+CONTEXTS: ["[    C1]","[    C1]"]
 
 [  602.265237][    C1] FAULT_INJECTION: forcing a failure.
 [  602.265237][    C1] name failslab, interval 1, probability 0, space 0, times 0
@@ -61,6 +62,33 @@ RBP: 00007f6d6741eca0 R08: 0000000000000000 R09: 0000000000000000
 R10: 0000000000000000 R11: 0000000000000246 R12: 00007f6d6741f6d4
 R13: 00000000004aa309 R14: 00000000006e90f0 R15: 0000000000000004
 WARNING: CPU: 2 PID: 1194 at net/xfrm/xfrm_state.c:2381 xfrm_state_fini+0x440/0x5c0
+Kernel panic - not syncing: panic_on_warn set ...
+CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Workqueue: netns cleanup_net
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:xfrm_state_fini+0x440/0x5c0
+RSP: 0018:ffff888068c37718 EFLAGS: 00010293
+RAX: ffff888068c28300 RBX: ffff88805fec4340 RCX: 0000000000000000
+RDX: 0000000000000000 RSI: ffffffff86c36c50 RDI: 1ffff1100d186ee9
+RBP: ffff888068c37810 R08: 0000000000000007 R09: ffff888068c28bf0
+R10: ffff888068c28300 R11: 0000000000000000 R12: 1ffff1100d186ee5
+R13: ffff888068c377e8 R14: ffff88805fec5e40 R15: ffff88801f9cb0e0
+ xfrm_net_exit+0x25/0x70
+ ops_exit_list.isra.0+0xb0/0x160
+ cleanup_net+0x51d/0xb10
+ process_one_work+0xd0c/0x1ce0
+ worker_thread+0x143/0x14a0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+TAIL REPORTS:
 Kernel panic - not syncing: panic_on_warn set ...
 CPU: 2 PID: 1194 Comm: kworker/u12:4 Not tainted 4.20.0-next-20190102+ #5
 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014

--- a/pkg/report/testdata/linux/report/349
+++ b/pkg/report/testdata/linux/report/349
@@ -1,6 +1,7 @@
 TITLE: INFO: task hung in jbd2_journal_commit_transaction
 ALT: hang in jbd2_journal_commit_transaction
 TYPE: HANG
+CONTEXTS: ["[ T1054]","[ T1054]","[ T1054]","[ T1054]","[ T1054]"]
 
 [ 1431.920513][ T1054] INFO: task jbd2/sda-8:3563 blocked for more than 140 seconds.
 [ 1431.921721][ T1054]       Not tainted 4.20.0-next-20190102+ #5
@@ -234,6 +235,22 @@ Call Trace:
  kjournald2+0x20f/0xb90
  kthread+0x357/0x430
  ret_from_fork+0x3a/0x50
+TAIL REPORTS:
+      Not tainted 4.20.0-next-20190102+ #5
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+jbd2/sda-8      D22600  3563      2 0x80000000
+Call Trace:
+ __schedule+0x897/0x1e60
+ schedule+0xfe/0x350
+ io_schedule+0x1c/0x70
+ bit_wait_io+0x17/0x90
+ __wait_on_bit+0xb3/0x130
+ out_of_line_wait_on_bit+0x1f4/0x3b0
+ __wait_on_buffer+0x6f/0x90
+ jbd2_journal_commit_transaction+0x658a/0x8ee4
+ kjournald2+0x20f/0xb90
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
 INFO: task kworker/u12:5:1980 blocked for more than 140 seconds.
       Not tainted 4.20.0-next-20190102+ #5
 "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
@@ -261,7 +278,67 @@ Call Trace:
  worker_thread+0x143/0x14a0
  kthread+0x357/0x430
  ret_from_fork+0x3a/0x50
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+      Not tainted 4.20.0-next-20190102+ #5
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+kworker/u12:5   D21864  1980      2 0x80000000
+Workqueue: writeback wb_workfn (flush-8:0)
+Call Trace:
+ __schedule+0x897/0x1e60
+ schedule+0xfe/0x350
+ io_schedule+0x1c/0x70
+ rq_qos_wait+0x2f2/0x600
+ wbt_wait+0x266/0x430
+ __rq_qos_throttle+0x58/0xb0
+ blk_mq_make_request+0x424/0x1e10
+ generic_make_request+0x902/0x17f0
+ submit_bio+0xba/0x480
+ ext4_io_submit+0x197/0x230
+ ext4_writepages+0x139d/0x4180
+ do_writepages+0x99/0x1a0
+ __writeback_single_inode+0x1c5/0x1620
+ writeback_sb_inodes+0x762/0x1260
+ __writeback_inodes_wb+0x16d/0x3d0
+ wb_writeback+0xa2d/0xf70
+ wb_workfn+0xccc/0x16f0
+ process_one_work+0xd0c/0x1ce0
+ worker_thread+0x143/0x14a0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
 INFO: task syz-executor2:6677 blocked for more than 140 seconds.
+      Not tainted 4.20.0-next-20190102+ #5
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+syz-executor2   D19624  6677  22450 0x00000004
+Call Trace:
+ __schedule+0x897/0x1e60
+ schedule+0xfe/0x350
+ io_schedule+0x1c/0x70
+ wait_on_page_bit_common+0xad5/0x1370
+ __filemap_fdatawait_range+0x614/0x890
+ file_write_and_wait_range+0xd1/0x100
+ ext4_sync_file+0x2da/0x14d0
+ vfs_fsync_range+0x144/0x230
+ ext4_file_write_iter+0x683/0x1400
+ do_iter_readv_writev+0x902/0xbc0
+ do_iter_write+0x184/0x610
+ vfs_iter_write+0x77/0xb0
+ iter_file_splice_write+0x885/0xfc0
+ direct_splice_actor+0x126/0x1a0
+ splice_direct_to_actor+0x3be/0x9d0
+ do_splice_direct+0x2c7/0x420
+ do_sendfile+0x61a/0xe60
+ __x64_sys_sendfile64+0x15a/0x240
+ do_syscall_64+0x1a3/0x800
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x4576a9
+Code: 3b 41 10 76 7d 48 81 ec 88 00 00 00 48 89 ac 24 80 00 00 00 48 8d ac 24 80 00 00 00 48 8b 59 20 48 85 db 75 67 48 8b b4 24 a0 <00> 00 00 8b 8c 24 a8 00 00 00 48 89 e7 f3 a4 48 8b 94 24 98 00 00
+RSP: 002b:00007f66fbce3c88 EFLAGS: 00000246 ORIG_RAX: 0000000000000028
+RAX: ffffffffffffffda RBX: 000000000071bf00 RCX: 00000000004576a9
+RDX: 0000000020000040 RSI: 0000000000000005 RDI: 0000000000000005
+RBP: 0000000000000004 R08: 0000000000000000 R09: 0000000000000000
+R10: 00008080fffffffe R11: 0000000000000246 R12: 00007f66fbce46d4
+R13: 00000000004abcac R14: 00000000006eb9b8 R15: 00000000ffffffff
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
       Not tainted 4.20.0-next-20190102+ #5
 "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
 syz-executor2   D19624  6677  22450 0x00000004
@@ -419,3 +496,67 @@ RDX: 0000000000000400 RSI: 00000000008d3ce0 RDI: 0000000000000002
 RBP: 00000000008d3ce0 R08: 00000000008d408d R09: 00007fc30b3ffe07
 R10: 0000000000000000 R11: 0000000000000293 R12: 0000000000000000
 R13: 00007fc30a024410 R14: 00007fc304002a50 R15: 00000000008d3ac0
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+R10: 0001000000020000 R11: 0000000000000246 R12: 00007f66fbcc36d4
+R13: 00000000004abcac R14: 00000000006eb9b8 R15: 00000000ffffffff
+Showing all locks held in the system:
+1 lock held by khungtaskd/1054:
+ #0: 00000000c542499d (rcu_read_lock){....}, at: debug_show_all_locks+0xc6/0x41d
+1 lock held by rsyslogd/5859:
+ #0: 00000000567e80cf (&f->f_pos_lock){+.+.}, at: __fdget_pos+0x1b3/0x1f0
+2 locks held by getty/5951:
+ #0: 000000003b0dfac2 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000281ebc43 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5952:
+ #0: 00000000f0d48c91 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000cff3c1fb (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5953:
+ #0: 00000000cb353a8f (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000373ded25 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5954:
+ #0: 000000005c8be537 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000d7aec815 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5955:
+ #0: 00000000eda8138a (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000f4fd60a6 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5956:
+ #0: 000000000745b5fb (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000a4c3442a (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+2 locks held by getty/5957:
+ #0: 000000002cb7c49e (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 000000009258e26f (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x30a/0x1eb0
+4 locks held by kworker/u12:5/1980:
+ #0: 000000005e902bc8 ((wq_completion)"writeback"){+.+.}, at: process_one_work+0xbc7/0x1ce0
+ #1: 0000000056cd520a ((work_completion)(&(&wb->dwork)->work)){+.+.}, at: process_one_work+0xc1d/0x1ce0
+ #2: 00000000146ba37b (&type->s_umount_key#30){++++}, at: trylock_super+0x22/0x110
+ #3: 00000000fec9c2c2 (&sbi->s_journal_flag_rwsem){.+.+}, at: do_writepages+0x99/0x1a0
+1 lock held by syz-executor2/6677:
+ #0: 000000007b67e744 (sb_writers#3){.+.+}, at: do_sendfile+0xad7/0xe60
+1 lock held by syz-executor2/6693:
+ #0: 000000007b67e744 (sb_writers#3){.+.+}, at: do_sendfile+0xad7/0xe60
+=============================================
+NMI backtrace for cpu 3
+CPU: 3 PID: 1054 Comm: khungtaskd Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ nmi_cpu_backtrace.cold+0x63/0xa4
+ nmi_trigger_cpumask_backtrace+0x1be/0x236
+ arch_trigger_cpumask_backtrace+0x14/0x20
+ watchdog+0xbbb/0x1170
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Sending NMI from CPU 3 to CPUs 0-2:
+Kernel panic - not syncing: hung_task: blocked tasks
+CPU: 3 PID: 1054 Comm: khungtaskd Not tainted 4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ panic+0x2cb/0x65c
+ watchdog+0xbcc/0x1170
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/350
+++ b/pkg/report/testdata/linux/report/350
@@ -3,6 +3,7 @@ ALT: BUG: soft lockup in smp_call_function_many
 ALT: stall in smp_call_function
 ALT: stall in smp_call_function_many
 TYPE: HANG
+CONTEXTS: ["[    C2]","[    C2]"]
 
 [ 1098.601132][    C2] watchdog: BUG: soft lockup - CPU#2 stuck for 136s! [syz-executor4:4888]
 [ 1098.605452][    C2] Modules linked in:
@@ -436,3 +437,101 @@ RDX: 0000000002398aa0 RSI: 00007fff245c5580 RDI: 00007fff245c6590
 RBP: 0000000000625500 R08: 0000000000001ca3 R09: 0000000000001ca3
 R10: 0000000000000000 R11: 0000000000000206 R12: 0000000002398aa0
 R13: 0000000000000007 R14: 0000000002387250 R15: 0000000000000005
+TAIL REPORTS:
+RAX: ffffffffffffffda RBX: 00000000ffffffff RCX: 00007fdf8c90e207
+RDX: 0000000002398aa0 RSI: 00007fff245c5580 RDI: 00007fff245c6590
+RBP: 0000000000625500 R08: 0000000000001ca3 R09: 0000000000001ca3
+R10: 0000000000000000 R11: 0000000000000206 R12: 0000000002398aa0
+R13: 0000000000000007 R14: 0000000002387250 R15: 0000000000000005
+Kernel panic - not syncing: softlockup: hung tasks
+CPU: 2 PID: 4888 Comm: syz-executor4 Tainted: G             L    4.20.0-next-20190102+ #5
+Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1 04/01/2014
+Call Trace:
+ <IRQ>
+ dump_stack+0x1db/0x2d0
+ panic+0x2cb/0x65c
+ watchdog_timer_fn.cold+0x16/0x33
+ __hrtimer_run_queues+0x3a7/0x1050
+ hrtimer_interrupt+0x314/0x770
+ smp_apic_timer_interrupt+0x18d/0x760
+ apic_timer_interrupt+0xf/0x20
+ </IRQ>
+RIP: 0010:__sanitizer_cov_trace_const_cmp4+0xd/0x20
+Code: d6 0f b7 f7 bf 03 00 00 00 48 89 e5 48 8b 4d 08 e8 d8 fe ff ff 5d c3 66 0f 1f 44 00 00 55 89 f2 89 fe bf 05 00 00 00 48 89 e5 <48> 8b 4d 08 e8 ba fe ff ff 5d c3 0f 1f 84 00 00 00 00 00 55 48 89
+RSP: 0018:ffff88803b35f218 EFLAGS: 00000246 ORIG_RAX: ffffffffffffff13
+RAX: 0000000000000004 RBX: ffffed100766be5a RCX: ffffffff81759ae5
+RDX: 0000000000000001 RSI: 0000000000000000 RDI: 0000000000000005
+RBP: ffff88803b35f218 R08: ffff88805a72a540 R09: ffff88805a72ae80
+R10: ffff88805a72a540 R11: 0000000000000000 R12: ffff88806c437fe0
+R13: 0000000000000001 R14: ffff88803b35f310 R15: 0000000000000003
+ smp_call_function_many+0x8d5/0xb10
+ smp_call_function+0x42/0x90
+ on_each_cpu+0x31/0x200
+ text_poke_bp+0x101/0x1e5
+ __jump_label_transform+0x33f/0x4d0
+ arch_jump_label_transform+0x2b/0x40
+ __jump_label_update+0x16a/0x210
+ jump_label_update+0x1ce/0x3d0
+ __static_key_slow_dec_cpuslocked+0xc5/0x220
+ static_key_slow_dec+0x60/0xa0
+ tracepoint_probe_unregister+0x73e/0x940
+ trace_event_reg+0x189/0x350
+ perf_trace_event_unreg.isra.0+0xbb/0x220
+ perf_trace_destroy+0xc1/0x100
+ tp_perf_event_destroy+0x16/0x20
+ _free_event+0x3ee/0x1640
+ put_event+0x47/0x60
+ perf_event_release_kernel+0x890/0xf70
+ perf_release+0x37/0x50
+ __fput+0x3c5/0xb10
+ ____fput+0x16/0x20
+ task_work_run+0x1f4/0x2b0
+ exit_to_usermode_loop+0x32a/0x3b0
+ do_syscall_64+0x696/0x800
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x411071
+Code: 75 14 b8 03 00 00 00 0f 05 48 3d 01 f0 ff ff 0f 83 74 1a 00 00 c3 48 83 ec 08 e8 0a fc ff ff 48 89 04 24 b8 03 00 00 00 0f 05 <48> 8b 3c 24 48 89 c2 e8 53 fc ff ff 48 89 d0 48 83 c4 08 48 3d 01
+RSP: 002b:00007ffffa2d80d0 EFLAGS: 00000293 ORIG_RAX: 0000000000000003
+RAX: 0000000000000000 RBX: 0000000000000004 RCX: 0000000000411071
+RDX: 0000001b2d420000 RSI: 00007fd53b7c3510 RDI: 0000000000000003
+RBP: 0000000000000000 R08: 00007fd53b7c3048 R09: 000000003df39a59
+R10: 00007ffffa2d8000 R11: 0000000000000293 R12: 0000000000000001
+R13: 0000000000000000 R14: 0000000000000000 R15: 00007ffffa2d8190
+Shutting down cpus with NMI
+Dumping ftrace buffer:
+---------------------------------
+syz-exec-31490   2...1 413720925us : 0: }D
+syz-exec-31490   2...1 413720950us : 0: }D
+syz-exec-31490   2...1 413720952us : 0: }D
+syz-exec-31490   2...1 413720954us : 0: }D
+syz-exec-31490   2...1 413720955us : 0: }D
+syz-exec-31490   2...1 413720957us : 0: }D
+syz-exec-31490   2...1 413720959us : 0: }D
+syz-exec-31490   2...1 413720960us : 0: }D
+syz-exec-31490   2...1 413720962us : 0: }D
+syz-exec-31490   2...1 413720963us : 0: }D
+syz-exec-31490   2...1 413720965us : 0: }D
+syz-exec-31490   2...1 413720967us : 0: }D
+syz-exec-31490   2...1 413720968us : 0: }D
+syz-exec-31490   2...1 413720970us : 0: }D
+syz-exec-31490   2...1 413720971us : 0: }D
+syz-exec-31490   2...1 413720973us : 0: }D
+syz-exec-31490   2...1 413720975us : 0: }D
+syz-exec-31490   2...1 413720976us : 0: }D
+syz-exec-31490   2...1 413720978us : 0: }D
+syz-exec-31490   2...1 413720979us : 0: }D
+syz-exec-31490   2...1 413720981us : 0: }D
+syz-exec-31490   2...1 413720983us : 0: }D
+syz-exec-31490   2...1 413720984us : 0: }D
+syz-exec-31490   2...1 413720986us : 0: }D
+syz-exec-31490   2...1 413720987us : 0: }D
+syz-exec-31490   2...1 413720989us : 0: }D
+syz-exec-31490   2...1 413720991us : 0: }D
+syz-exec-31490   2...1 413720992us : 0: }D
+syz-exec-31490   2...1 413720994us : 0: }D
+syz-exec-31490   2...1 413720995us : 0: }D
+syz-exec-31490   2...1 413720997us : 0: }D
+syz-exec-31490   2...1 413720998us : 0: }D
+syz-exec-31490   2...1 413721000us : 0: }D
+syz-exec-31490   2...1 413721002us : 0: }D
+syz-exec-31490   2...1 413721003us : 0: }D

--- a/pkg/report/testdata/linux/report/352
+++ b/pkg/report/testdata/linux/report/352
@@ -1,5 +1,6 @@
 TITLE: kernel BUG in __isolate_free_page
 TYPE: BUG
+CONTEXTS: ["[ T1043]","[ T1043]","[ T1043]","[ T1043]"]
 
 [ 1191.669874][ T1043] ------------[ cut here ]------------
 [ 1191.678706][ T1043] kernel BUG at mm/page_alloc.c:3112!
@@ -367,3 +368,276 @@ Call Trace:
 Modules linked in:
 
 ======================================================
+TAIL REPORTS:
+invalid opcode: 0000 [#1] PREEMPT SMP KASAN
+CPU: 0 PID: 1043 Comm: kcompactd0 Not tainted 5.0.0-rc1-next-20190111 #10
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+FS:  0000000000000000(0000) GS:ffff8880ae600000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000000000438ca0 CR3: 0000000009871000 CR4: 00000000001426f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000600
+Call Trace:
+ compaction_alloc+0xd05/0x2970
+ migrate_pages+0x48e/0x2cc0
+ compact_zone+0x2207/0x3e90
+ kcompactd_do_work+0x6de/0x1200
+ kcompactd+0x251/0x970
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Modules linked in:
+
+======================================================
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+CPU: 0 PID: 1043 Comm: kcompactd0 Not tainted 5.0.0-rc1-next-20190111 #10
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+FS:  0000000000000000(0000) GS:ffff8880ae600000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000000000438ca0 CR3: 0000000009871000 CR4: 00000000001426f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000600
+Call Trace:
+ compaction_alloc+0xd05/0x2970
+ migrate_pages+0x48e/0x2cc0
+ compact_zone+0x2207/0x3e90
+ kcompactd_do_work+0x6de/0x1200
+ kcompactd+0x251/0x970
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Modules linked in:
+======================================================
+WARNING: possible circular locking dependency detected
+5.0.0-rc1-next-20190111 #10 Not tainted
+------------------------------------------------------
+kcompactd0/1043 is trying to acquire lock:
+00000000a0848583 (console_owner){-.-.}, at: console_unlock+0x4ac/0x1040
+
+but task is already holding lock:
+00000000c8e67de2 (&(&zone->lock)->rlock){..-.}, at: compaction_alloc+0x6f3/0x2970
+
+which lock already depends on the new lock.
+
+
+the existing dependency chain (in reverse order) is:
+
+-> #3 (&(&zone->lock)->rlock){..-.}:
+       _raw_spin_lock_irqsave+0x95/0xcd
+       get_page_from_freelist+0xf6c/0x4870
+       __alloc_pages_nodemask+0x4fd/0xdc0
+       alloc_pages_current+0x107/0x210
+       depot_save_stack+0x3da/0x460
+       save_stack+0xa9/0xd0
+       __kasan_kmalloc.constprop.0+0xcf/0xe0
+       kasan_slab_alloc+0xf/0x20
+       __kmalloc+0x145/0x740
+       __tty_buffer_request_room+0x2bf/0x7e0
+       tty_insert_flip_string_fixed_flag+0x93/0x1f0
+       pty_write+0x133/0x200
+       tty_put_char+0x137/0x160
+       __process_echoes+0x5c8/0xa40
+       n_tty_receive_buf_common+0xc2c/0x2f30
+       n_tty_receive_buf2+0x34/0x40
+       tty_ldisc_receive_buf+0xaf/0x1c0
+       tty_port_default_receive_buf+0x114/0x190
+       flush_to_ldisc+0x3b2/0x590
+       process_one_work+0xd0c/0x1ce0
+       worker_thread+0x143/0x14a0
+       kthread+0x357/0x430
+       ret_from_fork+0x3a/0x50
+
+-> #2 (&(&port->lock)->rlock){-.-.}:
+       _raw_spin_lock_irqsave+0x95/0xcd
+       tty_port_tty_get+0x22/0x80
+       tty_port_default_wakeup+0x16/0x40
+       tty_port_tty_wakeup+0x5d/0x70
+       uart_write_wakeup+0x46/0x70
+       serial8250_tx_chars+0x4a4/0xb20
+       serial8250_handle_irq.part.0+0x1be/0x2e0
+       serial8250_default_handle_irq+0xc5/0x150
+       serial8250_interrupt+0xfb/0x1a0
+       __handle_irq_event_percpu+0x1c6/0xb10
+       handle_irq_event_percpu+0xa0/0x1d0
+       handle_irq_event+0xa7/0x134
+       handle_edge_irq+0x232/0x8a0
+       handle_irq+0x252/0x3d8
+       do_IRQ+0x99/0x1d0
+       ret_from_intr+0x0/0x1e
+       native_safe_halt+0x2/0x10
+       arch_cpu_idle+0x10/0x20
+       default_idle_call+0x36/0x90
+       do_idle+0x386/0x5d0
+       cpu_startup_entry+0x1b/0x20
+       start_secondary+0x435/0x620
+       secondary_startup_64+0xa4/0xb0
+
+-> #1 (&port_lock_key){-.-.}:
+       _raw_spin_lock_irqsave+0x95/0xcd
+       serial8250_console_write+0x253/0xab0
+       univ8250_console_write+0x5f/0x70
+       console_unlock+0xc9a/0x1040
+       vprintk_emit+0x370/0x960
+       vprintk_default+0x28/0x30
+       vprintk_func+0x7e/0x189
+       printk+0xba/0xed
+       register_console+0x74d/0xb50
+       univ8250_console_init+0x3e/0x4b
+       console_init+0x6b7/0x9fe
+       start_kernel+0x5df/0x8bd
+       x86_64_start_reservations+0x29/0x2b
+       x86_64_start_kernel+0x77/0x7b
+       secondary_startup_64+0xa4/0xb0
+
+-> #0 (console_owner){-.-.}:
+       lock_acquire+0x1db/0x570
+       console_unlock+0x516/0x1040
+       vprintk_emit+0x370/0x960
+       vprintk_default+0x28/0x30
+       vprintk_func+0x7e/0x189
+       printk+0xba/0xed
+       report_bug.cold+0x11/0x5e
+       do_error_trap+0x11b/0x200
+       do_invalid_op+0x37/0x50
+       invalid_op+0x14/0x20
+       __isolate_free_page+0x4a8/0x680
+       compaction_alloc+0xd05/0x2970
+       migrate_pages+0x48e/0x2cc0
+       compact_zone+0x2207/0x3e90
+       kcompactd_do_work+0x6de/0x1200
+       kcompactd+0x251/0x970
+       kthread+0x357/0x430
+       ret_from_fork+0x3a/0x50
+
+other info that might help us debug this:
+
+Chain exists of:
+  console_owner --> &(&port->lock)->rlock --> &(&zone->lock)->rlock
+
+ Possible unsafe locking scenario:
+
+       CPU0                    CPU1
+       ----                    ----
+  lock(&(&zone->lock)->rlock);
+                               lock(&(&port->lock)->rlock);
+                               lock(&(&zone->lock)->rlock);
+  lock(console_owner);
+
+ *** DEADLOCK ***
+
+2 locks held by kcompactd0/1043:
+ #0: 00000000c8e67de2 (&(&zone->lock)->rlock){..-.}, at: compaction_alloc+0x6f3/0x2970
+ #1: 0000000001912981 (console_lock){+.+.}, at: vprintk_emit+0x351/0x960
+
+stack backtrace:
+CPU: 0 PID: 1043 Comm: kcompactd0 Not tainted 5.0.0-rc1-next-20190111 #10
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ print_circular_bug.isra.0.cold+0x1cc/0x28f
+ __lock_acquire+0x2fed/0x4a10
+ lock_acquire+0x1db/0x570
+ console_unlock+0x516/0x1040
+ vprintk_emit+0x370/0x960
+ vprintk_default+0x28/0x30
+ vprintk_func+0x7e/0x189
+ printk+0xba/0xed
+ report_bug.cold+0x11/0x5e
+ do_error_trap+0x11b/0x200
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+ compaction_alloc+0xd05/0x2970
+ migrate_pages+0x48e/0x2cc0
+ compact_zone+0x2207/0x3e90
+Lost 33 message(s)!
+---[ end trace b088aebfc4c7ea50 ]---
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+FS:  0000000000000000(0000) GS:ffff8880ae600000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000000000438ca0 CR3: 0000000009871000 CR4: 00000000001426f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000600
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+                               lock(&(&port->lock)->rlock);
+                               lock(&(&zone->lock)->rlock);
+  lock(console_owner);
+ *** DEADLOCK ***
+2 locks held by kcompactd0/1043:
+ #0: 00000000c8e67de2 (&(&zone->lock)->rlock){..-.}, at: compaction_alloc+0x6f3/0x2970
+ #1: 0000000001912981 (console_lock){+.+.}, at: vprintk_emit+0x351/0x960
+stack backtrace:
+CPU: 0 PID: 1043 Comm: kcompactd0 Not tainted 5.0.0-rc1-next-20190111 #10
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x1db/0x2d0
+ print_circular_bug.isra.0.cold+0x1cc/0x28f
+ __lock_acquire+0x2fed/0x4a10
+ lock_acquire+0x1db/0x570
+ console_unlock+0x516/0x1040
+ vprintk_emit+0x370/0x960
+ vprintk_default+0x28/0x30
+ vprintk_func+0x7e/0x189
+ printk+0xba/0xed
+ report_bug.cold+0x11/0x5e
+ do_error_trap+0x11b/0x200
+ do_invalid_op+0x37/0x50
+ invalid_op+0x14/0x20
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+ compaction_alloc+0xd05/0x2970
+ migrate_pages+0x48e/0x2cc0
+ compact_zone+0x2207/0x3e90
+Lost 33 message(s)!
+---[ end trace b088aebfc4c7ea50 ]---
+RIP: 0010:__isolate_free_page+0x4a8/0x680
+Code: 4c 39 e3 77 c0 0f b6 8d 74 ff ff ff b8 01 00 00 00 48 d3 e0 e9 11 fd ff ff 48 c7 c6 a0 63 52 88 4c 89 e7 e8 6a 14 10 00 0f 0b <0f> 0b 48 c7 c6 c0 64 52 88 4c 89 e7 e8 57 14 10 00 0f 0b 48 89 cf
+RSP: 0000:ffff8880a78e6f58 EFLAGS: 00010007
+RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff88812fffc7e0
+RDX: 1ffff11025fff8fc RSI: 0000000000000007 RDI: ffff88812fffc7b0
+RBP: ffff8880a78e7018 R08: ffff8880a78ce000 R09: ffffed1014f1cdf2
+R10: ffffed1014f1cdf1 R11: 0000000000000003 R12: ffff88812fffc7b0
+R13: 1ffff11014f1cdf2 R14: ffff88812fffc7b0 R15: ffff8880a78e6ff0
+FS:  0000000000000000(0000) GS:ffff8880ae600000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000000000438ca0 CR3: 0000000009871000 CR4: 00000000001426f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000600
+Kernel panic - not syncing: Fatal exception
+Shutting down cpus with NMI
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/385
+++ b/pkg/report/testdata/linux/report/385
@@ -1,6 +1,7 @@
 TITLE: INFO: task hung in mount_bdev
 ALT: hang in mount_bdev
 TYPE: HANG
+CONTEXTS: ["[ T1042]","[ T1042]","[ T1042]","[ T1042]","[ T1042]","[ T1042]"]
 
 [  767.964958][ T1042] INFO: task syz-executor013:7561 blocked for more than 143 seconds.
 [  767.973200][ T1042]       Not tainted 5.1.0-rc6+ #90
@@ -280,7 +281,61 @@ RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
 RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
 R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
 R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
+TAIL REPORTS:
+      Not tainted 5.1.0-rc6+ #90
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+syz-executor013 D29336  7561   7543 0x00000004
+Call Trace:
+ __schedule+0x813/0x1cc0
+ schedule+0x92/0x180
+ schedule_preempt_disabled+0x13/0x20
+ __mutex_lock+0x726/0x1310
+ mutex_lock_nested+0x16/0x20
+ mount_bdev+0x93/0x3c0
+ udf_mount+0x35/0x40
+ legacy_get_tree+0xf2/0x200
+ vfs_get_tree+0x123/0x450
+ do_mount+0x1436/0x2c40
+ ksys_mount+0xdb/0x150
+ __x64_sys_mount+0xbe/0x150
+ do_syscall_64+0x103/0x610
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x44a739
+Code: 00 49 6e 76 61 6c 69 64 20 22 24 41 63 74 69 6f 6e 51 75 65 75 65 43 68 65 63 6b 70 6f 69 6e 74 49 6e 74 65 72 76 61 6c 22 2c <20> 65 72 72 6f 72 20 25 64 2e 20 49 67 6e 6f 72 65 64 2c 20 72 75
+RSP: 002b:00007f9541ef0db8 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+RAX: ffffffffffffffda RBX: 00000000006dbc28 RCX: 000000000044a739
+RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
+RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
+R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
 INFO: task syz-executor013:7563 blocked for more than 143 seconds.
+      Not tainted 5.1.0-rc6+ #90
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+syz-executor013 D29720  7563   7541 0x00000004
+Call Trace:
+ __schedule+0x813/0x1cc0
+ schedule+0x92/0x180
+ schedule_preempt_disabled+0x13/0x20
+ __mutex_lock+0x726/0x1310
+ mutex_lock_nested+0x16/0x20
+ mount_bdev+0x93/0x3c0
+ udf_mount+0x35/0x40
+ legacy_get_tree+0xf2/0x200
+ vfs_get_tree+0x123/0x450
+ do_mount+0x1436/0x2c40
+ ksys_mount+0xdb/0x150
+ __x64_sys_mount+0xbe/0x150
+ do_syscall_64+0x103/0x610
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x44a739
+Code: 00 49 6e 76 61 6c 69 64 20 22 24 41 63 74 69 6f 6e 51 75 65 75 65 43 68 65 63 6b 70 6f 69 6e 74 49 6e 74 65 72 76 61 6c 22 2c <20> 65 72 72 6f 72 20 25 64 2e 20 49 67 6e 6f 72 65 64 2c 20 72 75
+RSP: 002b:00007f9541ef0db8 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+RAX: ffffffffffffffda RBX: 00000000006dbc28 RCX: 000000000044a739
+RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
+RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
+R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
       Not tainted 5.1.0-rc6+ #90
 "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
 syz-executor013 D29720  7563   7541 0x00000004
@@ -337,7 +392,64 @@ RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
 RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
 R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
 R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+      Not tainted 5.1.0-rc6+ #90
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+syz-executor013 D29096  7559   7544 0x00000004
+Call Trace:
+ __schedule+0x813/0x1cc0
+ schedule+0x92/0x180
+ rwsem_down_write_failed+0x774/0xc30
+ call_rwsem_down_write_failed+0x17/0x30
+ down_write+0x53/0x90
+ grab_super+0xb4/0x290
+ sget_userns+0x1ab/0x560
+ sget+0x10c/0x150
+ mount_bdev+0xff/0x3c0
+ udf_mount+0x35/0x40
+ legacy_get_tree+0xf2/0x200
+ vfs_get_tree+0x123/0x450
+ do_mount+0x1436/0x2c40
+ ksys_mount+0xdb/0x150
+ __x64_sys_mount+0xbe/0x150
+ do_syscall_64+0x103/0x610
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x44a739
+Code: 00 49 6e 76 61 6c 69 64 20 22 24 41 63 74 69 6f 6e 51 75 65 75 65 43 68 65 63 6b 70 6f 69 6e 74 49 6e 74 65 72 76 61 6c 22 2c <20> 65 72 72 6f 72 20 25 64 2e 20 49 67 6e 6f 72 65 64 2c 20 72 75
+RSP: 002b:00007f9541ef0db8 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+RAX: ffffffffffffffda RBX: 00000000006dbc28 RCX: 000000000044a739
+RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
+RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
+R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
 INFO: task syz-executor013:7565 blocked for more than 144 seconds.
+      Not tainted 5.1.0-rc6+ #90
+"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+syz-executor013 D29720  7565   7542 0x00000004
+Call Trace:
+ __schedule+0x813/0x1cc0
+ schedule+0x92/0x180
+ schedule_preempt_disabled+0x13/0x20
+ __mutex_lock+0x726/0x1310
+ mutex_lock_nested+0x16/0x20
+ mount_bdev+0x93/0x3c0
+ udf_mount+0x35/0x40
+ legacy_get_tree+0xf2/0x200
+ vfs_get_tree+0x123/0x450
+ do_mount+0x1436/0x2c40
+ ksys_mount+0xdb/0x150
+ __x64_sys_mount+0xbe/0x150
+ do_syscall_64+0x103/0x610
+ entry_SYSCALL_64_after_hwframe+0x49/0xbe
+RIP: 0033:0x44a739
+Code: 00 49 6e 76 61 6c 69 64 20 22 24 41 63 74 69 6f 6e 51 75 65 75 65 43 68 65 63 6b 70 6f 69 6e 74 49 6e 74 65 72 76 61 6c 22 2c <20> 65 72 72 6f 72 20 25 64 2e 20 49 67 6e 6f 72 65 64 2c 20 72 75
+RSP: 002b:00007f9541ef0db8 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+RAX: ffffffffffffffda RBX: 00000000006dbc28 RCX: 000000000044a739
+RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
+RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
+R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
       Not tainted 5.1.0-rc6+ #90
 "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
 syz-executor013 D29720  7565   7542 0x00000004
@@ -491,3 +603,65 @@ RDX: 0000000020000240 RSI: 0000000020000200 RDI: 0000000020000080
 RBP: 00000000006dbc20 R08: 0000000000000000 R09: 0000000000000000
 R10: 0000000000000000 R11: 0000000000000246 R12: 00000000006dbc2c
 R13: 00007ffc6cf3cddf R14: 00007f9541ef19c0 R15: 0000000000000000
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+1 lock held by khungtaskd/1042:
+ #0: 000000006329251d (rcu_read_lock){....}, at: debug_show_all_locks+0x5f/0x27e
+1 lock held by rsyslogd/7425:
+ #0: 00000000d77ddd95 (&f->f_pos_lock){+.+.}, at: __fdget_pos+0xee/0x110
+2 locks held by getty/7515:
+ #0: 000000004c45b4e6 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000cb1f5c30 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7516:
+ #0: 0000000061e5eac7 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000aab03c35 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7517:
+ #0: 00000000205ee5b4 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 0000000002712bdb (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7518:
+ #0: 000000000cc046b2 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000d5140a4a (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7519:
+ #0: 000000003624da6d (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000f5b16893 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7520:
+ #0: 0000000082294f91 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000870dfcb5 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by getty/7521:
+ #0: 000000000f72fa86 (&tty->ldisc_sem){++++}, at: ldsem_down_read+0x33/0x40
+ #1: 00000000a044b2e0 (&ldata->atomic_read_lock){+.+.}, at: n_tty_read+0x232/0x1b70
+2 locks held by syz-executor013/7547:
+1 lock held by syz-executor013/7561:
+ #0: 00000000d97cb347 (&bdev->bd_fsfreeze_mutex){+.+.}, at: mount_bdev+0x93/0x3c0
+1 lock held by syz-executor013/7563:
+ #0: 00000000d97cb347 (&bdev->bd_fsfreeze_mutex){+.+.}, at: mount_bdev+0x93/0x3c0
+2 locks held by syz-executor013/7559:
+ #0: 00000000d97cb347 (&bdev->bd_fsfreeze_mutex){+.+.}, at: mount_bdev+0x93/0x3c0
+ #1: 000000001ecfe564 (&type->s_umount_key#39){+.+.}, at: grab_super+0xb4/0x290
+1 lock held by syz-executor013/7565:
+ #0: 00000000d97cb347 (&bdev->bd_fsfreeze_mutex){+.+.}, at: mount_bdev+0x93/0x3c0
+1 lock held by syz-executor013/7562:
+ #0: 00000000d97cb347 (&bdev->bd_fsfreeze_mutex){+.+.}, at: mount_bdev+0x93/0x3c0
+=============================================
+NMI backtrace for cpu 1
+CPU: 1 PID: 1042 Comm: khungtaskd Not tainted 5.1.0-rc6+ #90
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x172/0x1f0
+ nmi_cpu_backtrace.cold+0x63/0xa4
+ nmi_trigger_cpumask_backtrace+0x1be/0x236
+ arch_trigger_cpumask_backtrace+0x14/0x20
+ watchdog+0x9b7/0xec0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Sending NMI from CPU 1 to CPUs 0:
+Kernel panic - not syncing: hung_task: blocked tasks
+CPU: 1 PID: 1042 Comm: khungtaskd Not tainted 5.1.0-rc6+ #90
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x172/0x1f0
+ panic+0x2cb/0x65c
+ watchdog+0x9c8/0xec0
+ kthread+0x357/0x430
+ ret_from_fork+0x3a/0x50
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/4
+++ b/pkg/report/testdata/linux/report/4
@@ -137,3 +137,40 @@ Dumping ftrace buffer:
    (ftrace buffer empty)
 Kernel Offset: disabled
 Rebooting in 86400 seconds..
+TAIL REPORTS:
+Kernel panic - not syncing: panic_on_warn set ...
+
+CPU: 1 PID: 8377 Comm: syz-executor6 Not tainted 4.12.0-rc7+ #2
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x194/0x257
+ panic+0x1e4/0x3fb
+ __warn+0x1c4/0x1e0
+ report_bug+0x211/0x2d0
+ fixup_bug+0x40/0x90
+ do_trap+0x260/0x390
+ do_error_trap+0x120/0x390
+ do_invalid_op+0x1b/0x20
+ invalid_op+0x1e/0x30
+RIP: 0010:kvm_arch_vcpu_ioctl_run+0x1f7/0x5a00
+RSP: 0018:ffff8801c5e37720 EFLAGS: 00010212
+RAX: 0000000000010000 RBX: ffff8801c8baa000 RCX: ffffc90004763000
+RDX: 0000000000000052 RSI: ffffffff810de507 RDI: ffff8801c6358f60
+RBP: ffff8801c5e37a80 R08: 1ffffffff097c151 R09: 0000000000000001
+R10: 0000000000000000 R11: ffffffff81066ddc R12: 0000000000000000
+R13: ffff8801c52be780 R14: ffff8801c65be600 R15: ffff8801c6358d40
+ kvm_vcpu_ioctl+0x627/0x1110
+ do_vfs_ioctl+0x1b1/0x15c0
+ SyS_ioctl+0x8f/0xc0
+ entry_SYSCALL_64_fastpath+0x1f/0xbe
+RIP: 0033:0x4512c9
+RSP: 002b:00007f7e59d4fc08 EFLAGS: 00000216 ORIG_RAX: 0000000000000010
+RAX: ffffffffffffffda RBX: 0000000000718000 RCX: 00000000004512c9
+RDX: 0000000000000000 RSI: 000000000000ae80 RDI: 0000000000000016
+RBP: 0000000000000082 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000216 R12: 00000000004b93f0
+R13: 00000000ffffffff R14: 0000000020000000 R15: 0000000000ffa000
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/449
+++ b/pkg/report/testdata/linux/report/449
@@ -1,5 +1,6 @@
 TITLE: KCSAN: data-race in netlink_recvmsg / netlink_recvmsg
 TYPE: KCSAN-DATARACE
+CONTEXTS: ["[T19789]","[T19789]"]
 
 [  472.478762][T19789] ==================================================================
 [  472.486894][T19789] BUG: KCSAN: data-race in netlink_recvmsg / netlink_recvmsg
@@ -79,3 +80,49 @@ Reported by Kernel Concurrency Sanitizer on:
 CPU: 1 PID: 19789 Comm: syz-executor.0 Not tainted 5.4.0-rc6+ #0
 Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
 ==================================================================
+TAIL REPORTS:
+write to 0xffff8880b588efb2 of 2 bytes by task 19788 on cpu 0:
+ netlink_recvmsg+0x196/0x910
+ sock_recvmsg_nosec+0x5c/0x70
+ ___sys_recvmsg+0x1a0/0x3e0
+ do_recvmmsg+0x19a/0x5c0
+ __sys_recvmmsg+0x1ef/0x200
+ __x64_sys_recvmmsg+0x89/0xb0
+ do_syscall_64+0xcc/0x370
+ entry_SYSCALL_64_after_hwframe+0x44/0xa9
+write to 0xffff8880b588efb2 of 2 bytes by task 19789 on cpu 1:
+ netlink_recvmsg+0x196/0x910
+ sock_recvmsg+0x92/0xb0
+ __sys_recvfrom+0x1ae/0x2d0
+ __x64_sys_recvfrom+0x89/0xb0
+ do_syscall_64+0xcc/0x370
+ entry_SYSCALL_64_after_hwframe+0x44/0xa9
+Reported by Kernel Concurrency Sanitizer on:
+CPU: 1 PID: 19789 Comm: syz-executor.0 Not tainted 5.4.0-rc6+ #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+==================================================================
+Kernel panic - not syncing: panic_on_warn set ...
+CPU: 1 PID: 19789 Comm: syz-executor.0 Not tainted 5.4.0-rc6+ #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0xf5/0x159
+ panic+0x210/0x640
+ kcsan_report.cold+0xc/0xe
+ kcsan_setup_watchpoint+0x3fe/0x410
+ __tsan_unaligned_write2+0x143/0x1f0
+ netlink_recvmsg+0x196/0x910
+ sock_recvmsg+0x92/0xb0
+ __sys_recvfrom+0x1ae/0x2d0
+ __x64_sys_recvfrom+0x89/0xb0
+ do_syscall_64+0xcc/0x370
+ entry_SYSCALL_64_after_hwframe+0x44/0xa9
+RIP: 0033:0x45a219
+Code: ad b6 fb ff c3 66 2e 0f 1f 84 00 00 00 00 00 66 90 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 0f 83 7b b6 fb ff c3 66 2e 0f 1f 84 00 00 00 00
+RSP: 002b:00007f580a978c78 EFLAGS: 00000246 ORIG_RAX: 000000000000002d
+RAX: ffffffffffffffda RBX: 0000000000000006 RCX: 000000000045a219
+RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000005
+RBP: 000000000075bfc8 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 00007f580a9796d4
+R13: 00000000004c7c59 R14: 00000000004ddd80 R15: 00000000ffffffff
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/5
+++ b/pkg/report/testdata/linux/report/5
@@ -1,6 +1,7 @@
 TITLE: KASAN: invalid-free in selinux_tun_dev_free_security
 ALT: invalid-free in selinux_tun_dev_free_security
 TYPE: KASAN-INVALID-FREE
+CONTEXTS: ["console","console"]
 
 clock_gettime(0x0, &(0x7f0000475000-0x10)={<r2=>0x0, <r3=>0x0})
 write$sndseq(0xffffffffffffffff, &(0x7f0000929000-0x150)=[{0x3197a6bf, 0x0, 0x4, 0x100, @tick=0x6, {0x7, 0x6c}, {0x2, 0x9}, @connect={{0x1ff, 0x1}, {0x3ff, 0x118c}}}, {0x100000000, 0x2, 0xfffffffffffffffa, 0x2, @tick=0x5d0, {0xf556, 0x7}, {0x3, 0x1000}, @quote={{0x5, 0xfffffffffffffff7}, 0x401, &(0x7f000084a000)={0x10000, 0x9d, 0x8, 0x4, @tick=0x336f, {0x5, 0x1d}, {0x8, 0x7}, @time=@time={0x0, 0x989680}}}}, {0x200, 0x0, 0x99a, 0x6, @tick=0x1, {0x1, 0x158}, {0x200, 0x5}, @connect={{0x8, 0x4}, {0xf2, 0x100000000}}}, {0x40, 0xfffffffffffffffa, 0x100000000, 0x5, @time={r2, r3+10000000}, {0x7, 0x5}, {0x3, 0x0}, @raw32={[0x2, 0x225, 0x1]}}, {0x75f, 0x8, 0x80, 0x80, @tick=0x6, {0x9, 0x9}, {0x1, 0x6}, @queue={0x7, {0x7, 0x6}}}, {0x80, 0x6, 0x3f, 0x80000001, @time={0x0, 0x0}, {0x3f, 0x9}, {0x96, 0xfffffffffffff800}, @raw8={"e5660e9238e6f58b35448e94"}}, {0x6, 0x6f8, 0x3, 0x6, @time={0x77359400, 0x0}, {0x100000001, 0x0}, {0xe870, 0x7}, @connect={{0x4, 0x80}, {0x7ff, 0xfffffffffffffffa}}}], 0x150)
@@ -219,3 +220,38 @@ Memory state around the buggy address:
  ffff8801d5961a80: fb fb fb fb fc fc fc fc 00 00 00 fc fc fc fc fc
  ffff8801d5961b00: 04 fc fc fc fc fc fc fc fb fb fb fb fc fc fc fc
 ==================================================================
+TAIL REPORTS:
+                                           ^
+ ffff8801d5961a80: fb fb fb fb fc fc fc fc 00 00 00 fc fc fc fc fc
+ ffff8801d5961b00: 04 fc fc fc fc fc fc fc fb fb fb fb fc fc fc fc
+==================================================================
+Disabling lock debugging due to kernel taint
+Kernel panic - not syncing: panic_on_warn set ...
+
+CPU: 0 PID: 11514 Comm: syz-executor5 Tainted: G    B           4.12.0-rc7+ #2
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ dump_stack+0x194/0x257
+ panic+0x1e4/0x3fb
+ kasan_end_report+0x50/0x50
+ kasan_report_double_free+0x72/0x80
+ kasan_slab_free+0xa0/0xc0
+ kfree+0xd3/0x260
+ selinux_tun_dev_free_security+0x15/0x20
+ security_tun_dev_free_security+0x48/0x80
+ __tun_chr_ioctl+0x2cc1/0x3d60
+ tun_chr_ioctl+0x2a/0x40
+ do_vfs_ioctl+0x1b1/0x15c0
+ SyS_ioctl+0x8f/0xc0
+ entry_SYSCALL_64_fastpath+0x1f/0xbe
+RIP: 0033:0x4512c9
+RSP: 002b:00007fc65827bc08 EFLAGS: 00000216 ORIG_RAX: 0000000000000010
+RAX: ffffffffffffffda RBX: 0000000000718000 RCX: 00000000004512c9
+RDX: 000000002053c000 RSI: 00000000400454ca RDI: 0000000000000005
+RBP: 0000000000000082 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000216 R12: 00000000004baa97
+R13: 00000000ffffffff R14: 0000000020124ff3 R15: 0000000000000000
+Dumping ftrace buffer:
+   (ftrace buffer empty)
+Kernel Offset: disabled
+Rebooting in 86400 seconds..

--- a/pkg/report/testdata/linux/report/626
+++ b/pkg/report/testdata/linux/report/626
@@ -1,6 +1,7 @@
 TITLE: KMSAN: uninit-value in prepare_task_switch
 ALT: bad-access in prepare_task_switch
 TYPE: KMSAN-UNINIT-VALUE
+CONTEXTS: ["[    T1]","[    T1]"]
 
 [  567.476354][    T1] =====================================================
 [  567.483452][    T1] BUG: KMSAN: uninit-value in prepare_task_switch+0x284/0xd00
@@ -56,3 +57,33 @@ Local variable ----path@step_into created at:
  step_into+0xbc/0x1a00
  path_openat+0x3603/0x64c0
 =====================================================
+TAIL REPORTS:
+ prepare_task_switch+0x284/0xd00
+ __schedule+0x2da/0x520
+ __cond_resched+0x43/0xa0
+ __dentry_kill+0xdc2/0xe90
+ dentry_kill+0x22c/0x710
+ dput+0x3e1/0x640
+ step_into+0x923/0x1a00
+ path_openat+0x3603/0x64c0
+ do_filp_open+0x2cb/0x720
+ do_sys_openat2+0x273/0x870
+ __x64_sys_open+0x314/0x380
+ do_syscall_64+0x53/0xc0
+ entry_SYSCALL_64_after_hwframe+0x44/0xae
+Local variable ----path@step_into created at:
+ step_into+0xbc/0x1a00
+ path_openat+0x3603/0x64c0
+=====================================================
+Disabling lock debugging due to kernel taint
+Kernel panic - not syncing: panic_on_kmsan set ...
+CPU: 1 PID: 1 Comm: systemd Tainted: G    B             5.13.0-syzkaller #0c
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ __dump_stack lib/dump_stack.c:79 [inline]
+ dump_stack+0x25a/0x2f6 lib/dump_stack.c:120
+ panic+0x4c7/0xe98 kernel/panic.c:231
+ kmsan_report+0x2ee/0x300 mm/kmsan/report.c:179
+ __msan_warning+0xd7/0x150 mm/kmsan/instrumentation.c:205
+ prepare_task_switch+0x284/0xd00 kernel/sched/core.c:4146
+ context_switch kernel/sched/core.c:4302 [inline]

--- a/pkg/report/testdata/linux/report/715
+++ b/pkg/report/testdata/linux/report/715
@@ -1,5 +1,6 @@
 TITLE: WARNING in kvm_put_kvm
 TYPE: WARNING
+CONTEXTS: ["[T11919]","[T11919]"]
 
 [  554.863972][T11919] ------------[ cut here ]------------
 [  554.869480][T11919] WARNING: CPU: 0 PID: 11919 at kernel/rcu/srcutree.c:653 cleanup_srcu_struct+0x37c/0x520

--- a/pkg/report/testdata/linux/report/737
+++ b/pkg/report/testdata/linux/report/737
@@ -1,7 +1,7 @@
 TITLE: KASAN: slab-use-after-free Read in mptcp_pm_del_add_timer
 ALT: bad-access in mptcp_pm_del_add_timer
 TYPE: KASAN-USE-AFTER-FREE-READ
-FRAME: mptcp_pm_del_add_timer
+CONTEXTS: ["[    C0]","[    C0]"]
 
 [  366.491414][    C0] ==================================================================
 [  366.493841][    C0] BUG: KASAN: slab-use-after-free in lock_timer_base+0x1d9/0x220

--- a/pkg/report/testdata/linux/report/758
+++ b/pkg/report/testdata/linux/report/758
@@ -1,0 +1,790 @@
+TITLE: UBSAN: array-index-out-of-bounds in bpf_link_show_fdinfo
+ALT: bad-access in bpf_link_show_fdinfo
+TYPE: MEMORY_SAFETY_UBSAN
+EXECUTOR: proc=1, id=86
+CONTEXTS: ["[ T5524]","[ T5524]"]
+
+
+[   39.835000][   T38] audit: type=1400 audit(1758704777.688:82): avc:  denied  { name_bind } for  pid=5118 comm="sshd" src=30000 scontext=system_u:system_r:sshd_t tcontext=system_u:object_r:unreserved_port_t tclass=tcp_socket permissive=1
+[   39.869794][   T38] audit: type=1400 audit(1758704777.718:83): avc:  denied  { execute } for  pid=5120 comm="sh" name="syz-executor" dev="sda1" ino=1924 scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:etc_runtime_t tclass=file permissive=1
+[   39.872429][   T38] audit: type=1400 audit(1758704777.718:84): avc:  denied  { execute_no_trans } for  pid=5120 comm="sh" path="/syz-executor" dev="sda1" ino=1924 scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:etc_runtime_t tclass=file permissive=1
+[   41.164784][   T38] audit: type=1400 audit(1758704779.018:85): avc:  denied  { mounton } for  pid=5120 comm="syz-executor" path="/syzcgroup/unified" dev="sda1" ino=1926 scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:root_t tclass=dir permissive=1
+[   41.167868][   T38] audit: type=1400 audit(1758704779.018:86): avc:  denied  { mount } for  pid=5120 comm="syz-executor" name="/" dev="cgroup2" ino=1 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:cgroup_t tclass=filesystem permissive=1
+[   41.168575][ T5120] cgroup: Unknown subsys name 'net'
+[   41.357923][ T5120] cgroup: Unknown subsys name 'rlimit'
+[   41.638488][ T5125] SELinux:  Context root:object_r:swapfile_t is not valid (left unmapped).
+Setting up swapspace version 1, size = 127995904 bytes
+[   42.415599][ T5120] Adding 124996k swap on ./swap-file.  Priority:0 extents:1 across:124996k
+[   44.893809][   T38] kauditd_printk_skb: 17 callbacks suppressed
+[   44.893822][   T38] audit: type=1400 audit(1758704782.748:104): avc:  denied  { execmem } for  pid=5127 comm="syz-executor" scontext=root:sysadm_r:sysadm_t tcontext=root:sysadm_r:sysadm_t tclass=process permissive=1
+[   45.138492][   T38] audit: type=1400 audit(1758704782.988:105): avc:  denied  { create } for  pid=5131 comm="syz-executor" scontext=root:sysadm_r:sysadm_t tcontext=root:sysadm_r:sysadm_t tclass=bluetooth_socket permissive=1
+[   45.141571][   T38] audit: type=1400 audit(1758704782.988:106): avc:  denied  { read write } for  pid=5131 comm="syz-executor" name="vhci" dev="devtmpfs" ino=1103 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:vhost_device_t tclass=chr_file permissive=1
+[   45.144546][   T38] audit: type=1400 audit(1758704782.988:107): avc:  denied  { open } for  pid=5131 comm="syz-executor" path="/dev/vhci" dev="devtmpfs" ino=1103 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:vhost_device_t tclass=chr_file permissive=1
+[   45.150162][   T38] audit: type=1400 audit(1758704782.998:108): avc:  denied  { ioctl } for  pid=5133 comm="syz-executor" path="socket:[5449]" dev="sockfs" ino=5449 ioctlcmd=0x48c9 scontext=root:sysadm_r:sysadm_t tcontext=root:sysadm_r:sysadm_t tclass=bluetooth_socket permissive=1
+[   45.179370][ T5142] Bluetooth: hci0: unexpected cc 0x0c03 length: 249 > 1
+[   45.181827][ T5142] Bluetooth: hci0: unexpected cc 0x1003 length: 249 > 9
+[   45.183020][ T5142] Bluetooth: hci0: unexpected cc 0x1001 length: 249 > 9
+[   45.184364][ T5142] Bluetooth: hci0: unexpected cc 0x0c23 length: 249 > 4
+[   45.185536][ T5142] Bluetooth: hci0: unexpected cc 0x0c25 length: 249 > 3
+[   45.186308][ T5144] Bluetooth: hci2: unexpected cc 0x0c03 length: 249 > 1
+[   45.186479][ T5142] Bluetooth: hci0: unexpected cc 0x0c38 length: 249 > 2
+[   45.188303][ T5144] Bluetooth: hci2: unexpected cc 0x1003 length: 249 > 9
+[   45.191335][ T5145] Bluetooth: hci1: unexpected cc 0x0c03 length: 249 > 1
+[   45.191378][ T5142] Bluetooth: hci2: unexpected cc 0x1001 length: 249 > 9
+[   45.194049][ T5142] Bluetooth: hci1: unexpected cc 0x1003 length: 249 > 9
+[   45.195201][   T38] audit: type=1400 audit(1758704783.048:109): avc:  denied  { read } for  pid=5131 comm="syz-executor" dev="nsfs" ino=4026531840 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:nsfs_t tclass=file permissive=1
+[   45.195925][ T5146] Bluetooth: hci3: unexpected cc 0x0c03 length: 249 > 1
+[   45.197643][   T38] audit: type=1400 audit(1758704783.048:110): avc:  denied  { open } for  pid=5131 comm="syz-executor" path="net:[4026531840]" dev="nsfs" ino=4026531840 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:nsfs_t tclass=file permissive=1
+[   45.197673][   T38] audit: type=1400 audit(1758704783.048:111): avc:  denied  { mounton } for  pid=5131 comm="syz-executor" path="/" dev="sda1" ino=2 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:root_t tclass=dir permissive=1
+[   45.201391][ T5144] Bluetooth: hci2: unexpected cc 0x0c23 length: 249 > 4
+[   45.201877][ T5144] Bluetooth: hci2: unexpected cc 0x0c25 length: 249 > 3
+[   45.202276][ T5145] Bluetooth: hci1: unexpected cc 0x1001 length: 249 > 9
+[   45.205686][ T5146] Bluetooth: hci3: unexpected cc 0x1003 length: 249 > 9
+[   45.205730][ T5145] Bluetooth: hci1: unexpected cc 0x0c23 length: 249 > 4
+[   45.206463][ T5144] Bluetooth: hci2: unexpected cc 0x0c38 length: 249 > 2
+[   45.206551][ T5145] Bluetooth: hci1: unexpected cc 0x0c25 length: 249 > 3
+[   45.206817][ T5145] Bluetooth: hci1: unexpected cc 0x0c38 length: 249 > 2
+[   45.207587][ T5145] Bluetooth: hci3: unexpected cc 0x1001 length: 249 > 9
+[   45.219550][ T4580] Bluetooth: hci3: unexpected cc 0x0c23 length: 249 > 4
+[   45.220975][ T4580] Bluetooth: hci3: unexpected cc 0x0c25 length: 249 > 3
+[   45.222136][ T4580] Bluetooth: hci3: unexpected cc 0x0c38 length: 249 > 2
+[   45.485957][   T38] audit: type=1400 audit(1758704783.338:112): avc:  denied  { module_request } for  pid=5132 comm="syz-executor" kmod="rtnl-link-nicvf" scontext=root:sysadm_r:sysadm_t tcontext=system_u:system_r:kernel_t tclass=system permissive=1
+[   45.509602][ T5132] chnl_net:caif_netlink_parms(): no params data found
+[   45.576649][ T5131] chnl_net:caif_netlink_parms(): no params data found
+[   45.580556][ T5133] chnl_net:caif_netlink_parms(): no params data found
+[   45.732650][ T5132] bridge0: port 1(bridge_slave_0) entered blocking state
+[   45.733696][ T5132] bridge0: port 1(bridge_slave_0) entered disabled state
+[   45.735043][ T5132] bridge_slave_0: entered allmulticast mode
+[   45.736899][ T5132] bridge_slave_0: entered promiscuous mode
+[   45.744409][ T5135] chnl_net:caif_netlink_parms(): no params data found
+[   45.758337][ T5132] bridge0: port 2(bridge_slave_1) entered blocking state
+[   45.759288][ T5132] bridge0: port 2(bridge_slave_1) entered disabled state
+[   45.760272][ T5132] bridge_slave_1: entered allmulticast mode
+[   45.761790][ T5132] bridge_slave_1: entered promiscuous mode
+[   45.896141][ T5133] bridge0: port 1(bridge_slave_0) entered blocking state
+[   45.897350][ T5133] bridge0: port 1(bridge_slave_0) entered disabled state
+[   45.898296][ T5133] bridge_slave_0: entered allmulticast mode
+[   45.899842][ T5133] bridge_slave_0: entered promiscuous mode
+[   45.924638][ T5132] bond0: (slave bond_slave_0): Enslaving as an active interface with an up link
+[   45.926077][ T5131] bridge0: port 1(bridge_slave_0) entered blocking state
+[   45.926996][ T5131] bridge0: port 1(bridge_slave_0) entered disabled state
+[   45.928044][ T5131] bridge_slave_0: entered allmulticast mode
+[   45.929616][ T5131] bridge_slave_0: entered promiscuous mode
+[   45.932634][ T5131] bridge0: port 2(bridge_slave_1) entered blocking state
+[   45.933556][ T5131] bridge0: port 2(bridge_slave_1) entered disabled state
+[   45.934421][ T5131] bridge_slave_1: entered allmulticast mode
+[   45.936042][ T5131] bridge_slave_1: entered promiscuous mode
+[   45.937879][ T5133] bridge0: port 2(bridge_slave_1) entered blocking state
+[   45.939250][ T5133] bridge0: port 2(bridge_slave_1) entered disabled state
+[   45.940226][ T5133] bridge_slave_1: entered allmulticast mode
+[   45.942033][ T5133] bridge_slave_1: entered promiscuous mode
+[   45.949782][ T5132] bond0: (slave bond_slave_1): Enslaving as an active interface with an up link
+[   46.108189][ T5132] team0: Port device team_slave_0 added
+[   46.111846][ T5133] bond0: (slave bond_slave_0): Enslaving as an active interface with an up link
+[   46.135687][ T5131] bond0: (slave bond_slave_0): Enslaving as an active interface with an up link
+[   46.137436][ T5135] bridge0: port 1(bridge_slave_0) entered blocking state
+[   46.138582][ T5135] bridge0: port 1(bridge_slave_0) entered disabled state
+[   46.139732][ T5135] bridge_slave_0: entered allmulticast mode
+[   46.141305][ T5135] bridge_slave_0: entered promiscuous mode
+[   46.145279][ T5132] team0: Port device team_slave_1 added
+[   46.147956][ T5133] bond0: (slave bond_slave_1): Enslaving as an active interface with an up link
+[   46.151498][ T5131] bond0: (slave bond_slave_1): Enslaving as an active interface with an up link
+[   46.194087][ T5135] bridge0: port 2(bridge_slave_1) entered blocking state
+[   46.195302][ T5135] bridge0: port 2(bridge_slave_1) entered disabled state
+[   46.196453][ T5135] bridge_slave_1: entered allmulticast mode
+[   46.198230][ T5135] bridge_slave_1: entered promiscuous mode
+[   46.261863][ T5133] team0: Port device team_slave_0 added
+[   46.264679][ T5131] team0: Port device team_slave_0 added
+[   46.309179][ T5131] team0: Port device team_slave_1 added
+[   46.311567][ T5133] team0: Port device team_slave_1 added
+[   46.356146][ T5132] batman_adv: batadv0: Adding interface: batadv_slave_0
+[   46.357087][ T5132] batman_adv: batadv0: The MTU of interface batadv_slave_0 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.360170][ T5132] batman_adv: batadv0: Not using interface batadv_slave_0 (retrying later): interface not active
+[   46.404184][ T5135] bond0: (slave bond_slave_0): Enslaving as an active interface with an up link
+[   46.405686][ T5131] batman_adv: batadv0: Adding interface: batadv_slave_0
+[   46.406546][ T5131] batman_adv: batadv0: The MTU of interface batadv_slave_0 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.409655][ T5131] batman_adv: batadv0: Not using interface batadv_slave_0 (retrying later): interface not active
+[   46.411926][ T5132] batman_adv: batadv0: Adding interface: batadv_slave_1
+[   46.412851][ T5132] batman_adv: batadv0: The MTU of interface batadv_slave_1 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.415919][ T5132] batman_adv: batadv0: Not using interface batadv_slave_1 (retrying later): interface not active
+[   46.419662][ T5135] bond0: (slave bond_slave_1): Enslaving as an active interface with an up link
+[   46.440940][ T5131] batman_adv: batadv0: Adding interface: batadv_slave_1
+[   46.441963][ T5131] batman_adv: batadv0: The MTU of interface batadv_slave_1 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.445292][ T5131] batman_adv: batadv0: Not using interface batadv_slave_1 (retrying later): interface not active
+[   46.447181][ T5133] batman_adv: batadv0: Adding interface: batadv_slave_0
+[   46.448002][ T5133] batman_adv: batadv0: The MTU of interface batadv_slave_0 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.451438][ T5133] batman_adv: batadv0: Not using interface batadv_slave_0 (retrying later): interface not active
+[   46.478841][ T5133] batman_adv: batadv0: Adding interface: batadv_slave_1
+[   46.479693][ T5133] batman_adv: batadv0: The MTU of interface batadv_slave_1 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.482923][ T5133] batman_adv: batadv0: Not using interface batadv_slave_1 (retrying later): interface not active
+[   46.544576][ T5135] team0: Port device team_slave_0 added
+[   46.596807][ T5132] hsr_slave_0: entered promiscuous mode
+[   46.598418][ T5132] hsr_slave_1: entered promiscuous mode
+[   46.602758][ T5135] team0: Port device team_slave_1 added
+[   46.628907][ T5131] hsr_slave_0: entered promiscuous mode
+[   46.630226][ T5131] hsr_slave_1: entered promiscuous mode
+[   46.631481][ T5131] debugfs: Directory 'hsr0' with parent 'hsr' already present!
+[   46.632587][ T5131] Cannot create hsr debugfs directory
+[   46.737614][ T5135] batman_adv: batadv0: Adding interface: batadv_slave_0
+[   46.738746][ T5135] batman_adv: batadv0: The MTU of interface batadv_slave_0 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.742031][ T5135] batman_adv: batadv0: Not using interface batadv_slave_0 (retrying later): interface not active
+[   46.748286][ T5135] batman_adv: batadv0: Adding interface: batadv_slave_1
+[   46.749255][ T5135] batman_adv: batadv0: The MTU of interface batadv_slave_1 is too small (1500) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1560 would solve the problem.
+[   46.752590][ T5135] batman_adv: batadv0: Not using interface batadv_slave_1 (retrying later): interface not active
+[   46.757586][ T5133] hsr_slave_0: entered promiscuous mode
+[   46.759141][ T5133] hsr_slave_1: entered promiscuous mode
+[   46.760609][ T5133] debugfs: Directory 'hsr0' with parent 'hsr' already present!
+[   46.761824][ T5133] Cannot create hsr debugfs directory
+[   46.963539][ T5135] hsr_slave_0: entered promiscuous mode
+[   46.965413][ T5135] hsr_slave_1: entered promiscuous mode
+[   46.966616][ T5135] debugfs: Directory 'hsr0' with parent 'hsr' already present!
+[   46.967477][ T5135] Cannot create hsr debugfs directory
+[   47.211025][ T5140] Bluetooth: hci0: command 0x0409 tx timeout
+[   47.233029][ T5132] netdevsim netdevsim0 netdevsim0: renamed from eth0
+[   47.243944][ T5132] netdevsim netdevsim0 netdevsim1: renamed from eth1
+[   47.248610][ T5132] netdevsim netdevsim0 netdevsim2: renamed from eth2
+[   47.254618][ T5132] netdevsim netdevsim0 netdevsim3: renamed from eth3
+[   47.284088][ T5140] Bluetooth: hci1: command 0x0409 tx timeout
+[   47.284149][ T4580] Bluetooth: hci2: command 0x0409 tx timeout
+[   47.285328][ T5140] Bluetooth: hci3: command 0x0409 tx timeout
+[   47.294371][ T5131] netdevsim netdevsim2 netdevsim0: renamed from eth0
+[   47.299589][ T5131] netdevsim netdevsim2 netdevsim1: renamed from eth1
+[   47.304260][ T5131] netdevsim netdevsim2 netdevsim2: renamed from eth2
+[   47.311375][ T5131] netdevsim netdevsim2 netdevsim3: renamed from eth3
+[   47.352888][ T5133] netdevsim netdevsim3 netdevsim0: renamed from eth0
+[   47.357245][ T5133] netdevsim netdevsim3 netdevsim1: renamed from eth1
+[   47.369386][ T5133] netdevsim netdevsim3 netdevsim2: renamed from eth2
+[   47.375130][ T5133] netdevsim netdevsim3 netdevsim3: renamed from eth3
+[   47.451901][ T5132] 8021q: adding VLAN 0 to HW filter on device bond0
+[   47.455887][ T5135] netdevsim netdevsim1 netdevsim0: renamed from eth0
+[   47.459791][ T5135] netdevsim netdevsim1 netdevsim1: renamed from eth1
+[   47.463710][ T5135] netdevsim netdevsim1 netdevsim2: renamed from eth2
+[   47.466820][ T5135] netdevsim netdevsim1 netdevsim3: renamed from eth3
+[   47.482968][ T5132] 8021q: adding VLAN 0 to HW filter on device team0
+[   47.515451][ T1418] bridge0: port 1(bridge_slave_0) entered blocking state
+[   47.516482][ T1418] bridge0: port 1(bridge_slave_0) entered forwarding state
+[   47.518990][ T1418] bridge0: port 2(bridge_slave_1) entered blocking state
+[   47.519920][ T1418] bridge0: port 2(bridge_slave_1) entered forwarding state
+[   47.532445][ T5131] 8021q: adding VLAN 0 to HW filter on device bond0
+[   47.576092][ T5131] 8021q: adding VLAN 0 to HW filter on device team0
+[   47.590562][ T5178] bridge0: port 1(bridge_slave_0) entered blocking state
+[   47.591475][ T5178] bridge0: port 1(bridge_slave_0) entered forwarding state
+[   47.599002][ T5133] 8021q: adding VLAN 0 to HW filter on device bond0
+[   47.611010][   T39] bridge0: port 2(bridge_slave_1) entered blocking state
+[   47.612023][   T39] bridge0: port 2(bridge_slave_1) entered forwarding state
+[   47.640939][ T5133] 8021q: adding VLAN 0 to HW filter on device team0
+[   47.663012][ T5178] bridge0: port 1(bridge_slave_0) entered blocking state
+[   47.663911][ T5178] bridge0: port 1(bridge_slave_0) entered forwarding state
+[   47.668088][ T5178] bridge0: port 2(bridge_slave_1) entered blocking state
+[   47.669241][ T5178] bridge0: port 2(bridge_slave_1) entered forwarding state
+[   47.697366][   T38] audit: type=1400 audit(1758704785.548:113): avc:  denied  { sys_module } for  pid=5132 comm="syz-executor" capability=16  scontext=root:sysadm_r:sysadm_t tcontext=root:sysadm_r:sysadm_t tclass=capability permissive=1
+[   47.727292][ T5135] 8021q: adding VLAN 0 to HW filter on device bond0
+[   47.738624][ T5135] 8021q: adding VLAN 0 to HW filter on device team0
+[   47.746608][ T5177] bridge0: port 1(bridge_slave_0) entered blocking state
+[   47.747485][ T5177] bridge0: port 1(bridge_slave_0) entered forwarding state
+[   47.763025][ T5179] bridge0: port 2(bridge_slave_1) entered blocking state
+[   47.764003][ T5179] bridge0: port 2(bridge_slave_1) entered forwarding state
+[   47.792967][ T5132] 8021q: adding VLAN 0 to HW filter on device batadv0
+[   47.845041][ T5131] 8021q: adding VLAN 0 to HW filter on device batadv0
+[   47.854533][ T5132] veth0_vlan: entered promiscuous mode
+[   47.872097][ T5132] veth1_vlan: entered promiscuous mode
+[   47.888372][ T5133] 8021q: adding VLAN 0 to HW filter on device batadv0
+[   47.898395][ T5131] veth0_vlan: entered promiscuous mode
+[   47.912645][ T5131] veth1_vlan: entered promiscuous mode
+[   47.936560][ T5132] veth0_macvtap: entered promiscuous mode
+[   47.943762][ T5132] veth1_macvtap: entered promiscuous mode
+[   47.973888][ T5135] 8021q: adding VLAN 0 to HW filter on device batadv0
+[   47.979225][ T5132] batman_adv: batadv0: Interface activated: batadv_slave_0
+[   47.985148][ T5133] veth0_vlan: entered promiscuous mode
+[   47.991960][ T5131] veth0_macvtap: entered promiscuous mode
+[   47.999046][ T5133] veth1_vlan: entered promiscuous mode
+[   48.003403][ T5132] batman_adv: batadv0: Interface activated: batadv_slave_1
+[   48.011259][ T5131] veth1_macvtap: entered promiscuous mode
+[   48.015906][ T5132] netdevsim netdevsim0 netdevsim0: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.017189][ T5132] netdevsim netdevsim0 netdevsim1: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.018230][ T5132] netdevsim netdevsim0 netdevsim2: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.019347][ T5132] netdevsim netdevsim0 netdevsim3: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.033581][ T5131] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.035237][ T5131] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.037825][ T5131] batman_adv: batadv0: Interface activated: batadv_slave_0
+[   48.054609][ T5131] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.055960][ T5131] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.058431][ T5131] batman_adv: batadv0: Interface activated: batadv_slave_1
+[   48.078545][ T5135] veth0_vlan: entered promiscuous mode
+[   48.087588][ T5133] veth0_macvtap: entered promiscuous mode
+[   48.094864][ T5133] veth1_macvtap: entered promiscuous mode
+[   48.101584][ T5131] netdevsim netdevsim2 netdevsim0: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.102649][ T5131] netdevsim netdevsim2 netdevsim1: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.103714][ T5131] netdevsim netdevsim2 netdevsim2: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.105042][ T5131] netdevsim netdevsim2 netdevsim3: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.110502][ T5135] veth1_vlan: entered promiscuous mode
+[   48.135464][ T5133] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.137109][ T5133] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.138290][ T5133] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.139547][ T5133] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.142519][ T5133] batman_adv: batadv0: Interface activated: batadv_slave_0
+[   48.145836][ T5133] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.147089][ T5133] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.148259][ T5133] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.149609][ T5133] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.152479][ T5133] batman_adv: batadv0: Interface activated: batadv_slave_1
+[   48.182681][ T5133] netdevsim netdevsim3 netdevsim0: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.183942][ T5133] netdevsim netdevsim3 netdevsim1: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.185144][ T5133] netdevsim netdevsim3 netdevsim2: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.186167][ T5133] netdevsim netdevsim3 netdevsim3: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.197503][ T1081] wlan0: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.198619][ T1081] wlan0: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.238678][   T11] wlan0: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.239871][   T11] wlan0: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.241976][ T5135] veth0_macvtap: entered promiscuous mode
+[   48.270584][ T5135] veth1_macvtap: entered promiscuous mode
+[   48.272319][   T11] wlan1: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.273325][   T11] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.285745][ T1081] wlan1: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.286731][ T1081] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.295143][   T60] wlan0: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.296240][   T60] wlan0: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.315270][   T60] wlan1: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.315991][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.316269][   T60] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.317645][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.319623][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.321973][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.323132][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3e) already exists on: batadv_slave_0
+[   48.324285][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.326884][ T5135] batman_adv: batadv0: Interface activated: batadv_slave_0
+[   48.334208][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.335441][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.336547][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.337737][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.338865][ T5135] batman_adv: The newly added mac address (aa:aa:aa:aa:aa:3f) already exists on: batadv_slave_1
+[   48.340035][ T5135] batman_adv: It is strongly recommended to keep mac addresses unique to avoid problems!
+[   48.342940][ T5135] batman_adv: batadv0: Interface activated: batadv_slave_1
+[   48.347450][ T5135] netdevsim netdevsim1 netdevsim0: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.348540][ T5135] netdevsim netdevsim1 netdevsim1: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.349757][ T5135] netdevsim netdevsim1 netdevsim2: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.350785][ T5135] netdevsim netdevsim1 netdevsim3: set [1, 0] type 2 family 0 port 6081 - 0
+[   48.395652][ T1081] wlan0: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.396752][ T1081] wlan0: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.422769][ T1081] wlan1: Created IBSS using preconfigured BSSID 50:50:50:50:50:50
+[   48.423780][ T1081] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   48.445181][ T5204] netlink: 8 bytes leftover after parsing attributes in process `syz.0.1'.
+[   48.570012][ T5219] syz.0.10[5219]: memfd_create() called without MFD_EXEC or MFD_NOEXEC_SEAL set
+[   48.595951][ T5219] loop0: detected capacity change from 0 to 2048
+[   48.627475][ T5219] EXT4-fs (loop0): mounted filesystem 00000000-0000-0000-0000-000000000000 r/w without journal. Quota mode: none.
+[   48.629929][ T5219] ext4 filesystem being mounted at /2/file0 supports timestamps until 2038-01-19 (0x7fffffff)
+[   48.638954][ T5224] netlink: 12 bytes leftover after parsing attributes in process `syz.2.12'.
+[   48.648725][ T5229] loop3: detected capacity change from 0 to 256
+[   48.678033][ T5229] FAT-fs (loop3): Directory bread(block 64) failed
+[   48.679692][ T5229] FAT-fs (loop3): Directory bread(block 65) failed
+[   48.681825][ T5229] FAT-fs (loop3): Directory bread(block 66) failed
+[   48.682987][ T5229] FAT-fs (loop3): Directory bread(block 67) failed
+[   48.683766][ T5229] FAT-fs (loop3): Directory bread(block 68) failed
+[   48.684537][ T5229] FAT-fs (loop3): Directory bread(block 69) failed
+[   48.685331][ T5229] FAT-fs (loop3): Directory bread(block 70) failed
+[   48.685375][ T5132] EXT4-fs (loop0): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   48.686097][ T5229] FAT-fs (loop3): Directory bread(block 71) failed
+[   48.688492][ T5229] FAT-fs (loop3): Directory bread(block 72) failed
+[   48.689367][ T5229] FAT-fs (loop3): Directory bread(block 73) failed
+[   49.281017][ T5145] Bluetooth: hci0: command 0x041b tx timeout
+[   49.370841][ T5145] Bluetooth: hci3: command 0x041b tx timeout
+[   49.371812][ T5145] Bluetooth: hci2: command 0x041b tx timeout
+[   49.372647][ T5145] Bluetooth: hci1: command 0x041b tx timeout
+[   49.846600][ T5250] loop0: detected capacity change from 0 to 32768
+[   49.848550][ T5253] loop3: detected capacity change from 0 to 32768
+[   49.852937][ T5250] BTRFS: device fsid 395ef67a-297e-477c-816d-cd80a5b93e5d devid 1 transid 8 /dev/loop0 scanned by syz.0.22 (5250)
+[   49.858424][ T5253] BTRFS: device fsid ed167579-eb65-4e76-9a50-61ac97e9b59d devid 1 transid 8 /dev/loop3 scanned by syz.3.24 (5253)
+[   49.863451][ T5250] BTRFS info (device loop0): first mount of filesystem 395ef67a-297e-477c-816d-cd80a5b93e5d
+[   49.864847][ T5250] BTRFS info (device loop0): using sha256 (sha256-ni) checksum algorithm
+[   49.865966][ T5250] BTRFS info (device loop0): using free space tree
+[   49.869047][ T5253] BTRFS info (device loop3): first mount of filesystem ed167579-eb65-4e76-9a50-61ac97e9b59d
+[   49.870278][ T5253] BTRFS info (device loop3): using sha256 (sha256-ni) checksum algorithm
+[   49.872488][ T5253] BTRFS info (device loop3): setting incompat feature flag for COMPRESS_LZO (0x8)
+[   49.874152][ T5253] BTRFS info (device loop3): use lzo compression, level 0
+[   49.875207][ T5253] BTRFS info (device loop3): max_inline at 0
+[   49.875913][ T5253] BTRFS info (device loop3): force clearing of disk cache
+[   49.876754][ T5253] BTRFS info (device loop3): turning on sync discard
+[   49.877579][ T5253] BTRFS info (device loop3): disabling free space tree
+[   49.878776][ T5253] BTRFS info (device loop3): setting nodatasum
+[   49.902574][ T5257] loop1: detected capacity change from 0 to 32768
+[   49.903857][ T5257] =======================================================
+[   49.903857][ T5257] WARNING: The mand mount option has been deprecated and
+[   49.903857][ T5257]          and is ignored by this kernel. Remove the mand
+[   49.903857][ T5257]          option from the mount to silence this warning.
+[   49.903857][ T5257] =======================================================
+[   49.915808][ T5250] BTRFS info (device loop0): enabling ssd optimizations
+[   49.916680][ T5250] BTRFS info (device loop0): auto enabling async discard
+[   49.929826][ T5253] BTRFS info (device loop3): enabling ssd optimizations
+[   49.932363][ T5253] BTRFS info (device loop3): rebuilding free space tree
+[   49.967775][ T5253] BTRFS info (device loop3): disabling free space tree
+[   49.968739][ T5253] BTRFS info (device loop3): clearing compat-ro feature flag for FREE_SPACE_TREE (0x1)
+[   49.970063][ T5253] BTRFS info (device loop3): clearing compat-ro feature flag for FREE_SPACE_TREE_VALID (0x2)
+[   49.970419][ T5257] JBD2: Ignoring recovery information on journal
+[   49.976378][   T38] kauditd_printk_skb: 59 callbacks suppressed
+[   49.976386][   T38] audit: type=1400 audit(1758704787.828:173): avc:  denied  { write } for  pid=5249 comm="syz.0.22" name="file0" dev="loop0" ino=257 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:unlabeled_t tclass=dir permissive=1
+[   49.986975][   T38] audit: type=1400 audit(1758704787.838:174): avc:  denied  { add_name } for  pid=5249 comm="syz.0.22" name="bus" scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:unlabeled_t tclass=dir permissive=1
+[   49.990049][   T38] audit: type=1400 audit(1758704787.838:175): avc:  denied  { create } for  pid=5249 comm="syz.0.22" name="bus" scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:unlabeled_t tclass=file permissive=1
+[   49.997065][   T38] audit: type=1400 audit(1758704787.848:176): avc:  denied  { read write open } for  pid=5249 comm="syz.0.22" path="/4/file0/file0/bus" dev="loop0" ino=263 scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:unlabeled_t tclass=file permissive=1
+[   50.005354][ T5257] ocfs2: Mounting device (7,1) on (node local, slot 0) with ordered data mode.
+[   50.026454][   T38] audit: type=1400 audit(1758704787.878:177): avc:  denied  { setattr } for  pid=5251 comm="syz.3.24" path="/5/file1" dev="loop3" ino=256 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:unlabeled_t tclass=dir permissive=1
+[   50.029430][   T38] audit: type=1400 audit(1758704787.878:178): avc:  denied  { write } for  pid=5256 comm="syz.1.25" name="/" dev="loop1" ino=65 scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:unlabeled_t tclass=dir permissive=1
+[   50.034583][   T38] audit: type=1400 audit(1758704787.878:179): avc:  denied  { add_name } for  pid=5256 comm="syz.1.25" name="cgroup.controllers" scontext=root:sysadm_r:sysadm_t tcontext=system_u:object_r:unlabeled_t tclass=dir permissive=1
+[   50.047265][   T38] audit: type=1400 audit(1758704787.878:180): avc:  denied  { associate } for  pid=5256 comm="syz.1.25" name="cgroup.controllers" scontext=root:object_r:unlabeled_t tcontext=system_u:object_r:unlabeled_t tclass=filesystem permissive=1
+[   50.050306][   T38] audit: type=1400 audit(1758704787.878:181): avc:  denied  { create } for  pid=5251 comm="syz.3.24" name="file0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:unlabeled_t tclass=chr_file permissive=1
+[   50.055698][   T38] audit: type=1400 audit(1758704787.898:182): avc:  denied  { append } for  pid=5256 comm="syz.1.25" path="/4/file1/cgroup.controllers" dev="loop1" ino=17058 scontext=root:sysadm_r:sysadm_t tcontext=root:object_r:unlabeled_t tclass=file permissive=1
+[   50.078339][ T5132] BTRFS info (device loop0): last unmount of filesystem 395ef67a-297e-477c-816d-cd80a5b93e5d
+[   50.082029][ T5133] BTRFS info (device loop3): last unmount of filesystem ed167579-eb65-4e76-9a50-61ac97e9b59d
+[   50.233130][ T5135] ocfs2: Unmounting device (7,1) on (node local)
+[   50.328206][ T5301] loop0: detected capacity change from 0 to 4096
+[   50.336458][ T5301] ntfs3: loop0: Different NTFS sector size (1024) and media sector size (512).
+[   50.349871][ T5301] ntfs3: loop0: ino=3, ntfs_iget5
+[   50.350643][ T5301] ntfs3: loop0: Mark volume as dirty due to NTFS errors
+[   50.413872][ T5305] loop1: detected capacity change from 0 to 512
+[   50.421893][ T5299] loop3: detected capacity change from 0 to 32768
+[   50.421968][ T5305] EXT4-fs error (device loop1): ext4_xattr_ibody_find:2263: inode #15: comm syz.1.31: corrupted in-inode xattr: invalid ea_ino
+[   50.423674][ T5299] BTRFS: device fsid ed167579-eb65-4e76-9a50-61ac97e9b59d devid 1 transid 8 /dev/loop3 scanned by syz.3.29 (5299)
+[   50.424852][ T5305] EXT4-fs error (device loop1): ext4_orphan_get:1397: comm syz.1.31: couldn't read orphan inode 15 (err -117)
+[   50.428626][ T5305] EXT4-fs (loop1): mounted filesystem 00000000-0000-0000-0000-000000000000 r/w without journal. Quota mode: none.
+[   50.435145][ T5299] BTRFS info (device loop3): first mount of filesystem ed167579-eb65-4e76-9a50-61ac97e9b59d
+[   50.436869][ T5299] BTRFS info (device loop3): using sha256 (sha256-ni) checksum algorithm
+[   50.437952][ T5299] BTRFS info (device loop3): using free space tree
+[   50.459303][ T5299] BTRFS info (device loop3): enabling ssd optimizations
+[   50.460198][ T5299] BTRFS info (device loop3): auto enabling async discard
+[   50.462860][ T5135] EXT4-fs (loop1): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   50.517050][ T5299] BTRFS info (device loop3): balance: start -d -m
+[   50.526156][ T5299] BTRFS info (device loop3): relocating block group 6881280 flags data|metadata
+[   50.573524][ T5299] BTRFS info (device loop3): found 2 extents, stage: move data extents
+[   50.598078][ T5299] BTRFS info (device loop3): relocating block group 5242880 flags data|metadata
+[   50.658122][ T5299] BTRFS info (device loop3): found 9 extents, stage: move data extents
+[   50.696712][ T5299] BTRFS info (device loop3): found 1 extents, stage: update data pointers
+[   50.717964][ T5299] BTRFS info (device loop3): balance: ended with status: 0
+[   50.753551][ T5133] BTRFS info (device loop3): last unmount of filesystem ed167579-eb65-4e76-9a50-61ac97e9b59d
+[   50.770223][ T5338] loop2: detected capacity change from 0 to 2048
+[   50.799636][ T5338] UDF-fs: INFO Mounting volume 'LinuxUDF', timestamp 2022/11/22 14:59 (1000)
+[   51.012539][ T5358] loop2: detected capacity change from 0 to 512
+[   51.027843][ T5358] EXT4-fs error (device loop2): ext4_orphan_get:1394: inode #15: comm syz.2.46: casefold flag without casefold feature
+[   51.029589][ T5358] EXT4-fs error (device loop2): ext4_orphan_get:1397: comm syz.2.46: couldn't read orphan inode 15 (err -117)
+[   51.033727][ T5358] EXT4-fs (loop2): mounted filesystem 00000000-0000-0000-0000-000000000000 r/w without journal. Quota mode: writeback.
+[   51.071995][ T5360] kvm: kvm [5359]: vcpu1, guest rIP: 0xfff0 Unhandled WRMSR(0xc0010015) = 0xfffffeb7
+[   51.152826][ T5353] loop0: detected capacity change from 0 to 32768
+[   51.155490][ T5353] BTRFS: device fsid c9fe44da-de57-406a-8241-57ec7d4412cf devid 1 transid 8 /dev/loop0 scanned by syz.0.43 (5353)
+[   51.187417][ T5353] BTRFS info (device loop0): first mount of filesystem c9fe44da-de57-406a-8241-57ec7d4412cf
+[   51.188876][ T5353] BTRFS info (device loop0): using crc32c (crc32c-intel) checksum algorithm
+[   51.190563][ T5353] BTRFS info (device loop0): metadata ratio 4
+[   51.191978][ T5353] BTRFS info (device loop0): setting incompat feature flag for COMPRESS_LZO (0x8)
+[   51.193193][ T5353] BTRFS info (device loop0): force lzo compression, level 0
+[   51.194664][ T5353] BTRFS warning (device loop0): 'usebackuproot' is deprecated, use 'rescue=usebackuproot' instead
+[   51.196582][ T5353] BTRFS info (device loop0): trying to use backup root at mount time
+[   51.197853][ T5353] BTRFS info (device loop0): use zlib compression, level 3
+[   51.198464][ T5131] EXT4-fs (loop2): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   51.199170][ T5353] BTRFS info (device loop0): enabling ssd optimizations
+[   51.208422][ T5353] BTRFS info (device loop0): disabling tree log
+[   51.209601][ T5353] BTRFS info (device loop0): using free space tree
+[   51.251540][ T1082] BTRFS warning (device loop0): checksum verify failed on logical 5332992 mirror 1 wanted 0x0a5e5d25 found 0x26333c6f level 0
+[   51.254245][ T5353] BTRFS warning (device loop0): couldn't read tree root
+[   51.255048][ T5353] BTRFS warning (device loop0): try to load backup roots slot 1
+[   51.255988][ T5365] loop3: detected capacity change from 0 to 32768
+[   51.261942][ T1082] BTRFS warning (device loop0): checksum verify failed on logical 5324800 mirror 1 wanted 0x9f73850b found 0x78ca8373 level 0
+[   51.263651][ T5353] BTRFS warning (device loop0): couldn't read tree root
+[   51.264519][ T5353] BTRFS warning (device loop0): try to load backup roots slot 2
+[   51.267868][ T1082] BTRFS error (device loop0): level verify failed on logical 5255168 mirror 1 wanted 0 found 1
+[   51.269914][ T5353] BTRFS warning (device loop0): couldn't read tree root
+[   51.272209][ T5353] BTRFS warning (device loop0): try to load backup roots slot 3
+[   51.295287][ T5353] BTRFS info (device loop0): auto enabling async discard
+[   51.301566][ T5353] BTRFS info (device loop0): rebuilding free space tree
+[   51.321216][ T5353] BTRFS info (device loop0): checking UUID tree
+[   51.344723][ T5393] loop2: detected capacity change from 0 to 256
+[   51.371601][ T5140] Bluetooth: hci0: command 0x040f tx timeout
+[   51.384144][ T5393] exFAT-fs (loop2): failed to load upcase table (idx : 0x00010000, chksum : 0xbe675ead, utbl_chksum : 0xe619d30d)
+[   51.392397][ T5365] ERROR: (device loop3): jfs_readdir: JFS:Dtree error: ino = 2, bn=44, index = 1
+[   51.392397][ T5365]
+[   51.395546][ T5365] ERROR: (device loop3): remounting filesystem as read-only
+[   51.396491][ T5365] non-latin1 character 0x3ff found in JFS file name
+[   51.397305][ T5365] mount with iocharset=utf8 to access
+[   51.441987][ T5140] Bluetooth: hci2: command 0x040f tx timeout
+[   51.442120][ T5145] Bluetooth: hci3: command 0x040f tx timeout
+[   51.455909][ T5145] Bluetooth: hci1: command 0x040f tx timeout
+[   51.499246][ T5132] BTRFS info (device loop0): last unmount of filesystem c9fe44da-de57-406a-8241-57ec7d4412cf
+[   51.502598][ T5396] UDPLite6: UDP-Lite is deprecated and scheduled to be removed in 2025, please contact the netdev mailing list
+[   51.517180][ T5392] loop1: detected capacity change from 0 to 32768
+[   51.531113][ T5392] BTRFS: device fsid e417788f-7a09-42b2-9266-8ddc5d5d35d2 devid 1 transid 8 /dev/loop1 scanned by syz.1.53 (5392)
+[   51.575676][ T5392] BTRFS info (device loop1): first mount of filesystem e417788f-7a09-42b2-9266-8ddc5d5d35d2
+[   51.577191][ T5392] BTRFS info (device loop1): using xxhash64 (xxhash64-generic) checksum algorithm
+[   51.578308][ T5392] BTRFS info (device loop1): force zlib compression, level 3
+[   51.579437][ T5392] BTRFS info (device loop1): force clearing of disk cache
+[   51.580372][ T5392] BTRFS info (device loop1): setting nodatasum
+[   51.586801][ T5392] BTRFS info (device loop1): disabling tree log
+[   51.587765][ T5392] BTRFS info (device loop1): enabling disk space caching
+[   51.588619][ T5392] BTRFS info (device loop1): disk space caching is enabled
+[   51.708284][ T5392] BTRFS info (device loop1): auto enabling async discard
+[   51.709872][ T5392] BTRFS info (device loop1): rebuilding free space tree
+[   51.740155][ T5392] BTRFS info (device loop1): disabling free space tree
+[   51.744753][ T5392] BTRFS info (device loop1): clearing compat-ro feature flag for FREE_SPACE_TREE (0x1)
+[   51.746028][ T5392] BTRFS info (device loop1): clearing compat-ro feature flag for FREE_SPACE_TREE_VALID (0x2)
+[   51.814448][ T5411] loop0: detected capacity change from 0 to 32768
+[   51.821960][ T5411] BTRFS: device fsid 24c7a497-3402-47dd-bef8-82358f5f30e0 devid 1 transid 8 /dev/loop0 scanned by syz.0.56 (5411)
+[   51.841191][ T5411] BTRFS info (device loop0): first mount of filesystem 24c7a497-3402-47dd-bef8-82358f5f30e0
+[   51.842549][ T5411] BTRFS info (device loop0): using crc32c (crc32c-intel) checksum algorithm
+[   51.843782][ T5411] BTRFS info (device loop0): enabling disk space caching
+[   51.844657][ T5411] BTRFS info (device loop0): force clearing of disk cache
+[   51.845693][ T5411] BTRFS info (device loop0): setting incompat feature flag for COMPRESS_ZSTD (0x10)
+[   51.846954][ T5411] BTRFS info (device loop0): use zstd compression, level 3
+[   51.847811][ T5411] BTRFS info (device loop0): disk space caching is enabled
+[   51.930759][ T5411] BTRFS info (device loop0): enabling ssd optimizations
+[   51.931699][ T5411] BTRFS info (device loop0): auto enabling async discard
+[   51.933758][ T5411] BTRFS info (device loop0): rebuilding free space tree
+[   51.935760][ T5427] loop2: detected capacity change from 0 to 40427
+[   51.942814][ T5411] BTRFS info (device loop0): disabling free space tree
+[   51.943701][ T5411] BTRFS info (device loop0): clearing compat-ro feature flag for FREE_SPACE_TREE (0x1)
+[   51.949470][ T5411] BTRFS info (device loop0): clearing compat-ro feature flag for FREE_SPACE_TREE_VALID (0x2)
+[   51.956478][ T5427] F2FS-fs (loop2): invalid crc value
+[   51.965345][ T5427] F2FS-fs (loop2): Found nat_bits in checkpoint
+[   51.997821][ T5427] F2FS-fs (loop2): Mounted with checkpoint version = 48b305e5
+[   52.023703][ T5427] syz.2.61: attempt to access beyond end of device
+[   52.023703][ T5427] loop2: rw=2049, sector=45096, nr_sectors = 8 limit=40427
+[   52.101931][ T5132] BTRFS info (device loop0): last unmount of filesystem 24c7a497-3402-47dd-bef8-82358f5f30e0
+[   52.115284][ T5392] BTRFS warning (device loop1): this kernel does not support the compat:5,compat:6,compat:8,compat:13,compat:14,compat:21,compat:24,compat:29,compat:30,compat:32,compat:34,compat:37,compat:38,compat:41,compat:42,compat:43,compat:45,compat:46,compat:50,compat:52,compat:53,compat:54,compat:56,compat:61 feature bits
+[   52.157866][ T5135] BTRFS info (device loop1): last unmount of filesystem e417788f-7a09-42b2-9266-8ddc5d5d35d2
+[   52.467439][ T5463] Bluetooth: MGMT ver 1.22
+[   52.468396][ T5463] Bluetooth: hci1: too big key_count value 32778
+[   52.504091][ T5465] loop1: detected capacity change from 0 to 1024
+[   52.507100][ T5465] EXT4-fs (loop1): stripe (65535) is not aligned with cluster size (4096), stripe is disabled
+[   52.510219][ T5465] EXT4-fs (loop1): revision level too high, forcing read-only mode
+[   52.516295][ T5465] EXT4-fs (loop1): orphan cleanup on readonly fs
+[   52.518464][ T5465] EXT4-fs warning (device loop1): ext4_enable_quotas:7093: Failed to enable quota tracking (type=0, err=-5, ino=3). Please run e2fsck to fix.
+[   52.520628][ T5465] EXT4-fs (loop1): Cannot turn on quotas: error -5
+[   52.528177][ T5465] EXT4-fs (loop1): 1 truncate cleaned up
+[   52.529056][ T5465] EXT4-fs (loop1): mounted filesystem 00000000-0000-0000-0000-000000000000 ro without journal. Quota mode: writeback.
+[   52.582308][ T5135] EXT4-fs (loop1): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   52.699031][ T5476] loop1: detected capacity change from 0 to 1024
+[   52.700442][ T5476] EXT4-fs: Ignoring removed nobh option
+[   52.701923][ T5476] EXT4-fs: Ignoring removed bh option
+[   52.703083][ T5476] EXT4-fs: Warning: mounting with an experimental mount option 'dioread_nolock' for blocksize < PAGE_SIZE
+[   52.704993][ T5476] EXT4-fs (loop1): stripe (8) is not aligned with cluster size (16), stripe is disabled
+[   52.714318][ T5476] EXT4-fs (loop1): mounted filesystem 00000000-0000-0000-0000-000000000000 r/w without journal. Quota mode: none.
+[   52.756292][ T5459] loop2: detected capacity change from 0 to 65536
+[   52.768122][ T5459] XFS (loop2): DAX unsupported by block device. Turning off DAX.
+[   52.771022][ T5459] XFS (loop2): Mounting V5 Filesystem 9b7348e5-2fa0-41a5-9526-c53a678b01f3
+[   52.778303][ T5135] EXT4-fs (loop1): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   52.819009][ T5459] XFS (loop2): Ending clean mount
+[   52.832677][ T5488] loop1: detected capacity change from 0 to 2048
+[   52.860641][ T5489] NILFS (loop1): segctord starting. Construction interval = 5 seconds, CP frequency < 30 seconds
+[   52.909960][ T5131] XFS (loop2): Unmounting Filesystem 9b7348e5-2fa0-41a5-9526-c53a678b01f3
+[   52.996385][ T5489] NILFS (loop1): vblocknr = 23 has abnormal lifetime: start cno (= 4294967298) > current cno (= 3)
+[   52.998313][ T5489] NILFS error (device loop1): nilfs_bmap_propagate: broken bmap (inode number=4)
+[   53.013417][ T5489] Remounting filesystem read-only
+[   53.020726][ T1082] NILFS (loop1): discard dirty page: offset=4096, ino=6
+[   53.021878][ T1082] NILFS (loop1): discard dirty block: blocknr=39, size=1024
+[   53.022799][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.023917][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.025023][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.026116][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=3
+[   53.026946][ T1082] NILFS (loop1): discard dirty block: blocknr=42, size=1024
+[   53.027853][ T1082] NILFS (loop1): discard dirty block: blocknr=43, size=1024
+[   53.028836][ T1082] NILFS (loop1): discard dirty block: blocknr=44, size=1024
+[   53.029723][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.037018][ T1082] NILFS (loop1): discard dirty page: offset=65536, ino=3
+[   53.037896][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.039299][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.040461][ T1082] NILFS (loop1): discard dirty block: blocknr=0, size=1024
+[   53.050934][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.052080][ T1082] NILFS (loop1): discard dirty page: offset=98304, ino=3
+[   53.052974][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.054228][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.055469][ T1082] NILFS (loop1): discard dirty block: blocknr=0, size=1024
+[   53.056321][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.057434][ T1082] NILFS (loop1): discard dirty page: offset=196608, ino=3
+[   53.058284][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.059373][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.060436][ T1082] NILFS (loop1): discard dirty block: blocknr=49, size=1024
+[   53.066586][ T5491] loop0: detected capacity change from 0 to 16
+[   53.069517][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.071300][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=18
+[   53.072740][ T1082] NILFS (loop1): discard dirty block: blocknr=0, size=1024
+[   53.073661][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.074875][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.076011][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.082347][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=2
+[   53.083159][ T1082] NILFS (loop1): discard dirty block: blocknr=18, size=1024
+[   53.084008][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.085065][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.086287][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.087409][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=19
+[   53.088238][ T1082] NILFS (loop1): discard dirty block: blocknr=0, size=1024
+[   53.089186][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.090269][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.093140][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.094283][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=5
+[   53.095662][ T1082] NILFS (loop1): discard dirty block: blocknr=41, size=1024
+[   53.096554][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.097620][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.098750][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.099834][ T1082] NILFS (loop1): discard dirty page: offset=0, ino=4
+[   53.101548][ T1082] NILFS (loop1): discard dirty block: blocknr=40, size=1024
+[   53.102461][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.103551][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.104653][ T1082] NILFS (loop1): discard dirty block: blocknr=18446744073709551615, size=1024
+[   53.109636][ T5491] cramfs: Error -3 while decompressing!
+[   53.109721][ T5493] syz_tun: entered allmulticast mode
+[   53.111218][ T5135] NILFS (loop1): disposed unprocessed dirty file(s) when stopping log writer
+[   53.112445][ T5491] cramfs: ffffffff9216c968(27)->ffff88804a16c000(4096)
+[   53.114360][ T5491] cramfs: Error -3 while decompressing!
+[   53.114394][ T5135] NILFS (loop1): discard dirty page: offset=0, ino=6
+[   53.115062][ T5491] cramfs: ffffffff9216c983(16)->ffff88802df68000(4096)
+[   53.115873][ T5135] NILFS (loop1): discard dirty block: blocknr=35, size=1024
+[   53.117075][ T5491] cramfs: Error -3 while decompressing!
+[   53.117174][ T5492] syz_tun: left allmulticast mode
+[   53.117915][ T5135] NILFS (loop1): discard dirty block: blocknr=36, size=1024
+[   53.129390][ T5135] NILFS (loop1): discard dirty block: blocknr=37, size=1024
+[   53.131016][ T5135] NILFS (loop1): discard dirty block: blocknr=38, size=1024
+[   53.133263][ T5491] cramfs: ffffffff9216c968(27)->ffff88804a16c000(4096)
+[   53.417942][ T5499] loop0: detected capacity change from 0 to 32768
+[   53.440806][ T5145] Bluetooth: hci0: command 0x0419 tx timeout
+[   53.444796][ T5499] XFS (loop0): Mounting V5 Filesystem bfdc47fc-10d8-4eed-a562-11a831b3f791
+[   53.484771][ T5499] XFS (loop0): Ending clean mount
+[   53.492456][ T5499] XFS (loop0): Quotacheck needed: Please wait.
+[   53.519682][ T5499] XFS (loop0): Quotacheck: Done.
+[   53.529930][ T5145] Bluetooth: hci2: command 0x0419 tx timeout
+[   53.530848][ T5140] Bluetooth: hci1: command 0x0419 tx timeout
+[   53.530898][ T5140] Bluetooth: hci3: command 0x0419 tx timeout
+[   53.582010][ T5516] loop1: detected capacity change from 0 to 2048
+[   53.619577][ T5516] EXT4-fs (loop1): mounted filesystem 00000000-0000-0000-0000-000000000000 r/w without journal. Quota mode: writeback.
+[   53.649204][ T5132] XFS (loop0): Unmounting Filesystem bfdc47fc-10d8-4eed-a562-11a831b3f791
+[   53.661880][ T5135] EXT4-fs (loop1): unmounting filesystem 00000000-0000-0000-0000-000000000000.
+[   53.743252][ T5524] ================================================================================
+[   53.744600][ T5524] UBSAN: array-index-out-of-bounds in kernel/bpf/syscall.c:2906:24
+[   53.745559][ T5524] index 11 is out of range for type 'char *[10]'
+[   53.746432][ T5524] CPU: 0 PID: 5524 Comm: syz.1.86 Not tainted 6.6.6 #3
+[   53.747299][ T5524] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
+[   53.748858][ T5524] Call Trace:
+[   53.749302][ T5524]  <TASK>
+[   53.750442][ T5524]  dump_stack_lvl+0x131/0x1a0
+[   53.751285][ T5524]  ubsan_epilogue+0xa/0x40
+[   53.752399][ T5524]  __ubsan_handle_out_of_bounds+0x7d/0x8d
+[   53.753198][ T5524]  bpf_link_show_fdinfo+0x2e1/0x330
+[   53.753861][ T5524]  ? __bpf_prog_put_rcu+0xf0/0xf0
+[   53.754727][ T5524]  ? spin_bug+0x160/0x1d0
+[   53.755358][ T5524]  ? __bpf_prog_put_rcu+0xf0/0xf0
+[   53.755961][ T5524]  seq_show+0x56d/0x890
+[   53.756468][ T5524]  seq_read_iter+0x318/0x1230
+[   53.757065][ T5524]  seq_read+0x196/0x240
+[   53.757593][ T5524]  ? seq_read_iter+0x1230/0x1230
+[   53.758209][ T5524]  ? avc_policy_seqno+0x9/0x10
+[   53.758909][ T5524]  ? selinux_file_permission+0x9b/0x5d0
+[   53.759778][ T5524]  ? security_file_permission+0x9d/0x6f0
+[   53.760485][ T5524]  vfs_read+0x1dd/0x930
+[   53.761503][ T5524]  ? seq_read_iter+0x1230/0x1230
+[   53.762123][ T5524]  ? kernel_read+0x1b0/0x1b0
+[   53.762710][ T5524]  ? __fget_files+0x272/0x410
+[   53.763307][ T5524]  __x64_sys_pread64+0x1fa/0x250
+[   53.763926][ T5524]  ? ksys_pread64+0x1a0/0x1a0
+[   53.764516][ T5524]  ? syscall_enter_from_user_mode+0x7f/0x120
+[   53.765285][ T5524]  do_syscall_64+0x3a/0xb0
+[   53.765861][ T5524]  entry_SYSCALL_64_after_hwframe+0x63/0xcd
+[   53.766655][ T5524] RIP: 0033:0x7f141b78ebe9
+[   53.767232][ T5524] Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+[   53.769961][ T5524] RSP: 002b:00007f141c634038 EFLAGS: 00000246 ORIG_RAX: 0000000000000011
+[   53.771225][ T5524] RAX: ffffffffffffffda RBX: 00007f141b9c5fa0 RCX: 00007f141b78ebe9
+[   53.772404][ T5524] RDX: 0000000000000011 RSI: 0000200000002140 RDI: 0000000000000005
+[   53.773454][ T5524] RBP: 00007f141b811e19 R08: 0000000000000000 R09: 0000000000000000
+[   53.774432][ T5524] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+[   53.775493][ T5524] R13: 00007f141b9c6038 R14: 00007f141b9c5fa0 R15: 00007ffc73fe9088
+[   53.776491][ T5524]  </TASK>
+[   53.786402][ T5524] ================================================================================
+[   53.787528][ T5524] ==================================================================
+[   53.788518][ T5524] BUG: KASAN: global-out-of-bounds in bpf_link_show_fdinfo+0x2c5/0x330
+[   53.789600][ T5524] Read of size 8 at addr ffffffff8a73d798 by task syz.1.86/5524
+[   53.790577][ T5524]
+[   53.790885][ T5524] CPU: 0 PID: 5524 Comm: syz.1.86 Not tainted 6.6.6 #3
+[   53.791742][ T5524] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
+[   53.793125][ T5524] Call Trace:
+[   53.793691][ T5524]  <TASK>
+[   53.794161][ T5524]  dump_stack_lvl+0xd7/0x1a0
+[   53.794737][ T5524]  print_report+0xc4/0x630
+[   53.795294][ T5524]  ? __virt_addr_valid+0x5e/0x2d0
+[   53.795938][ T5524]  ? __phys_addr+0xc6/0x140
+[   53.796533][ T5524]  kasan_report+0xd8/0x110
+[   53.797158][ T5524]  ? bpf_link_show_fdinfo+0x2c5/0x330
+[   53.797830][ T5524]  ? bpf_link_show_fdinfo+0x2c5/0x330
+[   53.798483][ T5524]  bpf_link_show_fdinfo+0x2c5/0x330
+[   53.799155][ T5524]  ? __bpf_prog_put_rcu+0xf0/0xf0
+[   53.799785][ T5524]  ? spin_bug+0x160/0x1d0
+[   53.800353][ T5524]  ? __bpf_prog_put_rcu+0xf0/0xf0
+[   53.801030][ T5524]  seq_show+0x56d/0x890
+[   53.801644][ T5524]  seq_read_iter+0x318/0x1230
+[   53.802321][ T5524]  seq_read+0x196/0x240
+[   53.802851][ T5524]  ? seq_read_iter+0x1230/0x1230
+[   53.803460][ T5524]  ? avc_policy_seqno+0x9/0x10
+[   53.804065][ T5524]  ? selinux_file_permission+0x9b/0x5d0
+[   53.804791][ T5524]  ? security_file_permission+0x9d/0x6f0
+[   53.805493][ T5524]  vfs_read+0x1dd/0x930
+[   53.806009][ T5524]  ? seq_read_iter+0x1230/0x1230
+[   53.806632][ T5524]  ? kernel_read+0x1b0/0x1b0
+[   53.807219][ T5524]  ? __fget_files+0x272/0x410
+[   53.807820][ T5524]  __x64_sys_pread64+0x1fa/0x250
+[   53.808496][ T5524]  ? ksys_pread64+0x1a0/0x1a0
+[   53.809229][ T5524]  ? syscall_enter_from_user_mode+0x7f/0x120
+[   53.810018][ T5524]  do_syscall_64+0x3a/0xb0
+[   53.810627][ T5524]  entry_SYSCALL_64_after_hwframe+0x63/0xcd
+[   53.811384][ T5524] RIP: 0033:0x7f141b78ebe9
+[   53.811947][ T5524] Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+[   53.814558][ T5524] RSP: 002b:00007f141c634038 EFLAGS: 00000246 ORIG_RAX: 0000000000000011
+[   53.815656][ T5524] RAX: ffffffffffffffda RBX: 00007f141b9c5fa0 RCX: 00007f141b78ebe9
+[   53.816689][ T5524] RDX: 0000000000000011 RSI: 0000200000002140 RDI: 0000000000000005
+[   53.817695][ T5524] RBP: 00007f141b811e19 R08: 0000000000000000 R09: 0000000000000000
+[   53.818717][ T5524] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+[   53.819728][ T5524] R13: 00007f141b9c6038 R14: 00007f141b9c5fa0 R15: 00007ffc73fe9088
+[   53.820720][ T5524]  </TASK>
+[   53.821137][ T5524]
+[   53.821426][ T5524] The buggy address belongs to the variable:
+[   53.822144][ T5524]  bpf_link_type_strs+0x58/0x80
+[   53.822731][ T5524]
+[   53.823024][ T5524] The buggy address belongs to the physical page:
+[   53.823821][ T5524] page:ffffea000029cf40 refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0xa73d
+[   53.825084][ T5524] flags: 0xfff00000004000(reserved|node=0|zone=1|lastcpupid=0x7ff)
+[   53.826033][ T5524] page_type: 0xffffffff()
+[   53.826559][ T5524] raw: 00fff00000004000 ffffea000029cf48 ffffea000029cf48 0000000000000000
+[   53.827596][ T5524] raw: 0000000000000000 0000000000000000 00000001ffffffff 0000000000000000
+[   53.828662][ T5524] page dumped because: kasan: bad access detected
+[   53.829531][ T5524] page_owner info is not present (never set?)
+[   53.830313][ T5524]
+[   53.830599][ T5524] Memory state around the buggy address:
+[   53.831291][ T5524]  ffffffff8a73d680: 05 f9 f9 f9 f9 f9 f9 f9 00 05 f9 f9 f9 f9 f9 f9
+[   53.832290][ T5524]  ffffffff8a73d700: 00 03 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
+[   53.833311][ T5524] >ffffffff8a73d780: 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
+[   53.834304][ T5524]                             ^
+[   53.834910][ T5524]  ffffffff8a73d800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[   53.835873][ T5524]  ffffffff8a73d880: 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
+[   53.836853][ T5524] ==================================================================
+[   53.847664][ T5524] Disabling lock debugging due to kernel taint
+[   53.978580][ T5526] loop0: detected capacity change from 0 to 32768
+[   53.986688][ T5526] BTRFS: device fsid 14d642db-7b15-43e4-81e6-4b8fac6a25f8 devid 1 transid 8 /dev/loop0 scanned by syz.0.84 (5526)
+[   53.989868][ T5526] BTRFS info (device loop0): first mount of filesystem 14d642db-7b15-43e4-81e6-4b8fac6a25f8
+[   53.991513][ T5526] BTRFS info (device loop0): using blake2b (blake2b-256-generic) checksum algorithm
+[   53.992719][ T5526] BTRFS info (device loop0): setting incompat feature flag for COMPRESS_ZSTD (0x10)
+[   53.994392][ T5526] BTRFS info (device loop0): use zstd compression, level 3
+[   53.995398][ T5526] BTRFS info (device loop0): using free space tree
+[   54.000483][ T5473] loop3: detected capacity change from 0 to 262144
+[   54.006498][ T5473] BTRFS: device fsid 7e32c2af-f87a-45a1-bcba-64dea7c56a53 devid 1 transid 8 /dev/loop3 scanned by syz.3.71 (5473)
+[   54.009302][ T5473] BTRFS info (device loop3): first mount of filesystem 7e32c2af-f87a-45a1-bcba-64dea7c56a53
+[   54.009415][ T5526] BTRFS info (device loop0): enabling ssd optimizations
+[   54.010598][ T5473] BTRFS info (device loop3): using xxhash64 (xxhash64-generic) checksum algorithm
+[   54.012832][ T5526] BTRFS info (device loop0): auto enabling async discard
+[   54.013930][ T5473] BTRFS info (device loop3): turning on sync discard
+[   54.014820][ T5473] BTRFS info (device loop3): using free space tree
+[   54.066018][ T5132] BTRFS info (device loop0): last unmount of filesystem 14d642db-7b15-43e4-81e6-4b8fac6a25f8
+[   54.099107][ T5473] BTRFS info (device loop3): enabling ssd optimizations
+[   54.139536][ T5473] BTRFS info (device loop3): balance: start -d -msoft,profiles=data|system|metadata|raid1|dup|raid5|0x800,usage=4294478459,devid=18446744065119619255,vrange=18446744039349813511..42175,limit=18446744069414593304,stripes=0..0 -ssoft,profiles=data|system|metadata|raid1|dup|raid5|0x800,usage=4294478459,devid=18446744065119619255,vrange=18446744039349813511..42175,limit=18446744069414593304,stripes=0..0
+[   54.144968][ T5473] BTRFS info (device loop3): left=0, need=393216, flags=34
+[   54.145948][ T5473] BTRFS info (device loop3): space_info SYSTEM has 0 free, is not full
+[   54.147108][ T5473] BTRFS info (device loop3): space_info total=8388608, used=16384, pinned=0, reserved=0, may_use=0, readonly=8372224 zone_unusable=0
+[   54.149006][ T5473] BTRFS info (device loop3): global_block_rsv: size 5767168 reserved 5767168
+[   54.150227][ T5473] BTRFS info (device loop3): trans_block_rsv: size 0 reserved 0
+[   54.151305][ T5473] BTRFS info (device loop3): chunk_block_rsv: size 0 reserved 0
+[   54.152292][ T5473] BTRFS info (device loop3): delayed_block_rsv: size 0 reserved 0
+[   54.153376][ T5473] BTRFS info (device loop3): delayed_refs_rsv: size 0 reserved 0
+[   54.156100][ T5473] BTRFS info (device loop3): relocating block group 22020096 flags system|dup
+[   54.170238][ T5473] BTRFS info (device loop3): relocating block group 13631488 flags data
+
+REPORT:
+================================================================================
+UBSAN: array-index-out-of-bounds in kernel/bpf/syscall.c:2906:24
+index 11 is out of range for type 'char *[10]'
+CPU: 0 PID: 5524 Comm: syz.1.86 Not tainted 6.6.6 #3
+Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
+Call Trace:
+ <TASK>
+ dump_stack_lvl+0x131/0x1a0
+ ubsan_epilogue+0xa/0x40
+ __ubsan_handle_out_of_bounds+0x7d/0x8d
+ bpf_link_show_fdinfo+0x2e1/0x330
+ seq_show+0x56d/0x890
+ seq_read_iter+0x318/0x1230
+ seq_read+0x196/0x240
+ vfs_read+0x1dd/0x930
+ __x64_sys_pread64+0x1fa/0x250
+ do_syscall_64+0x3a/0xb0
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7f141b78ebe9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007f141c634038 EFLAGS: 00000246 ORIG_RAX: 0000000000000011
+RAX: ffffffffffffffda RBX: 00007f141b9c5fa0 RCX: 00007f141b78ebe9
+RDX: 0000000000000011 RSI: 0000200000002140 RDI: 0000000000000005
+RBP: 00007f141b811e19 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+R13: 00007f141b9c6038 R14: 00007f141b9c5fa0 R15: 00007ffc73fe9088
+ </TASK>
+================================================================================
+==================================================================
+TAIL REPORTS:
+index 11 is out of range for type 'char *[10]'
+CPU: 0 PID: 5524 Comm: syz.1.86 Not tainted 6.6.6 #3
+Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
+Call Trace:
+ <TASK>
+ dump_stack_lvl+0x131/0x1a0
+ ubsan_epilogue+0xa/0x40
+ __ubsan_handle_out_of_bounds+0x7d/0x8d
+ bpf_link_show_fdinfo+0x2e1/0x330
+ seq_show+0x56d/0x890
+ seq_read_iter+0x318/0x1230
+ seq_read+0x196/0x240
+ vfs_read+0x1dd/0x930
+ __x64_sys_pread64+0x1fa/0x250
+ do_syscall_64+0x3a/0xb0
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7f141b78ebe9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007f141c634038 EFLAGS: 00000246 ORIG_RAX: 0000000000000011
+RAX: ffffffffffffffda RBX: 00007f141b9c5fa0 RCX: 00007f141b78ebe9
+RDX: 0000000000000011 RSI: 0000200000002140 RDI: 0000000000000005
+RBP: 00007f141b811e19 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+R13: 00007f141b9c6038 R14: 00007f141b9c5fa0 R15: 00007ffc73fe9088
+ </TASK>
+================================================================================
+==================================================================
+BUG: KASAN: global-out-of-bounds in bpf_link_show_fdinfo+0x2c5/0x330
+Read of size 8 at addr ffffffff8a73d798 by task syz.1.86/5524
+CPU: 0 PID: 5524 Comm: syz.1.86 Not tainted 6.6.6 #3
+Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
+Call Trace:
+ <TASK>
+ dump_stack_lvl+0xd7/0x1a0
+ print_report+0xc4/0x630
+ kasan_report+0xd8/0x110
+ bpf_link_show_fdinfo+0x2c5/0x330
+ seq_show+0x56d/0x890
+ seq_read_iter+0x318/0x1230
+ seq_read+0x196/0x240
+ vfs_read+0x1dd/0x930
+ __x64_sys_pread64+0x1fa/0x250
+ do_syscall_64+0x3a/0xb0
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7f141b78ebe9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007f141c634038 EFLAGS: 00000246 ORIG_RAX: 0000000000000011
+RAX: ffffffffffffffda RBX: 00007f141b9c5fa0 RCX: 00007f141b78ebe9
+RDX: 0000000000000011 RSI: 0000200000002140 RDI: 0000000000000005
+RBP: 00007f141b811e19 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+R13: 00007f141b9c6038 R14: 00007f141b9c5fa0 R15: 00007ffc73fe9088
+ </TASK>
+The buggy address belongs to the variable:
+ bpf_link_type_strs+0x58/0x80
+The buggy address belongs to the physical page:
+page:ffffea000029cf40 refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0xa73d
+flags: 0xfff00000004000(reserved|node=0|zone=1|lastcpupid=0x7ff)
+page_type: 0xffffffff()
+raw: 00fff00000004000 ffffea000029cf48 ffffea000029cf48 0000000000000000
+raw: 0000000000000000 0000000000000000 00000001ffffffff 0000000000000000
+page dumped because: kasan: bad access detected
+page_owner info is not present (never set?)
+Memory state around the buggy address:
+ ffffffff8a73d680: 05 f9 f9 f9 f9 f9 f9 f9 00 05 f9 f9 f9 f9 f9 f9
+ ffffffff8a73d700: 00 03 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
+>ffffffff8a73d780: 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
+                            ^
+ ffffffff8a73d800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+ ffffffff8a73d880: 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
+==================================================================

--- a/pkg/report/testdata/linux/report/759
+++ b/pkg/report/testdata/linux/report/759
@@ -1,0 +1,654 @@
+TITLE: WARNING in __ieee80211_beacon_get
+TYPE: WARNING
+EXECUTOR: proc=9, id=803
+CONTEXTS: ["[    C0]", "[    C0]"]
+
+[  366.491414][    C0] ==================================================================
+[  366.496192][    C0] Read of size 4 at addr ffff88804c251150 by task kworker/0:4/5994
+[  366.499406][    C0]
+[  366.500718][    C0] CPU: 0 UID: 0 PID: 5994 Comm: kworker/0:4 Not tainted 6.13.0-rc5-syzkaller-00004-gccb98ccef0e5 #0
+[  366.503926][    C0] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2~bpo12+1 04/01/2014
+[  366.507144][    C0] Workqueue: events mptcp_worker
+[  366.508666][    C0] Call Trace:
+[  366.509672][    C0]  <IRQ>
+[  366.510557][    C0]  dump_stack_lvl+0x116/0x1f0
+[  366.511982][    C0]  print_report+0xc3/0x620
+[  366.513334][    C0]  ? __virt_addr_valid+0x5e/0x590
+[  366.514857][    C0]  ? __phys_addr+0xc6/0x150
+[  366.516247][    C0]  kasan_report+0xd9/0x110
+[  366.517624][    C0]  ? lock_timer_base+0x1d9/0x220
+[  366.519118][    C0]  ? lock_timer_base+0x1d9/0x220
+[  366.520622][    C0]  lock_timer_base+0x1d9/0x220
+[  366.522072][    C0]  __try_to_del_timer_sync+0x8d/0x170
+[  366.523702][    C0]  ? __pfx___try_to_del_timer_sync+0x10/0x10
+[  366.525476][    C0]  ? __timer_delete_sync+0x174/0x1b0
+[  366.527089][    C0]  __timer_delete_sync+0xf4/0x1b0
+[  366.528625][    C0]  sk_stop_timer_sync+0x1b/0x80
+[  366.530095][    C0]  mptcp_pm_del_add_timer+0x1ae/0x320
+[  366.531732][    C0]  mptcp_incoming_options+0x1f4d/0x26a0
+[  366.533412][    C0]  ? __pfx_mptcp_incoming_options+0x10/0x10
+[  366.535183][    C0]  ? tcp_parse_options+0x1f0/0x1380
+[  366.536945][    C0]  tcp_data_queue+0x187e/0x4d80
+[  366.538436][    C0]  ? tcp_urg+0x110/0xb80
+[  366.539729][    C0]  ? __pfx_tcp_data_queue+0x10/0x10
+[  366.541296][    C0]  ? tcp_send_dupack+0x7f0/0x810
+[  366.542995][    C0]  ? read_tsc+0x9/0x20
+[  366.544238][    C0]  ? ktime_get+0x1ac/0x300
+[  366.545590][    C0]  tcp_rcv_established+0x7df/0x20d0
+[  366.547163][    C0]  ? __pfx_tcp_rcv_established+0x10/0x10
+[  366.548859][    C0]  ? do_raw_spin_lock+0x12d/0x2c0
+[  366.550379][    C0]  ? __pfx_ipv4_dst_check+0x10/0x10
+[  366.552070][    C0]  tcp_v4_do_rcv+0x5ca/0xa90
+[  366.553464][    C0]  tcp_v4_rcv+0x33b4/0x43a0
+[  366.554862][    C0]  ? __pfx_tcp_v4_rcv+0x10/0x10
+[  366.556363][    C0]  ? __pfx_raw_local_deliver+0x10/0x10
+[  366.557985][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.559444][    C0]  ? __pfx_tcp_v4_rcv+0x10/0x10
+[  366.560924][    C0]  ip_protocol_deliver_rcu+0xba/0x4c0
+[  366.562542][    C0]  ip_local_deliver_finish+0x316/0x570
+[  366.564184][    C0]  ip_local_deliver+0x18e/0x1f0
+[  366.565653][    C0]  ? __pfx_ip_local_deliver+0x10/0x10
+[  366.567272][    C0]  ip_rcv+0x2c3/0x5d0
+[  366.568497][    C0]  ? __pfx_ip_rcv+0x10/0x10
+[  366.569867][    C0]  __netif_receive_skb_one_core+0x199/0x1e0
+[  366.571652][    C0]  ? __pfx___netif_receive_skb_one_core+0x10/0x10
+[  366.573549][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.574990][    C0]  ? process_backlog+0x3f1/0x15f0
+[  366.576533][    C0]  ? process_backlog+0x3f1/0x15f0
+[  366.578053][    C0]  __netif_receive_skb+0x1d/0x160
+[  366.579582][    C0]  process_backlog+0x443/0x15f0
+[  366.581063][    C0]  __napi_poll.constprop.0+0xb7/0x550
+[  366.582689][    C0]  net_rx_action+0xa94/0x1010
+[  366.584128][    C0]  ? __pfx_net_rx_action+0x10/0x10
+[  366.585672][    C0]  ? __pfx_mark_lock+0x10/0x10
+[  366.587126][    C0]  ? trace_rcu_utilization+0x106/0x170
+[  366.588856][    C0]  ? kvm_sched_clock_read+0x11/0x20
+[  366.590525][    C0]  ? sched_clock+0x38/0x60
+[  366.591880][    C0]  ? sched_clock_cpu+0x6d/0x4d0
+[  366.593336][    C0]  ? mark_held_locks+0x9f/0xe0
+[  366.594778][    C0]  handle_softirqs+0x213/0x8f0
+[  366.596233][    C0]  ? __pfx_handle_softirqs+0x10/0x10
+[  366.597822][    C0]  ? __mptcp_pm_send_ack+0x1d3/0x1f0
+[  366.599367][    C0]  do_softirq+0xb2/0xf0
+[  366.600632][    C0]  </IRQ>
+[  366.601520][    C0]  <TASK>
+[  366.602413][    C0]  __local_bh_enable_ip+0x100/0x120
+[  366.603999][    C0]  __mptcp_pm_send_ack+0x1d3/0x1f0
+[  366.605548][    C0]  mptcp_pm_nl_addr_send_ack+0x422/0x4b0
+[  366.607365][    C0]  ? __pfx_mptcp_pm_nl_addr_send_ack+0x10/0x10
+[  366.609229][    C0]  ? mptcp_pm_nl_work+0xa7/0x4f0
+[  366.610797][    C0]  mptcp_pm_nl_work+0x29e/0x4f0
+[  366.612544][    C0]  mptcp_worker+0x15a/0x1240
+[  366.614210][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.616073][    C0]  ? __pfx_mptcp_worker+0x10/0x10
+[  366.617599][    C0]  ? process_one_work+0x8bb/0x1b30
+[  366.619125][    C0]  ? lock_acquire+0x2f/0xb0
+[  366.620504][    C0]  ? process_one_work+0x8bb/0x1b30
+[  366.622030][    C0]  process_one_work+0x958/0x1b30
+[  366.623515][    C0]  ? __pfx_lock_acquire.part.0+0x10/0x10
+[  366.625229][    C0]  ? __pfx_process_one_work+0x10/0x10
+[  366.626848][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.628303][    C0]  ? assign_work+0x1a0/0x250
+[  366.629694][    C0]  worker_thread+0x6c8/0xf00
+[  366.631098][    C0]  ? __kthread_parkme+0x148/0x220
+[  366.632648][    C0]  ? __pfx_worker_thread+0x10/0x10
+[  366.634199][    C0]  kthread+0x2c1/0x3a0
+[  366.635434][    C0]  ? _raw_spin_unlock_irq+0x23/0x50
+[  366.637017][    C0]  ? __pfx_kthread+0x10/0x10
+[  366.638421][    C0]  ret_from_fork+0x45/0x80
+[  366.639778][    C0]  ? __pfx_kthread+0x10/0x10
+[  366.641174][    C0]  ret_from_fork_asm+0x1a/0x30
+[  366.642620][    C0]  </TASK>
+[  366.643737][    C0]
+[  366.644461][    C0] Allocated by task 14842:
+[  366.645801][    C0]  kasan_save_stack+0x33/0x60
+[  366.647222][    C0]  kasan_save_track+0x14/0x30
+[  366.648642][    C0]  __kasan_kmalloc+0xaa/0xb0
+[  366.650023][    C0]  mptcp_pm_alloc_anno_list+0x1cb/0x520
+[  366.651683][    C0]  mptcp_pm_create_subflow_or_signal_addr+0x6c5/0x23a0
+[  366.653754][    C0]  mptcp_pm_nl_add_addr_doit+0x68b/0xc80
+[  366.655429][    C0]  genl_family_rcv_msg_doit+0x202/0x2f0
+[  366.657142][    C0]  genl_rcv_msg+0x565/0x800
+[  366.658692][    C0]  netlink_rcv_skb+0x165/0x410
+[  366.660153][    C0]  genl_rcv+0x28/0x40
+[  366.661361][    C0]  netlink_unicast+0x53c/0x7f0
+[  366.662798][    C0]  netlink_sendmsg+0x8b8/0xd70
+[  366.664534][    C0]  ____sys_sendmsg+0x9ae/0xb40
+[  366.666331][    C0]  ___sys_sendmsg+0x135/0x1e0
+[  366.667941][    C0]  __sys_sendmsg+0x16e/0x220
+[  366.669402][    C0]  __do_fast_syscall_32+0x73/0x120
+[  366.671050][    C0]  do_fast_syscall_32+0x32/0x80
+[  366.672570][    C0]  entry_SYSENTER_compat_after_hwframe+0x84/0x8e
+[  366.674752][    C0]
+[  366.675481][    C0] Freed by task 14842:
+[  366.676740][    C0]  kasan_save_stack+0x33/0x60
+[  366.678148][    C0]  kasan_save_track+0x14/0x30
+[  366.679559][    C0]  kasan_save_free_info+0x3b/0x60
+[  366.681080][    C0]  __kasan_slab_free+0x51/0x70
+[  366.682520][    C0]  kfree+0x14f/0x4b0
+[  366.683723][    C0]  mptcp_pm_nl_flush_addrs_doit+0x526/0xeb0
+[  366.685485][    C0]  genl_family_rcv_msg_doit+0x202/0x2f0
+[  366.687138][    C0]  genl_rcv_msg+0x565/0x800
+[  366.688512][    C0]  netlink_rcv_skb+0x165/0x410
+[  366.689948][    C0]  genl_rcv+0x28/0x40
+[  366.691155][    C0]  netlink_unicast+0x53c/0x7f0
+[  366.692658][    C0]  netlink_sendmsg+0x8b8/0xd70
+[  366.694192][    C0]  ____sys_sendmsg+0x9ae/0xb40
+[  366.695647][    C0]  ___sys_sendmsg+0x135/0x1e0
+[  366.697097][    C0]  __sys_sendmsg+0x16e/0x220
+[  366.698805][    C0]  __do_fast_syscall_32+0x73/0x120
+[  366.700485][    C0]  do_fast_syscall_32+0x32/0x80
+[  366.702366][    C0]  entry_SYSENTER_compat_after_hwframe+0x84/0x8e
+[  366.704363][    C0]
+[  366.705339][    C0] The buggy address belongs to the object at ffff88804c251100
+[  366.705339][    C0]  which belongs to the cache kmalloc-192 of size 192
+[  366.710481][    C0] The buggy address is located 80 bytes inside of
+[  366.710481][    C0]  freed 192-byte region [ffff88804c251100, ffff88804c2511c0)
+[  366.715110][    C0]
+[  366.715935][    C0] The buggy address belongs to the physical page:
+[  366.718332][    C0] page: refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0x4c251
+[  366.721038][    C0] flags: 0x4fff00000000000(node=1|zone=1|lastcpupid=0x7ff)
+[  366.723221][    C0] page_type: f5(slab)
+[  366.724448][    C0] raw: 04fff00000000000 ffff88801ac423c0 dead000000000100 dead000000000122
+[  366.727027][    C0] raw: 0000000000000000 0000000080100010 00000001f5000000 0000000000000000
+[  366.729638][    C0] page dumped because: kasan: bad access detected
+[  366.731570][    C0] page_owner tracks the page as allocated
+[  366.733286][    C0] page last allocated via order 0, migratetype Unmovable, gfp_mask 0x52820(GFP_ATOMIC|__GFP_NOWARN|__GFP_NORETRY|__GFP_COMP), pid 12746, tgid 12746 (syz-executor), ts 293886128856, free_ts 293881630196
+[  366.739050][    C0]  post_alloc_hook+0x2d1/0x350
+[  366.740492][    C0]  get_page_from_freelist+0xfce/0x2f80
+[  366.742115][    C0]  __alloc_pages_noprof+0x223/0x25b0
+[  366.743711][    C0]  alloc_pages_mpol_noprof+0x2c9/0x610
+[  366.745354][    C0]  new_slab+0x2c9/0x410
+[  366.746622][    C0]  ___slab_alloc+0xce2/0x1650
+[  366.748049][    C0]  __slab_alloc.constprop.0+0x56/0xb0
+[  366.749653][    C0]  __kmalloc_cache_noprof+0xf6/0x420
+[  366.751240][    C0]  addr_event.part.0+0x7b/0x4f0
+[  366.752704][    C0]  inet6addr_event+0x165/0x1e0
+[  366.754315][    C0]  notifier_call_chain+0xb7/0x410
+[  366.755839][    C0]  atomic_notifier_call_chain+0x71/0x1c0
+[  366.757527][    C0]  ipv6_add_addr+0x13a2/0x2010
+[  366.758963][    C0]  addrconf_add_linklocal+0x2a6/0x620
+[  366.760582][    C0]  addrconf_addr_gen+0x37b/0x3d0
+[  366.762108][    C0]  addrconf_init_auto_addrs+0x446/0x820
+[  366.763760][    C0] page last free pid 11901 tgid 11901 stack trace:
+[  366.765697][    C0]  free_unref_page+0x661/0x1080
+[  366.767179][    C0]  vfree+0x174/0x950
+[  366.768378][    C0]  xt_compat_flush_offsets+0x8f/0x160
+[  366.769987][    C0]  translate_compat_table+0x128d/0x18e0
+[  366.771966][    C0]  compat_do_replace+0x35d/0x500
+[  366.773458][    C0]  do_ip6t_set_ctl+0x686/0xc20
+[  366.774905][    C0]  nf_setsockopt+0x8a/0xf0
+[  366.776274][    C0]  ipv6_setsockopt+0x135/0x170
+[  366.777697][    C0]  tcp_setsockopt+0xa4/0x100
+[  366.779092][    C0]  do_sock_setsockopt+0x222/0x480
+[  366.780611][    C0]  __sys_setsockopt+0x1a0/0x230
+[  366.782076][    C0]  __do_compat_sys_socketcall+0x51c/0x700
+[  366.783845][    C0]  __do_fast_syscall_32+0x73/0x120
+[  366.785380][    C0]  do_fast_syscall_32+0x32/0x80
+[  366.786860][    C0]  entry_SYSENTER_compat_after_hwframe+0x84/0x8e
+[  366.788775][    C0]
+[  366.789505][    C0] Memory state around the buggy address:
+[  366.791181][    C0]  ffff88804c251000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[  366.793842][    C0]  ffff88804c251080: 00 00 00 00 00 00 00 00 fc fc fc fc fc fc fc fc
+[  366.796255][    C0] >ffff88804c251100: fa fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  366.798638][    C0]                                                  ^
+[  366.800630][    C0]  ffff88804c251180: fb fb fb fb fb fb fb fb fc fc fc fc fc fc fc fc
+[  366.803012][    C0]  ffff88804c251200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[  366.805405][    C0] ==================================================================
+[  366.810020][    C0] CPU: 0 UID: 0 PID: 5994 Comm: kworker/0:4 Not tainted 6.13.0-rc5-syzkaller-00004-gccb98ccef0e5 #0
+[  366.813398][    C0] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.3-debian-1.16.3-2~bpo12+1 04/01/2014
+[  366.816669][    C0] Workqueue: events mptcp_worker
+[  366.818170][    C0] Call Trace:
+[  366.819242][    C0]  <IRQ>
+[  366.820130][    C0]  dump_stack_lvl+0x3d/0x1f0
+[  366.821529][    C0]  panic+0x71d/0x800
+[  366.823027][    C0]  ? __pfx_panic+0x10/0x10
+[  366.824657][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.826540][    C0]  ? __pfx_lock_release+0x10/0x10
+[  366.828446][    C0]  ? check_panic_on_warn+0x1f/0xb0
+[  366.830433][    C0]  check_panic_on_warn+0xab/0xb0
+[  366.832276][    C0]  end_report+0x117/0x180
+[  366.833907][    C0]  kasan_report+0xe9/0x110
+[  366.835659][    C0]  ? lock_timer_base+0x1d9/0x220
+[  366.837289][    C0]  ? lock_timer_base+0x1d9/0x220
+[  366.838821][    C0]  lock_timer_base+0x1d9/0x220
+[  366.840325][    C0]  __try_to_del_timer_sync+0x8d/0x170
+[  366.842020][    C0]  ? __pfx___try_to_del_timer_sync+0x10/0x10
+[  366.844039][    C0]  ? __timer_delete_sync+0x174/0x1b0
+[  366.846112][    C0]  __timer_delete_sync+0xf4/0x1b0
+[  366.848118][    C0]  sk_stop_timer_sync+0x1b/0x80
+[  366.850042][    C0]  mptcp_pm_del_add_timer+0x1ae/0x320
+[  366.852029][    C0]  mptcp_incoming_options+0x1f4d/0x26a0
+[  366.853981][    C0]  ? __pfx_mptcp_incoming_options+0x10/0x10
+[  366.855634][    C0]  ? tcp_parse_options+0x1f0/0x1380
+[  366.857150][    C0]  tcp_data_queue+0x187e/0x4d80
+[  366.858997][    C0]  ? tcp_urg+0x110/0xb80
+[  366.860622][    C0]  ? __pfx_tcp_data_queue+0x10/0x10
+[  366.862418][    C0]  ? tcp_send_dupack+0x7f0/0x810
+[  366.863976][    C0]  ? read_tsc+0x9/0x20
+[  366.865199][    C0]  ? ktime_get+0x1ac/0x300
+[  366.866557][    C0]  tcp_rcv_established+0x7df/0x20d0
+[  366.868134][    C0]  ? __pfx_tcp_rcv_established+0x10/0x10
+[  366.869988][    C0]  ? do_raw_spin_lock+0x12d/0x2c0
+[  366.871503][    C0]  ? __pfx_ipv4_dst_check+0x10/0x10
+[  366.872948][    C0]  tcp_v4_do_rcv+0x5ca/0xa90
+[  366.874291][    C0]  tcp_v4_rcv+0x33b4/0x43a0
+[  366.875668][    C0]  ? __pfx_tcp_v4_rcv+0x10/0x10
+[  366.877084][    C0]  ? __pfx_raw_local_deliver+0x10/0x10
+[  366.878713][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.880168][    C0]  ? __pfx_tcp_v4_rcv+0x10/0x10
+[  366.881651][    C0]  ip_protocol_deliver_rcu+0xba/0x4c0
+[  366.883384][    C0]  ip_local_deliver_finish+0x316/0x570
+[  366.885030][    C0]  ip_local_deliver+0x18e/0x1f0
+[  366.886504][    C0]  ? __pfx_ip_local_deliver+0x10/0x10
+[  366.888123][    C0]  ip_rcv+0x2c3/0x5d0
+[  366.889330][    C0]  ? __pfx_ip_rcv+0x10/0x10
+[  366.890716][    C0]  __netif_receive_skb_one_core+0x199/0x1e0
+[  366.892515][    C0]  ? __pfx___netif_receive_skb_one_core+0x10/0x10
+[  366.894429][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.895886][    C0]  ? process_backlog+0x3f1/0x15f0
+[  366.897414][    C0]  ? process_backlog+0x3f1/0x15f0
+[  366.898936][    C0]  __netif_receive_skb+0x1d/0x160
+[  366.900449][    C0]  process_backlog+0x443/0x15f0
+[  366.901925][    C0]  __napi_poll.constprop.0+0xb7/0x550
+[  366.903583][    C0]  net_rx_action+0xa94/0x1010
+[  366.905394][    C0]  ? __pfx_net_rx_action+0x10/0x10
+[  366.907437][    C0]  ? __pfx_mark_lock+0x10/0x10
+[  366.908973][    C0]  ? trace_rcu_utilization+0x106/0x170
+[  366.910614][    C0]  ? kvm_sched_clock_read+0x11/0x20
+[  366.912183][    C0]  ? sched_clock+0x38/0x60
+[  366.913526][    C0]  ? sched_clock_cpu+0x6d/0x4d0
+[  366.914985][    C0]  ? mark_held_locks+0x9f/0xe0
+[  366.916456][    C0]  handle_softirqs+0x213/0x8f0
+[  366.917890][    C0]  ? __pfx_handle_softirqs+0x10/0x10
+[  366.919474][    C0]  ? __mptcp_pm_send_ack+0x1d3/0x1f0
+[  366.921060][    C0]  do_softirq+0xb2/0xf0
+[  366.922350][    C0]  </IRQ>
+[  366.923336][    C0]  <TASK>
+[  366.924454][    C0]  __local_bh_enable_ip+0x100/0x120
+[  366.926093][    C0]  __mptcp_pm_send_ack+0x1d3/0x1f0
+[  366.927635][    C0]  mptcp_pm_nl_addr_send_ack+0x422/0x4b0
+[  366.929488][    C0]  ? __pfx_mptcp_pm_nl_addr_send_ack+0x10/0x10
+[  366.931328][    C0]  ? mptcp_pm_nl_work+0xa7/0x4f0
+[  366.932830][    C0]  mptcp_pm_nl_work+0x29e/0x4f0
+[  366.934286][    C0]  mptcp_worker+0x15a/0x1240
+[  366.935676][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.937139][    C0]  ? __pfx_mptcp_worker+0x10/0x10
+[  366.938643][    C0]  ? process_one_work+0x8bb/0x1b30
+[  366.940186][    C0]  ? lock_acquire+0x2f/0xb0
+[  366.941545][    C0]  ? process_one_work+0x8bb/0x1b30
+[  366.943414][    C0]  process_one_work+0x958/0x1b30
+[  366.944961][    C0]  ? __pfx_lock_acquire.part.0+0x10/0x10
+[  366.946664][    C0]  ? __pfx_process_one_work+0x10/0x10
+[  366.948450][    C0]  ? rcu_is_watching+0x12/0xc0
+[  366.950345][    C0]  ? assign_work+0x1a0/0x250
+[  366.952156][    C0]  worker_thread+0x6c8/0xf00
+[  366.953595][    C0]  ? __kthread_parkme+0x148/0x220
+[  366.955097][    C0]  ? __pfx_worker_thread+0x10/0x10
+[  366.956648][    C0]  kthread+0x2c1/0x3a0
+[  366.957868][    C0]  ? _raw_spin_unlock_irq+0x23/0x50
+[  366.959429][    C0]  ? __pfx_kthread+0x10/0x10
+[  366.960829][    C0]  ret_from_fork+0x45/0x80
+[  366.962162][    C0]  ? __pfx_kthread+0x10/0x10
+[  366.963546][    C0]  ret_from_fork_asm+0x1a/0x30
+[  366.964992][    C0]  </TASK>
+[  366.964992][    C1] next report starts here
+[  456.493487][    C0] WARNING: net/mac80211/tx.c:5024 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+[  456.504170][    C0] Modules linked in:
+[  456.508373][    C0] CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full)
+[  456.519883][    C0] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  456.529983][    C0] RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+[  456.536355][    C0] Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+[  456.556047][    C0] RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+[  456.562128][    C0] RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+[  456.570166][    C0] RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+[  456.578202][    C0] RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+[  456.586217][    C0] R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+[  456.594216][    C0] R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+[  456.602240][    C0] FS:  0000000000000000(0000) GS:ffff888125d40000(0000) knlGS:0000000000000000
+[  456.611234][    C0] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[  456.617865][    C0] CR2: 00007fd624370000 CR3: 000000000df38000 CR4: 00000000003526f0
+[  456.625879][    C0] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[  456.633857][    C0] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[  456.641894][    C0] Call Trace:
+[  456.645219][    C0]  <IRQ>
+[  456.648074][    C0]  ? __ieee80211_beacon_get+0x36/0x1630
+[  456.653659][    C0]  ieee80211_beacon_get_tim+0xb4/0x2b0
+[  456.659163][    C0]  ? __pfx_ieee80211_beacon_get_tim+0x10/0x10
+[  456.665278][    C0]  mac80211_hwsim_beacon_tx+0x3ce/0x860
+[  456.670840][    C0]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  456.678073][    C0]  __iterate_interfaces+0x2a8/0x590
+[  456.683279][    C0]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  456.689374][    C0]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  456.696631][    C0]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  456.702714][    C0]  ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+[  456.709773][    C0]  mac80211_hwsim_beacon+0xbb/0x1c0
+[  456.715007][    C0]  ? __pfx_mac80211_hwsim_beacon+0x10/0x10
+[  456.720827][    C0]  __hrtimer_run_queues+0x529/0xc60
+[  456.726075][    C0]  ? __pfx___hrtimer_run_queues+0x10/0x10
+[  456.731821][    C0]  ? read_tsc+0x9/0x20
+[  456.735918][    C0]  ? __pfx___local_bh_disable_ip+0x10/0x10
+[  456.741744][    C0]  hrtimer_run_softirq+0x187/0x2b0
+[  456.746878][    C0]  handle_softirqs+0x283/0x870
+[  456.751660][    C0]  ? __irq_exit_rcu+0xca/0x1f0
+[  456.756479][    C0]  ? __pfx_handle_softirqs+0x10/0x10
+[  456.761782][    C0]  ? irqtime_account_irq+0xb6/0x1c0
+[  456.767014][    C0]  __irq_exit_rcu+0xca/0x1f0
+[  456.771618][    C0]  ? __pfx___irq_exit_rcu+0x10/0x10
+[  456.776863][    C0]  irq_exit_rcu+0x9/0x30
+[  456.781118][    C0]  sysvec_apic_timer_interrupt+0xa6/0xc0
+[  456.786784][    C0]  </IRQ>
+[  456.789716][    C0]  <TASK>
+[  456.792650][    C0]  asm_sysvec_apic_timer_interrupt+0x1a/0x20
+[  456.798662][    C0] RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+[  456.805549][    C0] Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+[  456.825207][    C0] RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+[  456.831296][    C0] RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+[  456.839361][    C0] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+[  456.847373][    C0] RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+[  456.855378][    C0] R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+[  456.863355][    C0] R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+[  456.871366][    C0]  ? __folio_rmap_sanity_checks+0x120/0x700
+[  456.877308][    C0]  __folio_rmap_sanity_checks+0x120/0x700
+[  456.883046][    C0]  folio_remove_rmap_ptes+0x3b/0xaf0
+[  456.888367][    C0]  ? page_table_check_clear+0x187/0x700
+[  456.893919][    C0]  ? page_table_check_clear+0x4f3/0x700
+[  456.899501][    C0]  ? page_table_check_clear+0x187/0x700
+[  456.905089][    C0]  unmap_page_range+0x1e59/0x41c0
+[  456.910159][    C0]  ? __pfx_unmap_page_range+0x10/0x10
+[  456.915569][    C0]  ? mas_find+0x987/0xbc0
+[  456.919906][    C0]  ? unmap_vmas+0x144/0x580
+[  456.924420][    C0]  unmap_vmas+0x399/0x580
+[  456.928798][    C0]  ? __pfx_unmap_vmas+0x10/0x10
+[  456.933676][    C0]  exit_mmap+0x248/0xb50
+[  456.937950][    C0]  ? uprobe_clear_state+0x20f/0x290
+[  456.943161][    C0]  ? __pfx_exit_mmap+0x10/0x10
+[  456.947949][    C0]  ? __mutex_unlock_slowpath+0x1cd/0x700
+[  456.953604][    C0]  ? __pfx_exit_aio+0x10/0x10
+[  456.958321][    C0]  ? uprobe_clear_state+0x274/0x290
+[  456.963534][    C0]  __mmput+0x118/0x420
+[  456.967640][    C0]  exit_mm+0x1da/0x2c0
+[  456.971735][    C0]  ? __pfx_exit_mm+0x10/0x10
+[  456.976360][    C0]  ? rcu_is_watching+0x15/0xb0
+[  456.981142][    C0]  do_exit+0x648/0x22e0
+[  456.985330][    C0]  ? do_raw_spin_lock+0x121/0x290
+[  456.990364][    C0]  ? __pfx_do_exit+0x10/0x10
+[  456.994994][    C0]  do_group_exit+0x21c/0x2d0
+[  456.999602][    C0]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.004880][    C0]  get_signal+0x1286/0x1340
+[  457.009417][    C0]  arch_do_signal_or_restart+0x9a/0x750
+[  457.015006][    C0]  ? count_memcg_event_mm+0x21/0x260
+[  457.020330][    C0]  ? __pfx_arch_do_signal_or_restart+0x10/0x10
+[  457.026531][    C0]  ? exit_to_user_mode_loop+0x40/0x110
+[  457.032004][    C0]  exit_to_user_mode_loop+0x75/0x110
+[  457.037320][    C0]  do_syscall_64+0x2bd/0x3b0
+[  457.041925][    C0]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.047253][    C0]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.053325][    C0]  ? clear_bhb_loop+0x60/0xb0
+[  457.058030][    C0]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.063927][    C0] RIP: 0033:0x7f7ace38e929
+[  457.068361][    C0] Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+[  457.075399][    C0] RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+[  457.083837][    C0] RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+[  457.091854][    C0] RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+[  457.099854][    C0] RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+[  457.107865][    C0] R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+[  457.115864][    C0] R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+[  457.123853][    C0]  </TASK>
+[  457.126909][    C0] Kernel panic - not syncing: kernel: panic_on_warn set ...
+[  457.134192][    C0] CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full)
+[  457.145647][    C0] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+[  457.155703][    C0] Call Trace:
+[  457.158994][    C0]  <IRQ>
+[  457.161841][    C0]  dump_stack_lvl+0x99/0x250
+[  457.166445][    C0]  ? __asan_memcpy+0x40/0x70
+[  457.171045][    C0]  ? __pfx_dump_stack_lvl+0x10/0x10
+[  457.176251][    C0]  ? __pfx__printk+0x10/0x10
+[  457.180858][    C0]  panic+0x2db/0x790
+[  457.184770][    C0]  ? __pfx_panic+0x10/0x10
+[  457.189276][    C0]  __warn+0x334/0x4c0
+[  457.193266][    C0]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.198990][    C0]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.204719][    C0]  report_bug+0x2be/0x4f0
+[  457.209083][    C0]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.214820][    C0]  ? __ieee80211_beacon_get+0x125d/0x1630
+[  457.220556][    C0]  ? __ieee80211_beacon_get+0x125f/0x1630
+[  457.226277][    C0]  handle_bug+0x84/0x160
+[  457.230530][    C0]  exc_invalid_op+0x1a/0x50
+[  457.235043][    C0]  asm_exc_invalid_op+0x1a/0x20
+[  457.239897][    C0] RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+[  457.246228][    C0] Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+[  457.265836][    C0] RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+[  457.271906][    C0] RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+[  457.279880][    C0] RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+[  457.287854][    C0] RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+[  457.295827][    C0] R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+[  457.303796][    C0] R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+[  457.311783][    C0]  ? __ieee80211_beacon_get+0x36/0x1630
+[  457.317346][    C0]  ? __ieee80211_beacon_get+0x125c/0x1630
+[  457.323080][    C0]  ? __ieee80211_beacon_get+0x125c/0x1630
+[  457.328803][    C0]  ? __ieee80211_beacon_get+0x36/0x1630
+[  457.334382][    C0]  ieee80211_beacon_get_tim+0xb4/0x2b0
+[  457.339849][    C0]  ? __pfx_ieee80211_beacon_get_tim+0x10/0x10
+[  457.345937][    C0]  mac80211_hwsim_beacon_tx+0x3ce/0x860
+[  457.351498][    C0]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  457.358707][    C0]  __iterate_interfaces+0x2a8/0x590
+[  457.363912][    C0]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  457.369985][    C0]  ? ieee80211_iterate_active_interfaces_atomic+0x2a/0x180
+[  457.377189][    C0]  ? __pfx_mac80211_hwsim_beacon_tx+0x10/0x10
+[  457.383266][    C0]  ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+[  457.390297][    C0]  mac80211_hwsim_beacon+0xbb/0x1c0
+[  457.395513][    C0]  ? __pfx_mac80211_hwsim_beacon+0x10/0x10
+[  457.401342][    C0]  __hrtimer_run_queues+0x529/0xc60
+[  457.406570][    C0]  ? __pfx___hrtimer_run_queues+0x10/0x10
+[  457.412302][    C0]  ? read_tsc+0x9/0x20
+[  457.416387][    C0]  ? __pfx___local_bh_disable_ip+0x10/0x10
+[  457.422213][    C0]  hrtimer_run_softirq+0x187/0x2b0
+[  457.427333][    C0]  handle_softirqs+0x283/0x870
+[  457.432108][    C0]  ? __irq_exit_rcu+0xca/0x1f0
+[  457.436885][    C0]  ? __pfx_handle_softirqs+0x10/0x10
+[  457.442184][    C0]  ? irqtime_account_irq+0xb6/0x1c0
+[  457.447392][    C0]  __irq_exit_rcu+0xca/0x1f0
+[  457.451993][    C0]  ? __pfx___irq_exit_rcu+0x10/0x10
+[  457.457206][    C0]  irq_exit_rcu+0x9/0x30
+[  457.461460][    C0]  sysvec_apic_timer_interrupt+0xa6/0xc0
+[  457.467102][    C0]  </IRQ>
+[  457.470036][    C0]  <TASK>
+[  457.472966][    C0]  asm_sysvec_apic_timer_interrupt+0x1a/0x20
+[  457.478952][    C0] RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+[  457.485812][    C0] Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+[  457.505429][    C0] RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+[  457.511510][    C0] RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+[  457.519498][    C0] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+[  457.527473][    C0] RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+[  457.535453][    C0] R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+[  457.543444][    C0] R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+[  457.551441][    C0]  ? __folio_rmap_sanity_checks+0x120/0x700
+[  457.557400][    C0]  __folio_rmap_sanity_checks+0x120/0x700
+[  457.563133][    C0]  folio_remove_rmap_ptes+0x3b/0xaf0
+[  457.568437][    C0]  ? page_table_check_clear+0x187/0x700
+[  457.574019][    C0]  ? page_table_check_clear+0x4f3/0x700
+[  457.579578][    C0]  ? page_table_check_clear+0x187/0x700
+[  457.585143][    C0]  unmap_page_range+0x1e59/0x41c0
+[  457.590212][    C0]  ? __pfx_unmap_page_range+0x10/0x10
+[  457.595595][    C0]  ? mas_find+0x987/0xbc0
+[  457.599929][    C0]  ? unmap_vmas+0x144/0x580
+[  457.604438][    C0]  unmap_vmas+0x399/0x580
+[  457.608779][    C0]  ? __pfx_unmap_vmas+0x10/0x10
+[  457.613672][    C0]  exit_mmap+0x248/0xb50
+[  457.617935][    C0]  ? uprobe_clear_state+0x20f/0x290
+[  457.623144][    C0]  ? __pfx_exit_mmap+0x10/0x10
+[  457.627907][    C0]  ? __mutex_unlock_slowpath+0x1cd/0x700
+[  457.633563][    C0]  ? __pfx_exit_aio+0x10/0x10
+[  457.638254][    C0]  ? uprobe_clear_state+0x274/0x290
+[  457.643463][    C0]  __mmput+0x118/0x420
+[  457.647554][    C0]  exit_mm+0x1da/0x2c0
+[  457.651645][    C0]  ? __pfx_exit_mm+0x10/0x10
+[  457.656265][    C0]  ? rcu_is_watching+0x15/0xb0
+[  457.661066][    C0]  do_exit+0x648/0x22e0
+[  457.665252][    C0]  ? do_raw_spin_lock+0x121/0x290
+[  457.670295][    C0]  ? __pfx_do_exit+0x10/0x10
+[  457.674915][    C0]  do_group_exit+0x21c/0x2d0
+[  457.679523][    C0]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.684732][    C0]  get_signal+0x1286/0x1340
+[  457.689270][    C0]  arch_do_signal_or_restart+0x9a/0x750
+[  457.694831][    C0]  ? count_memcg_event_mm+0x21/0x260
+[  457.700146][    C0]  ? __pfx_arch_do_signal_or_restart+0x10/0x10
+[  457.706316][    C0]  ? exit_to_user_mode_loop+0x40/0x110
+[  457.711787][    C0]  exit_to_user_mode_loop+0x75/0x110
+[  457.717082][    C0]  do_syscall_64+0x2bd/0x3b0
+[  457.721684][    C0]  ? lockdep_hardirqs_on+0x9c/0x150
+[  457.726892][    C0]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.732965][    C0]  ? clear_bhb_loop+0x60/0xb0
+[  457.737651][    C0]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[  457.743551][    C0] RIP: 0033:0x7f7ace38e929
+[  457.747963][    C0] Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+[  457.754978][    C0] RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+[  457.763401][    C0] RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+[  457.771373][    C0] RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+[  457.779344][    C0] RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+[  457.787316][    C0] R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+[  457.795296][    C0] R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+[  457.803283][    C0]  </TASK>
+
+REPORT:
+ worker_thread+0x6c8/0xf00
+ kthread+0x2c1/0x3a0
+ ret_from_fork+0x45/0x80
+ ret_from_fork_asm+0x1a/0x30
+ </TASK>
+WARNING: net/mac80211/tx.c:5024 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+Modules linked in:
+CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full)
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+FS:  0000000000000000(0000) GS:ffff888125d40000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00007fd624370000 CR3: 000000000df38000 CR4: 00000000003526f0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+Call Trace:
+ <IRQ>
+ ieee80211_beacon_get_tim+0xb4/0x2b0
+ mac80211_hwsim_beacon_tx+0x3ce/0x860
+ __iterate_interfaces+0x2a8/0x590
+ ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+ mac80211_hwsim_beacon+0xbb/0x1c0
+ __hrtimer_run_queues+0x529/0xc60
+ hrtimer_run_softirq+0x187/0x2b0
+ handle_softirqs+0x283/0x870
+ __irq_exit_rcu+0xca/0x1f0
+ irq_exit_rcu+0x9/0x30
+ sysvec_apic_timer_interrupt+0xa6/0xc0
+ </IRQ>
+ <TASK>
+ asm_sysvec_apic_timer_interrupt+0x1a/0x20
+RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+ __folio_rmap_sanity_checks+0x120/0x700
+ folio_remove_rmap_ptes+0x3b/0xaf0
+ unmap_page_range+0x1e59/0x41c0
+ unmap_vmas+0x399/0x580
+ exit_mmap+0x248/0xb50
+ __mmput+0x118/0x420
+ exit_mm+0x1da/0x2c0
+ do_exit+0x648/0x22e0
+ do_group_exit+0x21c/0x2d0
+ get_signal+0x1286/0x1340
+ arch_do_signal_or_restart+0x9a/0x750
+ exit_to_user_mode_loop+0x75/0x110
+ do_syscall_64+0x2bd/0x3b0
+ entry_SYSCALL_64_after_hwframe+0x77/0x7f
+RIP: 0033:0x7f7ace38e929
+Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+ </TASK>
+TAIL REPORTS:
+RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+ </TASK>
+Kernel panic - not syncing: kernel: panic_on_warn set ...
+CPU: 1 UID: 0 PID: 11907 Comm: syz.9.803 Not tainted 6.16.0-rc2-next-20250616-syzkaller #0 PREEMPT(full)
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025
+Call Trace:
+ <IRQ>
+ dump_stack_lvl+0x99/0x250
+ panic+0x2db/0x790
+ __warn+0x334/0x4c0
+ report_bug+0x2be/0x4f0
+ handle_bug+0x84/0x160
+ exc_invalid_op+0x1a/0x50
+ asm_exc_invalid_op+0x1a/0x20
+RIP: 0010:__ieee80211_beacon_get+0x125d/0x1630
+Code: e7 e8 27 f2 2f f7 45 31 f6 4c 8b bc 24 a0 00 00 00 e9 78 fe ff ff e8 92 bf d6 f6 90 0f 0b 90 e9 e0 f7 ff ff e8 84 bf d6 f6 90 <0f> 0b 90 e9 38 fb ff ff e8 76 bf d6 f6 48 c7 c7 a0 5c 79 8f 4c 89
+RSP: 0000:ffffc90000a089f8 EFLAGS: 00010246
+RAX: ffffffff8ae9aaac RBX: ffffffff8ae99886 RCX: ffff8880254c1e00
+RDX: 0000000000000100 RSI: 0000000000000000 RDI: 0000000000000000
+RBP: 0000000000000000 R08: ffff8880254c1e00 R09: 0000000000000003
+R10: 0000000000000007 R11: 0000000000000100 R12: ffff888057086500
+R13: dffffc0000000000 R14: ffff8880570869d0 R15: ffff888058186024
+ ieee80211_beacon_get_tim+0xb4/0x2b0
+ mac80211_hwsim_beacon_tx+0x3ce/0x860
+ __iterate_interfaces+0x2a8/0x590
+ ieee80211_iterate_active_interfaces_atomic+0xdb/0x180
+ mac80211_hwsim_beacon+0xbb/0x1c0
+ __hrtimer_run_queues+0x529/0xc60
+ hrtimer_run_softirq+0x187/0x2b0
+ handle_softirqs+0x283/0x870
+ __irq_exit_rcu+0xca/0x1f0
+ irq_exit_rcu+0x9/0x30
+ sysvec_apic_timer_interrupt+0xa6/0xc0
+ </IRQ>
+ <TASK>
+ asm_sysvec_apic_timer_interrupt+0x1a/0x20
+RIP: 0010:__sanitizer_cov_trace_const_cmp8+0x37/0x90
+Code: 08 00 9e 92 65 8b 15 08 91 dd 10 81 e2 00 01 ff 00 74 11 81 fa 00 01 00 00 75 57 83 b9 3c 16 00 00 00 74 4e 8b 91 18 16 00 00 <83> fa 03 75 43 48 8b 91 20 16 00 00 44 8b 89 1c 16 00 00 49 c1 e1
+RSP: 0000:ffffc9000bc172c8 EFLAGS: 00000246
+RAX: ffffffff821345b0 RBX: ffffea0000c673c0 RCX: ffff8880254c1e00
+RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+RBP: 0000000000000001 R08: ffffea0000c673c7 R09: 1ffffd400018ce78
+R10: dffffc0000000000 R11: fffff9400018ce79 R12: 0000000000000000
+R13: dffffc0000000000 R14: dffffc0000000000 R15: ffffea0000c673c0
+ __folio_rmap_sanity_checks+0x120/0x700
+ folio_remove_rmap_ptes+0x3b/0xaf0
+ unmap_page_range+0x1e59/0x41c0
+ unmap_vmas+0x399/0x580
+ exit_mmap+0x248/0xb50
+ __mmput+0x118/0x420
+ exit_mm+0x1da/0x2c0
+ do_exit+0x648/0x22e0
+ do_group_exit+0x21c/0x2d0
+ get_signal+0x1286/0x1340
+ arch_do_signal_or_restart+0x9a/0x750
+ exit_to_user_mode_loop+0x75/0x110
+ do_syscall_64+0x2bd/0x3b0
+ entry_SYSCALL_64_after_hwframe+0x77/0x7f
+RIP: 0033:0x7f7ace38e929
+Code: Unable to access opcode bytes at 0x7f7ace38e8ff.
+RSP: 002b:00007f7acc1f6038 EFLAGS: 00000246 ORIG_RAX: 000000000000012b
+RAX: 0000000000010106 RBX: 00007f7ace5b6080 RCX: 00007f7ace38e929
+RDX: 0000000000010106 RSI: 00002000000000c0 RDI: 0000000000000003
+RBP: 00007f7ace410b39 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000002 R11: 0000000000000246 R12: 0000000000000000
+R13: 0000000000000001 R14: 00007f7ace5b6080 R15: 00007ffdb04f0738
+ </TASK>

--- a/pkg/report/testdata/linux/report/760
+++ b/pkg/report/testdata/linux/report/760
@@ -1,0 +1,50 @@
+TITLE: WARNING in report0_first_line
+TYPE: WARNING
+CONTEXTS: ["[    C1]","[    C2]","[    C1]"]
+
+[  0.0][    C1] WARNING: net/mac80211/tx.c:0 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+[  0.0][    C1] Call Trace:
+[  0.0][    C1]  <IRQ>
+[  0.0][    C1]  report0_first_line+0x0/0x0
+[  0.0][    C1]  report0_middle_line+0x0/0x0
+[  0.0][    C1]  report0_last_line+0x0/0x0
+[  0.0][    C1]  </IRQ>
+[  0.0][    C2] WARNING: net/mac80211/tx.c:1 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+[  0.0][    C2] Call Trace:
+[  0.0][    C2]  <IRQ>
+[  0.0][    C2]  report1_first_line+0x0/0x0
+[  0.0][    C2]  report1_middle_line+0x0/0x0
+[  0.0][    C1] WARNING: net/mac80211/tx.c:2 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+[  0.0][    C1] Call Trace:
+[  0.0][    C1]  <IRQ>
+[  0.0][    C1]  report2_first_line+0x0/0x0
+[  0.0][    C1]  report2_middle_line+0x0/0x0
+[  0.0][    C1]  report2_last_line+0x0/0x0
+[  0.0][    C1]  </IRQ>
+[  0.0][    C2]  report1_last_line+0x0/0x0
+[  0.0][    C2]  </IRQ>
+
+REPORT:
+WARNING: net/mac80211/tx.c:0 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+Call Trace:
+ <IRQ>
+ report0_first_line+0x0/0x0
+ report0_middle_line+0x0/0x0
+ report0_last_line+0x0/0x0
+ </IRQ>
+TAIL REPORTS:
+WARNING: net/mac80211/tx.c:1 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+Call Trace:
+ <IRQ>
+ report1_first_line+0x0/0x0
+ report1_middle_line+0x0/0x0
+ report1_last_line+0x0/0x0
+ </IRQ>
+<<<<<<<<<<<<<<< tail report >>>>>>>>>>>>>>>
+WARNING: net/mac80211/tx.c:2 at __ieee80211_beacon_get+0x125d/0x1630, CPU#1: syz.9.803/11907
+Call Trace:
+ <IRQ>
+ report2_first_line+0x0/0x0
+ report2_middle_line+0x0/0x0
+ report2_last_line+0x0/0x0
+ </IRQ>

--- a/tools/syz-symbolize/symbolize.go
+++ b/tools/syz-symbolize/symbolize.go
@@ -57,7 +57,7 @@ func main() {
 	if err != nil {
 		tool.Failf("failed to open input file: %v", err)
 	}
-	reps := report.ParseAll(reporter, text)
+	reps := report.ParseAll(reporter, text, 0)
 	if len(reps) == 0 {
 		rep := &report.Report{Report: text}
 		if err := reporter.Symbolize(rep); err != nil {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -6,8 +6,8 @@ package vm
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +16,6 @@ import (
 	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
-	"github.com/stretchr/testify/assert"
 )
 
 type testPool struct {
@@ -456,157 +455,3 @@ func TestVMType(t *testing.T) {
 		}
 	}
 }
-
-func TestExtractMultipleErrors(t *testing.T) {
-	inst, reporter := makeLinuxAMD64Futex(t)
-	mon := &monitor{
-		RunOptions: &RunOptions{},
-		inst:       inst,
-		reporter:   reporter,
-		output:     []byte(validKASANReport + strings.Repeat(someLine, 10) + validKASANReport),
-	}
-	reps := mon.extractErrors("unknown error")
-	assert.Len(t, reps, 2, "expected to see 2 reports, got %v", len(reps))
-	assert.Equal(t, reps[0].Title, reps[1].Title)
-	assert.False(t, reps[0].Corrupted)
-	assert.False(t, reps[1].Corrupted)
-}
-
-const someLine = "[   96.999999] some message \n"
-const validKASANReport = `
-[   96.262735] BUG: KASAN: double-free or invalid-free in selinux_tun_dev_free_security+0x15/0x20
-[   96.271481] 
-[   96.273098] CPU: 0 PID: 11514 Comm: syz-executor5 Not tainted 4.12.0-rc7+ #2
-[   96.280268] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
-[   96.289602] Call Trace:
-[   96.292180]  dump_stack+0x194/0x257
-[   96.295796]  ? arch_local_irq_restore+0x53/0x53
-[   96.300454]  ? load_image_and_restore+0x10f/0x10f
-[   96.305299]  ? selinux_tun_dev_free_security+0x15/0x20
-[   96.310565]  print_address_description+0x7f/0x260
-[   96.315393]  ? selinux_tun_dev_free_security+0x15/0x20
-[   96.320656]  ? selinux_tun_dev_free_security+0x15/0x20
-[   96.325919]  kasan_report_double_free+0x55/0x80
-[   96.330577]  kasan_slab_free+0xa0/0xc0
-[   96.334450]  kfree+0xd3/0x260
-[   96.337545]  selinux_tun_dev_free_security+0x15/0x20
-[   96.342636]  security_tun_dev_free_security+0x48/0x80
-[   96.347822]  __tun_chr_ioctl+0x2cc1/0x3d60
-[   96.352054]  ? tun_chr_close+0x60/0x60
-[   96.355925]  ? lock_downgrade+0x990/0x990
-[   96.360059]  ? lock_release+0xa40/0xa40
-[   96.364025]  ? __lock_is_held+0xb6/0x140
-[   96.368213]  ? check_same_owner+0x320/0x320
-[   96.372530]  ? tun_chr_compat_ioctl+0x30/0x30
-[   96.377005]  tun_chr_ioctl+0x2a/0x40
-[   96.380701]  ? tun_chr_ioctl+0x2a/0x40
-[   96.385099]  do_vfs_ioctl+0x1b1/0x15c0
-[   96.388981]  ? ioctl_preallocate+0x2d0/0x2d0
-[   96.393378]  ? selinux_capable+0x40/0x40
-[   96.397430]  ? SyS_futex+0x2b0/0x3a0
-[   96.401147]  ? security_file_ioctl+0x89/0xb0
-[   96.405547]  SyS_ioctl+0x8f/0xc0
-[   96.408912]  entry_SYSCALL_64_fastpath+0x1f/0xbe
-[   96.413651] RIP: 0033:0x4512c9
-[   96.416824] RSP: 002b:00007fc65827bc08 EFLAGS: 00000216 ORIG_RAX: 0000000000000010
-[   96.424603] RAX: ffffffffffffffda RBX: 0000000000718000 RCX: 00000000004512c9
-[   96.431863] RDX: 000000002053c000 RSI: 00000000400454ca RDI: 0000000000000005
-[   96.439133] RBP: 0000000000000082 R08: 0000000000000000 R09: 0000000000000000
-[   96.446389] R10: 0000000000000000 R11: 0000000000000216 R12: 00000000004baa97
-[   96.453647] R13: 00000000ffffffff R14: 0000000020124ff3 R15: 0000000000000000
-[   96.460931] 
-[   96.462552] Allocated by task 11514:
-[   96.466258]  save_stack_trace+0x16/0x20
-[   96.470212]  save_stack+0x43/0xd0
-[   96.473649]  kasan_kmalloc+0xaa/0xd0
-[   96.477347]  kmem_cache_alloc_trace+0x101/0x6f0
-[   96.481995]  selinux_tun_dev_alloc_security+0x49/0x170
-[   96.487250]  security_tun_dev_alloc_security+0x6d/0xa0
-[   96.492508]  __tun_chr_ioctl+0x16bc/0x3d60
-[   96.496722]  tun_chr_ioctl+0x2a/0x40
-[   96.500417]  do_vfs_ioctl+0x1b1/0x15c0
-[   96.504282]  SyS_ioctl+0x8f/0xc0
-[   96.507630]  entry_SYSCALL_64_fastpath+0x1f/0xbe
-[   96.512367] 
-[   96.513973] Freed by task 11514:
-[   96.517323]  save_stack_trace+0x16/0x20
-[   96.521276]  save_stack+0x43/0xd0
-[   96.524709]  kasan_slab_free+0x6e/0xc0
-[   96.528577]  kfree+0xd3/0x260
-[   96.531666]  selinux_tun_dev_free_security+0x15/0x20
-[   96.536747]  security_tun_dev_free_security+0x48/0x80
-[   96.541918]  tun_free_netdev+0x13b/0x1b0
-[   96.545959]  register_netdevice+0x8d0/0xee0
-[   96.550260]  __tun_chr_ioctl+0x1bae/0x3d60
-[   96.554475]  tun_chr_ioctl+0x2a/0x40
-[   96.558169]  do_vfs_ioctl+0x1b1/0x15c0
-[   96.562035]  SyS_ioctl+0x8f/0xc0
-[   96.565385]  entry_SYSCALL_64_fastpath+0x1f/0xbe
-[   96.570116] 
-[   96.571724] The buggy address belongs to the object at ffff8801d5961a40
-[   96.571724]  which belongs to the cache kmalloc-32 of size 32
-[   96.584186] The buggy address is located 0 bytes inside of
-[   96.584186]  32-byte region [ffff8801d5961a40, ffff8801d5961a60)
-[   96.595775] The buggy address belongs to the page:
-[   96.600686] page:ffffea00066b8d38 count:1 mapcount:0 mapping:ffff8801d5961000 index:0xffff8801d5961fc1
-[   96.610118] flags: 0x200000000000100(slab)
-[   96.614335] raw: 0200000000000100 ffff8801d5961000 ffff8801d5961fc1 000000010000003f
-[   96.622292] raw: ffffea0006723300 ffffea00066738b8 ffff8801dbc00100
-[   96.628675] page dumped because: kasan: bad access detected
-[   96.634373] 
-[   96.635978] Memory state around the buggy address:
-[   96.640884]  ffff8801d5961900: 00 00 01 fc fc fc fc fc 00 00 00 fc fc fc fc fc
-[   96.648222]  ffff8801d5961980: 00 00 00 00 fc fc fc fc fb fb fb fb fc fc fc fc
-[   96.655567] >ffff8801d5961a00: 00 00 00 fc fc fc fc fc fb fb fb fb fc fc fc fc
-[   96.663255]                                            ^
-[   96.668685]  ffff8801d5961a80: fb fb fb fb fc fc fc fc 00 00 00 fc fc fc fc fc
-[   96.676022]  ffff8801d5961b00: 04 fc fc fc fc fc fc fc fb fb fb fb fc fc fc fc
-[   96.683357] ==================================================================
-[   96.690692] Disabling lock debugging due to kernel taint
-[   96.696117] Kernel panic - not syncing: panic_on_warn set ...
-[   96.696117] 
-[   96.703470] CPU: 0 PID: 11514 Comm: syz-executor5 Tainted: G    B           4.12.0-rc7+ #2
-[   96.711847] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
-[   96.721354] Call Trace:
-[   96.723926]  dump_stack+0x194/0x257
-[   96.727539]  ? arch_local_irq_restore+0x53/0x53
-[   96.732366]  ? kasan_end_report+0x32/0x50
-[   96.736497]  ? lock_downgrade+0x990/0x990
-[   96.740631]  panic+0x1e4/0x3fb
-[   96.743807]  ? percpu_up_read_preempt_enable.constprop.38+0xae/0xae
-[   96.750194]  ? add_taint+0x40/0x50
-[   96.753723]  ? selinux_tun_dev_free_security+0x15/0x20
-[   96.758976]  ? selinux_tun_dev_free_security+0x15/0x20
-[   96.764233]  kasan_end_report+0x50/0x50
-[   96.768192]  kasan_report_double_free+0x72/0x80
-[   96.772843]  kasan_slab_free+0xa0/0xc0
-[   96.776711]  kfree+0xd3/0x260
-[   96.779802]  selinux_tun_dev_free_security+0x15/0x20
-[   96.784886]  security_tun_dev_free_security+0x48/0x80
-[   96.790061]  __tun_chr_ioctl+0x2cc1/0x3d60
-[   96.794285]  ? tun_chr_close+0x60/0x60
-[   96.798152]  ? lock_downgrade+0x990/0x990
-[   96.802803]  ? lock_release+0xa40/0xa40
-[   96.806763]  ? __lock_is_held+0xb6/0x140
-[   96.810829]  ? check_same_owner+0x320/0x320
-[   96.815137]  ? tun_chr_compat_ioctl+0x30/0x30
-[   96.819611]  tun_chr_ioctl+0x2a/0x40
-[   96.823306]  ? tun_chr_ioctl+0x2a/0x40
-[   96.827181]  do_vfs_ioctl+0x1b1/0x15c0
-[   96.831057]  ? ioctl_preallocate+0x2d0/0x2d0
-[   96.835450]  ? selinux_capable+0x40/0x40
-[   96.839494]  ? SyS_futex+0x2b0/0x3a0
-[   96.843200]  ? security_file_ioctl+0x89/0xb0
-[   96.847590]  SyS_ioctl+0x8f/0xc0
-[   96.850941]  entry_SYSCALL_64_fastpath+0x1f/0xbe
-[   96.855676] RIP: 0033:0x4512c9
-[   96.859020] RSP: 002b:00007fc65827bc08 EFLAGS: 00000216 ORIG_RAX: 0000000000000010
-[   96.866708] RAX: ffffffffffffffda RBX: 0000000000718000 RCX: 00000000004512c9
-[   96.873956] RDX: 000000002053c000 RSI: 00000000400454ca RDI: 0000000000000005
-[   96.881208] RBP: 0000000000000082 R08: 0000000000000000 R09: 0000000000000000
-[   96.888461] R10: 0000000000000000 R11: 0000000000000216 R12: 00000000004baa97
-[   96.895708] R13: 00000000ffffffff R14: 0000000020124ff3 R15: 0000000000000000
-[   96.903943] Dumping ftrace buffer:
-[   96.907460]    (ftrace buffer empty)
-[   96.911148] Kernel Offset: disabled
-`


### PR DESCRIPTION
Syzkaller is currently able to parse sequential reports from the kernel log and accumulate the statistics per report. You can see these reports in syzkaller only (not syzbot dashboard).
The problems:
1. These reports may be interleaving if are coming from the parallel contexts (threads)
2. Getting reports from one thread instead of all threads will hopefully give a higher signal/noise ratio.

This PR improves sequential reports parsing and is not expected to affect "first report" extraction.
Eventually the plan is to disable panic_on_warn and start getting sequential reports.

TODO:
1. Consider using MAX_REPORT_LINES.
1. Consider skipping next report if previous report truncated to the next one becomes invalid.
1. Comment code?
