### PR TITLE
dashboard: add date range filtering for bugs

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -482,18 +482,35 @@ type userBugFilter struct {
 	OnlyManager string // show bugs that happened ONLY on the manager
 	Labels      []string
 	NoSubsystem bool
+	DateFrom    time.Time
+	DateTo      time.Time
 }
 
 func MakeBugFilter(r *http.Request) (*userBugFilter, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, err
 	}
-	return &userBugFilter{
+	filter := &userBugFilter{
 		NoSubsystem: r.FormValue("no_subsystem") != "",
 		Manager:     r.FormValue("manager"),
 		OnlyManager: r.FormValue("only_manager"),
 		Labels:      r.Form["label"],
-	}, nil
+	}
+	if s := r.FormValue("date_from"); s != "" {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date_from: %w", err)
+		}
+		filter.DateFrom = t
+	}
+	if s := r.FormValue("date_to"); s != "" {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date_to: %w", err)
+		}
+		filter.DateTo = t.Add(24*time.Hour - time.Nanosecond)
+	}
+	return filter, nil
 }
 
 func (filter *userBugFilter) MatchManagerName(name string) bool {
@@ -530,7 +547,34 @@ func (filter *userBugFilter) MatchBug(bug *Bug) bool {
 			return false
 		}
 	}
+	if !filter.DateFrom.IsZero() || !filter.DateTo.IsZero() {
+		t := bug.FirstTime
+		if !bug.Closed.IsZero() {
+			t = bug.Closed
+		}
+		if !filter.DateFrom.IsZero() && t.Before(filter.DateFrom) {
+			return false
+		}
+		if !filter.DateTo.IsZero() && t.After(filter.DateTo) {
+			return false
+		}
+	}
 	return true
+}
+
+func (filter *userBugFilter) DateFromStr() string {
+	if filter.DateFrom.IsZero() {
+		return ""
+	}
+	return filter.DateFrom.Format("2006-01-02")
+}
+
+func (filter *userBugFilter) DateToStr() string {
+	if filter.DateTo.IsZero() {
+		return ""
+	}
+	// DateTo is stored as end-of-day; truncate back to the date.
+	return filter.DateTo.Truncate(24 * time.Hour).Format("2006-01-02")
 }
 
 func (filter *userBugFilter) Hash() string {
@@ -546,7 +590,8 @@ func (filter *userBugFilter) Any() bool {
 	if filter == nil {
 		return false
 	}
-	return len(filter.Labels) > 0 || filter.OnlyManager != "" || filter.Manager != "" || filter.NoSubsystem
+	return len(filter.Labels) > 0 || filter.OnlyManager != "" || filter.Manager != "" || filter.NoSubsystem ||
+		!filter.DateFrom.IsZero() || !filter.DateTo.IsZero()
 }
 
 // handleMain serves main page.

--- a/dashboard/app/main_test.go
+++ b/dashboard/app/main_test.go
@@ -194,6 +194,41 @@ func TestMainBugFilters(t *testing.T) {
 	assert.Contains(t, string(reply), crash1.Title) // the bug has no subsystems
 }
 
+func TestDateRangeFilter(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.client
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	crash.Title = "date-filter-crash"
+	client.ReportCrash(crash)
+	c.globalClient.pollBugs(1)
+
+	// Bug's FirstTime is around 2000-01-01 (mocked time).
+	reply, err := c.AuthGET(AccessAdmin, "/test1?date_from=2000-01-01&date_to=2000-12-31")
+	c.expectOK(err)
+	assert.Contains(t, string(reply), crash.Title)
+	assert.Contains(t, string(reply), "Applied filters")
+	assert.Contains(t, string(reply), "date_from=2000-01-01")
+
+	// Exclude the bug by specifying a range in the future.
+	reply, err = c.AuthGET(AccessAdmin, "/test1?date_from=2001-01-01")
+	c.expectOK(err)
+	assert.NotContains(t, string(reply), crash.Title)
+
+	// Exclude the bug by specifying a range in the past.
+	reply, err = c.AuthGET(AccessAdmin, "/test1?date_to=1999-12-31")
+	c.expectOK(err)
+	assert.NotContains(t, string(reply), crash.Title)
+
+	// Invalid date format returns an error.
+	_, err = c.AuthGET(AccessAdmin, "/test1?date_from=not-a-date")
+	assert.Error(t, err)
+}
+
 func TestSubsystemsList(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -151,6 +151,12 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{if .Filter.NoSubsystem}}
 		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem" "") "drop"}})
 	{{end}}
+	{{if .Filter.DateFromStr}}
+		date_from={{.Filter.DateFromStr}} ({{link (call .DropURL "date_from" "") "drop"}})
+	{{end}}
+	{{if .Filter.DateToStr}}
+		date_to={{.Filter.DateToStr}} ({{link (call .DropURL "date_to" "") "drop"}})
+	{{end}}
 	{{$drop := .DropURL}}
 	{{range .Filter.Labels}}
 		Label={{.}} ({{link (call $drop "label" .) "drop"}})


### PR DESCRIPTION
Adds ability to filter bugs by date range on the dashboard. Uses closure date when available, otherwise creation date. The date_to parameter is inclusive (end of day).

Fixes #6462