### PR TITLE
syz-ci: clone repository under sandbox user

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -689,8 +690,11 @@ func (jp *JobProcessor) initJobRepo(mgr *Manager, repoDir string) error {
 	}
 	if osutil.IsExist(mgr.kernelBuildDir) {
 		jp.Logf(0, "cloning job repo from %v using reference", mgr.kernelBuildDir)
-		output, err := osutil.RunCmd(time.Hour, "", "git", "clone",
-			"--reference", mgr.kernelBuildDir, mgr.kernelBuildDir, repoDir)
+		cmd := exec.Command("git", "clone", "--reference", mgr.kernelBuildDir, mgr.kernelBuildDir, repoDir)
+		if err := osutil.Sandbox(cmd, true, false); err != nil {
+			return fmt.Errorf("failed to sandbox clone: %w", err)
+		}
+		output, err := osutil.Run(time.Hour, cmd)
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
Since we'll be fetching the target kernel from under a different user, we may run into access problems. Do the `git clone --reference` from under the target user to avoid this. It must succeed since the per-manager repo is owner by that user as well.

Follow-up after https://github.com/google/syzkaller/pull/7088