### PR TITLE
dashboard/app: update the instruction for port mapping

### DIFF
--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -33,7 +33,7 @@ var (
 
 // Run the test with:
 //
-//	DOCKERARGS=-p=50556:50556 tools/syz-env go test -run TestLocalUI -timeout=0 -v ./dashboard/app \
+//	DOCKERARGS=-p=127.0.0.1:50556:50556 tools/syz-env go test -run TestLocalUI -timeout=0 -v ./dashboard/app \
 //		-local-ui -local-ui-addr=:50556
 //
 // or if you have gcloud installed (faster, and opens the browser):


### PR DESCRIPTION
Advice passing DOCKERARGS=-p=127.0.0.1:50556:50556 to syz-env to ensure that the test does not listen on any other interfaces.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
