### PR TITLE
dashboard/app: apply actionable label after AI moderation

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -514,6 +514,23 @@ func aiBugLabel(job *aidb.Job) (typ BugLabelType, value string, set bool, err0 e
 			return RaceLabel, BenignRace, true, nil
 		}
 		return RaceLabel, HarmfulRace, true, nil
+	case ai.WorkflowModeration:
+		// For now we require a manual correctness check.
+		if !job.Correct.Valid {
+			return
+		}
+		if !job.Correct.Bool {
+			return ActionableLabel, "", false, nil
+		}
+		res, err := castJobResults[ai.ModerationOutputs](job)
+		if err != nil {
+			err0 = err
+			return
+		}
+		if !res.Confident {
+			return
+		}
+		return ActionableLabel, "", res.Actionable, nil
 	}
 	return
 }

--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1171,7 +1171,8 @@ The specified label value is incorrect.
 Please use one of the supported label values.
 
 The following labels are suported:
-missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
+actionable, missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {..
+see below ..}
 The list of subsystems: https://testapp.appspot.com/access-public-email/subsystems?all=true
 
 `)
@@ -1281,7 +1282,8 @@ The specified label "label" is unknown.
 Please use one of the supported labels.
 
 The following labels are suported:
-missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {.. see below ..}
+actionable, missing-backport, no-reminders, prio: {low, normal, high}, subsystems: {..
+see below ..}
 The list of subsystems: https://testapp.appspot.com/access-public-email/subsystems?all=true
 
 `)

--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -20,6 +20,7 @@ const (
 	OriginLabel          BugLabelType = "origin"
 	MissingBackportLabel BugLabelType = "missing-backport"
 	RaceLabel            BugLabelType = "race"
+	ActionableLabel      BugLabelType = "actionable"
 )
 
 type BugPrio string
@@ -48,6 +49,7 @@ func makeLabelSet(ctx context.Context, bug *Bug) *labelSet {
 		}),
 		NoRemindersLabel:     trueFalse{},
 		MissingBackportLabel: trueFalse{},
+		ActionableLabel:      trueFalse{},
 	}
 	typ := crash.TitleToType(bug.Title)
 	if typ == crash.KCSANDataRace {

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -38,3 +38,9 @@ type AssessmentKCSANOutputs struct {
 	Benign      bool
 	Explanation string
 }
+
+type ModerationOutputs struct {
+	Confident   bool
+	Actionable  bool
+	Explanation string
+}

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -19,15 +19,9 @@ type moderationInputs struct {
 	KernelConfig string
 }
 
-type moderationOutputs struct {
-	Confident   bool
-	Actionable  bool
-	Explanation string
-}
-
 // nolint:dupl
 func init() {
-	aflow.Register[moderationInputs, moderationOutputs](
+	aflow.Register[moderationInputs, ai.ModerationOutputs](
 		ai.WorkflowModeration,
 		"assess if a bug report is consistent and actionable or not",
 		&aflow.Flow{


### PR DESCRIPTION
This allows auto-upstreamming of actionable bugs.

Fixes #6779
