### PR TITLE
.github/workflows: fix one more triage usage

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -174,7 +174,6 @@ jobs:
     needs:
       - 'dispatch'
       - 'review'
-      - 'triage'
       - 'invoke'
       - 'plan-execute'
     if: |-


### PR DESCRIPTION
We removed the triage workflow but the code is still referring to it.
