### PR TITLE
tools/clang/json: Escape strings properly

### DIFF
--- a/pkg/codesearch/testdata/query-def-source-quote-type
+++ b/pkg/codesearch/testdata/query-def-source-quote-type
@@ -1,0 +1,7 @@
+def-source source0.c function_with_quotes_in_type yes
+
+function function_with_quotes_in_type is defined in source0.c:
+
+  35:	void function_with_quotes_in_type(void __attribute__((btf_type_tag("user"))) *)
+  36:	{
+  37:	}

--- a/pkg/codesearch/testdata/query-file-index-source
+++ b/pkg/codesearch/testdata/query-file-index-source
@@ -5,5 +5,6 @@ file source0.c defines the following entities:
 function close
 function func_accepting_a_struct
 function function_with_comment_in_header
+function function_with_quotes_in_type
 function open
 struct struct_in_c_file

--- a/pkg/codesearch/testdata/source0.c
+++ b/pkg/codesearch/testdata/source0.c
@@ -31,3 +31,7 @@ int func_accepting_a_struct(struct some_struct* p)
 	return ((some_struct_t*)p)->x +
 	       ((union some_union*)p)->x;
 }
+
+void function_with_quotes_in_type(void __attribute__((btf_type_tag("user"))) *)
+{
+}

--- a/pkg/codesearch/testdata/source0.c.json
+++ b/pkg/codesearch/testdata/source0.c.json
@@ -1,16 +1,6 @@
 {
 	"definitions": [
 		{
-			"name": "some_enum",
-			"kind": "enum",
-			"body": {
-				"file": "source0.h",
-				"start_line": 45,
-				"end_line": 48
-			},
-			"comment": {}
-		},
-		{
 			"name": "close",
 			"type": "int ()",
 			"kind": "function",
@@ -90,6 +80,17 @@
 			]
 		},
 		{
+			"name": "function_with_quotes_in_type",
+			"type": "void (void  __attribute__((btf_type_tag(\"user\")))*)",
+			"kind": "function",
+			"body": {
+				"file": "source0.c",
+				"start_line": 35,
+				"end_line": 37
+			},
+			"comment": {}
+		},
+		{
 			"name": "open",
 			"type": "int ()",
 			"kind": "function",
@@ -149,6 +150,26 @@
 			"comment": {}
 		},
 		{
+			"name": "some_union",
+			"kind": "union",
+			"body": {
+				"file": "source0.h",
+				"start_line": 40,
+				"end_line": 43
+			},
+			"comment": {}
+		},
+		{
+			"name": "some_enum",
+			"kind": "enum",
+			"body": {
+				"file": "source0.h",
+				"start_line": 45,
+				"end_line": 48
+			},
+			"comment": {}
+		},
+		{
 			"name": "another_struct_t",
 			"kind": "typedef",
 			"body": {
@@ -185,16 +206,6 @@
 				"file": "source0.h",
 				"start_line": 32,
 				"end_line": 34
-			},
-			"comment": {}
-		},
-		{
-			"name": "some_union",
-			"kind": "union",
-			"body": {
-				"file": "source0.h",
-				"start_line": 40,
-				"end_line": 43
 			},
 			"comment": {}
 		}

--- a/tools/clang/json.h
+++ b/tools/clang/json.h
@@ -52,11 +52,47 @@ private:
   Scope Top;
 };
 
+inline void print(JSONPrinter& Printer, const char* V) {
+  printf("\"");
+  if (V) {
+    for (; *V; ++V) {
+      switch (*V) {
+      case '"':
+        printf("\\\"");
+        break;
+      case '\\':
+        printf("\\\\");
+        break;
+      case '\b':
+        printf("\\b");
+        break;
+      case '\f':
+        printf("\\f");
+        break;
+      case '\n':
+        printf("\\n");
+        break;
+      case '\r':
+        printf("\\r");
+        break;
+      case '\t':
+        printf("\\t");
+        break;
+      default:
+        if ((unsigned char)*V < 0x20)
+          printf("\\u%04x", (unsigned char)*V);
+        else
+          printf("%c", *V);
+      }
+    }
+  }
+  printf("\"");
+}
+
 inline void print(JSONPrinter& Printer, int V) { printf("%d", V); }
 inline void print(JSONPrinter& Printer, unsigned V) { printf("%u", V); }
 inline void print(JSONPrinter& Printer, int64_t V) { printf("%ld", V); }
 inline void print(JSONPrinter& Printer, bool V) { printf("%s", V ? "true" : "false"); }
-inline void print(JSONPrinter& Printer, const char* V) { printf("\"%s\"", V ? V : ""); }
 inline void print(JSONPrinter& Printer, const std::string& V) { print(Printer, V.c_str()); }
 
 template <typename E> void print(JSONPrinter& Printer, const std::unique_ptr<E>& V) {


### PR DESCRIPTION
When preparing a codesearch index, I encountered errors which I narrowed down to lines like the following in the json output of codesearch:

  "type": "void (void  __attribute__((btf_type_tag("user")))*, const void *, size_t, size_t)",

After this change, the line gets formatted like this:

  "type": "void (void  __attribute__((btf_type_tag(\"user\")))*, const void *, size_t, size_t)",

This fixes the errors I encountered