### PR TITLE
pkg/report: don't print empty FRAME in failing tests

### DIFF
--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -67,7 +67,7 @@ func (test *ParseTest) Equal(other *ParseTest) bool {
 	return test.Executor == other.Executor
 }
 
-func (test *ParseTest) Headers(includeFrame bool) []byte {
+func (test *ParseTest) Headers() []byte {
 	buf := new(bytes.Buffer)
 	fmt.Fprintf(buf, "TITLE: %v\n", test.Title)
 	for _, t := range test.AltTitles {
@@ -76,7 +76,7 @@ func (test *ParseTest) Headers(includeFrame bool) []byte {
 	if test.Type != crash.UnknownType {
 		fmt.Fprintf(buf, "TYPE: %v\n", test.Type)
 	}
-	if includeFrame {
+	if test.Frame != "" {
 		fmt.Fprintf(buf, "FRAME: %v\n", test.Frame)
 	}
 	if test.Corrupted {
@@ -238,7 +238,7 @@ func testParseImpl(t *testing.T, reporter *Reporter, test *ParseTest) {
 			updateReportTest(t, test, parsed)
 		}
 		t.Fatalf("want:\n%s\ngot:\n%sCorrupted reason: %q",
-			test.Headers(true), parsed.Headers(true), parsed.corruptedReason)
+			test.Headers(), parsed.Headers(), parsed.corruptedReason)
 	}
 	if parsed.Title != "" && len(rep.Report) == 0 {
 		t.Fatalf("found crash message but report is empty")
@@ -293,7 +293,7 @@ func checkReport(t *testing.T, reporter *Reporter, rep *Report, test *ParseTest)
 
 func updateReportTest(t *testing.T, test, parsed *ParseTest) {
 	buf := new(bytes.Buffer)
-	buf.Write(parsed.Headers(test.Frame != ""))
+	buf.Write(parsed.Headers())
 	fmt.Fprintf(buf, "\n%s", test.Log)
 	if test.HasReport {
 		fmt.Fprintf(buf, "REPORT:\n%s", parsed.Report)
@@ -396,7 +396,7 @@ func testSymbolizeFile(t *testing.T, reporter *Reporter, fn string) {
 		}
 		assert.Equal(t, string(test.Report), string(rep.Report), "extracted wrong report")
 		t.Fatalf("want:\n%s\ngot:\n%sCorrupted reason: %q",
-			test.Headers(true), parsed.Headers(true), parsed.corruptedReason)
+			test.Headers(), parsed.Headers(), parsed.corruptedReason)
 	}
 }
 


### PR DESCRIPTION
Minus one parameter we don't actually need.
Is a preparation before #6376.
