### PR TITLE
prog: add support for decimal arguments in text format

### DIFF
--- a/docs/program_syntax.md
+++ b/docs/program_syntax.md
@@ -26,7 +26,7 @@ line = assignment | call
 assignment = variable " = " call
 call = syscall-name "(" [arg ["," arg]*] ")"  ["(" [call-prop ["," call-prop*] ")"]
 arg = "nil" | "AUTO" | const-arg | resource-arg | result-arg | pointer-arg | string-arg | struct-arg | array-arg | union-arg
-const-arg = "0x" hex-integer
+const-arg = integer
 resource-arg = variable ["/" hex-integer] ["+" hex-integer]
 result-arg = "<" variable "=>" arg
 pointer-arg = "&" pointer-arg-addr ["=ANY"] "=" arg
@@ -37,8 +37,9 @@ array-arg = "[" [arg ["," arg]*] "]"
 union-arg = "@" field-name ["=" arg]
 call-prop = prop-name ": " prop-value
 variable = "r" dec-integer
-pointer-addr = hex-integer
-region-size = hex-integer
+pointer-addr = integer
+region-size = integer
+integer = dec-integer | oct-integer | "0x" hex-integer
 ```
 
 Programs may also contain blank lines and comments.

--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -469,9 +469,10 @@ func (p *parser) parseArgImpl(typ Type, dir Dir) (Arg, error) {
 		p.eatExcessive(true, "non-nil argument for nil type")
 		return nil, nil
 	}
-	switch p.Char() {
-	case '0':
+	if ch := p.Char(); ch >= '0' && ch <= '9' {
 		return p.parseArgInt(typ, dir)
+	}
+	switch p.Char() {
 	case 'r':
 		return p.parseArgRes(typ, dir)
 	case '&':

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -245,6 +245,14 @@ func TestDeserialize(t *testing.T) {
 			In: `test$excessive_fields1(0xffffffffffffffff)`,
 		},
 		{
+			In:  `serialize1(&(0x7f0000000000)="0000000000000000", 300000)`,
+			Out: `serialize1(&(0x7f0000000000)=""/8, 0x493e0)`,
+		},
+		{
+			In:  `serialize1(&(0x7f0000000000)="0000000000000000", 010)`,
+			Out: `serialize1(&(0x7f0000000000)=""/8, 0x8)`,
+		},
+		{
 			In: `test$excessive_fields1(0xfffffffffffffffe)`,
 		},
 		{


### PR DESCRIPTION
Previously, the parser only expected the '0' character to begin an integer argument, which effectively meant it only handled hexadecimal formatting (e.g., `0x...`) when parsing arguments.

This change modifies parseArgImpl() to route any starting digit ('0'-'9') to the integer parsing logic. Since `strconv.ParseUint` already handles base-10 parsing using the "0" base flag, this cleanly enables the parser to natively deserialize decimal arguments.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
