### PR TITLE
syz-agent: make the prod config more flexible

### DIFF
--- a/syz-agent/k8s/overlays/prod/agent-config.json
+++ b/syz-agent/k8s/overlays/prod/agent-config.json
@@ -1,6 +1,6 @@
 {
   "dashboard_addr": "https://syzbot.org",
-  "dashboard_client": "agent",
+  "dashboard_client": "gcp-secret:syz-agent-dashboard-client",
   "dashboard_key": "gcp-secret:syz-agent-dashboard-key",
   "gemini_api_key": "gcp-secret:syz-agent-gemini-key",
   "target": "linux/amd64",


### PR DESCRIPTION
Turn the client name into a GCP secret key name.