### PR TITLE
pkg/aflow: allow to specify model per-flow

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -207,8 +207,13 @@ func makeUIAITrajectory(trajetory []*aidb.TrajectorySpan) []*uiAITrajectorySpan 
 }
 
 func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
-	if len(req.Workflows) == 0 || req.CodeRevision == "" || req.LLMModel == "" {
+	if len(req.Workflows) == 0 || req.CodeRevision == "" {
 		return nil, fmt.Errorf("invalid request")
+	}
+	for _, flow := range req.Workflows {
+		if flow.Type == "" || flow.Name == "" || flow.LLMModel == "" {
+			return nil, fmt.Errorf("invalid request")
+		}
 	}
 	if err := aidb.UpdateWorkflows(ctx, req.Workflows); err != nil {
 		return nil, fmt.Errorf("failed UpdateWorkflows: %w", err)

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -63,11 +63,10 @@ func TestAIBugWorkflows(t *testing.T) {
 
 	_, err := c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: "patching", Name: "patching"},
-			{Type: "patching", Name: "patching-foo"},
-			{Type: "patching", Name: "patching-bar"},
+			{Type: "patching", Name: "patching", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-foo", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-bar", LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err)
@@ -77,25 +76,23 @@ func TestAIBugWorkflows(t *testing.T) {
 
 	_, err = c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: "patching", Name: "patching"},
-			{Type: "patching", Name: "patching-bar"},
-			{Type: "patching", Name: "patching-baz"},
-			{Type: "assessment-kcsan", Name: "assessment-kcsan"},
+			{Type: "patching", Name: "patching", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-bar", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-baz", LLMModel: "smarty"},
+			{Type: "assessment-kcsan", Name: "assessment-kcsan", LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err)
 
 	_, err = c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: "patching", Name: "patching"},
-			{Type: "patching", Name: "patching-bar"},
-			{Type: "patching", Name: "patching-qux"},
-			{Type: "assessment-kcsan", Name: "assessment-kcsan"},
-			{Type: "assessment-kcsan", Name: "assessment-kcsan-foo"},
+			{Type: "patching", Name: "patching", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-bar", LLMModel: "smarty"},
+			{Type: "patching", Name: "patching-qux", LLMModel: "smarty"},
+			{Type: "assessment-kcsan", Name: "assessment-kcsan", LLMModel: "smarty"},
+			{Type: "assessment-kcsan", Name: "assessment-kcsan-foo", LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err)
@@ -117,9 +114,8 @@ func TestAIJob(t *testing.T) {
 
 	resp, err := c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: "assessment-kcsan", Name: "assessment-kcsan"},
+			{Type: "assessment-kcsan", Name: "assessment-kcsan", LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err)
@@ -137,9 +133,8 @@ func TestAIJob(t *testing.T) {
 
 	resp2, err2 := c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: "assessment-kcsan", Name: "assessment-kcsan"},
+			{Type: "assessment-kcsan", Name: "assessment-kcsan", LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err2)
@@ -214,9 +209,8 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 
 	resp, err := c.aiClient.AIJobPoll(&dashapi.AIJobPollReq{
 		CodeRevision: prog.GitRevision,
-		LLMModel:     "smarty",
 		Workflows: []dashapi.AIWorkflow{
-			{Type: ai.WorkflowAssessmentKCSAN, Name: string(ai.WorkflowAssessmentKCSAN)},
+			{Type: ai.WorkflowAssessmentKCSAN, Name: string(ai.WorkflowAssessmentKCSAN), LLMModel: "smarty"},
 		},
 	})
 	require.NoError(t, err)

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -128,11 +128,13 @@ func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
 			}
 			job = jobs[0]
 		}
