### PR TITLE
vm: starnix: add Android based VM support

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -4435,7 +4435,8 @@ static void getcon(char* context, size_t context_size)
 	int fd = open(SELINUX_CONTEXT_FILE, O_RDONLY);
 	if (fd < 0)
 		fail("getcon: couldn't open context file");
-
+	memset(context, 0, context_size);
+	
 	ssize_t nread = read(fd, context, context_size);
 
 	close(fd);
@@ -4455,7 +4456,7 @@ static void getcon(char* context, size_t context_size)
 // - Uses fail() instead of returning an error code
 static void setcon(const char* context)
 {
-	char new_context[512];
+	char new_context[512] = {0};
 
 	// Attempt to write the new context
 	int fd = open(SELINUX_CONTEXT_FILE, O_WRONLY);
@@ -4485,7 +4486,7 @@ static void setcon(const char* context)
 // - Uses fail() instead of returning an error code
 static void setfilecon(const char* path, const char* context)
 {
-	char new_context[512];
+	char new_context[512] = {0};
 
 	if (setxattr(path, SELINUX_XATTR_NAME, context, strlen(context) + 1, 0) != 0)
 		fail("setfilecon: setxattr failed");


### PR DESCRIPTION
Added some changes to the starnix VM implementation to allow `adb` usage with Android containers. The container should be started by `ffx emu start` and `ffx starnix adb connect` is used to discover it.

This can be used to fuzz an Android container running on Starnix with SELinux enabled.