### PR TITLE
dashboard/app: fix nil pointer dereference in loadAllManagers

### DIFF
--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -807,7 +807,8 @@ func loadAllManagers(ctx context.Context, ns string) ([]*Manager, []*db.Key, err
 	var result []*Manager
 	var resultKeys []*db.Key
 	for i, mgr := range managers {
-		if getNsConfig(ctx, mgr.Namespace).Managers[mgr.Name].Decommissioned {
+		cfg := getNsConfig(ctx, mgr.Namespace)
+		if cfg == nil || cfg.Managers[mgr.Name].Decommissioned {
 			continue
 		}
 		result = append(result, mgr)


### PR DESCRIPTION
When a namespace is removed from the dashboard configuration, its associated Manager entities might still exist in the Datastore. During loadAllManagers(), getNsConfig(ctx, mgr.Namespace) will return nil for these Managers, causing a nil pointer dereference.

Add a nil check for the returned namespace configuration to safely skip these stale managers as if they were decommissioned.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
