### PR TITLE
Makefile: fix codesearch compilation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,8 @@ bin/syz-extract:
 codesearch: bin/syz-codesearch
 
 bin/syz-codesearch: tools/clang/codesearch/* tools/clang/*
-	$(CXX) -Itools/clang $(shell llvm-config --cxxflags) -O2 -o $@ $< \
+	mkdir -p bin
+	$(CXX) -Itools/clang $(shell llvm-config --cxxflags) -O2 -o $@ tools/clang/codesearch/codesearch.cpp \
 		-lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
 		-lclangToolingCore -lclangParse -lclangSema -lclangAPINotes -lclangAnalysis \
 		-lclangASTMatchers -lclangRewrite -lclangEdit -lclangAST -lclangLex -lclangBasic -lclangSupport \


### PR DESCRIPTION
Running "make codesearch" on a fresh checkout fails due to a missing "bin" directory with the following error:
```
/usr/bin/ld: cannot open output file bin/syz-codesearch: No such file or directory
collect2: error: ld returned 1 exit status
```

Also depending on the order of the files on the filesystem, the current code tries to compile other files than `tools/clang/codesearch/codesearch.cpp` like `tools/clang/codesearch/README.md` like in the error below:

```
Makefile:31: run command via tools/syz-env for best compatibility, see:
Makefile:32: [https://github.com/google/syzkaller/blob/master/docs/contributing.md#using-syz-env](https://www.google.com/url?q=https://github.com/google/syzkaller/blob/master/docs/contributing.md%23using-syz-env&sa=D&source=editors&ust=1769432037643936&usg=AOvVaw1USxWMInBrZIY7wRxQSqwT)
g++ -Itools/clang -I/usr/lib/llvm-19/include -std=c++17 -fno-exceptions -funwind-tables -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -O2 -o bin/syz-codesearch tools/clang/codesearch/README.md \
-lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
-lclangToolingCore -lclangParse -lclangSema -lclangAPINotes -lclangAnalysis \
-lclangASTMatchers -lclangRewrite -lclangEdit -lclangAST -lclangLex -lclangBasic -lclangSupport \
-L/usr/lib/llvm-19/lib -lLLVM-19
/usr/bin/ld:tools/clang/codesearch/README.md: file format not recognized; treating as linker script
/usr/bin/ld:tools/clang/codesearch/README.md:3: syntax error
collect2: error: ld returned 1 exit status
make: * [Makefile:246: bin/syz-codesearch] Error 1
```

This PR fixes these two errors.