### PR TITLE
pkg/build: disable build profiling for Fuchsia builds

### DIFF
--- a/pkg/build/starnix.go
+++ b/pkg/build/starnix.go
@@ -59,6 +59,15 @@ func (st starnix) build(params Params) (ImageDetails, error) {
 	if err := osutil.SandboxChown(localDir); err != nil {
 		return ImageDetails{}, err
 	}
+
+	if _, err := runSandboxed(
+		30*time.Second,
+		params.KernelDir,
+		"scripts/fx", "build-profile", "disable",
+	); err != nil {
+		return ImageDetails{}, err
+	}
+
 	buildSubdir := "out/" + arch
 	if _, err := runSandboxed(
 		time.Hour,


### PR DESCRIPTION
This was recently enabled by default and depends on external tools not present on the syzkaller instances.