### PR TITLE
pkg/aflow: add explicit DoWhile.MaxIterations

### DIFF
--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -78,7 +78,8 @@ func init() {
 						},
 						crash.TestPatch, // -> PatchDiff or TestError
 					),
-					While: "TestError",
+					While:         "TestError",
+					MaxIterations: 10,
 				},
 				&aflow.LLMAgent{
 					Name:        "description-generator",

--- a/pkg/aflow/loop_test.go
+++ b/pkg/aflow/loop_test.go
@@ -47,7 +47,8 @@ func TestDoWhile(t *testing.T) {
 					return testResults{Diff: "diff"}, nil
 				}),
 			),
-			While: "TestError",
+			While:         "TestError",
+			MaxIterations: 10,
 		},
 		nil,
 	)
@@ -63,7 +64,8 @@ func TestDoWhileErrors(t *testing.T) {
 				}) (struct{}, error) {
 					return struct{}{}, nil
 				}),
-				While: "Condition",
+				While:         "Condition",
+				MaxIterations: 10,
 			},
 		))
 
@@ -76,6 +78,7 @@ func TestDoWhileErrors(t *testing.T) {
 				}) (struct{}, error) {
 					return struct{}{}, nil
 				}),
+				MaxIterations: 10,
 			},
 		))
 
@@ -90,7 +93,34 @@ func TestDoWhileErrors(t *testing.T) {
 				Do: NewFuncAction("body", func(ctx *Context, args struct{}) (output, error) {
 					return output{}, nil
 				}),
+				While:         "Output1",
+				MaxIterations: 10,
+			},
+		))
+	testRegistrationError[struct{}, struct{}](t,
+		"flow test: action DoWhile: bad MaxIterations value 0, should be within [1, 1000]",
+		Pipeline(
+			&DoWhile{
+				Do: NewFuncAction("body", func(ctx *Context, args struct{}) (output, error) {
+					return output{}, nil
+				}),
 				While: "Output1",
 			},
 		))
+}
+
+func TestDoWhileMaxIters(t *testing.T) {
+	type actionResults struct {
+		Error string
+	}
+	testFlow[struct{}, struct{}](t, nil, "DoWhile loop is going in cycles for 3 iterations",
+		&DoWhile{
+			Do: NewFuncAction("nop", func(ctx *Context, args struct{}) (actionResults, error) {
+				return actionResults{"failed"}, nil
+			}),
+			While:         "Error",
+			MaxIterations: 3,
+		},
+		nil,
+	)
 }

--- a/pkg/aflow/testdata/TestDoWhileMaxIters.trajectory.json
+++ b/pkg/aflow/testdata/TestDoWhileMaxIters.trajectory.json
@@ -1,0 +1,133 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:04Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Results": {
+			"Error": "failed"
+		}
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:08Z",
+		"Finished": "0001-01-01T00:00:09Z",
+		"Results": {
+			"Error": "failed"
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:10Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:12Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "nop",
+		"Started": "0001-01-01T00:00:12Z",
+		"Finished": "0001-01-01T00:00:13Z",
+		"Results": {
+			"Error": "failed"
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:14Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:15Z",
+		"Error": "DoWhile loop is going in cycles for 3 iterations"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:16Z",
+		"Error": "DoWhile loop is going in cycles for 3 iterations"
+	}
+]


### PR DESCRIPTION
Add DoWhile.MaxIterations and make it mandatory.
I think it's useful to make workflow implementer to think
explicitly about a reasonable cap on the number of iterations.
