### PR TITLE
pkg/build: build starnix in debug mode

### DIFF
--- a/pkg/build/starnix.go
+++ b/pkg/build/starnix.go
@@ -74,6 +74,7 @@ func (st starnix) build(params Params) (ImageDetails, error) {
 		params.KernelDir,
 		"scripts/fx", "--dir", buildSubdir,
 		"set", product,
+		"--debug",
 		"--assembly-override", fmt.Sprintf("//products/workbench/*=//local:%s", overrideName),
 	); err != nil {
 		return ImageDetails{}, err


### PR DESCRIPTION
Some debug features, like dynamic mutex cycle
detection, are no longer included by the default
build config. Add the --debug flag to fx set in
order to turn these features back on.