### PR TITLE
pkg/aflow/action/crash: fix the reversed res.Report/Error

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -109,7 +109,7 @@ func reproduce(ctx *aflow.Context, args ReproduceArgs) (reproduceResult, error) 
 		if err != nil {
 			return res, err
 		}
-		res.Error, res.Report, err = ReproduceCrash(args, workdir)
+		res.Report, res.Error, err = ReproduceCrash(args, workdir)
 		return res, err
 	})
 	if err != nil {


### PR DESCRIPTION
Right now res.Report and res.Error seem reversed. The successful crash report is returned into res.Error, and interrupts the normal flow/pipeline.
