### PR TITLE
pkg/aflow/flow/patching: allow to configure base repo

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1089,6 +1089,7 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 	}); err != nil {
 		return "", fmt.Errorf("addCrashReference failed: %w", err)
 	}
+	cfg := getNsConfig(ctx, bug.Namespace)
 	args := map[string]any{
 		"BugTitle":        bug.Title,
 		"ReproOpts":       string(crash.ReproOpts),
@@ -1100,6 +1101,9 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 		"KernelCommit":    build.KernelCommit,
 		"KernelConfigID":  build.KernelConfig,
 		"SyzkallerCommit": build.SyzkallerCommit,
+		"BaseRepository":  cfg.AI.BaseRepository,
+		"BaseBranch":      cfg.AI.BaseBranch,
+		"BaseCommit":      cfg.AI.BaseCommit,
 	}
 	for k, v := range extraArgs {
 		args[k] = v

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -232,6 +232,9 @@ func TestAIJob(t *testing.T) {
 		"ReproSyz":        "",
 		"ReproC":          "",
 		"ReproOpts":       "",
+		"BaseRepository":  "git://ai/base.git",
+		"BaseBranch":      "ai-base",
+		"BaseCommit":      "RC",
 	})
 
 	resp2, err2 := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
@@ -357,6 +360,9 @@ func TestAIJobActions(t *testing.T) {
 		"ReproSyz":        "syncfs(1)",
 		"ReproC":          "int main() { return 1; }",
 		"ReproOpts":       "repro opts 1",
+		"BaseRepository":  "git://ai/base.git",
+		"BaseBranch":      "ai-base",
+		"BaseCommit":      "RC",
 	})
 	require.NoError(t, c.globalClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:      resp.ID,
@@ -403,6 +409,9 @@ func TestAIJobActions(t *testing.T) {
 		"ReproSyz":        "syncfs(2)",
 		"ReproC":          "",
 		"ReproOpts":       "repro opts 2",
+		"BaseRepository":  "git://ai/base.git",
+		"BaseBranch":      "ai-base",
+		"BaseCommit":      "RC",
 	})
 }
 
