### PR TITLE
dashboard/app: support aflow workflow extraction

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -92,6 +92,12 @@ type uiAIJobPage struct {
 	Reportings     []*uiJobReporting
 }
 
+type uiAIJobDetails struct {
+	Job        *uiAIJob
+	Trajectory []*aflowhtml.UIAITrajectorySpan
+	Args       []*uiAIJobArg
+}
+
 type uiJobReporting struct {
 	Reporting *aidb.JobReporting
 	Comments  []*aidb.JobComment
@@ -192,6 +198,12 @@ func handleAIJobsPage(ctx context.Context, w http.ResponseWriter, r *http.Reques
 		DefaultRepo:     defaultRepo,
 		DefaultBranch:   defaultBranch,
 	}
+
+	if r.FormValue("json") == "1" {
+		w.Header().Set("Content-Type", "application/json")
+		return writeJSONVersionOf(w, page)
+	}
+
 	return serveTemplate(w, "ai_jobs.html", page)
 }
 
@@ -415,6 +427,14 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		CurrentStage:   currentStageStr,
 		NextStage:      nextStageStr,
 		Reportings:     uiReportings,
+	}
+	if r.FormValue("json") == "1" {
+		w.Header().Set("Content-Type", "application/json")
+		return writeJSONVersionOf(w, &uiAIJobDetails{
+			Job:        uiJob,
+			Trajectory: uiTrajectory,
+			Args:       uiArgs,
+		})
 	}
 	return serveTemplate(w, "ai_job.html", page)
 }

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -380,6 +380,11 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 	_, err = c.GET(fmt.Sprintf("/ai_job?id=%v", resp.ID))
 	require.NoError(t, err)
 
+	// Verify JSON output.
+	respJSON, err := c.GET(fmt.Sprintf("/ai_job?id=%v&json=1", resp.ID))
+	require.NoError(t, err)
+	require.Contains(t, string(respJSON), `"Trajectory"`)
+
 	// Since the job is not completed, setting correctness must fail.
 	_, err = c.GET(fmt.Sprintf("/ai_job?id=%v&correct=%v", resp.ID, aiCorrectnessCorrect))
 	require.Error(t, err)
