### PR TITLE
tools/extract_workflows: extract only finished workflows by default

### DIFF
--- a/pkg/aflow/docs/extract-workflows.md
+++ b/pkg/aflow/docs/extract-workflows.md
@@ -33,7 +33,7 @@ The extraction process is automated by a bash script located at `tools/extract_w
 
 1.  **Commit Date**: The script gets the timestamp of the specified commit using `git log`.
 2.  **Fetch List**: It calls the dashboard list endpoint with `?json=1` to get all jobs.
-3.  **Filter**: It iterates over the jobs and filters out those older than the specified commit date, unless the job's `CodeRevision` matches the target commit exactly.
+3.  **Filter**: It iterates over the jobs and filters out those older than the specified commit date, unless the job's `CodeRevision` matches the target commit exactly. It also filters to include only workflows that have finished.
 4.  **Fetch Details**: For each matching job, it calls the job details endpoint with `?json=1` to get the full trajectory.
 5.  **Store**: It creates a directory named after the workflow type (e.g., `repro`, `repro-c`) inside the output directory and saves the job details as a JSON file named `<job_id>.json`.
 

--- a/tools/extract_workflows.sh
+++ b/tools/extract_workflows.sh
@@ -39,7 +39,8 @@ BASE_URL=$(echo "$URL" | grep -oE '^https?://[^/]+')
 echo "Processing jobs..."
 
 # Extract jobs info in TSV format: ID, Workflow, Created, CodeRevision
-printf "%s\n" "$DATA" | jq -r '.Jobs[] | "\(.ID)\t\(.Workflow)\t\(.Created)\t\(.CodeRevision)"' | while IFS=$'\t' read -r ID WORKFLOW CREATED REVISION; do
+# Filter to only include finished workflows (Finished time is not the zero value)
+printf "%s\n" "$DATA" | jq -r '.Jobs[] | select(.Finished != "0001-01-01T00:00:00Z") | "\(.ID)\t\(.Workflow)\t\(.Created)\t\(.CodeRevision)"' | while IFS=$'\t' read -r ID WORKFLOW CREATED REVISION; do
   if [ -z "$ID" ] || [ "$ID" == "null" ]; then
     continue
   fi


### PR DESCRIPTION
Modify the jq filter to exclude jobs where Finished is the zero time. Update documentation to reflect this change.
