### PR TITLE
pkg/gce: vm/gce: allow specifying instance tags in manager config

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -118,7 +118,7 @@ func NewContext(customZoneID string) (*Context, error) {
 }
 
 func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
-	preemptible, displayDevice bool) (string, error) {
+	tags []string, preemptible, displayDevice bool) (string, error) {
 	prefix := "https://www.googleapis.com/compute/v1/projects/" + ctx.ProjectID
 	sshkeyAttr := "syzkaller:" + sshkey
 	oneAttr := "1"
@@ -165,6 +165,7 @@ func (ctx *Context) CreateInstance(name, machineType, image, sshkey string,
 		DisplayDevice: &compute.DisplayDevice{
 			EnableDisplay: displayDevice,
 		},
+		Tags: &compute.Tags{Items: tags},
 	}
 retry:
 	if !instance.Scheduling.Preemptible && strings.HasPrefix(machineType, "e2-") {

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -59,7 +59,8 @@ type Config struct {
 	// Leave empty for non-OS Login GCP projects.
 	// Otherwise generate one and upload it:
 	// `gcloud compute os-login ssh-keys add --key-file some-key.pub`.
-	SerialPortKey string `json:"serial_port_key"`
+	SerialPortKey string   `json:"serial_port_key"`
+	Tags          []string `json:"tags"` // GCE instance tags
 }
 
 type Pool struct {
@@ -195,7 +196,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 	}
 	log.Logf(0, "creating instance: %v", name)
 	ip, err := pool.GCE.CreateInstance(name, pool.cfg.MachineType, pool.cfg.GCEImage,
-		string(gceKeyPub), pool.cfg.Preemptible, pool.cfg.DisplayDevice)
+		string(gceKeyPub), pool.cfg.Tags, pool.cfg.Preemptible, pool.cfg.DisplayDevice)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GCE instance tags can be used for various purposes, such as applying network firewall rules or filtering VMs for scheduling onto specific hosts.
To support these use cases, syzkaller needs the ability to set instance tags during VM creation.

This patch introduces a new tags field to the gce VM configuration that allows users to specify a list of tags to be attached to GCE instances created by syz-manager.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
