### PR TITLE
vm/gce: copy files to instance-specific directory

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -281,7 +281,11 @@ func (inst *instance) Forward(port int) (string, error) {
 }
 
 func (inst *instance) Copy(hostSrc string) (string, error) {
-	vmDst := "./" + filepath.Base(hostSrc)
+	vmDstDir := filepath.Join("./", inst.env.Name)
+	if _, err := inst.ssh("mkdir", "-p", vmDstDir); err != nil {
+		return "", err
+	}
+	vmDst := filepath.Join(vmDstDir, filepath.Base(hostSrc))
 	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
 		Debug:         inst.debug,
 		Key:           inst.Key,


### PR DESCRIPTION
Copy files into an isolated subdirectory named after the environment name (inst.env.Name) instead of the default directory on the remote VM. This prevents potential binary overwrites.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
