### PR TITLE
pkg/vcs: prevent leaking background git processes

### DIFF
--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -91,6 +91,10 @@ func Run(timeout time.Duration, cmd *exec.Cmd) ([]byte, error) {
 func CommandContext(ctx context.Context, bin string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	setPdeathsig(cmd, true)
+	cmd.Cancel = func() error {
+		killPgroup(cmd)
+		return nil
+	}
 	return cmd
 }
 

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -6,6 +6,7 @@ package vcs
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -694,7 +695,9 @@ func (git Git) fetchCommits(since, base, user, domain string, greps []string, fi
 		args = append(args, "--grep", grep)
 	}
 	args = append(args, base)
-	cmd := exec.Command("git", args...)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := osutil.CommandContext(ctx, "git", args...)
 	cmd.Dir = git.Dir
 	cmd.Env = filterEnv()
 	if git.Sandbox {
@@ -710,7 +713,6 @@ func (git Git) fetchCommits(since, base, user, domain string, greps []string, fi
 		return nil, err
 	}
 	defer cmd.Wait()
-	defer cmd.Process.Kill()
 	var (
 		s           = bufio.NewScanner(stdout)
 		buf         = new(bytes.Buffer)

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -5,13 +5,13 @@ package vcs
 
 import (
 	"fmt"
-	"os/exec"
 	"reflect"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -645,7 +645,7 @@ func TestBaseForDiffMerge(t *testing.T) {
 
 	// Merge master into branchA, resolve the conflict.
 	repo.Git("checkout", "branchA")
-	if err := exec.Command("git", "-C", repo.Dir, "merge", "master").Run(); err == nil {
+	if _, err := osutil.RunCmd(time.Minute, repo.Dir, "git", "merge", "master"); err == nil {
 		t.Fatalf("conflict expected during merge -> branchA")
 	}
 	repo.CommitChangeset("merge master->branchA",
@@ -655,7 +655,7 @@ func TestBaseForDiffMerge(t *testing.T) {
 
 	// Merge master into branchB, resolve the conflict.
 	repo.Git("checkout", "branchB")
-	if err := exec.Command("git", "-C", repo.Dir, "merge", "master").Run(); err == nil {
+	if _, err := osutil.RunCmd(time.Minute, repo.Dir, "git", "merge", "master"); err == nil {
 		t.Fatalf("conflict expected during merge -> branchB")
 	}
 	repo.CommitChangeset("merge master->branchB",


### PR DESCRIPTION
Git periodically forks background maintenance tasks like git gc --auto
during operations that create objects (e.g., merge, commit). Go's
cmd.Wait() only waits for the main foreground process to exit. When
tests finish, the background git processes are orphaned.

Switch from exec.Command to osutil.CommandContext and osutil.RunCmd.
This places git commands in their own process groups and guarantees
that all child processes are killed when the context is cancelled
or the timeout expires, preventing process leaks.