### PR TITLE
dashboard/app: don't auto-generate AI repro jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -708,10 +708,6 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 	})
 }
 
-// In how many days after a bug is reported we create the first AI repro job
-// (provided no reproducer has been found in the meanwhile).
-const aiReproTriggerDays = 14
-
 // autoCreateAIJobs attempts to auto-assign AI jobs for the given requested workflows.
 // To avoid race conditions between concurrent agents, it operates in two phases,
 // both leveraging Datastore transactions:
@@ -892,9 +888,6 @@ func workflowsForBug(ctx context.Context, bug *Bug, manual bool) map[ai.Workflow
 	}
 	if typ == crash.KCSANDataRace {
 		workflows[ai.WorkflowAssessmentKCSAN] = true
-	}
-	if bug.ReproLevel == dashapi.ReproLevelNone && timeSince(ctx, bug.FirstTime) > aiReproTriggerDays*24*time.Hour {
-		workflows[ai.WorkflowRepro] = true
 	}
 	if manual {
 		// Types we don't create automatically yet, but can be created manually.

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -548,47 +548,6 @@ func TestAIJobAutoCreate(t *testing.T) {
 	require.Equal(t, pollResp7.ID, "")
 }
 
-func TestAIRepro(t *testing.T) {
-	c := NewSpannerCtx(t)
-	defer c.Close()
-
-	build := testBuild(1)
-	c.aiClient.UploadBuild(build)
-	crash := testCrash(build, 1)
-	c.aiClient.ReportCrash(crash)
-	c.aiClient.pollEmailExtID()
-
-	pollReq := &dashapi.AIJobPollReq{
-		AgentName:    "agent-repro",
-		CodeRevision: prog.GitRevision,
-		Workflows: []dashapi.AIWorkflow{
-			{Type: ai.WorkflowRepro, Name: string(ai.WorkflowRepro)},
-		},
-	}
-	// No job should be created initially.
-	pollResp0, _ := c.agentClient.AIJobPoll(pollReq)
-	require.Equal(t, pollResp0.ID, "")
-
-	c.advanceTime(15 * 24 * time.Hour)
-	pollResp2, _ := c.agentClient.AIJobPoll(pollReq)
-	require.NotEqual(t, pollResp2.ID, "")
-	require.Equal(t, pollResp2.Args["CrashLog"], "log1")
-
-	c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
-		ID: pollResp2.ID,
-	})
-
-	// A second bug with a repro.
-	crash2 := testCrashWithRepro(build, 2)
-	c.aiClient.ReportCrash(crash2)
-	c.aiClient.pollEmailExtID()
-
-	c.advanceTime(15 * 24 * time.Hour)
-	// No AI job should be created.
-	pollResp4, _ := c.agentClient.AIJobPoll(pollReq)
-	require.Equal(t, pollResp4.ID, "")
-}
-
 func TestAIPendingJobs(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
@@ -680,7 +639,7 @@ func TestAIAgentLastActive(t *testing.T) {
 	c.aiClient.UploadBuild(build)
 	crash := testCrash(build, 1)
 	c.aiClient.ReportCrash(crash)
-	c.aiClient.pollEmailExtID()
+	extID := c.aiClient.pollEmailExtID()
 
 	agentName := "test-agent-123"
 	pollReq := &dashapi.AIJobPollReq{
@@ -690,7 +649,9 @@ func TestAIAgentLastActive(t *testing.T) {
 			{Type: ai.WorkflowRepro, Name: string(ai.WorkflowRepro)},
 		},
 	}
-	c.advanceTime(15 * 24 * time.Hour)
+	c.agentClient.AIJobPoll(pollReq)
+	c.createAIJob(extID, string(ai.WorkflowRepro), "")
+	c.advanceTime(time.Hour)
 
 	// Poll, get the repro job and verify the last active timestamp.
 	pollResp, _ := c.agentClient.AIJobPoll(pollReq)


### PR DESCRIPTION
The workflow is not yet 100% ready, so there's no sense to generate the jobs for it yet.