### PR TITLE
vm: react to context cancellation and better handle errors in VM creation

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -658,7 +658,7 @@ func (env *env) test() (*testResult, error) {
 		var verr *osutil.VerboseError
 		var kerr *build.KernelError
 		if errors.As(err, &verr) {
-			errInfo += verr.Title
+			errInfo += verr.Error()
 			env.saveDebugFile(current.Hash, 0, verr.Output)
 		} else if errors.As(err, &kerr) {
 			errInfo += string(kerr.Report)

--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -54,7 +54,7 @@ options 	DIAGNOSTIC
 		// because FreeBSD's build doesn't correctly order the two
 		// targets. Its output is useful for debugging though, so
 		// include it here.
-		return ImageDetails{}, osutil.PrependContext(string(output), err)
+		return ImageDetails{}, fmt.Errorf("%s: %w", string(output), err)
 	}
 
 	kernelObjDir := filepath.Join(objPrefix, params.KernelDir,

--- a/pkg/build/netbsd.go
+++ b/pkg/build/netbsd.go
@@ -130,7 +130,7 @@ func (ctx netbsd) copyKernelToDisk(targetArch, vmType, outputDir, kernel string)
 		return fmt.Errorf("failed to create a Reporter: %w", err)
 	}
 	// Create a VM instance (we need only one).
-	inst, err := pool.Create(0)
+	inst, err := pool.Create(context.Background(), 0)
 	if err != nil {
 		return fmt.Errorf("failed to create the VM Instance: %w", err)
 	}

--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -283,7 +284,8 @@ func buildTestBinary(t *testing.T, target *targets.Target, test *Test, dir strin
 	}
 	if _, err := osutil.RunCmd(time.Hour, "", target.CCompiler, ldflags...); err != nil {
 		// Arm linker in the env image has a bug when linking a clang-produced files.
-		if regexp.MustCompile(`arm-linux-gnueabi.* assertion fail`).MatchString(err.Error()) {
+		var vErr *osutil.VerboseError
+		if errors.As(err, &vErr) && regexp.MustCompile(`arm-linux-gnueabi.* assertion fail`).Match(vErr.Output) {
 			t.Skipf("skipping test, broken arm linker (%v)", err)
 		}
 		t.Fatal(err)

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -91,7 +91,7 @@ func SetupExecProg(vmInst *vm.Instance, mgrCfg *mgrconfig.Config, reporter *repo
 
 func CreateExecProgInstance(vmPool *vm.Pool, vmIndex int, mgrCfg *mgrconfig.Config,
 	reporter *report.Reporter, opt *OptionalConfig) (*ExecProgInstance, error) {
-	vmInst, err := vmPool.Create(vmIndex)
+	vmInst, err := vmPool.Create(context.Background(), vmIndex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VM: %w", err)
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -6,6 +6,7 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -314,7 +315,7 @@ type EnvTestResult struct {
 }
 
 func (inst *inst) test() EnvTestResult {
-	vmInst, err := inst.vmPool.Create(inst.vmIndex)
+	vmInst, err := inst.vmPool.Create(context.Background(), inst.vmIndex)
 	if err != nil {
 		testErr := &TestError{
 			Boot:  true,

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -568,7 +568,7 @@ func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
 			var verboseErr *osutil.VerboseError
 			if errors.As(retErr, &verboseErr) {
 				// Include more details into the report.
-				prefix := fmt.Sprintf("%s, exit code %d\n\n", verboseErr.Title, verboseErr.ExitCode)
+				prefix := fmt.Sprintf("%s, exit code %d\n\n", verboseErr, verboseErr.ExitCode)
 				output = append([]byte(prefix), output...)
 			}
 			rep := &report.Report{

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -401,7 +401,7 @@ func (mgr *Manager) build(kernelCommit *vcs.Commit) error {
 			rep.Output = kernelError.Output
 			rep.Recipients = kernelError.Recipients
 		case errors.As(err, &verboseError):
-			rep.Report = []byte(verboseError.Title)
+			rep.Report = []byte(verboseError.Error())
 			rep.Output = verboseError.Output
 		case errors.As(err, &build.InfraError{}):
 			return err

--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -263,8 +263,8 @@ func buildKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest) (*BuildR
 			ret.Finding.Log = kernelError.Output
 			return ret, nil
 		case errors.As(err, &verboseError):
-			tracer.Log("verbose error: %q / %s", verboseError.Title, verboseError.Output)
-			ret.Finding.Report = []byte(verboseError.Title)
+			tracer.Log("verbose error: %s / %s", verboseError, verboseError.Output)
+			ret.Finding.Report = []byte(verboseError.Error())
 			ret.Finding.Log = verboseError.Output
 			return ret, nil
 		default:

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -157,7 +157,7 @@ func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instanc
 	if err != nil {
 		var verr *osutil.VerboseError
 		if errors.As(err, &verr) {
-			log.Printf("BUILD BROKEN: %v", verr.Title)
+			log.Printf("BUILD BROKEN: %s", verr)
 			saveLog(com.Hash, 0, verr.Output)
 		} else {
 			log.Printf("BUILD BROKEN: %v", err)

--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -129,7 +129,7 @@ func (pool *Pool) Count() int {
 	return len(pool.cfg.Devices)
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	device, err := loadDevice(pool.cfg.Devices[index])
 	if err != nil {
 		return nil, err

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -83,7 +83,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	inst := &instance{
 		cfg:   pool.cfg,
 		debug: pool.env.Debug,

--- a/vm/cuttlefish/cuttlefish.go
+++ b/vm/cuttlefish/cuttlefish.go
@@ -66,8 +66,8 @@ func (pool *Pool) Count() int {
 	return pool.gcePool.Count()
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
-	gceInst, err := pool.gcePool.Create(workdir, index)
+func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl.Instance, error) {
+	gceInst, err := pool.gcePool.Create(ctx, workdir, index)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create underlying gce instance: %w", err)
 	}

--- a/vm/dispatcher/pool.go
+++ b/vm/dispatcher/pool.go
@@ -19,7 +19,7 @@ type Instance interface {
 
 type UpdateInfo func(cb func(info *Info))
 type Runner[T Instance] func(ctx context.Context, inst T, updInfo UpdateInfo)
-type CreateInstance[T Instance] func(int) (T, error)
+type CreateInstance[T Instance] func(context.Context, int) (T, error)
 
 // Pool[T] provides the functionality of a generic pool of instances.
 // The instance is assumed to boot, be controlled by one Runner and then be re-created.
@@ -125,7 +125,7 @@ func (p *Pool[T]) runInstance(ctx context.Context, inst *poolInstance[T]) {
 	inst.status(StateBooting)
 	defer inst.status(StateOffline)
 
-	obj, err := p.creator(inst.idx)
+	obj, err := p.creator(ctx, inst.idx)
 	if err != nil {
 		p.reportBootError(ctx, err)
 		return

--- a/vm/dispatcher/pool_test.go
+++ b/vm/dispatcher/pool_test.go
@@ -21,7 +21,7 @@ func TestPoolDefault(t *testing.T) {
 
 	mgr := NewPool[*testInstance](
 		count,
-		func(idx int) (*testInstance, error) {
+		func(_ context.Context, idx int) (*testInstance, error) {
 			pool[idx].reset()
 			return &pool[idx], nil
 		},
@@ -62,7 +62,7 @@ func TestPoolSplit(t *testing.T) {
 
 	mgr := NewPool[*testInstance](
 		count,
-		func(idx int) (*testInstance, error) {
+		func(_ context.Context, idx int) (*testInstance, error) {
 			pool[idx].reset()
 			return &pool[idx], nil
 		},
@@ -131,7 +131,7 @@ func TestPoolStress(t *testing.T) {
 	// The test to aid the race detector.
 	mgr := NewPool[*nilInstance](
 		10,
-		func(idx int) (*nilInstance, error) {
+		func(_ context.Context, idx int) (*nilInstance, error) {
 			return &nilInstance{}, nil
 		},
 		func(ctx context.Context, _ *nilInstance, _ UpdateInfo) {
@@ -166,7 +166,7 @@ func TestPoolNewDefault(t *testing.T) {
 	// The test to aid the race detector.
 	mgr := NewPool[*nilInstance](
 		10,
-		func(idx int) (*nilInstance, error) {
+		func(_ context.Context, idx int) (*nilInstance, error) {
 			return &nilInstance{}, nil
 		},
 		func(ctx context.Context, _ *nilInstance, _ UpdateInfo) {
@@ -205,7 +205,7 @@ func TestPoolNewDefault(t *testing.T) {
 func TestPoolPause(t *testing.T) {
 	mgr := NewPool[*nilInstance](
 		10,
-		func(idx int) (*nilInstance, error) {
+		func(_ context.Context, idx int) (*nilInstance, error) {
 			return &nilInstance{}, nil
 		},
 		func(ctx context.Context, _ *nilInstance, _ UpdateInfo) {
@@ -242,7 +242,7 @@ func TestPoolCancelRun(t *testing.T) {
 	// The test to aid the race detector.
 	mgr := NewPool[*nilInstance](
 		10,
-		func(idx int) (*nilInstance, error) {
+		func(_ context.Context, idx int) (*nilInstance, error) {
 			return &nilInstance{}, nil
 		},
 		func(ctx context.Context, _ *nilInstance, _ UpdateInfo) {
@@ -293,7 +293,7 @@ func TestPoolBootErrors(t *testing.T) {
 
 	mgr := NewPool[*testInstance](
 		3,
-		func(idx int) (*testInstance, error) {
+		func(_ context.Context, idx int) (*testInstance, error) {
 			failCount.Add(1)
 			return nil, fmt.Errorf("boot error")
 		},

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -176,7 +176,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	name := fmt.Sprintf("%v-%v", pool.env.Name, index)
 	// Create SSH key for the instance.
 	gceKey := filepath.Join(workdir, "key")

--- a/vm/gvisor/gvisor.go
+++ b/vm/gvisor/gvisor.go
@@ -88,7 +88,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	rootDir := filepath.Clean(filepath.Join(workdir, "..", "gvisor_root"))
 	imageDir := filepath.Join(workdir, "image")
 	bundleDir := filepath.Join(workdir, "bundle")

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -92,7 +92,7 @@ func (pool *Pool) Count() int {
 	return len(pool.cfg.Targets)
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	targetAddr, targetPort, _ := splitTargetPort(pool.cfg.Targets[index])
 	inst := &instance{
 		cfg: pool.cfg,

--- a/vm/proxyapp/proxyappclient.go
+++ b/vm/proxyapp/proxyappclient.go
@@ -154,7 +154,7 @@ func (p *pool) Count() int {
 	return p.count
 }
 
-func (p *pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (p *pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	p.mu.Lock()
 	proxy := p.proxy
 	p.mu.Unlock()

--- a/vm/proxyapp/proxyappclient_test.go
+++ b/vm/proxyapp/proxyappclient_test.go
@@ -239,7 +239,7 @@ func TestPool_Create_Ok(t *testing.T) {
 		On("CreateInstance", mock.Anything, mock.Anything).
 		Return(nil)
 
-	inst, err := p.Create("workdir", 0)
+	inst, err := p.Create(t.Context(), "workdir", 0)
 	assert.NotNil(t, inst)
 	assert.Nil(t, err)
 }
@@ -257,7 +257,7 @@ func TestPool_Create_ProxyNilError(t *testing.T) {
 
 	p.(io.Closer).Close()
 
-	inst, err := p.Create("workdir", 0)
+	inst, err := p.Create(t.Context(), "workdir", 0)
 	assert.Nil(t, inst)
 	assert.NotNil(t, err)
 }
@@ -272,7 +272,7 @@ func TestPool_Create_OutOfPoolError(t *testing.T) {
 		}).
 		Return(fmt.Errorf("out of pool size"))
 
-	inst, err := p.Create("workdir", p.Count())
+	inst, err := p.Create(t.Context(), "workdir", p.Count())
 	assert.Nil(t, inst)
 	assert.NotNil(t, err)
 }
@@ -283,7 +283,7 @@ func TestPool_Create_ProxyFailure(t *testing.T) {
 		On("CreateInstance", mock.Anything, mock.Anything).
 		Return(fmt.Errorf("create instance failure"))
 
-	inst, err := p.Create("workdir", 0)
+	inst, err := p.Create(t.Context(), "workdir", 0)
 	assert.Nil(t, inst)
 	assert.NotNil(t, err)
 }
@@ -300,7 +300,7 @@ func createInstanceFixture(t *testing.T) (*mock.Mock, vmimpl.Instance) {
 		}).
 		Return(nil)
 
-	inst, err := p.Create("workdir", 0)
+	inst, err := p.Create(t.Context(), "workdir", 0)
 	assert.Nil(t, err)
 	assert.NotNil(t, inst)
 

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -348,6 +348,12 @@ func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl
 		if err == nil {
 			return inst, nil
 		}
+		if strings.Contains(err.Error(), "can't ssh into the instance") {
+			// If there was a boot error, immediately return it.
+			// In this case, the string search below also matches against boot time output,
+			// and e.g. "Device or resource busy" is quite often in there.
+			return nil, err
+		}
 		// Older qemu prints "could", newer -- "Could".
 		if i < 1000 && strings.Contains(err.Error(), "ould not set up host forwarding rule") {
 			continue
@@ -358,6 +364,7 @@ func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl
 		if i < 1000 && strings.Contains(err.Error(), "Address already in use") {
 			continue
 		}
+
 		return nil, err
 	}
 }

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -324,7 +324,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	sshkey := pool.env.SSHKey
 	sshuser := pool.env.SSHUser
 	if pool.env.Image == "9p" {
@@ -341,6 +341,9 @@ func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
 	}
 
 	for i := 0; ; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		inst, err := pool.ctor(workdir, sshkey, sshuser, index)
 		if err == nil {
 			return inst, nil

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -348,10 +349,8 @@ func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl
 		if err == nil {
 			return inst, nil
 		}
-		if strings.Contains(err.Error(), "can't ssh into the instance") {
-			// If there was a boot error, immediately return it.
-			// In this case, the string search below also matches against boot time output,
-			// and e.g. "Device or resource busy" is quite often in there.
+		if errors.Is(err, vmimpl.ErrCantSSH) {
+			// It is most likely a boot crash, just return the error as is.
 			return nil, err
 		}
 		// Older qemu prints "could", newer -- "Could".

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -100,7 +100,7 @@ func (pool *Pool) Count() int {
 	return pool.count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	inst := &instance{
 		fuchsiaDir: pool.env.KernelSrc,
 		ffxDir:     pool.ffxDir,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -157,7 +157,7 @@ func (pool *Pool) Count() int {
 	return pool.count
 }
 
-func (pool *Pool) Create(index int) (*Instance, error) {
+func (pool *Pool) Create(ctx context.Context, index int) (*Instance, error) {
 	if index < 0 || index >= pool.count {
 		return nil, fmt.Errorf("invalid VM index %v (count %v)", index, pool.count)
 	}
@@ -170,7 +170,7 @@ func (pool *Pool) Create(index int) (*Instance, error) {
 			return nil, err
 		}
 	}
-	impl, err := pool.impl.Create(workdir, index)
+	impl, err := pool.impl.Create(ctx, workdir, index)
 	if err != nil {
 		os.RemoveAll(workdir)
 		return nil, err

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -26,7 +26,7 @@ func (pool *testPool) Count() int {
 	return 1
 }
 
-func (pool *testPool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *testPool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	return &testInstance{
 		outc: make(chan []byte, 10),
 		errc: make(chan error, 1),
@@ -376,7 +376,7 @@ func makeLinuxAMD64Futex(t *testing.T) (*Instance, *report.Reporter) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inst, err := pool.Create(0)
+	inst, err := pool.Create(t.Context(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -58,12 +58,14 @@ func WaitForSSH(timeout time.Duration, opts SSHOptions, OS string, stop chan err
 		}
 		if time.Since(startTime) > timeout {
 			return &osutil.VerboseError{
-				Err:    fmt.Errorf("can't ssh into the instance"),
+				Err:    ErrCantSSH,
 				Output: []byte(err.Error()),
 			}
 		}
 	}
 }
+
+var ErrCantSSH = fmt.Errorf("can't ssh into the instance")
 
 func SSHArgs(debug bool, sshKey string, port int, systemSSHCfg bool) []string {
 	return sshArgs(debug, sshKey, "-p", port, 0, systemSSHCfg)

--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -57,7 +57,10 @@ func WaitForSSH(timeout time.Duration, opts SSHOptions, OS string, stop chan err
 			log.Logf(0, "ssh failed: %v", err)
 		}
 		if time.Since(startTime) > timeout {
-			return &osutil.VerboseError{Title: "can't ssh into the instance", Output: []byte(err.Error())}
+			return &osutil.VerboseError{
+				Err:    fmt.Errorf("can't ssh into the instance"),
+				Output: []byte(err.Error()),
+			}
 		}
 	}
 }

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -33,7 +33,7 @@ type Pool interface {
 	Count() int
 
 	// Create creates and boots a new VM instance.
-	Create(workdir string, index int) (Instance, error)
+	Create(ctx context.Context, workdir string, index int) (Instance, error)
 }
 
 // Instance represents a single VM.

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -104,7 +104,7 @@ func MakeBootError(err error, output []byte) error {
 	}
 	var verboseError *osutil.VerboseError
 	if errors.As(err, &verboseError) {
-		return BootError{verboseError.Title, append(verboseError.Output, output...)}
+		return BootError{verboseError.Error(), append(verboseError.Output, output...)}
 	}
 	return BootError{err.Error(), output}
 }

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -93,7 +93,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	var tee io.Writer
 	if pool.env.Debug {
 		tee = os.Stdout

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -77,7 +77,7 @@ func (pool *Pool) Count() int {
 	return pool.cfg.Count
 }
 
-func (pool *Pool) Create(workdir string, index int) (vmimpl.Instance, error) {
+func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.Instance, error) {
 	createTime := strconv.FormatInt(time.Now().UnixNano(), 10)
 	vmx := filepath.Join(workdir, createTime, "syzkaller.vmx")
 	sshkey := pool.env.SSHKey


### PR DESCRIPTION
Enable external abortion of the instance creation process. This is
especially useful for the qemu case where we retry the creation/boot up
to 1000 times, which can take significant time (e.g. it timeouts
syz-cluster pods on unstable kernels).

The context can be further propagated to WaitForSSH, but that requires
another quite significant vm/ refactoring.

***

In almost all cases these mean some boot time crash.
It also doesn't make much sense to continue string matching since the
boot output may contain the matched strings in benign contexts.

***

This sequence also asks for another change - we abuse `osutil.VerboseError` in too many different contexts and in a way that contradicts current Go error wrapping APIs. In this particular case it prevents an adequate ssh timeout error detection (which should have been something like `errors.Is(err, vmimpl.ErrSSHTimeout)`). I'll see how tricky it will be to replace `VerboseError`s `Title` by some nested `Error`.