### PR TITLE
tools/clang/codesearch: improve codesearch to handle global variables

### DIFF
--- a/pkg/codesearch/database.go
+++ b/pkg/codesearch/database.go
@@ -60,7 +60,7 @@ const (
 	EntityKindFunction
 	EntityKindStruct
 	EntityKindUnion
-	EntityKindVariable
+	EntityKindGlobalVariable
 	EntityKindMacro
 	EntityKindEnum
 	EntityKindTypedef
@@ -69,14 +69,14 @@ const (
 )
 
 var entityKindNames = [...]string{
-	EntityKindFunction: "function",
-	EntityKindStruct:   "struct",
-	EntityKindUnion:    "union",
-	EntityKindVariable: "variable",
-	EntityKindMacro:    "macro",
-	EntityKindEnum:     "enum",
-	EntityKindTypedef:  "typedef",
-	EntityKindField:    "field",
+	EntityKindFunction:       "function",
+	EntityKindStruct:         "struct",
+	EntityKindUnion:          "union",
+	EntityKindGlobalVariable: "global_variable",
+	EntityKindMacro:          "macro",
+	EntityKindEnum:           "enum",
+	EntityKindTypedef:        "typedef",
+	EntityKindField:          "field",
 }
 
 var entityKindBytes = func() [entityKindLast][]byte {

--- a/pkg/codesearch/testdata/global_vars.c
+++ b/pkg/codesearch/testdata/global_vars.c
@@ -1,0 +1,18 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+#define DEFINE_VAR(name) int name = 1
+#define DEFINE_STATIC_VAR(name) static int name = 2
+
+DEFINE_VAR(macro_var);
+
+DEFINE_STATIC_VAR(static_macro_var);
+
+int global_var = 3;
+static int local_to_file_var = 4;
+
+void some_function(void)
+{
+	int local_var = 5;
+	(void)local_var;
+}

--- a/pkg/codesearch/testdata/global_vars.c.json
+++ b/pkg/codesearch/testdata/global_vars.c.json
@@ -1,0 +1,61 @@
+{
+	"definitions": [
+		{
+			"name": "some_function",
+			"type": "void (void)",
+			"kind": "function",
+			"body": {
+				"file": "global_vars.c",
+				"start_line": 14,
+				"end_line": 18
+			},
+			"comment": {}
+		},
+		{
+			"name": "global_var",
+			"type": "int",
+			"kind": "global_variable",
+			"body": {
+				"file": "global_vars.c",
+				"start_line": 11,
+				"end_line": 11
+			},
+			"comment": {}
+		},
+		{
+			"name": "local_to_file_var",
+			"type": "int",
+			"kind": "global_variable",
+			"is_static": true,
+			"body": {
+				"file": "global_vars.c",
+				"start_line": 12,
+				"end_line": 12
+			},
+			"comment": {}
+		},
+		{
+			"name": "macro_var",
+			"type": "int",
+			"kind": "global_variable",
+			"body": {
+				"file": "global_vars.c",
+				"start_line": 7,
+				"end_line": 7
+			},
+			"comment": {}
+		},
+		{
+			"name": "static_macro_var",
+			"type": "int",
+			"kind": "global_variable",
+			"is_static": true,
+			"body": {
+				"file": "global_vars.c",
+				"start_line": 9,
+				"end_line": 9
+			},
+			"comment": {}
+		}
+	]
+}

--- a/pkg/codesearch/testdata/query-dir-index-root
+++ b/pkg/codesearch/testdata/query-dir-index-root
@@ -4,6 +4,7 @@ directory / subdirs:
  - mm
 
 directory / files:
+ - global_vars.c
  - refs.c
  - source0.c
  - source0.h

--- a/pkg/codesearch/testdata/query-dir-index-root2
+++ b/pkg/codesearch/testdata/query-dir-index-root2
@@ -4,6 +4,7 @@ directory /mm/.. subdirs:
  - mm
 
 directory /mm/.. files:
+ - global_vars.c
  - refs.c
  - source0.c
  - source0.h

--- a/tools/clang/codesearch/output.h
+++ b/tools/clang/codesearch/output.h
@@ -13,7 +13,7 @@
 constexpr char EntityKindFunction[] = "function";
 constexpr char EntityKindStruct[] = "struct";
 constexpr char EntityKindUnion[] = "union";
-constexpr char EntityKindVariable[] = "variable";
+constexpr char EntityKindGlobalVariable[] = "global_variable";
 constexpr char EntityKindMacro[] = "macro";
 constexpr char EntityKindEnum[] = "enum";
 constexpr char EntityKindTypedef[] = "typedef";


### PR DESCRIPTION
Contributes to #6469.

To handle global variables:

* Add `EntityKindGlobalVariable`
* Modify `TraverseVarDecl()` function logic
* Add a check to ensure `StartLine` and `EndLine` are in the same file
* Fix missing `#include <cstdint>` in json.h