### PR TITLE
vm/gce: add support for nic_type and nested_virtualization

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -65,7 +65,7 @@ type InstanceConfig struct {
 	NicType              string
 }
 
-func NewContext(customZoneID string) (*Context, error) {
+func NewContext(customZoneID, customProjectID string) (*Context, error) {
 	ctx := &Context{
 		apiRateGate: time.NewTicker(time.Second).C,
 	}
@@ -80,21 +80,24 @@ func NewContext(customZoneID string) (*Context, error) {
 		return nil, fmt.Errorf("failed to create compute service: %w", err)
 	}
 	// Obtain project name, zone and current instance IP address.
-	ctx.ProjectID, err = ctx.getMeta("project/project-id")
-	if err != nil {
-		return nil, fmt.Errorf("failed to query gce project-id: %w", err)
-	}
-	myZoneID, err := ctx.getMeta("instance/zone")
-	if err != nil {
-		return nil, fmt.Errorf("failed to query gce zone: %w", err)
-	}
-	if i := strings.LastIndexByte(myZoneID, '/'); i != -1 {
-		myZoneID = myZoneID[i+1:] // the query returns some nonsense prefix
+	if customProjectID != "" {
+		ctx.ProjectID = customProjectID
+	} else {
+		ctx.ProjectID, err = ctx.getMeta("project/project-id")
+		if err != nil {
+			return nil, fmt.Errorf("failed to query gce project-id: %w", err)
+		}
 	}
 	if customZoneID != "" {
 		ctx.ZoneID = customZoneID
 	} else {
-		ctx.ZoneID = myZoneID
+		ctx.ZoneID, err = ctx.getMeta("instance/zone")
+		if err != nil {
+			return nil, fmt.Errorf("failed to query gce zone: %w", err)
+		}
+		if i := strings.LastIndexByte(ctx.ZoneID, '/'); i != -1 {
+			ctx.ZoneID = ctx.ZoneID[i+1:] // the query returns some nonsense prefix
+		}
 	}
 	if !validateZone(ctx.ZoneID) {
 		return nil, fmt.Errorf("%q is not a valid zone name", ctx.ZoneID)
@@ -107,7 +110,7 @@ func NewContext(customZoneID string) (*Context, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to query gce instance name: %w", err)
 	}
-	inst, err := ctx.computeService.Instances.Get(ctx.ProjectID, myZoneID, ctx.Instance).Do()
+	inst, err := ctx.computeService.Instances.Get(ctx.ProjectID, ctx.ZoneID, ctx.Instance).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error getting instance info: %w", err)
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1541,7 +1541,7 @@ func publicWebAddr(addr string) string {
 		if host, err := os.Hostname(); err == nil {
 			addr = net.JoinHostPort(host, port)
 		}
-		if GCE, err := gce.NewContext(""); err == nil {
+		if GCE, err := gce.NewContext("", ""); err == nil {
 			addr = net.JoinHostPort(GCE.ExternalIP, port)
 		}
 	}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -46,6 +46,7 @@ func init() {
 type Config struct {
 	Count                int    `json:"count"`                 // number of VMs to use
 	ZoneID               string `json:"zone_id"`               // GCE zone (if it's different from that of syz-manager)
+	ProjectID            string `json:"project_id"`            // GCE project (if it's different from that of syz-manager)
 	MachineType          string `json:"machine_type"`          // GCE machine type (e.g. "n1-highcpu-2")
 	GCSPath              string `json:"gcs_path"`              // GCS path to upload image
 	GCEImage             string `json:"gce_image"`             // pre-created GCE image to use
@@ -119,7 +120,7 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 		return nil, fmt.Errorf("both image and gce_image are specified")
 	}
 
-	GCE, err := initGCE(cfg.ZoneID)
+	GCE, err := initGCE(cfg.ZoneID, cfg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 	return pool, nil
 }
 
-func initGCE(zoneID string) (*gce.Context, error) {
+func initGCE(zoneID, projectID string) (*gce.Context, error) {
 	// There happen some transient GCE init errors on and off.
 	// Let's try it several times before aborting.
 	const (
@@ -166,7 +167,7 @@ func initGCE(zoneID string) (*gce.Context, error) {
 		if i > 1 {
 			time.Sleep(gceInitBackoff)
 		}
-		GCE, err = gce.NewContext(zoneID)
+		GCE, err = gce.NewContext(zoneID, projectID)
 		if err == nil {
 			return GCE, nil
 		}


### PR DESCRIPTION
Add the ability to specify the network interface type (`nic_type`) and enable nested virtualization (`nested_virtualization`) for GCE instances.

These fields are mapped to `NetworkInterfaces[0].NicType` and `AdvancedMachineFeatures.EnableNestedVirtualization` in the Google Cloud Compute API during instance creation, which allows syzkaller to utilize specific NIC architectures (e.g., GVNIC) and hardware-assisted virtualization within its VMs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
