### PR TITLE
dashboard/app: fix kernel-source-git export

### DIFF
--- a/dashboard/app/public_json_api.go
+++ b/dashboard/app/public_json_api.go
@@ -68,7 +68,7 @@ func getExtAPIDescrForBug(bug *uiBugDetails) *api.Bug {
 					SyzReproducerLink:  crash.ReproSyzLink,
 					CReproducerLink:    crash.ReproCLink,
 					KernelConfigLink:   crash.KernelConfigLink,
-					KernelSourceGit:    crash.KernelCommitLink,
+					KernelSourceGit:    crash.KernelRepo,
 					KernelSourceCommit: crash.KernelCommit,
 					SyzkallerGit:       crash.SyzkallerCommitLink,
 					SyzkallerCommit:    crash.SyzkallerCommit,

--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -31,6 +31,7 @@ func TestJSONAPIIntegration(t *testing.T) {
 		{
 			"title": "title1",
 			"kernel-config": "/text?tag=KernelConfig\u0026x=a989f27ebc47e2dc",
+			"kernel-source-git": "repo1",
 			"kernel-source-commit": "1111111111111111111111111111111111111111",
 			"syzkaller-git": "https://github.com/google/syzkaller/commits/syzkaller_commit1",
 			"syzkaller-commit": "syzkaller_commit1",
@@ -53,6 +54,7 @@ func TestJSONAPIIntegration(t *testing.T) {
 			"syz-reproducer": "/text?tag=ReproSyz\u0026x=13000000000000",
 			"c-reproducer": "/text?tag=ReproC\u0026x=17000000000000",
 			"kernel-config": "/text?tag=KernelConfig\u0026x=a989f27ebc47e2dc",
+			"kernel-source-git": "repo1",
 			"kernel-source-commit": "1111111111111111111111111111111111111111",
 			"syzkaller-git": "https://github.com/google/syzkaller/commits/syzkaller_commit1",
 			"syzkaller-commit": "syzkaller_commit1",
@@ -198,6 +200,7 @@ func TestJSONAPIFixCommits(t *testing.T) {
 		{
 			"title": "title1",
 			"kernel-config": "/text?tag=KernelConfig\u0026x=a989f27ebc47e2dc",
+			"kernel-source-git": "repo1",
 			"kernel-source-commit": "1111111111111111111111111111111111111111",
 			"syzkaller-git": "https://github.com/google/syzkaller/commits/syzkaller_commit1",
 			"syzkaller-commit": "syzkaller_commit1",
@@ -241,6 +244,7 @@ func TestJSONAPICauseBisection(t *testing.T) {
 			"syz-reproducer": "/text?tag=ReproSyz\u0026x=16000000000000",
 			"c-reproducer": "/text?tag=ReproC\u0026x=11000000000000",
 			"kernel-config": "/text?tag=KernelConfig\u0026x=4d11162a90e18f28",
+			"kernel-source-git": "repo1",
 			"kernel-source-commit": "1111111111111111111111111111111111111111",
 			"syzkaller-git": "https://github.com/google/syzkaller/commits/syzkaller_commit1",
 			"syzkaller-commit": "syzkaller_commit1",

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	_ "github.com/google/syzkaller/pkg/aflow/flow"
@@ -126,16 +125,9 @@ func downloadBug(id, inputFile, token string) error {
 	}
 	crash := info["crashes"].([]any)[0].(map[string]any)
 
-	repoURL, _ := crash["kernel-source-git"].(string)
-
-	// Clean the URL to end at .git.
-	if dotGitIndex := strings.Index(repoURL, ".git"); dotGitIndex != -1 {
-		repoURL = repoURL[:dotGitIndex+4]
-	}
-
 	inputs := map[string]any{
 		"SyzkallerCommit": crash["syzkaller-commit"],
-		"KernelRepo":      repoURL,
+		"KernelRepo":      crash["kernel-source-git"],
 		"KernelCommit":    crash["kernel-source-commit"],
 	}
 


### PR DESCRIPTION
The traffic MUST be switched before the PR integration because this PR relaxes aflow side assumptions.

Note: tested on AppEngine, looks good.