### PR TITLE
dashboard/app: fix menu items height

### DIFF
--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -15,11 +15,12 @@ h1, h2, h3, h4 {
 	font-weight: bold;
 }
 
-.navigation_tab {
+.navigation .navigation_tab {
 	border: 1px solid black;
 	padding: 4px;
 	margin: 4px;
-	display: inline-block;
+	display: flex;
+	align-items: center;
 }
 
 .navigation_tab a:hover {background-color: #ddd;}
@@ -36,7 +37,6 @@ h1, h2, h3, h4 {
 	padding-top: 15px;
 	padding-bottom: 6px;
 	display: flex;
-	align-items: center;
 	flex-wrap: wrap;
 }
 
@@ -500,6 +500,8 @@ aside {
 	border: none;
 	font-family: inherit;
 	font-size: inherit;
+	padding: 0;
+	margin: 0;
 }
 
 /* The container <div> - needed to position the dropdown content */


### PR DESCRIPTION
menu items with dropdown had different height
Vibe-coded. It required a few iterations.
1. Everything works but the code has extra formatting attempts I didn't ask for.
2. Remove formatting attempts. Makes sense to ask for the minimal change. Tool decided to replace the symlink by content.

It costed ~1 hour of background work and ~3 single-line code review comments.

The way agent did it: it created the reproducer with a few menu items, ~30 lines of html code. Then it was running the web browser experimenting with the CSS file. Working with web browser required manual approvals for almost any code injection... that's where the 1 hour delay comes from.
Now I want the agent to be as autonomous as possible.