### PR TITLE
tools/syz-aflow: download BugTitle

### DIFF
--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -128,6 +128,7 @@ func downloadBug(id, inputFile, token string) error {
 	inputs := map[string]any{
 		"KernelRepo":   crash["kernel-source-git"],
 		"KernelCommit": crash["kernel-source-commit"],
+		"BugTitle":     crash["title"],
 	}
 
 	fetchText := func(key string) (string, error) {


### PR DESCRIPTION
`go run ./tools/syz-aflow -download-bug=` doesn't provide BugTitle.
BugTitle is needed for the subsequent `go run ./tools/syz-aflow -workflow=repro`.
