### PR TITLE
dashboard/app: add admin handler to force commit info update

### DIFF
--- a/dashboard/app/admin.go
+++ b/dashboard/app/admin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
@@ -375,6 +376,40 @@ func updateBatch[T any](ctx context.Context, keys []*db.Key, transform func(key 
 		log.Warningf(ctx, "updated %v bugs", len(batchKeys))
 	}
 	return nil
+}
+
+func forceCommitInfoUpdate(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	// Read an optional "?limit=X" parameter from the URL.
+	limit := 0
+	if limitStr := r.FormValue("limit"); limitStr != "" {
+		parsed, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return fmt.Errorf("invalid limit parameter %q: %w", limitStr, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("limit parameter must be positive")
+		}
+		limit = parsed
+	}
+
+	var keys []*db.Key
+	err := foreachBug(ctx, nil, func(bug *Bug, key *db.Key) error {
+		if limit > 0 && len(keys) >= limit {
+			return nil // Stop accumulating if we hit our requested limit.
+		}
+		if len(bug.Commits) > 0 && !bug.NeedCommitInfo {
+			keys = append(keys, key)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Warningf(ctx, "fetched %v bugs for commit info update", len(keys))
+	return updateBatch(ctx, keys, func(_ *db.Key, bug *Bug) {
+		bug.NeedCommitInfo = true
+	})
 }
 
 // Prevent warnings about dead code.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -983,6 +983,8 @@ func handleAdmin(ctx context.Context, w http.ResponseWriter, r *http.Request) er
 		return restartFailedBisections(ctx, w, r)
 	case "setMissingBugFields":
 		return setMissingBugFields(ctx, w, r)
+	case "force_commit_info_update":
+		return forceCommitInfoUpdate(ctx, w, r)
 	case "emergency_stop":
 		if err := recordEmergencyStop(ctx); err != nil {
 			return fmt.Errorf("failed to record an emergency stop: %w", err)


### PR DESCRIPTION
Add the /admin/force_commit_info handler to retroactively extract AuthorName for historical bugs. Since AuthorName is a recently introduced field, existing bugs in the Datastore only have the legacy Author string.

Iterating over Fixed bugs and setting NeedCommitInfo = true ensures that they are surfaced in the CommitPoll endpoint. This forces syz-ci to re-fetch their commit metadata and push the fully populated CommitInfo struct (including the correct AuthorName) back to the dashboard via UploadCommits.

The handler includes an optional ?limit=X parameter to allow safely batching the Datastore updates and syz-ci polling without causing massive request spikes or transaction timeouts.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
