### PR TITLE
dashboard/app: fix forwarding loop for duplicate mailing list emails

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1454,6 +1454,19 @@ Author: someone@mail.com
 				EmailOptCC(append(append([]string{}, msg.Cc...), msg.To...)))
 			c.expectNoEmail()
 		})
+
+		t.Run("duplicate-from-mailing-list", func(t *testing.T) {
+			mailingList := c.config().Namespaces["access-public-email"].Reporting[0].Config.(*EmailConfig).Email
+			// Ensure we don't forward the same email when we receive it again via a mailing list.
+			c.incomingEmail(from,
+				"#syz invalid",
+				EmailOptSubject("test subject"),
+				EmailOptMessageID(1),
+				EmailOptFrom("someone@mail.com"),
+				EmailOptCC([]string{"some@list.com"}), // same as original
+				EmailOptSender(mailingList))           // this makes msg.MailingList set
+			c.expectNoEmail()
+		})
 	})
 
 	t.Run("no command", func(t *testing.T) {

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -659,6 +659,10 @@ func processInboxEmail(ctx context.Context, msg *email.Email, inbox *PerInboxCon
 		// Also, we don't care about the emails that don't include any BugIDs.
 		return nil
 	}
+	if msg.MailingList != "" {
+		log.Infof(ctx, "duplicate email from mailing list, ignoring")
+		return nil
+	}
 	needForwardTo := map[string]bool{}
 	for _, cc := range inbox.ForwardTo {
 		needForwardTo[cc] = true


### PR DESCRIPTION
When an email is sent to an address matching `MonitoredInboxes` and also CCed to a mailing list, the dashboard receives multiple copies. The `processInboxEmail` forwarding logic lacked the `msg.MailingList != ""` deduplication check that is present in `processIncomingEmail`. This caused every copy from every mailing list to trigger an additional blind forward back to the author.

Add the missing `msg.MailingList != ""` check and an integration test.