### PR TITLE
pkg/aflow/tool/grepper: add the tool

### DIFF
--- a/pkg/aflow/flow/assessment/kcsan.go
+++ b/pkg/aflow/flow/assessment/kcsan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
 type kcsanInputs struct {
@@ -39,7 +40,7 @@ func init() {
 					Temperature: 1,
 					Instruction: kcsanInstruction,
 					Prompt:      kcsanPrompt,
-					Tools:       codesearcher.Tools,
+					Tools:       append(codesearcher.Tools, grepper.Tool),
 				},
 			),
 		},

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
 type moderationInputs struct {
@@ -46,7 +47,7 @@ func init() {
 					Temperature: 1,
 					Instruction: moderationInstruction,
 					Prompt:      moderationPrompt,
-					Tools:       codesearcher.Tools,
+					Tools:       append(codesearcher.Tools, grepper.Tool),
 				},
 			),
 		},

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codeeditor"
 	"github.com/google/syzkaller/pkg/aflow/tool/codeexpert"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
 type Inputs struct {
@@ -36,7 +37,7 @@ type Inputs struct {
 }
 
 func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
-	commonTools := slices.Clip(append([]aflow.Tool{codeexpert.Tool}, codesearcher.Tools...))
+	commonTools := slices.Clip(append([]aflow.Tool{codeexpert.Tool, grepper.Tool}, codesearcher.Tools...))
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(

--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -1,0 +1,77 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package grepper
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+var Tool = aflow.NewFuncTool("grepper", grepper, `
+The tool executes git grep on the kernel sources and returns the output.
+The codesearch set of tools provide more precise results,
+use them instead of this tool if they can answer your question.
+
+The following git grep flags are used:
+--extended-regexp: you need to provide expression in extended regexp syntax
+--line-number: line numbers are shown in the output
+--show-function: name of the function/struct/etc containing the match is shown in the output
+-C1: one line of before/after context is shown
+
+Lines with matches have ':' after the line number.
+Content lines have '-'  after the line number.
+Containing function/struct lines have '=' after the line number.
+`)
+
+type state struct {
+	KernelSrc string
+}
+
+type args struct {
+	Expression string `jsonschema:"Git grep expression in extended regexp syntax."`
+}
+
+type results struct {
+	Output string `jsonschema:"Output of the grep command."`
+}
+
+func grepper(ctx *aflow.Context, state state, args args) (results, error) {
+	output, err := osutil.RunCmd(time.Hour, state.KernelSrc, "git", "grep", "--extended-regexp",
+		"--line-number", "--show-function", "-C1", "--no-color", args.Expression)
+	if err != nil {
+		// This should mean an invalid expression.
+		if bytes.Contains(output, []byte("fatal:")) {
+			return results{}, aflow.BadCallError("bad expression: %s", bytes.TrimSpace(output))
+		}
+		if strings.Contains(err.Error(), "exit status 1") && len(output) == 0 {
+			return results{}, aflow.BadCallError("no matches")
+		}
+		return results{}, fmt.Errorf("%w\n%s", err, output)
+	}
+	// There is a potential DoS by LLM is it searches for ".*",
+	// "kmalloc" would be pretty bad (and useless) too.
+	// We can't show whole output in these cases, and need to truncate it.
+	// Output of ".*" for kernel is 3.2GB (40MLOC), so we don't bother
+	// handling it with more efficient streaming. That's lots of memory,
+	// but should be bearable for syz-agent.
+	// Each match takes 3-6 lines (counting context, function lines, and -- delimiters).
+	const maxLines = 500
+	lines := slices.Collect(bytes.Lines(output))
+	if len(lines) <= maxLines {
+		return results{string(output)}, nil
+	}
+	res := fmt.Sprintf(`
+Full output is too long, showing %v out of %v lines.
+Use more precise expression if possible.
+
+%s
+`, maxLines, len(lines), slices.Concat(lines[:maxLines]))
+	return results{res}, nil
+}

--- a/pkg/aflow/tool/grepper/grepper_test.go
+++ b/pkg/aflow/tool/grepper/grepper_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package grepper
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrepper(t *testing.T) {
+	repo := vcs.MakeTestRepo(t, t.TempDir())
+	repo.CommitChangeset("description",
+		vcs.FileContent{
+			File: "foo.c",
+			Content: `
+int some_func(void)
+{
+	line;
+	foobar;
+	line;
+}
+			`,
+		},
+		vcs.FileContent{
+			File: "bar.c",
+			Content: `
+int another_func(int) {
+	foobar;
+}
+			`,
+		},
+		vcs.FileContent{
+			File: "overflow.c",
+			Content: strings.Repeat(`
+int some_func(int) {
+	barfoo;
+}
+			`, 1000),
+		},
+	)
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "foobar"},
+		results{Output: `bar.c=2=int another_func(int) {
+bar.c:3:	foobar;
+bar.c-4-}
+--
+foo.c=2=int some_func(void)
+--
+foo.c-4-	line;
+foo.c:5:	foobar;
+foo.c-6-	line;
+`},
+		"")
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "barfoo"},
+		func(got results) {
+			assert.True(t, strings.Contains(got.Output,
+				"Full output is too long, showing 500 out of 3999 lines."),
+				"%v", got)
+			assert.Equal(t, 505, strings.Count(got.Output, "\n"))
+		},
+		"")
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "something that never appears"},
+		results{},
+		"no matches")
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "bad expression ("},
+		results{},
+		`bad expression: fatal: command line, 'bad expression (': Unmatched ( or \(`)
+}

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -273,10 +273,10 @@ func TestObject(t *testing.T) {
 	firstRev := []byte("First revision")
 	secondRev := []byte("Second revision")
 
-	repo.commitChangeset("first",
-		writeFile{"object.txt", string(firstRev)})
-	repo.commitChangeset("second",
-		writeFile{"object.txt", string(secondRev)})
+	repo.CommitChangeset("first",
+		FileContent{"object.txt", string(firstRev)})
+	repo.CommitChangeset("second",
+		FileContent{"object.txt", string(secondRev)})
 
 	commits, err := repo.repo.LatestCommits("", time.Time{})
 	if err != nil {
@@ -489,8 +489,8 @@ index f70f10e..0000000
 
 func TestGitFileHashes(t *testing.T) {
 	repo := MakeTestRepo(t, t.TempDir())
-	commit1 := repo.commitChangeset("first commit", writeFile{"object.txt", "some text"})
-	commit2 := repo.commitChangeset("second commit", writeFile{"object2.txt", "some text2"})
+	commit1 := repo.CommitChangeset("first commit", FileContent{"object.txt", "some text"})
+	commit2 := repo.CommitChangeset("second commit", FileContent{"object2.txt", "some text2"})
 
 	map1, err := repo.repo.fileHashes(commit1.Hash, []string{"object.txt", "object2.txt"})
 	require.NoError(t, err)
@@ -504,17 +504,17 @@ func TestGitFileHashes(t *testing.T) {
 
 func TestBaseForDiff(t *testing.T) {
 	repo := MakeTestRepo(t, t.TempDir())
-	repo.commitChangeset("first commit",
-		writeFile{"a.txt", "content of a.txt"},
-		writeFile{"b.txt", "content of b.txt"},
+	repo.CommitChangeset("first commit",
+		FileContent{"a.txt", "content of a.txt"},
+		FileContent{"b.txt", "content of b.txt"},
 	)
-	commit2 := repo.commitChangeset("second commit",
-		writeFile{"c.txt", "content of c.txt"},
-		writeFile{"d.txt", "content of d.txt"},
+	commit2 := repo.CommitChangeset("second commit",
+		FileContent{"c.txt", "content of c.txt"},
+		FileContent{"d.txt", "content of d.txt"},
 	)
 	// Create a diff.
-	commit3 := repo.commitChangeset("third commit",
-		writeFile{"a.txt", "update a.txt"},
+	commit3 := repo.CommitChangeset("third commit",
+		FileContent{"a.txt", "update a.txt"},
 	)
 	diff, err := repo.repo.Diff(commit2.Hash, commit3.Hash)
 	require.NoError(t, err)
@@ -523,8 +523,8 @@ func TestBaseForDiff(t *testing.T) {
 		require.NoError(t, err)
 		// Create a different change on top of commit2.
 		repo.Git("checkout", "-b", "branch-a")
-		repo.commitChangeset("patch a.txt",
-			writeFile{"a.txt", "another change to a.txt"},
+		repo.CommitChangeset("patch a.txt",
+			FileContent{"a.txt", "another change to a.txt"},
 		)
 		// Yet the patch could only be applied to commit1 or commit2.
 		base, err := repo.repo.BaseForDiff(diff, &debugtracer.TestTracer{T: t})
@@ -544,8 +544,8 @@ func TestBaseForDiff(t *testing.T) {
 		// Git does not remember milliseconds, so otherwise the commit sorting may be flaky.
 		time.Sleep(time.Second)
 		repo.Git("checkout", "-b", "branch-b")
-		commit4 := repo.commitChangeset("unrelated commit",
-			writeFile{"new.txt", "create new file"},
+		commit4 := repo.CommitChangeset("unrelated commit",
+			FileContent{"new.txt", "create new file"},
 		)
 		// Since the commit did not touch a.txt, it's the expected one.
 		base, err := repo.repo.BaseForDiff(diff, &debugtracer.TestTracer{T: t})

--- a/pkg/vcs/git_test_util.go
+++ b/pkg/vcs/git_test_util.go
@@ -78,24 +78,24 @@ func (repo *TestRepo) CommitFileChange(branch, change string) {
 }
 
 func (repo *TestRepo) CommitChange(description string) *Commit {
-	return repo.commitChangeset(description)
+	return repo.CommitChangeset(description)
 }
 
-type writeFile struct {
+type FileContent struct {
 	File    string
 	Content string
 }
 
-func (wf *writeFile) Apply(repo *TestRepo) error {
-	err := os.WriteFile(filepath.Join(repo.Dir, wf.File), []byte(wf.Content), 0644)
+func (fc *FileContent) Apply(repo *TestRepo) error {
+	err := os.WriteFile(filepath.Join(repo.Dir, fc.File), []byte(fc.Content), 0644)
 	if err != nil {
 		return err
 	}
-	repo.Git("add", wf.File)
+	repo.Git("add", fc.File)
 	return nil
 }
 
-func (repo *TestRepo) commitChangeset(description string, actions ...writeFile) *Commit {
+func (repo *TestRepo) CommitChangeset(description string, actions ...FileContent) *Commit {
 	for i, action := range actions {
 		if err := action.Apply(repo); err != nil {
 			repo.t.Fatalf("failed to apply action %d: %v", i, err)


### PR DESCRIPTION
Add a tool that executes git grep with the given expression.
It can handle long tail of cases that codesearcher can't handle,
while still providing less output than reading whole files.
