### PR TITLE
syz-cluster: log HEAD commit date during triage

### DIFF
--- a/syz-cluster/pkg/triage/commit.go
+++ b/syz-cluster/pkg/triage/commit.go
@@ -45,7 +45,7 @@ func (cs *CommitSelector) Select(series *api.Series, tree *api.Tree, lastBuild *
 	if err != nil || head == nil {
 		return SelectResult{}, err
 	}
-	cs.tracer.Log("current HEAD: %q (%v)", head.Hash, head.Date)
+	cs.tracer.Log("current HEAD: %q (commit date: %v)", head.Hash, head.CommitDate)
 	// If the series is already too old, it may be incompatible even if it applies cleanly.
 	const seriesLagsBehind = time.Hour * 24 * 7
 	if diff := head.CommitDate.Sub(series.PublishedAt); series.PublishedAt.Before(head.CommitDate) &&


### PR DESCRIPTION
Currently triage logs look a bit confusing since for some commits they include author date and for other commit date. Use commit date everywhere.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
