### PR TITLE
syz-agent: fix k8s deployment with numeric env variables

### DIFF
--- a/syz-agent/Makefile
+++ b/syz-agent/Makefile
@@ -25,14 +25,14 @@ k8s-minikube:
 	@kubectl kustomize ./k8s/overlays/minikube/ | sed \
 		-e "s~\$${IMAGE_NAME}~$(IMAGE_NAME)~g" \
 		-e "s~\$${IMAGE_TAG}~$(IMAGE_TAG)~g" \
-		-e "s~\$${GOOGLE_API_KEY}~$(GOOGLE_API_KEY)~g" \
-		-e "s~\$${DASHBOARD_KEY}~$(DASHBOARD_KEY)~g"
+		-e "s~\$${GOOGLE_API_KEY}~'$(GOOGLE_API_KEY)'~g" \
+		-e "s~\$${DASHBOARD_KEY}~'$(DASHBOARD_KEY)'~g"
 
 k8s-prod-agent:
 	@kubectl kustomize ./k8s/overlays/prod-agent/ | sed \
 		-e "s~\$${IMAGE_NAME}~$(IMAGE_NAME)~g" \
 		-e "s~\$${IMAGE_TAG}~$(IMAGE_TAG)~g" \
-		-e "s~\$${GIT_COOKIE_DAEMON}~$(GIT_COOKIE_DAEMON)~g"
+		-e "s~\$${GIT_COOKIE_DAEMON}~'$(GIT_COOKIE_DAEMON)'~g"
 
 k8s-prod-lore:
 	@kubectl kustomize ./k8s/overlays/prod-lore/ | sed \


### PR DESCRIPTION
kubectl kustomize strips quotes from placeholders like ${VAR} in its output. When sed replaces these with numeric values (e.g. 0 or 1), the resulting YAML contains an integer instead of a string. This causes Kubernetes to reject the manifest with a "cannot convert int64 to string" error for environment variable values.

Explicitly add quotes in the Makefile's sed commands to ensure these values are always rendered as strings in the generated YAML.