### PR TITLE
pkg/gce: pass local project id to Instances.Get()

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -84,13 +84,14 @@ func NewContext(customZoneID, customProjectID string) (*Context, error) {
 		return nil, fmt.Errorf("failed to create compute service: %w", err)
 	}
 	// Obtain project name, zone and current instance IP address.
+	instanceProject, err := ctx.getMeta("project/project-id")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query gce project-id: %w", err)
+	}
 	if customProjectID != "" {
 		ctx.ProjectID = customProjectID
 	} else {
-		ctx.ProjectID, err = ctx.getMeta("project/project-id")
-		if err != nil {
-			return nil, fmt.Errorf("failed to query gce project-id: %w", err)
-		}
+		ctx.ProjectID = instanceProject
 	}
 	instanceZone, err := ctx.localZone()
 	if err != nil {
@@ -112,7 +113,7 @@ func NewContext(customZoneID, customProjectID string) (*Context, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to query gce instance name: %w", err)
 	}
-	inst, err := ctx.computeService.Instances.Get(ctx.ProjectID, instanceZone, ctx.Instance).Do()
+	inst, err := ctx.computeService.Instances.Get(instanceProject, instanceZone, ctx.Instance).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error getting instance info: %w", err)
 	}


### PR DESCRIPTION
This fixes the bug introduced in #6928: to obtain the local IP, we need to pass the local project id, not the custom one.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
