### PR TITLE
tools/clang: build clang tools on linux only

### DIFF
--- a/tools/clang/codesearch/codesearch.cpp
+++ b/tools/clang/codesearch/codesearch.cpp
@@ -4,6 +4,8 @@
 // Clang-based tool that indexes kernel source code to power
 // pkg/aflow/tool/codesearcher/codesearcher.go agentic tool.
 
+//go:build linux
+
 #include "json.h"
 #include "output.h"
 

--- a/tools/clang/declextract/declextract.cpp
+++ b/tools/clang/declextract/declextract.cpp
@@ -1,6 +1,8 @@
 // Copyright 2024 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build linux
+
 #include "json.h"
 #include "output.h"
 


### PR DESCRIPTION
This will hopefully prevent:

imports github.com/google/syzkaller/tools/clang/codesearch:
	C++ source files not allowed when not using cgo or SWIG: codesearch.cpp
