### PR TITLE
executor: sys/linux: SYZOS: add AMD VMLOAD and VMSAVE primitives

### DIFF
--- a/sys/linux/dev_kvm_amd64.txt
+++ b/sys/linux/dev_kvm_amd64.txt
@@ -191,6 +191,8 @@ syzos_api_call$x86 [
 	nested_amd_clgi			syzos_api$x86[383, void]
 	nested_amd_inject_event		syzos_api$x86[384, syzos_api_nested_amd_inject_event]
 	nested_amd_set_intercept	syzos_api$x86[385, syzos_api_nested_amd_set_intercept]
+	nested_amd_vmload		syzos_api$x86[386, syzos_api_vm_id]
+	nested_amd_vmsave		syzos_api$x86[387, syzos_api_vm_id]
 ] [varlen]
 
 kvm_text_x86 [

--- a/sys/linux/test/amd64-syz_kvm_nested_vmload_vmsave
+++ b/sys/linux/test/amd64-syz_kvm_nested_vmload_vmsave
@@ -1,0 +1,11 @@
+#
+# requires: arch=amd64 -threaded
+#
+
+# VMLOAD/VMSAVE Reproducer
+#
+r0 = openat$kvm(0xffffffffffffff9c, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, 0x0, 0x0)
+r2 = syz_kvm_setup_syzos_vm$x86(r1, &(0x7f0000000000/0x400000)=nil)
+r3 = syz_kvm_add_vcpu$x86(r2, &AUTO={0x0, &AUTO=[@enable_nested={0x12c, 0x18, 0x0}, @nested_create_vm={0x12d, 0x18, 0x1}, @nested_amd_vmsave={0x183, 0x18, 0x1}, @nested_amd_vmload={0x182, 0x18, 0x1}], 0x0})
+ioctl$KVM_RUN(r3, 0x0, 0x0)


### PR DESCRIPTION
This patch introduces SYZOS_API_NESTED_AMD_VMLOAD and SYZOS_API_NESTED_AMD_VMSAVE.

These primitives allow the L1 guest to execute the VMLOAD and VMSAVE instructions, which load/store additional guest state (FS, GS, TR, LDTR, etc.) to/from the VMCB specified by the 'vm_id' argument.

This stresses the KVM L0 instruction emulator, which must validate the L1-provided physical address in RAX and perform the state transfer.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
