### PR TITLE
pkg/aflow: allow to reliably reference tools in prompts

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -238,7 +238,7 @@ Reviewers' feedback suggested that a new version is needed for the following rea
 Note: Double-check this reasoning before proceeding.
 
 IMPORTANT: The previous version of the patch (shown above) is CURRENTLY APPLIED
-to the source tree. Do not start from scratch! Use the codeeditor tool to modify
+to the source tree. Do not start from scratch! Use the {{.toolCodeeditor}} tool to modify
 the currently applied patch so that it addresses the reviewers' feedback.
 
 {{if .TestError}}
@@ -261,7 +261,7 @@ If the error is fixable, create a new fixed patch based on your approach.
 If the error points to a fundamental issue with the approach, try a different strategy.
 Note: The source tree has been reverted back to the previous version of the patch (V1). 
 Your broken changes (V2) are NOT in the source tree, so you need to recreate them
-from scratch using the codeeditor tool.
+from scratch using the {{.toolCodeeditor}} tool.
 {{else}}
 If the strategy looks reasonable to you, proceed with patch generation.
 {{end}}

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -126,7 +126,7 @@ You are an experienced Linux kernel developer tasked with creating a fix for a k
 You will be given a crash report, and an initial explanation of the root cause done by another
 kernel expert.
 
-Use the codeedit tool to do code edits.
+Use the {{.toolCodeeditor}} tool to do code edits.
 Note: you will not see your changes when looking at the code using codesearch tools.
 
 Your final reply should contain explanation of what you did in the patch and why
@@ -186,7 +186,7 @@ If the error points to a fundamental issue with the approach in the patch,
 then create a new patch from scratch.
 Note: in both cases the source tree does not contain the patch yet
 (so if you want to create a new fixed patch, you need to recreate it
-in its entirety from scratch using the codeeditor tool).
+in its entirety from scratch using the {{.toolCodeeditor}} tool).
 {{else}}
 If the strategy looks reasonable to you, proceed with patch generation.
 {{end}}

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -4,6 +4,7 @@
 package aflow
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/pkg/hash"
@@ -378,13 +380,8 @@ func (a *LLMAgent) slide(req []*genai.Content, summary *genai.Content) ([]*genai
 }
 
 func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, map[string]Tool) {
-	instruction := formatTemplate(a.Instruction, ctx.state)
 	toolList := a.Tools
-	if len(toolList) != 0 {
-		instruction += llmMultipleToolsInstruction
-	}
 	if a.Outputs != nil {
-		instruction += llmOutputsInstruction
 		toolList = append(toolList, a.Outputs.tool)
 	}
 	toolMap := make(map[string]Tool)
@@ -394,6 +391,17 @@ func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, m
 		toolMap[decl.Name] = tool
 		tools = append(tools, &genai.Tool{
 			FunctionDeclarations: []*genai.FunctionDeclaration{decl}})
+	}
+	state := maps.Clone(ctx.state)
+	for name := range toolMap {
+		state[toolTemplateName(name)] = name
+	}
+	instruction := formatTemplate(a.Instruction, state)
+	if len(a.Tools) != 0 {
+		instruction += llmMultipleToolsInstruction
+	}
+	if a.Outputs != nil {
+		instruction += llmOutputsInstruction
 	}
 	return &genai.GenerateContentConfig{
 		ResponseModalities: []string{"TEXT"},
@@ -645,6 +653,10 @@ func (a *LLMAgent) verify(ctx *verifyContext) {
 	a.verifyTemplate(ctx, "Instruction", a.Instruction)
 	a.verifyTemplate(ctx, "Prompt", a.Prompt)
 	for _, tool := range a.Tools {
+		name := tool.declaration().Name
+		if !toolNameRe.MatchString(name) {
+			ctx.errorf(a.Name, "bad tool name %q, expect %s", name, toolNameRe)
+		}
 		tool.verify(ctx)
 	}
 	if a.Reply != llmToolReply {
@@ -670,12 +682,23 @@ func (a *LLMAgent) verifyTemplate(ctx *verifyContext, what, text string) {
 	for name, state := range ctx.state {
 		vars[name] = state.typ
 	}
+	for _, tool := range a.Tools {
+		name := tool.declaration().Name
+		templName := toolTemplateName(name)
+		if _, ok := vars[templName]; ok {
+			ctx.errorf(a.Name, "tool %q is duplicated", name)
+			return
+		}
+		vars[templName] = reflect.TypeFor[string]()
+	}
 	used, err := verifyTemplate(text, vars)
 	if err != nil {
 		ctx.errorf(a.Name, "%v: %v", what, err)
 	}
 	for name := range used {
-		ctx.state[name].used = true
+		if ctx.state[name] != nil {
+			ctx.state[name].used = true
+		}
 	}
 }
 
@@ -705,4 +728,25 @@ func (a *LLMAgent) checkDuplicateCall(call *genai.FunctionCall) error {
 	}
 
 	return nil
+}
+
+var toolNameRe = regexp.MustCompile(`^[a-z][a-z0-9-]+[a-z0-9]$`)
+
+func toolTemplateName(name string) string {
+	buf := new(bytes.Buffer)
+	buf.WriteString("tool")
+	cap := true
+	for _, c := range name {
+		if c == '-' {
+			cap = true
+			continue
+		}
+		if cap {
+			buf.WriteRune(unicode.ToUpper(c))
+		} else {
+			buf.WriteRune(c)
+		}
+		cap = false
+	}
+	return buf.String()
 }

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -273,19 +273,71 @@ func TestNilToolArg(t *testing.T) {
 			Model:       "model",
 			Reply:       "Result",
 			TaskType:    FormalReasoningTask,
-			Instruction: "Instructions",
+			Instruction: "Instructions: use the provided tool {{.toolSwissKnife}} for something.",
 			Prompt:      "Initial Prompt",
 			Tools: []Tool{
-				NewFuncTool("tool", func(ctx *Context, state struct{}, args toolArgs) (struct{}, error) {
+				NewFuncTool("swiss-knife", func(ctx *Context, state struct{}, args toolArgs) (struct{}, error) {
 					require.Equal(t, args.Optional, nil)
 					return struct{}{}, nil
-				}, "tool"),
+				}, "tool description"),
 			},
 		},
 		[]any{
-			&genai.Part{FunctionCall: &genai.FunctionCall{Name: "tool", Args: map[string]any{"Optional": nil}}},
+			&genai.Part{FunctionCall: &genai.FunctionCall{Name: "swiss-knife", Args: map[string]any{"Optional": nil}}},
 			genai.NewPartFromText("Result"),
 		},
 		nil,
 	)
+}
+
+func TestAgentRegistrationErrors(t *testing.T) {
+	testRegistrationError[struct{}, struct{}](t,
+		`flow test: action smarty: Instruction: template: :1: function "NonExistentFoo" not defined`,
+		&Flow{
+			Root: &LLMAgent{
+				Name:        "smarty",
+				Model:       "model",
+				Reply:       "Result",
+				TaskType:    FormalReasoningTask,
+				Instruction: "{{NonExistentFoo}}",
+				Prompt:      "Prompt",
+			},
+		})
+	testRegistrationError[struct{}, struct{}](t,
+		`flow test: action smarty: bad tool name "BadTool_name", expect ^[a-z][a-z0-9-]+[a-z0-9]$`,
+		&Flow{
+			Root: &LLMAgent{
+				Name:        "smarty",
+				Model:       "model",
+				Reply:       "Result",
+				TaskType:    FormalReasoningTask,
+				Instruction: "Instruction",
+				Prompt:      "Prompt",
+				Tools: []Tool{
+					NewFuncTool("BadTool_name", func(ctx *Context, state struct{}, args struct{}) (struct{}, error) {
+						return struct{}{}, nil
+					}, "tool description"),
+				},
+			},
+		})
+	testRegistrationError[struct{}, struct{ Result string }](t,
+		`flow test: action smarty: tool "swiss-knife" is duplicated`,
+		&Flow{
+			Root: &LLMAgent{
+				Name:        "smarty",
+				Model:       "model",
+				Reply:       "Result",
+				TaskType:    FormalReasoningTask,
+				Instruction: "Instruction",
+				Prompt:      "Prompt",
+				Tools: []Tool{
+					NewFuncTool("swiss-knife", func(ctx *Context, state struct{}, args struct{}) (struct{}, error) {
+						return struct{}{}, nil
+					}, "tool description"),
+					NewFuncTool("swiss-knife", func(ctx *Context, state struct{}, args struct{}) (struct{}, error) {
+						return struct{}{}, nil
+					}, "tool description"),
+				},
+			},
+		})
 }

