### PR TITLE
pkg/instance: fix 386 repros/jobs

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -198,9 +198,8 @@ func (inst *ExecProgInstance) RunSyzProgFile(progFile string, duration time.Dura
 	if err != nil {
 		return nil, &TestError{Title: fmt.Sprintf("failed to copy prog to VM: %v", err)}
 	}
-	target := inst.mgrCfg.SysTarget
-	command := ExecprogCmd(inst.execprogBin, inst.executorBin, target.OS, target.Arch, inst.mgrCfg.Type, opts,
-		!inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, vmProgFile)
+	command := ExecprogCmd(inst.execprogBin, inst.executorBin, inst.mgrCfg.TargetOS, inst.mgrCfg.TargetArch,
+		inst.mgrCfg.Type, opts, !inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, vmProgFile)
 	return inst.runCommand(command, duration, exitCondition)
 }
 


### PR DESCRIPTION
All repros and jobs that use syz rerpos are broken for linux/amd64/386 since Mar 2022 with:

SYZFAIL: failed to recv rpc
aborting RPC server: mismatching manager/executor arches: amd64 vs 386

The problem is that ExecProgInstance.RunSyzProgFile passes sysTarget.Arch
(which is VMArch) to syz-execprog, so it expects executor to be amd64.

Restore the orignal logic.
