### PR TITLE
executor: apply optnone to guest_handle_nested_vmentry_intel()

### DIFF
--- a/executor/common_kvm_amd64_syzos.h
+++ b/executor/common_kvm_amd64_syzos.h
@@ -1151,7 +1151,10 @@ guest_handle_nested_load_code(struct api_call_nested_load_code* cmd, uint64 cpu_
 	}
 }
 
-GUEST_CODE static noinline void
+// Clang's LTO may ignore noinline and attempt to inline this function into both callers,
+// which results in duplicate declaration of after_vmentry_label.
+// Applying __optnone should prevent this behavior.
+GUEST_CODE static noinline __optnone void
 guest_handle_nested_vmentry_intel(uint64 vm_id, uint64 cpu_id, bool is_launch)
 {
 	uint64 vmx_error_code = 0;

--- a/executor/common_kvm_syzos.h
+++ b/executor/common_kvm_syzos.h
@@ -35,6 +35,15 @@
 #define __addrspace_guest
 #endif
 
+// Disable optimizations for a particular function.
+#if defined(__clang__)
+#define __optnone __attribute__((optnone))
+#elif defined(__GNUC__)
+#define __optnone __attribute__((optimize("O0")))
+#else
+#define __optnone
+#endif
+
 // Host will map the code in this section into the guest address space.
 #define GUEST_CODE __attribute__((section("guest"))) __no_stack_protector __addrspace_guest
 


### PR DESCRIPTION
Florent Revest reported ThinLTO builds failing with the following error:

  <inline asm>:2:1: error: symbol 'after_vmentry_label' is already defined
  after_vmentry_label:
  ^
  error: cannot compile inline asm

, which turned out to be caused by the compiler not respecting `noinline`.

Adding __attribute__((optnone)) fixes the problem.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
