### PR TITLE
pkg/html/pages: fix menu

### DIFF
--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -519,6 +519,9 @@ aside {
 	position: absolute;
 	background-color: #f1f1f1;
 	z-index: 1;
+	top: 100%;
+	left: 0;
+	margin-top: 1px;
 }
 
 /* Links inside the dropdown */


### PR DESCRIPTION
After the recent changes, the nested menu covers the main menu. These lines fix the alignment.

<img width="247" height="211" alt="image" src="https://github.com/user-attachments/assets/ee727c52-d7ca-4961-802a-1b2ad7245778" />
