### PR TITLE
dashboard/app: reply with error for #syz unfix on fixed bugs

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -742,6 +742,36 @@ func TestEmailUnfix(t *testing.T) {
 	c.expectNoEmail()
 }
 
+// Test for unfix command on a bug that is already marked as fixed.
+func TestEmailUnfixFixedBug(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.client2.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	c.client2.ReportCrash(crash)
+
+	msg := c.pollEmailBug()
+
+	c.incomingEmail(msg.Sender, "#syz fix: some commit")
+	c.expectNoEmail()
+
+	build2 := testBuild(2)
+	build2.Manager = build.Manager
+	build2.Commits = []string{"some commit"}
+	c.client2.UploadBuild(build2)
+
+	// Now the bug should be fixed.
+	// Try to unfix it. It should reply with an error.
+	c.incomingEmail(msg.Sender, "#syz unfix")
+	reply := c.pollEmailBug()
+	if !strings.Contains(reply.Body, "This bug is already marked as fixed.") {
+		t.Fatalf("expected reply about bug being already fixed, got %q", reply.Body)
+	}
+}
+
 func TestEmailManagerCC(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -830,6 +830,10 @@ func handleBugCommand(ctx context.Context, bugInfo *bugInfoResult, msg *email.Em
 			}
 			cmd.FixCommits = []string{command.Args}
 		case email.CmdUnFix:
+			if bugInfo.bug.Status == BugStatusFixed {
+				return "This bug is already marked as fixed. Syzbot does not support unfixing bugs " +
+					"that are already closed (i.e. the fixing commit has reached all tested trees)."
+			}
 			cmd.ResetFixCommits = true
 		case email.CmdDup:
 			if command.Args == "" {


### PR DESCRIPTION
Previously, syzbot was silent when #syz unfix was used on a bug that was already marked as fixed. This happened because updates to closed bugs are rejected silently to avoid spamming discussions. However, this left users confused as to why the command failed.

Now, syzbot will reply with a clear error message: 'This bug is already marked as fixed. Syzbot does not support unfixing bugs that are already closed.'

Also added a dedicated test case to verify this behavior.

Updates #7131.