### PR TITLE
dashboard/app: wire more admin handlers

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -967,6 +967,12 @@ func handleAdmin(c context.Context, w http.ResponseWriter, r *http.Request) erro
 		}
 	case "invalidate_bisection":
 		return handleInvalidateBisection(c, w, r)
+	case "updateBugReporting":
+		return updateBugReporting(c, w, r)
+	case "restartFailedBisections":
+		return restartFailedBisections(c, w, r)
+	case "setMissingBugFields":
+		return setMissingBugFields(c, w, r)
 	case "emergency_stop":
 		if err := recordEmergencyStop(c); err != nil {
 			return fmt.Errorf("failed to record an emergency stop: %w", err)


### PR DESCRIPTION
Make it possible 3 more admin handlers that look useful for future and safe.
Now that we don't deploy the app from local machines, it's problematic
to call them without this wiring.
Remove one old handler that we don't need anymore.
