### PR TITLE
dashboard/app: reimplement the auto AI job creation

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -461,7 +462,7 @@ func pollAIJob(ctx context.Context, req *dashapi.AIJobPollReq) (*aidb.Job, error
 	if job != nil {
 		return job, nil
 	}
-	if created, err := autoCreateAIJobs(ctx); err != nil || !created {
+	if created, err := autoCreateAIJobs(ctx, req.Workflows); err != nil || !created {
 		return nil, err
 	}
 	job, err = aidb.StartJob(ctx, req)
@@ -711,64 +712,133 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 // (provided no reproducer has been found in the meanwhile).
 const aiReproTriggerDays = 14
 
-// autoCreateAIJobs incrementally creates AI jobs for existing bugs, returns if any new jobs were created.
+// autoCreateAIJobs attempts to auto-assign AI jobs for the given requested workflows.
+// To avoid race conditions between concurrent agents, it operates in two phases,
+// both leveraging Datastore transactions:
+//  1. findPendingJobs: checks bugs that have matching AIPendingWorkflows.
+//  2. processStaleBugs: evaluates stale bugs (AIJobCheck < currentDate).
 //
-// The idea is as follows. We have a predicate (workflowsForBug) which says what workflows need to be
-// created for a bug. Each bug has AIJobCheck integer field, which holds date when the predicate was
-// applied to the bug. We fetch some number of bugs with AIJobCheck<currentDate and check if we need to create
-// new jobs for them. The check is done by executing workflowsForBug for the bug, loading existing
-// pending/finished jobs for the bug, and finding any jobs returned by workflowsForBug that don't exist yet.
-func autoCreateAIJobs(ctx context.Context) (bool, error) {
+// Both phases (re-)compute applicable workflows and update AIJobCheck and AIPendingWorkflows.
+func autoCreateAIJobs(ctx context.Context, reqWorkflows []dashapi.AIWorkflow) (bool, error) {
 	date := int64(timeDate(timeNow(ctx)))
 	for ns, cfg := range getConfig(ctx).Namespaces {
 		if cfg.AI == nil {
 			continue
 		}
-		var bugs []*Bug
-		keys, err := db.NewQuery("Bug").
-			Filter("Namespace=", ns).
-			Filter("Status=", BugStatusOpen).
-			Filter("AIJobCheck<", date).
-			Limit(100).
-			GetAll(ctx, &bugs)
-		if err != nil {
-			return false, fmt.Errorf("failed to fetch bugs: %w", err)
-		}
-		if len(bugs) == 0 {
-			continue
-		}
-		created := false
-		var updateKeys []*db.Key
-		for i, bug := range bugs {
-			updateKeys = append(updateKeys, keys[i])
-			created, err = autoCreateAIJob(ctx, bug, keys[i])
-			if err != nil {
-				return false, err
-			}
-			if created {
-				break
-			}
-		}
-		if err := updateBatch(ctx, updateKeys, func(_ *db.Key, bug *Bug) {
-			bug.AIJobCheck = date
-		}); err != nil {
+		if created, err := findPendingJobs(ctx, ns, date, reqWorkflows); err != nil {
 			return false, err
+		} else if created {
+			return true, nil
 		}
-		if created {
+		if created, err := processStaleBugs(ctx, ns, date, reqWorkflows); err != nil {
+			return false, err
+		} else if created {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func autoCreateAIJob(ctx context.Context, bug *Bug, bugKey *db.Key) (bool, error) {
+func findPendingJobs(ctx context.Context, ns string, date int64, reqWorkflows []dashapi.AIWorkflow) (bool, error) {
+	for _, req := range reqWorkflows {
+		var bugs []*Bug
+		keys, err := db.NewQuery("Bug").
+			Filter("Namespace=", ns).
+			Filter("Status=", BugStatusOpen).
+			Filter("AIPendingWorkflows=", string(req.Type)).
+			Limit(1).
+			GetAll(ctx, &bugs)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch pending bugs: %w", err)
+		}
+		if len(bugs) == 0 {
+			continue
+		}
+		created, err := tryCreateAIJobForBug(ctx, bugs[0], keys[0], date, reqWorkflows)
+		if created || err != nil {
+			return created, err
+		}
+	}
+	return false, nil
+}
+
+func processStaleBugs(ctx context.Context, ns string, date int64, reqWorkflows []dashapi.AIWorkflow) (bool, error) {
+	var bugs []*Bug
+	keys, err := db.NewQuery("Bug").
+		Filter("Namespace=", ns).
+		Filter("Status=", BugStatusOpen).
+		Filter("AIJobCheck<", date).
+		Limit(100).
+		GetAll(ctx, &bugs)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch stale bugs: %w", err)
+	}
+
+	for i, bug := range bugs {
+		created, err := tryCreateAIJobForBug(ctx, bug, keys[i], date, reqWorkflows)
+		if created || err != nil {
+			return created, err
+		}
+	}
+	return false, nil
+}
+
+func tryCreateAIJobForBug(ctx context.Context, bug *Bug, bugKey *db.Key, date int64,
+	reqWorkflows []dashapi.AIWorkflow) (bool, error) {
+	pending, err := pendingWorkflowsForBug(ctx, bug, bugKey)
+	if err != nil {
+		log.Errorf(ctx, "failed to LoadBugJobs for bug %v: %v", bugKey.StringID(), err)
+		return false, nil
+	}
+
+	created := false
+	var matchedReq dashapi.AIWorkflow
+	for _, req := range reqWorkflows {
+		idx := slices.Index(pending, string(req.Type))
+		if idx != -1 {
+			pending = slices.Delete(pending, idx, idx+1)
+			created = true
+			matchedReq = req
+			break
+		}
+	}
+
+	errConflict := fmt.Errorf("bug already evaluated or modified")
+	err = updateSingleBug(ctx, bugKey, func(txBug *Bug) error {
+		if txBug.AIJobCheck != bug.AIJobCheck || !slices.Equal(txBug.AIPendingWorkflows, bug.AIPendingWorkflows) {
+			return errConflict
+		}
+		txBug.AIJobCheck = max(txBug.AIJobCheck, date)
+		txBug.AIPendingWorkflows = pending
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, errConflict) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if created {
+		if _, createErr := bugJobCreate(ctx, matchedReq.Name, matchedReq.Type, bug, nil); createErr != nil {
+			return false, fmt.Errorf("failed to create ai job %v for bug %v: %w", matchedReq.Type, bugKey.StringID(), createErr)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// pendingWorkflowsForBug returns a list of workflow types that the bug qualifies for,
+// excluding workflows that already have running or completed jobs, or jobs that are
+// in exponential backoff.
+func pendingWorkflowsForBug(ctx context.Context, bug *Bug, bugKey *db.Key) ([]string, error) {
 	workflows := workflowsForBug(ctx, bug, false)
 	if len(workflows) == 0 {
-		return false, nil
+		return nil, nil
 	}
 	jobs, err := aidb.LoadBugJobs(ctx, bugKey.StringID())
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	workflowAttempts := map[ai.WorkflowType]struct {
 		count int
@@ -803,12 +873,12 @@ func autoCreateAIJob(ctx context.Context, bug *Bug, bugKey *db.Key) (bool, error
 			delete(workflows, typ)
 		}
 	}
+	var pending []string
 	for workflow := range workflows {
-		if _, err := bugJobCreate(ctx, string(workflow), workflow, bug, nil); err != nil {
-			return false, err
-		}
+		pending = append(pending, string(workflow))
 	}
-	return len(workflows) != 0, nil
+	slices.Sort(pending)
+	return pending, nil
 }
 
 func workflowsForBug(ctx context.Context, bug *Bug, manual bool) map[ai.WorkflowType]bool {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/google/syzkaller/dashboard/app/aidb"
 	"github.com/google/syzkaller/dashboard/dashapi"
@@ -584,6 +587,89 @@ func TestAIRepro(t *testing.T) {
 	// No AI job should be created.
 	pollResp4, _ := c.agentClient.AIJobPoll(pollReq)
 	require.Equal(t, pollResp4.ID, "")
+}
+
+func TestAIPendingJobs(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	crash.Title = "KCSAN: data-race in foo / bar"
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+	// Initial poll for only "patching". Ensures "assessment-kcsan" is left in pending.
+	pollResp, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "patching-agent",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatching, Name: "patching-job"},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, pollResp.ID) // No patching jobs for KCSAN
+
+	// No AI jobs should be created yet since the KCSAN workflow is just pending.
+	bug, _, _ := c.loadBug(extID)
+	jobs, err := aidb.LoadBugJobs(c.ctx, bug.keyHash(c.ctx))
+	require.NoError(t, err)
+	require.Empty(t, jobs)
+
+	// Poll for "assessment-kcsan" should pick up the pending job via Phase 1 fast-path.
+	pollRespKcsan, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "kcsan-agent",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowAssessmentKCSAN, Name: "kcsan-job"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, pollRespKcsan.ID)
+	require.Equal(t, "kcsan-job", pollRespKcsan.Workflow)
+}
+
+func TestAIJobParallelPoll(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	crash.Title = "KCSAN: data-race in foo / bar"
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// Spawn multiple routines to poll for jobs concurrently.
+	var eg errgroup.Group
+	const numPollers = 15
+	var assignedJobs int32
+	for i := 0; i < numPollers; i++ {
+		eg.Go(func() error {
+			pollResp, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+				AgentName:    fmt.Sprintf("agent-%v", i),
+				CodeRevision: prog.GitRevision,
+				Workflows: []dashapi.AIWorkflow{
+					{Type: ai.WorkflowAssessmentKCSAN, Name: "kcsan-job"},
+				},
+			})
+			if err == nil && pollResp.ID != "" {
+				atomic.AddInt32(&assignedJobs, 1)
+			}
+			return err
+		})
+	}
+	require.NoError(t, eg.Wait())
+
+	require.Equal(t, int32(1), assignedJobs)
+
+	// Ensure exactly 1 Job entity actually exists in the Datastore.
+	bug, _, _ := c.loadBug(extID)
+	jobs, err := aidb.LoadBugJobs(c.ctx, bug.keyHash(c.ctx))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(jobs))
 }
 
 func TestAIAgentLastActive(t *testing.T) {

--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -131,7 +131,10 @@ type Bug struct {
 	// FixCandidateJob holds the key of the latest successful cross-tree fix bisection job.
 	FixCandidateJob string
 	ReproAttempts   []BugReproAttempt
-	AIJobCheck      int64
+	// AIJobCheck holds the date (YYYYMMDD) when AI jobs were last checked for this bug.
+	AIJobCheck int64
+	// AIPendingWorkflows holds the list of AI workflow types that are pending for this bug.
+	AIPendingWorkflows []string
 }
 
 type BugTreeTestInfo struct {

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -268,3 +268,10 @@ indexes:
   - name: Namespace
   - name: Manager
   - name: AttemptsLeft
+
+- kind: Bug
+  properties:
+  - name: Namespace
+  - name: Status
+  - name: AIJobCheck
+  - name: AIPendingWorkflows


### PR DESCRIPTION
Closes https://github.com/google/syzkaller/issues/6920

Change the logic to:
a) Only create the jobs actually requested by the agent.
b) Better handle concurrent job poll requests.

The existing code always automatically creates all AI jobs for a processed bug, even if the polling agent does not enable some of the workflow types.

To both keep on doing per-bug analysis only once per day and to lazily create the actually necessary jobs, split the process into several steps:
1) Calculate the workflow types we could have created for the job.
2) In a transaction, update bug's workflows, excluding the workflow type
   we are about to create. If we are the first to update the bug,
   proceed.
3) Spawn the job if the possible workflow types intersect with the ones
   from the request.

The objective is to avoid creating duplicate and unnecessary jobs. If we fail at step 3, the daily recalculation of the pending jobs will the lost workflow type back.
