### PR TITLE
dashboard: fix manuallyUpstreamed

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -650,6 +650,12 @@ var testConfig = &GlobalConfig{
 					DailyLimit: 1000,
 					Config:     &TestConfig{Index: 1},
 					Embargo:    4 * 24 * time.Hour,
+					Filter: func(bug *Bug) FilterResult {
+						if bug.Title == "skip reporting1" {
+							return FilterSkip
+						}
+						return FilterReport
+					},
 				},
 				{
 					Name:       "reporting2",

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -392,6 +392,10 @@ func (bug *Bug) manuallyUpstreamed(name string) bool {
 	if reporting == nil {
 		return false
 	}
+	if reporting.Reported.IsZero() {
+		// Either not reported yet, or fully skipped (if Closed is not empty).
+		return false
+	}
 	return !reporting.Closed.IsZero() && !reporting.Auto
 }
 

--- a/dashboard/app/reporting_test.go
+++ b/dashboard/app/reporting_test.go
@@ -1466,4 +1466,16 @@ func TestSkipStage(t *testing.T) {
 		client.pollNotifs(0)
 		client.pollBugs(0)
 	}
+
+	{
+		// Don't react to skipped reporting stages.
+		crash := testCrash(build, 4)
+		crash.Title = "skip reporting1"
+		client.ReportCrash(crash)
+		rep := client.pollBug()
+		c.expectEQ(string(rep.Config), `{"Index":2}`)
+		// If we do react, there would be an upstreaming notification.
+		client.pollNotifs(0)
+		c.client.updateBug(rep.ID, dashapi.BugStatusInvalid, "")
+	}
 }


### PR DESCRIPTION
The function returned incorrect result when the reporting stage of interest was completely skipped and never reported.