### PR TITLE
build/freebsd: Remove the unused kernel compilation option

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -73,6 +73,7 @@ Kamil Rytarowski
 Siddharth Muralee
 Dan Robertson
 Mark Johnston
+ShengYi Hung
 Intel Corporation
  Pengfei Xu
  Yanting Jiang

--- a/pkg/build/freebsd.go
+++ b/pkg/build/freebsd.go
@@ -32,7 +32,6 @@ options 	KASAN
 options 	TCPHPTS
 options 	RATELIMIT
 
-options 	DEBUG_VFS_LOCKS
 options 	DIAGNOSTIC
 `)
 	}


### PR DESCRIPTION
As VFS debug option has been subsumed into INVARIANTS, we remove the option that build for the test image.