### PR TITLE
pkg/gce: attach configurable GCP labels to managed VMs and images

### DIFF
--- a/pkg/gce/gce.go
+++ b/pkg/gce/gce.go
@@ -60,6 +60,7 @@ type InstanceConfig struct {
 	Image                string
 	SSHKey               string
 	Tags                 []string
+	Labels               map[string]string
 	Preemptible          bool
 	DisplayDevice        bool
 	NestedVirtualization bool
@@ -145,6 +146,7 @@ func (ctx *Context) CreateInstance(cfg *InstanceConfig) (string, error) {
 		Name:        cfg.Name,
 		Description: "syzkaller worker",
 		MachineType: prefix + "/zones/" + ctx.ZoneID + "/machineTypes/" + cfg.MachineType,
+		Labels:      cfg.Labels,
 		Disks: []*compute.AttachedDisk{
 			{
 				AutoDelete: true,
@@ -154,6 +156,7 @@ func (ctx *Context) CreateInstance(cfg *InstanceConfig) (string, error) {
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					DiskName:    cfg.Name,
 					SourceImage: prefix + "/global/images/" + cfg.Image,
+					Labels:      cfg.Labels,
 				},
 			},
 		},
@@ -288,7 +291,7 @@ func (ctx *Context) IsInstanceRunning(name string) bool {
 	return inst.Status == "RUNNING"
 }
 
-func (ctx *Context) CreateImage(imageName, gcsFile, OS string) error {
+func (ctx *Context) CreateImage(imageName, gcsFile, OS string, labels map[string]string) error {
 	var features []*compute.GuestOsFeature
 	if OS == targets.Linux {
 		features = []*compute.GuestOsFeature{
@@ -298,7 +301,8 @@ func (ctx *Context) CreateImage(imageName, gcsFile, OS string) error {
 		}
 	}
 	image := &compute.Image{
-		Name: imageName,
+		Name:   imageName,
+		Labels: labels,
 		RawDisk: &compute.ImageRawDisk{
 			Source: "https://storage.googleapis.com/" + gcsFile,
 		},

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -62,8 +62,9 @@ type Config struct {
 	// Leave empty for non-OS Login GCP projects.
 	// Otherwise generate one and upload it:
 	// `gcloud compute os-login ssh-keys add --key-file some-key.pub`.
-	SerialPortKey string   `json:"serial_port_key"`
-	Tags          []string `json:"tags"` // GCE instance tags
+	SerialPortKey string            `json:"serial_port_key"`
+	Tags          []string          `json:"tags"`   // GCE instance tags
+	Labels        map[string]string `json:"labels"` // GCE instance labels
 }
 
 type Pool struct {
@@ -100,6 +101,9 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 		Preemptible: true,
 		// Display device is not supported on other platforms.
 		DisplayDevice: env.Arch == targets.AMD64,
+		Labels: map[string]string{
+			"managed-by": "syzkaller",
+		},
 	}
 	if err := config.LoadData(env.Config, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse gce vm config: %w", err)
@@ -139,7 +143,7 @@ func Ctor(env *vmimpl.Env, consoleReadCmd string) (*Pool, error) {
 		if err := GCE.DeleteImage(cfg.GCEImage); err != nil {
 			return nil, fmt.Errorf("failed to delete GCE image: %w", err)
 		}
-		if err := GCE.CreateImage(cfg.GCEImage, gcsImage, env.OS); err != nil {
+		if err := GCE.CreateImage(cfg.GCEImage, gcsImage, env.OS, cfg.Labels); err != nil {
 			return nil, fmt.Errorf("failed to create GCE image: %w", err)
 		}
 	}
@@ -204,6 +208,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		Image:                pool.cfg.GCEImage,
 		SSHKey:               string(gceKeyPub),
 		Tags:                 pool.cfg.Tags,
+		Labels:               pool.cfg.Labels,
 		Preemptible:          pool.cfg.Preemptible,
 		DisplayDevice:        pool.cfg.DisplayDevice,
 		NestedVirtualization: pool.cfg.NestedVirtualization,


### PR DESCRIPTION
By default, attach 'managed-by: syzkaller' to all VMs, Disks, and Images created by syz-manager. This allows better accounting of GCP resources.