### PR TITLE
executor: use uint64 instead of uint64_t

### DIFF
--- a/executor/common_kvm_arm64.h
+++ b/executor/common_kvm_arm64.h
@@ -380,7 +380,7 @@ static long syz_kvm_assert_syzos_uexit(volatile long a0, volatile long a1,
 		return -1;
 	}
 
-	uint64_t actual_code = ((uint64_t*)(run->mmio.data))[0];
+	uint64 actual_code = ((uint64*)(run->mmio.data))[0];
 	if (actual_code != expect) {
 #if !SYZ_EXECUTOR
 		fprintf(stderr, "[SYZOS-DEBUG] Exit Code Mismatch on VCPU %d\n", cpufd);


### PR DESCRIPTION
Executor code relies on uint32/uint64 types rather than uint*_t. Using uint64_t causes type mismatches in generated C reproducers for programs.

Switch uint64_t to uint64 to keep executor headers consistent.

No functional changes.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
