### PR TITLE
pkg/gce, vm/gce: auto delete instances if VMRunningTime is set in config

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -61,6 +61,7 @@ type InstanceConfig struct {
 	Tags          []string
 	Preemptible   bool
 	DisplayDevice bool
+	VMRunningTime time.Duration
 }
 
 func NewContext(customZoneID string) (*Context, error) {
@@ -175,6 +176,13 @@ func (ctx *Context) CreateInstance(cfg *InstanceConfig) (string, error) {
 			EnableDisplay: cfg.DisplayDevice,
 		},
 		Tags: &compute.Tags{Items: cfg.Tags},
+	}
+	if cfg.VMRunningTime != 0 {
+		instance.Scheduling.MaxRunDuration = &compute.Duration{
+			// Give the manager an extra hour to ensure it has time to do its own cleanup.
+			Seconds: int64((cfg.VMRunningTime + time.Hour) / time.Second),
+		}
+		instance.Scheduling.InstanceTerminationAction = "DELETE"
 	}
 retry:
 	if !instance.Scheduling.Preemptible && strings.HasPrefix(cfg.MachineType, "e2-") {

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -203,6 +203,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		Tags:          pool.cfg.Tags,
 		Preemptible:   pool.cfg.Preemptible,
 		DisplayDevice: pool.cfg.DisplayDevice,
+		VMRunningTime: pool.env.Timeouts.VMRunningTime,
 	}
 	ip, err := pool.GCE.CreateInstance(instCfg)
 	if err != nil {


### PR DESCRIPTION
This ensures that instances are deleted by GCE even if the manager crashes and fails to delete them. Add a 5-minute margin to the timeout to give the manager enough time to finish its own cleanup.