@@ -554,7 +563,7 @@ func TestAIJobCustomCommit(t *testing.T) {
 
 	require.True(t, job.Args.Valid)
 	args := job.Args.Value.(map[string]any)
-	require.Equal(t, "custom123", args["FixedBaseCommit"])
+	require.Equal(t, "custom123", args["BaseCommit"])
 }
 
 func TestAIJobAutoCreate(t *testing.T) {

--- a/dashboard/app/app_test.go
+++ b/dashboard/app/app_test.go
@@ -633,7 +633,11 @@ var testConfig = &GlobalConfig{
 			},
 		},
 		"ains": {
-			AI:          &AIConfig{},
+			AI: &AIConfig{
+				BaseRepository: "git://ai/base.git",
+				BaseBranch:     "ai-base",
+				BaseCommit:     "RC",
+			},
 			AccessLevel: AccessPublic,
 			Key:         "publickeypublickeypublickey",
 			Clients: map[string]APIClient{

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -151,6 +151,11 @@ type AIConfig struct {
 	UploadPatchesToGerrit bool
 	Stages                []AIPatchStageConfig
 	SecurityPrio          func(*Bug, ai.AssessmentSecurityOutputs) BugPrio `json:"-"`
+
+	// These are passed to the patching workflow, see the workflow inputs for details.
+	BaseRepository string
+	BaseBranch     string
+	BaseCommit     string
 }
 
 // AIPatchStageConfig describes a single stage in the AI patch reporting pipeline.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1228,7 +1228,7 @@ func parseAIJobArgs(r *http.Request, workflow string, aiWorkflows []*uiWorkflow)
 		if r.FormValue("base_commit") == "" {
 			return nil, fmt.Errorf("custom base commit is empty")
 		}
-		args["FixedBaseCommit"] = r.FormValue("base_commit")
+		args["BaseCommit"] = r.FormValue("base_commit")
 	}
 	return args, nil
 }

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -815,7 +815,7 @@ func (ctx *Ctx) createAIJob(bugExitID, workflow, baseCommit string) string {
 	bug, _, _ := ctx.loadBug(bugExitID)
 	args := map[string]any{}
 	if baseCommit != "" {
-		args["FixedBaseCommit"] = baseCommit
+		args["BaseCommit"] = baseCommit
 	}
 	id, err := aiBugJobCreate(ctx.ctx, workflow, bug, args)
 	require.NoError(ctx.t, err)

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -22,9 +22,9 @@ import (
 var baseCommitPicker = aflow.NewFuncAction("base-commit-picker", pickBaseCommit)
 
 type baseCommitArgs struct {
-	// Can be used to override the selected base commit (for manual testing).
-	FixedBaseCommit string
-	FixedRepository string
+	BaseRepository string
+	BaseBranch     string
+	BaseCommit     string
 }
 
 type baseCommitResult struct {
@@ -34,50 +34,39 @@ type baseCommitResult struct {
 }
 
 func pickBaseCommit(ctx *aflow.Context, args baseCommitArgs) (baseCommitResult, error) {
-	// Currently we use the latest RC of the mainline tree as the base.
-	// This is a reasonable choice overall in lots of cases, and it enables good caching
-	// of all artifacts (we need to rebuild them only approx every week).
-	// Potentially we can use subsystem trees for few important, well-maintained subsystems
-	// (mm, net, etc). However, it will work poorly for all subsystems. First, there is no
-	// machine-usable mapping of subsystems to repo/branch; second, lots of them are poorly
-	// maintained (can be much older than latest RC); third, it will make artifact caching
-	// much worse.
-	// In the future we ought to support automated rebasing of patches to requested trees/commits.
-	// We need it anyway, but it will also alleviate imperfect base commit picking.
-	const (
-		baseRepo   = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
-		baseBranch = "master"
-	)
-
-	res := baseCommitResult{
-		KernelRepo:   baseRepo,
-		KernelBranch: baseBranch,
-		KernelCommit: args.FixedBaseCommit,
-	}
-	if args.FixedRepository != "" {
-		res.KernelRepo = args.FixedRepository
-	}
-	if args.FixedBaseCommit != "" {
-		return res, nil
-	}
-
+	commit := ""
 	err := kernel.UseLinuxRepo(ctx, func(_ string, repo vcs.Repo) error {
-		head, err := repo.Poll(baseRepo, baseBranch)
+		head, err := repo.Poll(args.BaseRepository, args.BaseBranch)
 		if err != nil {
 			return err
 		}
-		tag, err := repo.ReleaseTag(head.Hash)
-		if err != nil {
-			return err
+		switch args.BaseCommit {
+		case "HEAD":
+			commit = head.Hash
+		case "RC":
+			tag, err := repo.ReleaseTag(head.Hash)
+			if err != nil {
+				return err
+			}
+			com, err := repo.SwitchCommit(tag)
+			if err != nil {
+				return err
+			}
+			commit = com.Hash
+		default:
+			com, err := repo.SwitchCommit(args.BaseCommit)
+			if err != nil {
+				return err
+			}
+			commit = com.Hash
 		}
-		com, err := repo.SwitchCommit(tag)
-		if err != nil {
-			return err
-		}
-		res.KernelCommit = com.Hash
 		return err
 	})
-	return res, err
+	return baseCommitResult{
+		KernelRepo:   args.BaseRepository,
+		KernelBranch: args.BaseBranch,
+		KernelCommit: commit,
+	}, err
 }
 
 var getMaintainers = aflow.NewFuncAction("get-maintainers", maintainers)

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -34,9 +34,10 @@ type PatchIterationInputs struct {
 	// Discussion history grouped by patch version.
 	PatchHistory []ai.PatchHistoryEntry
 
-	// Use this fixed base kernel commit (for testing/local running).
-	FixedBaseCommit string
-	FixedRepository string
+	// See patching workflow.
+	BaseRepository string
+	BaseBranch     string
+	BaseCommit     string
 }
 
 func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -29,9 +29,16 @@ type Inputs struct {
 	Type      string
 	VM        json.RawMessage
 
-	// Use this fixed based kernel commit (for testing/local running).
-	FixedBaseCommit string
-	FixedRepository string
+	// Parameters used to pick the base commit for the patch.
+	// The workflow first fetches BaseRepository/BaseBranch,
+	// and then uses BaseCommit to pick the exact commit.
+	// BaseCommit can be either:
+	//  - exact commit hash (for testing/local running)
+	//  - "HEAD": use the current branch HEAD
+	//  - "RC": use the latest release/release candidate tag in the branch
+	BaseRepository string
+	BaseBranch     string
+	BaseCommit     string
 }
 
 func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -323,12 +323,10 @@ func (s *Server) resetModelQuota() {
 
 func initState(cfg *Config, syzkallerDir string) map[string]any {
 	return map[string]any{
-		"Syzkaller":       osutil.Abs(syzkallerDir),
-		"Image":           cfg.Image,
-		"Type":            cfg.Type,
-		"VM":              cfg.VM,
-		"KernelConfig":    cfg.kernelConfigData,
-		"FixedBaseCommit": cfg.FixedBaseCommit,
-		"FixedRepository": cfg.FixedRepository,
+		"Syzkaller":    osutil.Abs(syzkallerDir),
+		"Image":        cfg.Image,
+		"Type":         cfg.Type,
+		"VM":           cfg.VM,
+		"KernelConfig": cfg.kernelConfigData,
 	}
 }

--- a/syz-agent/agent/config.go
+++ b/syz-agent/agent/config.go
@@ -27,8 +27,6 @@ type Config struct {
 	Type            string          `json:"type"`
 	VM              json.RawMessage `json:"vm"`
 	CacheSize       uint64          `json:"cache_size"`
-	FixedBaseCommit string          `json:"fixed_base_commit"`
-	FixedRepository string          `json:"repo"`
 	Model           string          `json:"model"`
 	Workflows       []string        `json:"workflows"`
 	GeminiAPIKey    string          `json:"gemini_api_key"`


### PR DESCRIPTION
Allow to configure base repo to use with patching in the dashboard config.
This is required for non-upstream namespaces.
