### PR TITLE
syz-cluster/workflow/triage: fix tree lookup by exact name

### DIFF
--- a/syz-cluster/pkg/triage/tree.go
+++ b/syz-cluster/pkg/triage/tree.go
@@ -4,6 +4,7 @@
 package triage
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -54,4 +55,14 @@ func FindTree(trees []*api.Tree, branch string) (int, string) {
 		}
 	}
 	return -1, ""
+}
+
+func FindTreeByName(trees []*api.Tree, name string) *api.Tree {
+	idx := slices.IndexFunc(trees, func(t *api.Tree) bool {
+		return t.Name == name
+	})
+	if idx != -1 {
+		return trees[idx]
+	}
+	return nil
 }

--- a/syz-cluster/pkg/triage/tree_test.go
+++ b/syz-cluster/pkg/triage/tree_test.go
@@ -86,3 +86,10 @@ func TestTreeFromBranch(t *testing.T) {
 	treeIdx, _ = FindTree(trees, "c/some_branch")
 	assert.Equal(t, -1, treeIdx)
 }
+
+func TestFindTreeByName(t *testing.T) {
+	trees := []*api.Tree{{Name: "a"}, {Name: "b"}}
+	assert.Equal(t, "a", FindTreeByName(trees, "a").Name)
+	assert.Equal(t, "b", FindTreeByName(trees, "b").Name)
+	assert.Nil(t, FindTreeByName(trees, "c"))
+}

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -171,8 +171,8 @@ func (triager *seriesTriager) prepareJobTask(
 ) (*api.TriageResult, error) {
 	var targets []*api.TestTarget
 	for i, task := range job.FindingGroups {
-		treeIndex, _ := triage.FindTree(trees, task.Build.TreeName)
-		if treeIndex == -1 {
+		foundTree := triage.FindTreeByName(trees, task.Build.TreeName)
+		if foundTree == nil {
 			return &api.TriageResult{
 				SkipReason: fmt.Sprintf("tree %q is no longer known", task.Build.TreeName),
 			}, nil


### PR DESCRIPTION
The prepareJobTask function was incorrectly using triage.FindTree to find a tree by its exact name. FindTree expects a composite string in the format "TreeName/BranchName" (e.g., "net-next/master") and fails when given just the tree name (e.g., "net-next"), resulting in a "tree is no longer known" error.

Add a new triage.FindTreeByName helper function to correctly look up trees by their exact name and update the workflow to use it.