### PR TITLE
syz-cluster/email-reporter: improve replies for unsupported commands

### DIFF
--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -136,6 +136,10 @@ func (h *Handler) IncomingEmail(ctx context.Context, msg *email.Email) error {
 		case email.CmdInvalid:
 			// Reply nothing on success.
 			err = h.apiClient.InvalidateReport(ctx, reportID)
+		case email.CmdFix, email.CmdUnFix, email.CmdDup, email.CmdUnDup,
+			email.CmdTest, email.CmdUnCC, email.CmdSet, email.CmdUnset,
+			email.CmdRegenerate:
+			reply = fmt.Sprintf("syzbot-ci does not support `%s` command", command.Str)
 		default:
 			reply = "Unknown command"
 		}

--- a/syz-cluster/email-reporter/handler_test.go
+++ b/syz-cluster/email-reporter/handler_test.go
@@ -134,6 +134,7 @@ func TestInvalidReply(t *testing.T) {
 			Commands: []*email.SingleCommand{
 				{
 					Command: email.CmdFix,
+					Str:     "fix:",
 				},
 			},
 			Body: `#syz fix: abcd`,
@@ -148,7 +149,7 @@ func TestInvalidReply(t *testing.T) {
 			InReplyTo: "user-reply-msg-id",
 			Body: []byte(`> #syz fix: abcd
 
-Unknown command
+syzbot-ci does not support` + " `fix:` " + `command
 
 `),
 		}, reply)


### PR DESCRIPTION
Instead of a generic "Unknown command" reply, provide a more specific message for commands that are recognized but not yet supported by syzbot-ci. This should reduce the number of emails of users retrying commands that failed.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
