### PR TITLE
dashboard: mark more errors as request-related

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -141,7 +141,7 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 	if correct := r.FormValue("correct"); correct != "" {
 		if !job.Finished.Valid || job.Error != "" {
-			return fmt.Errorf("job is in wrong state to set correct status")
+			return badRequestErr("job is in wrong state to set correct status")
 		}
 		switch correct {
 		case aiCorrectnessCorrect:
@@ -310,11 +310,11 @@ func makeUIJobReviewHistory(history []*aidb.Journal) []*uiJobReviewHistory {
 
 func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 	if len(req.Workflows) == 0 || req.CodeRevision == "" {
-		return nil, fmt.Errorf("invalid request")
+		return nil, badRequestErr("invalid request")
 	}
 	for _, flow := range req.Workflows {
 		if flow.Type == "" || flow.Name == "" {
-			return nil, fmt.Errorf("invalid request")
+			return nil, badRequestErr("invalid request")
 		}
 	}
 	if err := aidb.UpdateWorkflows(ctx, req.Workflows); err != nil {
@@ -385,7 +385,7 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 		return nil, err
 	}
 	if job.Finished.Valid {
-		return nil, fmt.Errorf("the job %v is already finished", req.ID)
+		return nil, badRequestErr("the job %v is already finished", req.ID)
 	}
 	job.Finished = spanner.NullTime{Time: timeNow(ctx), Valid: true}
 	job.Error = req.Error[:min(len(req.Error), 4<<10)]
@@ -532,7 +532,7 @@ func aiBugJobCreate(ctx context.Context, workflow string, bug *Bug, extraArgs ma
 		}
 	}
 	if typ == "" {
-		return fmt.Errorf("workflow %v does not exist", workflow)
+		return badRequestErr("workflow %v does not exist", workflow)
 	}
 	return bugJobCreate(ctx, workflow, typ, bug, extraArgs)
 }

--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -615,7 +615,7 @@ func createCheckBox(r *http.Request, caption string, values []string) (*uiCheckb
 	id := caption
 	for _, formVal := range r.Form[id] {
 		if !stringInList(values, formVal) {
-			return nil, ErrClientBadRequest
+			return nil, badRequestErr("invalid value %q for %s", formVal, id)
 		}
 	}
 	ui := &uiCheckbox{

--- a/dashboard/app/handler.go
+++ b/dashboard/app/handler.go
@@ -182,16 +182,17 @@ type (
 )
 
 var ErrClientNotFound = &ErrClient{errors.New("resource not found")}
-var ErrClientBadRequest = &ErrClient{errors.New("bad request")}
 
 func (ce *ErrClient) HTTPStatus() int {
 	switch ce {
 	case ErrClientNotFound:
 		return http.StatusNotFound
-	case ErrClientBadRequest:
-		return http.StatusBadRequest
 	}
-	return http.StatusInternalServerError
+	return http.StatusBadRequest
+}
+
+func badRequestErr(format string, args ...any) error {
+	return &ErrClient{fmt.Errorf(format, args...)}
 }
 
 func handleAuth(fn contextHandler) contextHandler {
@@ -390,7 +391,7 @@ func (g *gzipResponseWriterCloser) writeResult(r *http.Request) error {
 		return err
 	}
 	if g.plainResponseSize > 31<<20 { // 32MB is the AppEngine hard limit for the response size.
-		return fmt.Errorf("len(response) > 31M, try to request gzipped: %w", ErrClientBadRequest)
+		return badRequestErr("len(response) > 31M, try to request gzipped")
 	}
 	gzr, err := gzip.NewReader(g.buf)
 	if err != nil {


### PR DESCRIPTION
Such errors result in a 4xx status and do not pollute project logs. Add a helper function to simplify the code.
