### PR TITLE
.github/workflows: fix unsupported gh flag in upload-coverage

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUM=$(gh pr list --repo ${{ github.event.workflow_run.repository.full_name }} --commit ${{ github.event.workflow_run.head_sha }} --json number --jq '.[0].number')
+          PR_NUM=$(gh pr list --repo ${{ github.event.workflow_run.repository.full_name }} --search "${{ github.event.workflow_run.head_sha }}" -s all --json number --jq '.[0].number')
           if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
             echo "number=$PR_NUM" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Fix unsupported flag.