### PR TITLE
SCP updates

### DIFF
--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -315,12 +315,15 @@ func (inst *instance) Forward(port int) (string, error) {
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	vmDst := filepath.Join("/root", filepath.Base(hostSrc))
-	args := append(vmimpl.SCPArgs(inst.debug, inst.Key, inst.Port, false),
-		hostSrc, inst.User+"@"+inst.Addr+":"+vmDst)
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-	}
-	_, err := osutil.RunCmd(10*time.Minute, "", "scp", args...)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:        inst.debug,
+		Key:          inst.Key,
+		Port:         inst.Port,
+		SystemSSHCfg: false,
+		User:         inst.User,
+		Addr:         inst.Addr,
+		Timeout:      10 * time.Minute,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -278,9 +278,17 @@ func (inst *instance) Forward(port int) (string, error) {
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	vmDst := "./" + filepath.Base(hostSrc)
-	args := append(vmimpl.SCPArgs(true, inst.Key, inst.Port, false),
-		hostSrc, inst.User+"@"+inst.Addr+":"+vmDst)
-	if err := runCmd(inst.debug, "scp", args...); err != nil {
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:         inst.debug,
+		Key:           inst.Key,
+		Port:          inst.Port,
+		SystemSSHCfg:  false,
+		User:          inst.User,
+		Addr:          inst.Addr,
+		Timeout:       time.Minute,
+		VerboseOutput: true,
+	})
+	if err != nil {
 		return "", err
 	}
 	return vmDst, nil
@@ -567,15 +575,4 @@ func uploadImageToGCS(localImage, gcsImage string) error {
 		return fmt.Errorf("failed to write image file: %w", err)
 	}
 	return nil
-}
-
-func runCmd(debug bool, bin string, args ...string) error {
-	if debug {
-		log.Logf(0, "running command: %v %#v", bin, args)
-	}
-	output, err := osutil.RunCmd(time.Minute, "", bin, args...)
-	if debug {
-		log.Logf(0, "result: %v\n%s", err, output)
-	}
-	return err
 }

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -285,27 +285,15 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	baseName := filepath.Base(hostSrc)
 	vmDst := filepath.Join(inst.cfg.TargetDir, baseName)
 	inst.ssh("pkill -9 '" + baseName + "'; rm -f '" + vmDst + "'")
-	args := append(vmimpl.SCPArgs(inst.debug, inst.Key, inst.Port, inst.cfg.SystemSSHCfg),
-		hostSrc, inst.User+"@"+inst.Addr+":"+vmDst)
-	cmd := osutil.Command("scp", args...)
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stdout
-	}
-	if err := cmd.Start(); err != nil {
-		return "", err
-	}
-	done := make(chan bool)
-	go func() {
-		select {
-		case <-time.After(3 * time.Minute):
-			cmd.Process.Kill()
-		case <-done:
-		}
-	}()
-	err := cmd.Wait()
-	close(done)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:        inst.debug,
+		Key:          inst.Key,
+		Port:         inst.Port,
+		SystemSSHCfg: inst.cfg.SystemSSHCfg,
+		User:         inst.User,
+		Addr:         inst.Addr,
+		Timeout:      3 * time.Minute,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -674,12 +674,16 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		inst.files[vmDst] = hostSrc
 	}
 
-	args := append(vmimpl.SCPArgs(true, inst.Key, inst.Port, false),
-		hostSrc, inst.User+"@localhost:"+vmDst)
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-	}
-	_, err := osutil.RunCmd(10*time.Minute*inst.timeouts.Scale, "", "scp", args...)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:         inst.debug,
+		Key:           inst.Key,
+		Port:          inst.Port,
+		SystemSSHCfg:  false,
+		User:          inst.User,
+		Addr:          "localhost",
+		Timeout:       10 * time.Minute * inst.timeouts.Scale,
+		VerboseOutput: true,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -423,18 +422,6 @@ func (inst *instance) copyFfxConfigValuesToIsolate(keys ...string) error {
 	return nil
 }
 
-// Runs a command inside the fuchsia directory.
-func (inst *instance) runCommand(cmd string, args ...string) error {
-	if inst.debug {
-		log.Logf(1, "instance %s: running command: %s %q", inst.name, cmd, args)
-	}
-	output, err := osutil.RunCmd(5*time.Minute, inst.fuchsiaDir, cmd, args...)
-	if inst.debug {
-		log.Logf(1, "instance %s: %s", inst.name, output)
-	}
-	return err
-}
-
 func (inst *instance) Forward(port int) (string, error) {
 	if port == 0 {
 		return "", fmt.Errorf("vm/starnix: forward port is zero")
@@ -452,15 +439,15 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	if inst.debug {
 		log.Logf(1, "instance %s: attempting to push binary %s to instance over scp", inst.name, base)
 	}
-	err := inst.runCommand(
-		"scp",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-i", inst.sshPrivKey,
-		"-P", strconv.Itoa(inst.port),
-		hostSrc,
-		fmt.Sprintf("root@localhost:%s", vmDst),
-	)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:   inst.debug,
+		Key:     inst.sshPrivKey,
+		Port:    inst.port,
+		User:    "root",
+		Addr:    "localhost",
+		Dir:     inst.fuchsiaDir,
+		Timeout: 5 * time.Minute,
+	})
 	if err == nil {
 		return vmDst, err
 	}

