### PR TITLE
pkg/aflow/action/crash: collect test coverage

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/build"
@@ -16,6 +18,7 @@ import (
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -43,26 +46,35 @@ type reproduceResult struct {
 	CrashReport string
 }
 
-// ReproduceCrash tests reproducer and returns:
-//   - Report: if the reproducer caused the kernel crash
-//   - boot failure: if the kernel failed to boot or function properly
-//     (if kernel crashed during build/boot, the Report is not returned)
-//   - error: for unexpected failures
-//
-// All 3 values are empty, if everything went well, and kernel has not crashed.
-func ReproduceCrash(args ReproduceArgs, workdir string) (*report.Report, string, error) {
+type RunTestResult struct {
+	// Returned if the program caused a kernel crash.
+	Report *report.Report
+	// Returned if the kernel failed to boot or function properly
+	// (Report is not returned in this case).
+	BootError string
+	// Per-call coverage, if requested with collectCoverage
+	// and the kernel has not crashed.
+	Coverage [][]symbolizer.Frame
+}
+
+// RunTest boots the kernel and runs a single test program.
+func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestResult, error) {
+	res := RunTestResult{}
 	if args.Type != "qemu" {
-		return nil, "", errors.New("only qemu VM type is supported")
+		return res, errors.New("RunTest: only qemu VM type is supported")
+	}
+	if collectCoverage && args.ReproSyz == "" {
+		return res, errors.New("RunTest: coverage collection requires a syzkaller program")
 	}
 
 	var vmConfig map[string]any
 	if err := json.Unmarshal(args.VM, &vmConfig); err != nil {
-		return nil, "", fmt.Errorf("failed to parse VM config: %w", err)
+		return res, fmt.Errorf("failed to parse VM config: %w", err)
 	}
 	vmConfig["kernel"] = filepath.Join(args.KernelObj, filepath.FromSlash(build.LinuxKernelImage(targets.AMD64)))
 	vmCfg, err := json.Marshal(vmConfig)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to serialize VM config: %w", err)
+		return res, fmt.Errorf("failed to serialize VM config: %w", err)
 	}
 
 	cfg := mgrconfig.DefaultValues()
@@ -75,37 +87,43 @@ func ReproduceCrash(args ReproduceArgs, workdir string) (*report.Report, string,
 	cfg.Type = args.Type
 	cfg.VM = vmCfg
 	if err := mgrconfig.SetTargets(cfg); err != nil {
-		return nil, "", err
+		return res, err
 	}
 	if err := mgrconfig.Complete(cfg); err != nil {
-		return nil, "", err
+		return res, err
 	}
 	env, err := instance.NewEnv(cfg, nil, nil)
 	if err != nil {
-		return nil, "", err
+		return res, err
 	}
 	// TODO: run multiple instances, handle TestError.Infra, and aggregate results.
-	results, err := env.Test(1, nil, nil, []byte(args.ReproC))
+	results, err := env.Test(1, nil, nil, []byte(args.ReproC), collectCoverage)
 	if err != nil {
-		return nil, "", err
+		return res, err
 	}
 	if err := results[0].Error; err != nil {
 		if crashErr := new(instance.CrashError); errors.As(err, &crashErr) {
-			return crashErr.Report, "", nil
+			res.Report = crashErr.Report
 		} else if testErr := new(instance.TestError); errors.As(err, &testErr) {
-			return parseTestError(testErr)
+			if testErr.Infra {
+				// No point in showing this to LLM and asking to fix.
+				return res, fmt.Errorf("%v\n%v\n%s",
+					testErr.Error(), testErr.Title, testErr.Output)
+			}
+			res.BootError = parseTestError(testErr)
 		} else {
-			return nil, err.Error(), nil
+			res.BootError = err.Error()
 		}
 	}
-	return nil, "", nil
+	coverage, err := symbolize(args.KernelObj, results[0].Coverage)
+	if err != nil {
+		return res, fmt.Errorf("failed to symbolize coverage: %w", err)
+	}
+	res.Coverage = coverage
+	return res, nil
 }
 
-func parseTestError(err *instance.TestError) (*report.Report, string, error) {
-	if err.Infra {
-		// No point in showing this to LLM and asking to fix.
-		return nil, "", fmt.Errorf("%v\n%v\n%s", err.Error(), err.Title, err.Output)
-	}
+func parseTestError(err *instance.TestError) string {
 	what := "Basic kernel testing failed"
 	if err.Boot {
 		what = "Kernel failed to boot"
@@ -115,7 +133,7 @@ func parseTestError(err *instance.TestError) (*report.Report, string, error) {
 	if err.Report != nil && err.Report.Report != nil {
 		extraInfo = err.Report.Report
 	}
-	return nil, fmt.Sprintf("%v: %v\n%s", what, err.Title, extraInfo), nil
+	return fmt.Sprintf("%v: %v\n%s", what, err.Title, extraInfo)
 }
 
 func reproduce(ctx *aflow.Context, args ReproduceArgs) (reproduceResult, error) {
@@ -138,12 +156,12 @@ func reproduce(ctx *aflow.Context, args ReproduceArgs) (reproduceResult, error) 
 		if err != nil {
 			return res, err
 		}
-		rep, bootError, err := ReproduceCrash(args, workdir)
-		if rep != nil {
-			res.BugTitle = rep.Title
-			res.Report = string(rep.Report)
+		testRes, err := RunTest(args, workdir, false)
+		if testRes.Report != nil {
+			res.BugTitle = testRes.Report.Title
+			res.Report = string(testRes.Report.Report)
 		}
-		res.Error = bootError
+		res.Error = testRes.BootError
 		return res, err
 	})
 	if err != nil {
@@ -158,4 +176,37 @@ func reproduce(ctx *aflow.Context, args ReproduceArgs) (reproduceResult, error) 
 		BugTitle:    cached.BugTitle,
 		CrashReport: cached.Report,
 	}, nil
+}
+
+func symbolize(kernelObj string, coverage [][]uint64) ([][]symbolizer.Frame, error) {
+	pcs := make(map[uint64][]symbolizer.Frame)
+	for _, call := range coverage {
+		for _, pc := range call {
+			pcs[pc] = nil
+		}
+	}
+	target := targets.Get(targets.Linux, targets.AMD64)
+	vmlinux := filepath.Join(kernelObj, target.KernelObject)
+	symb := symbolizer.Make(target)
+	defer symb.Close()
+	frames, err := symb.Symbolize(vmlinux, slices.Collect(maps.Keys(pcs))...)
+	if err != nil {
+		return nil, err
+	}
+	for _, frame := range frames {
+		pcs[frame.PC] = append(pcs[frame.PC], frame)
+	}
+	var res [][]symbolizer.Frame
+	// TODO(dvyukov): figure out how we want to aggregate/deduplicate frames
+	// We may leave only the last call. We also most likely want to handle
+	// inline frames in some way. We may also want to deduplicate/aggregate
+	// the full trace in some way.
+	for _, call := range coverage {
+		var frames []symbolizer.Frame
+		for _, pc := range call {
+			frames = append(frames, pcs[pc]...)
+		}
+		res = append(res, frames)
+	}
+	return res, nil
 }

--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -92,11 +92,11 @@ func testPatch(ctx *aflow.Context, args testArgs) (testResult, error) {
 			KernelCommit: args.KernelCommit,
 			KernelConfig: args.KernelConfig,
 		}
-		rep, bootError, err := ReproduceCrash(reproduceArgs, workdir)
-		if rep != nil {
-			res.TestError = string(rep.Report)
+		testRes, err := RunTest(reproduceArgs, workdir, false)
+		if testRes.Report != nil {
+			res.TestError = string(testRes.Report.Report)
 		} else {
-			res.TestError = bootError
+			res.TestError = testRes.BootError
 		}
 		return res, err
 	})

--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -683,7 +683,7 @@ func (env *env) test() (*testResult, error) {
 
 	testStart := time.Now()
 
-	results, err := env.inst.Test(numTests, cfg.Repro.Syz, cfg.Repro.Opts, cfg.Repro.C)
+	results, err := env.inst.Test(numTests, cfg.Repro.Syz, cfg.Repro.Opts, cfg.Repro.C, false)
 	env.testTime += time.Since(testStart)
 	if err != nil {
 		problem := fmt.Sprintf("repro testing failure: %v", err)

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -54,7 +54,8 @@ func (env *testEnv) BuildKernel(buildCfg *instance.BuildKernelConfig) (string, b
 	return "", details, nil
 }
 
-func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]instance.EnvTestResult, error) {
+func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collectCoverage bool) (
+	[]instance.EnvTestResult, error) {
 	commit := env.headCommit()
 	if commit >= env.test.brokenStart && commit <= env.test.brokenEnd ||
 		env.config == "baseline-skip" {

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -4,9 +4,14 @@
 package instance
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/google/syzkaller/pkg/csource"
@@ -40,6 +45,7 @@ type RunResult struct {
 	Output   []byte
 	Report   *report.Report
 	Duration time.Duration
+	Coverage [][]uint64
 }
 
 const (
@@ -165,8 +171,9 @@ type ExecParams struct {
 	CProg   *prog.Prog
 	SyzProg []byte
 
-	Opts     csource.Options
-	Duration time.Duration
+	Opts            csource.Options
+	Duration        time.Duration
+	CollectCoverage bool
 	// If ExitConditions is empty, RunSyzProg() will assume instance.SyzExitConditions.
 	// RunCProg() always runs with binExitConditions.
 	ExitConditions vm.ExitCondition
@@ -193,14 +200,41 @@ func (inst *ExecProgInstance) RunCProgRaw(src []byte, target *prog.Target,
 }
 
 func (inst *ExecProgInstance) RunSyzProgFile(progFile string, duration time.Duration,
-	opts csource.Options, exitCondition vm.ExitCondition) (*RunResult, error) {
+	opts csource.Options, collectCoverage bool, exitCondition vm.ExitCondition) (*RunResult, error) {
+	coverFile := ""
+	if collectCoverage {
+		coverDir, err := os.MkdirTemp("", "syz-cover")
+		if err != nil {
+			return nil, err
+		}
+		defer osutil.RemoveAll(coverDir)
+		coverFile = filepath.Join(coverDir, "cover")
+	}
 	vmProgFile, err := inst.VMInstance.Copy(progFile)
 	if err != nil {
 		return nil, &TestError{Title: fmt.Sprintf("failed to copy prog to VM: %v", err)}
 	}
 	command := ExecprogCmd(inst.execprogBin, inst.executorBin, inst.mgrCfg.TargetOS, inst.mgrCfg.TargetArch,
-		inst.mgrCfg.Type, opts, !inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, vmProgFile)
-	return inst.runCommand(command, duration, exitCondition)
+		inst.mgrCfg.Type, opts, !inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, coverFile, vmProgFile)
+	res, err := inst.runCommand(command, duration, exitCondition)
+	if err != nil {
+		return nil, err
+	}
+	if coverFile != "" {
+		files, err := filepath.Glob(coverFile + "*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob cover files: %w", err)
+		}
+		slices.Sort(files)
+		for _, f := range files {
+			cover, err := parseCoverageFile(f)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse cover file: %w", err)
+			}
+			res.Coverage = append(res.Coverage, cover)
+		}
+	}
+	return res, nil
 }
 
 func (inst *ExecProgInstance) RunSyzProg(params ExecParams) (*RunResult, error) {
@@ -213,5 +247,22 @@ func (inst *ExecProgInstance) RunSyzProg(params ExecParams) (*RunResult, error) 
 	if params.ExitConditions == 0 {
 		params.ExitConditions = SyzExitConditions
 	}
-	return inst.RunSyzProgFile(progFile, params.Duration, params.Opts, params.ExitConditions)
+	return inst.RunSyzProgFile(progFile, params.Duration, params.Opts,
+		params.CollectCoverage, params.ExitConditions)
+}
+
+func parseCoverageFile(filename string) ([]uint64, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var res []uint64
+	for s := bufio.NewScanner(bytes.NewReader(data)); s.Scan(); {
+		v, err := strconv.ParseUint(s.Text(), 16, 64)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, v)
+	}
+	return res, nil
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -34,7 +34,7 @@ type Env interface {
 	BuildSyzkaller(string, string) (string, error)
 	CleanKernel(*BuildKernelConfig) error
 	BuildKernel(*BuildKernelConfig) (string, build.ImageDetails, error)
-	Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]EnvTestResult, error)
+	Test(numVMs int, reproSyz, reproOpts, reproC []byte, collectCoverage bool) ([]EnvTestResult, error)
 }
 
 type env struct {
@@ -258,7 +258,7 @@ func (err *CrashError) Error() string {
 // Test boots numVMs VMs, tests basic kernel operation, and optionally tests the provided reproducer.
 // *TestError is returned if there is a problem with kernel/image (crash, reboot loop, etc).
 // *CrashError is returned if the reproducer crashes kernel.
-func (env *env) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]EnvTestResult, error) {
+func (env *env) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collectCoverage bool) ([]EnvTestResult, error) {
 	if env.testSem != nil {
 		env.testSem.Wait()
 		defer env.testSem.Signal()
@@ -279,14 +279,15 @@ func (env *env) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]EnvTestR
 	res := make(chan EnvTestResult, numVMs)
 	for i := 0; i < numVMs; i++ {
 		inst := &inst{
-			cfg:           env.cfg,
-			optionalFlags: env.optionalFlags,
-			reporter:      reporter,
-			vmPool:        vmPool,
-			vmIndex:       i,
-			reproSyz:      reproSyz,
-			reproOpts:     reproOpts,
-			reproC:        reproC,
+			cfg:             env.cfg,
+			optionalFlags:   env.optionalFlags,
+			reporter:        reporter,
+			vmPool:          vmPool,
+			vmIndex:         i,
+			reproSyz:        reproSyz,
+			reproOpts:       reproOpts,
+			reproC:          reproC,
+			collectCoverage: collectCoverage,
 		}
 		go func() { res <- inst.test() }()
 	}
@@ -298,20 +299,22 @@ func (env *env) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]EnvTestR
 }
 
 type inst struct {
-	cfg           *mgrconfig.Config
-	optionalFlags bool
-	reporter      *report.Reporter
-	vmPool        *vm.Pool
-	vm            *vm.Instance
-	vmIndex       int
-	reproSyz      []byte
-	reproOpts     []byte
-	reproC        []byte
+	cfg             *mgrconfig.Config
+	optionalFlags   bool
+	reporter        *report.Reporter
+	vmPool          *vm.Pool
+	vm              *vm.Instance
+	vmIndex         int
+	reproSyz        []byte
+	reproOpts       []byte
+	reproC          []byte
+	collectCoverage bool
 }
 
 type EnvTestResult struct {
 	Error     error
 	RawOutput []byte
+	Coverage  [][]uint64
 }
 
 func (inst *inst) test() EnvTestResult {
@@ -362,7 +365,7 @@ func (inst *inst) test() EnvTestResult {
 		return ret
 	}
 	if len(inst.reproSyz) != 0 || len(inst.reproC) != 0 {
-		ret.RawOutput, ret.Error = inst.testRepro()
+		ret.RawOutput, ret.Coverage, ret.Error = inst.testRepro()
 	}
 	return ret
 }
