### PR TITLE
dashboard/app/aidb: better isolate transaction retries

### DIFF
--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -157,6 +157,9 @@ func StartJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) {
 	}
 	var job *Job
 	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Reset job from previous transaction runs, otherwise we might return stale
+		// result if the job has been taken by a concurent thread (the len(jobs) == 0 case).
+		job = nil
 		iter := txn.Query(ctx, spanner.Statement{
 			SQL: selectJobs() + `WHERE Workflow IN UNNEST(@workflows)
 					AND Started IS NULL
@@ -192,6 +195,8 @@ func NextStaleJob(ctx context.Context, req *dashapi.AIJobPollReq) (*Job, error) 
 	cutoff := TimeNow(ctx).Add(-8 * time.Hour)
 	var job *Job
 	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Avoid reusing the entities from previous transaction commit attempts.
+		job = nil
 		var jobs []*Job
 
 		// First, check if the requesting agent has any unfinished jobs (implying a restart).


### PR DESCRIPTION
In two cases, the code enabled the following unwanted situation: 
1) We start a transaction and set a *Job value to be returned.
2) Transaction is aborted due to a conflict.
3) Transaction is restarted.
4) We do a new SELECT query, which now returns 0 jobs to process.
5) We return with a nil error and a stale job.

Fixes https://github.com/google/syzkaller/issues/7054