### PR TITLE
pkg/mgrconfig: change the snapshot attr semantics

### DIFF
--- a/docs/syscall_descriptions_syntax.md
+++ b/docs/syscall_descriptions_syntax.md
@@ -110,8 +110,7 @@ Call attributes are:
 	string argument is a fsck-like command that will be called to verify the filesystem.
 "remote_cover": wait longer to collect remote coverage for this call.
 "kfuzz_test": the call is a kfuzztest target.
-"snapshot": the call is enabled by default only in snapshot fuzzing mode,
-	but "enable_syscalls" and "disable_syscalls" config parameters override this.
+"snapshot": the call can only be enabled in snapshot fuzzing mode.
 	It is generally used to mark calls that are not safe to execute in non-snapshot mode
 	(can lead to false positives, or lost connections to test machines.
 ```

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -438,13 +438,17 @@ func ParseEnabledSyscalls(target *prog.Target, enabled, disabled []string,
 		}
 	} else {
 		for _, call := range target.Syscalls {
-			if call.Attrs.Snapshot && (descriptionsMode&SnapshotDescriptions) == 0 {
-				continue
-			}
 			syscalls[call.ID] = true
 		}
 	}
-
+	if descriptionsMode&SnapshotDescriptions == 0 {
+		// Drop snapshot calls in the non-snapshot mode.
+		for _, call := range target.Syscalls {
+			if call.Attrs.Snapshot {
+				delete(syscalls, call.ID)
+			}
+		}
+	}
 	for call := range syscalls {
 		if target.Syscalls[call].Attrs.Disabled ||
 			(descriptionsMode&AutoDescriptions) == 0 && target.Syscalls[call].Attrs.Automatic ||


### PR DESCRIPTION
At the moment of its introduction, the attribute was overridable by enable_syscalls. However, since some of the malicious calls are actually variants of generic syscalls (e.g. ioctl), it has de-facto made it very easy to enable them also on non-snapshot instances.

Do not let enable_syscalls override this. Instead, only activate snapshot calls on the snapshot instances.