### PR TITLE
dashboard/app: fix Google Analytics integration in dungeon templates

### DIFF
--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -87,9 +87,10 @@ func TestLocalUI(t *testing.T) {
 }
 
 var localUIConfig = &GlobalConfig{
-	AccessLevel:      AccessPublic,
-	DefaultNamespace: "upstream",
-	DungeonNamespace: "upstream",
+	AccessLevel:         AccessPublic,
+	DefaultNamespace:    "upstream",
+	DungeonNamespace:    "upstream",
+	AnalyticsTrackingID: "UA-TEST-12345",
 	Clients: map[string]APIClient{
 		localUIGlobalClient: {Key: localUIGlobalPassword},
 	},

--- a/dashboard/app/templates/dungeon-hero.html
+++ b/dashboard/app/templates/dungeon-hero.html
@@ -7,7 +7,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <head>
   <title>{{.HeroName}} - Syzkaller Dungeon</title>
-  {{template "dungeon-theme"}}
+  {{template "dungeon-theme" .}}
 </head>
 
 <body>

--- a/dashboard/app/templates/dungeon-kingdom.html
+++ b/dashboard/app/templates/dungeon-kingdom.html
@@ -7,7 +7,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <head>
   <title>{{.KingdomName}} - Syzkaller Dungeon</title>
-  {{template "dungeon-theme"}}
+  {{template "dungeon-theme" .}}
 </head>
 
 <body>

--- a/dashboard/app/templates/dungeon.html
+++ b/dashboard/app/templates/dungeon.html
@@ -7,7 +7,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 <head>
   <title>Syzkaller Dungeon</title>
-  {{template "dungeon-theme"}}
+  {{template "dungeon-theme" .}}
 </head>
 
 <body>


### PR DESCRIPTION
The Google Analytics script in `dungeon-theme.html` was not rendering because the template was included without passing the current context (the dot `.`) in `dungeon.html`, `dungeon-hero.html`, and `dungeon-kingdom.html`.

In Go templates, invoking a template without a pipeline (e.g., `{{template "dungeon-theme"}}`) sets the value of the dot `.` inside that template to `nil`. This caused the check
`{{if .Header.AnalyticsTrackingID}}` to fail, preventing the tracking script from being included in the rendered HTML.

This change passes the current context to the template call (`{{template "dungeon-theme" .}}`), ensuring that the header and the tracking ID are accessible.

Also add a dummy tracking ID to dashboard/app/local_ui_test.go.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
