### PR TITLE
syz-cluster/controller: fix rare TestProcessor timeout

### DIFF
--- a/syz-cluster/controller/processor_test.go
+++ b/syz-cluster/controller/processor_test.go
@@ -153,33 +153,39 @@ func awaitFinishedSessions(t *testing.T, seriesRepo *db.SeriesRepository, wantFi
 
 type mockedWorkflows struct {
 	workflow.MockService
-	finish  chan struct{}
-	created map[string]struct{}
+	finish   chan struct{}
+	created  map[string]struct{}
+	finished map[string]struct{}
+	mu       sync.Mutex
 }
 
 func newMockedWorkflows() *mockedWorkflows {
 	obj := mockedWorkflows{
-		finish:  make(chan struct{}),
-		created: make(map[string]struct{}),
+		finish:   make(chan struct{}, 100),
+		created:  make(map[string]struct{}),
+		finished: make(map[string]struct{}),
 	}
 	obj.PollDelayValue = time.Millisecond
 	obj.OnStart = func(id string) error {
+		obj.mu.Lock()
+		defer obj.mu.Unlock()
 		obj.created[id] = struct{}{}
 		return nil
 	}
 	obj.OnStatus = func(id string) (workflow.Status, []byte, error) {
-		_, ok := obj.created[id]
-		if !ok {
+		obj.mu.Lock()
+		defer obj.mu.Unlock()
+		if _, ok := obj.created[id]; !ok {
 			return workflow.StatusNotFound, nil, nil
 		}
-		finished := false
+		if _, ok := obj.finished[id]; ok {
+			return workflow.StatusFinished, nil, nil
+		}
 		select {
 		case <-obj.finish:
-			finished = true
-		default:
-		}
-		if finished {
+			obj.finished[id] = struct{}{}
 			return workflow.StatusFinished, nil, nil
+		default:
 		}
 		return workflow.StatusRunning, nil, nil
 	}


### PR DESCRIPTION
TestProcessor simulates a service restart by canceling the context mid-flight. Previously, if a worker goroutine was aborted by this cancellation and then encountered a transient Spanner error upon restart, it would loop and call the workflow mock's Status() method a second time.

Because the mock's channel was unbuffered and stateless regarding completions, the looping worker would consume a second token from the channel. This would starve another legitimate session, causing the test thread to block forever on channel send and panic after 10 minutes.

Fix the mock by making it stateful with a `finished` map and a mutex, and buffer the finish channel to decouple the test thread from worker polling.

***

Fixed #6972.