### PR TITLE
pkg/gce, vm/gce: auto delete instances

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -64,6 +64,7 @@ type InstanceConfig struct {
 	DisplayDevice        bool
 	NestedVirtualization bool
 	NicType              string
+	VMRunningTime        time.Duration
 }
 
 var metadataURL = "http://metadata.google.internal/computeMetadata/v1/"
@@ -187,6 +188,14 @@ func (ctx *Context) CreateInstance(cfg *InstanceConfig) (string, error) {
 			EnableNestedVirtualization: cfg.NestedVirtualization,
 		},
 	}
+	if cfg.VMRunningTime != 0 {
+		instance.Scheduling.MaxRunDuration = &compute.Duration{
+			// Give the manager an extra hour to ensure it has time to do its own cleanup.
+			Seconds: int64((cfg.VMRunningTime + time.Hour) / time.Second),
+		}
+		instance.Scheduling.InstanceTerminationAction = "DELETE"
+		instance.Scheduling.ProvisioningModel = "SPOT"
+	}
 retry:
 	if !instance.Scheduling.Preemptible && strings.HasPrefix(cfg.MachineType, "e2-") {
 		// Otherwise we get "Error 400: Efficient instances do not support
@@ -205,6 +214,7 @@ retry:
 		var resourcePoolExhaustedError resourcePoolExhaustedError
 		if errors.As(err, &resourcePoolExhaustedError) && instance.Scheduling.Preemptible {
 			instance.Scheduling.Preemptible = false
+			instance.Scheduling.ProvisioningModel = ""
 			goto retry
 		}
 		return "", err

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -208,6 +208,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		DisplayDevice:        pool.cfg.DisplayDevice,
 		NestedVirtualization: pool.cfg.NestedVirtualization,
 		NicType:              pool.cfg.NicType,
+		VMRunningTime:        pool.env.Timeouts.VMRunningTime,
 	}
 	ip, err := pool.GCE.CreateInstance(instCfg)
 	if err != nil {


### PR DESCRIPTION
setup gce to auto delete an instance if VMRunningTime is set in config. This ensures that instances are deleted even if the manager crashes and fails to delete them. Add a 1-hour margin to the timeout to give the manager enough time to finish its own cleanup.

See previous discussion #6842
Submitted as a separate PR as requested in #6905