### PR TITLE
executor, sys/linux: add SYZOS_API_MEMOP for riscv64

### DIFF
--- a/executor/common_kvm_riscv64_syzos.h
+++ b/executor/common_kvm_riscv64_syzos.h
@@ -17,6 +17,7 @@ typedef enum {
 	SYZOS_API_CODE = 10,
 	SYZOS_API_CSRR = 100,
 	SYZOS_API_CSRW = 101,
+	SYZOS_API_MEMOP = 110,
 	SYZOS_API_STOP, // Must be the last one
 } syzos_api_id;
 
@@ -29,6 +30,7 @@ GUEST_CODE static void guest_uexit(uint64 exit_code);
 GUEST_CODE static void guest_execute_code(uint32* insns, uint64 size);
 GUEST_CODE static void guest_handle_csrr(uint32 csr);
 GUEST_CODE static void guest_handle_csrw(uint32 csr, uint64 val);
+GUEST_CODE static void guest_handle_memop(struct api_call_5* cmd);
 
 // Main guest function that performs necessary setup and passes the control to the user-provided
 // payload.
@@ -64,6 +66,10 @@ guest_main(uint64 size, uint64 cpu)
 			// Execute a csrw instruction.
 			struct api_call_2* ccmd = (struct api_call_2*)cmd;
 			guest_handle_csrw(ccmd->args[0], ccmd->args[1]);
+		} else if (call == SYZOS_API_MEMOP) {
+			// Execute a memory operation.
+			struct api_call_5* ccmd = (struct api_call_5*)cmd;
+			guest_handle_memop(ccmd);
 		}
 		addr += cmd->size;
 		size -= cmd->size;
@@ -143,6 +149,61 @@ guest_handle_csrw(uint32 csr, uint64 val)
 	    :
 	    : "r"(val), "r"(insn)
 	    : "a0", "ra", "memory");
+}
+
+// Execute a memory operation.
+GUEST_CODE static noinline void
+guest_handle_memop(struct api_call_5* cmd)
+{
+	uint64 base_addr = cmd->args[0];
+	uint64 offset = cmd->args[1];
+	uint64 value = cmd->args[2];
+	uint64 len = cmd->args[3];
+	uint64 op = cmd->args[4];
+	uint64 addr = base_addr + offset;
+	asm volatile("fence rw, rw" ::: "memory");
+
+	// Write operation.
+	if (op == 1) {
+		if (len == 1) {
+			volatile uint8* p = (uint8*)addr;
+			*p = (uint8)value;
+		} else if (len == 2) {
+			volatile uint16* p = (uint16*)addr;
+			*p = (uint16)value;
+		} else if (len == 4) {
+			volatile uint32* p = (uint32*)addr;
+			*p = (uint32)value;
+		} else {
+			volatile uint64* p = (uint64*)addr;
+			*p = (uint64)value;
+		}
+		// Ensure write completion.
+		asm volatile("fence rw, rw" ::: "memory");
+	} else { // Read operation (op == 0).
+		uint64 result = 0;
+		if (len == 1) {
+			volatile uint8* p = (uint8*)addr;
+			result = *p;
+		} else if (len == 2) {
+			volatile uint16* p = (uint16*)addr;
+			result = *p;
+		} else if (len == 4) {
+			volatile uint32* p = (uint32*)addr;
+			result = *p;
+		} else {
+			volatile uint64* p = (uint64*)addr;
+			result = *p;
+		}
+		// Ensure read completion.
+		asm volatile("fence rw, rw" ::: "memory");
+		// Return read value in register sscratch.
+		asm volatile(
+		    "csrw sscratch, %0"
+		    :
+		    : "r"(result)
+		    : "memory");
+	}
 }
 
 // The exception vector table setup and SBI invocation here follow the

--- a/sys/linux/dev_kvm_riscv64.txt
+++ b/sys/linux/dev_kvm_riscv64.txt
@@ -78,11 +78,24 @@ riscv64_csr_or_any [
 # https://elixir.bootlin.com/linux/v6.19-rc5/source/arch/riscv/include/uapi/asm/kvm.h#L75 .
 riscv64_csr = 0x100, 0x104, 0x105, 0x140, 0x141, 0x142, 0x143, 0x144, 0x180, 0x106, 0x10a
 
+# Valid lengths for memory operations.
+syzos_memop_len = 1, 2, 4, 8
+
+# Memory operation API.
+syzos_api_memop {
+	base	int64
+	offset	int64[0:4096]
+	value	int64
+	len	flags[syzos_memop_len, int64]
+	op	int8[0:1]
+}
+
 syzos_api_call$riscv64 [
 	uexit	syzos_api$riscv64[0, intptr]
 	code	syzos_api$riscv64[10, syzos_api_code$riscv64]
 	csrr	syzos_api$riscv64[100, syzos_api_csrr]
 	csrw	syzos_api$riscv64[101, syzos_api_csrw]
+	memop	syzos_api$riscv64[110, syzos_api_memop]
 ] [varlen]
 
 # Test assertions, will not be used by the fuzzer.

--- a/sys/linux/test/riscv64-syz_kvm_setup_syzos_vm-memop
+++ b/sys/linux/test/riscv64-syz_kvm_setup_syzos_vm-memop
@@ -1,0 +1,28 @@
+#
+# requires: arch=riscv64 -threaded
+#
+# This test verifies that SYZOS can execute memory operations
+# inside a RISC-V KVM guest.
+#
+r0 = openat$kvm(0, &AUTO='/dev/kvm\x00', 0x0, 0x0)
+r1 = ioctl$KVM_CREATE_VM(r0, AUTO, 0x0)
+r2 = syz_kvm_setup_syzos_vm$riscv64(r1, &(0x7f0000c00000/0x400000)=nil)
+
+# Write 0x12345678 to stack memory (RISCV64_ADDR_STACK_BASE = 0x80020000).
+# Then read it back. The read value will be stored in register a0.
+# Finally, trigger uexit with code -1.
+#
+r3 = syz_kvm_add_vcpu$riscv64(r2, &AUTO={0x0, &AUTO=[@memop={AUTO, AUTO, {0x80020000, 0x0, 0x12345678, 0x4, 0x1}}, @memop={AUTO, AUTO, {0x80020000, 0x0, 0x0, 0x4, 0x0}}, @uexit={AUTO, AUTO, 0xffffffffffffffff}], AUTO}, 0x0, 0x0)
+
+r4 = ioctl$KVM_GET_VCPU_MMAP_SIZE(r0, AUTO)
+r5 = mmap$KVM_VCPU(&(0x7f0000009000/0x1000)=nil, r4, 0x3, 0x1, r3, 0x0)
+
+# Run till uexit.
+#
+ioctl$KVM_RUN(r3, AUTO, 0x0)
+syz_kvm_assert_syzos_uexit$riscv64(r3, r5, 0xffffffffffffffff)
+
+# Verify that register sscratch contains the value we wrote (0x12345678).
+# Register ID for sscratch is 0x8030000003000003.
+#
+syz_kvm_assert_reg$riscv64(r3, 0x8030000003000003, 0x12345678)


### PR DESCRIPTION
Summary
  - Add SYZOS_API_MEMOP for riscv64
  - Add riscv64-syz_kvm_setup_syzos_vm-memop to verify memory operation functionality

<img width="867" height="489" alt="image" src="https://github.com/user-attachments/assets/79e883b3-c716-4742-ae9b-bdaecc062d06" />


Assisted by AI.