### PR TITLE
.github/workflows: fix filed gemini-cli workflow

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -142,20 +142,6 @@ jobs:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
 
-  triage:
-    needs: 'dispatch'
-    if: |-
-      ${{ needs.dispatch.outputs.command == 'triage' }}
-    uses: './.github/workflows/gemini-triage.yml'
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-      issues: 'write'
-      pull-requests: 'write'
-    with:
-      additional_context: '${{ needs.dispatch.outputs.additional_context }}'
-    secrets: 'inherit'
-
   invoke:
     needs: 'dispatch'
     if: |-


### PR DESCRIPTION
`.github/workflows/gemini-triage.yml` was removed and it confuses workflow.

<img width="2722" height="330" alt="image" src="https://github.com/user-attachments/assets/0e3236e4-419e-4487-a3ed-ec44c8d29360" />