--- a/pkg/aflow/testdata/TestNilToolArg.llm.json
+++ b/pkg/aflow/testdata/TestNilToolArg.llm.json
@@ -5,7 +5,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n"
+						"text": "Instructions: use the provided tool swiss-knife for something.\nPrefer calling several tools at the same time to save round-trips.\n"
 					}
 				],
 				"role": "user"
@@ -15,8 +15,8 @@
 				{
 					"functionDeclarations": [
 						{
-							"description": "tool",
-							"name": "tool",
+							"description": "tool description",
+							"name": "swiss-knife",
 							"parametersJsonSchema": {
 								"additionalProperties": false,
 								"properties": {
@@ -74,7 +74,7 @@
 							"args": {
 								"Optional": null
 							},
-							"name": "tool"
+							"name": "swiss-knife"
 						}
 					}
 				],
@@ -84,7 +84,7 @@
 				"parts": [
 					{
 						"functionResponse": {
-							"name": "tool",
+							"name": "swiss-knife",
 							"response": {
 								"error": "missing argument \"Optional\""
 							}

--- a/pkg/aflow/testdata/TestNilToolArg.trajectory.json
+++ b/pkg/aflow/testdata/TestNilToolArg.trajectory.json
@@ -13,7 +13,7 @@
 		"Name": "smarty",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Instruction": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Instruction": "Instructions: use the provided tool swiss-knife for something.\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "Initial Prompt"
 	},
 	{
@@ -37,7 +37,7 @@
 		"Seq": 3,
 		"Nesting": 2,
 		"Type": "tool",
-		"Name": "tool",
+		"Name": "swiss-knife",
 		"Started": "0001-01-01T00:00:05Z",
 		"Args": {
 			"Optional": null
@@ -47,7 +47,7 @@
 		"Seq": 3,
 		"Nesting": 2,
 		"Type": "tool",
-		"Name": "tool",
+		"Name": "swiss-knife",
 		"Started": "0001-01-01T00:00:05Z",
 		"Finished": "0001-01-01T00:00:06Z",
 		"Error": "missing argument \"Optional\"",
@@ -80,7 +80,7 @@
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
 		"Finished": "0001-01-01T00:00:09Z",
-		"Instruction": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Instruction": "Instructions: use the provided tool swiss-knife for something.\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "Initial Prompt",
 		"Reply": "Result"
 	},


### PR DESCRIPTION
Currently one has to hard-code tool names in prompts/instructions if one wants to reference tools.
This is error-prone. Provide tool names as inputs to prompt templates to catch any errors.

Fixes #7058
