### PR TITLE
pkg/debugtracer: rename Log to Logf

### DIFF
--- a/pkg/asset/backend_gcs.go
+++ b/pkg/asset/backend_gcs.go
@@ -22,7 +22,7 @@ type cloudStorageBackend struct {
 }
 
 func makeCloudStorageBackend(bucket string, tracer debugtracer.DebugTracer) (*cloudStorageBackend, error) {
-	tracer.Log("created gcs backend for bucket '%s'", bucket)
+	tracer.Logf("created gcs backend for bucket '%s'", bucket)
 	client, err := gcs.NewClient(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("the call to NewClient failed: %w", err)
@@ -44,7 +44,7 @@ type writeErrorLogger struct {
 func (wel *writeErrorLogger) Write(p []byte) (n int, err error) {
 	n, err = wel.writeCloser.Write(p)
 	if err != nil {
-		wel.tracer.Log("cloud storage write error: %s", err)
+		wel.tracer.Logf("cloud storage write error: %s", err)
 	}
 	return
 }
@@ -52,7 +52,7 @@ func (wel *writeErrorLogger) Write(p []byte) (n int, err error) {
 func (wel *writeErrorLogger) Close() error {
 	err := wel.writeCloser.Close()
 	if err != nil {
-		wel.tracer.Log("cloud storage writer close error: %s", err)
+		wel.tracer.Logf("cloud storage writer close error: %s", err)
 	}
 	return err
 }
@@ -70,7 +70,7 @@ func (csb *cloudStorageBackend) upload(req *uploadRequest) (*uploadResponse, err
 		return nil, &FileExistsError{req.savePath}
 	}
 	w, err := csb.client.FileWriter(path, req.contentType, req.contentEncoding)
-	csb.tracer.Log("gcs upload: obtained a writer for %s, error %s", path, err)
+	csb.tracer.Logf("gcs upload: obtained a writer for %s, error %s", path, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/storage.go
+++ b/pkg/asset/storage.go
@@ -131,7 +131,7 @@ func (storage *Storage) uploadFileStream(reader io.Reader, assetType dashapi.Ass
 	res, err := compressor(req, storage.backend.upload)
 	var existsErr *FileExistsError
 	if errors.As(err, &existsErr) {
-		storage.tracer.Log("asset %s already exists", path)
+		storage.tracer.Logf("asset %s already exists", path)
 		if extra == nil || !extra.SkipIfExists {
 			return "", err
 		}
@@ -245,7 +245,7 @@ func (storage *Storage) DeprecateAssets() (DeprecateStats, error) {
 		needed[path] = true
 	}
 	stats.Needed = len(needed)
-	storage.tracer.Log("queried needed assets: %#v", needed)
+	storage.tracer.Logf("queried needed assets: %#v", needed)
 
 	existing, err := storage.backend.list()
 	if err != nil {
@@ -265,7 +265,7 @@ func (storage *Storage) DeprecateAssets() (DeprecateStats, error) {
 			keep = true
 			intersection++
 		}
-		storage.tracer.Log("-- object %v, %v: keep %t", obj.Path, obj.CreatedAt, keep)
+		storage.tracer.Logf("-- object %v, %v: keep %t", obj.Path, obj.CreatedAt, keep)
 		if !keep {
 			toDelete = append(toDelete, obj.Path)
 		}
@@ -279,7 +279,7 @@ func (storage *Storage) DeprecateAssets() (DeprecateStats, error) {
 	}
 	for _, path := range toDelete {
 		err := storage.backend.remove(path)
-		storage.tracer.Log("-- deleted %v: %v", path, err)
+		storage.tracer.Logf("-- deleted %v: %v", path, err)
 		// Several syz-ci's might be sharing the same storage. So let's tolerate
 		// races during file deletion.
 		if err != nil && err != ErrAssetDoesNotExist {

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -1061,7 +1061,7 @@ func (env *env) logf(msg string, args ...any) {
 	if false {
 		_ = fmt.Sprintf(msg, args...) // enable printf checker
 	}
-	env.cfg.Trace.Log(msg, args...)
+	env.cfg.Trace.Logf(msg, args...)
 }
 
 // pickReleaseTags() picks a subset of revisions to test.

--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -176,7 +176,7 @@ func runMake(params Params, extraArgs ...string) error {
 		"KBUILD_BUILD_HOST=syzkaller",
 	)
 	output, err := osutil.Run(time.Hour, cmd)
-	params.Tracer.Log("Build log:\n%s", output)
+	params.Tracer.Logf("build log:\n%s", output)
 	return err
 }
 
@@ -364,7 +364,7 @@ func elfBinarySignature(bin string, tracer debugtracer.DebugTracer) (string, err
 		hasher1.Write(data)
 		hash := hasher1.Sum(nil)
 		hasher.Write(hash)
-		tracer.Log("section %v: size %v signature %v", sec.Name, len(data), hex.EncodeToString(hash[:8]))
+		tracer.Logf("section %v: size %v signature %v", sec.Name, len(data), hex.EncodeToString(hash[:8]))
 		tracer.SaveFile(sec.Name, data)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil

--- a/pkg/debugtracer/debug.go
+++ b/pkg/debugtracer/debug.go
@@ -14,7 +14,7 @@ import (
 )
 
 type DebugTracer interface {
-	Log(msg string, args ...any)
+	Logf(msg string, args ...any)
 	SaveFile(filename string, data []byte)
 }
 
@@ -31,7 +31,7 @@ type TestTracer struct {
 type NullTracer struct {
 }
 
-func (gt *GenericTracer) Log(msg string, args ...any) {
+func (gt *GenericTracer) Logf(msg string, args ...any) {
 	if gt.WithTime {
 		timeStr := time.Now().Format("02-Jan-2006 15:04:05")
 		newArgs := append([]any{timeStr}, args...)
@@ -49,15 +49,15 @@ func (gt *GenericTracer) SaveFile(filename string, data []byte) {
 	osutil.WriteFile(filepath.Join(gt.OutDir, filename), data)
 }
 
-func (tt *TestTracer) Log(msg string, args ...any) {
-	tt.T.Log(msg, args)
+func (tt *TestTracer) Logf(msg string, args ...any) {
+	tt.T.Logf(msg, args...)
 }
 
 func (tt *TestTracer) SaveFile(filename string, data []byte) {
 	// Not implemented.
 }
 
-func (nt *NullTracer) Log(msg string, args ...any) {
+func (nt *NullTracer) Logf(msg string, args ...any) {
 	// Not implemented.
 }
 

--- a/pkg/kconfig/minimize.go
+++ b/pkg/kconfig/minimize.go
@@ -20,7 +20,7 @@ import (
 func (kconf *KConfig) Minimize(base, full *ConfigFile, pred func(*ConfigFile) (bool, error),
 	maxSteps int, dt debugtracer.DebugTracer) (*ConfigFile, error) {
 	diff, other := kconf.missingLeafConfigs(base, full)
-	dt.Log("kconfig minimization: base=%v full=%v leaves diff=%v", len(base.Configs), len(full.Configs), len(diff))
+	dt.Logf("kconfig minimization: base=%v full=%v leaves diff=%v", len(base.Configs), len(full.Configs), len(diff))
 
 	diffToConfig := func(part []string) (*ConfigFile, []string) {
 		if len(part) == 0 {
@@ -49,7 +49,7 @@ func (kconf *KConfig) Minimize(base, full *ConfigFile, pred func(*ConfigFile) (b
 		minimize.Config[string]{
 			Pred:     minimizePred,
 			MaxSteps: maxSteps,
-			Logf:     dt.Log,
+			Logf:     dt.Logf,
 		},
 		diff,
 	)
@@ -58,7 +58,7 @@ func (kconf *KConfig) Minimize(base, full *ConfigFile, pred func(*ConfigFile) (b
 	}
 	config, suspects := diffToConfig(result)
 	if suspects != nil {
-		dt.Log("minimized to %d configs; suspects: %v", len(result), suspects)
+		dt.Logf("minimized to %d configs; suspects: %v", len(result), suspects)
 		kconf.writeSuspects(dt, suspects)
 	}
 	return config, nil

--- a/pkg/subsystem/extractor.go
+++ b/pkg/subsystem/extractor.go
@@ -47,7 +47,7 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 	for i, crash := range crashes {
 		if crash.GuiltyPath != "" {
 			extracted := e.raw.FromPath(crash.GuiltyPath)
-			tracer.Log("Crash #%d: guilty=%s subsystems=%s", i+1,
+			tracer.Logf("crash #%d: guilty=%s subsystems=%s", i+1,
 				crash.GuiltyPath, e.readableSubsystems(extracted))
 			subsystems = append(subsystems, extracted...)
 		}
@@ -69,11 +69,11 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 			continue
 		}
 		reproSubsystems := e.raw.FromProg(crash.SyzRepro)
-		tracer.Log("Crash #%d: repro subsystems=%s", i+1, e.readableSubsystems(reproSubsystems))
+		tracer.Logf("crash #%d: repro subsystems=%s", i+1, e.readableSubsystems(reproSubsystems))
 		for _, subsystem := range reproSubsystems {
 			reproCounts[subsystem]++
 			if reproCounts[subsystem] == reproCount {
-				tracer.Log("Subsystem %s exists in all reproducers", subsystem.Name)
+				tracer.Logf("subsystem %s exists in all reproducers", subsystem.Name)
 				fromRepro = append(fromRepro, subsystem)
 			}
 		}
@@ -90,7 +90,7 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 			parents[reproSubsystem] = struct{}{} // also include the subsystem itself
 			for _, subsystem := range subsystems {
 				if _, ok := parents[subsystem]; ok {
-					tracer.Log("Picking %s because %s is one of its parents",
+					tracer.Logf("picking %s because %s is one of its parents",
 						reproSubsystem.Name, subsystem.Name)
 					newSubsystems = append(newSubsystems, reproSubsystem)
 					break
@@ -99,7 +99,7 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 		}
 		if len(newSubsystems) > 0 {
 			// Just pick those subsystems.
-			tracer.Log("Set %s because they appear both in repros and stack tracex",
+			tracer.Logf("set %s because they appear both in repros and stack tracex",
 				e.readableSubsystems(newSubsystems))
 			return newSubsystems
 		}
@@ -110,7 +110,7 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 		if reproCount >= cutOff {
 			// But if the guilty paths are non-controversial, also take the leading candidate.
 			fromStacks := mostVoted(counts, 0.66)
-			tracer.Log("There are %d reproducers, so take %s from them and %s from stack traces",
+			tracer.Logf("there are %d reproducers, so take %s from them and %s from stack traces",
 				reproCount, e.readableSubsystems(fromRepro), e.readableSubsystems(fromStacks))
 			return append(fromRepro, fromStacks...)
 		}
@@ -123,7 +123,7 @@ func (e *Extractor) TracedExtract(crashes []*Crash, tracer debugtracer.DebugTrac
 
 	// Let's pick all subsystems that received >= 33% of votes (thus no more than 3).
 	afterVoting := mostVoted(counts, 0.33)
-	tracer.Log("Take %s from voting results", e.readableSubsystems(afterVoting))
+	tracer.Logf("take %s from voting results", e.readableSubsystems(afterVoting))
 	return removeParents(afterVoting)
 }
 

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -428,7 +428,7 @@ func (git *gitRepo) Bisect(bad, good string, dt debugtracer.DebugTracer, pred fu
 		return nil, err
 	}
 	defer git.Reset()
-	dt.Log("# git bisect start %v %v\n%s", bad, good, output)
+	dt.Logf("# git bisect start %v %v\n%s", bad, good, output)
 	current, err := git.Commit(HEAD)
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (git *gitRepo) Bisect(bad, good string, dt debugtracer.DebugTracer, pred fu
 			firstBad = current
 		}
 		output, err = git.Run("bisect", bisectTerms[res])
-		dt.Log("# git bisect %v %v\n%s", bisectTerms[res], current.Hash, output)
+		dt.Logf("# git bisect %v %v\n%s", bisectTerms[res], current.Hash, output)
 		if err != nil {
 			if bytes.Contains(output, []byte("There are only 'skip'ped commits left to test")) {
 				return git.bisectInconclusive(output)
@@ -802,7 +802,7 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 			return nil, fmt.Errorf("hash verification failed: %w", err)
 		} else if !ok {
 			// The object is not known in this repository, so we won't find the exact base commit.
-			tracer.Log("unknown object %s, stopping base commit search", file.LeftHash)
+			tracer.Logf("unknown object %s, stopping base commit search", file.LeftHash)
 			return nil, nil
 		}
 		if _, ok := nameToHash[file.Name]; !ok {
@@ -813,7 +813,7 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 		}
 		args = append(args, "--find-object="+file.LeftHash)
 	}
-	tracer.Log("extracted %d left blob hashes", len(nameToHash))
+	tracer.Logf("extracted %d left blob hashes", len(nameToHash))
 	if len(nameToHash) == 0 {
 		return nil, nil
 	}
@@ -853,7 +853,7 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 	}
 	var ret []*BaseCommit
 	for commit, branches := range commitBranches {
-		tracer.Log("considering %q [%q]", commit, branches)
+		tracer.Logf("considering %q [%q]", commit, branches)
 		fileHashes, err := git.fileHashes(commit, fileNames)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract hashes for %s: %w", commit, err)
@@ -865,7 +865,7 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 			}
 		}
 		if len(noMatch) != 0 {
-			tracer.Log("hashes don't match for %q", noMatch)
+			tracer.Logf("hashes don't match for %q", noMatch)
 			continue
 		}
 		var branchList []string
@@ -877,7 +877,7 @@ func (git Git) BaseForDiff(diff []byte, tracer debugtracer.DebugTracer) ([]*Base
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract commit info: %w", err)
 		}
-		tracer.Log("hashes match, commit date is %v, branches %v", info.CommitDate, branchList)
+		tracer.Logf("hashes match, commit date is %v, branches %v", info.CommitDate, branchList)
 		ret = append(ret, &BaseCommit{Commit: info, Branches: branchList})
 	}
 	return git.minimizeBaseCommits(ret)

--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -289,7 +289,7 @@ const configBisectTag = "# Minimized by syzkaller"
 func (ctx *linux) Minimize(target *targets.Target, original, baseline []byte, types []crash.Type,
 	dt debugtracer.DebugTracer, pred func(test []byte) (BisectResult, error)) ([]byte, error) {
 	if bytes.HasPrefix(original, []byte(configBisectTag)) {
-		dt.Log("# configuration already minimized\n")
+		dt.Logf("# configuration already minimized")
 		return original, nil
 	}
 	kconf, err := kconfig.Parse(target, filepath.Join(ctx.gitRepo.Dir, "Kconfig"))
@@ -372,7 +372,7 @@ func (ctx *minimizeLinuxCtx) minimizeAgainst(base *kconfig.ConfigFile) error {
 }
 
 func (ctx *minimizeLinuxCtx) dropInstrumentation(types []crash.Type) error {
-	ctx.Log("check whether we can drop unnecessary instrumentation")
+	ctx.Logf("check whether we can drop unnecessary instrumentation")
 	oldTransform := ctx.transform
 	transform := func(c *kconfig.ConfigFile) {
 		oldTransform(c)
@@ -381,7 +381,7 @@ func (ctx *minimizeLinuxCtx) dropInstrumentation(types []crash.Type) error {
 	newConfig := ctx.config.Clone()
 	transform(newConfig)
 	if bytes.Equal(ctx.config.Serialize(), newConfig.Serialize()) {
-		ctx.Log("there was nothing we could disable; skip")
+		ctx.Logf("there was nothing we could disable; skip")
 		return nil
 	}
 	ctx.SaveFile("no-instrumentation.config", newConfig.Serialize())
@@ -390,7 +390,7 @@ func (ctx *minimizeLinuxCtx) dropInstrumentation(types []crash.Type) error {
 		return err
 	}
 	if ok {
-		ctx.Log("the bug reproduces without the instrumentation")
+		ctx.Logf("the bug reproduces without the instrumentation")
 		ctx.transform = transform
 		ctx.config = newConfig
 	}

--- a/pkg/vcs/linux_configs.go
+++ b/pkg/vcs/linux_configs.go
@@ -165,6 +165,6 @@ func setLinuxSanitizerConfigs(cf *kconfig.ConfigFile, types []crash.Type, dt deb
 		disabled = append(disabled, categoryName)
 	}
 	if len(disabled) > 0 {
-		dt.Log("disabling configs for %v, they are not needed", disabled)
+		dt.Logf("disabling configs for %v, they are not needed", disabled)
 	}
 }

--- a/syz-cluster/pkg/triage/commit.go
+++ b/syz-cluster/pkg/triage/commit.go
@@ -44,12 +44,12 @@ func (cs *CommitSelector) Select(series *api.Series, tree *api.Tree, lastBuild *
 	if err != nil || head == nil {
 		return SelectResult{}, err
 	}
-	cs.tracer.Log("current HEAD: %q (commit date: %v)", head.Hash, head.CommitDate)
+	cs.tracer.Logf("current HEAD: %q (commit date: %v)", head.Hash, head.CommitDate)
 	// If the series is already too old, it may be incompatible even if it applies cleanly.
 	const seriesLagsBehind = time.Hour * 24 * 7
 	if diff := head.CommitDate.Sub(series.PublishedAt); series.PublishedAt.Before(head.CommitDate) &&
 		diff > seriesLagsBehind {
-		cs.tracer.Log("the series is too old: %v before the HEAD", diff)
+		cs.tracer.Logf("the series is too old: %v before the HEAD", diff)
 		return SelectResult{Reason: reasonSeriesTooOld}, nil
 	}
 
@@ -63,19 +63,19 @@ func (cs *CommitSelector) Select(series *api.Series, tree *api.Tree, lastBuild *
 	if lastBuild != nil {
 		// Check if the commit is still good enough.
 		if diff := head.CommitDate.Sub(lastBuild.CommitDate); diff > seriesLagsBehind {
-			cs.tracer.Log("the last successful build is already too old: %v, skipping", diff)
+			cs.tracer.Logf("the last successful build is already too old: %v, skipping", diff)
 		} else {
 			hashes = append(hashes, lastBuild.CommitHash)
 		}
 	}
 	for _, hash := range append(hashes, head.Hash) {
-		cs.tracer.Log("considering %q", hash)
+		cs.tracer.Logf("considering %q", hash)
 		err := cs.ops.ApplySeries(hash, series.PatchBodies())
 		if err == nil {
-			cs.tracer.Log("series can be applied to %q", hash)
+			cs.tracer.Logf("series can be applied to %q", hash)
 			return SelectResult{Commit: hash}, nil
 		} else {
-			cs.tracer.Log("failed to apply to %q: %v", hash, err)
+			cs.tracer.Logf("failed to apply to %q: %v", hash, err)
 		}
 	}
 	return SelectResult{Reason: reasonNotApplies}, nil

--- a/syz-cluster/workflow/boot-step/main.go
+++ b/syz-cluster/workflow/boot-step/main.go
@@ -103,7 +103,7 @@ func runTest(ctx context.Context, client *api.Client, tracer debugtracer.DebugTr
 
 	var rep *report.Report
 	for i := 0; i < retryCount; i++ {
-		tracer.Log("starting attempt #%d", i)
+		tracer.Logf("starting attempt #%d", i)
 		var err error
 		rep, err = instance.RunSmokeTest(cfg)
 		if err != nil {
@@ -111,10 +111,10 @@ func runTest(ctx context.Context, client *api.Client, tracer debugtracer.DebugTr
 		} else if rep == nil {
 			return true, nil
 		}
-		tracer.Log("attempt failed: %q", rep.Title)
+		tracer.Logf("attempt failed: %q", rep.Title)
 	}
 	if *flagFindings {
-		tracer.Log("reporting the finding")
+		tracer.Logf("reporting the finding")
 		findingErr := client.UploadFinding(ctx, &api.NewFinding{
 			SessionID: *flagSession,
 			TestName:  *flagTestName,
@@ -126,8 +126,8 @@ func runTest(ctx context.Context, client *api.Client, tracer debugtracer.DebugTr
 			return false, fmt.Errorf("failed to report the finding: %w", findingErr)
 		}
 	} else {
-		tracer.Log("report:\n%s", rep.Report)
-		tracer.Log("output:\n%s", rep.Output)
+		tracer.Logf("report:\n%s", rep.Report)
+		tracer.Logf("output:\n%s", rep.Output)
 	}
 	return false, nil
 }

--- a/syz-cluster/workflow/build-step/main.go
+++ b/syz-cluster/workflow/build-step/main.go
@@ -192,7 +192,7 @@ func readRequest() *api.BuildRequest {
 }
 
 func checkoutKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest, series *api.Series) (*vcs.Commit, error) {
-	tracer.Log("checking out %q", req.CommitHash)
+	tracer.Logf("checking out %q", req.CommitHash)
 	ops, err := triage.NewGitTreeOps(*flagRepository, true)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ func checkoutKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest, serie
 		patches = series.PatchBodies()
 	}
 	if len(patches) > 0 {
-		tracer.Log("applying %d patches", len(patches))
+		tracer.Logf("applying %d patches", len(patches))
 	}
 	err = ops.ApplySeries(commit.Hash, patches)
 	return commit, err
@@ -239,10 +239,10 @@ func buildKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest) (*BuildR
 		Config:       kernelConfig,
 		Tracer:       tracer,
 	}
-	tracer.Log("started build: %q", req)
+	tracer.Logf("started build: %q", req)
 	info, err := build.Image(params)
-	tracer.Log("compiler: %q", info.CompilerID)
-	tracer.Log("signature: %q", info.Signature)
+	tracer.Logf("compiler: %q", info.CompilerID)
+	tracer.Logf("signature: %q", info.Signature)
 	// We can fill this regardless of whether it succeeded.
 	ret := &BuildResult{
 		Compiler: info.CompilerID,
@@ -258,25 +258,25 @@ func buildKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest) (*BuildR
 		var verboseError *osutil.VerboseError
 		switch {
 		case errors.As(err, &kernelError):
-			tracer.Log("kernel error: %q / %s", kernelError.Report, kernelError.Output)
+			tracer.Logf("kernel error: %q / %s", kernelError.Report, kernelError.Output)
 			ret.Finding.Report = kernelError.Report
 			ret.Finding.Log = kernelError.Output
 			return ret, nil
 		case errors.As(err, &verboseError):
-			tracer.Log("verbose error: %s / %s", verboseError, verboseError.Output)
+			tracer.Logf("verbose error: %s / %s", verboseError, verboseError.Output)
 			ret.Finding.Report = []byte(verboseError.Error())
 			ret.Finding.Log = verboseError.Output
 			return ret, nil
 		default:
-			tracer.Log("other error: %v", err)
+			tracer.Logf("other error: %v", err)
 		}
 		return nil, err
 	}
-	tracer.Log("build finished successfully")
+	tracer.Logf("build finished successfully")
 
 	err = saveSymbolHashes(tracer)
 	if err != nil {
-		tracer.Log("failed to save symbol hashes: %s", err)
+		tracer.Logf("failed to save symbol hashes: %s", err)
 	}
 	// Note: Output directory has the following structure:
 	//   |-- image
@@ -293,7 +293,7 @@ func saveSymbolHashes(tracer debugtracer.DebugTracer) error {
 	if err != nil {
 		return fmt.Errorf("failed to query symbol hashes: %w", err)
 	}
-	tracer.Log("extracted hashes for %d text symbols and %d data symbols",
+	tracer.Logf("extracted hashes for %d text symbols and %d data symbols",
 		len(hashes.Text), len(hashes.Data))
 	file, err := os.Create(filepath.Join(*flagOutput, "symbol_hashes.json"))
 	if err != nil {

--- a/tools/syz-build/build.go
+++ b/tools/syz-build/build.go
@@ -75,6 +75,6 @@ func main() {
 	if err != nil {
 		tool.Fail(err)
 	}
-	params.Tracer.Log("signature: %v", details.Signature)
-	params.Tracer.Log("compiler: %v", details.CompilerID)
+	params.Tracer.Logf("signature: %v", details.Signature)
+	params.Tracer.Logf("compiler: %v", details.CompilerID)
 }


### PR DESCRIPTION
The methods are used for formatted output, so rename them to follow Go conventions. Additionally, fix TestTracer to use formatted output (t.Logf) instead of unformatted output (t.Log).

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
