### PR TITLE
dashboard/app: filter by workflows in NextStaleJob

### DIFF
--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -709,7 +709,7 @@ func TestAIAgentJobOvertake(t *testing.T) {
 	pollResp1, _ := c.agentClient.AIJobPoll(pollReq)
 	require.Equal(t, pollResp1.ID, jobID)
 
-	pollReq2 := &dashapi.AIJobPollReq{
+	pollReqFresh := &dashapi.AIJobPollReq{
 		AgentName:    testAgentFresh,
 		CodeRevision: prog.GitRevision,
 		Workflows: []dashapi.AIWorkflow{
@@ -718,21 +718,33 @@ func TestAIAgentJobOvertake(t *testing.T) {
 	}
 
 	c.advanceTime(1 * time.Hour)
-	pollResp2, _ := c.agentClient.AIJobPoll(pollReq2)
-	require.Equal(t, pollResp2.ID, "")
+	pollRespFresh, _ := c.agentClient.AIJobPoll(pollReqFresh)
+	require.Equal(t, pollRespFresh.ID, "")
 
 	c.advanceTime(8 * time.Hour)
 
-	pollResp3, _ := c.agentClient.AIJobPoll(pollReq2)
-	require.NotEqual(t, pollResp3.ID, "")
-	require.NotEqual(t, pollResp3.ID, pollResp1.ID)
+	// An agent requesting a different workflow should not get the stale repro job.
+	pollReqPatching := &dashapi.AIJobPollReq{
+		AgentName:    testAgentFresh,
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatching, Name: string(ai.WorkflowPatching)},
+		},
+	}
+	pollRespPatching, _ := c.agentClient.AIJobPoll(pollReqPatching)
+	require.Equal(t, pollRespPatching.ID, "")
+
+	// But if workflow matches, it should get the job.
+	pollRespFreshOvertake, _ := c.agentClient.AIJobPoll(pollReqFresh)
+	require.NotEqual(t, pollRespFreshOvertake.ID, "")
+	require.NotEqual(t, pollRespFreshOvertake.ID, pollResp1.ID)
 
 	job1, err := aidb.LoadJob(c.ctx, pollResp1.ID)
 	require.NoError(t, err)
 	require.True(t, job1.Finished.Valid)
 	require.Contains(t, job1.Error, "inactive")
 
-	job2, err := aidb.LoadJob(c.ctx, pollResp3.ID)
+	job2, err := aidb.LoadJob(c.ctx, pollRespFreshOvertake.ID)
 	require.NoError(t, err)
 	require.True(t, job2.Started.Valid)
 	require.False(t, job2.Finished.Valid)

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -177,6 +177,10 @@ func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
 }
 
 func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
+	var workflows []string
+	for _, flow := range req.Workflows {
+		workflows = append(workflows, flow.Name)
+	}
 	client, err := dbClient(ctx)
 	if err != nil {
 		return nil, err
@@ -190,9 +194,10 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 		if req.AgentName != "" {
 			iter := txn.Query(ctx, spanner.Statement{
 				SQL: selectJobs() + ` WHERE Started IS NOT NULL AND Finished IS NULL
-					AND AgentName = @agentName LIMIT 1`,
+					AND AgentName = @agentName AND Workflow IN UNNEST(@workflows) LIMIT 1`,
 				Params: map[string]any{
 					"agentName": req.AgentName,
+					"workflows": workflows,
 				},
 			})
 			defer iter.Stop()
@@ -206,9 +211,10 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 			iter := txn.Query(ctx, spanner.Statement{
 				SQL: selectJobs() + ` JOIN Agents USING(AgentName)
 					WHERE Started IS NOT NULL AND Finished IS NULL
-					AND LastActive <= @cutoff LIMIT 1`,
+					AND LastActive <= @cutoff AND Workflow IN UNNEST(@workflows) LIMIT 1`,
 				Params: map[string]any{
-					"cutoff": cutoff,
+					"cutoff":    cutoff,
+					"workflows": workflows,
 				},
 			})
 			defer iter.Stop()


### PR DESCRIPTION
We were ignoring the workflows passed by the agent in the job poll request in the context of restarting failed jobs.

Fix it and add test coverage.