### PR TITLE
syz-cluster: disable some trace calls for non-bpf targets

### DIFF
--- a/syz-cluster/pkg/fuzzconfig/testdata/mixed/bpf_io_uring.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/mixed/bpf_io_uring.base.cfg
@@ -85,6 +85,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/mixed/bpf_io_uring.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/mixed/bpf_io_uring.patched.cfg
@@ -86,6 +86,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/bpf.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/bpf.base.cfg
@@ -68,6 +68,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/bpf.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/bpf.patched.cfg
@@ -69,6 +69,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/default.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/default.base.cfg
@@ -21,9 +21,11 @@
 	"reproduce": true,
 	"preserve_corpus": true,
 	"disable_syscalls": [
-		"perf_event_open*",
 		"syz_mount_image$hfs",
-		"syz_mount_image$gfs*"
+		"syz_mount_image$gfs*",
+		"perf_event_open*",
+		"ioctl$PERF*",
+		"bpf$BPF_RAW_TRACEPOINT_OPEN"
 	],
 	"strace_bin": "",
 	"strace_bin_on_target": false,
@@ -44,6 +46,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/default.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/default.patched.cfg
@@ -22,9 +22,11 @@
 	"fuzzing_vms": 3,
 	"preserve_corpus": true,
 	"disable_syscalls": [
-		"perf_event_open*",
 		"syz_mount_image$hfs",
-		"syz_mount_image$gfs*"
+		"syz_mount_image$gfs*",
+		"perf_event_open*",
+		"ioctl$PERF*",
+		"bpf$BPF_RAW_TRACEPOINT_OPEN"
 	],
 	"strace_bin": "",
 	"strace_bin_on_target": false,
@@ -45,6 +47,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/fs.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/fs.base.cfg
@@ -163,6 +163,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/fs.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/fs.patched.cfg
@@ -164,6 +164,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/io_uring.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/io_uring.base.cfg
@@ -58,6 +58,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/io_uring.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/io_uring.patched.cfg
@@ -59,6 +59,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/kvm.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/kvm.base.cfg
@@ -52,6 +52,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/kvm.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/kvm.patched.cfg
@@ -53,6 +53,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/net.base.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/net.base.cfg
@@ -94,6 +94,11 @@
 		"openat$ptp*",
 		"ioctl$PTP*"
 	],
+	"disable_syscalls": [
+		"perf_event_open*",
+		"ioctl$PERF*",
+		"bpf$BPF_RAW_TRACEPOINT_OPEN"
+	],
 	"strace_bin": "",
 	"strace_bin_on_target": false,
 	"execprog_bin_on_target": "",
@@ -113,6 +118,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }

--- a/syz-cluster/pkg/fuzzconfig/testdata/singular/net.patched.cfg
+++ b/syz-cluster/pkg/fuzzconfig/testdata/singular/net.patched.cfg
@@ -95,6 +95,11 @@
 		"openat$ptp*",
 		"ioctl$PTP*"
 	],
+	"disable_syscalls": [
+		"perf_event_open*",
+		"ioctl$PERF*",
+		"bpf$BPF_RAW_TRACEPOINT_OPEN"
+	],
 	"strace_bin": "",
 	"strace_bin_on_target": false,
 	"execprog_bin_on_target": "",
@@ -114,6 +119,7 @@
 		"reset_acc_state": false,
 		"remote_cover": true,
 		"cover_edges": false,
-		"descriptions_mode": "manual"
+		"descriptions_mode": "manual",
+		"enable_kfuzztest": false
 	}
 }


### PR DESCRIPTION
These calls only cause unrelated hungs and lost connection to machine bugs.
The diff has some unrelated lines due to the new configuration parameters added since the last time it was updated.