### PR TITLE
pkg/aflow/tool/grepper: disable tests on non-linux

### DIFF
--- a/pkg/aflow/tool/grepper/grepper_test.go
+++ b/pkg/aflow/tool/grepper/grepper_test.go
@@ -1,6 +1,9 @@
 // Copyright 2026 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+// Some of these error messages and grep responses are linux-specific.
+//go:build linux
+
 package grepper
 
 import (


### PR DESCRIPTION
The tests fail on OpenBSD with:

expected: "bad expression: fatal: command line, 'bad expression (': Unmatched ( or \\("
actual  : "bad expression: fatal: command line, 'bad expression (': parentheses not balanced"

Disable the tests on non-linux for now.
