### PR TITLE
pkg/build: update fuchsia image type in starnix build script

### DIFF
--- a/pkg/build/starnix.go
+++ b/pkg/build/starnix.go
@@ -107,7 +107,7 @@ func (st starnix) build(params Params) (ImageDetails, error) {
 		"-c", "log.enabled=false,ffx.analytics.disabled=true,daemon.autostart=false",
 		"product", "get-image-path", productBundlePath,
 		"--slot", "a",
-		"--image-type", "fxfs",
+		"--image-type", "fxfs.fastboot",
 	)
 	if err != nil {
 		return ImageDetails{}, err


### PR DESCRIPTION
Fuchsia product bundles have switched to including only sparse fxfs images,
and the --image-type flag value that we were previously passing to 
ffx product get-image-path is now obsolete. Replaced with the name of the
new option referring to the sparse image.

