### PR TITLE
pkg/aflow: fix MCP tool names

### DIFF
--- a/pkg/aflow/flow/flows_test.go
+++ b/pkg/aflow/flow/flows_test.go
@@ -4,6 +4,7 @@
 package flow
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -13,6 +14,9 @@ import (
 
 func TestMCPTools(t *testing.T) {
 	for tool := range aflow.MCPTools {
+		if strings.Contains(tool.Name, "-") {
+			t.Errorf("MCP tool %q contains '-'", tool.Name)
+		}
 		t.Log(tool.Name)
 	}
 }

--- a/pkg/aflow/mcp.go
+++ b/pkg/aflow/mcp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
@@ -87,6 +88,7 @@ func registerMCP(tool *mcp.Tool, handler MCPToolFunc) {
 	if !registerMCPTools || tool.Name == llmSetResultsTool {
 		return
 	}
+	tool.Name = strings.ReplaceAll(tool.Name, "-", "_")
 	if mcpToolNames[tool.Name] {
 		panic(fmt.Sprintf("MCP tool %q is already registered", tool.Name))
 	}


### PR DESCRIPTION
Replace '-' with '_' in MCP tool names because '-' results in
invalid Python method names in MCP clients.

Fixes #6935
