### PR TITLE
pkg/aflow: support setting a custom repository

### DIFF
--- a/pkg/aflow/flow/patching/base_commit.go
+++ b/pkg/aflow/flow/patching/base_commit.go
@@ -14,6 +14,7 @@ var baseCommitPicker = aflow.NewFuncAction("base-commit-picker", pickBaseCommit)
 type baseCommitArgs struct {
 	// Can be used to override the selected base commit (for manual testing).
 	FixedBaseCommit string
+	FixedRepository string
 }
 
 type baseCommitResult struct {
@@ -40,6 +41,9 @@ func pickBaseCommit(ctx *aflow.Context, args baseCommitArgs) (baseCommitResult, 
 	res := baseCommitResult{
 		KernelRepo:   baseRepo,
 		KernelCommit: args.FixedBaseCommit,
+	}
+	if args.FixedRepository != "" {
+		res.KernelRepo = args.FixedRepository
 	}
 	if args.FixedBaseCommit != "" {
 		return res, nil

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -29,6 +29,7 @@ type Inputs struct {
 
 	// Use this fixed based kernel commit (for testing/local running).
 	FixedBaseCommit string
+	FixedRepository string
 }
 
 type Outputs struct {

--- a/syz-agent/agent.go
+++ b/syz-agent/agent.go
@@ -47,6 +47,8 @@ type Config struct {
 	CacheSize uint64 `json:"cache_size"`
 	// Use fixed base commit for patching jobs (for testing).
 	FixedBaseCommit string `json:"fixed_base_commit"`
+	// Use a different repo than torvalds's mainline.
+	FixedRepository string `json:"repo"`
 	// Use this LLM model (for testing, if empty use workflow-default model).
 	Model string `json:"model"`
 }
@@ -221,6 +223,7 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ma
 		"Type":              s.cfg.Type,
 		"VM":                s.cfg.VM,
 		"FixedBaseCommit":   s.cfg.FixedBaseCommit,
+		"FixedRepository":   s.cfg.FixedRepository,
 	}
 	maps.Insert(inputs, maps.All(req.Args))
 	onEvent := func(span *trajectory.Span) error {


### PR DESCRIPTION
For situations where the user wants to reproduce bugs against a different repository than mainline.