### PR TITLE
.github/workflows: shard tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,13 @@ jobs:
           cd gopath/src/github.com/google/syzkaller
           .github/workflows/run.sh make presubmit_aux
 
-  build:
-    runs-on: ubuntu-22.04-16core
+  lint:
+    runs-on: ubuntu-latest
     container: gcr.io/syzkaller/env:latest
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
       TERM: dumb
-      GITHUB_ACTIONS: true
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,22 +71,21 @@ jobs:
       - name: run
         run: |
           cd gopath/src/github.com/google/syzkaller
-          .github/workflows/run.sh make presubmit_build
-      - name: upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-unittests
-          path: gopath/src/github.com/google/syzkaller/.coverage.txt
-          include-hidden-files: true
+          # Run build and lint without tests
+          .github/workflows/run.sh make presubmit_lint
 
-  dashboard:
-    runs-on: ubuntu-22.04-16core
+  test:
+    name: test (${{ matrix.test_shard }})
+    runs-on: ubuntu-latest
     container: gcr.io/syzkaller/env:latest
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
       TERM: dumb
       GITHUB_ACTIONS: true
+    strategy:
+      matrix:
+        test_shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -98,16 +96,32 @@ jobs:
         with:
           path: /syzkaller/.cache
           key: ${{ runner.os }}-syzenv-
-      - name: run
+      - name: run unit tests
         run: |
           cd gopath/src/github.com/google/syzkaller
-          .github/workflows/run.sh timeout --signal=SIGINT 15m make presubmit_dashboard
-      - name: upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+          TEST_SHARD=${{ matrix.test_shard }} \
+            .github/workflows/run.sh make presubmit_test
+      - name: codecov unit tests
+        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
         with:
-          name: coverage-dashboard
-          path: gopath/src/github.com/google/syzkaller/.coverage.txt
-          include-hidden-files: true
+          codecov_yml_path: ${{env.GOPATH}}/src/github.com/google/syzkaller/.github/codecov.yml
+          file: ${{env.GOPATH}}/src/github.com/google/syzkaller/.coverage.txt
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+      - name: run dashboard tests
+        run: |
+          cd gopath/src/github.com/google/syzkaller
+          TEST_SHARD=${{ matrix.test_shard }} \
+            .github/workflows/run.sh timeout --signal=SIGINT 15m make presubmit_dashboard
+      - name: codecov dashboard tests
+        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
+        with:
+          codecov_yml_path: ${{env.GOPATH}}/src/github.com/google/syzkaller/.github/codecov.yml
+          file: ${{env.GOPATH}}/src/github.com/google/syzkaller/.coverage.txt
+          flags: dashboard
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   arch:
     runs-on: ubuntu-latest
@@ -134,39 +148,18 @@ jobs:
           cd gopath/src/github.com/google/syzkaller
           .github/workflows/run.sh make ${{ matrix.target }}
 
-  race:
-    runs-on: ubuntu-22.04-16core
+  race_sharded:
+    name: race (${{ matrix.test_shard }})
+    runs-on: ubuntu-latest
     container: gcr.io/syzkaller/env:latest
-    timeout-minutes: 15 # Q1 2024 experiments may affect timeout, let's relax it
+    timeout-minutes: 15
     env:
       GOPATH: /__w/syzkaller/syzkaller/gopath
       CI: true
       TERM: dumb
-    steps:
-      - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: gopath/src/github.com/google/syzkaller
-
-      # https://github.com/golang/go/issues/61608 to cache -race results.
-      - name: restore cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: /syzkaller/.cache
-          key: ${{ runner.os }}-syzenv-
-
-      - name: run
-        run: |
-          cd gopath/src/github.com/google/syzkaller
-          .github/workflows/run.sh make presubmit_race
-
-  race_dashboard:
-    runs-on: ubuntu-22.04-16core
-    container: gcr.io/syzkaller/env:latest
-    env:
-      GOPATH: /__w/syzkaller/syzkaller/gopath
-      CI: true
-      TERM: dumb
+    strategy:
+      matrix:
+        test_shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -177,10 +170,16 @@ jobs:
         with:
           path: /syzkaller/.cache
           key: ${{ runner.os }}-syzenv-
