### PR TITLE
pkg/aflow: use thinking level instead of thinking budget

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -192,7 +192,7 @@ func (ctx *Context) generateContentGemini(model string, cfg *genai.GenerateConte
 			// See https://ai.google.dev/gemini-api/docs/thinking#set-budget
 			// However, thoughts output also consumes total output token budget.
 			// We may consider adjusting ThinkingLevel parameter.
-			ThinkingBudget: genai.Ptr[int32](-1),
+			ThinkingLevel: genai.ThinkingLevelHigh,
 		}
 	}
 	// Sometimes LLM requests just hang dead for tens of minutes,


### PR DESCRIPTION
Google recommends using `ThinkingLevel` instead of `ThinkingBudget` for Gemini 3+. Using `ThinkingBudget` "may result in unexpected performance". Use ThinkingLevelHigh instead, which provides the same effect of dynamic thinking as ThinkingBudget=-1.

Context: #6966.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
