### PR TITLE
syz-cluster: filter by series with failed steps

### DIFF
--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -127,6 +127,7 @@ func (h *dashboardHandler) seriesList(w http.ResponseWriter, r *http.Request) er
 			{db.SessionStatusInProgress, "in progress"},
 			{db.SessionStatusFinished, "finished"},
 			{db.SessionStatusSkipped, "skipped"},
+			{db.SessionStatusStepsFailed, "steps failed"},
 		},
 	}
 

--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -87,7 +87,8 @@ const (
 	SessionStatusFinished   SessionStatus = "finished"
 	SessionStatusSkipped    SessionStatus = "skipped"
 	// To be used in filters.
-	SessionStatusAny SessionStatus = ""
+	SessionStatusAny         SessionStatus = ""
+	SessionStatusStepsFailed SessionStatus = "steps_failed"
 )
 
 // It could have been a calculated field in Spanner, but the Go library for Spanner currently

--- a/syz-cluster/pkg/db/series_repo_test.go
+++ b/syz-cluster/pkg/db/series_repo_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,6 +172,22 @@ func TestSeriesRepositoryList(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, list, 1)
 		assert.Equal(t, 0, list[0].Findings)
+	})
+
+	t.Run("steps_failed", func(t *testing.T) {
+		list, err := repo.ListLatest(ctx, SeriesFilter{Status: SessionStatusStepsFailed}, time.Time{})
+		assert.NoError(t, err)
+		assert.Len(t, list, 0)
+		err = NewSessionTestRepository(client).InsertOrUpdate(ctx, &SessionTest{
+			SessionID: session.ID,
+			TestName:  "test",
+			Result:    api.TestFailed,
+			UpdatedAt: time.Now(),
+		}, nil)
+		assert.NoError(t, err)
+		list, err = repo.ListLatest(ctx, SeriesFilter{Status: SessionStatusStepsFailed}, time.Time{})
+		assert.NoError(t, err)
+		assert.Len(t, list, 1)
 	})
 }
 


### PR DESCRIPTION
Add a new series status into the filtering dropbox, which will help us quickly determine the cases that need further debugging.
