### PR TITLE
pkg/email/lore: fix tests when default branch is not master

### DIFF
--- a/pkg/email/lore/test_util.go
+++ b/pkg/email/lore/test_util.go
@@ -18,8 +18,10 @@ type TestLoreArchive struct {
 }
 
 func NewTestLoreArchive(t *testing.T, dir string) *TestLoreArchive {
+	repo := vcs.MakeTestRepo(t, dir)
+	repo.Git("checkout", "-B", "master")
 	return &TestLoreArchive{
-		Repo: vcs.MakeTestRepo(t, dir),
+		Repo: repo,
 	}
 }
 


### PR DESCRIPTION
The lore poller hardcodes 'master' as the branch to poll. When tests are run in an environment where git init defaults to 'main' (or anything else), the initial poll fails because the requested branch does not exist in the test repository.

Explicitly create and checkout the 'master' branch in the test archive setup to ensure consistency across environments.