### PR TITLE
dashboard/app: specify namespaces for AI clients

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -361,6 +361,7 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 	if len(req.Workflows) == 0 || req.CodeRevision == "" || req.AgentName == "" {
 		return nil, fmt.Errorf("invalid request")
 	}
+	client := apiContext(ctx).client
 	if err := aidb.AgentIsAlive(ctx, req.AgentName); err != nil {
 		log.Errorf(ctx, "failed to update agent %q: %v", req.AgentName, err)
 	}
@@ -375,7 +376,7 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 	if err := aidb.UpdateWorkflows(ctx, req.AgentName, req.Workflows); err != nil {
 		return nil, fmt.Errorf("failed UpdateWorkflows: %w", err)
 	}
-	job, err := pollAIJob(ctx, req)
+	job, err := pollAIJob(ctx, req, client)
 	if err != nil {
 		return nil, err
 	}
@@ -425,33 +426,45 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 	}, nil
 }
 
-func pollAIJob(ctx context.Context, req *dashapi.AIJobPollReq) (*aidb.Job, error) {
-	job, err := aidb.StartJob(ctx, req)
+func pollAIJob(ctx context.Context, req *dashapi.AIJobPollReq, client APIClient) (*aidb.Job, error) {
+	job, err := aidb.StartJob(ctx, req, client.AIJobNamespaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed StartJob: %w", err)
 	}
 	if job != nil {
 		return job, nil
 	}
-	job, err = aidb.NextStaleJob(ctx, req)
+	job, err = aidb.NextStaleJob(ctx, req, client.AIJobNamespaces)
 	if err != nil {
 		log.Errorf(ctx, "NextStaleJob failed: %v", err)
 	}
 	if job != nil {
 		return job, nil
 	}
-	if created, err := autoCreateAIJobs(ctx, req.Workflows); err != nil || !created {
+	if created, err := autoCreateAIJobs(ctx, req.Workflows, client); err != nil || !created {
 		return nil, err
 	}
-	job, err = aidb.StartJob(ctx, req)
+	job, err = aidb.StartJob(ctx, req, client.AIJobNamespaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed StartJob after autoCreate: %w", err)
 	}
 	return job, nil
 }
 
+func checkAiJobAccess(ctx context.Context, jobID string) (*aidb.Job, error) {
+	job, err := aidb.LoadJob(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+	client := apiContext(ctx).client
+	if !client.AllowedNamespace(job.Namespace) {
+		return nil, fmt.Errorf("client not authorized for namespace %q", job.Namespace)
+	}
+	return job, nil
+}
+
 func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
-	job, err := aidb.LoadJob(ctx, req.ID)
+	job, err := checkAiJobAccess(ctx, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -587,12 +600,16 @@ func parseJSON[T any](val spanner.NullJSON) (T, error) {
 }
 
 func apiAITrajectoryLog(ctx context.Context, req *dashapi.AITrajectoryReq) (any, error) {
+	_, err := checkAiJobAccess(ctx, req.JobID)
+	if err != nil {
+		return nil, err
+	}
 	if req.AgentName != "" {
 		if err := aidb.AgentIsAlive(ctx, req.AgentName); err != nil {
 			log.Errorf(ctx, "failed to update agent %q: %v", req.AgentName, err)
 		}
 	}
-	err := aidb.StoreTrajectorySpan(ctx, req.JobID, req.Span)
+	err = aidb.StoreTrajectorySpan(ctx, req.JobID, req.Span)
 	return nil, err
 }
 
@@ -696,10 +713,10 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 //  2. processStaleBugs: evaluates stale bugs (AIJobCheck < currentDate).
 //
 // Both phases (re-)compute applicable workflows and update AIJobCheck and AIPendingWorkflows.
-func autoCreateAIJobs(ctx context.Context, reqWorkflows []dashapi.AIWorkflow) (bool, error) {
+func autoCreateAIJobs(ctx context.Context, reqWorkflows []dashapi.AIWorkflow, client APIClient) (bool, error) {
 	date := int64(timeDate(timeNow(ctx)))
 	for ns, cfg := range getConfig(ctx).Namespaces {
-		if cfg.AI == nil {
+		if cfg.AI == nil || !client.AllowedNamespace(ns) {
 			continue
 		}
 		if created, err := findPendingJobs(ctx, ns, date, reqWorkflows); err != nil {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -823,4 +824,94 @@ func TestCompactAIJobs(t *testing.T) {
 	assert.Equal(t, "2", got[1].ID)
 	assert.Equal(t, "3", got[2].ID)
 	assert.Equal(t, "5", got[3].ID)
+}
+
+func TestAIJobNamespaces(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	// Add a restricted client to config via transformContext.
+	c.transformContext = func(ctx context.Context) context.Context {
+		cfg := *getConfig(ctx)
+		newClients := map[string]APIClient{}
+		for k, v := range cfg.Clients {
+			newClients[k] = v
+		}
+		newClients["restricted-ai"] = APIClient{
+			Key:             "restrictedkey123456",
+			Methods:         AIMethods,
+			AIJobNamespaces: []string{"ains"}, // Only allow "ains"
+		}
+		cfg.Clients = newClients
+		return contextWithConfig(ctx, &cfg)
+	}
+
+	restrictedClient := c.makeClient("restricted-ai", "restrictedkey123456", false)
+	unrestrictedClient := c.makeClient("unrestricted-ai", "unrestrictedkey1234", false)
+
+	// Create a job in access-public namespace (which restricted client should NOT see).
+	jobIDPublic, err := aidb.CreateJob(c.ctx, &aidb.Job{
+		Type:      ai.WorkflowRepro,
+		Workflow:  string(ai.WorkflowRepro),
+		Namespace: "access-public",
+	})
+	require.NoError(t, err)
+
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "restricted-agent",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowRepro, Name: string(ai.WorkflowRepro)},
+		},
+	}
+
+	// Poll should NOT return the job for access-public because the client is restricted to ains.
+	pollResp1, err := restrictedClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEqual(t, jobIDPublic, pollResp1.ID)
+
+	// Unrestricted client should get the job.
+	pollRespGlobal, err := unrestrictedClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, jobIDPublic, pollRespGlobal.ID)
+
+	// Create a job for ains (which restricted client CAN see).
+	jobIDAins, err := aidb.CreateJob(c.ctx, &aidb.Job{
+		Type:      ai.WorkflowRepro,
+		Workflow:  string(ai.WorkflowRepro),
+		Namespace: "ains",
+	})
+	require.NoError(t, err)
+
+	pollResp2, err := restrictedClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, jobIDAins, pollResp2.ID)
+
+	// Unrestricted client should also be able to see jobs in ains.
+	jobIDAins2, err := aidb.CreateJob(c.ctx, &aidb.Job{
+		Type:      ai.WorkflowRepro,
+		Workflow:  string(ai.WorkflowRepro),
+		Namespace: "ains",
+	})
+	require.NoError(t, err)
+
+	pollResp3, err := unrestrictedClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, jobIDAins2, pollResp3.ID)
+
+	// Verify trajectory log upload.
+	err = restrictedClient.AITrajectoryLog(&dashapi.AITrajectoryReq{JobID: jobIDPublic, Span: &trajectory.Span{}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authorized")
+
+	err = restrictedClient.AITrajectoryLog(&dashapi.AITrajectoryReq{JobID: jobIDAins, Span: &trajectory.Span{}})
+	require.NoError(t, err)
+
+	// .. and job completion.
+	err = restrictedClient.AIJobDone(&dashapi.AIJobDoneReq{ID: jobIDPublic})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authorized")
+
+	err = restrictedClient.AIJobDone(&dashapi.AIJobDoneReq{ID: jobIDAins})
+	require.NoError(t, err)
 }

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -146,11 +146,19 @@ func cloneJob(ctx context.Context, orig *Job) *Job {
 	}
 }
 
-func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
+func StartJob(ctx context.Context, req *dashapi.AIJobPollReq, namespaces []string) (*Job, error) {
 	var workflows []string
 	for _, flow := range req.Workflows {
 		workflows = append(workflows, flow.Name)
 	}
+	params := map[string]any{
+		"workflows":  workflows,
+		"namespaces": namespaces,
+	}
+	sql := selectJobs() + `WHERE Workflow IN UNNEST(@workflows) AND Started IS NULL
+			AND Namespace IN UNNEST(@namespaces)
+		ORDER BY Created ASC LIMIT 1`
+
 	client, err := dbClient(ctx)
 	if err != nil {
 		return nil, err
@@ -161,12 +169,8 @@ func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
 		// result if the job has been taken by a concurent thread (the len(jobs) == 0 case).
 		job = nil
 		iter := txn.Query(ctx, spanner.Statement{
-			SQL: selectJobs() + `WHERE Workflow IN UNNEST(@workflows)
-					AND Started IS NULL
-				ORDER BY Created ASC LIMIT 1`,
-			Params: map[string]any{
-				"workflows": workflows,
-			},
+			SQL:    sql,
+			Params: params,
 		})
 		defer iter.Stop()
 		var jobs []*Job
@@ -183,7 +187,7 @@ func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
 	return job, err
 }
 
-func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
+func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq, namespaces []string) (*Job, error) {
 	var workflows []string
 	for _, flow := range req.Workflows {
 		workflows = append(workflows, flow.Name)
@@ -201,14 +205,7 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 
 		// First, check if the requesting agent has any unfinished jobs (implying a restart).
 		if req.AgentName != "" {
-			iter := txn.Query(ctx, spanner.Statement{
-				SQL: selectJobs() + ` WHERE Started IS NOT NULL AND Finished IS NULL
-					AND AgentName = @agentName AND Workflow IN UNNEST(@workflows) LIMIT 1`,
-				Params: map[string]any{
-					"agentName": req.AgentName,
-					"workflows": workflows,
-				},
-			})
+			iter := txn.Query(ctx, unfinishedAgentJobs(req, workflows, namespaces))
 			defer iter.Stop()
 			if err := spanner.SelectAll(iter, &jobs); err != nil {
 				return err
@@ -217,15 +214,7 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 
 		// Check if any other agent has stale/abandoned jobs.
 		if len(jobs) == 0 {
-			iter := txn.Query(ctx, spanner.Statement{
-				SQL: selectJobs() + ` JOIN Agents USING(AgentName)
-					WHERE Started IS NOT NULL AND Finished IS NULL
-					AND LastActive <= @cutoff AND Workflow IN UNNEST(@workflows) LIMIT 1`,
-				Params: map[string]any{
-					"cutoff":    cutoff,
-					"workflows": workflows,
-				},
-			})
+			iter := txn.Query(ctx, staleUnfinishedJobs(cutoff, workflows, namespaces))
 			defer iter.Stop()
 			if err := spanner.SelectAll(iter, &jobs); err != nil {
 				return err
@@ -263,6 +252,31 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 		return txn.BufferWrite([]*spanner.Mutation{mut})
 	})
 	return job, err
+}
+
+func unfinishedAgentJobs(req *dashapi.AIJobPollReq, workflows, namespaces []string) spanner.Statement {
+	sql := selectJobs() + ` WHERE Started IS NOT NULL AND Finished IS NULL
+			AND AgentName = @agentName AND Workflow IN UNNEST(@workflows)
+			AND Namespace IN UNNEST(@namespaces) LIMIT 1`
+	params := map[string]any{
+		"agentName":  req.AgentName,
+		"workflows":  workflows,
+		"namespaces": namespaces,
+	}
+	return spanner.Statement{SQL: sql, Params: params}
+}
+
+func staleUnfinishedJobs(cutoff time.Time, workflows, namespaces []string) spanner.Statement {
+	sql := selectJobs() + ` JOIN Agents USING(AgentName)
+			WHERE Started IS NOT NULL AND Finished IS NULL
+			AND LastActive <= @cutoff AND Workflow IN UNNEST(@workflows)
+			AND Namespace IN UNNEST(@namespaces) LIMIT 1`
+	params := map[string]any{
+		"cutoff":     cutoff,
+		"workflows":  workflows,
+		"namespaces": namespaces,
+	}
+	return spanner.Statement{SQL: sql, Params: params}
 }
 
 type JobFilter struct {

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -74,6 +74,10 @@ var testConfig = &GlobalConfig{
 			Methods:          AIMethods,
 			AIWorkflowSuffix: "-foobar",
 		},
+		"unrestricted-ai": {
+			Key:     "unrestrictedkey1234",
+			Methods: AIMethods,
+		},
 	},
 	EmailBlocklist: []string{
 		"\"Bar\" <Blocked@Domain.com>",

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -10,6 +10,7 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -157,6 +158,13 @@ type APIClient struct {
 	Methods map[string]bool
 	// Suffix of AI jobs this client is allowed to execute.
 	AIWorkflowSuffix string
+	// AIJobNamespaces restricts which namespaces this global client can operate on.
+	// If empty, the client can access all namespaces (useful for development).
+	AIJobNamespaces []string
+}
+
+func (client APIClient) AllowedNamespace(ns string) bool {
+	return slices.Contains(client.AIJobNamespaces, ns)
 }
 
 var (
@@ -529,12 +537,32 @@ func checkConfig(cfg *GlobalConfig) {
 	if cfg.Namespaces[cfg.DungeonNamespace] == nil {
 		panic(fmt.Sprintf("dungeon namespace %q is not found", cfg.DungeonNamespace))
 	}
-	for ns, cfg := range cfg.Namespaces {
-		checkNamespace(ns, cfg, namespaces, clientNames)
+	var allNamespaces []string
+	for ns, nsCfg := range cfg.Namespaces {
+		checkNamespace(ns, nsCfg, namespaces, clientNames)
+		allNamespaces = append(allNamespaces, ns)
+	}
+	slices.Sort(allNamespaces)
+	for name, client := range cfg.Clients {
+		if len(client.AIJobNamespaces) == 0 {
+			client.AIJobNamespaces = allNamespaces
+			cfg.Clients[name] = client
+		}
+	}
+	for name, client := range cfg.Clients {
+		checkClientAIJobNamespaces(name, client, namespaces)
 	}
 	checkDiscussionEmails(cfg.DiscussionEmails)
 	checkMonitoredInboxes(cfg.MonitoredInboxes)
 	checkACL(cfg.ACL)
+}
+
+func checkClientAIJobNamespaces(name string, client APIClient, namespaces map[string]bool) {
+	for _, ns := range client.AIJobNamespaces {
+		if !namespaces[ns] {
+			panic(fmt.Sprintf("client %q references unknown namespace %q", name, ns))
+		}
+	}
 }
 
 func checkACL(acls []*ACLItem) {


### PR DESCRIPTION
Make it possible to restrict AI agents to specific namespaces.

Since we want syz-agents to serve several namespaces at once, it's very inconvenient to switch back to nsHandler - it would mean a unique AI client name for each served namespace.

As a straightforward solution, let's add an explicit list of namespaces for which AI jobs are to be served. Add a test to verify the new behavior.