### PR TITLE
pkg/vcs: check for local commit presence before fetching

### DIFF
--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -158,6 +158,14 @@ func (git *gitRepo) CheckoutCommit(repo, commit string) (*Commit, error) {
 }
 
 func (git *gitRepo) fetchRemote(repo, commit string) error {
+	if commit != "" && gitFullHashRe.MatchString(commit) {
+		// If the commit is already present locally, we don't need to fetch it.
+		// This also makes us resilient to cases where the remote has force-pushed
+		// and the commit is no longer reachable there (but we still have it).
+		if ok, _ := git.CommitExists(commit); ok {
+			return nil
+		}
+	}
 	repoHash := hash.String([]byte(repo))
 	// Ignore error as we can double add the same remote and that will fail.
 	git.Run("remote", "add", repoHash, repo)

--- a/pkg/vcs/git_repo_test.go
+++ b/pkg/vcs/git_repo_test.go
@@ -110,6 +110,32 @@ func TestGitRepo(t *testing.T) {
 	}
 }
 
+func TestCheckoutCommitLocal(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+
+	// Create a remote repo and a local checkout.
+	remote := CreateTestRepo(t, baseDir, "remote")
+	local := newGitRepo(filepath.Join(baseDir, "local"), nil, nil)
+
+	// Initial poll to populate local repo.
+	com0, err := local.Poll(remote.Dir, "master")
+	require.NoError(t, err)
+	require.Equal(t, remote.Commits["master"]["1"], com0)
+
+	// Get a commit that exists in both.
+	want := remote.Commits["master"]["0"]
+
+	// Now try to fetch the same commit but from a DIFFERENT remote that doesn't have it.
+	otherRemote := CreateTestRepo(t, baseDir, "otherRemote")
+
+	// This should fail if it tries to fetch from otherRemote,
+	// but succeed because it finds the commit locally.
+	com, err := local.CheckoutCommit(otherRemote.Dir, want.Hash)
+	require.NoError(t, err)
+	require.Equal(t, want.Hash, com.Hash)
+}
+
 func TestMetadata(t *testing.T) {
 	t.Parallel()
 	repoDir := t.TempDir()


### PR DESCRIPTION
If the commit is already present locally, we don't need to fetch it. This also makes us resilient to cases where the remote has force-pushed and the commit is no longer reachable there (but we still have it).

***

We observe it e.g. on `syz-ci` when 
* Build on the latest revision got broken.
* We try to run the last good build.
* But the commit is no longer in the remote repo.