### PR TITLE
all: add missing broken compiler checks

### DIFF
--- a/pkg/aflow/flow/patching/actions_test.go
+++ b/pkg/aflow/flow/patching/actions_test.go
@@ -6,10 +6,12 @@ package patching
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +66,10 @@ syz-cluster: rewrite fuzz config generation
 }
 
 func TestSyzlangToC(t *testing.T) {
+	sysTarget := targets.Get("linux", "amd64")
+	if runtime.GOOS != sysTarget.BuildOS || sysTarget.BrokenCompiler != "" {
+		t.Skip("cannot build linux/amd64 on this host")
+	}
 	validProg := `r0 = openat(0xffffffffffffff9c, &AUTO='./file1\x00', 0x42, 0x1ff)
 write(r0, &AUTO="01010101", 0x4)
 `

--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -342,6 +342,10 @@ func TestWriteLLM(t *testing.T) {
 	t.Parallel()
 	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)
 	require.NoError(t, err)
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("compiler is broken: %v", sysTarget.BrokenCompiler)
+	}
 
 	p, err := target.Deserialize([]byte(`
 r0 = csource0(0x1)


### PR DESCRIPTION
This should resolve recent test failures on OpenBSD.

Cc @blackgnezdo 