--- a/vm/virtualbox/virtualbox.go
+++ b/vm/virtualbox/virtualbox.go
@@ -257,15 +257,15 @@ func (inst *instance) Close() error {
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	base := filepath.Base(hostSrc)
 	vmDest := "/" + base
-
-	args := vmimpl.SCPArgs(inst.debug, inst.SSHOptions.Key, inst.SSHOptions.Port, false)
-	args = append(args, hostSrc, fmt.Sprintf("%v@127.0.0.1:%v", inst.SSHOptions.User, vmDest))
-
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-	}
-
-	if _, err := osutil.RunCmd(3*time.Minute, "", "scp", args...); err != nil {
+	err := vmimpl.SCP(hostSrc, vmDest, vmimpl.SCPOptions{
+		Debug:   inst.debug,
+		Key:     inst.SSHOptions.Key,
+		Port:    inst.SSHOptions.Port,
+		User:    inst.SSHOptions.User,
+		Addr:    "127.0.0.1",
+		Timeout: 3 * time.Minute,
+	})
+	if err != nil {
 		return "", err
 	}
 	return vmDest, nil

--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -4,6 +4,7 @@
 package vmimpl
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -103,4 +104,40 @@ func sshArgs(debug bool, sshKey, portArg string, port, forwardPort int, systemSS
 		args = append(args, "-v")
 	}
 	return args
+}
+
+type SCPOptions struct {
+	Debug         bool
+	Key           string
+	Port          int
+	SystemSSHCfg  bool
+	User          string
+	Addr          string
+	Timeout       time.Duration
+	Dir           string
+	VerboseOutput bool
+}
+
+func SCP(hostSrc, vmDst string, opts SCPOptions) error {
+	args := append(SCPArgs(opts.VerboseOutput, opts.Key, opts.Port, opts.SystemSSHCfg),
+		hostSrc, opts.User+"@"+opts.Addr+":"+vmDst)
+	if opts.Debug {
+		log.Logf(0, "running command: scp %#v", args)
+	}
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+	output, err := osutil.RunCmd(timeout, opts.Dir, "scp", args...)
+	if err != nil {
+		var verr *osutil.VerboseError
+		if errors.As(err, &verr) {
+			return fmt.Errorf("scp failed: %w\n%s", err, string(verr.Output))
+		}
+		return fmt.Errorf("scp failed: %w", err)
+	}
+	if opts.Debug {
+		log.Logf(0, "result: %s", output)
+	}
+	return nil
 }

--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -76,7 +76,7 @@ func SSHArgsForward(debug bool, sshKey string, port, forwardPort int, systemSSHC
 	return sshArgs(debug, sshKey, "-p", port, forwardPort, systemSSHCfg)
 }
 
-func SCPArgs(debug bool, sshKey string, port int, systemSSHCfg bool) []string {
+func scpArgs(debug bool, sshKey string, port int, systemSSHCfg bool) []string {
 	return sshArgs(debug, sshKey, "-P", port, 0, systemSSHCfg)
 }
 
@@ -119,7 +119,7 @@ type SCPOptions struct {
 }
 
 func SCP(hostSrc, vmDst string, opts SCPOptions) error {
-	args := append(SCPArgs(opts.VerboseOutput, opts.Key, opts.Port, opts.SystemSSHCfg),
+	args := append(scpArgs(opts.VerboseOutput, opts.Key, opts.Port, opts.SystemSSHCfg),
 		hostSrc, opts.User+"@"+opts.Addr+":"+vmDst)
 	if opts.Debug {
 		log.Logf(0, "running command: scp %#v", args)

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -239,12 +239,14 @@ func (inst *instance) Forward(port int) (string, error) {
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	vmDst := filepath.Join("/root", filepath.Base(hostSrc))
-	args := append(vmimpl.SCPArgs(inst.debug, inst.Key, inst.Port, false),
-		hostSrc, inst.User+"@"+inst.Addr+":"+vmDst)
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-	}
-	_, err := osutil.RunCmd(10*time.Minute, "", "scp", args...)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:        inst.debug,
+		Key:          inst.Key,
+		Port:         inst.Port,
+		SystemSSHCfg: false,
+		User:         inst.User,
+		Addr:         inst.Addr,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -159,15 +159,15 @@ func (inst *instance) Close() error {
 func (inst *instance) Copy(hostSrc string) (string, error) {
 	base := filepath.Base(hostSrc)
 	vmDst := filepath.Join("/", base)
-
-	args := append(vmimpl.SCPArgs(inst.debug, inst.sshkey, 22, false),
-		hostSrc, fmt.Sprintf("%v@%v:%v", inst.sshuser, inst.ipAddr, vmDst))
-
-	if inst.debug {
-		log.Logf(0, "running command: scp %#v", args)
-	}
-
-	_, err := osutil.RunCmd(3*time.Minute, "", "scp", args...)
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:        inst.debug,
+		Key:          inst.sshkey,
+		Port:         22,
+		SystemSSHCfg: false,
+		User:         inst.sshuser,
+		Addr:         inst.ipAddr,
+		Timeout:      3 * time.Minute,
+	})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
vm: refactor SCP usage to use centralized vmimpl.SCP

Behavioral differences:
  - All VMs using vmimpl.SCP with debug enabled will now log the output on success.
  - vm/starnix: Added standard SSH options (IdentitiesOnly, BatchMode, ConnectTimeout).
  - vm/isolated: the timeout implementation was simplified to use osutil.RunCmd timeout handling. Additionally, output is no longer streamed on debug, instead it will be logged at the end of execution, similar to all VM implementations.