### PR TITLE
tools/syz-aflow/aflow.go: Add CrashReport, KernelRepo and KernelCommit to inputs when downloading a bug

### DIFF
--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	_ "github.com/google/syzkaller/pkg/aflow/flow"
@@ -124,9 +125,17 @@ func downloadBug(id, inputFile, token string) error {
 		)
 	}
 	crash := info["crashes"].([]any)[0].(map[string]any)
+
+	repoURL, _ := crash["kernel-source-git"].(string)
+
+	// Clean the URL to end at .git.
+	if dotGitIndex := strings.Index(repoURL, ".git"); dotGitIndex != -1 {
+		repoURL = repoURL[:dotGitIndex+4]
+	}
+
 	inputs := map[string]any{
 		"SyzkallerCommit": crash["syzkaller-commit"],
-		"KernelRepo":      crash["kernel-source-git"],
+		"KernelRepo":      repoURL,
 		"KernelCommit":    crash["kernel-source-commit"],
 	}
 


### PR DESCRIPTION
# tools/syz-aflow/aflow.go: Add CrashReport, KernelRepo and KernelCommit to inputs when downloading a bug
When using `tools/syz-aflow` with `-download-bug` flag, the tool creates an inputs json file with inputs necessary for patching workflow. 

This PR makes it download inputs needed for `assessment-kcsan` workflow as well. 
### Quickrun 
(assuming disk.raw is available and make commands are run)
```
go run ./tools/syz-aflow -input=input-incomplete.json -download-bug=f98189ed18c1f5f32e00
jq --arg syzkaller "$PWD"   '.ReproOpts = "" | 
   .FixedRepository = "" | 
   .FixedBaseCommit = "" | 
   .Type = "qemu" | 
   .Syzkaller = $syzkaller | 
   .Image = ($syzkaller + "/disk.raw") | 
   .CodesearchToolBin = ($syzkaller + "/bin/syz-codesearch") | 
   .VM.cpu = 2 | 
   .VM.mem = 2048 | 
   .VM.cmdline = "root=/dev/sda1"'   input-incomplete.json > aflow-cfg.json


go run ./tools/syz-aflow -input=aflow-cfg.json \
    -workflow=assessment-kcsan -workdir=workdir -model=gemini-2.5-flash-preview    
```
**Before**:
```
flow inputs are missing: assessmenet.kcsanInputs: field "CrashReport" is not present when converting map
exit status 1
```

**After**:
```
2026/01/27 11:05:18 starting flow assessment-kcsan (0/0)...
2026/01/27 11:05:18 starting action kernel-checkouter (1/1)...
2026/01/27 11:06:22 finished action kernel-checkouter (1/1) in 1m3.718968086s
[...]
```