### PR TITLE
pkg/aflow: add ability to generate several candidate replies for LLM agents

### DIFF
--- a/pkg/aflow/template.go
+++ b/pkg/aflow/template.go
@@ -70,6 +70,10 @@ func walkTemplate(n parse.Node, used map[string]bool, errp *error) {
 		walkTemplate(n.Pipe, used, errp)
 		walkTemplate(n.List, used, errp)
 		walkTemplate(n.ElseList, used, errp)
+	case *parse.RangeNode:
+		walkTemplate(n.Pipe, used, errp)
+		walkTemplate(n.List, used, errp)
+		walkTemplate(n.ElseList, used, errp)
 	case *parse.ActionNode:
 		walkTemplate(n.Pipe, used, errp)
 	case *parse.PipeNode:

--- a/pkg/aflow/template_test.go
+++ b/pkg/aflow/template_test.go
@@ -44,6 +44,17 @@ func TestTemplate(t *testing.T) {
 		},
 		{
 			template: `
+				{{range $i, $v := .array}}
+					{{$i}} {{$v}}
+				{{end}}
+				`,
+			vars: map[string]reflect.Type{
+				"array": reflect.TypeFor[[]int](),
+			},
+			used: []string{"array"},
+		},
+		{
+			template: `
 				{{if .bar}}
 					{{.foo}}
 				{{end}}

--- a/pkg/aflow/trajectory/trajectory.go
+++ b/pkg/aflow/trajectory/trajectory.go
@@ -39,12 +39,16 @@ type Span struct {
 
 type SpanType string
 
+// Note: don't change string values of these consts w/o a good reason.
+// They are stored in the dashboard database as strings.
 const (
 	SpanFlow   = SpanType("flow") // always the first outermost span
 	SpanAction = SpanType("action")
 	SpanAgent  = SpanType("agent")
 	SpanLLM    = SpanType("llm")
 	SpanTool   = SpanType("tool")
+	// Logical grouping of several invocations of the same agent.
+	SpanAgentCandidates = SpanType("agent-candidates")
 )
 
 func (span *Span) String() string {

--- a/pkg/aflow/verify.go
+++ b/pkg/aflow/verify.go
@@ -91,6 +91,12 @@ func provideOutputs[T any](ctx *verifyContext, who string) {
 	}
 }
 
+func provideArrayOutputs[T any](ctx *verifyContext, who string) {
+	for name, typ := range foreachFieldOf[T]() {
+		ctx.provideOutput(who, name, reflect.SliceOf(typ), true)
+	}
+}
+
 func requireSchema[T any](ctx *verifyContext, who, what string) {
 	if _, err := schemaFor[T](); err != nil {
 		ctx.errorf(who, "%v: %v", what, err)


### PR DESCRIPTION
Add LLMAgent.Candidates parameter.
If set to a value N>1, then the agent is invoked N times,
and all outputs become slices.

The results can be later aggregated by another agent,
as shown in the test.
