### PR TITLE
vm/dispatcher: fix flaky TestPoolDefault

### DIFF
--- a/vm/dispatcher/pool_test.go
+++ b/vm/dispatcher/pool_test.go
@@ -353,8 +353,11 @@ func (ti *testInstance) waitRun() {
 }
 
 func (ti *testInstance) stopRun() {
-	close(ti.stop)
+	// The order is important: clear hasRun before unblocking the job.
+	// Otherwise, the pool might quickly restart the job and set hasRun to true
+	// before we execute Store(false) here, leading to a deadlock in waitRun.
 	ti.hasRun.Store(false) // make subsequent waitRun() actually wait for the next command.
+	close(ti.stop)
 }
 
 func (ti *testInstance) Index() int {


### PR DESCRIPTION
In the test mock's stopRun, closing the ti.stop channel before clearing the ti.hasRun flag introduces a race condition. If the testing goroutine is preempted immediately after closing the channel, the dispatcher pool can quickly restart the instance and set hasRun to true. The test goroutine would then resume and erroneously overwrite it to false.

This resulted in waitRun blocking indefinitely and triggering a 10-minute timeout. The fix ensures the state is cleared before the channel is closed.

Fixes https://github.com/google/syzkaller/issues/7011.
