### PR TITLE
dashboard/app: use the same XG in updateSingleBug

### DIFF
--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -214,7 +214,9 @@ func updateSingleBug(ctx context.Context, bugKey *db.Key, transform func(*Bug) e
 		}
 		return nil
 	}
-	return runInTransaction(ctx, tx, nil)
+	return runInTransaction(ctx, tx, &db.TransactionOptions{
+		XG: true, // We need the same XG as in the consequent transactions.
+	})
 }
 
 func (bug *Bug) hasUserSubsystems() bool {


### PR DESCRIPTION
Dashboard tests are failing b/o `(datastore_v3: BAD_REQUEST): Transaction should have same options as previous_transaction`:
<details>
  <summary>Click me</summary>
<pre>
--- FAIL: TestAIJobParallelPoll (5.40s)
    util_test.go:611: : API(upload_build): &dashapi.Build{Manager:"manager1", ID:"build1", OS:"linux", Arch:"amd64", VMArch:"amd64", SyzkallerCommit:"syzkaller_commit1", SyzkallerCommitDate:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), CompilerID:"compiler1", KernelRepo:"repo1", KernelBranch:"branch1", KernelCommit:"1111111111111111111111111111111111111111", KernelCommitTitle:"kernel_commit_title1", KernelCommitDate:time.Date(1, time.February, 3, 4, 5, 6, 0, time.UTC), KernelConfig:[]uint8{0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x31}, Commits:[]string(nil), FixCommits:[]dashapi.Commit(nil), Assets:[]dashapi.NewAsset(nil)}
Error: : API(upload_build): &dashapi.Build{Manager:"manager1", ID:"build1", OS:"linux", Arch:"amd64", VMArch:"amd64", SyzkallerCommit:"syzkaller_commit1", SyzkallerCommitDate:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), CompilerID:"compiler1", KernelRepo:"repo1", KernelBranch:"branch1", KernelCommit:"1111111111111111111111111111111111111111", KernelCommitTitle:"kernel_commit_title1", KernelCommitDate:time.Date(1, time.February, 3, 4, 5, 6, 0, time.UTC), KernelConfig:[]uint8{0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x31}, Commits:[]string(nil), FixCommits:[]dashapi.Commit(nil), Assets:[]dashapi.NewAsset(nil)}
    util_test.go:611: : API(upload_build): REPLY: <nil>
Error: : API(upload_build): REPLY: <nil>
    util_test.go:611: : API(report_crash): &dashapi.Crash{BuildID:"build1", Title:"KCSAN: data-race in foo / bar", AltTitles:[]string(nil), Corrupted:false, Suppressed:false, Maintainers:[]string(nil), Recipients:dashapi.Recipients(nil), Log:[]uint8{0x6c, 0x6f, 0x67, 0x31}, Flags:0, Report:[]uint8{0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x31}, MachineInfo:[]uint8{0x6d, 0x61, 0x63, 0x68, 0x69, 0x6e, 0x65, 0x20, 0x69, 0x6e, 0x66, 0x6f, 0x20, 0x31}, Assets:[]dashapi.NewAsset(nil), GuiltyFiles:[]string(nil), ReproOpts:[]uint8(nil), ReproSyz:[]uint8(nil), ReproC:[]uint8(nil), ReproLog:[]uint8(nil), OriginalTitle:""}
Error: : API(report_crash): &dashapi.Crash{BuildID:"build1", Title:"KCSAN: data-race in foo / bar", AltTitles:[]string(nil), Corrupted:false, Suppressed:false, Maintainers:[]string(nil), Recipients:dashapi.Recipients(nil), Log:[]uint8{0x6c, 0x6f, 0x67, 0x31}, Flags:0, Report:[]uint8{0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x31}, MachineInfo:[]uint8{0x6d, 0x61, 0x63, 0x68, 0x69, 0x6e, 0x65, 0x20, 0x69, 0x6e, 0x66, 0x6f, 0x20, 0x31}, Assets:[]dashapi.NewAsset(nil), GuiltyFiles:[]string(nil), ReproOpts:[]uint8(nil), ReproSyz:[]uint8(nil), ReproC:[]uint8(nil), ReproLog:[]uint8(nil), OriginalTitle:""}
    util_test.go:611: : API(report_crash): REPLY: &dashapi.ReportCrashResp{NeedRepro:true}
Error: : API(report_crash): REPLY: &dashapi.ReportCrashResp{NeedRepro:true}
    util_test.go:448: GET: /cron/email_poll
Error: GET: /cron/email_poll
    util_test.go:467: REPLY: 200
Error: REPLY: 200
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-14", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-14", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-0", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-0", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-9", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-9", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-2", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-2", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-10", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-10", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-3", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-3", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-5", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-5", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-1", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-1", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-11", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-11", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-12", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-12", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-6", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-6", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-13", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-13", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-7", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-7", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-4", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-4", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-8", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
Error: API(ai_job_poll): &dashapi.AIJobPollReq{AgentName:"agent-8", CodeRevision:"unknown", Workflows:[]dashapi.AIWorkflow{dashapi.AIWorkflow{Type:"assessment-kcsan", Name:"kcsan-job"}}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): ERROR: request failed with Internal Server Error: method "ai_job_poll" ns "" err: API error 1 (datastore_v3: BAD_REQUEST): Transaction should have same options as previous_transaction
Error: API(ai_job_poll): ERROR: request failed with Internal Server Error: method "ai_job_poll" ns "" err: API error 1 (datastore_v3: BAD_REQUEST): Transaction should have same options as previous_transaction
        request: {AgentName:agent-11 CodeRevision:unknown Workflows:[{Type:assessment-kcsan Name:kcsan-job}]}
    util_test.go:615: 
        asm_amd64.s:1771
        errgroup.go:93
        ai_test.go:610: request failed with Internal Server Error: method "ai_job_poll" ns "" err: API error 1 (datastore_v3: BAD_REQUEST): Transaction should have same options as previous_transaction
Error: request failed with Internal Server Error: method "ai_job_poll" ns "" err: API error 1 (datastore_v3: BAD_REQUEST): Transaction should have same options as previous_transaction
        request: {AgentName:agent-11 CodeRevision:unknown Workflows:[{Type:assessment-kcsan Name:kcsan-job}]}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"60c4ed52-8ad7-4695-99bb-4cec44bc6b41", Workflow:"kcsan-job", Args:map[string]interface {}{"BugTitle":"KCSAN: data-race in foo / bar", "CrashLog":"log1", "CrashReport":"report1", "KernelCommit":"1111111111111111111111111111111111111111", "KernelConfig":"config1", "KernelRepo":"repo1", "ReproOpts":"", "SyzkallerCommit":"syzkaller_commit1"}}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"60c4ed52-8ad7-4695-99bb-4cec44bc6b41", Workflow:"kcsan-job", Args:map[string]interface {}{"BugTitle":"KCSAN: data-race in foo / bar", "CrashLog":"log1", "CrashReport":"report1", "KernelCommit":"1111111111111111111111111111111111111111", "KernelConfig":"config1", "KernelRepo":"repo1", "ReproOpts":"", "SyzkallerCommit":"syzkaller_commit1"}}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
    util_test.go:611: asm_amd64.s:1771
Error: asm_amd64.s:1771
        errgroup.go:93: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
Error: API(ai_job_poll): REPLY: &dashapi.AIJobPollResp{ID:"", Workflow:"", Args:map[string]interface {}(nil)}
</pre>
</details>