### PR TITLE
pkg/report: double-free is at least as severe as UAF write

### DIFF
--- a/pkg/report/README.md
+++ b/pkg/report/README.md
@@ -11,7 +11,7 @@ prioritize the triaging queue.
 KASAN detected bugs are typically more dangerous than KMSAN detected bugs. And KMSAN detected bugs are typically more
 dangerous than KCSAN detected bugs.
 
-### Use-after-free write > invalid-free(double-free) > use-after-free read.
+### Invalid-free (double-free) >= use-after-free write > use-after-free read.
 
 ### KASAN write > KASAN read
 KASAN write indicates an out-of-bounds or use-after-free write operation. Any uncontrolled write to kernel memory is

--- a/pkg/report/impact_score.go
+++ b/pkg/report/impact_score.go
@@ -13,11 +13,11 @@ import (
 // entries are considered more severe.
 var impactOrder = []crash.Type{
 	// Highest Priority (Direct Memory Corruption - Write)
+	crash.KASANInvalidFree,
+	crash.KFENCEInvalidFree,
 	crash.KASANUseAfterFreeWrite,
 	crash.KASANWrite,
 	// High Priority (Memory Corruption)
-	crash.KASANInvalidFree,
-	crash.KFENCEInvalidFree,
 	crash.KFENCEMemoryCorruption,
 	crash.KASANUseAfterFreeRead,
 	crash.KMSANUseAfterFreeRead,


### PR DESCRIPTION
Double-free is at least as severe as a UAF write because in case of UAF write, the vulnerable object is given and you have to find the right victim object - the writable offset and size needs to match.

In case of double-free you can choose both your victim and attacker object, giving more options for a successful exploitation (there are attacker objects which can basically write all offset and sizes).

This assumes that double-free is controlled in a way that the attacker can spray a victim object between the two `kfree()`s.
