### PR TITLE
executor: disallow O_CREAT in syz_open_dev

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -2422,7 +2422,7 @@ static long syz_open_dev(volatile long a0, volatile long a1, volatile long a2)
 			*hash = '0' + (char)(nb % 10); // 10 devices should be enough for everyone.
 			nb /= 10;
 		}
-		return open(buf, a2, 0);
+		return open(buf, a2 & ~O_CREAT, 0);
 	}
 }
 #endif


### PR DESCRIPTION
I can't think of a valid reason to create nodes under /dev/ if they don't already exist.

On systems where /dev/ isn't backed by a virtual/temp file system, O_CREAT lets syzkaller create persistent files on disk and may unnecessarily clutter or fill the disk with files that have nothing to do with the intended syscall descriptions.