### PR TITLE
syz-cluster: set workflow step retry strategy

### DIFF
--- a/syz-cluster/workflow/build-step/workflow-template.yaml
+++ b/syz-cluster/workflow/build-step/workflow-template.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   templates:
     - name: build-step
+      retryStrategy:
+        limit: "3"
+        backoff:
+          duration: "5m"
       inputs:
         parameters:
           - name: findings

--- a/syz-cluster/workflow/triage-step/workflow-template.yaml
+++ b/syz-cluster/workflow/triage-step/workflow-template.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   templates:
     - name: triage-step
+      retryStrategy:
+        limit: "3"
+        backoff:
+          duration: "5m"
       initContainers:
         - name: setup-overlays
           image: alpine/git:latest


### PR DESCRIPTION
When a triage or build step coincides with a cron job that polls new kernel trees, they often fail due to git command noticing that the repository is being updated.

In this case, the step logs an error and exits with status=1. Argo workflows offers a functionality to retry such steps up to the specific number of times and with exponentially increasing backoffs.

Configure the build and triage step templates to retry 3 times with 5 and then 10 minutes distance between the retries.