### PR TITLE
dashboard/app: auto-moderate subsystem reminders

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -285,6 +285,10 @@ type BugListReportingConfig struct {
 	// If ModerationConfig is set, bug lists will be first sent there for human confirmation.
 	// For now, only EmailConfig is supported.
 	ModerationConfig ReportingType
+	// SkipModeration determines whether a monthly report should skip the moderation stage.
+	// If it returns true, the report skips the moderation stage (if any) and goes straight to public.
+	// If it returns false, the report goes through moderation first.
+	SkipModeration func(bugs []*Bug) bool `json:"-"`
 	// Config specifies how exactly such notifications should be delivered.
 	// For now, only EmailConfig is supported.
 	Config ReportingType

--- a/dashboard/app/linux_reporting.go
+++ b/dashboard/app/linux_reporting.go
@@ -3,6 +3,10 @@
 
 package main
 
+import (
+	"strings"
+)
+
 // The objective of this file is to collect config parts and routines useful for Linux bugs management,
 // thus reducing the size of the dashboard config file.
 
@@ -11,6 +15,17 @@ func canBeVfsBug(bug *Bug) bool {
 	for _, subsystem := range bug.LabelValues(SubsystemLabel) {
 		// The "vfs" one is left for compatibility with the older matching code.
 		if subsystem.Value == "vfs" || subsystem.Value == "fs" {
+			return true
+		}
+	}
+	return false
+}
+
+// isWorthMonthlyReport determines whether a monthly report is worth sending.
+// It returns true if there are any bug titles that do not begin with "INFO:".
+func isWorthMonthlyReport(bugs []*Bug) bool {
+	for _, bug := range bugs {
+		if !strings.HasPrefix(bug.Title, "INFO:") {
 			return true
 		}
 	}

--- a/dashboard/app/linux_reporting_test.go
+++ b/dashboard/app/linux_reporting_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFsSubsystemFlow(t *testing.T) {
@@ -150,4 +151,48 @@ renameat2(r0, &(0x7f00000004c0)='./file0\x00', r0, &(0x7f0000000500)='./bus/file
 	// .. and poll the email.
 	reply := c.pollEmailBug()
 	c.expectEQ(reply.Subject, "[syzbot] [fs?] WARNING in do_mkdirat2")
+}
+
+func TestIsWorthMonthlyReport(t *testing.T) {
+	tests := []struct {
+		name string
+		bugs []*Bug
+		want bool
+	}{
+		{
+			name: "all INFO",
+			bugs: []*Bug{
+				{Title: "INFO: task hung"},
+				{Title: "INFO: rcu detected stall"},
+			},
+			want: false,
+		},
+		{
+			name: "some not INFO",
+			bugs: []*Bug{
+				{Title: "INFO: task hung"},
+				{Title: "WARNING: abcd"},
+			},
+			want: true,
+		},
+		{
+			name: "none INFO",
+			bugs: []*Bug{
+				{Title: "WARNING: abcd"},
+				{Title: "KASAN: use-after-free"},
+			},
+			want: true,
+		},
+		{
+			name: "empty",
+			bugs: []*Bug{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isWorthMonthlyReport(tt.bugs)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/dashboard/app/reporting_lists.go
+++ b/dashboard/app/reporting_lists.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/subsystem"
-	"google.golang.org/appengine/v2"
 	db "google.golang.org/appengine/v2/datastore"
 	"google.golang.org/appengine/v2/log"
 )
@@ -76,7 +75,7 @@ const maxNewListsPerNs = 5
 
 // handleSubsystemReports is periodically invoked to construct fresh SubsystemReport objects.
 func handleSubsystemReports(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := r.Context()
 	registry, err := makeSubsystemRegistry(ctx)
 	if err != nil {
 		log.Errorf(ctx, "failed to load subsystems: %v", err)
@@ -309,14 +308,15 @@ func querySubsystemReport(ctx context.Context, subsystem *Subsystem, reporting *
 		}
 		return cmp.Compare(a.Title, b.Title)
 	})
+	if len(takeBugs) > config.BugsInReport {
+		takeBugs = takeBugs[:config.BugsInReport]
+	}
+	skipModeration := config.SkipModeration != nil && config.SkipModeration(takeBugs)
 	keys := []*db.Key{}
 	for _, bug := range takeBugs {
 		keys = append(keys, bug.key(ctx))
 	}
-	if len(keys) > config.BugsInReport {
-		keys = keys[:config.BugsInReport]
-	}
-	report := makeSubsystemReport(ctx, config, keys)
+	report := makeSubsystemReport(ctx, config, keys, skipModeration)
 	report.TotalStats = makeSubsystemReportStats(ctx, rawOpenBugs, fixedBugs, 0)
 	report.PeriodStats = makeSubsystemReportStats(ctx, rawOpenBugs, fixedBugs, config.PeriodDays)
 	return report, nil
@@ -391,7 +391,7 @@ func queryMatchingBugs(ctx context.Context, ns, name string, reporting *Reportin
 
 // makeSubsystemReport creates a new SubsystemReminder object.
 func makeSubsystemReport(ctx context.Context, config *BugListReportingConfig,
-	keys []*db.Key) *SubsystemReport {
+	keys []*db.Key, skipModeration bool) *SubsystemReport {
 	ret := &SubsystemReport{
 		Created: timeNow(ctx),
 	}
@@ -399,7 +399,7 @@ func makeSubsystemReport(ctx context.Context, config *BugListReportingConfig,
 		ret.BugKeys = append(ret.BugKeys, key.Encode())
 	}
 	baseID := hash.String([]byte(fmt.Sprintf("%v-%v", timeNow(ctx), ret.BugKeys)))
-	if config.ModerationConfig != nil {
+	if config.ModerationConfig != nil && !skipModeration {
 		ret.Stages = append(ret.Stages, SubsystemReportStage{
 			ID:         bugListReportingHash(baseID, "moderation"),
 			Moderation: true,

--- a/dashboard/app/subsystem_test.go
+++ b/dashboard/app/subsystem_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -525,6 +526,79 @@ To change bug's subsystems, reply with:
 
 You may send multiple commands in a single email message.
 `, bugToExtID["WARNING: a first"], bugToExtID["WARNING: a second"]))
+}
+
+func TestSubsystemRemindersSkipModeration(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientSubsystemRemind, keySubsystemRemind, true)
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	ns := "subsystem-reminders"
+
+	// Enable WorthReporting callback.
+	c.transformContext = func(ctx context.Context) context.Context {
+		newConfig := replaceNamespaceConfig(ctx, ns, func(cfg *Config) *Config {
+			ret := *cfg
+			r := *ret.Subsystems.Reminder
+			r.SkipModeration = isWorthMonthlyReport
+			ret.Subsystems.Reminder = &r
+			return &ret
+		})
+		return contextWithConfig(ctx, newConfig)
+	}
+
+	// Report two INFO bugs.
+	aFirst := testCrash(build, 1)
+	aFirst.Title = `INFO: a first`
+	aFirst.GuiltyFiles = []string{"a.c"}
+	client.ReportCrash(aFirst)
+	client.pollEmailExtID()
+	c.advanceTime(time.Hour)
+
+	aSecond := testCrash(build, 1)
+	aSecond.Title = `INFO: a second`
+	aSecond.GuiltyFiles = []string{"a.c"}
+	client.ReportCrash(aSecond)
+	client.pollEmailExtID()
+	c.advanceTime(time.Hour)
+
+	// Report them again to pretend they're still valid.
+	c.advanceTime(time.Hour * 24 * 14)
+	client.ReportCrash(aFirst)
+	client.ReportCrash(aSecond)
+
+	// Trigger report generation.
+	_, err := c.GET("/cron/subsystem_reports")
+	c.expectOK(err)
+
+	// Expect a report to moderation because all bugs are INFO.
+	reply := client.pollEmailBug()
+	c.expectTrue(strings.Contains(reply.Subject, "[moderation] Monthly subsystemA report"))
+
+	// Now report a non-INFO bug.
+	aThird := testCrash(build, 1)
+	aThird.Title = `WARNING: a third`
+	aThird.GuiltyFiles = []string{"a.c"}
+	client.ReportCrash(aThird)
+	client.pollEmailExtID()
+	c.advanceTime(time.Hour)
+
+	// Report all bugs again to keep them active.
+	c.advanceTime(time.Hour * 24 * 31)
+	client.ReportCrash(aFirst)
+	client.ReportCrash(aSecond)
+	client.ReportCrash(aThird)
+
+	// Trigger report generation again.
+	_, err = c.GET("/cron/subsystem_reports")
+	c.expectOK(err)
+
+	// Expect the reminder to go straight to public because we have a WARNING bug.
+	reply = client.pollEmailBug()
+	c.expectEQ(reply.Subject, "[syzbot] Monthly subsystemA report (Feb 2000)")
 }
 
 func TestSubsystemReportGeneration(t *testing.T) {


### PR DESCRIPTION
Add a call-back to automatically moderate certain monthly reports.
Add a test that replicates the desired behavior change.
Add an isWorthMonthlyReport helper to be used in production.