### PR TITLE
pkg/csource: fix check for sysTarget.BrokenCompiler()

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -43,11 +43,11 @@ func TestGenerate(t *testing.T) {
 			continue
 		}
 		t.Run(target.OS+"/"+target.Arch, func(t *testing.T) {
+			if err := sysTarget.BrokenCompiler; err != "" {
+				t.Skipf("target compiler is broken: %v", err)
+			}
 			full := !checked[target.OS]
 			if full || !testing.Short() {
-				if err := sysTarget.BrokenCompiler; err != "" {
-					t.Skipf("target compiler is broken: %v", err)
-				}
 				checked[target.OS] = true
 				t.Parallel()
 				testTarget(t, target, full)


### PR DESCRIPTION
Make sure arches with the broken compiler are correctly skipped.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