-      - name: run
+      - name: run race tests
         run: |
           cd gopath/src/github.com/google/syzkaller
-          .github/workflows/run.sh make presubmit_race_dashboard
+          TEST_SHARD=${{ matrix.test_shard }} \
+            .github/workflows/run.sh make presubmit_race
+      - name: run race dashboard tests
+        run: |
+          cd gopath/src/github.com/google/syzkaller
+          TEST_SHARD=${{ matrix.test_shard }} \
+            .github/workflows/run.sh make presubmit_race_dashboard
 
   old:
     runs-on: ubuntu-latest
@@ -230,3 +229,9 @@ jobs:
           cd gopath/src/github.com/google/syzkaller
           make
           .github/workflows/run.sh bash -xe tools/gvisor-smoke-test.sh
+
+  ci:
+    needs: [aux, lint, test, arch, race_sharded, old, gvisor]
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 	format format_go format_cpp format_sys \
 	tidy deadcode test test_race \
 	check_copyright check_language check_whitespace check_sql_newlines check_links check_diff check_commits check_shebang check_html \
-	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd \
+	presubmit presubmit_aux presubmit_lint presubmit_test presubmit_arch_linux presubmit_arch_freebsd \
 	presubmit_arch_netbsd presubmit_arch_openbsd presubmit_arch_darwin presubmit_arch_windows \
 	presubmit_arch_executor presubmit_dashboard presubmit_race presubmit_race_dashboard presubmit_old
 
@@ -311,7 +311,8 @@ deadcode:
 
 presubmit:
 	$(MAKE) presubmit_aux
-	$(MAKE) presubmit_build
+	$(MAKE) presubmit_lint
+	$(MAKE) presubmit_test
 	$(MAKE) presubmit_arch_linux
 	$(MAKE) presubmit_arch_freebsd
 	$(MAKE) presubmit_arch_netbsd
@@ -327,11 +328,13 @@ presubmit_aux:
 	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_k8s tidy
 	$(GO) mod tidy
 
-presubmit_build: descriptions
+presubmit_lint: descriptions
 	# Run go build before lint for better error messages if build is broken.
 	# This does not check build of test files, but running go test takes too long (even for building).
 	$(GO) build ./...
 	$(MAKE) lint
+
+presubmit_test: descriptions
 	SYZ_SKIP_DEV_APPSERVER_TESTS=1 $(MAKE) test
 
 presubmit_arch_linux: descriptions
@@ -376,18 +379,18 @@ presubmit_arch_executor: descriptions
 	TARGETOS=test TARGETARCH=32_fork TARGETVMARCH=32_fork $(MAKE) executor
 
 presubmit_dashboard: descriptions
-	SYZ_CLANG=yes $(GO) test -short -vet=off -coverprofile=.coverage.txt ./dashboard/app
+	SYZ_CLANG=yes ./tools/go_test_sharded.sh ./dashboard/app -short -vet=off -coverprofile=.coverage.txt
 
 presubmit_race: descriptions
 	# -race requires cgo
 	CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
-	CGO_ENABLED=1 SYZ_SKIP_DEV_APPSERVER_TESTS=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./... ;\
+	SYZ_SKIP_DEV_APPSERVER_TESTS=1 ./tools/go_test_sharded.sh ./... -race -short -vet=off -bench=.* -benchtime=.2s ;\
 	fi
 
 presubmit_race_dashboard: descriptions
 	# -race requires cgo
 	CGO_ENABLED=1 $(GO) test -race; if test $$? -ne 2; then \
-	CGO_ENABLED=1 $(GO) test -race -short -vet=off -bench=.* -benchtime=.2s ./dashboard/app/... ;\
+	./tools/go_test_sharded.sh ./dashboard/app -race -short -vet=off -bench=.* -benchtime=.2s ;\
 	fi
 
 presubmit_old: descriptions
