### PR TITLE
pkg/osutil: fix CreationTime

### DIFF
--- a/pkg/manager/crash.go
+++ b/pkg/manager/crash.go
@@ -235,7 +235,7 @@ func (cs *CrashStore) BugInfo(id string, full bool) (*BugInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	stat, err := os.Stat(filepath.Join(dir, "description"))
+	ret.FirstTime, ret.LastTime, err = osutil.FileTimes(filepath.Join(dir, "description"))
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +250,6 @@ func (cs *CrashStore) BugInfo(id string, full bool) (*BugInfo, error) {
 		}
 	}
 
-	ret.FirstTime = osutil.CreationTime(stat)
-	ret.LastTime = stat.ModTime()
 	files, err := osutil.ListDir(dir)
 	if err != nil {
 		return nil, err

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -351,10 +351,9 @@ func Abs(path string) string {
 	return filepath.Clean(path)
 }
 
-// CreationTime returns file creation time.
-// May return zero time, if not known.
-func CreationTime(fi os.FileInfo) time.Time {
-	return creationTime(fi)
+// FileTimes returns file creation and modification times.
+func FileTimes(file string) (time.Time, time.Time, error) {
+	return fileTimes(file)
 }
 
 // MonotonicNano returns monotonic time in nanoseconds from some unspecified point in time.

--- a/pkg/osutil/osutil_nonlinux.go
+++ b/pkg/osutil/osutil_nonlinux.go
@@ -12,8 +12,14 @@ import (
 	"time"
 )
 
-func creationTime(fi os.FileInfo) time.Time {
-	return time.Time{}
+func fileTimes(file string) (time.Time, time.Time, error) {
+	stat, err := os.Stat(file)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	// Creation time is not present in stat, so we use modification time for both.
+	modTime := stat.ModTime()
+	return modTime, modTime, nil
 }
 
 func RemoveAll(dir string) error {


### PR DESCRIPTION
We return Ctime from CreationTime. But "C" does not stand for "creation", it stands for "status change" (inode update). It may or may not be the creation time.

Use Btime (birth time) for creation time.

Fixes #6547
