### PR TITLE
pkg/report: adapt to the new WARN format

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1811,7 +1811,7 @@ var linuxOopses = append([]*oops{
 		[]byte("WARNING:"),
 		[]oopsFormat{
 			{
-				title: compile("WARNING: .*lib/debugobjects\\.c.* (?:debug_print|debug_check)"),
+				title: compile("WARNING: .*lib/debugobjects\\.c.* (?:debug_print|debug_check|at)"),
 				fmt:   "WARNING: ODEBUG bug in %[1]v",
 				// Skip all users of ODEBUG as well.
 				stack: warningStackFmt("debug_", "rcu", "hrtimer_", "timer_",
@@ -1819,22 +1819,22 @@ var linuxOopses = append([]*oops{
 					"vfree", "__free_", "debug_check", "kobject_"),
 			},
 			{
-				title: compile("WARNING: .*mm/usercopy\\.c.* usercopy_warn"),
+				title: compile("WARNING: .*mm/usercopy\\.c.* (?:usercopy_warn|at)"),
 				fmt:   "WARNING: bad usercopy in %[1]v",
 				stack: warningStackFmt("usercopy", "__check"),
 			},
 			{
-				title: compile("WARNING: .*lib/kobject\\.c.* kobject_"),
+				title: compile("WARNING: .*lib/kobject\\.c.* (?:kobject_|at)"),
 				fmt:   "WARNING: kobject bug in %[1]v",
 				stack: warningStackFmt("kobject_"),
 			},
 			{
-				title: compile("WARNING: .*fs/proc/generic\\.c.* proc_register"),
+				title: compile("WARNING: .*fs/proc/generic\\.c.* (?:proc_register|at)"),
 				fmt:   "WARNING: proc registration bug in %[1]v",
 				stack: warningStackFmt("proc_"),
 			},
 			{
-				title: compile("WARNING: .*lib/refcount\\.c.* refcount_"),
+				title: compile("WARNING: .*lib/refcount\\.c.* (?:refcount_|at)"),
 				fmt:   "WARNING: refcount bug in %[1]v",
 				stack: warningStackFmt("refcount", "kobject_"),
 			},
@@ -1873,6 +1873,12 @@ var linuxOopses = append([]*oops{
 				title: compile("WARNING: .* usb_submit_urb"),
 				fmt:   "WARNING in %[1]v/usb_submit_urb",
 				stack: warningStackFmt("usb_submit_urb", "usb_start_wait_urb", "usb_bulk_msg", "usb_interrupt_msg", "usb_control_msg"),
+			},
+			{
+				// Format introduced in https://lore.kernel.org/all/20251110114633.202485143@infradead.org/.
+				title: compile(`WARNING: {{SRC}} at 0x\d+, CPU#\d+`),
+				fmt:   "WARNING in %[2]v",
+				stack: warningStackFmt(),
 			},
 			{
 				title: compile("WARNING: .* at {{SRC}} {{FUNC}}"),

--- a/pkg/report/testdata/linux/report/753
+++ b/pkg/report/testdata/linux/report/753
@@ -1,0 +1,154 @@
+TITLE: WARNING: ODEBUG bug in handle_softirqs
+TYPE: WARNING
+FRAME: handle_softirqs
+
+[ 1448.582383][    C1] ------------[ cut here ]------------
+[ 1448.582480][    C1] ODEBUG: free active (active state 0) object: ffff88807b3c4490 object type: timer_list hint: rose_t0timer_expiry+0x0/0x350
+[ 1448.582538][    C1] WARNING: lib/debugobjects.c:615 at 0x0, CPU#1: kworker/1:3/17677
+[ 1448.582567][    C1] Modules linked in:
+[ 1448.582646][    C1] CPU: 1 UID: 0 PID: 17677 Comm: kworker/1:3 Not tainted syzkaller #0 PREEMPT(full) 
+[ 1448.582667][    C1] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 10/25/2025
+[ 1448.582682][    C1] Workqueue: usb_hub_wq hub_event
+[ 1448.582706][    C1] RIP: 0010:debug_check_no_obj_freed+0x44a/0x550
+[ 1448.582735][    C1] Code: 89 44 24 20 e8 57 86 87 fd 48 8b 44 24 20 4c 8b 4d 00 4c 89 ef 48 c7 c6 00 4d e1 8b 48 c7 c2 00 52 e1 8b 8b 0c 24 4d 89 f8 50 <67> 48 0f b9 3a 48 83 c4 08 4c 8b 6c 24 18 48 b9 00 00 00 00 00 fc
+[ 1448.582754][    C1] RSP: 0018:ffffc90000a08a70 EFLAGS: 00010246
+[ 1448.582773][    C1] RAX: ffffffff8a52f8d0 RBX: ffffffff99ef7010 RCX: 0000000000000000
+[ 1448.582790][    C1] RDX: ffffffff8be15200 RSI: ffffffff8be14d00 RDI: ffffffff8fc9dd10
+[ 1448.582806][    C1] RBP: ffffffff8b8d0a00 R08: ffff88807b3c4490 R09: ffffffff8b8d1b40
+[ 1448.582822][    C1] R10: dffffc0000000000 R11: ffffffff81aee640 R12: ffff88807b3c4600
+[ 1448.582838][    C1] R13: ffffffff8fc9dd10 R14: ffff88807b3c4000 R15: ffff88807b3c4490
+[ 1448.582853][    C1] FS:  0000000000000000(0000) GS:ffff888125b3e000(0000) knlGS:0000000000000000
+[ 1448.582878][    C1] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 1448.582894][    C1] CR2: 00007effee671ff0 CR3: 0000000034f00000 CR4: 00000000003526f0
+[ 1448.582914][    C1] Call Trace:
+[ 1448.582923][    C1]  <IRQ>
+[ 1448.582930][    C1]  ? __pfx_rose_t0timer_expiry+0x10/0x10
+[ 1448.582965][    C1]  ? rose_timer_expiry+0x4cb/0x600
+[ 1448.582985][    C1]  kfree+0x13b/0x660
+[ 1448.583020][    C1]  rose_timer_expiry+0x4cb/0x600
+[ 1448.583046][    C1]  call_timer_fn+0x16e/0x590
+[ 1448.583070][    C1]  ? __pfx_rose_timer_expiry+0x10/0x10
+[ 1448.583092][    C1]  ? call_timer_fn+0xbe/0x590
+[ 1448.583118][    C1]  ? __pfx_call_timer_fn+0x10/0x10
+[ 1448.583153][    C1]  ? _raw_spin_unlock_irq+0x23/0x50
+[ 1448.583183][    C1]  ? lockdep_hardirqs_on+0x98/0x140
+[ 1448.583201][    C1]  ? __pfx_rose_timer_expiry+0x10/0x10
+[ 1448.583228][    C1]  __run_timer_base+0x61a/0x860
+[ 1448.583269][    C1]  ? __pfx___run_timer_base+0x10/0x10
+[ 1448.583292][    C1]  ? seqcount_lockdep_reader_access+0x15e/0x1c0
+[ 1448.583345][    C1]  run_timer_softirq+0xb7/0x180
+[ 1448.583371][    C1]  handle_softirqs+0x27d/0x850
+[ 1448.583402][    C1]  ? __irq_exit_rcu+0xca/0x1f0
+[ 1448.583433][    C1]  ? __pfx_handle_softirqs+0x10/0x10
+[ 1448.583464][    C1]  ? irqtime_account_irq+0xb6/0x1c0
+[ 1448.583500][    C1]  __irq_exit_rcu+0xca/0x1f0
+[ 1448.583525][    C1]  ? __pfx___irq_exit_rcu+0x10/0x10
+[ 1448.583560][    C1]  irq_exit_rcu+0x9/0x30
+[ 1448.583583][    C1]  sysvec_apic_timer_interrupt+0xa6/0xc0
+[ 1448.583616][    C1]  </IRQ>
+[ 1448.583624][    C1]  <TASK>
+[ 1448.583636][    C1]  asm_sysvec_apic_timer_interrupt+0x1a/0x20
+[ 1448.583660][    C1] RIP: 0010:console_flush_all+0x846/0xb60
+[ 1448.583692][    C1] Code: ff ff e8 8d 23 20 00 90 0f 0b 90 e9 53 fc ff ff e8 7f 23 20 00 e8 3a 65 c0 09 48 85 db 74 c0 e8 70 23 20 00 fb 48 8b 5c 24 10 <48> 8b 44 24 20 42 80 3c 20 00 4c 8b 74 24 18 74 08 4c 89 f7 e8 f1
+[ 1448.583711][    C1] RSP: 0018:ffffc900048fe2e0 EFLAGS: 00000287
+[ 1448.583733][    C1] RAX: ffffffff81a1bc90 RBX: ffffc900048fe480 RCX: 0000000000100000
+[ 1448.583750][    C1] RDX: ffffc9001215d000 RSI: 000000000002bfc9 RDI: 000000000002bfca
+[ 1448.583767][    C1] RBP: ffffc900048fe430 R08: ffffffff8fbf8277 R09: 1ffffffff1f7f04e
+[ 1448.583785][    C1] R10: dffffc0000000000 R11: fffffbfff1f7f04f R12: dffffc0000000000
+[ 1448.583802][    C1] R13: 0000000000000001 R14: 0000000000000000 R15: ffffffff8eb89b80
+[ 1448.583827][    C1]  ? console_flush_all+0x840/0xb60
+[ 1448.583876][    C1]  ? console_flush_all+0x131/0xb60
+[ 1448.583914][    C1]  ? __pfx_console_flush_all+0x10/0x10
+[ 1448.583956][    C1]  ? is_printk_cpu_sync_owner+0x32/0x40
+[ 1448.583983][    C1]  console_unlock+0xbb/0x190
+[ 1448.584012][    C1]  ? __pfx___down_trylock_console_sem+0x10/0x10
+[ 1448.584044][    C1]  ? __pfx_console_unlock+0x10/0x10
+[ 1448.584083][    C1]  vprintk_emit+0x4f8/0x5f0
+[ 1448.584115][    C1]  ? __pfx_vprintk_emit+0x10/0x10
+[ 1448.584148][    C1]  ? __pfx_snprintf+0x10/0x10
+[ 1448.584180][    C1]  ? do_raw_spin_lock+0x121/0x290
+[ 1448.584218][    C1]  dev_vprintk_emit+0x337/0x3f0
+[ 1448.584251][    C1]  ? __pfx_dev_vprintk_emit+0x10/0x10
+[ 1448.584288][    C1]  ? do_raw_spin_lock+0x121/0x290
+[ 1448.584325][    C1]  dev_printk_emit+0xe0/0x130
+[ 1448.584352][    C1]  ? rcu_is_watching+0x15/0xb0
+[ 1448.584389][    C1]  ? __pfx_dev_printk_emit+0x10/0x10
+[ 1448.584432][    C1]  __netdev_printk+0x3e1/0x480
+[ 1448.584471][    C1]  netdev_warn+0x10a/0x160
+[ 1448.584493][    C1]  ? __pfx__raw_spin_unlock_irqrestore+0x10/0x10
+[ 1448.584523][    C1]  ? trace_rpm_return_int+0x83/0x1e0
+[ 1448.584560][    C1]  ? __pfx_netdev_warn+0x10/0x10
+[ 1448.584587][    C1]  ? __pm_runtime_idle+0x13c/0x1a0
+[ 1448.584616][    C1]  ? usbnet_read_cmd+0xbb/0xe0
+[ 1448.584655][    C1]  smsc75xx_wait_eeprom+0x256/0x290
+[ 1448.584686][    C1]  ? __pm_runtime_idle+0xef/0x1a0
+[ 1448.584715][    C1]  ? __pfx_smsc75xx_wait_eeprom+0x10/0x10
+[ 1448.584750][    C1]  ? usbnet_write_cmd+0xbb/0xe0
+[ 1448.584787][    C1]  smsc75xx_read_eeprom+0x128/0x350
+[ 1448.584822][    C1]  ? __pfx_smsc75xx_read_eeprom+0x10/0x10
+[ 1448.584870][    C1]  smsc75xx_bind+0x55d/0xd40
+[ 1448.584906][    C1]  ? __pfx_smsc75xx_bind+0x10/0x10
+[ 1448.584945][    C1]  ? usbnet_probe+0x934/0x28f0
+[ 1448.584981][    C1]  usbnet_probe+0xab5/0x28f0
+[ 1448.585013][    C1]  ? usb_unlocked_disable_lpm+0x8c/0xb0
+[ 1448.585058][    C1]  ? __pfx_usbnet_probe+0x10/0x10
+[ 1448.585087][    C1]  ? _raw_spin_unlock_irqrestore+0xad/0x110
+[ 1448.585119][    C1]  ? __pfx__raw_spin_unlock_irqrestore+0x10/0x10
+[ 1448.585149][    C1]  ? ktime_get_mono_fast_ns+0x2af/0x2d0
+[ 1448.585182][    C1]  ? usb_disable_lpm+0x77/0x3e0
+[ 1448.585212][    C1]  usb_probe_interface+0x668/0xc90
+[ 1448.585252][    C1]  ? __pfx_usb_probe_interface+0x10/0x10
+[ 1448.585279][    C1]  really_probe+0x26d/0xad0
+[ 1448.585318][    C1]  __driver_probe_device+0x18c/0x320
+[ 1448.585353][    C1]  driver_probe_device+0x4f/0x240
+[ 1448.585389][    C1]  __device_attach_driver+0x279/0x430
+[ 1448.585426][    C1]  bus_for_each_drv+0x251/0x2e0
+[ 1448.585452][    C1]  ? __pfx___device_attach_driver+0x10/0x10
+[ 1448.585485][    C1]  ? __pfx_bus_for_each_drv+0x10/0x10
+[ 1448.585522][    C1]  __device_attach+0x2b8/0x430
+[ 1448.585556][    C1]  ? __pfx___device_attach+0x10/0x10
+[ 1448.585589][    C1]  ? do_raw_spin_unlock+0x122/0x240
+[ 1448.585625][    C1]  bus_probe_device+0x185/0x260
+[ 1448.585655][    C1]  device_add+0x7b6/0xb80
+[ 1448.585689][    C1]  usb_set_configuration+0x1a87/0x2110
+[ 1448.585745][    C1]  usb_generic_driver_probe+0x8d/0x150
+[ 1448.585774][    C1]  usb_probe_device+0x1c4/0x3c0
+[ 1448.585805][    C1]  ? __pfx_usb_probe_device+0x10/0x10
+[ 1448.585831][    C1]  really_probe+0x26d/0xad0
+[ 1448.585874][    C1]  __driver_probe_device+0x18c/0x320
+[ 1448.585909][    C1]  driver_probe_device+0x4f/0x240
+[ 1448.585945][    C1]  __device_attach_driver+0x279/0x430
+[ 1448.585981][    C1]  bus_for_each_drv+0x251/0x2e0
+[ 1448.586008][    C1]  ? __pfx___device_attach_driver+0x10/0x10
+[ 1448.586040][    C1]  ? __pfx_bus_for_each_drv+0x10/0x10
+[ 1448.586077][    C1]  __device_attach+0x2b8/0x430
+[ 1448.586110][    C1]  ? __pfx___device_attach+0x10/0x10
+[ 1448.586146][    C1]  ? do_raw_spin_unlock+0x122/0x240
+[ 1448.586182][    C1]  bus_probe_device+0x185/0x260
+[ 1448.586212][    C1]  device_add+0x7b6/0xb80
+[ 1448.586245][    C1]  usb_new_device+0xa39/0x1720
+[ 1448.586281][    C1]  ? __pfx_usb_new_device+0x10/0x10
+[ 1448.586305][    C1]  ? _raw_spin_unlock_irq+0x23/0x50
+[ 1448.586336][    C1]  ? lockdep_hardirqs_on+0x98/0x140
+[ 1448.586364][    C1]  hub_event+0x29b1/0x4ef0
+[ 1448.586443][    C1]  ? __pfx_hub_event+0x10/0x10
+[ 1448.586468][    C1]  ? process_one_work+0x868/0x15a0
+[ 1448.586499][    C1]  ? _raw_spin_unlock_irq+0x23/0x50
+[ 1448.586534][    C1]  ? process_one_work+0x868/0x15a0
+[ 1448.586556][    C1]  process_one_work+0x93a/0x15a0
+[ 1448.586604][    C1]  ? __pfx_process_one_work+0x10/0x10
+[ 1448.586637][    C1]  ? assign_work+0x3a1/0x410
+[ 1448.586666][    C1]  worker_thread+0x9b0/0xee0
+[ 1448.586718][    C1]  kthread+0x711/0x8a0
+[ 1448.586752][    C1]  ? __pfx_worker_thread+0x10/0x10
+[ 1448.586777][    C1]  ? __pfx_kthread+0x10/0x10
+[ 1448.586809][    C1]  ? _raw_spin_unlock_irq+0x23/0x50
+[ 1448.586839][    C1]  ? lockdep_hardirqs_on+0x98/0x140
+[ 1448.586859][    C1]  ? __pfx_kthread+0x10/0x10
+[ 1448.586894][    C1]  ret_from_fork+0x599/0xb30
+[ 1448.586921][    C1]  ? __pfx_ret_from_fork+0x10/0x10
+[ 1448.586956][    C1]  ? __switch_to_asm+0x39/0x70
+[ 1448.586985][    C1]  ? __switch_to_asm+0x33/0x70
+[ 1448.587013][    C1]  ? __pfx_kthread+0x10/0x10
+[ 1448.587043][    C1]  ret_from_fork_asm+0x1a/0x30
+[ 1448.587091][    C1]  </TASK>

--- a/pkg/report/testdata/linux/report/754
+++ b/pkg/report/testdata/linux/report/754
@@ -1,0 +1,68 @@
+TITLE: WARNING: refcount bug in __vma_enter_locked
+TYPE: REFCOUNT_WARNING
+FRAME: __vma_enter_locked
+EXECUTOR: proc=3, id=20
+
+
+[   99.057804][ T6051] ------------[ cut here ]------------
+[   99.063495][ T6051] refcount_t: saturated; leaking memory.
+[   99.069428][ T6051] WARNING: lib/refcount.c:19 at 0x0, CPU#1: syz.3.20/6051
+[   99.078460][ T6051] Modules linked in:
+[   99.082515][ T6051] CPU: 1 UID: 0 PID: 6051 Comm: syz.3.20 Not tainted syzkaller #0 PREEMPT(full) 
+[   99.084063][ T5884] Bluetooth: hci3: command tx timeout
+[   99.091778][ T6051] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 10/25/2025
+[   99.108470][ T6051] RIP: 0010:refcount_warn_saturate+0xc5/0x110
+[   99.115982][ T6051] Code: 91 0e 33 0b 67 48 0f b9 3a eb 37 e8 95 1c 2b fd 48 8d 3d 8e 0e 33 0b 67 48 0f b9 3a eb 24 e8 82 1c 2b fd 48 8d 3d 8b 0e 33 0b <67> 48 0f b9 3a eb 11 e8 6f 1c 2b fd 48 8d 3d 88 0e 33 0b 67 48 0f
+[   99.135953][ T6051] RSP: 0018:ffffc90003017568 EFLAGS: 00010293
+[   99.142036][ T6051] RAX: ffffffff8496c3fe RBX: 0000000000000000 RCX: ffff888033329e80
+[   99.150505][ T6051] RDX: 0000000000000000 RSI: ffffffff8ea87240 RDI: ffffffff8fc9d290
+[   99.159979][ T6051] RBP: ffffc90003017690 R08: ffff888033329e80 R09: 0000000000000005
+[   99.168296][ T6051] R10: 0000000000000004 R11: 0000000000000000 R12: ffff888074927bc0
+[   99.176450][ T6051] R13: ffff888074927b40 R14: ffff888074927bc0 R15: 0000000000000000
+[   99.184247][ T3067] wlan1: Creating new IBSS network, BSSID 50:50:50:50:50:50
+[   99.184486][ T6051] FS:  00007f3c56b436c0(0000) GS:ffff888125b41000(0000) knlGS:0000000000000000
+[   99.200803][ T6051] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[   99.208522][ T6051] CR2: 00007fc5622e2a90 CR3: 0000000074a98000 CR4: 00000000003526f0
+[   99.217473][ T6051] Call Trace:
+[   99.220803][ T6051]  <TASK>
+[   99.223753][ T6051]  __vma_enter_locked+0x62e/0x6a0
+[   99.229335][ T6051]  ? __vma_start_write+0x23/0x140
+[   99.235141][ T6051]  ? __pfx___vma_enter_locked+0x10/0x10
+[   99.240967][ T6051]  __vma_start_write+0x23/0x140
+[   99.246265][ T6051]  vma_modify+0xf62/0x1a70
+[   99.250960][ T6051]  vma_modify_flags_uffd+0x204/0x250
+[   99.256449][ T6051]  ? __pfx_vma_modify_flags_uffd+0x10/0x10
+[   99.262313][ T6051]  ? mas_find+0xb0e/0xd30
+[   99.266871][ T6051]  userfaultfd_release_all+0x34c/0x5d0
+[   99.272385][ T6051]  ? __pfx_userfaultfd_release_all+0x10/0x10
+[   99.279680][ T6051]  userfaultfd_release+0xe7/0x1b0
+[   99.284853][ T6051]  ? __pfx_userfaultfd_release+0x10/0x10
+[   99.290503][ T6051]  ? preempt_schedule_common+0x83/0xd0
+[   99.296110][ T6051]  ? preempt_schedule+0xae/0xc0
+[   99.301081][ T6051]  ? __pfx_preempt_schedule+0x10/0x10
+[   99.306683][ T6051]  ? evm_file_release+0x107/0x1e0
+[   99.312839][ T6051]  ? __pfx_userfaultfd_release+0x10/0x10
+[   99.320116][ T6051]  __fput+0x44c/0xa70
+[   99.324441][ T6051]  task_work_run+0x1d4/0x260
+[   99.329243][ T6051]  ? __pfx_task_work_run+0x10/0x10
+[   99.334445][ T6051]  get_signal+0x11ec/0x1340
+[   99.338989][ T6051]  arch_do_signal_or_restart+0x9a/0x7a0
+[   99.344642][ T6051]  ? __pfx_task_work_add+0x10/0x10
+[   99.349787][ T6051]  ? __pfx_arch_do_signal_or_restart+0x10/0x10
+[   99.356052][ T6051]  ? __fput_deferred+0x215/0x390
+[   99.361030][ T6051]  ? exit_to_user_mode_loop+0x55/0x4f0
+[   99.366760][ T6051]  exit_to_user_mode_loop+0x87/0x4f0
+[   99.372084][ T6051]  ? rcu_is_watching+0x15/0xb0
+[   99.377392][ T6051]  do_syscall_64+0x2e3/0xf80
+[   99.382025][ T6051]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   99.388226][ T6051]  ? clear_bhb_loop+0x60/0xb0
+[   99.392940][ T6051]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   99.399055][ T6051] RIP: 0033:0x7f3c55d8f749
+[   99.403592][ T6051] Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+[   99.424712][ T6051] RSP: 002b:00007f3c56b43038 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
+[   99.433370][ T6051] RAX: fffffffffffffffc RBX: 00007f3c55fe5fa0 RCX: 00007f3c55d8f749
+[   99.443455][ T6051] RDX: 0000200000000100 RSI: 00000000c028aa05 RDI: 0000000000000003
+[   99.451556][ T6051] RBP: 00007f3c55e13f91 R08: 0000000000000000 R09: 0000000000000000
+[   99.460458][ T6051] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
+[   99.468534][ T6051] R13: 00007f3c55fe6038 R14: 00007f3c55fe5fa0 R15: 00007ffe60821b78
+[   99.477252][ T6051]  </TASK>

--- a/pkg/report/testdata/linux/report/755
+++ b/pkg/report/testdata/linux/report/755
@@ -1,0 +1,76 @@
+TITLE: WARNING in ext4_xattr_inode_update_ref
+TYPE: WARNING
+FRAME: ext4_xattr_inode_update_ref
+EXECUTOR: proc=0, id=17
+
+[   92.518566][ T5982] ------------[ cut here ]------------
+[   92.524796][ T5982] EA inode 11 i_nlink=2
+[   92.524882][ T5982] WARNING: fs/ext4/xattr.c:1058 at 0x0, CPU#0: syz.0.17/5982
+[   92.537107][ T5982] Modules linked in:
+[   92.541176][ T5982] CPU: 0 UID: 0 PID: 5982 Comm: syz.0.17 Not tainted syzkaller #0 PREEMPT(full) 
+[   92.550634][ T5982] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 10/25/2025
+[   92.561124][ T5982] RIP: 0010:ext4_xattr_inode_update_ref+0x4dc/0x570
+[   92.567942][ T5982] Code: 74 08 4c 89 ef e8 14 b0 9a ff 4d 8b 6d 00 48 b8 00 00 00 00 00 fc ff df 41 0f b6 04 06 84 c0 75 77 41 8b 17 4c 89 e7 4c 89 ee <67> 48 0f b9 3a 4c 8b 6c 24 28 e9 bd fe ff ff e8 20 af ca 08 44 89
+[   92.588213][ T5982] RSP: 0018:ffffc90003117100 EFLAGS: 00010246
+[   92.594460][ T5982] RAX: 0000000000000000 RBX: 1ffff1100bb197c9 RCX: dffffc0000000000
+[   92.602723][ T5982] RDX: 0000000000000002 RSI: 000000000000000b RDI: ffffffff8f845a00
+[   92.611969][ T5982] RBP: ffffc900031171f8 R08: ffff88805d8cbe4f R09: 1ffff1100bb197c9
+[   92.620220][ T5982] R10: dffffc0000000000 R11: ffffed100bb197ca R12: ffffffff8f845a00
+[   92.628334][ T5982] R13: 000000000000000b R14: 1ffff1100bb19794 R15: ffff88805d8cbca0
+[   92.636412][ T5982] FS:  000055557939f500(0000) GS:ffff888125e8b000(0000) knlGS:0000000000000000
+[   92.645478][ T5982] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[   92.652323][ T5982] CR2: 00007f3939572a60 CR3: 0000000074ca6000 CR4: 00000000003526f0
+[   92.660779][ T5982] Call Trace:
+[   92.664385][ T5982]  <TASK>
+[   92.667663][ T5982]  ? __pfx_inode_set_ctime_to_ts+0x10/0x10
+[   92.673557][ T5982]  ? __pfx_ext4_xattr_inode_update_ref+0x10/0x10
+[   92.679902][ T5982]  ? ext4_xattr_inode_iget+0x3d2/0x5f0
+[   92.685672][ T5982]  ext4_xattr_set_entry+0xabb/0x1e20
+[   92.691132][ T5982]  ext4_xattr_ibody_set+0x254/0x6a0
+[   92.696590][ T5982]  ext4_expand_extra_isize_ea+0x13ad/0x1ea0
+[   92.702534][ T5982]  __ext4_expand_extra_isize+0x30d/0x400
+[   92.708350][ T5982]  __ext4_mark_inode_dirty+0x45c/0x6e0
+[   92.714057][ T5982]  ext4_evict_inode+0x79c/0xe60
+[   92.719052][ T5982]  ? __pfx_ext4_evict_inode+0x10/0x10
+[   92.724565][ T5982]  ? do_raw_spin_unlock+0x122/0x240
+[   92.729790][ T5982]  ? __pfx_ext4_evict_inode+0x10/0x10
+[   92.735341][ T5982]  evict+0x5f4/0xae0
+[   92.739271][ T5982]  ? __pfx_evict+0x10/0x10
+[   92.743784][ T5982]  ? _raw_spin_unlock+0x28/0x50
+[   92.748665][ T5982]  ? iput+0xcc6/0x1030
+[   92.752967][ T5982]  ext4_orphan_cleanup+0xc20/0x1460
+[   92.759239][ T5982]  ? __pfx_ext4_orphan_cleanup+0x10/0x10
+[   92.765079][ T5982]  ? ext4_register_li_request+0x640/0x720
+[   92.770862][ T5982]  ? errseq_check_and_advance+0x66/0x120
+[   92.776581][ T5982]  ext4_fill_super+0x5946/0x6200
+[   92.781752][ T5982]  ? __pfx_ext4_fill_super+0x10/0x10
+[   92.787273][ T5982]  ? snprintf+0xda/0x120
+[   92.791822][ T5982]  ? __pfx_snprintf+0x10/0x10
+[   92.796611][ T5982]  ? set_blocksize+0x21e/0x500
+[   92.801601][ T5982]  ? sb_set_blocksize+0x155/0x240
+[   92.806934][ T5982]  ? setup_bdev_super+0x4c1/0x5b0
+[   92.812002][ T5982]  get_tree_bdev_flags+0x40e/0x4d0
+[   92.817700][ T5982]  ? __pfx_ext4_fill_super+0x10/0x10
+[   92.824046][ T5982]  ? __pfx_get_tree_bdev_flags+0x10/0x10
+[   92.829727][ T5982]  vfs_get_tree+0x92/0x2a0
+[   92.834405][ T5982]  do_new_mount+0x302/0xa10
+[   92.838970][ T5982]  ? apparmor_capable+0x137/0x1a0
+[   92.845392][ T5982]  ? __pfx_do_new_mount+0x10/0x10
+[   92.850851][ T5982]  ? ns_capable+0x8a/0xf0
+[   92.855658][ T5982]  ? kmem_cache_free+0x197/0x620
+[   92.860625][ T5982]  __se_sys_mount+0x313/0x410
+[   92.866399][ T5982]  ? __pfx___se_sys_mount+0x10/0x10
+[   92.871999][ T5982]  ? do_syscall_64+0xbe/0xf80
+[   92.876791][ T5982]  ? __x64_sys_mount+0x20/0xc0
+[   92.881596][ T5982]  do_syscall_64+0xfa/0xf80
+[   92.886160][ T5982]  ? entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   92.892335][ T5982]  ? clear_bhb_loop+0x60/0xb0
+[   92.897669][ T5982]  entry_SYSCALL_64_after_hwframe+0x77/0x7f
+[   92.904447][ T5982] RIP: 0033:0x7f3939590eea
+[   92.909010][ T5982] Code: d8 64 89 02 48 c7 c0 ff ff ff ff eb a6 e8 de 1a 00 00 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 49 89 ca b8 a5 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 a8 ff ff ff f7 d8 64 89 01 48
+[   92.929288][ T5982] RSP: 002b:00007fffa9553f88 EFLAGS: 00000246 ORIG_RAX: 00000000000000a5
+[   92.938034][ T5982] RAX: ffffffffffffffda RBX: 00007fffa9554010 RCX: 00007f3939590eea
+[   92.946954][ T5982] RDX: 0000200000000180 RSI: 00002000000001c0 RDI: 00007fffa9553fd0
+[   92.955125][ T5982] RBP: 0000200000000180 R08: 00007fffa9554010 R09: 0000000000800700
+[   92.963266][ T5982] R10: 0000000000800700 R11: 0000000000000246 R12: 00002000000001c0
+[   92.971924][ T5982] R13: 00007fffa9553fd0 R14: 000000000000046f R15: 000000000000002c


### PR DESCRIPTION
The format has been changed recently:
https://lore.kernel.org/all/20251110114633.202485143@infradead.org/

This commit addresses the duplicates we currently see among the linux-next bugs, but likely there are more. We'll fix it once we notice them.