### PR TITLE
pkg/email: fix environment-dependent time comparison in TestParse

### DIFF
--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -121,6 +121,12 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// If the parsed date represents the same instant as the expected date,
+			// align the location to avoid failures due to environment-dependent
+			// location pointers in testify's Equal (e.g. time.Local vs fixed zone).
+			if test.res.Date.Equal(email.Date) {
+				email.Date = test.res.Date
+			}
 			assert.Equal(t, &test.res, email)
 		}
 		t.Run(fmt.Sprint(i), func(t *testing.T) { body(t, test) })


### PR DESCRIPTION
The test TestParse was failing in environments where the local time zone offset matched the offset in the email date string (-0700). This caused mail.ParseDate to return a time with time.Local location, which failed equality with the expected fixed zone location in testify's assert.Equal.

To fix this, we now use time.Equal to check if the times represent the same instant, and if so, align the location before calling assert.Equal.

To reproduce the problem, run:
CI=true ./tools/syz-env 'TZ="America/Los_Angeles" go test ./pkg/email -run TestParse -count=1'

Update #6915.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
