### PR TITLE
syz-cluster: checkout the mm-new tree

### DIFF
--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -231,6 +231,12 @@ var DefaultTrees = []*Tree{
 		EmailLists: []string{`kvm@vger.kernel.org`},
 	},
 	{
+		Name:       `mm-new`,
+		URL:        `https://kernel.googlesource.com/pub/scm/linux/kernel/git/akpm/mm.git`,
+		Branch:     `mm-new`,
+		EmailLists: []string{`linux-mm@kvack.org`},
+	},
+	{
 		Name:       `torvalds`,
 		URL:        `https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux`,
 		Branch:     `master`,


### PR DESCRIPTION
A number of mm patches do not apply neither on top of torvalds, nor on top of linux-next. The mm/mm-new branch seems to be a more reliable base.