### PR TITLE
syz-cluster: simplify shared git repo mounting code

### DIFF
--- a/syz-cluster/workflow/build-step/Dockerfile
+++ b/syz-cluster/workflow/build-step/Dockerfile
@@ -19,11 +19,17 @@ FROM gcr.io/syzkaller/syzbot:latest
 RUN mkdir -p /disk-images
 ADD https://storage.googleapis.com/syzkaller/images/buildroot_amd64_2024.09.gz /disk-images/buildroot_amd64_2024.09.gz
 RUN gzip -d /disk-images/buildroot_amd64_2024.09.gz
+RUN chmod 644 /disk-images/*
 
 # Download base kernel configs.
 RUN mkdir -p /kernel-configs
 ADD https://raw.githubusercontent.com/google/syzkaller/refs/heads/master/dashboard/config/linux/upstream-apparmor-kasan.config /kernel-configs/upstream-apparmor-kasan.config
 ADD https://raw.githubusercontent.com/google/syzkaller/refs/heads/master/dashboard/config/linux/upstream-kmsan.config /kernel-configs/upstream-kmsan.config
+RUN chmod 644 /kernel-configs/*
+
+# Prevent "fatal: detected dubious ownership in repository" errors.
+RUN git config --system --add safe.directory /workdir
+RUN git config --system --add safe.directory /kernel-repo
 
 COPY --from=build-step-builder /build/build-step-bin /bin/build-step
 

--- a/syz-cluster/workflow/build-step/workflow-template.yaml
+++ b/syz-cluster/workflow/build-step/workflow-template.yaml
@@ -12,6 +12,9 @@ spec:
         limit: "3"
         backoff:
           duration: "5m"
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 10000
       inputs:
         parameters:
           - name: findings
@@ -27,34 +30,25 @@ spec:
           - name: request
             path: /tmp/request.json
       initContainers:
-      - name: setup-overlays
-        image: alpine/git:latest
+      - name: setup-repo
+        image: ${IMAGE_PREFIX}build-step:${IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         command:
           - sh
           - -c
           - |
-            mkdir /data/overlayfs /data/.git
-            mount -t tmpfs -o size=128M tmpfs /data/overlayfs
-            mkdir /data/overlayfs/upper /data/overlayfs/work
-            mount -t overlay overlay -o lowerdir=/kernel-repo,upperdir=/data/overlayfs/upper,workdir=/data/overlayfs/work /data/.git
-            chmod 0777 /data/.git
-            git --git-dir=/data/.git --work-tree=/workdir checkout v3.0
-            chmod -R 0777 /data/.git/logs
-            chmod -R 0777 /workdir
+            git clone --reference /kernel-repo /kernel-repo ./workdir
+        env:
+        - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
+          value: "1"
+        - name: HOME # Otherwise it's failing with "warning: unable to access '/root/.config/git/attributes': Permission denied.".
+          value: "/home/syzkaller"
         volumeMounts:
-        - name: shared-git-repo
-          mountPath: /data
-          mountPropagation: Bidirectional
         - name: base-kernel-repo
           mountPath: /kernel-repo
           readOnly: true
         - name: workdir
           mountPath: /workdir
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
       container:
         image: ${IMAGE_PREFIX}build-step:${IMAGE_TAG}
         imagePullPolicy: IfNotPresent
@@ -75,18 +69,7 @@ spec:
           limits:
             cpu: 32
             memory: 96G
-        env:
-        - name: GIT_DIR
-          value: "/data/.git"
-        - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
-          value: "1"
-        - name: GIT_WORK_TREE
-          value: "/workdir"
-        - name: HOME # Otherwise it's failing with "warning: unable to access '/root/.config/git/attributes': Permission denied.".
-          value: "/home/syzkaller"
         volumeMounts:
-        - name: shared-git-repo
-          mountPath: /data
         - name: base-kernel-repo
           mountPath: /kernel-repo
           readOnly: true
@@ -102,9 +85,6 @@ spec:
         - name: base-kernel-repo
           persistentVolumeClaim:
             claimName: base-kernel-repo-pv-claim
-        - name: shared-git-repo
-          emptyDir:
-            medium: Memory
         - name: workdir
           emptyDir: {}
         - name: output

--- a/syz-cluster/workflow/triage-step/Dockerfile
+++ b/syz-cluster/workflow/triage-step/Dockerfile
@@ -26,7 +26,10 @@ RUN apt-get update && \
     apt-get install -y git
 
 # pkg/osutil uses syzkaller user for sandboxing.
-RUN useradd --create-home syzkaller
+RUN useradd -u 10000 --create-home syzkaller
+# Prevent "fatal: detected dubious ownership in repository" errors.
+RUN git config --system --add safe.directory /workdir
+RUN git config --system --add safe.directory /kernel-repo
 
 COPY --from=triage-step-builder /build/triage-step-bin /bin/triage-step
 

--- a/syz-cluster/workflow/triage-step/workflow-template.yaml
+++ b/syz-cluster/workflow/triage-step/workflow-template.yaml
@@ -12,35 +12,27 @@ spec:
         limit: "3"
         backoff:
           duration: "5m"
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 10000
       initContainers:
-        - name: setup-overlays
-          image: alpine/git:latest
+        - name: setup-repo
+          image: ${IMAGE_PREFIX}triage-step:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c
             - |
-              mkdir /data/overlayfs /data/.git
-              mount -t tmpfs -o size=128M tmpfs /data/overlayfs
-              mkdir /data/overlayfs/upper /data/overlayfs/work
-              mount -t overlay overlay -o lowerdir=/kernel-repo,upperdir=/data/overlayfs/upper,workdir=/data/overlayfs/work /data/.git
-              chmod 0777 /data/.git
-              git --git-dir=/data/.git --work-tree=/workdir checkout v3.0
-              chmod -R 0777 /data/.git/logs
-              chmod -R 0777 /workdir
+              git clone --reference /kernel-repo /kernel-repo /workdir
+          env:
+            - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
+              value: "1"
           volumeMounts:
-            - name: shared-git-repo
-              mountPath: /data
-              mountPropagation: Bidirectional
             - name: base-kernel-repo
               mountPath: /kernel-repo
               readOnly: true
             - name: workdir
               mountPath: /workdir
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
       container:
           image: ${IMAGE_PREFIX}triage-step:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
@@ -58,17 +50,11 @@ spec:
               cpu: 4
               memory: 16G
           env:
-            - name: GIT_DIR
-              value: "/data/.git"
             - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
               value: "1"
-            - name: GIT_WORK_TREE
-              value: "/workdir"
             - name: HOME # Otherwise it's failing with "warning: unable to access '/root/.config/git/attributes': Permission denied.".
               value: "/home/syzkaller"
           volumeMounts:
-            - name: shared-git-repo
-              mountPath: /data
             - name: base-kernel-repo
               mountPath: /kernel-repo
               readOnly: true
@@ -80,9 +66,6 @@ spec:
         - name: base-kernel-repo
           persistentVolumeClaim:
             claimName: base-kernel-repo-pv-claim
-        - name: shared-git-repo
-          emptyDir:
-            medium: Memory
         - name: workdir
           emptyDir: {}
         - name: output


### PR DESCRIPTION
Instead of a complicated overlayfs setup, do a lightweight git clone in a way that the cloned local copy keeps on referencing the git object storage on the NFS.

It's simpler code-wise and hopefully will be less susceptible to failures when local git operations coincide with a git fetch on the shared repository.
