### PR TITLE
kfuzztest: various build/test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,13 @@ syz-build:
 bisect: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-bisect github.com/google/syzkaller/tools/syz-bisect
 
+ifeq ($(HOSTOS), linux)
 kfuzztest: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-kfuzztest github.com/google/syzkaller/syz-kfuzztest
+else
+kfuzztest:
+	@echo "Skipping kfuzztest build (it's Linux-only)"
+endif
 
 verifier: descriptions
 	# TODO: switch syz-verifier to use syz-executor.

--- a/pkg/kfuzztest-manager/manager.go
+++ b/pkg/kfuzztest-manager/manager.go
@@ -1,5 +1,8 @@
 // Copyright 2025 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux
+
 package kfuzztestmanager
 
 import (

--- a/pkg/kfuzztest/description_generation_test.go
+++ b/pkg/kfuzztest/description_generation_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -25,6 +26,9 @@ func TestBuildDescriptions(t *testing.T) {
 	require.NoError(t, err)
 
 	target := targets.Get(targets.Linux, targets.AMD64)
+	if runtime.GOOS != target.BuildOS {
+		t.Skip("we cannot build Linux on this target")
+	}
 	if target.BrokenCompiler != "" {
 		t.Skip("skipping the test due to broken cross-compiler:\n" + target.BrokenCompiler)
 	}

--- a/syz-kfuzztest/main.go
+++ b/syz-kfuzztest/main.go
@@ -1,5 +1,8 @@
 // Copyright 2025 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux
+
 package main
 
 import (


### PR DESCRIPTION
Address kFuzzTest errors that appear on e.g. OpenBSD: https://syzkaller.appspot.com/text?tag=CrashLog&x=109bd534580000

See individual commits.