### PR TITLE
vm/proxyapp: fix race condition in TCP mock server

### DIFF
--- a/vm/proxyapp/proxyappclient_tcp_test.go
+++ b/vm/proxyapp/proxyappclient_tcp_test.go
@@ -179,6 +179,9 @@ func TestCtor_TCP_Reconnect_PoolChanged(t *testing.T) {
 		}).
 		Return(nil).
 		On("PoolLogs", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-t.Context().Done()
+		}).
 		Return(nil)
 
 	p, _ := ctor(makeTestParams(), testTCPEnv(port))
@@ -211,11 +214,11 @@ func makeMockProxyAppServerWithListener(t *testing.T, l net.Listener) (*mockProx
 			if err != nil {
 				panic("failed to accept connection")
 			}
-			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
-
 			connsMu.Lock()
 			conns = append(conns, conn)
 			connsMu.Unlock()
+
+			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
 


### PR DESCRIPTION
The mock TCP server used in TestCtor_TCP_Reconnect_PoolChanged started the RPC ServeCodec goroutine before appending the connection to the tracked `conns` slice.

The test intends to simulate a server disconnect by calling `closeServerConnections()`. Due to the race condition, the active connection was sometimes missing from `conns` and left open. Because the connection remained open and the mocked `PoolLogs` returned success, the client never detected a disconnect. Consequently, it never attempted to reconnect, causing the test to wait indefinitely.

Fix the race condition by safely appending the connection to the slice before starting the handler. Also, explicitly block the `PoolLogs` mock with an empty select to correctly simulate the long-polling behavior of log streaming instead of busy-looping on success.

Fixes https://github.com/google/syzkaller/issues/6479