### PR TITLE
syz-cluster: preserve branches when cloning a repo

### DIFF
--- a/syz-cluster/kernel-disk/fetch-kernels-template.yaml
+++ b/syz-cluster/kernel-disk/fetch-kernels-template.yaml
@@ -70,5 +70,5 @@ spec:
             echo "${NAME}: ${REPO}/${BRANCH}"
             git remote remove ${NAME} || true
             git remote add ${NAME} ${REPO}
-            git fetch ${NAME} ${BRANCH} --tags
+            git fetch ${NAME} ${BRANCH} --tags "+refs/heads/*:refs/heads/${NAME}/*" "+refs/tags/*:refs/tags/${NAME}/*"
             git tag -f ${NAME}-head ${NAME}/${BRANCH}

--- a/syz-cluster/workflow/build-step/workflow-template.yaml
+++ b/syz-cluster/workflow/build-step/workflow-template.yaml
@@ -37,7 +37,7 @@ spec:
           - sh
           - -c
           - |
-            git clone --reference /kernel-repo /kernel-repo ./workdir
+            git clone --reference /kernel-repo -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo ./workdir
         env:
         - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
           value: "1"

--- a/syz-cluster/workflow/triage-step/workflow-template.yaml
+++ b/syz-cluster/workflow/triage-step/workflow-template.yaml
@@ -23,7 +23,7 @@ spec:
             - sh
             - -c
             - |
-              git clone --reference /kernel-repo /kernel-repo /workdir
+              git clone --reference /kernel-repo -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo /workdir
           env:
             - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
               value: "1"


### PR DESCRIPTION
Remap remote branches to local ones both when polling remote repositories and when cloning the distributed repository.

This will ensure that the branches are still accessible via TreeName/BranchName (it got broken during the latest changes).