### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@1360a344ccb0ab6e9475edef90ad2f46bf8003b1 # v3.0.6
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261  # v4.8.2


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/dependency-review-action` | [`1360a34`](https://github.com/actions/dependency-review-action/commit/1360a344ccb0ab6e9475edef90ad2f46bf8003b1) | [`3c4e3dc`](https://github.com/actions/dependency-review-action/commit/3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261) | [Release](https://github.com/actions/dependency-review-action/releases/tag/v4) | depsreview.yaml |
| `codecov/codecov-action` | [`5ecb98a`](https://github.com/codecov/codecov-action/commit/5ecb98a3c6b747ed38dc09f787459979aebb39be) | [`671740a`](https://github.com/codecov/codecov-action/commit/671740ac38dd9b0130fbe1cec585b89eea48d3de) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | ci.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
