### PR TITLE
fix(updater): add ValidateConfigs hook to reject incompatible builds before deployment

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -57,6 +57,11 @@ type Config struct {
 	SyzkallerDescriptions string
 	Targets               map[Target]bool
 	MakeTargets           []string // host make targets to build besides the targets-specific ones
+	// ValidateConfigs is an optional callback invoked after a successful build to verify
+	// that the deployment configuration is still compatible with the newly built binaries.
+	// syzkallerDir is the directory containing the freshly built syzkaller tree.
+	// If it returns an error the build is rejected and treated as a build failure.
+	ValidateConfigs func(syzkallerDir string) error
 }
 
 type Target struct {
@@ -307,6 +312,11 @@ func (upd *Updater) build(commit *vcs.Commit) error {
 	}, os.Environ()...)
 	if _, err := osutil.Run(time.Hour, cmd); err != nil {
 		return fmt.Errorf("testing failed: %w", err)
+	}
+	if upd.cfg.ValidateConfigs != nil {
+		if err := upd.cfg.ValidateConfigs(upd.syzkallerDir); err != nil {
+			return fmt.Errorf("config validation failed: %w", err)
+		}
 	}
 	tagFile := filepath.Join(upd.syzkallerDir, "tag")
 	if err := osutil.WriteFile(tagFile, []byte(commit.Hash)); err != nil {


### PR DESCRIPTION
The `updater` package in `pkg/updater/updater.go` had no way for callers to verify that a freshly built syzkaller tree was still compatible with the existing deployment configuration before it was committed to use. This meant a build that compiled successfully could still break running instances if the configuration format or binary interface had changed in an incompatible way.

This fix adds an optional `ValidateConfigs func(syzkallerDir string) error` field to the `Config` struct. After a successful build and test run, the `build` method in `updater.go` now calls this callback (if set) with the path to the new syzkaller directory. If the callback returns an error, the build is rejected and treated as a build failure, preventing the incompatible binaries from being deployed.

Callers that do not need this check are unaffected because the field is optional and the call is guarded by a nil check.

Fixes #7025
