### PR TITLE
prog: accelerate TestCrossTarget

### DIFF
--- a/prog/prog.go
+++ b/prog/prog.go
@@ -52,6 +52,17 @@ func (p *Prog) FilterInplace(allowed map[*Syscall]bool) {
 	}
 }
 
+// countArgs is used in tests to filter out particularly large programs.
+func (p *Prog) countArgs() int {
+	total := 0
+	for _, call := range p.Calls {
+		ForeachArg(call, func(_ Arg, _ *ArgCtx) {
+			total++
+		})
+	}
+	return total
+}
+
 // These properties are parsed and serialized according to the tag and the type
 // of the corresponding fields.
 // IMPORTANT: keep the exact values of "key" tag for existing props unchanged,


### PR DESCRIPTION
The test performs randomized minimization, which, in the test mode where we do validation at each step, takes quardatic time on the number of prog arguments. For particularly larget programs, it sometimes takes way more than 10 minutes and causes our testing pipeline to timeout.

Calculate the number of arguments in the generated/mutated programs and skip the large ones.
