### PR TITLE
syz-cluster: refactor triage result structure

### DIFF
--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -10,14 +10,15 @@ type TriageResult struct {
 	// If set, ignore the patch series completely.
 	SkipReason string `json:"skip_reason"`
 	// Fuzzing configuration to try (NULL if nothing).
-	Fuzz []*FuzzTask `json:"fuzz"`
+	Targets []*TestTarget `json:"targets"`
 }
 
-// The data layout faclitates the simplicity of the workflow definition.
-type FuzzTask struct {
+// TestTarget groups the testing tasks that share the same base/patched builds.
+type TestTarget struct {
 	Base    BuildRequest `json:"base"`
 	Patched BuildRequest `json:"patched"`
-	FuzzConfig
+	Track   string       `json:"track"` // E.g. KASAN.
+	Fuzz    *FuzzConfig  `json:"fuzz"`
 }
 
 const (
@@ -31,7 +32,6 @@ const (
 // FuzzConfig represents a set of parameters passed to the fuzz step.
 // The triage step aggregates multiple KernelFuzzConfig to construct FuzzConfig.
 type FuzzConfig struct {
-	Track      string   `json:"track"` // E.g. KASAN.
 	Focus      []string `json:"focus"`
 	CorpusURLs []string `json:"corpus_urls"`
 	// Don't expect kernel coverage for the patched area.

--- a/syz-cluster/pkg/triage/fuzz_target.go
+++ b/syz-cluster/pkg/triage/fuzz_target.go
@@ -36,6 +36,7 @@ func SelectFuzzConfigs(series *api.Series, fuzzConfigs []*api.FuzzTriageTarget) 
 
 type MergedFuzzConfig struct {
 	KernelConfig string
+	Track        string
 	FuzzConfig   *api.FuzzConfig
 }
 
@@ -61,6 +62,7 @@ func MergeKernelFuzzConfigs(configs []*api.KernelFuzzConfig) []*MergedFuzzConfig
 		// TODO: is there way to auto-generate a prefix?
 		ret = append(ret, &MergedFuzzConfig{
 			KernelConfig: key.config,
+			Track:        key.track,
 			FuzzConfig:   mergeFuzzConfigs(groups[key]),
 		})
 	}
@@ -79,7 +81,6 @@ func mergeFuzzConfigs(configs []*api.KernelFuzzConfig) *api.FuzzConfig {
 		ret.SkipCoverCheck = ret.SkipCoverCheck || config.SkipCoverCheck
 		// Must be the same.
 		ret.BugTitleRe = config.BugTitleRe
-		ret.Track = config.Track
 	}
 	ret.Focus = unique(ret.Focus)
 	ret.CorpusURLs = unique(ret.CorpusURLs)

--- a/syz-cluster/pkg/triage/fuzz_target_test.go
+++ b/syz-cluster/pkg/triage/fuzz_target_test.go
@@ -64,15 +64,15 @@ func TestMergeKernelFuzzConfigs(t *testing.T) {
 		assert.Equal(t, []*MergedFuzzConfig{
 			{
 				KernelConfig: "kasan_config",
+				Track:        "KASAN",
 				FuzzConfig: &api.FuzzConfig{
-					Track: "KASAN",
 					Focus: []string{"net"},
 				},
 			},
 			{
 				KernelConfig: "kmsan_config",
+				Track:        "KMSAN",
 				FuzzConfig: &api.FuzzConfig{
-					Track: "KMSAN",
 					Focus: []string{"net"},
 				},
 			},
@@ -93,8 +93,8 @@ func TestMergeKernelFuzzConfigs(t *testing.T) {
 		assert.Equal(t, []*MergedFuzzConfig{
 			{
 				KernelConfig: "kasan_config",
+				Track:        "KASAN",
 				FuzzConfig: &api.FuzzConfig{
-					Track: "KASAN",
 					Focus: []string{"bpf", "net"},
 				},
 			},

--- a/syz-cluster/pkg/workflow/template.yaml
+++ b/syz-cluster/pkg/workflow/template.yaml
@@ -39,16 +39,16 @@ spec:
         - - name: abort-on-skip-outcome
             template: exit-workflow
             when: "{{=jsonpath(steps['run-triage'].outputs.parameters.result, '$.skip_reason') != ''}}"
-        - - name: run-process-fuzz
-            template: process-fuzz
+        - - name: run-process-target
+            template: process-target
             arguments:
               parameters:
                 - name: element
                   value: "{{item}}"
-            withParam: "{{=jsonpath(steps['run-triage'].outputs.parameters.result, '$.fuzz')}}"
+            withParam: "{{=jsonpath(steps['run-triage'].outputs.parameters.result, '$.targets')}}"
             continueOn:
               failed: true
-    - name: process-fuzz
+    - name: process-target
       inputs:
         parameters:
           - name: element
@@ -90,8 +90,6 @@ spec:
                 - name: kernel
                   from: "{{steps.base-build.outputs.artifacts.kernel}}"
               parameters:
-                - name: config
-                  value: "{{=jsonpath(inputs.parameters.element, '$.config')}}"
                 - name: base-build-id
                   value: "{{=jsonpath(steps['base-build'].outputs.parameters.result, '$.build_id')}}"
                 - name: test-name
@@ -126,8 +124,6 @@ spec:
                 - name: kernel
                   from: "{{steps.patched-build.outputs.artifacts.kernel}}"
               parameters:
-                - name: config
-                  value: "{{=jsonpath(inputs.parameters.element, '$.config')}}"
                 - name: patched-build-id
                   value: "{{=jsonpath(steps['patched-build'].outputs.parameters.result, '$.build_id')}}"
                 - name: report-findings
@@ -137,12 +133,42 @@ spec:
         - - name: abort-if-patched-boot-failed
             template: exit-workflow
             when: "{{=jsonpath(steps['boot-test-patched'].outputs.parameters.result, '$.success') == false}}"
+        - - name: run-fuzz
+            template: fuzz-campaign
+            when: "{{=jsonpath(inputs.parameters.element, '$.fuzz') != nil}}"
+            arguments:
+              parameters:
+                - name: config
+                  value: "{{=jsonpath(inputs.parameters.element, '$.fuzz')}}"
+                - name: patched-build-id
+                  value: "{{=jsonpath(steps['patched-build'].outputs.parameters.result, '$.build_id')}}"
+                - name: base-build-id
+                  value: "{{=jsonpath(steps['base-build'].outputs.parameters.result, '$.build_id')}}"
+                - name: track
+                  value: "{{=jsonpath(inputs.parameters.element, '$.track')}}"
+              artifacts:
+                - name: base-kernel
+                  from: "{{steps.base-build.outputs.artifacts.kernel}}"
+                - name: patched-kernel
+                  from: "{{steps.patched-build.outputs.artifacts.kernel}}"
+
+    - name: fuzz-campaign
+      inputs:
+        parameters:
+          - name: config
+          - name: track
+          - name: base-build-id
+          - name: patched-build-id
+        artifacts:
+          - name: base-kernel
+          - name: patched-kernel
+      steps:
         - - name: save-fuzz-config
             template: convert-artifact
             arguments:
               parameters:
                 - name: data
-                  value: "{{=jsonpath(inputs.parameters.element, '$')}}"
+                  value: "{{inputs.parameters.config}}"
         - - name: fuzz
             templateRef:
               name: fuzz-action-template
@@ -150,14 +176,16 @@ spec:
             arguments:
               parameters:
                 - name: patched-build-id
-                  value: "{{=jsonpath(steps['patched-build'].outputs.parameters.result, '$.build_id')}}"
+                  value: "{{inputs.parameters.patched-build-id}}"
                 - name: base-build-id
-                  value: "{{=jsonpath(steps['base-build'].outputs.parameters.result, '$.build_id')}}"
+                  value: "{{inputs.parameters.base-build-id}}"
+                - name: test-name
+                  value: "[{{inputs.parameters.track}}] Fuzz"
               artifacts:
                 - name: base-kernel
-                  from: "{{steps.base-build.outputs.artifacts.kernel}}"
+                  from: "{{inputs.artifacts.base-kernel}}"
                 - name: patched-kernel
-                  from: "{{steps.patched-build.outputs.artifacts.kernel}}"
+                  from: "{{inputs.artifacts.patched-kernel}}"
                 - name: config
                   from: "{{steps.save-fuzz-config.outputs.artifacts.artifact}}"
     - name: convert-artifact

--- a/syz-cluster/workflow/boot/main.go
+++ b/syz-cluster/workflow/boot/main.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	flagConfig       = flag.String("config", "", "syzkaller config")
 	flagSession      = flag.String("session", "", "session ID")
 	flagTestName     = flag.String("test_name", "", "test name")
 	flagBaseBuild    = flag.String("base_build", "", "base build ID")
@@ -33,8 +32,8 @@ var (
 
 func main() {
 	flag.Parse()
-	if *flagConfig == "" || *flagSession == "" || *flagTestName == "" {
-		app.Fatalf("--config, --session and --test_name must be set")
+	if *flagSession == "" || *flagTestName == "" {
+		app.Fatalf("--session and --test_name must be set")
 	}
 
 	ctx := context.Background()

--- a/syz-cluster/workflow/boot/workflow-template.yaml
+++ b/syz-cluster/workflow/boot/workflow-template.yaml
@@ -10,14 +10,12 @@ spec:
     - name: boot-action
       inputs:
         parameters:
-          - name: config
-            value: ""
           - name: base-build-id
             value: ""
           - name: patched-build-id
             value: ""
           - name: test-name
-            value: ""
+            value: "Boot"
           - name: report-findings
             value: "false"
         artifacts:
@@ -28,7 +26,6 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/boot-action"]
         args: [
-          "--config", "{{inputs.parameters.config}}",
           "--output", "/output/result.json",
           "--session", "{{workflow.parameters.session-id}}",
           "--test_name", "{{inputs.parameters.test-name}}",

--- a/syz-cluster/workflow/fuzz/workflow-template.yaml
+++ b/syz-cluster/workflow/fuzz/workflow-template.yaml
@@ -14,6 +14,8 @@ spec:
             value: ""
           - name: patched-build-id
             value: ""
+          - name: test-name
+            value: "Fuzz"
         artifacts:
           - name: base-kernel
             path: /base
@@ -31,6 +33,7 @@ spec:
           "--session", "{{workflow.parameters.session-id}}",
           "--base_build", "{{inputs.parameters.base-build-id}}",
           "--patched_build", "{{inputs.parameters.patched-build-id}}",
+          "--test_name", "{{inputs.parameters.test-name}}",
           "--time", "3h",
           "--workdir", "/workdir",
           "--vv", "1"

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -96,9 +96,9 @@ func (triager *seriesTriager) GetVerdict(ctx context.Context, sessionID string) 
 		} else if err != nil {
 			return nil, err
 		}
-		ret.Fuzz = append(ret.Fuzz, fuzzTask)
+		ret.Targets = append(ret.Targets, fuzzTask)
 	}
-	if len(ret.Fuzz) > 0 {
+	if len(ret.Targets) > 0 {
 		// If we have prepared at least one fuzzing task, the series was not skipped.
 		ret.SkipReason = ""
 	}
@@ -106,7 +106,7 @@ func (triager *seriesTriager) GetVerdict(ctx context.Context, sessionID string) 
 }
 
 func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *api.Series, trees []*api.Tree,
-	target *triage.MergedFuzzConfig) (*api.FuzzTask, error) {
+	target *triage.MergedFuzzConfig) (*api.TestTarget, error) {
 	var result *SelectResult
 	var err error
 	if series.BaseCommitHint != "" {
@@ -136,13 +136,14 @@ func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *ap
 			CommitHash: result.Commit,
 			Arch:       result.Arch,
 		}
-		fuzz := &api.FuzzTask{
-			Base:       base,
-			Patched:    base,
-			FuzzConfig: *target.FuzzConfig,
+		testTarget := &api.TestTarget{
+			Base:    base,
+			Patched: base,
+			Track:   target.Track,
+			Fuzz:    target.FuzzConfig,
 		}
-		fuzz.Patched.SeriesID = series.ID
-		return fuzz, nil
+		testTarget.Patched.SeriesID = series.ID
+		return testTarget, nil
 	}
 	return nil, SkipError("no base commit found")
 }


### PR DESCRIPTION
Combine kernel build requests with a list of actions to perform on those kernel builds. This will simplify adding more actions later.

***

No functional changes intended. Taken out of #6832.