### PR TITLE
pkg/aflow: fix "unhandled span type" panic msg

### DIFF
--- a/pkg/aflow/trajectory/trajectory.go
+++ b/pkg/aflow/trajectory/trajectory.go
@@ -70,6 +70,8 @@ func (span *Span) String() string {
 		case SpanLLM:
 		case SpanTool:
 			printMap(sb, span.Args, "args")
+		case SpanLoop:
+		case SpanLoopIteration:
 		default:
 			panic(fmt.Sprintf("unhandled span type %v", span.Type))
 		}
@@ -92,6 +94,8 @@ func (span *Span) String() string {
 			}
 		case SpanTool:
 			printMap(sb, span.Results, "results")
+		case SpanLoop:
+		case SpanLoopIteration:
 		default:
 			panic(fmt.Sprintf("unhandled span type %v", span.Type))
 		}


### PR DESCRIPTION

This avoids printing the following panic messages in the log:

```
2026/01/26 14:15:43 %!v(PANIC=String method: unhandled span type loop)
2026/01/26 14:15:43 %!v(PANIC=String method: unhandled span type iteration)
```

Because loop does not use span fields and iteration only uses span.Name (which is already printed), we don't need to print anything further.