### PR TITLE
docs/linux: update buildroot link in qemu setup

### DIFF
--- a/docs/linux/setup_linux-host_qemu-vm_arm64-kernel.md
+++ b/docs/linux/setup_linux-host_qemu-vm_arm64-kernel.md
@@ -5,7 +5,7 @@ This document will detail the steps involved in setting up a Syzkaller instance 
 ## Create a disk image
 
 We will use buildroot to create the disk image.
-You can obtain buildroot from [here](https://buildroot.uclibc.org/download.html).
+You can obtain buildroot from [here](https://buildroot.org/download.html).
 Extract the tarball and perform a `make menuconfig` inside it.
 Choose the following options.
 


### PR DESCRIPTION
Minor update of old link that was not working (couldn't be able to download buildroot)

Have written before PR to [syzkaller@googlegroups.com](https://groups.google.com/forum/#!forum/syzkaller):
[Link to the conversation](https://groups.google.com/g/syzkaller/c/W_tNpVJfcGw)
