### PR TITLE
syz-cluster: add link to download the whole series

### DIFF
--- a/syz-cluster/dashboard/handler_test.go
+++ b/syz-cluster/dashboard/handler_test.go
@@ -54,6 +54,36 @@ func TestURLs(t *testing.T) {
 	}
 }
 
+func TestAllPatches(t *testing.T) {
+	env, ctx := app.TestEnvironment(t)
+	client := controller.TestServer(t, env)
+	testSeries := &api.Series{
+		ExtID: "ext-id",
+		Title: "test series name",
+		Link:  "http://link/to/series",
+		Patches: []api.SeriesPatch{
+			{
+				Seq:   1,
+				Title: "first patch title",
+				Body:  []byte("first content\n"),
+			},
+			{
+				Seq:   2,
+				Title: "second patch title",
+				Body:  []byte("second content\n"),
+			},
+		},
+	}
+	ids := controller.UploadTestSeries(t, ctx, client, testSeries)
+	_, baseURL := testServer(t, env)
+
+	resp, err := http.Get(baseURL + "/series/" + ids.SeriesID + "/all_patches")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, "first content\nsecond content\n", string(body))
+}
+
 func testServer(t *testing.T, env *app.AppEnvironment) (*dashboardHandler, string) {
 	handler, err := newHandler(env)
 	require.NoError(t, err)

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -71,7 +71,7 @@
             <thead>
                 <tr>
                     <th>Name</th>
-                    <th>Content</th>
+                    <th>Content <a href="/series/{{.ID}}/all_patches">[All]</a></th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
This will simplify debugging of mistriaged patch series that ended up either not applying anywhere or ended up with a build error.