### PR TITLE
pkg/aflow: add repro-c workflow skeleton

### DIFF
--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -13,6 +13,7 @@ const (
 	WorkflowModeration      = WorkflowType("moderation")
 	WorkflowAssessmentKCSAN = WorkflowType("assessment-kcsan")
 	WorkflowRepro           = WorkflowType("repro")
+	WorkflowReproC          = WorkflowType("repro-c")
 )
 
 // Outputs of various workflow types.
@@ -52,4 +53,9 @@ type ReproOutputs struct {
 	SyzkallerCommit       string
 	Reproduced            bool
 	ReproducedCrashReport string
+}
+
+type ReproCOutputs struct {
+	ReproC          string
+	SyzkallerCommit string // Tracked for debugging and provenance.
 }

--- a/pkg/aflow/flow/flows.go
+++ b/pkg/aflow/flow/flows.go
@@ -7,4 +7,5 @@ import (
 	_ "github.com/google/syzkaller/pkg/aflow/flow/assessment"
 	_ "github.com/google/syzkaller/pkg/aflow/flow/patching"
 	_ "github.com/google/syzkaller/pkg/aflow/flow/repro"
+	_ "github.com/google/syzkaller/pkg/aflow/flow/reproc"
 )

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -1,0 +1,52 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package reproc
+
+import (
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/action/kernel"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+)
+
+type ReproCInputs struct {
+	BugDescription  string
+	SyzkallerCommit string // Forwarded to output for debugging and provenance.
+
+	KernelRepo   string
+	KernelCommit string
+	KernelConfig string
+}
+
+func init() {
+	aflow.Register[ReproCInputs, ai.ReproCOutputs](
+		ai.WorkflowReproC,
+		"reproduce a kernel crash and generate a C reproducer",
+		&aflow.Flow{
+			Root: aflow.Pipeline(
+				kernel.Checkout,
+				kernel.Build,
+				&aflow.LLMAgent{
+					Name:        "crash-reproc-finder",
+					Model:       aflow.BestExpensiveModel,
+					Reply:       "ReproC",
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: reprocInstruction,
+					Prompt:      reprocPrompt,
+				},
+			),
+		},
+	)
+}
+
+const reprocInstruction = `
+You are an expert in linux kernel fuzzing. Your goal is to write a C program to trigger a specific bug.
+Print only the C program that could be executed directly, without backticks.
+
+{{if .KernelObj}}{{end}}
+`
+
+const reprocPrompt = `
+Bug Description:
+{{.BugDescription}}
+`


### PR DESCRIPTION
Add the skeleton implementation for the repro-c workflow, which transforms a bug description into a standalone C reproducer.

Updates #7103