### PR TITLE
prog: more helpful error message

### DIFF
--- a/prog/target.go
+++ b/prog/target.go
@@ -106,7 +106,7 @@ func GetTarget(OS, arch string) (*Target, error) {
 			supported = append(supported, fmt.Sprintf("%v/%v", t.OS, t.Arch))
 		}
 		sort.Strings(supported)
-		return nil, fmt.Errorf("unknown target: %v (supported: %v)", key, supported)
+		return nil, fmt.Errorf("unknown target: %v (supported: %v) did you run `make generate`?", key, supported)
 	}
 	target.init.Do(target.lazyInit)
 	return target, nil


### PR DESCRIPTION
If the system descriptions have not been generated (e.g. on a fresh checkout), tests fail with an "unknown target" error and an empty supported list.

Update the error message to explicitly suggest running 'make generate' to help users diagnose the issue quickly.

