### PR TITLE
vm/gce: attempt vm creation before deletion

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/syzkaller/pkg/report"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
+	"google.golang.org/api/googleapi"
 )
 
 func init() {
@@ -193,10 +194,6 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	log.Logf(0, "deleting instance: %v", name)
-	if err := pool.GCE.DeleteInstance(name, true); err != nil {
-		return nil, err
-	}
 	log.Logf(0, "creating instance: %v", name)
 	instCfg := &gce.InstanceConfig{
 		Name:                 name,
@@ -211,6 +208,13 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		VMRunningTime:        pool.env.Timeouts.VMRunningTime,
 	}
 	ip, err := pool.GCE.CreateInstance(instCfg)
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == 409 {
+		log.Logf(0, "deleting existing instance due to conflict: %v", name)
+		if err = pool.GCE.DeleteInstance(name, true); err == nil {
+			ip, err = pool.GCE.CreateInstance(instCfg)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When creating a GCE VM, we first attempt to delete it in case it already exists. This only occurs if the manager crashed before managing to delete its resources. We create and delete a lot of instances everyday, and our managers rarely crash. This results in an unnecessary deletion call that results in an error. Assume an optimistic path where the manager succeeds, and attempt creation first. If creation fails, delete then create again.