### PR TITLE
pkg/flatrpc: fix a test failure on FreeBSD

### DIFF
--- a/pkg/flatrpc/conn_test.go
+++ b/pkg/flatrpc/conn_test.go
@@ -47,7 +47,7 @@ func TestConn(t *testing.T) {
 		},
 	}
 
-	serv, err := Listen(":0")
+	serv, err := Listen("127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In some configurations, connecting to 0.0.0.0 isn't permitted, so the subsequent dial(t, serv.Addr.String()) can fail.  Use the standard loopback address instead.
