### PR TITLE
pkg/repro: avoid slipping to low-priority crashes

### DIFF
--- a/pkg/report/crash/title_to_type.go
+++ b/pkg/report/crash/title_to_type.go
@@ -270,6 +270,10 @@ var titleToType = []struct {
 		crashType: DoS,
 	},
 	{
+		includePrefixes: []string{"no output from test machine"},
+		crashType:       NoOutput,
+	},
+	{
 		includePrefixes: []string{"unexpected kernel reboot"},
 		crashType:       UnexpectedReboot,
 	},

--- a/pkg/report/crash/types.go
+++ b/pkg/report/crash/types.go
@@ -49,6 +49,7 @@ const (
 	Warning                 = Type("WARNING")
 	// keep-sorted end
 	LostConnection   = Type("LOST_CONNECTION")
+	NoOutput         = Type("NO_OUTPUT")
 	SyzFailure       = Type("SYZ_FAILURE")
 	UnexpectedReboot = Type("REBOOT")
 )

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -63,7 +63,7 @@ type reproContext struct {
 	stats          *Stats
 	report         *report.Report
 	timeouts       targets.Timeouts
-	observedTitles map[string]bool
+	observedTitles map[string]crash.Type
 	fast           bool
 }
 
@@ -148,10 +148,11 @@ func runInner(ctx context.Context, crashLog []byte, env Environment, exec execIn
 		startOpts:      createStartOptions(cfg, env.Features, crashType),
 		stats:          new(Stats),
 		timeouts:       cfg.Timeouts,
-		observedTitles: map[string]bool{},
+		observedTitles: map[string]crash.Type{},
 		fast:           env.Fast,
 		logf:           env.logf,
 	}
+
 	return reproCtx.run()
 }
 
@@ -708,16 +709,40 @@ func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, er
 		ctx.reproLogf(2, "not a leak crash: %v", rep.Title)
 		return verdict{false, result.Duration}, nil
 	}
-	if strict && len(ctx.observedTitles) > 0 {
-		if !ctx.observedTitles[rep.Title] {
-			ctx.reproLogf(2, "a never seen crash title: %v, ignore", rep.Title)
-			return verdict{false, result.Duration}, nil
-		}
+	if _, ok := ctx.observedTitles[rep.Title]; ok {
+		// Already established title, always permit.
+	} else if !isHighPrioReport(rep.Type) && ctx.observedHighPrioCrash() {
+		ctx.reproLogf(2, "ignore low priority crash: %v", rep.Title)
+		return verdict{false, result.Duration}, nil
+	} else if strict && len(ctx.observedTitles) > 0 {
+		ctx.reproLogf(2, "a never seen crash title: %v, ignore", rep.Title)
+		return verdict{false, result.Duration}, nil
 	} else {
-		ctx.observedTitles[rep.Title] = true
+		ctx.observedTitles[rep.Title] = rep.Type
 	}
 	ctx.report = rep
 	return verdict{true, result.Duration}, nil
+}
+
+func (ctx *reproContext) observedHighPrioCrash() bool {
+	if isHighPrioReport(ctx.crashType) {
+		return true
+	}
+	for _, typ := range ctx.observedTitles {
+		if isHighPrioReport(typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHighPrioReport(typ crash.Type) bool {
+	switch typ {
+	case crash.LostConnection, crash.NoOutput, crash.SyzFailure, crash.UnexpectedReboot:
+		return false
+	default:
+		return true
+	}
 }
 
 var ErrNoVMs = errors.New("all VMs failed to boot")

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/google/syzkaller/pkg/instance"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/report/crash"
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
@@ -180,6 +182,7 @@ func fakeCrashResult(title string) *instance.RunResult {
 	if title != "" {
 		ret.Report = &report.Report{
 			Title: title,
+			Type:  crash.TitleToType(title),
 		}
 	}
 	return ret
@@ -375,4 +378,36 @@ func TestBrokenCompilerRepro(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, false, result.CRepro, "C repro should have been skipped")
+}
+
+func TestAvoidLostConnection(t *testing.T) {
+	const log = `
+2015/12/21 12:18:05 executing program 1:
+pause()
+2015/12/21 12:18:10 executing program 2:
+alarm(0xa)
+`
+	panicLog := log + "\npanic: some error\n"
+
+	result, _, err := runTestRepro(t, panicLog, &testExecInterface{
+		run: func(p []byte) (*instance.RunResult, error) {
+			if strings.Contains(string(p), "alarm(0xa)") && !strings.Contains(string(p), "pause()") {
+				// alarm(0xa) alone causes a system failure.
+				return &instance.RunResult{
+					Report: &report.Report{
+						Title: "lost connection to test machine",
+						Type:  crash.LostConnection,
+					},
+				}, nil
+			}
+			if strings.Contains(string(p), "pause()") && strings.Contains(string(p), "alarm(0xa)") {
+				// The combination causes the target bug.
+				return fakeCrashResult("panic: some error"), nil
+			}
+			return fakeCrashResult(""), nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "pause()\nalarm(0xa)\n", string(result.Prog.Serialize()))
 }


### PR DESCRIPTION
During reproduction, if we have already established a "high-priority" crash (like KASAN or BUG), we should ignore "low-priority" reports like "lost connection to test machine" or "SYZFATAL".

Previously, if such a generic failure happened during minimization, it would be added to the observed titles and the reproduction would happily continue with it, effectively losing the original bug.

Also store crash types in observedTitles and use them to simplify the priority logic.