### PR TITLE
dashboard/app: add pprof handlers

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -25,7 +25,8 @@ handlers:
 - url: /static
   static_dir: dashboard/app/static
   secure: always
-- url: /(admin|cron/.*)
+# debug is for net/http/pprof handlers.
+- url: /(admin|debug|cron/.*)
   script: auto
   login: admin
   secure: always

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	_ "net/http/pprof" // app.yaml restricts this to admins
 	"net/url"
 	"os"
 	"regexp"


### PR DESCRIPTION
These are useful for debugging of deadlocks, hangs (slowness),
and memory consumption issues.
Can be used on a local instance during development.
On the production system pprof handlers are restricted to admins only.
