### PR TITLE
pkg/db: reject oversized keyLen in deserializeRecord to prevent OOM

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -173,6 +173,9 @@ const (
 	// maxKeyLen guards against OOM when parsing a crafted corpus DB file.
 	// Real keys are SHA-256 hex strings (64 bytes); 64 KiB is a generous cap.
 	maxKeyLen = 64 << 10 // 65536
+	// maxValLen guards against decompression-bomb OOM in deserializeRecord.
+	// Corpus values are syscall-sequence programs; 16 MiB is a generous cap.
+	maxValLen = 16 << 20 // 16 MiB
 )
 
 func serializeHeader(w *bytes.Buffer, version uint64) {
@@ -305,10 +308,17 @@ func deserializeRecord(r *bufio.Reader) (key string, val []byte, seq uint64, err
 	}
 	if valLen != 0 {
 		fr := flate.NewReader(&io.LimitedReader{R: r, N: int64(valLen)})
-		if val, err = io.ReadAll(fr); err != nil {
+		// +1 so len(val) > maxValLen detects output that exactly equals the limit.
+		lr := &io.LimitedReader{R: fr, N: int64(maxValLen) + 1}
+		val, err = io.ReadAll(lr)
+		fr.Close()
+		if err != nil {
 			return
 		}
-		fr.Close()
+		if len(val) > maxValLen {
+			err = fmt.Errorf("decompressed record value exceeds maximum %d bytes", maxValLen)
+			return
+		}
 	}
 	return
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -170,6 +170,9 @@ const (
 	recMagic   = uint32(0xfee1bad)
 	curVersion = uint32(2)
 	seqDeleted = ^uint64(0)
+	// maxKeyLen guards against OOM when parsing a crafted corpus DB file.
+	// Real keys are SHA-256 hex strings (64 bytes); 64 KiB is a generous cap.
+	maxKeyLen = 64 << 10 // 65536
 )
 
 func serializeHeader(w *bytes.Buffer, version uint64) {
@@ -279,6 +282,10 @@ func deserializeRecord(r *bufio.Reader) (key string, val []byte, seq uint64, err
 	}
 	var keyLen uint32
 	if err = binary.Read(r, binary.LittleEndian, &keyLen); err != nil {
+		return
+	}
+	if keyLen > maxKeyLen {
+		err = fmt.Errorf("record key length %d exceeds maximum %d", keyLen, maxKeyLen)
 		return
 	}
 	keyBuf := make([]byte, keyLen)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
@@ -256,6 +257,33 @@ func tempFile(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return fn
+}
+
+func TestDecompressionBombValLen(t *testing.T) {
+	// Regression test for decompression bomb: io.ReadAll(flate.NewReader(...))
+	// had no output size limit. A record whose decompressed value exceeds
+	// maxValLen must be rejected with an error.
+	fn := tempFile(t)
+	defer os.Remove(fn)
+
+	// Build a corpus DB with a single record whose value decompresses to
+	// maxValLen+1 bytes (a long run of zeros compresses very well).
+	bigVal := make([]byte, maxValLen+1)
+	var buf bytes.Buffer
+	serializeHeader(&buf, 0)
+	serializeRecord(&buf, "testkey", bigVal, 1)
+	if err := os.WriteFile(fn, buf.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(fn, true)
+	if err == nil {
+		t.Fatal("Open should have returned an error for decompression bomb value")
+	}
+	if db == nil {
+		t.Fatal("db must be non-nil in repair mode even on error")
+	}
+	t.Logf("correctly rejected decompression bomb: %v", err)
 }
 
 func TestOversizeKeyLen(t *testing.T) {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"os"
@@ -255,4 +256,41 @@ func tempFile(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return fn
+}
+
+func TestOversizeKeyLen(t *testing.T) {
+	// Regression test for OOM: keyLen is a raw uint32 with no bounds check.
+	// A crafted 24-byte corpus DB file with keyLen=maxKeyLen+1 must be rejected
+	// with an error rather than causing a large allocation.
+	f, err := os.CreateTemp("", "syz-db-oom-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	// Header: dbMagic(4) + curVersion(4) + userVersion(8)
+	header := make([]byte, 0, 16)
+	header = binary.LittleEndian.AppendUint32(header, dbMagic)
+	header = binary.LittleEndian.AppendUint32(header, curVersion)
+	header = binary.LittleEndian.AppendUint64(header, 0)
+	// Record: recMagic(4) + keyLen > maxKeyLen (4)
+	header = binary.LittleEndian.AppendUint32(header, recMagic)
+	header = binary.LittleEndian.AppendUint32(header, maxKeyLen+1)
+
+	if _, err := f.Write(header); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(f.Name(), true)
+	if err == nil {
+		t.Fatal("Open should have returned an error for oversize keyLen")
+	}
+	if db == nil {
+		t.Fatal("db must be non-nil in repair mode even on error")
+	}
+	// No records should have been recovered — the first record was malformed.
+	if len(db.Records) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(db.Records))
+	}
 }


### PR DESCRIPTION
## Summary

`deserializeRecord()` in `pkg/db/db.go` reads `keyLen` as a raw `uint32`
from the corpus DB binary file and passes it directly to `make([]byte, keyLen)`
with no bounds check. A crafted 24-byte corpus DB file can trigger a
**4 GB allocation** in `syz-manager` or `syz-hub` on startup, causing an OOM crash.

### Vulnerable code (db.go line 284, before this fix)

```go
var keyLen uint32
binary.Read(r, binary.LittleEndian, &keyLen)
keyBuf := make([]byte, keyLen) // no bounds check: up to 4 GB
```

### Root cause

`keyLen` is controlled by the on-disk file content. Real keys are
SHA-256 hex strings (64 bytes). There is no maximum-size guard.

### Proof of concept

A minimal trigger (24 bytes):

| Field | Value |
|---|---|
| dbMagic | `0x000baddb` (4 B LE) |
| curVersion | `0x00000002` (4 B LE) |
| userVersion | `0x0000000000000000` (8 B LE) |
| recMagic | `0x0fee1bad` (4 B LE) |
| keyLen | `0xffffffff` (4 B LE) |

Running the standalone reproducer (keyLen set to 512 MB to avoid crashing the host):

```
[*] Crafted corpus DB file: 24 bytes
[*] Encoded keyLen: 0x20000000 (512 MB)
[*] TotalAlloc before parse: 0 MB
[*] TotalAlloc after parse:  512 MB (delta: +512 MB)
[!] VULNERABLE: 512 MB allocated from a 24-byte corpus DB file.
[!] With keyLen=0xFFFFFFFF the allocation is 4 GB.
```

### Fix

Add `maxKeyLen = 64 KiB` constant and check `keyLen` against it before
the allocation. Real keys are 64-byte SHA-256 hex strings; 64 KiB is
a generous upper bound that cannot be exceeded by any legitimate record.

### Testing

`TestOversizeKeyLen` in `pkg/db/db_test.go` verifies that `Open()` returns
an error (without allocating) when given a crafted file with an oversized `keyLen`.

Note: there is a secondary issue where `valLen` is used with
`flate.NewReader` but the decompressed output is not bounded
(`io.ReadAll` is unbounded). A sufficiently crafted corpus file could
trigger a decompression bomb. That is left for a follow-up.