### PR TITLE
dashboard: add a manuallyUpstreamed helper

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -631,6 +631,44 @@ var testConfig = &GlobalConfig{
 				},
 			},
 		},
+		"skip-stage": {
+			AccessLevel: AccessPublic,
+			Key:         "publickeypublickeypublickey",
+			Clients: map[string]string{
+				clientSkipStage: keySkipStage,
+			},
+			Repos: []KernelRepo{
+				{
+					URL:    "git://syzkaller.org/access-public.git",
+					Branch: "access-public",
+					Alias:  "access-public",
+				},
+			},
+			Reporting: []Reporting{
+				{
+					Name:       "reporting1",
+					DailyLimit: 1000,
+					Config:     &TestConfig{Index: 1},
+					Embargo:    4 * 24 * time.Hour,
+				},
+				{
+					Name:       "reporting2",
+					DailyLimit: 1000,
+					Config:     &TestConfig{Index: 2},
+					Filter: func(bug *Bug) FilterResult {
+						if bug.manuallyUpstreamed("reporting1") {
+							return FilterSkip
+						}
+						return FilterReport
+					},
+				},
+				{
+					Name:       "reporting3",
+					DailyLimit: 1000,
+					Config:     &TestConfig{Index: 3},
+				},
+			},
+		},
 	},
 }
 
@@ -683,6 +721,8 @@ const (
 	keyTreeTests          = "keyTreeTestskeyTreeTestskeyTreeTests"
 	clientAI              = "client-ai"
 	keyAI                 = "clientaikeyclientaikeyclientaikey"
+	clientSkipStage       = "client-skip-stage"
+	keySkipStage          = "skipstagekeyskipstagekeyskipstagekey"
 
 	restrictedManager     = "restricted-manager"
 	noFixBisectionManager = "no-fix-bisection-manager"

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -387,6 +387,14 @@ func (bug *Bug) managerConfig(c context.Context) *ConfigManager {
 	return &mgr
 }
 
+func (bug *Bug) manuallyUpstreamed(name string) bool {
+	reporting := bugReportingByName(bug, name)
+	if reporting == nil {
+		return false
+	}
+	return !reporting.Closed.IsZero() && !reporting.Auto
+}
+
 func createNotification(c context.Context, typ dashapi.BugNotif, public bool, text string, bug *Bug,
 	reporting *Reporting, bugReporting *BugReporting) (*dashapi.BugNotification, error) {
 	reportingConfig, err := json.Marshal(reporting.Config)


### PR DESCRIPTION
This helper function can be used in the reporting filtering rules to skip certain reporting stages depending on whether the previous stage(s) have been manually upstreamed.

Add tests that it does have the intended effect.

Cc #6554.
