### PR TITLE
docs: fix punctuation consistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ For other OS kernels check:
 [OpenBSD](docs/openbsd/setup.md),
 [Starnix](docs/starnix/README.md),
 [Windows](docs/windows/README.md),
-[gVisor](docs/gvisor/README.md).
-[Akaros](docs/akaros/README.md),
+[gVisor](docs/gvisor/README.md),
+[Akaros](docs/akaros/README.md).
 
 - [How to install syzkaller](docs/setup.md)
 - [How to use syzkaller](docs/usage.md)


### PR DESCRIPTION
Fixed inconsistent punctuation in the OS kernel documentation links section. The Akaros entry had a comma while gVisor had a period, now they're consistent.