### PR TITLE
syz-cluster: display monthly report stats table

### DIFF
--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -242,6 +242,7 @@ func (h *dashboardHandler) statsPage(w http.ResponseWriter, r *http.Request) err
 		Delay         []*db.DelayPerWeek
 		Distribution  []*db.StatusPerWeek
 		PreventedBugs []*db.PreventedBugsStats
+		MonthlyStats  MonthlyStats
 	}
 	var data StatsPageData
 	var err error
@@ -269,7 +270,32 @@ func (h *dashboardHandler) statsPage(w http.ResponseWriter, r *http.Request) err
 	if err != nil {
 		return fmt.Errorf("failed to query prevented bugs data: %w", err)
 	}
+
+	reportsPerMonth, err := h.statsRepo.ReportsPerMonth(r.Context())
+	if err != nil {
+		return fmt.Errorf("failed to query reports per month: %w", err)
+	}
+	data.MonthlyStats = makeMonthlyStats(reportsPerMonth)
+
 	return h.renderTemplate(w, "graphs.html", data)
+}
+
+type MonthlyStats struct {
+	Totals *db.ReportsPerMonth
+	Months []*db.ReportsPerMonth
+}
+
+func makeMonthlyStats(reports []*db.ReportsPerMonth) MonthlyStats {
+	totals := &db.ReportsPerMonth{}
+	for _, r := range reports {
+		totals.Reports += r.Reports
+		totals.Findings += r.Findings
+	}
+
+	return MonthlyStats{
+		Totals: totals,
+		Months: reports,
+	}
 }
 
 func groupFindings(findings []*db.Finding) map[string][]*db.Finding {

--- a/syz-cluster/dashboard/local_ui_test.go
+++ b/syz-cluster/dashboard/local_ui_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/controller"
 	"github.com/google/syzkaller/syz-cluster/pkg/db"
+	"github.com/google/syzkaller/syz-cluster/pkg/reporter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -181,5 +182,29 @@ func populateData(t *testing.T, ctx context.Context, client *api.Client, env *ap
 		Target:   api.StepTargetBase,
 		Log:      []byte("base error log"),
 	})
+	require.NoError(t, err)
+
+	// Finish the session.
+	err = sessionRepo.Update(ctx, ids.SessionID, func(s *db.Session) error {
+		s.SetFinishedAt(time.Now())
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Generate a report.
+	err = reporter.NewGenerator(env).Process(ctx, 10)
+	require.NoError(t, err)
+
+	reportClient := reporter.TestServer(t, env)
+
+	// Send it upstream (moves it from Moderation to reported list but it still needs confirmation).
+	nextResp, err := reportClient.GetNextReport(ctx, api.LKMLReporter)
+	require.NoError(t, err)
+	err = reportClient.UpstreamReport(ctx, nextResp.Report.ID, &api.UpstreamReportReq{User: "local-ui"})
+	require.NoError(t, err)
+
+	nextResp, err = reportClient.GetNextReport(ctx, api.LKMLReporter)
+	require.NoError(t, err)
+	err = reportClient.ConfirmReport(ctx, nextResp.Report.ID)
 	require.NoError(t, err)
 }

--- a/syz-cluster/dashboard/templates/graphs.html
+++ b/syz-cluster/dashboard/templates/graphs.html
@@ -23,6 +23,35 @@
         <p class="text-muted small">How many reports with findings have been published.</p>
         <div id="reports_chart_div" style="width: 100%; height: 400px;"></div>
         <p class="text-muted small">Click and drag to zoom into a time range. Right-click to reset.</p>
+
+        {{if .MonthlyStats.Months}}
+        <h3 class="h5 mt-4">Monthly Summaries</h3>
+        <table class="table table-striped table-sm" style="max-width: 600px;">
+          <thead>
+            <tr>
+              <th>Month</th>
+              <th>Reports</th>
+              <th>Findings</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .MonthlyStats.Months}}
+            <tr>
+              <td>{{.Date.Format "2006-01"}}</td>
+              <td>{{.Reports}}</td>
+              <td>{{.Findings}}</td>
+            </tr>
+            {{end}}
+          </tbody>
+          <tfoot class="fw-bold">
+            <tr>
+              <td>Total</td>
+              <td>{{.MonthlyStats.Totals.Reports}}</td>
+              <td>{{.MonthlyStats.Totals.Findings}}</td>
+            </tr>
+          </tfoot>
+        </table>
+        {{end}}
       </div>
 
       <hr class="my-4">

--- a/syz-cluster/pkg/db/stats_repo.go
+++ b/syz-cluster/pkg/db/stats_repo.go
@@ -54,6 +54,27 @@ ORDER BY Date`,
 	})
 }
 
+type ReportsPerMonth struct {
+	Date     time.Time `spanner:"Date"`
+	Reports  int64     `spanner:"Reports"`
+	Findings int64     `spanner:"Findings"`
+}
+
+func (repo *StatsRepository) ReportsPerMonth(ctx context.Context) (
+	[]*ReportsPerMonth, error) {
+	return readEntities[ReportsPerMonth](ctx, repo.client.Single(), spanner.Statement{
+		SQL: `SELECT
+  TIMESTAMP_TRUNC(SessionReports.ReportedAt, MONTH, 'UTC') as Date,
+  COUNT(DISTINCT SessionReports.ID) as Reports,
+  COUNT(Findings.ID) as Findings
+FROM SessionReports
+JOIN Findings ON Findings.SessionID = SessionReports.SessionID
+WHERE SessionReports.Moderation = FALSE AND SessionReports.ReportedAt IS NOT NULL
+GROUP BY Date
+ORDER BY Date DESC`,
+	})
+}
+
 func (repo *StatsRepository) FindingsPerWeek(ctx context.Context) (
 	[]*CountPerWeek, error) {
 	return readEntities[CountPerWeek](ctx, repo.client.Single(), spanner.Statement{

--- a/syz-cluster/pkg/db/stats_repo_test.go
+++ b/syz-cluster/pkg/db/stats_repo_test.go
@@ -27,6 +27,8 @@ func TestStatsSQLs(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = statsRepo.ReportsPerWeek(ctx)
 		assert.NoError(t, err)
+		_, err = statsRepo.ReportsPerMonth(ctx)
+		assert.NoError(t, err)
 		_, err = statsRepo.PreventedBugsPerMonth(ctx)
 		assert.NoError(t, err)
 	}


### PR DESCRIPTION
Graphs are convenient for visualization, but a poor source of actual numbers.
Let's also include a table with monthly report/findings data.