### PR TITLE
tools/syz-env: support GOPROXY environment variable

### DIFF
--- a/tools/syz-env
+++ b/tools/syz-env
@@ -94,6 +94,7 @@ docker run \
 	--workdir /syzkaller/gopath/src/github.com/google/syzkaller \
 	--env HOME=/syzkaller \
 	--env GOPATH=/syzkaller/gopath:/gopath \
+	--env GOPROXY \
 	--env FUZZIT_API_KEY \
 	--env GITHUB_REF \
 	--env GITHUB_SHA \


### PR DESCRIPTION
Working in a firewalled environment where Go proxy services are blocked. To work around this, we need to set GORPOXY=direct in order to make go builds download packages directly from source rather than using a proxy. Support such setups by passing the user's GOPROXY setting into the syz-env Docker container.

## Testing

Without the change, builds are failing in my environment:

```
# ./tools/syz-env make
gcr.io/syzkaller/env:latest
go list -f '{{.Stale}}' -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  ./sys/syz-sysgen | grep -q false || go install -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  ./sys/syz-sysgen
make .descriptions
bin/syz-sysgen
touch .descriptions
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-manager github.com/google/syzkaller/syz-manager
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-repro github.com/google/syzkaller/tools/syz-repro
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-mutate github.com/google/syzkaller/tools/syz-mutate
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-prog2c github.com/google/syzkaller/tools/syz-prog2c
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-db github.com/google/syzkaller/tools/syz-db
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-upgrade github.com/google/syzkaller/tools/syz-upgrade
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/linux_amd64/syz-execprog github.com/google/syzkaller/tools/syz-execprog
mkdir -p ./bin/linux_amd64
g++ -o ./bin/linux_amd64/syz-executor executor/executor.cc \
	-m64 -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384 -Wno-stringop-overflow -Wno-array-bounds -Wno-format-overflow -Wno-unused-but-set-variable -Wno-unused-command-line-argument -static-pie -std=c++17 -I. -Iexecutor/_include   -DGOOS_linux=1 -DGOARCH_amd64=1 \
	-DHOSTGOOS_linux=1 -DGIT_REVISION=\"ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+\"
go: downloading cloud.google.com/go/bigquery v1.72.0
go: downloading cloud.google.com/go/bigquery v1.72.0
pkg/covermerger/bq_csv_reader.go:12:2: cloud.google.com/go/bigquery@v1.72.0: Get "https://proxy.golang.org/cloud.google.com/go/bigquery/@v/v1.72.0.zip": tls: failed to verify certificate: x509: certificate is valid for chalupa-dns-sinkhole.corp.amazon.com, not proxy.golang.org
make: *** [Makefile:167: execprog] Error 1
make: *** Waiting for unfinished jobs....
pkg/covermerger/bq_csv_reader.go:12:2: cloud.google.com/go/bigquery@v1.72.0: Get "https://proxy.golang.org/cloud.google.com/go/bigquery/@v/v1.72.0.zip": tls: failed to verify certificate: x509: certificate is valid for chalupa-dns-sinkhole.corp.amazon.com, not proxy.golang.org
make: *** [Makefile:164: manager] Error 1
/usr/bin/ld: /tmp/ccU7sbY9.o: in function `Connection::Connect(char const*, char const*)':
executor.cc:(.text._ZN10Connection7ConnectEPKcS1_[_ZN10Connection7ConnectEPKcS1_]+0x104): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

With the change, I can use `GOPROXY=direct` as expected:

```
# GOPROXY=direct ./tools/syz-env make
gcr.io/syzkaller/env:latest
go list -f '{{.Stale}}' -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  ./sys/syz-sysgen | grep -q false || go install -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  ./sys/syz-sysgen
make .descriptions
make[1]: '.descriptions' is up to date.
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-manager github.com/google/syzkaller/syz-manager
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-repro github.com/google/syzkaller/tools/syz-repro
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-mutate github.com/google/syzkaller/tools/syz-mutate
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-prog2c github.com/google/syzkaller/tools/syz-prog2c
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-db github.com/google/syzkaller/tools/syz-db
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/syz-upgrade github.com/google/syzkaller/tools/syz-upgrade
GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/google/syzkaller/prog.GitRevision=ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+ -X github.com/google/syzkaller/prog.gitRevisionDate=20251117-092759"  -o ./bin/linux_amd64/syz-execprog github.com/google/syzkaller/tools/syz-execprog
mkdir -p ./bin/linux_amd64
g++ -o ./bin/linux_amd64/syz-executor executor/executor.cc \
	-m64 -O2 -pthread -Wall -Werror -Wparentheses -Wunused-const-variable -Wframe-larger-than=16384 -Wno-stringop-overflow -Wno-array-bounds -Wno-format-overflow -Wno-unused-but-set-variable -Wno-unused-command-line-argument -static-pie -std=c++17 -I. -Iexecutor/_include   -DGOOS_linux=1 -DGOARCH_amd64=1 \
	-DHOSTGOOS_linux=1 -DGIT_REVISION=\"ef766cd7419cd6574f2bc8df4b866b93bc12bcb1+\"
go: downloading cloud.google.com/go/bigquery v1.72.0
go: downloading cloud.google.com/go/bigquery v1.72.0
/usr/bin/ld: /tmp/ccBEBqnT.o: in function `Connection::Connect(char const*, char const*)':
executor.cc:(.text._ZN10Connection7ConnectEPKcS1_[_ZN10Connection7ConnectEPKcS1_]+0x104): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
./tools/check-syzos.sh 2>/dev/null
```