### PR TITLE
pkg/aflow/tool/grepper: fix grep invocation

### DIFF
--- a/pkg/aflow/tool/grepper/grepper_test.go
+++ b/pkg/aflow/tool/grepper/grepper_test.go
@@ -81,4 +81,14 @@ foo.c-6-	line;
 		args{Expression: "bad expression ("},
 		results{},
 		`bad expression: fatal: command line, 'bad expression (': Unmatched ( or \(`)
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "->root"},
+		results{},
+		"no matches")
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: `-\>root`},
+		results{},
+		"no matches")
 }


### PR DESCRIPTION
If LLM searches for "->", grep considered it as a flag and failed.
Add "--" before the expression to fix such cases.
