### PR TITLE
pkg/aflow: implement Race Condition Toolkit for C reproducers

### DIFF
--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/aflow/tool/toolkit"
 	"github.com/google/syzkaller/pkg/csource"
 )
 
@@ -131,6 +132,22 @@ func LoopControllerFunc(ctx *aflow.Context, args LoopControllerArgs) (LoopContro
 
 var LoopController = aflow.NewFuncAction("loop-controller", LoopControllerFunc)
 
+type ExpandToolkitArgs struct {
+	RawCandidateReproC string
+}
+
+type ExpandToolkitResult struct {
+	CandidateReproC string
+}
+
+func ExpandToolkitFunc(ctx *aflow.Context, args ExpandToolkitArgs) (ExpandToolkitResult, error) {
+	includeStr := `#include "race_toolkit.h"`
+	repro := strings.ReplaceAll(args.RawCandidateReproC, includeStr, toolkit.GetRaceToolkit())
+	return ExpandToolkitResult{CandidateReproC: repro}, nil
+}
+
+var ExpandToolkit = aflow.NewFuncAction("expand-toolkit", ExpandToolkitFunc)
+
 type MergeStrategyArgs struct {
 	InitialReproStrategy string
 	RefinedReproStrategy string
@@ -190,7 +207,7 @@ func init() {
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: initialResearcherInstruction,
 					Prompt:      initialResearcherPrompt,
-					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+					Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool, toolkit.ToolGetToolkit),
 				},
 				&aflow.DoWhile{
 					MaxIterations: 5,
@@ -205,19 +222,20 @@ func init() {
 								TaskType:    aflow.FormalReasoningTask,
 								Instruction: refinerInstruction,
 								Prompt:      refinerPrompt,
-								Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+								Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool, toolkit.ToolGetToolkit),
 							},
 						},
 						MergeStrategy,
 						&aflow.LLMAgent{
 							Name:        "repro-generator",
 							Model:       aflow.BestExpensiveModel,
-							Reply:       "CandidateReproC",
+							Reply:       "RawCandidateReproC",
 							TaskType:    aflow.FormalReasoningTask,
 							Instruction: generatorInstruction,
 							Prompt:      generatorPrompt,
-							Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+							Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool, toolkit.ToolGetToolkit),
 						},
+						ExpandToolkit,
 						FormatC,
 						crash.RunCRepro,
 						TruncateLog,
@@ -228,7 +246,7 @@ func init() {
 							TaskType:    aflow.FormalReasoningTask,
 							Instruction: oracleInstruction,
 							Prompt:      oraclePrompt,
-							Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool),
+							Tools:       aflow.Tools(codesearcher.Tools, grepper.Tool, toolkit.ToolGetToolkit),
 						},
 						LoopController,
 					),
@@ -260,6 +278,7 @@ to check if the bug is triggered or not.
 Do NOT generate an exploit or weaponized code. Generate only the minimal code needed to trigger
 the specific crash or condition described, to help developers confirm the bug and its fix.
 Focus on the technical reproduction of the state, not on weaponization or payload delivery.
