### PR TITLE
vm/adb: Use the correct path for debugfs

### DIFF
--- a/vm/adb/adb.go
+++ b/vm/adb/adb.go
@@ -406,7 +406,7 @@ func (inst *instance) repair() error {
 	inst.waitForBootCompletion()
 
 	// Mount debugfs.
-	if _, err := inst.adb("shell", "ls /sys/kernel/debug/kcov"); err != nil {
+	if _, err := inst.adb("shell", "ls /sys/kernel/debug"); err != nil {
 		log.Logf(2, "debugfs was unmounted mounting")
 		// This prop only exist on Android 12+
 		inst.adb("shell", "setprop persist.dbg.keep_debugfs_mounted 1")


### PR DESCRIPTION
Probe for the debugfs rootdir instead of the kcov
sub-path to prevent the fuzzer from entering in
device reboot loop in case the android device
doesn't support kcov.

Fixes: #6600

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
