### PR TITLE
vm/gce: check that instance is running after copying files

### DIFF
--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -299,6 +299,10 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// This indicates the machine was likely preempted.
+	if !inst.GCE.IsInstanceRunning(inst.name) {
+		return "", fmt.Errorf("scp succeeded but instance is not running")
+	}
 	return vmDst, nil
 }
 


### PR DESCRIPTION
In some cases, a VM is preempted and binaries are copied to the wrong VM due to GCE quickly assigning its IP to a new machine. This results in lots of "mismatching manager/executor" errors. Now that we copy to an instance specific directory, checking that a VM is still running before execution should completely avoid these errors.

Fixes #7014

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
