### PR TITLE
pkg/aflow: handle input token overflow for LLM tools

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -105,6 +105,15 @@ func (err *modelQuotaError) Error() string {
 	return fmt.Sprintf("model %q is over daily quota", err.model)
 }
 
+func isTokenOverflowError(err error) bool {
+	var overflowErr *tokenOverflowError
+	return errors.As(err, &overflowErr)
+}
+
+type tokenOverflowError struct {
+	error
+}
+
 // QuotaResetTime returns the time when RPD quota will be reset
 // for a quota overflow happened at time t.
 func QuotaResetTime(t time.Time) time.Time {

--- a/pkg/aflow/testdata/TestLLMTool.llm.json
+++ b/pkg/aflow/testdata/TestLLMTool.llm.json
@@ -396,7 +396,7 @@
 				"parts": [
 					{
 						"functionCall": {
-							"id": "id2",
+							"id": "id3",
 							"args": {
 								"Something": "subtool input 2"
 							},
@@ -410,9 +410,219 @@
 				"parts": [
 					{
 						"functionResponse": {
-							"id": "id2",
+							"id": "id3",
 							"name": "researcher-tool"
 						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 2,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher-tool description",
+							"name": "researcher-tool",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"Something": {
+										"description": "something",
+										"type": "string"
+									}
+								},
+								"required": [
+									"Something"
+								],
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"responseModalities": [
+				"TEXT"
+			]
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "But really?"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id3",
+							"args": {
+								"Something": "subtool input 2"
+							},
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id3",
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id4",
+							"args": {
+								"Something": "subtool input 3"
+							},
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id4",
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 2,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher-tool description",
+							"name": "researcher-tool",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"Something": {
+										"description": "something",
+										"type": "string"
+									}
+								},
+								"required": [
+									"Something"
+								],
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"toolConfig": {
+				"functionCallingConfig": {
+					"mode": "NONE"
+				}
+			},
+			"responseModalities": [
+				"TEXT"
+			]
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "But really?"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id3",
+							"args": {
+								"Something": "subtool input 2"
+							},
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id3",
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id4",
+							"args": {
+								"Something": "subtool input 3"
+							},
+							"name": "researcher-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"text": "\nProvide a best-effort answer to the original question with all of the information\nyou have so far without calling any more tools!\n"
 					}
 				],
 				"role": "user"

--- a/pkg/aflow/testdata/TestLLMTool.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMTool.trajectory.json
@@ -229,13 +229,70 @@
 		"Finished": "0001-01-01T00:00:24Z"
 	},
 	{
+		"Seq": 14,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "researcher-tool",
+		"Started": "0001-01-01T00:00:25Z",
+		"Args": {
+			"Something": "subtool input 3"
+		}
+	},
+	{
+		"Seq": 14,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "researcher-tool",
+		"Started": "0001-01-01T00:00:25Z",
+		"Finished": "0001-01-01T00:00:26Z",
+		"Args": {
+			"Something": "subtool input 3"
+		},
+		"Results": {}
+	},
+	{
+		"Seq": 15,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:27Z"
+	},
+	{
+		"Seq": 15,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:27Z",
+		"Finished": "0001-01-01T00:00:28Z",
+		"Error": "Error 400, Message: The input token count exceeds the maximum number of tokens allowed 1048576., Status: , Details: []"
+	},
+	{
+		"Seq": 16,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:29Z"
+	},
+	{
+		"Seq": 16,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:29Z",
+		"Finished": "0001-01-01T00:00:30Z"
+	},
+	{
 		"Seq": 10,
 		"Nesting": 3,
 		"Type": "agent",
 		"Name": "researcher",
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:18Z",
-		"Finished": "0001-01-01T00:00:25Z",
+		"Finished": "0001-01-01T00:00:31Z",
 		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "But really?",
 		"Reply": "Still nothing."
@@ -246,7 +303,7 @@
 		"Type": "tool",
 		"Name": "researcher",
 		"Started": "0001-01-01T00:00:17Z",
-		"Finished": "0001-01-01T00:00:26Z",
+		"Finished": "0001-01-01T00:00:32Z",
 		"Args": {
 			"Question": "But really?"
 		},
@@ -255,21 +312,21 @@
 		}
 	},
 	{
-		"Seq": 14,
+		"Seq": 17,
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:27Z"
+		"Started": "0001-01-01T00:00:33Z"
 	},
 	{
-		"Seq": 14,
+		"Seq": 17,
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:27Z",
-		"Finished": "0001-01-01T00:00:28Z"
+		"Started": "0001-01-01T00:00:33Z",
+		"Finished": "0001-01-01T00:00:34Z"
 	},
 	{
 		"Seq": 1,
@@ -278,7 +335,7 @@
 		"Name": "smarty",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Finished": "0001-01-01T00:00:29Z",
+		"Finished": "0001-01-01T00:00:35Z",
 		"Instruction": "Do something!\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "Prompt",
 		"Reply": "YES"
@@ -289,7 +346,7 @@
 		"Type": "flow",
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
-		"Finished": "0001-01-01T00:00:30Z",
+		"Finished": "0001-01-01T00:00:36Z",
 		"Results": {
 			"Reply": "YES"
 		}


### PR DESCRIPTION
Handle LLM tool input token overflow by removing the last tool reply,
and replacing it with an order to answer right now.
I've seen an LLM tool went into too deap research and in the end
just overflowed input tokens. It could provide at least some answer instead.
