### PR TITLE
syz-agent/agent: resolve dashboard_client secret

### DIFF
--- a/syz-agent/agent/config.go
+++ b/syz-agent/agent/config.go
@@ -53,6 +53,12 @@ func loadConfig(configFile string) (*Config, error) {
 	}
 	cfg.DashboardKey = resolvedDashKey
 
+	resolvedDashClient, err := gcpsecret.Resolve(context.Background(), cfg.DashboardClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve DashboardClient: %w", err)
+	}
+	cfg.DashboardClient = resolvedDashClient
+
 	resolvedGeminiKey, err := gcpsecret.Resolve(context.Background(), cfg.GeminiAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve GeminiAPIKey: %w", err)

--- a/syz-agent/agent/config_test.go
+++ b/syz-agent/agent/config_test.go
@@ -18,6 +18,7 @@ func TestConfigPlainValues(t *testing.T) {
 
 	confFile := filepath.Join(tmpDir, "config.json")
 	content := `{
+		"dashboard_client": "test-dashboard-client",
 		"dashboard_key": "test-dashboard-key",
 		"gemini_api_key": "test-gemini-key"
 	}`
@@ -27,6 +28,7 @@ func TestConfigPlainValues(t *testing.T) {
 	cfg, err := loadConfig(confFile)
 	assert.NoError(t, err)
 
+	assert.Equal(t, "test-dashboard-client", cfg.DashboardClient)
 	assert.Equal(t, "test-dashboard-key", cfg.DashboardKey)
 	assert.Equal(t, "test-gemini-key", cfg.GeminiAPIKey)
 }
@@ -38,18 +40,21 @@ func TestConfigEnvResolution(t *testing.T) {
 
 	confFile := filepath.Join(tmpDir, "config.json")
 	content := `{
+		"dashboard_client": "env:CLIENT_ENV",
 		"dashboard_key": "env:DASHBOARD_ENV",
 		"gemini_api_key": "env:GEMINI_ENV"
 	}`
 	err = os.WriteFile(confFile, []byte(content), 0644)
 	assert.NoError(t, err)
 
+	os.Setenv("CLIENT_ENV", "resolved-client")
 	os.Setenv("DASHBOARD_ENV", "resolved-dashboard")
 	os.Setenv("GEMINI_ENV", "resolved-gemini")
 
 	cfg, err := loadConfig(confFile)
 	assert.NoError(t, err)
 
+	assert.Equal(t, "resolved-client", cfg.DashboardClient)
 	assert.Equal(t, "resolved-dashboard", cfg.DashboardKey)
 	assert.Equal(t, "resolved-gemini", cfg.GeminiAPIKey)
 }


### PR DESCRIPTION
Now that dashboard_client is configured as a GCP secret in the prod environment, syz-agent needs to resolve it at startup.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
