### PR TITLE
syz-cluster: update Go version in the Dockerfiles

### DIFF
--- a/syz-cluster/Dockerfile.go-tests
+++ b/syz-cluster/Dockerfile.go-tests
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye
+FROM golang:1.26-bookworm
 
 RUN apt-get update && \
     apt-get install -y git

--- a/syz-cluster/controller/Dockerfile
+++ b/syz-cluster/controller/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS controller-builder
+FROM golang:1.26-alpine AS controller-builder
 
 WORKDIR /build
 

--- a/syz-cluster/dashboard/Dockerfile
+++ b/syz-cluster/dashboard/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS dashboard-builder
+FROM golang:1.26-alpine AS dashboard-builder
 
 WORKDIR /build
 

--- a/syz-cluster/email-reporter/Dockerfile
+++ b/syz-cluster/email-reporter/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS email-reporter-builder
+FROM golang:1.26-alpine AS email-reporter-builder
 
 WORKDIR /build
 

--- a/syz-cluster/reporter-server/Dockerfile
+++ b/syz-cluster/reporter-server/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS reporter-builder
+FROM golang:1.26-alpine AS reporter-builder
 
 WORKDIR /build
 

--- a/syz-cluster/series-tracker/Dockerfile
+++ b/syz-cluster/series-tracker/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright 2024 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-FROM golang:1.24-alpine AS series-tracker-builder
+FROM golang:1.26-alpine AS series-tracker-builder
 
 WORKDIR /build
 

--- a/syz-cluster/series-tracker/Dockerfile.test
+++ b/syz-cluster/series-tracker/Dockerfile.test
@@ -12,7 +12,7 @@ RUN git fetch docs-0
 RUN git checkout docs-0/master
 
 # II. Build the tool.
-FROM golang:1.24-alpine AS series-tracker-builder
+FROM golang:1.26-alpine AS series-tracker-builder
 
 WORKDIR /build
 

--- a/syz-cluster/tools/db-mgmt/Dockerfile
+++ b/syz-cluster/tools/db-mgmt/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/syz-cluster/tools/send-test-email/Dockerfile
+++ b/syz-cluster/tools/send-test-email/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # Copyright 2025 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/syz-cluster/workflow/boot/Dockerfile
+++ b/syz-cluster/workflow/boot/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY --exclude=syz-cluster . .
 RUN make TARGETARCH=amd64
 
-FROM golang:1.24-alpine AS boot-action-builder
+FROM golang:1.26-alpine AS boot-action-builder
 WORKDIR /build
 
 # Copy the code and the dependencies.

--- a/syz-cluster/workflow/triage/Dockerfile
+++ b/syz-cluster/workflow/triage/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright 2024 syzkaller project authors. All rights reserved.
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-FROM golang:1.24-alpine AS triage-action-builder
+FROM golang:1.26-alpine AS triage-action-builder
 
 WORKDIR /build
 


### PR DESCRIPTION
The builds broke after the recent update of go.mod.