### PR TITLE
tools: temporarily unset LD_LIBRARY_PATH when generating ssh key

### DIFF
--- a/tools/create-buildroot-image.sh
+++ b/tools/create-buildroot-image.sh
@@ -197,7 +197,7 @@ Subsystem	sftp	/usr/libexec/sftp-server
 EOF
 
 # Generate sshd host keys.
-ssh-keygen -A -f $1
+env -u LD_LIBRARY_PATH ssh-keygen -A -f $1
 mkdir -p $1/var/db/dhcpcd
 
 EOFEOF


### PR DESCRIPTION
When running tools/create-buildroot-image.sh, the following error occurs:

```
OpenSSL version mismatch. Built against 30000020, you have 30400010
make: *** [fs/ext2/ext2.mk:65: /vol/linux/bisect/buildroot/output/images/rootfs.ext2] Error 255
```

The reason is that buildroot set `LD_LIBRARY_PATH` to include `$BUILDROOT/output/host/lib`. When the script invokes host's ssh-keygen, the dynamic linker loads the OpenSSL libraries built by buildroot instead of the host, which may resulting in version mismatch.

To fix this issue, temporarily unset `LD_LIBRARY_PATH` when invoking ssh-keygen.