### PR TITLE
pkg/aflow: implement hybrid loop detection for tool calls

### DIFF
--- a/pkg/aflow/func_tool_test.go
+++ b/pkg/aflow/func_tool_test.go
@@ -5,6 +5,7 @@ package aflow
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"google.golang.org/genai"
@@ -57,4 +58,41 @@ func TestToolErrors(t *testing.T) {
 		},
 		nil,
 	)
+}
+
+func TestToolLoopDetection(t *testing.T) {
+	agent := &LLMAgent{Name: "test-agent"}
+	args := map[string]any{"Query": "test"}
+
+	// Record defaultLoopDetectionLimit identical calls.
+	for range defaultLoopDetectionLimit {
+		agent.recordToolCall("test-tool", args)
+	}
+
+	// The 4th call should be detected as a duplicate.
+	call := &genai.FunctionCall{
+		Name: "test-tool",
+		Args: args,
+	}
+	err := agent.checkDuplicateCall(call)
+	if err == nil {
+		t.Fatalf("expected loop error, got nil")
+	}
+	var badCallErr *badCallError
+	if !errors.As(err, &badCallErr) {
+		t.Fatalf("expected BadCallError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "repeating the same tool call") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	// A different call should not be detected as a duplicate.
+	diffCall := &genai.FunctionCall{
+		Name: "diff-tool",
+		Args: args,
+	}
+	err = agent.checkDuplicateCall(diffCall)
+	if err != nil {
+		t.Fatalf("unexpected error on different call: %v", err)
+	}
 }

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -49,13 +49,25 @@ type LLMAgent struct {
 	// Number of historical message (sliding window) to keep. If zero, we don't enable the sliding
 	// window summary feature (don't toss old messages).
 	SummaryWindow int
+
+	// Track recent tool calls for loop detection.
+	toolHistory []toolCallRecord
 }
 
-// Consts to use for LLMAgent.Model.
-// See https://ai.google.dev/gemini-api/docs/models
+type toolCallRecord struct {
+	Name string
+	Args map[string]any
+}
+
 const (
+	// Consts to use for LLMAgent.Model.
+	// See https://ai.google.dev/gemini-api/docs/models
 	BestExpensiveModel = "gemini-3.1-pro-preview"
 	GoodBalancedModel  = "gemini-3-flash-preview"
+
+	// Default limit for consecutive identical tool calls.
+	defaultLoopDetectionLimit = 3
+	maxHistorySize            = 20 // Large enough to catch alternating loops.
 )
 
 type TaskType int
@@ -212,6 +224,7 @@ func (a *LLMAgent) executeMany(ctx *Context) error {
 
 func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]any, error) {
 	cfg, instruction, tools := a.config(ctx)
+
 	span := &trajectory.Span{
 		Type:        trajectory.SpanAgent,
 		Name:        a.Name,
@@ -408,7 +421,12 @@ func (a *LLMAgent) callTools(ctx *Context, tools map[string]Tool, calls []*genai
 		toolErr := BadCallError("tool %q does not exist, please correct the name", call.Name)
 		tool := tools[call.Name]
 		if tool != nil {
-			span.Results, toolErr = tool.execute(ctx, call.Args)
+			if err := a.checkDuplicateCall(call); err != nil {
+				toolErr = err
+			} else {
+				a.recordToolCall(call.Name, call.Args)
+				span.Results, toolErr = tool.execute(ctx, call.Args)
+			}
 		}
 		if toolErr != nil {
 			span.Error = toolErr.Error()
@@ -659,4 +677,32 @@ func (a *LLMAgent) verifyTemplate(ctx *verifyContext, what, text string) {
 	for name := range used {
 		ctx.state[name].used = true
 	}
+}
+
+func (a *LLMAgent) recordToolCall(name string, args map[string]any) {
+	a.toolHistory = append(a.toolHistory, toolCallRecord{Name: name, Args: args})
+	if len(a.toolHistory) > maxHistorySize {
+		a.toolHistory = a.toolHistory[1:] // Keep it a rolling window.
+	}
+}
+
+func (a *LLMAgent) checkDuplicateCall(call *genai.FunctionCall) error {
+	limit := defaultLoopDetectionLimit
+	if len(a.toolHistory) < limit {
+		return nil
+	}
+
+	repeats := 0
+	for _, record := range a.toolHistory {
+		if record.Name == call.Name && reflect.DeepEqual(record.Args, call.Args) {
+			repeats++
+		}
+	}
+
+	if repeats >= limit {
+		return BadCallError("You are repeating the same tool call with the exact same arguments. " +
+			"Please synthesize the information you already have instead of repeating queries.")
+	}
+
+	return nil
 }

--- a/pkg/aflow/testdata/TestSummaryWindow.llm.json
+++ b/pkg/aflow/testdata/TestSummaryWindow.llm.json
@@ -216,7 +216,7 @@
 							"id": "id4",
 							"name": "tick",
 							"response": {
-								"ResFoo": 123
+								"error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 							}
 						}
 					},
@@ -260,7 +260,7 @@
 							"id": "id5",
 							"name": "tick",
 							"response": {
-								"ResFoo": 123
+								"error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 							}
 						}
 					}
@@ -312,7 +312,7 @@
 							"id": "id6",
 							"name": "tick",
 							"response": {
-								"ResFoo": 123
+								"error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 							}
 						}
 					},
@@ -356,7 +356,7 @@
 							"id": "id7",
 							"name": "tick",
 							"response": {
-								"ResFoo": 123
+								"error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 							}
 						}
 					}

--- a/pkg/aflow/testdata/TestSummaryWindow.trajectory.json
+++ b/pkg/aflow/testdata/TestSummaryWindow.trajectory.json
@@ -153,9 +153,7 @@
 		"Name": "tick",
 		"Started": "0001-01-01T00:00:17Z",
 		"Finished": "0001-01-01T00:00:18Z",
-		"Results": {
-			"ResFoo": 123
-		}
+		"Error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 	},
 	{
 		"Seq": 10,
@@ -189,9 +187,7 @@
 		"Name": "tick",
 		"Started": "0001-01-01T00:00:21Z",
 		"Finished": "0001-01-01T00:00:22Z",
-		"Results": {
-			"ResFoo": 123
-		}
+		"Error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 	},
 	{
 		"Seq": 12,
@@ -224,9 +220,7 @@
 		"Name": "tick",
 		"Started": "0001-01-01T00:00:25Z",
 		"Finished": "0001-01-01T00:00:26Z",
-		"Results": {
-			"ResFoo": 123
-		}
+		"Error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 	},
 	{
 		"Seq": 14,
@@ -260,9 +254,7 @@
 		"Name": "tick",
 		"Started": "0001-01-01T00:00:29Z",
 		"Finished": "0001-01-01T00:00:30Z",
-		"Results": {
-			"ResFoo": 123
-		}
+		"Error": "You are repeating the same tool call with the exact same arguments. Please synthesize the information you already have instead of repeating queries."
 	},
 	{
 		"Seq": 16,


### PR DESCRIPTION
pkg/aflow: implement tool call loop detection

Add history tracking for tool calls to LLMAgent to detect and prevent
infinite loops.

The agent now maintains a rolling window of the last 20 tool calls and
prevents executing the same tool call with identical arguments if it has
already been called 3 times within that window.

Updates tests and test data to reflect this change.