### PR TITLE
tools/syz-linter: ensure one empty line between top-level defs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -853,8 +853,6 @@ func aiBugWorkflows(ctx context.Context, bug *Bug) ([]*uiWorkflow, error) {
 	return result, nil
 }
 
-// aiBugWorkflows returns active workflows that are applicable for the bug.
-
 func aiBugJobCreate(ctx context.Context, workflow string, bug *Bug, extraArgs map[string]any) (string, error) {
 	workflows, err := aidb.LoadActiveWorkflows(ctx)
 	if err != nil {

--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -1799,7 +1799,6 @@ func recordEmergencyStop(ctx context.Context) error {
 // Share crash logs for non-reproduced bugs with syz-managers.
 // In future, this can also take care of repro exchange between instances
 // in the place of syz-hub.
-
 func apiReproTaskDone(ctx context.Context, ns string, req *dashapi.ReproTaskDoneReq) (any, error) {
 	taskKey := db.NewKey(ctx, "ReproTask", "", req.ReqID, nil)
 	task := new(ReproTask)

--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -228,7 +228,6 @@ func (bug *Bug) hasUserSubsystems() bool {
 // it turned out that we'd better store all labels together.
 // Let's keep this conversion code until "Tags" are removed from all bugs.
 // Then it can be removed.
-
 type Bug202304 struct {
 	Tags BugTags202304
 }

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1448,10 +1448,12 @@ type jobSorter struct {
 }
 
 func (sorter *jobSorter) Len() int { return len(sorter.jobs) }
+
 func (sorter *jobSorter) Less(i, j int) bool {
 	// Give priority to user-initiated jobs to reduce the perceived processing time.
 	return sorter.jobs[i].User != "" && sorter.jobs[j].User == ""
 }
+
 func (sorter *jobSorter) Swap(i, j int) {
 	sorter.jobs[i], sorter.jobs[j] = sorter.jobs[j], sorter.jobs[i]
 	sorter.keys[i], sorter.keys[j] = sorter.keys[j], sorter.keys[i]

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -1525,6 +1525,7 @@ type bugReportSorter []*Bug
 
 func (a bugReportSorter) Len() int      { return len(a) }
 func (a bugReportSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
 func (a bugReportSorter) Less(i, j int) bool {
 	if a[i].ReproLevel != a[j].ReproLevel {
 		return a[i].ReproLevel > a[j].ReproLevel

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -571,6 +571,7 @@ func sendMailTemplate(ctx context.Context, params *mailSendParams) error {
 	log.Infof(ctx, "sending email %q to %q", params.title, to)
 	return sendMailText(ctx, params.cfg.getSubject(params.title), from, to, params.replyTo, body.String())
 }
+
 func generateEmailBugTitle(rep *dashapi.BugReport, emailConfig *EmailConfig) string {
 	title := ""
 	for i := len(rep.Subsystems) - 1; i >= 0; i-- {

--- a/dashboard/app/tree.go
+++ b/dashboard/app/tree.go
@@ -384,6 +384,7 @@ type runReproOn any
 // runReproOn subtypes.
 type runOnAny struct{} // attempts to find any result, if unsuccessful, runs on HEAD
 type runOnHEAD struct{}
+
 type runOnMergeBase struct {
 	Repo   string
 	Branch string

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -131,7 +131,6 @@ func (dash *Dashboard) UploadBuild(build *Build) error {
 // builder will pass subset of the commit titles that are present in the build
 // in Build.Commits field and list of {bug ID, commit title} pairs extracted
 // from git log.
-
 type BuilderPollReq struct {
 	Manager string
 }
@@ -160,7 +159,6 @@ func (dash *Dashboard) BuilderPoll(manager string) (*BuilderPollResp, error) {
 //   - when syz-ci finishes the job, it sends JobDoneReq which contains
 //     job execution result (Build, Crash or Error details),
 //     ID must match JobPollResp.ID.
-
 type JobResetReq struct {
 	Managers []string
 }

--- a/pkg/asset/storage.go
+++ b/pkg/asset/storage.go
@@ -181,6 +181,7 @@ func (storage *Storage) UploadBuildAsset(reader io.Reader, fileName string, asse
 		DownloadURL: url,
 	}, nil
 }
+
 func (storage *Storage) ReportBuildAssets(build *dashapi.Build, assets ...dashapi.NewAsset) error {
 	// If the server denies the reques, we'll delete the orphaned file during deprecated files
 	// deletion later.

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -38,7 +38,6 @@ type FlagValue interface {
 }
 
 // Top-level AST nodes.
-
 type NewLine struct {
 	Pos Pos
 }
@@ -194,7 +193,6 @@ func (n *TypeDef) Info() (Pos, string, string) {
 }
 
 // Not top-level AST nodes.
-
 type Ident struct {
 	Pos  Pos
 	Name string

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -523,6 +523,7 @@ No patch, just text`,
 		})
 	}
 }
+
 func TestLink(t *testing.T) {
 	tests := []struct {
 		id     string

--- a/pkg/fuzzer/queue/prio_queue.go
+++ b/pkg/fuzzer/queue/prio_queue.go
@@ -29,7 +29,6 @@ func (pq *priorityQueueOps[T]) Pop() T {
 
 // The implementation below is based on the example provided
 // by https://pkg.go.dev/container/heap.
-
 type priorityQueueItem[T any] struct {
 	value T
 	prio  int

--- a/pkg/stat/set.go
+++ b/pkg/stat/set.go
@@ -134,7 +134,6 @@ func (s *set) Collect(level Level) []UI {
 }
 
 // Additional options for Val metrics.
-
 // Level controls if the metric should be printed to console in periodic heartbeat logs,
 // or showed on the simple web interface, or showed in the expert interface only.
 type Level int
@@ -184,7 +183,6 @@ func FormatMB(v int, period time.Duration) string {
 
 // Addittionally a custom 'func() int' can be passed to read the metric value from the function.
 // and 'func(int, time.Duration) string' can be passed for custom formatting of the metric value.
-
 func (s *set) New(name, desc string, opts ...any) *Val {
 	v := &Val{
 		name:  name,

--- a/pkg/subsystem/linux/maintainers.go
+++ b/pkg/subsystem/linux/maintainers.go
@@ -75,10 +75,12 @@ type maintainersLexer struct {
 }
 
 type recordTitle string
+
 type recordProperty struct {
 	key   string
 	value string
 }
+
 type endOfFile struct{}
 
 var propertyRe = regexp.MustCompile(`^([[:alpha:]]):\s+(.*).*$`)

--- a/prog/types.go
+++ b/prog/types.go
@@ -223,15 +223,19 @@ func (ti Ref) DefaultArg(dir Dir) Arg                                { panic("pr
 func (ti Ref) Clone() Type                                           { panic("prog.Ref method called") }
 func (ti Ref) isDefaultArg(arg Arg) bool                             { panic("prog.Ref method called") }
 func (ti Ref) generate(r *randGen, s *state, dir Dir) (Arg, []*Call) { panic("prog.Ref method called") }
+
 func (ti Ref) mutate(r *randGen, s *state, arg Arg, ctx ArgCtx) ([]*Call, bool, bool) {
 	panic("prog.Ref method called")
 }
+
 func (ti Ref) getMutationPrio(target *Target, arg Arg, ignoreSpecial, ignoreLengths bool) (float64, bool) {
 	panic("prog.Ref method called")
 }
+
 func (ti Ref) minimize(ctx *minimizeArgsCtx, arg Arg, path string) bool {
 	panic("prog.Ref method called")
 }
+
 func (ti Ref) ref() Ref       { panic("prog.Ref method called") }
 func (ti Ref) setRef(ref Ref) { panic("prog.Ref method called") }
 

--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -80,7 +80,6 @@ type DashapiConfig struct {
 }
 
 // The project configuration is expected to be mounted at /config/config.yaml.
-
 func Config() (*AppConfig, error) {
 	configLoadedOnce.Do(func() {
 		config, configErr = loadConfig(configPath)

--- a/syz-cluster/pkg/retest/retest_test.go
+++ b/syz-cluster/pkg/retest/retest_test.go
@@ -24,10 +24,13 @@ type mockEnv struct {
 }
 
 func (m *mockEnv) BuildSyzkaller(repo, commit string) (string, error) { return "", nil }
+
 func (m *mockEnv) BuildKernel(cfg *instance.BuildKernelConfig) (string, build.ImageDetails, error) {
 	return "", build.ImageDetails{}, nil
 }
+
 func (m *mockEnv) CleanKernel(cfg *instance.BuildKernelConfig) error { return nil }
+
 func (m *mockEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collectCoverage bool) (
 	[]instance.EnvTestResult, error) {
 	return m.results, m.err

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -70,7 +70,6 @@ type Kernel struct {
 // =============================================================================
 // Verifier
 // =============================================================================.
-
 func (vrf *Verifier) RunVerifierFuzzer(ctx context.Context) error {
 	log.Logf(0, "starting verifier fuzzer")
 	eg, ctx := errgroup.WithContext(ctx)
@@ -429,7 +428,6 @@ func (vrf *Verifier) createRequests(prog *prog.Prog) (map[int]*queue.Request, []
 // =============================================================================
 // Kernel
 // =============================================================================.
-
 func (kernel *Kernel) FuzzerInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
 	index := inst.Index()
 	injectExec := make(chan bool, 10)

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -96,8 +96,50 @@ func run(p *analysis.Pass) (any, error) {
 				pass.checkComment(comment, stmts, len(group.List) == 1)
 			}
 		}
+		pass.checkTopLevelDecls(file)
 	}
 	return nil, nil
+}
+
+func (pass *Pass) checkTopLevelDecls(file *ast.File) {
+	for i := range len(file.Decls) - 1 {
+		d1, d2 := file.Decls[i], file.Decls[i+1]
+
+		isFuncOrType := func(d ast.Decl) bool {
+			switch x := d.(type) {
+			case *ast.FuncDecl:
+				return true
+			case *ast.GenDecl:
+				return x.Tok == token.TYPE
+			}
+			return false
+		}
+
+		if isFuncOrType(d1) && isFuncOrType(d2) {
+			d1Start := pass.Fset.Position(d1.Pos()).Line
+			d1End := pass.Fset.Position(d1.End()).Line
+
+			startPos := d2.Pos()
+			switch v := d2.(type) {
+			case *ast.FuncDecl:
+				if v.Doc != nil {
+					startPos = v.Doc.Pos()
+				}
+			case *ast.GenDecl:
+				if v.Doc != nil {
+					startPos = v.Doc.Pos()
+				}
+			}
+			d2Start := pass.Fset.Position(startPos).Line
+			d2End := pass.Fset.Position(d2.End()).Line
+
+			exactlyOne := d2Start-d1End == 2
+			canBeGrouped := d1Start == d1End && d2Start == d2End && d2Start-d1End == 1
+			if !exactlyOne && !canBeGrouped {
+				pass.report(d2, "Keep one empty line between top-level declarations")
+			}
+		}
+	}
 }
 
 type Pass analysis.Pass

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -48,7 +48,6 @@ func checkCommentSpace() {
 }
 
 //No space.			// want "Use either //<one-or-more-spaces>comment or //<one-or-more-tabs>comment format for comments"
-
 func funcArgsGood(a, b int) (int, int) {
 	return 0, 0
 }
@@ -283,3 +282,33 @@ func stringsCut() {
 		_ = pos
 	}
 }
+
+// Missing empty lines between declarations.
+func missingEmptyLine1() {
+}
+func missingEmptyLine2() { // want "Keep one empty line between top-level declarations"
+}
+type MissingEmptyLineStruct struct { // want "Keep one empty line between top-level declarations"
+}
+
+// Comment for func 3
+func missingEmptyLine3() {
+}
+
+// Single-line functions can be grouped.
+func grouped1() {}
+func grouped2() {}
+func grouped3() {}
+
+func multiLineGrouped() {
+}
+func grouped4() {} // want "Keep one empty line between top-level declarations"
+
+func grouped5() {}
+func multiLineGrouped2() { // want "Keep one empty line between top-level declarations"
+}
+
+func twoEmptyLines1() {}
+
+
+func twoEmptyLines2() {} // want "Keep one empty line between top-level declarations"

--- a/vm/proxyapp/proxyappclient_test.go
+++ b/vm/proxyapp/proxyappclient_test.go
@@ -507,10 +507,10 @@ func TestInstance_RunReadProgress_Failed(t *testing.T) {
 }
 
 // TODO: test for periodical proxyapp subprocess crashes handling.
-//  [option] check pool size was changed
-
+//
+//	[option] check pool size was changed
+//
 // TODO: test pool.Close() calls plugin API and return error.
-
 func contextWithTimeout(t *testing.T, timeout time.Duration) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)

--- a/vm/vmimpl/merger.go
+++ b/vm/vmimpl/merger.go
@@ -105,6 +105,7 @@ func (merger *OutputMerger) AddDecoder(name string, typ OutputType, r io.ReadClo
 		state.err = MergerError{name, r, err}
 	}()
 }
+
 func (merger *OutputMerger) runDecoder(typ OutputType, r io.ReadCloser,
 	decoder func(data []byte) (start, size int, decoded []byte)) error {
 	var pending []byte


### PR DESCRIPTION
AI code generation tools seem to frequently mess up the empty lines and
neither syz-linter nor `go fmt` fix it. It's quite annoying to fix it
manually.

Let's add one more check to syz-linter to enforce that there must be
only one empty line between top level declarations.