### PR TITLE
syz-cluster: simplify session polling in controller

### DIFF
--- a/syz-cluster/controller/processor.go
+++ b/syz-cluster/controller/processor.go
@@ -79,7 +79,6 @@ func (sp *SeriesProcessor) Loop(ctx context.Context) error {
 }
 
 func (sp *SeriesProcessor) streamSeries(ctx context.Context, ch chan<- *db.Session) {
-	var next *db.NextSession
 	for {
 		select {
 		case <-ctx.Done():
@@ -92,12 +91,18 @@ func (sp *SeriesProcessor) streamSeries(ctx context.Context, ch chan<- *db.Sessi
 		}
 		var err error
 		var list []*db.Session
-		list, next, err = sp.sessionRepo.ListWaiting(ctx, next, cap(ch))
+		list, err = sp.sessionRepo.ListWaiting(ctx, cap(ch))
 		if err != nil {
 			app.Errorf("failed to query series: %v", err)
 			continue
 		}
 		for _, session := range list {
+			// Mark as started in DB immediately to avoid re-querying it.
+			err := sp.sessionRepo.Start(ctx, session.ID)
+			if err != nil {
+				app.Errorf("failed to mark session started: %v", err)
+				continue
+			}
 			select {
 			case ch <- session:
 			case <-ctx.Done():

--- a/syz-cluster/email-reporter/handler_test.go
+++ b/syz-cluster/email-reporter/handler_test.go
@@ -219,7 +219,7 @@ func TestSyzTestFlow(t *testing.T) {
 	assert.Nil(t, reply, "syz test should be silent on success")
 
 	repo := db.NewSessionRepository(env.Spanner)
-	list, _, err := repo.ListWaiting(context.Background(), nil, 2)
+	list, err := repo.ListWaiting(context.Background(), 2)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	controller.FakeJobSession(t, env, handler.apiClient, list[0].ID)

--- a/syz-cluster/pkg/db/session_repo.go
+++ b/syz-cluster/pkg/db/session_repo.go
@@ -81,35 +81,17 @@ func (repo *SessionRepository) ListRunning(ctx context.Context) ([]*Session, err
 	})
 }
 
-type NextSession struct {
-	id        string
-	createdAt time.Time
-}
-
-func (repo *SessionRepository) ListWaiting(ctx context.Context, from *NextSession,
-	limit int) ([]*Session, *NextSession, error) {
+func (repo *SessionRepository) ListWaiting(ctx context.Context, limit int) ([]*Session, error) {
+	// We give priority to the job-related sessions to improve user experience.
+	// Otherwise, follow the FIFO order.
 	stmt := spanner.Statement{
-		SQL:    "SELECT * FROM `Sessions` WHERE `StartedAt` IS NULL",
+		SQL: "SELECT * FROM `Sessions` WHERE `StartedAt` IS NULL " +
+			"ORDER BY CASE WHEN `JobID` IS NOT NULL THEN 0 ELSE 1 END, `CreatedAt`",
+
 		Params: map[string]any{},
 	}
-	if from != nil {
-		stmt.SQL += " AND ((`CreatedAt` > @from) OR (`CreatedAt` = @from AND `ID` > @id))"
-		stmt.Params["from"] = from.createdAt
-		stmt.Params["id"] = from.id
-	}
-	stmt.SQL += " ORDER BY `CreatedAt`, `ID`"
 	addLimit(&stmt, limit)
-	list, err := repo.readEntities(ctx, stmt)
-
-	var next *NextSession
-	if err == nil && len(list) > 0 {
-		last := list[len(list)-1]
-		next = &NextSession{
-			id:        last.ID,
-			createdAt: last.CreatedAt,
-		}
-	}
-	return list, next, err
+	return repo.readEntities(ctx, stmt)
 }
 
 // golint sees too much similarity with SeriesRepository's ListPatches, but in reality there's not.

--- a/syz-cluster/pkg/db/session_repo_test.go
+++ b/syz-cluster/pkg/db/session_repo_test.go
@@ -52,11 +52,9 @@ func TestSeriesInsertSession(t *testing.T) {
 func TestQueryWaitingSessions(t *testing.T) {
 	client, ctx := NewTransientDB(t)
 	sessionRepo := NewSessionRepository(client)
-	seriesRepo := NewSeriesRepository(client)
 
-	series := &Series{ExtID: "some-series"}
-	err := seriesRepo.Insert(ctx, series, nil)
-	assert.NoError(t, err)
+	dummy := &dummyTestData{t: t, ctx: ctx, client: client}
+	series := dummy.dummySeries()
 
 	nthTime := func(i int) time.Time {
 		return time.Date(2009, time.January, 1, 1, i, 0, 0, time.UTC)
@@ -67,18 +65,52 @@ func TestQueryWaitingSessions(t *testing.T) {
 			SeriesID:  series.ID,
 			CreatedAt: nthTime(i),
 		}
-		err = sessionRepo.Insert(ctx, session)
+		err := sessionRepo.Insert(ctx, session)
 		assert.NoError(t, err)
 	}
 
-	var next *NextSession
+	list, err := sessionRepo.ListWaiting(ctx, 5)
+	assert.NoError(t, err)
+	assert.Len(t, list, 5)
 	for i := range 5 {
-		var list []*Session
-		list, next, err = sessionRepo.ListWaiting(ctx, next, 1)
-		assert.NoError(t, err)
-		assert.Len(t, list, 1)
-		assert.Equal(t, nthTime(i), list[0].CreatedAt)
+		assert.Equal(t, nthTime(i), list[i].CreatedAt)
 	}
+}
+
+func TestPrioritizeJobSessions(t *testing.T) {
+	client, ctx := NewTransientDB(t)
+	sessionRepo := NewSessionRepository(client)
+	jobRepo := NewJobRepository(client)
+
+	dummy := &dummyTestData{t: t, ctx: ctx, client: client}
+	series := dummy.dummySeries()
+	sessionBase := dummy.dummySession(series)
+	report := dummy.dummyReport(sessionBase)
+
+	job := &Job{ID: "job-1", ExtID: "ext-1", Type: JobPatchTest, ReportID: report.ID}
+	err := jobRepo.Insert(ctx, job, nil)
+	assert.NoError(t, err)
+
+	session1 := &Session{
+		SeriesID:  series.ID,
+		CreatedAt: time.Now().Add(-time.Hour),
+	}
+	err = sessionRepo.Insert(ctx, session1)
+	assert.NoError(t, err)
+
+	session2 := &Session{
+		SeriesID:  series.ID,
+		CreatedAt: time.Now(),
+		JobID:     spanner.NullString{StringVal: "job-1", Valid: true},
+	}
+	err = sessionRepo.Insert(ctx, session2)
+	assert.NoError(t, err)
+
+	list, err := sessionRepo.ListWaiting(ctx, 2)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, "job-1", list[0].JobID.StringVal)
+	assert.Equal(t, session1.ID, list[1].ID)
 }
 
 func TestJobSessionDoesNotUpdateLatestSession(t *testing.T) {


### PR DESCRIPTION
Instead of an explicit cursor, just query all not yet started sessions. Also, give priority to job sessions.