### PR TITLE
dashboard: basic support for repro ai workflows

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -397,6 +397,9 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 			return &dashapi.AIJobPollResp{}, nil
 		}
 	}
+	if !job.Args.Valid {
+		job.Args.Value = map[string]any{}
+	}
 	args := make(map[string]any)
 	var textErr error
 	assignText := func(anyID any, tag, name string) {
@@ -413,20 +416,17 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 		}
 		args[name] = string(data)
 	}
-	if !job.Args.Valid {
-		job.Args.Value = map[string]any{}
+	textFields := map[string]struct{ tag, name string }{
+		"ReproSyzID":     {textReproSyz, "ReproSyz"},
+		"ReproCID":       {textReproC, "ReproC"},
+		"CrashReportID":  {textCrashReport, "CrashReport"},
+		"CrashLogID":     {textCrashLog, "CrashLog"},
+		"KernelConfigID": {textKernelConfig, "KernelConfig"},
 	}
 	for name, val := range job.Args.Value.(map[string]any) {
-		switch name {
-		case "ReproSyzID":
-			assignText(val, textReproSyz, "ReproSyz")
-		case "ReproCID":
-			assignText(val, textReproC, "ReproC")
-		case "CrashReportID":
-			assignText(val, textCrashReport, "CrashReport")
-		case "KernelConfigID":
-			assignText(val, textKernelConfig, "KernelConfig")
-		default:
+		if text, ok := textFields[name]; ok {
+			assignText(val, text.tag, text.name)
+		} else {
 			args[name] = val
 		}
 	}
@@ -651,6 +651,7 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 		"ReproSyzID":      crash.ReproSyz,
 		"ReproCID":        crash.ReproC,
 		"CrashReportID":   crash.Report,
+		"CrashLogID":      crash.Log,
 		"KernelRepo":      build.KernelRepo,
 		"KernelCommit":    build.KernelCommit,
 		"KernelConfigID":  build.KernelConfig,
@@ -670,11 +671,9 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 	})
 }
 
-const (
-	// In how many days after a bug is reported we create the first AI repro job
-	// (provided no reproducer has been found in the meanwhile).
-	aiReproTriggerDays = 14
-)
+// In how many days after a bug is reported we create the first AI repro job
+// (provided no reproducer has been found in the meanwhile).
+const aiReproTriggerDays = 14
 
 // autoCreateAIJobs incrementally creates AI jobs for existing bugs, returns if any new jobs were created.
 //
@@ -799,6 +798,7 @@ func workflowsForBug(ctx context.Context, bug *Bug, manual bool) map[ai.Workflow
 		if bug.HeadReproLevel > dashapi.ReproLevelNone {
 			workflows[ai.WorkflowPatching] = true
 		}
+		workflows[ai.WorkflowRepro] = true
 	}
 	return workflows
 }

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -209,6 +209,7 @@ func TestAIJob(t *testing.T) {
 	require.Equal(t, resp.Args, map[string]any{
 		"BugTitle":        "KCSAN: data-race in foo / bar",
 		"CrashReport":     "report1",
+		"CrashLog":        "log1",
 		"KernelRepo":      "repo1",
 		"KernelCommit":    "1111111111111111111111111111111111111111",
 		"KernelConfig":    "config1",
@@ -554,6 +555,7 @@ func TestAIRepro(t *testing.T) {
 	c.advanceTime(15 * 24 * time.Hour)
 	pollResp2, _ := c.agentClient.AIJobPoll(pollReq)
 	require.NotEqual(t, pollResp2.ID, "")
+	require.Equal(t, pollResp2.Args["CrashLog"], "log1")
 
 	c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: pollResp2.ID,


### PR DESCRIPTION
* Create the workflow for the bugs without a reproducer.
* Include the console log to the workflow inputs.

Ideally, we should also retry such workflows once in a while (they will definitely not find a reproducer in 100% of the cases), but let's handle it separately.