### PR TITLE
dashboard/app: fix up pprof handlers access

### DIFF
--- a/dashboard/app/app.yaml
+++ b/dashboard/app/app.yaml
@@ -26,7 +26,7 @@ handlers:
   static_dir: dashboard/app/static
   secure: always
 # debug is for net/http/pprof handlers.
-- url: /(admin|debug|cron/.*)
+- url: /(admin|debug/.*|cron/.*)
   script: auto
   login: admin
   secure: always


### PR DESCRIPTION
The url pattern needs to include all debug/.* subpaths, not just debug page itself.
