### PR TITLE
pkg/aflow: add session-initializer MCP tool

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -109,3 +109,113 @@ R13: 00007efe6bbf4eb0 R14: 0000000000000000 R15: 0000000000000000
  </TASK>
 ---[ end trace ]---
 ```
+
+A manual unit test for the MCP server:
+
+```bash
+MCP_SESSION_ID=$(curl -i -X POST http://localhost:59999/mcp \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--data '{
+		"jsonrpc": "2.0",
+		"method": "initialize",
+		"id": "init-request-1",
+		"params": {
+			"protocolVersion": "2025-11-25",
+			"clientInfo": {
+				"name": "curl-client",
+				"version": "1.0"
+			}, "capabilities": {}
+		}
+	}' \
+	| grep "Mcp-Session-Id:" | sed 's/Mcp-Session-Id\: //' | sed 's/[[:space:]]//g')
+echo "Mcp-Session-Id: ${MCP_SESSION_ID}"
+
+curl --location "http://localhost:59999/mcp" \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--header "mcp-session-id: ${MCP_SESSION_ID}" \
+	--data '{
+		"jsonrpc": "2.0",
+		"method": "tools/call",
+		"id": "call-session-initializer-req-1",
+		"params": {
+			"name": "session-initializer",
+			"arguments": {
+				"ReproSyz": "getpid()",
+				"ReproOpts":  "{\"threaded\":true, \"repeat\":true}",
+				"ReproC": ""
+			}
+		}
+	}'
+echo
+
+for tool in "base-commit-picker" "kernel-checkouter" "kernel-builder" "crash-reproducer" "codesearch-prepare" "kernel-scratch-checkouter"; do
+curl --location "http://localhost:59999/mcp" \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--header "mcp-session-id: ${MCP_SESSION_ID}" \
+	--data "{
+		\"jsonrpc\": \"2.0\",
+		\"method\": \"tools/call\",
+		\"id\": \"call-${tool}-req-1\",
+		\"params\": {
+			\"name\": \"${tool}\",
+			\"arguments\": {}
+		}
+	}";
+echo
+done
+
+curl --location "http://localhost:59999/mcp" \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--header "mcp-session-id: ${MCP_SESSION_ID}" \
+	--data '{
+		"jsonrpc": "2.0",
+		"method": "tools/call",
+		"id": "call-codesearch-struct-layout-req-1",
+		"params": {
+			"name": "codesearch-struct-layout",
+			"arguments": {
+				"ContextFile": "kernel/kcov.c",
+				"Name": "kcov"
+			}
+		}
+	}'
+echo
+
+curl --location "http://localhost:59999/mcp" \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--header "mcp-session-id: ${MCP_SESSION_ID}" \
+	--data '{
+		"jsonrpc": "2.0",
+		"method": "tools/call",
+		"id": "call-codeeditor-req-1",
+		"params": {
+			"name": "codeeditor",
+			"arguments": {
+				"SourceFile": "kernel/kcov.c",
+				"CurrentCode": "struct kcov {",
+				"NewCode": "struct kcov { /*some comment/*"
+			}
+		}
+	}'
+echo
+
+curl --location "http://localhost:59999/mcp" \
+	--header "Content-Type: application/json" \
+	--header "Accept: application/json, text/event-stream" \
+	--header "mcp-session-id: ${MCP_SESSION_ID}" \
+	--data '{
+		"jsonrpc": "2.0",
+		"method": "tools/call",
+		"id": "call-test-patch-req-1",
+		"params": {
+			"name": "test-patch",
+			"arguments": {}
+		}
+	}'
+echo
+```

--- a/pkg/aflow/mcp.go
+++ b/pkg/aflow/mcp.go
@@ -60,14 +60,20 @@ func registerMCPAction[Args, Results any](a *funcAction[Args, Results]) {
 		Name:         a.name,
 		Description:  a.name,
 		InputSchema:  mustSchemaFor[struct{}](),
-		OutputSchema: mustSchemaFor[struct{}](),
+		OutputSchema: uncheckedSchemaFor[Results](),
 	}
 	handler := func(ctx *Context, args map[string]any) (*mcp.CallToolResult, error) {
 		err := a.execute(ctx)
-		reply := &mcp.CallToolResult{
-			StructuredContent: struct{}{},
+		if err != nil {
+			return nil, err
 		}
-		return reply, err
+		res, err := convertFromMap[Results](ctx.state, false, false)
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.CallToolResult{
+			StructuredContent: res,
+		}, nil
 	}
 	registerMCP(tool, handler)
 }
@@ -86,4 +92,20 @@ func registerMCP(tool *mcp.Tool, handler MCPToolFunc) {
 	}
 	mcpToolNames[tool.Name] = true
 	MCPTools[tool] = handler
+}
+
+func init() {
+	NewFuncTool("session-initializer", func(ctx *Context, state struct{}, args struct {
+		ReproSyz  string `jsonschema:"syzkaller program that reproduces the bug."`
+		ReproOpts string `jsonschema:"syzkaller program execution options."`
+		ReproC    string `jsonschema:"C program that reproduces the bug."`
+	}) (struct{}, error) {
+		ctx.state["ReproSyz"] = args.ReproSyz
+		ctx.state["ReproOpts"] = args.ReproOpts
+		ctx.state["ReproC"] = args.ReproC
+		return struct{}{}, nil
+	}, `
+The tool populates session state for other tools/actions to use.
+It is supposed to be called first, and substitutes input workflow arguments in MCP mode.
+`)
 }

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -22,15 +22,19 @@ func schemaFor[T any]() (*jsonschema.Schema, error) {
 	if err := checkSchemaType(typ); err != nil {
 		return nil, err
 	}
+	return uncheckedSchemaFor[T](), nil
+}
+
+func uncheckedSchemaFor[T any]() *jsonschema.Schema {
 	schema, err := jsonschema.For[T](nil)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	resolved, err := schema.Resolve(nil)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return resolved.Schema(), nil
+	return resolved.Schema()
 }
 
 func checkSchemaType(typ reflect.Type) error {


### PR DESCRIPTION
The tool populates session state for other tools/actions to use.
It is supposed to be called first, and substitutes input workflow arguments in MCP mode.

Also provide results of actions as tool results.
Now they are both stored in the session state, and returned as MCP tool results.
This allows to get access to ReproducedCrashReport/PatchDiff/TestError/etc.

Add instructions on how to manually test MCP server.

Fixes #6929
