### PR TITLE
sys/generated: don't do lazy initialization of all targets

### DIFF
--- a/sys/generated/generated.go
+++ b/sys/generated/generated.go
@@ -24,7 +24,8 @@ type Desc struct {
 }
 
 func Register(os, arch, revision string, init func(*prog.Target), files embed.FS) {
-	sysTarget := targets.Get(os, arch)
+	// Does not call targets.Get b/c it does slow lazy initialization of targets.
+	sysTarget := targets.List[os][arch]
 	target := &prog.Target{
 		OS:         os,
 		Arch:       arch,


### PR DESCRIPTION
Currently registration of targets calls targets.Get which does slow lazy initialization.
This adds several seconds to start of every binary and test. Don't do that.
