### PR TITLE
vm/vmimpl: log verbose scp output instead of returning it in error

### DIFF
--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -132,7 +132,7 @@ func SCP(hostSrc, vmDst string, opts SCPOptions) error {
 	if err != nil {
 		var verr *osutil.VerboseError
 		if errors.As(err, &verr) {
-			return fmt.Errorf("scp failed: %w\n%s", err, string(verr.Output))
+			log.Logf(0, "scp failed: %v\n%s", err, string(verr.Output))
 		}
 		return fmt.Errorf("scp failed: %w", err)
 	}


### PR DESCRIPTION
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
