### PR TITLE
dvyukov linter empty lines

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -287,6 +287,7 @@ The comments you need to evaluate are provided as JSON objects.
 Note that the contents are JSON-encoded to prevent injection. Code snippets will appear
 with standard JSON escapes (like \n for newlines and \" for quotes), but are otherwise intact.
 `
+
 const verdictPrompt = `
 Bug title: {{jsonMarshal .BugTitle}}
 Crash report:

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -262,10 +262,12 @@ Your goal is to analyze a Linux kernel bug description and propose a strategy to
 with a minimal, standalone C program.
 This is for the strictly defensive purpose of verifying a bugfix in an isolated environment.
 Do NOT propose an exploit. Focus on minimal technical reproduction of the bug state.`
+
 const initialResearcherPrompt = `Bug Description: {{.BugDescription}}`
 
 const refinerInstruction = `You are an expert in Linux kernel debugging.
 Refine the reproduction strategy based on feedback from previous attempts.`
+
 const refinerPrompt = `Bug Description: {{.BugDescription}}
 Current Strategy: {{.CurrentReproStrategy}}
 Feedback: {{.OracleFeedback}}`
@@ -280,6 +282,7 @@ the specific crash or condition described, to help developers confirm the bug an
 Focus on the technical reproduction of the state, not on weaponization or payload delivery.
 
 Print only the C program that could be executed directly, without backticks.`
+
 const generatorPrompt = `Bug Description: {{.BugDescription}}
 Strategy: {{.CurrentReproStrategy}}`
 
@@ -288,6 +291,7 @@ Analyze the results of running the reproducer and determine if it was successful
 When Reproduced is false, analyze TruncatedConsoleOutput for execution patterns
 (hangs, immediate exits, syscall failures)
 to provide detailed feedback on why it failed and how to fix it.`
+
 const oraclePrompt = `Bug Description: {{.BugDescription}}
 Reproduced: {{.Reproduced}}
 Console Output: {{.TruncatedConsoleOutput}}

--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -324,9 +324,11 @@ func abs(a int64) int64 {
 	return a
 }
 
-//go:embed templates/heatmap.html
-var templatesHeatmap string
-var templateHeatmapFuncs = template.FuncMap{
-	"approxInstr": approximateInstrumented,
-}
-var heatmapTemplate = template.Must(template.New("").Funcs(templateHeatmapFuncs).Parse(templatesHeatmap))
+var (
+	//go:embed templates/heatmap.html
+	templatesHeatmap     string
+	templateHeatmapFuncs = template.FuncMap{
+		"approxInstr": approximateInstrumented,
+	}
+	heatmapTemplate = template.Must(template.New("").Funcs(templateHeatmapFuncs).Parse(templatesHeatmap))
+)

--- a/pkg/csource/csource.go
+++ b/pkg/csource/csource.go
@@ -252,6 +252,7 @@ func (ctx *context) generateSyscallDefines() string {
 }
 
 const indent string = "  " // Two spaces.
+
 // clang-format produces nicer comments with '//' prefixing versus '/* ... */' style comments.
 const commentPrefix string = "//"
 

--- a/pkg/ifuzz/x86/pseudo.go
+++ b/pkg/ifuzz/x86/pseudo.go
@@ -551,6 +551,7 @@ func pciAddrPort(r *rand.Rand) (addr uint32, port uint16, size int) {
 }
 
 var controlRegisters = []uint8{0, 3, 4, 8}
+
 var controlRegistersBits = map[uint8][]uint8{
 	0: {0, 1, 2, 3, 4, 5, 16, 18, 29, 30, 31},
 	3: {3, 5},

--- a/pkg/kconfig/kconfig.go
+++ b/pkg/kconfig/kconfig.go
@@ -63,6 +63,7 @@ const (
 	MenuChoice
 	MenuComment
 )
+
 const (
 	_ ConfigType = iota
 	TypeBool

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1149,6 +1149,7 @@ var linuxCorruptedTitles = []*regexp.Regexp{
 // missing stack trace does not necessarily mean the log is corrupted. Match the last line printed by show_regs(),
 // before the stack dump.
 var riscvSpecialStackStart = regexp.MustCompile(`status: [0-9a-f]{16} badaddr: [0-9a-f]{16} cause: [0-9a-f]{16}`)
+
 var linuxStackParams = &stackParams{
 	stackStartRes: []*regexp.Regexp{
 		regexp.MustCompile(`Call (?:T|t)race`),

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -104,24 +104,21 @@ func run(p *analysis.Pass) (any, error) {
 }
 
 func (pass *Pass) checkTopLevelDecls(file *ast.File, commentLines map[int]bool) {
+	isRelevantDecl := func(d ast.Decl) token.Token {
+		switch x := d.(type) {
+		case *ast.FuncDecl:
+			return token.FUNC
+		case *ast.GenDecl:
+			return x.Tok
+		}
+		return token.ILLEGAL
+	}
+
 topLoop:
 	for i := range len(file.Decls) - 1 {
 		d1, d2 := file.Decls[i], file.Decls[i+1]
-
-		isRelevantDecl := func(d ast.Decl) bool {
-			switch x := d.(type) {
-			case *ast.FuncDecl:
-				return true
-			case *ast.GenDecl:
-				switch x.Tok {
-				case token.TYPE, token.CONST, token.VAR:
-					return true
-				}
-			}
-			return false
-		}
-
-		if !isRelevantDecl(d1) || !isRelevantDecl(d2) {
+		t1, t2 := isRelevantDecl(d1), isRelevantDecl(d2)
+		if t1 == token.ILLEGAL || t2 == token.ILLEGAL {
 			continue
 		}
 
@@ -143,7 +140,7 @@ topLoop:
 		d2End := pass.Fset.Position(d2.End()).Line
 
 		exactlyOne := d2Start-d1End == 2
-		canBeGrouped := d1Start == d1End && d2Start == d2End && d2Start-d1End == 1
+		canBeGrouped := d1Start == d1End && d2Start == d2End && d2Start-d1End == 1 && t1 == t2
 		if exactlyOne || canBeGrouped {
 			continue
 		}

--- a/tools/syz-linter/linter.go
+++ b/tools/syz-linter/linter.go
@@ -91,54 +91,69 @@ func run(p *analysis.Pass) (any, error) {
 			}
 			return true
 		})
+		commentLines := make(map[int]bool)
 		for _, group := range file.Comments {
 			for _, comment := range group.List {
+				commentLines[pass.Fset.Position(comment.Pos()).Line] = true
 				pass.checkComment(comment, stmts, len(group.List) == 1)
 			}
 		}
-		pass.checkTopLevelDecls(file)
+		pass.checkTopLevelDecls(file, commentLines)
 	}
 	return nil, nil
 }
 
-func (pass *Pass) checkTopLevelDecls(file *ast.File) {
+func (pass *Pass) checkTopLevelDecls(file *ast.File, commentLines map[int]bool) {
+topLoop:
 	for i := range len(file.Decls) - 1 {
 		d1, d2 := file.Decls[i], file.Decls[i+1]
 
-		isFuncOrType := func(d ast.Decl) bool {
+		isRelevantDecl := func(d ast.Decl) bool {
 			switch x := d.(type) {
 			case *ast.FuncDecl:
 				return true
 			case *ast.GenDecl:
-				return x.Tok == token.TYPE
+				switch x.Tok {
+				case token.TYPE, token.CONST, token.VAR:
+					return true
+				}
 			}
 			return false
 		}
 
-		if isFuncOrType(d1) && isFuncOrType(d2) {
-			d1Start := pass.Fset.Position(d1.Pos()).Line
-			d1End := pass.Fset.Position(d1.End()).Line
+		if !isRelevantDecl(d1) || !isRelevantDecl(d2) {
+			continue
+		}
 
-			startPos := d2.Pos()
-			switch v := d2.(type) {
-			case *ast.FuncDecl:
-				if v.Doc != nil {
-					startPos = v.Doc.Pos()
-				}
-			case *ast.GenDecl:
-				if v.Doc != nil {
-					startPos = v.Doc.Pos()
-				}
+		d1Start := pass.Fset.Position(d1.Pos()).Line
+		d1End := pass.Fset.Position(d1.End()).Line
+
+		startPos := d2.Pos()
+		switch v := d2.(type) {
+		case *ast.FuncDecl:
+			if v.Doc != nil {
+				startPos = v.Doc.Pos()
 			}
-			d2Start := pass.Fset.Position(startPos).Line
-			d2End := pass.Fset.Position(d2.End()).Line
-
-			exactlyOne := d2Start-d1End == 2
-			canBeGrouped := d1Start == d1End && d2Start == d2End && d2Start-d1End == 1
-			if !exactlyOne && !canBeGrouped {
-				pass.report(d2, "Keep one empty line between top-level declarations")
+		case *ast.GenDecl:
+			if v.Doc != nil {
+				startPos = v.Doc.Pos()
 			}
 		}
+		d2Start := pass.Fset.Position(startPos).Line
+		d2End := pass.Fset.Position(d2.End()).Line
+
+		exactlyOne := d2Start-d1End == 2
+		canBeGrouped := d1Start == d1End && d2Start == d2End && d2Start-d1End == 1
+		if exactlyOne || canBeGrouped {
+			continue
+		}
+		// Ensure the lines in between are not stand-alone comments.
+		for line := d1End + 1; line < d2Start; line++ {
+			if commentLines[line] {
+				continue topLoop
+			}
+		}
+		pass.report(d2, "Keep one empty line between top-level declarations")
 	}
 }
 

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -320,3 +320,8 @@ type groupedType1 struct {
 
 type groupedType2 struct {
 }
+
+// Declarations of different types shouldn't be grouped.
+func groupedFunc() {}
+type groupedType struct{} // want "Keep one empty line between top-level declarations"
+const groupedConst = 1 // want "Keep one empty line between top-level declarations"

--- a/tools/syz-linter/testdata/src/lintertest/lintertest.go
+++ b/tools/syz-linter/testdata/src/lintertest/lintertest.go
@@ -312,3 +312,11 @@ func twoEmptyLines1() {}
 
 
 func twoEmptyLines2() {} // want "Keep one empty line between top-level declarations"
+
+type groupedType1 struct {
+}
+
+// Stand-alone comment that is not groupedType2 Doc.
+
+type groupedType2 struct {
+}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -473,6 +473,7 @@ func TestExtractMultipleErrors(t *testing.T) {
 }
 
 const someLine = "[   96.999999] some message \n"
+
 const validKASANReport = `
 [   96.262735] BUG: KASAN: double-free or invalid-free in selinux_tun_dev_free_security+0x15/0x20
 [   96.271481] 


### PR DESCRIPTION
- **tools/syz-linter: enforce empty line rules for consts/vars too**
- **tools/syz-linter: don't allow grouping of declarations of different types**