+
 Print only the C program that could be executed directly, without backticks.`
 const generatorPrompt = `Bug Description: {{.BugDescription}}
 Strategy: {{.CurrentReproStrategy}}`

--- a/pkg/aflow/tool/toolkit/race_toolkit.h
+++ b/pkg/aflow/tool/toolkit/race_toolkit.h
@@ -1,0 +1,116 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// IMPORTANT: Do not copy the macros or definitions below directly into your reproducer.
+// Instead, add the following line to your reproducer:
+// #include "race_toolkit.h"
+
+// --- Race Condition Toolkit ---
+// Macros and snippets for CPU pinning, memory barriers, and userfaultfd.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <linux/userfaultfd.h>
+#include <poll.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// Unbuffered I/O: Ensure logs are written immediately.
+#define SETUP_UNBUFFERED_IO() setvbuf(stdout, NULL, _IONBF, 0)
+
+// CPU Pinning: Pin the current thread to a specific CPU core.
+#define PIN_TO_CPU(cpu)                                                \
+	do {                                                           \
+		cpu_set_t mask;                                        \
+		CPU_ZERO(&mask);                                       \
+		CPU_SET(cpu, &mask);                                   \
+		if (sched_setaffinity(0, sizeof(mask), &mask) == -1) { \
+			perror("sched_setaffinity");                   \
+		}                                                      \
+	} while (0)
+
+// Memory Barrier: Ensure memory ordering.
+#define MB() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+
+// Spin-wait Barrier: Wait until a memory location has a specific value.
+// Best for tight race windows (low latency, no context switches).
+#define WAIT_ON(addr, val)                                                 \
+	do {                                                               \
+		while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) != (val)) { \
+			__builtin_ia32_pause();                            \
+		}                                                          \
+	} while (0)
+
+// Signal: Set a memory location to a specific value to release a WAIT_ON.
+#define SIGNAL(addr, val) __atomic_store_n(addr, val, __ATOMIC_RELEASE)
+
+// Futex-based Event: Shared with syzkaller executor.
+// Best for general synchronization or longer waits to save CPU.
+typedef struct {
+	int state;
+} event_t;
+
+static void event_init(event_t* ev)
+{
+	ev->state = 0;
+}
+static void event_reset(event_t* ev)
+{
+	ev->state = 0;
+}
+
+static void event_set(event_t* ev)
+{
+	if (__atomic_load_n(&ev->state, __ATOMIC_ACQUIRE)) {
+		fprintf(stderr, "event already set\n");
+		exit(1);
+	}
+	__atomic_store_n(&ev->state, 1, __ATOMIC_RELEASE);
+	syscall(SYS_futex, &ev->state, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1000000);
+}
+
+static void event_wait(event_t* ev)
+{
+	while (!__atomic_load_n(&ev->state, __ATOMIC_ACQUIRE))
+		syscall(SYS_futex, &ev->state, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, 0, 0);
+}
+
+// userfaultfd setup: Register a memory range for page fault handling.
+static int setup_uffd(void* addr, size_t len)
+{
+	int uffd = syscall(__NR_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+	if (uffd == -1)
+		return -1;
+	struct uffdio_api api = {.api = UFFD_API, .features = 0};
+	if (ioctl(uffd, UFFDIO_API, &api) == -1) {
+		close(uffd);
+		return -1;
+	}
+	struct uffdio_register reg = {
+	    .range = {.start = (uintptr_t)addr, .len = len},
+	    .mode = UFFDIO_REGISTER_MODE_MISSING};
+	if (ioctl(uffd, UFFDIO_REGISTER, &reg) == -1) {
+		close(uffd);
+		return -1;
+	}
+	return uffd;
+}
+
+// --- Guidance on Usage ---
+// 1. Use WAIT_ON/SIGNAL for tight race conditions to avoid scheduling overhead.
+// 2. Use event_t (futexes) for general coordination or when waiting for longer periods.
+// 3. Always use PIN_TO_CPU to increase race probability on multi-core systems.
+// 4. Use setup_uffd to register a memory range for page fault handling. This allows you to
+//    pause a thread accessing that memory until you handle the fault, creating a reliable
+//    and controllable race window.
+// 5. Call SETUP_UNBUFFERED_IO() at the start of main() to ensure that logs are printed
+//    immediately. This is essential for understanding the exact interleaving of events
+//    when debugging race conditions.

--- a/pkg/aflow/tool/toolkit/testdata/toolkit_functional_test.c
+++ b/pkg/aflow/tool/toolkit/testdata/toolkit_functional_test.c
@@ -1,0 +1,82 @@
+#define _GNU_SOURCE
+#include "../race_toolkit.h"
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static int flag = 0;
+void* wait_thread(void* arg)
+{
+	WAIT_ON(&flag, 1);
+	return NULL;
+}
+
+void test_wait_on_signal()
+{
+	pthread_t t;
+	pthread_create(&t, NULL, wait_thread, NULL);
+	sleep(1);
+	SIGNAL(&flag, 1);
+	pthread_join(t, NULL);
+	printf("test_wait_on_signal passed\n");
+}
+
+void* event_thread(void* arg)
+{
+	event_t* ev = (event_t*)arg;
+	event_wait(ev);
+	return NULL;
+}
+
+void test_event()
+{
+	event_t ev;
+	event_init(&ev);
+	pthread_t t;
+	pthread_create(&t, NULL, event_thread, &ev);
+	sleep(1);
+	event_set(&ev);
+	pthread_join(t, NULL);
+	printf("test_event passed\n");
+}
+
+void test_setup_uffd()
+{
+	size_t len = 4096;
+	void* addr = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	assert(addr != MAP_FAILED);
+
+	int uffd = setup_uffd(addr, len);
+	if (uffd == -1) {
+		if (errno == EPERM || errno == ENOSYS) {
+			printf("setup_uffd skipped (missing privileges or not supported)\n");
+		} else {
+			perror("setup_uffd");
+			exit(1);
+		}
+	} else {
+		printf("setup_uffd passed\n");
+		close(uffd);
+	}
+	munmap(addr, len);
+}
+
+void test_pin_to_cpu()
+{
+	PIN_TO_CPU(0);
+	printf("test_pin_to_cpu passed\n");
+}
+
+int main()
+{
+	SETUP_UNBUFFERED_IO();
+	test_pin_to_cpu();
+	test_wait_on_signal();
+	test_event();
+	test_setup_uffd();
+	return 0;
+}

--- a/pkg/aflow/tool/toolkit/testdata/toolkit_standalone_test.c
+++ b/pkg/aflow/tool/toolkit/testdata/toolkit_standalone_test.c
@@ -1,0 +1,10 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+#include "../race_toolkit.h"
+
+int main()
+{
+	// This file just needs to compile to verify that race_toolkit.h is valid C.
+	return 0;
+}

--- a/pkg/aflow/tool/toolkit/toolkit.go
+++ b/pkg/aflow/tool/toolkit/toolkit.go
@@ -1,0 +1,39 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package toolkit
+
+import (
+	_ "embed"
+	"github.com/google/syzkaller/pkg/aflow"
+)
+
+var (
+	ToolGetToolkit = aflow.NewFuncTool("get-toolkit", getToolkit, `
+Tool provides a specialized toolkit of C macros and snippets for a given name.
+Available toolkits:
+ - "race": Use it when you need specific primitives (like spin-wait barriers or CPU pinning) to reproduce complex bugs.
+`)
+)
+
+type getToolkitArgs struct {
+	Name string `jsonschema:"Name of the toolkit to retrieve (e.g., 'race')."`
+}
+
+type getToolkitResult struct {
+	Toolkit string `jsonschema:"The C macros and snippets for the requested toolkit."`
+}
+
+//go:embed race_toolkit.h
+var raceConditionToolkit string
+
+func getToolkit(ctx *aflow.Context, _ struct{}, args getToolkitArgs) (getToolkitResult, error) {
+	if args.Name == "race" {
+		return getToolkitResult{Toolkit: raceConditionToolkit}, nil
+	}
+	return getToolkitResult{}, aflow.BadCallError("unknown toolkit: %s. Available toolkits: race", args.Name)
+}
+
+func GetRaceToolkit() string {
+	return raceConditionToolkit
+}

--- a/pkg/aflow/tool/toolkit/toolkit_test.go
+++ b/pkg/aflow/tool/toolkit/toolkit_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package toolkit
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestToolkitsInTestData(t *testing.T) {
+	compiler := "gcc"
+	if _, err := exec.LookPath(compiler); err != nil {
+		compiler = "clang"
+		if _, err := exec.LookPath(compiler); err != nil {
+			t.Skip("neither gcc nor clang found, skipping C tests")
+		}
+	}
+
+	files, err := filepath.Glob("testdata/*.c")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cFile := range files {
+		t.Run(filepath.Base(cFile), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			outputExe := filepath.Join(tmpDir, "test_bin")
+
+			cmd := exec.Command(compiler, cFile, "-o", outputExe, "-I", ".", "-pthread")
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("compilation failed: %v\n%s", err, output)
+			}
+
+			cmd = exec.Command(outputExe)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("execution failed: %v\n%s", err, output)
+			} else {
+				t.Logf("execution output:\n%s", output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a set of C macros and snippets for the agent to use when generating reproducers for race conditions. These include:
- CPU pinning (PIN_TO_CPU)
- Memory barriers (MB())
- Spin-wait barriers (WAIT_ON, SIGNAL)
- userfaultfd setup helpers
- futex-based event_t primitives copied from executor/common_linux.h.

This toolkit is implemented as a function tool (get-toolkit) that the agent can call dynamically, reducing prompt size and giving the agent autonomy.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
