### PR TITLE
Add skeptic agent to independently validate LLM analysis

### DIFF
--- a/pkg/aflow/flow/assessment/kcsan.go
+++ b/pkg/aflow/flow/assessment/kcsan.go
@@ -18,7 +18,6 @@ type kcsanInputs struct {
 	KernelConfig string
 }
 
-// nolint:dupl
 func init() {
 	aflow.Register[kcsanInputs, ai.AssessmentKCSANOutputs](
 		ai.WorkflowAssessmentKCSAN,
@@ -33,13 +32,22 @@ func init() {
 					Model: aflow.GoodBalancedModel,
 					Reply: "Explanation",
 					Outputs: aflow.LLMOutputs[struct {
-						Confident bool `jsonschema:"If you are confident in the verdict of the analysis or not."`
-						Benign    bool `jsonschema:"If the data race is benign or not."`
+						Benign bool `jsonschema:"If the data race is benign or not."`
 					}](),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: kcsanInstruction,
 					Prompt:      kcsanPrompt,
 					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+				},
+				&aflow.LLMAgent{
+					Name:  "skeptic",
+					Model: aflow.GoodBalancedModel,
+					Outputs: aflow.LLMOutputs[struct {
+						Confident bool `jsonschema:"If the expert's analysis is correct and well-supported or not."`
+					}](),
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: kcsanSkepticInstruction,
+					Prompt:      kcsanSkepticPrompt,
 				},
 			),
 		},
@@ -89,4 +97,25 @@ const kcsanPrompt = `
 The data race report is:
 
 {{.CrashReport}}
+`
+
+const kcsanSkepticInstruction = `
+You are reviewing a kernel developer's analysis of a KCSAN data race report.
+You did NOT write this analysis. Evaluate it critically and independently.
+
+Set Confident to true only if the reasoning is sound, the conclusion is clearly
+supported by evidence, and there are no significant gaps or unverified assumptions.
+Set Confident to false if there is meaningful doubt about the correctness of the verdict.
+`
+
+const kcsanSkepticPrompt = `
+The original data race report:
+{{.CrashReport}}
+
+The expert concluded the race is {{if .Benign}}benign{{else}}not benign{{end}}.
+
+Their explanation:
+{{.Explanation}}
+
+Is the conclusion well-supported? Are you confident in it?
 `

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -19,7 +19,6 @@ type moderationInputs struct {
 	KernelConfig string
 }
 
-// nolint:dupl
 func init() {
 	aflow.Register[moderationInputs, ai.ModerationOutputs](
 		ai.WorkflowModeration,
@@ -34,13 +33,22 @@ func init() {
 					Model: aflow.GoodBalancedModel,
 					Reply: "Explanation",
 					Outputs: aflow.LLMOutputs[struct {
-						Confident  bool `jsonschema:"If you are confident in the verdict of the analysis or not."`
 						Actionable bool `jsonschema:"If the report is actionable or not."`
 					}](),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: moderationInstruction,
 					Prompt:      moderationPrompt,
 					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+				},
+				&aflow.LLMAgent{
+					Name:  "skeptic",
+					Model: aflow.GoodBalancedModel,
+					Outputs: aflow.LLMOutputs[struct {
+						Confident bool `jsonschema:"If the expert's analysis is correct and well-supported or not."`
+					}](),
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: moderationSkepticInstruction,
+					Prompt:      moderationSkepticPrompt,
 				},
 			),
 		},
@@ -81,4 +89,25 @@ const moderationPrompt = `
 The bug report is:
 
 {{.CrashReport}}
+`
+
+const moderationSkepticInstruction = `
+You are reviewing a kernel developer's assessment of a bug report.
+You did NOT write this assessment. Evaluate it critically and independently.
+
+Set Confident to true only if the reasoning is sound, the conclusion is clearly
+supported by evidence, and there are no significant gaps or unverified assumptions.
+Set Confident to false if there is meaningful doubt about the correctness of the verdict.
+`
+
+const moderationSkepticPrompt = `
+The original bug report:
+{{.CrashReport}}
+
+The expert concluded the report is {{if .Actionable}}actionable{{else}}not actionable{{end}}.
+
+Their explanation:
+{{.Explanation}}
+
+Is the conclusion well-supported? Are you confident in it?
 `


### PR DESCRIPTION
Instead of asking the LLM if it's confident in its own verdict, we now have a separate skeptic agent review the analysis and assess whether it's actually sound. Removes the Confident field from the primary agent and adds independent verification to both kcsan and moderation assessment flows.