### PR TITLE
dashboard/app: fix local UI test

### DIFF
--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -72,6 +72,7 @@ var testConfig = &GlobalConfig{
 	Namespaces: map[string]*Config{
 		"test1": {
 			AccessLevel:           AccessAdmin,
+			AI:                    true,
 			Key:                   "test1keytest1keytest1key",
 			FixBisectionAutoClose: true,
 			SimilarityDomain:      testDomain,

--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -44,14 +44,14 @@ func TestLocalUI(t *testing.T) {
 	}
 	c := NewSpannerCtx(t)
 	defer c.Close()
-	checkConfig(localUIConfig)
+	checkConfig(testConfig)
 	c.transformContext = func(ctx context.Context) context.Context {
-		return contextWithConfig(ctx, localUIConfig)
+		return contextWithConfig(ctx, testConfig)
 	}
 	ln, err := net.Listen("tcp4", *flagLocalUIAddr)
 	require.NoError(t, err)
 	url := fmt.Sprintf("http://%v", ln.Addr())
-	exec.Command("xdg-open", url+"/linux").Start()
+	exec.Command("xdg-open", url+"/test1").Start()
 	go func() {
 		populateLocalUIDB(t, c)
 		// Let the dev_appserver print tons of unuseful garbage to the console
@@ -75,41 +75,6 @@ func TestLocalUI(t *testing.T) {
 		aetest.Login(makeUser(AuthorizedAdmin), req)
 		http.DefaultServeMux.ServeHTTP(w, req)
 	})))
-}
-
-var localUIConfig = &GlobalConfig{
-	AccessLevel:      AccessPublic,
-	DefaultNamespace: "linux",
-	Namespaces: map[string]*Config{
-		"linux": {
-			DisplayTitle: "Linux",
-			AccessLevel:  AccessPublic,
-			AI:           true,
-			Key:          password1,
-			Clients: map[string]string{
-				client1: password1,
-			},
-			Repos: []KernelRepo{
-				{
-					URL:    "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
-					Branch: "master",
-					Alias:  "upstream",
-				},
-			},
-			Reporting: []Reporting{
-				{
-					AccessLevel: AccessPublic,
-					Name:        "email-reporting",
-					DailyLimit:  1000,
-					Config: &EmailConfig{
-						Email:            "test@syzkaller.com",
-						HandleListEmails: true,
-						SubjectPrefix:    "[syzbot]",
-					},
-				},
-			},
-		},
-	},
 }
 
 func populateLocalUIDB(t *testing.T, c *Ctx) {


### PR DESCRIPTION
Right now when we run local test (local_ui_test.go), there has been another config [installed in app_test.go](https://github.com/google/syzkaller/blob/6b8752f20c06eee857545047ab920e63322bf4c8/dashboard/app/app_test.go#L39). That install is [exclusive](https://github.com/google/syzkaller/blob/6b8752f20c06eee857545047ab920e63322bf4c8/dashboard/app/config.go#L434) so we cannot install new configs. With the given config, we don't have a namespace "linux". So the newly added local config (which defaults all URLs to "linux/xyz") will not have links working.

IIUC we just need an arbitrary test config. So the fix is just to pick up the existing config's "test1" namespace, with the "AI"  option enabled.

I verified locally that this made the non-working links re-working.