### PR TITLE
pkg/csource: exclude auto-generated syscalls from tests

### DIFF
--- a/prog/rand.go
+++ b/prog/rand.go
@@ -670,9 +670,9 @@ func (target *Target) PseudoSyscalls() []*Syscall {
 }
 
 // GenSampleProg generates a single sample program for the call.
-func (target *Target) GenSampleProg(meta *Syscall, rs rand.Source) *Prog {
+func (target *Target) GenSampleProg(meta *Syscall, rs rand.Source, ct *ChoiceTable) *Prog {
 	r := newRand(target, rs)
-	s := newState(target, target.DefaultChoiceTable(), nil)
+	s := newState(target, ct, nil)
 	p := &Prog{
 		Target: target,
 	}

--- a/prog/target.go
+++ b/prog/target.go
@@ -370,6 +370,17 @@ func (target *Target) DefaultChoiceTable() *ChoiceTable {
 	return target.defaultChoiceTable
 }
 
+func (target *Target) NoAutoChoiceTable() *ChoiceTable {
+	calls := map[*Syscall]bool{}
+	for _, c := range target.Syscalls {
+		if c.Attrs.Automatic {
+			continue
+		}
+		calls[c] = true
+	}
+	return target.BuildChoiceTable(nil, calls)
+}
+
 func (target *Target) RequiredGlobs() []string {
 	globs := make(map[string]bool)
 	ForeachType(target.Syscalls, func(typ Type, ctx *TypeCtx) {


### PR DESCRIPTION
Auto-generated syscall descriptions currently do not properly mark arch-specific syscalls like socketcall (which is only available on 32 bit systems), which leads to TestGenerate breakages.

Until the syz-declextract tool is fixed and descriptions are re-generated, don't use such calls in TestGenerate tests. It has recently caused numerous syzkaller update erorrs on syzbot.

Cc #5410.
Closes #6468.