### PR TITLE
dashboard/app: fix up top menu

### DIFF
--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -59,7 +59,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		{{if not (eq .URLPath "/admin")}}
 		<div class="navigation">
 			<div class="navigation_tab{{if eq .URLPath (printf "/%v" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}'><span style="color:DeepPink;">🐞</span> Open [{{$.BugCounts.Open}}]</a>
+				<a href='/{{$.Namespace}}'><span style="color:DeepPink;">🐞 Open [{{$.BugCounts.Open}}]</span></a>
 			</div>
 
 			{{if .ShowSubsystems}}
@@ -69,11 +69,11 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{end}}
 
 			<div class="navigation_tab{{if eq .URLPath (printf "/%v/fixed" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/fixed'><span style="color:ForestGreen;">🐞</span> Fixed [{{$.BugCounts.Fixed}}]</a>
+				<a href='/{{$.Namespace}}/fixed'><span style="color:ForestGreen;">🐞 Fixed [{{$.BugCounts.Fixed}}]</span></a>
 			</div>
 
 			<div class="navigation_tab{{if eq .URLPath (printf "/%v/invalid" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/invalid'>
-				<a href='/{{$.Namespace}}/invalid'><span style="color:RoyalBlue;">🐞</span> Invalid [{{$.BugCounts.Invalid}}]</a>
+				<a href='/{{$.Namespace}}/invalid'><span style="color:RoyalBlue;">🐞 Invalid [{{$.BugCounts.Invalid}}]</span></a>
 			</div>
 
 			{{if gt .MissingBackports 0}}
@@ -116,7 +116,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			</div>
 			{{end}}
 			{{if .ContactEmail}}
-			<div class="navigation_tab navigation_right">
+			<div class="navigation_tab">
 				<a href='mailto:{{.ContactEmail}}'><span style="color:ForestGreen;">💬</span> Send us feedback</a>
 			</div>
 			{{end}}


### PR DESCRIPTION
Colors do not affect 🐞, so extend the color to text as well.
Remove navigation_right style, it does not exist.