-		job.Started = spanner.NullTime{
-			Time:  TimeNow(ctx),
-			Valid: true,
+		job.Started = spanner.NullTime{Time: TimeNow(ctx), Valid: true}
+		for _, flow := range req.Workflows {
+			if job.Workflow == flow.Name {
+				job.LLMModel = flow.LLMModel
+				break
+			}
 		}
-		job.LLMModel = req.LLMModel
 		job.CodeRevision = req.CodeRevision
 		mut, err := spanner.InsertOrUpdateStruct("Jobs", job)
 		if err != nil {

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -9,14 +9,14 @@ import (
 )
 
 type AIJobPollReq struct {
-	LLMModel     string // LLM model that will be used to execute jobs
 	CodeRevision string // git commit of the syz-agent server
 	Workflows    []AIWorkflow
 }
 
 type AIWorkflow struct {
-	Type ai.WorkflowType
-	Name string
+	Type     ai.WorkflowType
+	Name     string
+	LLMModel string // LLM model that will be used to execute this workflow
 }
 
 type AIJobPollResp struct {

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -18,9 +18,11 @@ import (
 	"google.golang.org/genai"
 )
 
-// https://ai.google.dev/gemini-api/docs/models
-const DefaultModel = "gemini-3-pro-preview"
-
+// Execute executes the given AI workflow with provided inputs and returns workflow outputs.
+// The model argument sets Gemini model name to execute the workflow.
+// The workdir argument should point to a dir owned by aflow to store private data,
+// it can be shared across parallel executions in the same process, and preferably
+// preserved across process restarts for caching purposes.
 func (flow *Flow) Execute(c context.Context, model, workdir string, inputs map[string]any,
 	cache *Cache, onEvent onEvent) (map[string]any, error) {
 	if err := flow.checkInputs(inputs); err != nil {

--- a/pkg/aflow/flow.go
+++ b/pkg/aflow/flow.go
@@ -22,8 +22,9 @@ import (
 // Actions are nodes of the graph, and they consume/produce some named values
 // (input/output fields, and intermediate values consumed by other actions).
 type Flow struct {
-	Name string // Empty for the main workflow for the workflow type.
-	Root Action
+	Name  string // Empty for the main workflow for the workflow type.
+	Model string // The default Gemini model name to execute this workflow.
+	Root  Action
 
 	*FlowType
 }
@@ -34,6 +35,12 @@ type FlowType struct {
 	checkInputs    func(map[string]any) error
 	extractOutputs func(map[string]any) map[string]any
 }
+
+// See https://ai.google.dev/gemini-api/docs/models
+const (
+	BestExpensiveModel = "gemini-3-pro-preview"
+	GoodBalancedModel  = "gemini-3-flash-preview"
+)
 
 var Flows = make(map[string]*Flow)
 
@@ -88,6 +95,7 @@ func registerOne[Inputs, Outputs any](all map[string]*Flow, flow *Flow) error {
 		actions: make(map[string]bool),
 		state:   make(map[string]*varState),
 	}
+	ctx.requireNotEmpty(flow.Name, "Model", flow.Model)
 	provideOutputs[Inputs](ctx, "flow inputs")
 	flow.Root.verify(ctx)
 	requireInputs[Outputs](ctx, "flow outputs")

--- a/pkg/aflow/flow/assessment/kcsan.go
+++ b/pkg/aflow/flow/assessment/kcsan.go
@@ -23,6 +23,7 @@ func init() {
 		ai.WorkflowAssessmentKCSAN,
 		"assess if a KCSAN report is about a benign race that only needs annotations or not",
 		&aflow.Flow{
+			Model: aflow.GoodBalancedModel,
 			Root: &aflow.Pipeline{
 				Actions: []aflow.Action{
 					kernel.Checkout,

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -33,6 +33,7 @@ func init() {
 		ai.WorkflowModeration,
 		"assess if a bug report is consistent and actionable or not",
 		&aflow.Flow{
+			Model: aflow.GoodBalancedModel,
 			Root: &aflow.Pipeline{
 				Actions: []aflow.Action{
 					aflow.NewFuncAction("extract-crash-type", extractCrashType),

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -43,6 +43,7 @@ func init() {
 		ai.WorkflowPatching,
 		"generate a kernel patch fixing a provided bug reproducer",
 		&aflow.Flow{
+			Model: aflow.BestExpensiveModel,
 			Root: &aflow.Pipeline{
 				Actions: []aflow.Action{
 					baseCommitPicker,

--- a/pkg/aflow/flow_test.go
+++ b/pkg/aflow/flow_test.go
@@ -76,7 +76,8 @@ func TestWorkflow(t *testing.T) {
 	flows := make(map[string]*Flow)
 	err := register[flowInputs, flowOutputs]("test", "description", flows, []*Flow{
 		{
-			Name: "flow",
+			Name:  "flow",
+			Model: "model",
 			Root: NewPipeline(
 				NewFuncAction("func-action",
 					func(ctx *Context, args firstFuncInputs) (firstFuncOutputs, error) {
@@ -530,6 +531,7 @@ func TestNoInputs(t *testing.T) {
 	flows := make(map[string]*Flow)
 	err := register[flowInputs, flowOutputs]("test", "description", flows, []*Flow{
 		{
+			Model: "model",
 			Root: NewFuncAction("func-action",
 				func(ctx *Context, args flowInputs) (flowOutputs, error) {
 					return flowOutputs{}, nil


### PR DESCRIPTION
We may want to use a weaker model for some workflows.
Allow to use different models for different workflows.
