### PR TITLE
vm/gce: wait for instance deletion in Close()

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -266,7 +266,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 
 func (inst *instance) Close() error {
 	close(inst.closed)
-	err := inst.GCE.DeleteInstance(inst.name, false)
+	err := inst.GCE.DeleteInstance(inst.name, true)
 	if inst.consolew != nil {
 		err2 := inst.consolew.Close()
 		if err == nil {


### PR DESCRIPTION
We issue the deletion request but we don't wait for it. When we try to create a new instance, the older instance hasn't been fully deleted yet and it causes a "resource already exists" error. Avoid that error by waiting in Close().

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
