### PR TITLE
pkg/aflow: expect CitationMetadata

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -191,9 +191,9 @@ func (a *LLMAgent) parseResponse(resp *genai.GenerateContentResponse) (
 		err = fmt.Errorf("%v (%v)", candidate.FinishMessage, candidate.FinishReason)
 		return
 	}
-	// We don't expect to receive these now.
-	if candidate.GroundingMetadata != nil || candidate.CitationMetadata != nil ||
-		candidate.LogprobsResult != nil {
+	// We don't expect to receive these fields now.
+	// Note: CitationMetadata may be present sometimes, but we don't have uses for it.
+	if candidate.GroundingMetadata != nil || candidate.LogprobsResult != nil {
 		err = fmt.Errorf("unexpected reply fields (%+v)", *candidate)
 		return
 	}


### PR DESCRIPTION
CitationMetadata may be present in replies sometimes.
CitationMetadata is a specific field in the Gemini API's response object
that alerts you when the model has directly quoted or closely derived
content from a specific source, such as a book, website, or open-source code repository.

We've got the following error:

syz-agent: unexpected reply fields ({Content:0xc0058eb4a0 CitationMetadata:0xc0094009a8
	FinishMessage: TokenCount:0 FinishReason:STOP AvgLogprobs:0
	GroundingMetadata:<nil> Index:0 LogprobsResult:<nil> SafetyRatings:[]
	URLContextMetadata:<nil>})
