### PR TITLE
pkg/aflow/flow/patching: fix getting list of recent commits

### DIFF
--- a/pkg/aflow/flow/patching/actions_test.go
+++ b/pkg/aflow/flow/patching/actions_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecentCommits(t *testing.T) {
@@ -17,8 +19,11 @@ func TestRecentCommits(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("skipping on CI because of shallow git checkout")
 	}
-	aflow.TestAction(t, getRecentCommits, recentCommitsArgs{
-		KernelSrc:    filepath.FromSlash("../../../.."),
+	dir := t.TempDir()
+	require.NoError(t, osutil.MkdirAll(filepath.Join(dir, "repo")))
+	require.NoError(t, os.Symlink(osutil.Abs(filepath.FromSlash("../../../..")),
+		filepath.Join(dir, "repo", "linux")))
+	aflow.TestAction(t, getRecentCommits, dir, recentCommitsArgs{
 		KernelCommit: "e01a0ca6c12c9851ea7090f13879255ef82291e7",
 		PatchDiff: `
 diff --git a/dashboard/app/ai.go b/dashboard/app/ai.go

--- a/pkg/aflow/test_action.go
+++ b/pkg/aflow/test_action.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAction(t *testing.T, a Action, initArgs, wantResults any, wantError string) {
+func TestAction(t *testing.T, a Action, workdir string, initArgs, wantResults any, wantError string) {
 	type tester interface {
 		testVerify(t *testing.T, ctx *verifyContext, args, results any) (
 			map[string]any, map[string]any, func(map[string]any) map[string]any)
@@ -22,6 +22,7 @@ func TestAction(t *testing.T, a Action, initArgs, wantResults any, wantError str
 	// We don't init all fields, init more, if necessary.
 	ctx := &Context{
 		state:   args,
+		Workdir: workdir,
 		onEvent: func(*trajectory.Span) error { return nil },
 		stubContext: stubContext{
 			timeNow: time.Now,


### PR DESCRIPTION
We need to run git log in the master git repo b/c out KernelSrc/KernelScratchSrc
are shallow checkouts that don't have history.
