### PR TITLE
pkg/aflow: add Tools function

### DIFF
--- a/pkg/aflow/flow/assessment/kcsan.go
+++ b/pkg/aflow/flow/assessment/kcsan.go
@@ -39,7 +39,7 @@ func init() {
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: kcsanInstruction,
 					Prompt:      kcsanPrompt,
-					Tools:       append(codesearcher.Tools, grepper.Tool),
+					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
 				},
 			),
 		},

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -40,7 +40,7 @@ func init() {
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: moderationInstruction,
 					Prompt:      moderationPrompt,
-					Tools:       append(codesearcher.Tools, grepper.Tool),
+					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
 				},
 			),
 		},

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -5,7 +5,6 @@ package patching
 
 import (
 	"encoding/json"
-	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/crash"
@@ -35,7 +34,7 @@ type Inputs struct {
 }
 
 func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
-	commonTools := slices.Clip(append([]aflow.Tool{codeexpert.Tool, grepper.Tool}, codesearcher.Tools...))
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool)
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(
@@ -65,7 +64,7 @@ func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
 						TaskType:      aflow.FormalReasoningTask,
 						Instruction:   patchInstruction,
 						Prompt:        patchPrompt,
-						Tools:         append(commonTools, codeeditor.Tool),
+						Tools:         aflow.Tools(commonTools, codeeditor.Tool),
 						SummaryWindow: summaryWindow,
 					},
 					crash.TestPatch, // -> PatchDiff or TestError

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -87,6 +87,24 @@ type Tool interface {
 	execute(*Context, map[string]any) (map[string]any, error)
 }
 
+// Tools combine all passed tools into a single slice
+// avoiding aliasing issues with existing slices.
+// The passed elements can be either Tool, or []Tool.
+func Tools(tools ...any) []Tool {
+	var res []Tool
+	for _, t := range tools {
+		switch tool := t.(type) {
+		case Tool:
+			res = append(res, tool)
+		case []Tool:
+			res = append(res, tool...)
+		default:
+			panic(fmt.Sprintf("unsupported type %T", t))
+		}
+	}
+	return res
+}
+
 // LLMOutputs creates a special tool that can be used by LLM to provide structured outputs.
 func LLMOutputs[Args any]() *llmOutputs {
 	return &llmOutputs{


### PR DESCRIPTION
When we combine tool sets for agents, there is always a protential
problem with aliasing existing slices and introducing subtle bugs.
Add Tools function that can append tool/tool sets w/o alising problem.
