### PR TITLE
pkg/vcs: consider merge commits as base commits

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -770,6 +770,8 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 		"log",
 		"--all",
 		"--no-renames",
+		// Merge commits sometimes also change the file hashes.
+		"-m",
 		// Note that we cannot accelerate it by specifying "--since"
 		"-n", "100",
 		`--format=%H:%P`,


### PR DESCRIPTION
Sometimes merge commits also modify files, so we should consider them when picking the base commit as well.

Cc #6777.