### PR TITLE
pkg/manager: match full function names in focus areas

### DIFF
--- a/pkg/manager/diff.go
+++ b/pkg/manager/diff.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -817,11 +818,15 @@ func PatchFocusAreas(cfg *mgrconfig.Config, gitPatches [][]byte, baseHashes, pat
 	funcs := modifiedSymbols(baseHashes, patchedHashes)
 	if len(funcs) > 0 {
 		log.Logf(0, "adding modified_functions to focus areas: %q", funcs)
+		var regexps []string
+		for _, name := range funcs {
+			regexps = append(regexps, fmt.Sprintf("^%s$", regexp.QuoteMeta(name)))
+		}
 		cfg.Experimental.FocusAreas = append(cfg.Experimental.FocusAreas,
 			mgrconfig.FocusArea{
 				Name: symbolsArea,
 				Filter: mgrconfig.CovFilterCfg{
-					Functions: funcs,
+					Functions: regexps,
 				},
 				Weight: 6.0,
 			})

--- a/pkg/manager/diff_test.go
+++ b/pkg/manager/diff_test.go
@@ -55,7 +55,7 @@ index 103167d..fbf7a68 100644
 		{
 			Name: symbolsArea,
 			Filter: mgrconfig.CovFilterCfg{
-				Functions: []string{"function"},
+				Functions: []string{"^function$"},
 			},
 			Weight: 6.0,
 		},


### PR DESCRIPTION
When configuring focus areas before directed fuzzing, construct regular expressions that match the exact function names. Otherwise, we end up adding more functions than intended.