### PR TITLE
pkg/report: skip handle_bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ International Business Machines Corporation
 Institute of Software Chinese Academy of Sciences
 Berk Cem Goksel
 Nikolay Ivchenko
+Siwei Zhang

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -160,3 +160,4 @@ Nikolay Ivchenko
 Oleg Kulachenko
 Daniel Bransky
 Matan Kalina
+Siwei Zhang

--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1190,6 +1190,7 @@ var linuxStackParams = &stackParams{
 		"invalid_op",
 		"report_bug",
 		"fixup_bug",
+		"handle_bug",
 		"print_report",
 		"print_usage_bug",
 		"do_error",


### PR DESCRIPTION
The kernel commit a0cb371b521dde44f32cfe954b6ef6f82b407393 ("x86/bug: Handle __WARN_printf() trap in early_fixup_exception()") introduce handle_bug into the call stack.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
