### PR TITLE
prog: tolerate whitespaces before newlines

### DIFF
--- a/prog/encoding.go
+++ b/prog/encoding.go
@@ -1190,13 +1190,17 @@ func (p *parser) Scan() bool {
 		return false
 	}
 	nextLine := bytes.IndexByte(p.data, '\n')
+	var line []byte
 	if nextLine != -1 {
-		p.s = string(p.data[:nextLine])
+		line = p.data[:nextLine]
 		p.data = p.data[nextLine+1:]
 	} else {
-		p.s = string(p.data)
+		line = p.data
 		p.data = nil
 	}
+	line = bytes.TrimLeft(line, " \t")
+	line = bytes.TrimRight(line, " \t\r")
+	p.s = string(line)
 	p.i = 0
 	p.l++
 	return true

--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -373,6 +373,22 @@ func TestDeserialize(t *testing.T) {
 			In:  `mutate9(&(0x7f0000000000)='/escaping/filename\x00')`,
 			Err: `escaping filename`,
 		},
+		{
+			In:  "test$opt2(0x0)\r",
+			Out: "test$opt2(0x0)",
+		},
+		{
+			In:  "test$opt2(0x0)\r\n",
+			Out: "test$opt2(0x0)",
+		},
+		{
+			In:  "test$opt2(0x0) \t\r\n",
+			Out: "test$opt2(0x0)",
+		},
+		{
+			In:  "  test$opt2(0x0)",
+			Out: "test$opt2(0x0)",
+		},
 	})
 }
 


### PR DESCRIPTION
Ignore whitespace symbols at the end of the syzlang calls.
It pops up e.g. while copy-pasting reproducers for sending them to individual syz-managers on the web dashboard.
Also, it may make prog parsing more tolerant for pkg/aflow-generated inputs.
