### PR TITLE
tools/clang: restrict cgo build to linux to fix OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,12 @@ hub: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-hub github.com/google/syzkaller/syz-hub
 
 agent: descriptions
-	# syz-agent uses codesearch clang tool which requires cgo.
+ifeq ("$(HOSTOS)", "linux")
+	# syz-agent uses codesearch clang tool which requires cgo on linux.
 	CGO_ENABLED=1 GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-agent github.com/google/syzkaller/syz-agent
+else
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-agent github.com/google/syzkaller/syz-agent
+endif
 
 repro: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-repro github.com/google/syzkaller/tools/syz-repro

--- a/tools/clang/build.go
+++ b/tools/clang/build.go
@@ -1,6 +1,8 @@
 // Copyright 2026 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build linux
+
 package clangtoolimpl
 
 //// Common build flags for all C++ clang tools.


### PR DESCRIPTION
The clang tools use cgo with C++ code, which requires CGO_ENABLED=1. On OpenBSD, enabling cgo with C++ in the dependency tree causes the C++ compiler to be used for runtime/cgo C files, triggering:
  c++: error: treating 'c' input as 'c++' when in C++ mode,
  this behavior is deprecated [-Werror,-Wdeprecated]

Fix this by adding a //go:build linux constraint to build.go (the file with import "C" and cgo directives). On non-Linux platforms, the cgo/C++ code is excluded and only the Go constant definitions remain. The Makefile agent target now only forces CGO_ENABLED=1 on Linux.

Fixes https://syzkaller.appspot.com/bug?extid=88b211a5ff32c5ae494b

https://claude.ai/code/session_01Qiw3ANA4tFaFj26XufVBxB

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
