### PR TITLE
dashboard: share Spanner clients

### DIFF
--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -301,6 +301,7 @@ func (ctx *Ctx) Close() {
 			}
 		}
 	}
+	aidb.CloseClient(ctx.ctx)
 	unregisterContext(ctx)
 	validateGlobalConfig()
 }


### PR DESCRIPTION
Instead of creating a new Spanner client/connection per each DB operation, cache the clients per each appID. In normal operation, there will be just one appID and one client. For tests, we create a different appID per each NewSpannerCtx anyway.