### PR TITLE
executor: sys/linux: implement SYZOS_API_NESTED_INTEL_VMWRITE_MASK

### DIFF
--- a/sys/linux/dev_kvm_amd64.txt
+++ b/sys/linux/dev_kvm_amd64.txt
@@ -101,23 +101,54 @@ syzos_api_nested_load_code {
 	insns	text[x86_64]
 } [packed]
 
+# VMCS Component Encoding is a 32-bit value, but only bits 0:15 are used.
+# Certain bit combinations are invalid, because the number encodes additional
+# parameters like access type and width.
+# Constants as per Intel SDM vol. 3C, Appendix B.
+vmcs_field_encoding [
+	control16	int64[0x0:0x4, 2]
+	guest16		int64[0x800:0x812, 2]
+	host16		int64[0xc00:0xc0c, 2]
+	control64	int64[0x2000:0x2033]
+	ro64		int64[0x2400:0x2401]
+	guest64		int64[0x2800:0x2813]
+	host64		int64[0x2c00:0x2c05]
+	control32	int64[0x4000:0x4022, 2]
+	ro32		int64[0x4400:0x440e, 2]
+	guest32		int64[0x4800:0x482e, 2]
+	host32		int64[0x4c00:0x4c00]
+	control_nat	int64[0x6000:0x600e, 2]
+	ro_nat		int64[0x6400:0x640a, 2]
+	guest_nat	int64[0x6800:0x6826, 2]
+	host_nat	int64[0x6c00:0x6c16, 2]
+]
+
+syzos_api_nested_intel_vmwrite_mask {
+	vm_id		syzos_api_vm_id
+	field		vmcs_field_encoding
+	set_mask	int64
+	unset_mask	int64
+	flip_mask	int64
+}
+
 # IDs here must match those in executor/common_kvm_amd64_syzos.h.
 syzos_api_call$x86 [
-	uexit			syzos_api$x86[0, intptr]
-	code			syzos_api$x86[10, syzos_api_code$x86]
-	cpuid			syzos_api$x86[100, syzos_api_cpuid]
-	wrmsr			syzos_api$x86[101, syzos_api_wrmsr]
-	rdmsr			syzos_api$x86[102, syzos_api_rdmsr]
-	wr_crn			syzos_api$x86[103, syzos_api_wr_crn]
-	wr_drn			syzos_api$x86[104, syzos_api_wr_drn]
-	in_dx			syzos_api$x86[105, syzos_api_in_dx]
-	out_dx			syzos_api$x86[106, syzos_api_out_dx]
-	set_irq_handler		syzos_api$x86[200, syzos_api_set_irq_handler]
-	enable_nested		syzos_api$x86[300, const[0, intptr]]
-	nested_create_vm	syzos_api$x86[301, syzos_api_vm_id]
-	nested_load_code	syzos_api$x86[302, syzos_api_nested_load_code]
-	nested_vmlaunch		syzos_api$x86[303, syzos_api_vm_id]
-	nested_vmresume		syzos_api$x86[304, syzos_api_vm_id]
+	uexit				syzos_api$x86[0, intptr]
+	code				syzos_api$x86[10, syzos_api_code$x86]
+	cpuid				syzos_api$x86[100, syzos_api_cpuid]
+	wrmsr				syzos_api$x86[101, syzos_api_wrmsr]
+	rdmsr				syzos_api$x86[102, syzos_api_rdmsr]
+	wr_crn				syzos_api$x86[103, syzos_api_wr_crn]
+	wr_drn				syzos_api$x86[104, syzos_api_wr_drn]
+	in_dx				syzos_api$x86[105, syzos_api_in_dx]
+	out_dx				syzos_api$x86[106, syzos_api_out_dx]
+	set_irq_handler			syzos_api$x86[200, syzos_api_set_irq_handler]
+	enable_nested			syzos_api$x86[300, const[0, intptr]]
+	nested_create_vm		syzos_api$x86[301, syzos_api_vm_id]
+	nested_load_code		syzos_api$x86[302, syzos_api_nested_load_code]
+	nested_vmlaunch			syzos_api$x86[303, syzos_api_vm_id]
+	nested_vmresume			syzos_api$x86[304, syzos_api_vm_id]
+	nested_intel_vmwrite_mask	syzos_api$x86[340, syzos_api_nested_intel_vmwrite_mask]
 ] [varlen]
 
 kvm_text_x86 [

--- a/sys/linux/test/amd64-syz_kvm_nested_vmwrite_mask
+++ b/sys/linux/test/amd64-syz_kvm_nested_vmwrite_mask
@@ -1,0 +1,40 @@
+#
+# requires: arch=amd64 -threaded
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm$x86(r1, &(0x7f0000c00000/0x400000)=nil)
+
+# Create a nested VM that performs HLT and INVD.
+# 1. L2 executes HLT -> exit to L1.
+# 2. L1 disables HLT exiting via vmwrite to CPU_BASED_VM_EXEC_CONTROL.
+# 3. L1 resumes L2 (RIP still at HLT).
+# 4. L2 executes HLT (no exit), which is delivered to L0.
+# 5. L0 resumes L1, which is still running L2.
+# 6. L2 executes INVD -> exit to L1.
+#
+r3 = syz_kvm_add_vcpu$x86(r2, &AUTO={0x0, &AUTO=[@enable_nested={AUTO, AUTO, 0x0}, @nested_create_vm={AUTO, AUTO, 0x0}, @nested_load_code={AUTO, AUTO, {0x0, "f40f08"}}, @nested_vmlaunch={AUTO, AUTO, 0x0}, @nested_intel_vmwrite_mask={AUTO, AUTO, {0x0, @control32=0x4002, 0x0, 0x80, 0x0}}, @nested_vmresume={AUTO, AUTO, 0x0}], AUTO})
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# L2 VM executes HLT. Exit reason is mapped to 0xe2e20001.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit$x86(r5, 0xe2e20001)
+
+# L1 disables HLT exiting and resumes L2. L2 resumes at HLT, and breaks out of KVM_RUN.
+# 0x05 is KVM_EXIT_HLT.
+# This confirms that the vmwrite command to disable HLT exiting was successful.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_kvm_exit$x86(r5, 0x5)
+
+# After resuming, L2 executes INVD. Exit reason is mapped to 0xe2e20002.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit$x86(r5, 0xe2e20002)
+
+# guest_main should finish with guest_uexit(-1).
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit$x86(r5, 0xffffffff)


### PR DESCRIPTION
The new command allows mutation of Intel VMCS fields with the help of vmwrite instruction.
In addition to VM ID and field ID, @nested_intel_vmwrite_mask takes three 64-bit numbers: the set mask, the unset mask, and the flip mask. This allows to make bitwise modifications to VMCS without disturbing the execution too much.

Also add sys/linux/test/amd64-syz_kvm_nested_vmwrite_mask to test the new command behavior.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