@@ -404,7 +407,7 @@ presubmit_gvisor: host target
 
 test: descriptions
 	# Clang tools require cgo.
-	CGO_ENABLED=1 $(GO) test -short -coverprofile=.coverage.txt ./...
+	./tools/go_test_sharded.sh ./... -short -coverprofile=.coverage.txt
 
 clean:
 	rm -rf ./bin .descriptions executor/defs.h executor/syscalls.h sys/gen sys/register.go

--- a/tools/go_test_sharded.sh
+++ b/tools/go_test_sharded.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+set -euo pipefail
+
+test_path="${1:-}"
+if [ -z "$test_path" ]; then
+	echo "Usage: $0 <test_path> [go_flags...]"
+	exit 1
+fi
+shift
+
+if [ -z "${TEST_SHARD:-}" ]; then
+	CGO_ENABLED=1 go test "$@" "$test_path"
+	exit 0
+fi
+
+IFS='/' read -r index_str total_str <<< "$TEST_SHARD"
+
+if [ -z "$index_str" ] || [ -z "$total_str" ]; then
+	echo "Invalid TEST_SHARD format: $TEST_SHARD. Expected 'index/total' (e.g. 1/5)."
+	exit 1
+fi
+
+shard_index=$((index_str - 1))
+shard_count=$total_str
+
+if [ $shard_index -lt 0 ] || [ $shard_index -ge $shard_count ]; then
+	echo "Invalid shard index: $shard_index. Must be between 0 and $((shard_count - 1))."
+	exit 1
+fi
+
+if [ "$test_path" = "./..." ]; then
+	# For full tree tests, use package-based sharding to avoid building the entire tree.
+	packages=$(CGO_ENABLED=1 go list ./... | awk "NR % $shard_count == $shard_index")
+	if [ -n "$packages" ]; then
+		CGO_ENABLED=1 go test "$@" $packages
+	fi
+else
+	# Wildcard paths (except ./...) are not supported with name-based sharding
+	# because clashing test names in subpackages would be run multiple times across shards.
+	if [[ "$test_path" == *"/..." ]]; then
+		echo "Error: Wildcard paths (except ./...) are not supported with name-based sharding."
+		exit 1
+	fi
+
+	# For specific paths (like dashboard), use name-based sharding for fine-grained parallelization.
+	tests=$(CGO_ENABLED=1 go test -list . "$test_path" | grep ^Test | \
+		awk "NR % $shard_count == $shard_index" | paste -sd "|")
+
+	if [ -n "$tests" ]; then
+		CGO_ENABLED=1 go test "$@" -run "^($tests)$" "$test_path"
+	else
+		echo "No tests selected for shard $TEST_SHARD"
+	fi
+fi


### PR DESCRIPTION
Closes #7000

```
              Job (shards): time + ...
                       aux:  4:27
                      lint:  7:14
          lint_sharded (5):  It is not easy to do. I think it is better to skip it for now.
          test_sharded (1): 10:22
          test_sharded (2):  6:24 + 8:21
          test_sharded (5):  5:15 + 6:30 + 5:19 + 5:29 + 5:33
     dashboard_sharded (1):  8:51
     dashboard_sharded (2):  6:21 + 6:20
     dashboard_sharded (5):  5:10 + 5:04 + 5:16 + 4:55 + 5:11
                      arch: 11:26 (arch_linux) - 3:38
          race_sharded (1): 14:04
          race_sharded (2):  9:28 + 10:23
         race_sharded (10):  4:44 + 5:19 + 5:47 + 5:38 + 4:57 + 5:31 + 5:50 + 5:28 + 5:47 + 6:12
race_dashboard_sharded (1): 10:56
race_dashboard_sharded (2):  8:27 + 7:53
race_dashboard_sharded (5):  6:21 + 5:57 + 6:53 + 6:26 + 6:40
                       old:  7:42
                    gvisor:  4:42
```