@@ -403,44 +406,45 @@ func (inst *inst) testInstance() error {
 	return nil
 }
 
-func (inst *inst) testRepro() ([]byte, error) {
+func (inst *inst) testRepro() ([]byte, [][]uint64, error) {
 	execProg, err := SetupExecProg(inst.vm, inst.cfg, inst.reporter, &OptionalConfig{
 		OldFlagsCompatMode: !inst.optionalFlags,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	transformError := func(res *RunResult, err error) ([]byte, error) {
+	transformError := func(res *RunResult, err error) ([]byte, [][]uint64, error) {
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if res != nil && res.Report != nil {
-			return res.Output, &CrashError{Report: res.Report}
+		if res.Report != nil {
+			err = &CrashError{Report: res.Report}
 		}
-		return res.Output, nil
+		return res.Output, res.Coverage, err
 	}
-	out := []byte{}
+	out, coverage := []byte{}, [][]uint64{}
 	if len(inst.reproSyz) > 0 {
 		opts, err := inst.csourceOptions()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		out, err = transformError(execProg.RunSyzProg(ExecParams{
-			SyzProg:  inst.reproSyz,
-			Duration: inst.cfg.Timeouts.NoOutputRunningTime,
-			Opts:     opts,
+		out, coverage, err = transformError(execProg.RunSyzProg(ExecParams{
+			SyzProg:         inst.reproSyz,
+			Duration:        inst.cfg.Timeouts.NoOutputRunningTime,
+			Opts:            opts,
+			CollectCoverage: inst.collectCoverage,
 		}))
 		if err != nil {
-			return out, err
+			return out, coverage, err
 		}
 	}
 	if len(inst.reproC) > 0 {
 		// We should test for more than full "no output" timeout, but the problem is that C reproducers
 		// don't print anything, so we will get a false "no output" crash.
-		out, err = transformError(execProg.RunCProgRaw(inst.reproC, inst.cfg.Target,
+		out, _, err = transformError(execProg.RunCProgRaw(inst.reproC, inst.cfg.Target,
 			inst.cfg.Timeouts.NoOutput/2))
 	}
-	return out, err
+	return out, coverage, err
 }
 
 func (inst *inst) csourceOptions() (csource.Options, error) {
@@ -462,7 +466,7 @@ func (inst *inst) csourceOptions() (csource.Options, error) {
 
 // nolint:revive
 func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Options,
-	optionalFlags bool, slowdown int, progFile string) string {
+	optionalFlags bool, slowdown int, coverFile, progFile string) string {
 	repeatCount := 1
 	if opts.Repeat {
 		repeatCount = 0
@@ -488,11 +492,15 @@ func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Optio
 			{Name: "type", Value: fmt.Sprint(vmType)},
 		})
 	}
+	coverArg := ""
+	if coverFile != "" {
+		coverArg = " -cover=%v -coverfile=" + coverFile
+	}
 	return fmt.Sprintf("%v -executor=%v -arch=%v%v -sandbox=%v"+
-		" -procs=%v -repeat=%v -threaded=%v -collide=%v -cover=0%v %v",
+		" -procs=%v -repeat=%v -threaded=%v -collide=%v%v%v %v",
 		execprog, executor, arch, osArg, sandbox,
 		opts.Procs, repeatCount, opts.Threaded, opts.Collide,
-		optionalArg, progFile)
+		coverArg, optionalArg, progFile)
 }
 
 var MakeBin = func() string {

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -50,7 +50,7 @@ func TestExecprogCmd(t *testing.T) {
 				FaultCall: 2,
 				FaultNth:  3,
 			},
-		}, true, 10, "myprog")
+		}, true, 10, "", "myprog")
 	args := strings.Split(cmdLine, " ")[1:]
 	if err := tool.ParseFlags(flags, args); err != nil {
 		t.Fatal(err)

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -659,7 +659,7 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 		}
 	}
 	jp.Logf(0, "job: testing...")
-	results, err := env.Test(3, req.ReproSyz, req.ReproOpts, req.ReproC)
+	results, err := env.Test(3, req.ReproSyz, req.ReproOpts, req.ReproC, false)
 	if err != nil {
 		return fmt.Errorf("%w\n\nsyzkaller build log:\n%s", err, syzBuildLog)
 	}

--- a/syz-cluster/pkg/retest/retest.go
+++ b/syz-cluster/pkg/retest/retest.go
@@ -81,7 +81,7 @@ type testResult struct {
 
 func testOnEnv(env instance.Env, finding *api.RawFinding) *testResult {
 	const runAttempts = 3
-	results, err := env.Test(runAttempts, finding.SyzRepro, finding.SyzReproOpts, finding.CRepro)
+	results, err := env.Test(runAttempts, finding.SyzRepro, finding.SyzReproOpts, finding.CRepro, false)
 
 	ret := &testResult{
 		Status: api.StepResultPassed,

--- a/syz-cluster/pkg/retest/retest_test.go
+++ b/syz-cluster/pkg/retest/retest_test.go
@@ -28,7 +28,8 @@ func (m *mockEnv) BuildKernel(cfg *instance.BuildKernelConfig) (string, build.Im
 	return "", build.ImageDetails{}, nil
 }
 func (m *mockEnv) CleanKernel(cfg *instance.BuildKernelConfig) error { return nil }
-func (m *mockEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte) ([]instance.EnvTestResult, error) {
+func (m *mockEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collectCoverage bool) (
+	[]instance.EnvTestResult, error) {
 	return m.results, m.err
 }
 

--- a/tools/syz-crush/crush.go
+++ b/tools/syz-crush/crush.go
@@ -179,7 +179,7 @@ func runInstance(cfg *mgrconfig.Config, reporter *report.Reporter,
 	if runType == LogFile {
 		opts := csource.DefaultOpts(cfg)
 		opts.Repeat, opts.Threaded = true, true
-		res, err = inst.RunSyzProgFile(file, timeout, opts, instance.SyzExitConditions)
+		res, err = inst.RunSyzProgFile(file, timeout, opts, false, instance.SyzExitConditions)
 	} else {
 		var src []byte
 		src, err = os.ReadFile(file)

--- a/tools/syz-testbuild/testbuild.go
+++ b/tools/syz-testbuild/testbuild.go
@@ -165,7 +165,7 @@ func test(repo vcs.Repo, bisecter vcs.Bisecter, kernelConfig []byte, env instanc
 		return
 	}
 	log.Printf("build OK")
-	results, err := env.Test(numTests, nil, nil, nil)
+	results, err := env.Test(numTests, nil, nil, nil, false)
 	if err != nil {
 		tool.Fail(err)
 	}


### PR DESCRIPTION
Collect code coverage for test programs.
This is likley to be needed for #6878 and seed generation workflow.
For now it's not wired into any workflow/tool and is not tested.
But this should provide most of the plumbing to wire it up.
