### PR TITLE
dashboard/app: add a no-upstream label

### DIFF
--- a/dashboard/app/label.go
+++ b/dashboard/app/label.go
@@ -21,6 +21,7 @@ const (
 	MissingBackportLabel BugLabelType = "missing-backport"
 	RaceLabel            BugLabelType = "race"
 	ActionableLabel      BugLabelType = "actionable"
+	NoUpstreamLabel      BugLabelType = "no-upstream"
 )
 
 type BugPrio string


### PR DESCRIPTION
In the context of #6554, we could use this label to mark the bugs like "no output from test machine", "corrupted report", etc, to prevent their reporting to LKML.

The label could be used in the reporting rules for the public moderation stage.