### PR TITLE
pkg/vcs: be more strict in BaseForDiff

### DIFF
--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -551,8 +551,8 @@ func TestBaseForDiff(t *testing.T) {
 		assert.Equal(t, commit4.Hash, base[0].Hash)
 		assert.Equal(t, commit2.Hash, base[1].Hash)
 	})
-	t.Run("ignore unknown objects", func(t *testing.T) {
-		// It's okay if the diff contains unknown hashes.
+	t.Run("unknown objects", func(t *testing.T) {
+		// It's not okay if the diff contains unknown hashes.
 		diff2 := `
 diff --git a/b.txt b/b.txt
 deleted file mode 100644
@@ -564,6 +564,33 @@ index f70f10e..0000000
 		twoDiffs := append(append([]byte{}, diff...), diff2...)
 		base, err := repo.repo.BaseForDiff(twoDiffs, &debugtracer.TestTracer{T: t})
 		require.NoError(t, err)
+		require.Nil(t, base)
+	})
+	t.Run("ignore new files", func(t *testing.T) {
+		diff2 := `
+diff --git a/a.txt b/a.txt
+new file mode 100644
+index 0000000..fa49b07
+--- /dev/null
++++ b/a.txt
+@@ -0,0 +1 @@
++new file
+diff --git a/a.txt b/a.txt
+index fa49b07..01c887f 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-new file
++edit file
+`
+		twoDiffs := append(append([]byte{}, diff...), diff2...)
+		base, err := repo.repo.BaseForDiff(twoDiffs, &debugtracer.TestTracer{T: t})
+		require.NoError(t, err)
 		require.Len(t, base, 2)
+	})
+	t.Run("empty patch", func(t *testing.T) {
+		base, err := repo.repo.BaseForDiff([]byte{}, &debugtracer.TestTracer{T: t})
+		require.NoError(t, err)
+		require.Nil(t, base)
 	})
 }


### PR DESCRIPTION
Do not tolerate unknown blob hashes - it means that we are unable to find the correct base commit given the repository. Explicitly ignore newly added files - we definitely won't find their hashes.
Explicitly skip malformed patches that won't have any blob hashes - otherwise we could end up with too many candidates and waste too much time.