### PR TITLE
.github/workflows: secure Codecov uploads for forks via workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,12 @@ jobs:
         run: |
           cd gopath/src/github.com/google/syzkaller
           .github/workflows/run.sh make presubmit_build
-      - name: codecov
-        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
+      - name: upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          codecov_yml_path: ${{env.GOPATH}}/src/github.com/google/syzkaller/.github/codecov.yml
-          file: ${{env.GOPATH}}/src/github.com/google/syzkaller/.coverage.txt
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+          name: coverage-unittests
+          path: gopath/src/github.com/google/syzkaller/.coverage.txt
+          include-hidden-files: true
 
   dashboard:
     runs-on: ubuntu-22.04-16core
@@ -101,14 +99,12 @@ jobs:
         run: |
           cd gopath/src/github.com/google/syzkaller
           .github/workflows/run.sh timeout --signal=SIGINT 15m make presubmit_dashboard
-      - name: codecov
-        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
+      - name: upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          codecov_yml_path: ${{env.GOPATH}}/src/github.com/google/syzkaller/.github/codecov.yml
-          file: ${{env.GOPATH}}/src/github.com/google/syzkaller/.coverage.txt
-          flags: dashboard
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+          name: coverage-dashboard
+          path: gopath/src/github.com/google/syzkaller/.coverage.txt
+          include-hidden-files: true
 
   arch:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,0 +1,55 @@
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name: upload-coverage
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            .github/codecov.yml
+          sparse-checkout-cone-mode: false
+
+      - name: download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: coverage-reports
+
+      - name: upload unittests coverage
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          codecov_yml_path: .github/codecov.yml
+          files: coverage-reports/coverage-unittests/.coverage.txt
+          flags: unittests
+          slug: ${{ github.event.workflow_run.repository.full_name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+          pr: ${{ github.event.workflow_run.pull_requests[0].number }}
+          verbose: true
+
+      - name: upload dashboard coverage
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          codecov_yml_path: .github/codecov.yml
+          files: coverage-reports/coverage-dashboard/.coverage.txt
+          flags: dashboard
+          slug: ${{ github.event.workflow_run.repository.full_name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+          pr: ${{ github.event.workflow_run.pull_requests[0].number }}
+          verbose: true


### PR DESCRIPTION
Implement the workflow_run pattern to securely support Codecov coverage uploads for Pull Requests from forks. This separates untrusted test execution from trusted coverage upload using repository secrets.

upload-coverage.yml will start working once merged. There is no way to test it now.
