### PR TITLE
pkg/aflow: add notion of flow errors

### DIFF
--- a/pkg/aflow/action/kernel/build.go
+++ b/pkg/aflow/action/kernel/build.go
@@ -47,7 +47,7 @@ func buildKernel(ctx *aflow.Context, args buildArgs) (buildResult, error) {
 		compileCommnads := "compile_commands.json"
 		makeArgs = append(makeArgs, path.Base(image), compileCommnads)
 		if _, err := osutil.RunCmd(time.Hour, args.KernelSrc, "make", makeArgs...); err != nil {
-			return err
+			return aflow.FlowError(err)
 		}
 		// Remove main intermediate build files, we don't need them anymore
 		// and they take lots of space. Keep generated source files.

--- a/syz-agent/agent.go
+++ b/syz-agent/agent.go
@@ -199,7 +199,7 @@ func (s *Server) poll(ctx context.Context) (
 	if err := s.dash.AIJobDone(doneReq); err != nil {
 		return false, err
 	}
-	if jobErr != nil {
+	if jobErr != nil && !aflow.IsFlowError(jobErr) {
 		return false, jobErr
 	}
 	return true, nil


### PR DESCRIPTION
Flow errors denote failure of the flow itself,
rather than an infrastructure error. A flow errors mean an expected
condition in the flow when it cannot continue, and cannot produce
expected outputs. For example, if we are doing something with the kernel,
but the kernel build fails. Flow errors shouldn't be flagged in

Fixes #6610
