### PR TITLE
tools/syz-aflow/aflow.go: improve error handling for non-JSON responses

### DIFF
--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -118,7 +118,10 @@ func downloadBug(id, inputFile, token string) error {
 	}
 	var info map[string]any
 	if err := json.Unmarshal([]byte(resp), &info); err != nil {
-		return err
+		return fmt.Errorf(
+			"response for bug ID %v was not valid JSON: %w",
+			id, err,
+		)
 	}
 	crash := info["crashes"].([]any)[0].(map[string]any)
 	inputs := map[string]any{


### PR DESCRIPTION
When an extID exists but access is restricted, the syzbot server may return an HTTP 200 OK response containing an HTML instead of the expected JSON payload.

Currently, this causes "json.Unmarshal" in "downloadBug" to fail with the generic error message:
"invalid character '<' looking for beginning of value".

This change wraps the unmarshalling error to return an explicit message:
"response for bug ID <id> was not valid JSON: <original error>"

This makes it clear the issue is the response format (HTML vs JSON).