### PR TITLE
vm/vmimpl: increase wait for output timeout

### DIFF
--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -167,7 +167,7 @@ func (cc CmdCloser) Close() error {
 	return cc.Wait()
 }
 
-var WaitForOutputTimeout = 10 * time.Second
+var WaitForOutputTimeout = 20 * time.Second
 
 type MultiplexConfig struct {
 	Console     io.Closer


### PR DESCRIPTION
Apparently, the current timeout is not always enough in case of task hungs on a loaded VM:
https://groups.google.com/g/syzkaller-bugs/c/rI2gfkV02Ks

We only wait in case of crashes, so increasing the value should have a significant performance impact.