### PR TITLE
pkg/instance: increase smoke test logging

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -530,7 +530,7 @@ func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
 	}
 	timeout := 30 * time.Minute * cfg.Timeouts.Scale
 	bin := filepath.Join(cfg.Syzkaller, "bin", "syz-manager")
-	output, retErr := osutil.RunCmd(timeout, "", bin, "-config", configFile, "-mode=smoke-test")
+	output, retErr := osutil.RunCmd(timeout, "", bin, "-config", configFile, "-mode=smoke-test", "-vv=2")
 	if retErr == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Let's increase the logging level of the smoke test. It will simplify debugging of its failures.