@@ -462,6 +467,11 @@ func TestAIJobsFiltering(t *testing.T) {
 	resp, err = c.GET("/ains/ai?workflow=patching")
 	require.NoError(t, err)
 	require.NotContains(t, string(resp), "KCSAN: data-race")
+
+	// Verify JSON output.
+	resp, err = c.GET("/ains/ai?json=1")
+	require.NoError(t, err)
+	require.Contains(t, string(resp), `"Workflow": "assessment-kcsan"`)
 }
 
 func TestAIJobCustomCommit(t *testing.T) {

--- a/dashboard/app/public_json_api.go
+++ b/dashboard/app/public_json_api.go
@@ -199,7 +199,7 @@ func GetJSONDescrFor(page any) ([]byte, error) {
 		res = getExtAPIDescrForBugGroups(i.Groups)
 	case *uiBackportsPage:
 		res = getExtAPIDescrForBackports(i.Groups)
-	case *uiDungeonPage, *uiDungeonPlayer, *uiDungeonKingdom:
+	case *uiDungeonPage, *uiDungeonPlayer, *uiDungeonKingdom, *uiAIJobsPage, *uiAIJobDetails:
 		res = i
 	default:
 		return nil, ErrClientNotFound

--- a/pkg/aflow/docs/extract-workflows.md
+++ b/pkg/aflow/docs/extract-workflows.md
@@ -1,0 +1,54 @@
+# Aflow Data Extraction Tool
+
+## Overview
+
+The Aflow Data Extraction Tool is designed to export agentic workflow execution data from the syzbot dashboard for offline analysis and optimization. It leverages a JSON API exposed by the dashboard to fetch workflow runs and stores them in a structured directory format.
+
+## Design
+
+### Dashboard Integration
+
+To enable data extraction, the syzbot dashboard supports a `json=1` query parameter on AI job pages:
+
+1.  **AI Jobs List**: `/{ns}/ai?json=1` returns a JSON list of all AI jobs in the namespace, including metadata like workflow type, status, and code revision.
+2.  **AI Job Details**: `/ai_job?id=<id>&json=1` returns detailed information about a specific job, including the full execution trajectory (spans representing flow, action, agent, and tool executions).
+
+These endpoints use the existing `writeJSONVersionOf` helper to serialize the internal page data structures to JSON.
+
+### Extraction Script
+
+The extraction process is automated by a bash script located at `tools/extract_workflows.sh`.
+
+#### Usage
+
+```bash
+./tools/extract_workflows.sh <dashboard_url> <commit> [output_dir]
+```
+
+-   `dashboard_url`: The URL of the AI jobs page (e.g., `http://localhost:8080/linux/ai`).
+-   `commit`: A syzkaller commit hash. The script will only extract workflows run on this commit or newer (based on date comparison).
+-   `output_dir`: Optional directory to store the extracted data. Defaults to `extracted_workflows`.
+
+#### Process
+
+1.  **Commit Date**: The script gets the timestamp of the specified commit using `git log`.
+2.  **Fetch List**: It calls the dashboard list endpoint with `?json=1` to get all jobs.
+3.  **Filter**: It iterates over the jobs and filters out those older than the specified commit date, unless the job's `CodeRevision` matches the target commit exactly.
+4.  **Fetch Details**: For each matching job, it calls the job details endpoint with `?json=1` to get the full trajectory.
+5.  **Store**: It creates a directory named after the workflow type (e.g., `repro`, `repro-c`) inside the output directory and saves the job details as a JSON file named `<job_id>.json`.
+
+## Output Structure
+
+The extracted data is organized as follows:
+
+```
+output_dir/
+├── repro/
+│   ├── 12345678-1234-5678-1234-567812345678.json
+│   └── ...
+├── repro-c/
+│   ├── ...
+└── ...
+```
+
+Each JSON file contains a snapshot of a workflow run, suitable for analysis by other tools.

--- a/tools/extract_workflows.sh
+++ b/tools/extract_workflows.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+set -e
+
+URL="$1"
+COMMIT="$2"
+OUTPUT_DIR="$3"
+
+if [ -z "$URL" ] || [ -z "$COMMIT" ]; then
+  echo "Usage: $0 <dashboard_ai_url> <commit> [output_dir]"
+  exit 1
+fi
+
+if [ -z "$OUTPUT_DIR" ]; then
+  OUTPUT_DIR="extracted_workflows"
+fi
+
+# Get commit date timestamp
+COMMIT_DATE=$(git log -1 --format=%ct "$COMMIT")
+
+CURL_OPTS=(-s -A "")
+if [ -n "$ACCESS_TOKEN" ]; then
+  CURL_OPTS+=(-H "Authorization: Bearer $ACCESS_TOKEN")
+fi
+
+echo "Fetching job list from $URL..."
+if [[ "$URL" == *"?"* ]]; then
+  LIST_URL="${URL}&json=1"
+else
+  LIST_URL="${URL}?json=1"
+fi
+
+DATA=$(curl "${CURL_OPTS[@]}" "$LIST_URL")
+
+BASE_URL=$(echo "$URL" | grep -oE '^https?://[^/]+')
+
+echo "Processing jobs..."
+
+# Extract jobs info in TSV format: ID, Workflow, Created, CodeRevision
+printf "%s\n" "$DATA" | jq -r '.Jobs[] | "\(.ID)\t\(.Workflow)\t\(.Created)\t\(.CodeRevision)"' | while IFS=$'\t' read -r ID WORKFLOW CREATED REVISION; do
+  if [ -z "$ID" ] || [ "$ID" == "null" ]; then
+    continue
+  fi
+
+  # Convert created time to timestamp
+  JOB_DATE=$(date -d "$CREATED" +%s)
+
+  # Filter by date or exact commit match
+  if [ "$JOB_DATE" -lt "$COMMIT_DATE" ] && [ "$REVISION" != "$COMMIT" ]; then
+    continue
+  fi
+
+  echo "Fetching details for job $ID..."
+  DETAIL_URL="${BASE_URL}/ai_job?id=${ID}&json=1"
+
+  TARGET_DIR="${OUTPUT_DIR}/${WORKFLOW}"
+  mkdir -p "$TARGET_DIR"
+
+  FILE_PATH="${TARGET_DIR}/${ID}.json"
+
+  # Fetch and save
+  curl "${CURL_OPTS[@]}" "$DETAIL_URL" > "$FILE_PATH"
+done
+
+echo "Extraction complete."


### PR DESCRIPTION
To enable offline analysis and optimization of aflow (Agentic Flow) workflows, this patch adds support for extracting workflow execution data from the syzbot dashboard.

Changes:
- dashboard/app/ai.go: Added json=1 support to return jobs and trajectories in JSON format.
- dashboard/app/public_json_api.go: Added support for serializing new pages to JSON.
- tools/extract_workflows.sh: Created a pure Bash script using curl and jq to fetch, filter, and save workflow runs.
- pkg/aflow/docs/extract-workflows.md: Added design documentation.
- dashboard/app/ai_test.go: Added tests to verify JSON output.
