### PR TITLE
syz-agent: systematically show verbose error messages

### DIFF
--- a/pkg/aflow/action/kernel/build.go
+++ b/pkg/aflow/action/kernel/build.go
@@ -52,8 +52,8 @@ func BuildKernel(buildDir, srcDir, cfg string, cleanup bool) error {
 		"ccache", buildDir, runtime.NumCPU())
 	const compileCommands = "compile_commands.json"
 	makeArgs = append(makeArgs, "-s", path.Base(image), compileCommands)
-	if out, err := osutil.RunCmd(time.Hour, srcDir, "make", makeArgs...); err != nil {
-		return aflow.FlowError(fmt.Errorf("make failed: %w\n%s", err, out))
+	if _, err := osutil.RunCmd(time.Hour, srcDir, "make", makeArgs...); err != nil {
+		return aflow.FlowError(err)
 	}
 	if !cleanup {
 		return nil

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -5,7 +5,6 @@ package patching
 
 import (
 	"errors"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -137,7 +136,7 @@ func recentCommits(ctx *aflow.Context, args recentCommitsArgs) (recentCommitsRes
 		gitArgs := append([]string{"log", "--format=%s", "--no-merges", "-n", "20", args.KernelCommit}, files...)
 		output, err := osutil.RunCmd(10*time.Minute, kernelRepoDir, "git", gitArgs...)
 		if err != nil {
-			return aflow.FlowError(fmt.Errorf("%w\n%s", err, output))
+			return aflow.FlowError(err)
 		}
 		res.RecentCommits = string(output)
 		return nil

--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -56,7 +56,7 @@ func grepper(ctx *aflow.Context, state state, args args) (results, error) {
 				return results{}, aflow.BadCallError("bad expression: %s", bytes.TrimSpace(output))
 			}
 		}
-		return results{}, fmt.Errorf("%w\n%s", err, output)
+		return results{}, err
 	}
 	// There is a potential DoS by LLM is it searches for ".*",
 	// "kmalloc" would be pretty bad (and useless) too.

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -125,6 +125,14 @@ func (err *VerboseError) Unwrap() error {
 	return err.Err
 }
 
+func VerboseMessage(err error) string {
+	msg := err.Error()
+	if verr := new(VerboseError); errors.As(err, &verr) {
+		msg += "\n" + string(verr.Output)
+	}
+	return msg
+}
+
 func IsDir(name string) bool {
 	fileInfo, err := os.Stat(name)
 	return err == nil && fileInfo.IsDir()

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -5,6 +5,7 @@ package osutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsExist(t *testing.T) {
@@ -197,4 +199,14 @@ func TestDiskUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectUsage(1, 1<<10)
+}
+
+func TestVerboseMessage(t *testing.T) {
+	assert.Equal(t, "error message", VerboseMessage(errors.New("error message")))
+	verr := &VerboseError{
+		Err:    errors.New("verbose error"),
+		Output: []byte("verbose text"),
+	}
+	assert.Equal(t, "verbose error\nverbose text", VerboseMessage(verr))
+	assert.Equal(t, "wrapped: verbose error\nverbose text", VerboseMessage(fmt.Errorf("wrapped: %w", verr)))
 }

--- a/syz-agent/agent.go
+++ b/syz-agent/agent.go
@@ -247,7 +247,11 @@ func (s *Server) poll(ctx context.Context) (bool, error) {
 	results, jobErr := s.executeJob(ctx, resp)
 	doneReq.Results = results
 	if jobErr != nil {
-		doneReq.Error = jobErr.Error()
+		// Errors may include verbose errors from running git/make/grep/etc binaries.
+		// By default the verbose stdout/stderr output is not included in errors,
+		// but we want to include it here (otherwise it will be lost, and the error
+		// will just say "command X failed with exit status Y").
+		doneReq.Error = osutil.VerboseMessage(jobErr)
 		if model := aflow.IsModelQuotaError(jobErr); model != "" {
 			// If a model is over quota, we will avoid requesting more jobs
 			// for workflows that use the model.

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -69,7 +69,7 @@ func main() {
 		tool.Fail(err)
 	}
 	if err := run(context.Background(), *flagModel, *flagFlow, *flagInput, *flagWorkdir, cacheSize); err != nil {
-		tool.Fail(err)
+		tool.Failf("%v", osutil.VerboseMessage(err))
 	}
 }
 


### PR DESCRIPTION
Currently we added custom code to kernel build action,
and few others to expose verbose errors from executed binaries (notably make).
But lots of other binary executions missing this logic,
e.g. for git failure we currently see unuseful:

failed to run ["git" "fetch" "--force" "--tags" exit status 128

Instead of adding more and more custom code to do the same,
remove the custom code and always add verbose output
in syz-agent and tools/syz-aflow.
