### PR TITLE
syz-cluster: extend the search for known base kernel crashes

### DIFF
--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -172,8 +172,9 @@ type ReportReply struct {
 // BaseFinding collects all crashes observed on the base kernel tree.
 // It will be used to avoid unnecessary bug reproduction attempts.
 type BaseFinding struct {
-	CommitHash string `spanner:"CommitHash"`
-	Config     string `spanner:"Config"`
-	Arch       string `spanner:"Arch"`
-	Title      string `spanner:"Title"`
+	CommitHash string           `spanner:"CommitHash"`
+	CommitDate spanner.NullTime `spanner:"CommitDate"`
+	Config     string           `spanner:"Config"`
+	Arch       string           `spanner:"Arch"`
+	Title      string           `spanner:"Title"`
 }

--- a/syz-cluster/pkg/db/migrations/10_add_commit_date_to_base_findings.down.sql
+++ b/syz-cluster/pkg/db/migrations/10_add_commit_date_to_base_findings.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX BaseFindingsByConfigArchTitleDate;
+ALTER TABLE BaseFindings DROP COLUMN CommitDate;

--- a/syz-cluster/pkg/db/migrations/10_add_commit_date_to_base_findings.up.sql
+++ b/syz-cluster/pkg/db/migrations/10_add_commit_date_to_base_findings.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE BaseFindings ADD COLUMN CommitDate TIMESTAMP;
+CREATE INDEX BaseFindingsByConfigArchTitleDate ON BaseFindings(Config, Arch, Title, CommitDate);

--- a/syz-cluster/pkg/service/base_finding.go
+++ b/syz-cluster/pkg/service/base_finding.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"cloud.google.com/go/spanner"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/db"
@@ -59,6 +60,7 @@ func (s *BaseFindingService) makeBaseFinding(ctx context.Context, info *api.Base
 	}
 	return &db.BaseFinding{
 		CommitHash: build.CommitHash,
+		CommitDate: spanner.NullTime{Time: build.CommitDate, Valid: true},
 		Config:     build.ConfigName,
 		Arch:       build.Arch,
 		Title:      info.Title,


### PR DESCRIPTION
Now that we may use totally different base commits for the patch series, it has become way less efficient to only check for the base crashes seen at an exact base commit.

Look for a time window by its commit date instead.