### PR TITLE
pkg/kfuzztest: skip description generation test on non-amd64 arches

### DIFF
--- a/pkg/kfuzztest/description_generation_test.go
+++ b/pkg/kfuzztest/description_generation_test.go
@@ -25,6 +25,9 @@ func TestBuildDescriptions(t *testing.T) {
 	require.NoError(t, err)
 
 	target := targets.Get(targets.Linux, targets.AMD64)
+	if target.BrokenCompiler != "" {
+		t.Skip("skipping the test due to broken cross-compiler:\n" + target.BrokenCompiler)
+	}
 	for _, tc := range testCases {
 		t.Run(tc.dir, func(t *testing.T) {
 			runTest(t, target, tc)


### PR DESCRIPTION
Skip the description generation test on non-x86 architectures if no cross-compiler could be found.

We usually do not want to run amd64-specific unit tests on the s390x platform.
