### PR TITLE
vm/qemu: fix sshArgs passing user instead of key

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -148,3 +148,4 @@ International Business Machines Corporation
  Andrew Donnellan
  Alexander Egorenkov
  Alexey Kardashevskiy
+Yuan Tan

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -786,7 +786,7 @@ func (inst *instance) ssh(args ...string) ([]byte, error) {
 }
 
 func (inst *instance) sshArgs(args ...string) []string {
-	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.User, inst.Port, false), inst.User+"@localhost")
+	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.Key, inst.Port, false), inst.User+"@localhost")
 	return append(sshArgs, args...)
 }
 


### PR DESCRIPTION
The sshArgs function was incorrectly passing inst.User (username) to vmimpl.SSHArgs instead of inst.Key (SSH key path).

This bug was not discovered during normal fuzzing because sshArgs() is only called via ssh(), which is only used by the Diagnose() function for crash diagnosis. The main fuzzing operations (Copy and Run) construct their SSH arguments directly using vmimpl.SCPArgs and vmimpl.SSHArgsForward with the correct inst.Key parameter.

