### PR TITLE
syz-ci, pkg/updater: validate manager configs on new syzkaller builds

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -57,6 +57,11 @@ type Config struct {
 	SyzkallerDescriptions string
 	Targets               map[Target]bool
 	MakeTargets           []string // host make targets to build besides the targets-specific ones
+	// CheckConfigs is an optional callback invoked after a successful syzkaller build.
+	// It should validate that all manager configs are still compatible with the new revision
+	// (e.g. that enable_syscalls entries refer to syscalls that exist in the new build).
+	// Returning an error causes the build to be rejected.
+	CheckConfigs func() error
 }
 
 type Target struct {
@@ -307,6 +312,11 @@ func (upd *Updater) build(commit *vcs.Commit) error {
 	}, os.Environ()...)
 	if _, err := osutil.Run(time.Hour, cmd); err != nil {
 		return fmt.Errorf("testing failed: %w", err)
+	}
+	if upd.cfg.CheckConfigs != nil {
+		if err := upd.cfg.CheckConfigs(); err != nil {
+			return fmt.Errorf("manager config check failed: %w", err)
+		}
 	}
 	tagFile := filepath.Join(upd.syzkallerDir, "tag")
 	if err := osutil.WriteFile(tagFile, []byte(commit.Hash)); err != nil {

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -293,6 +293,9 @@ func main() {
 		SyzkallerDescriptions: cfg.SyzkallerDescriptions,
 		Targets:               updateTargets,
 		MakeTargets:           []string{"manager", "ci"},
+		CheckConfigs: func() error {
+			return checkManagerConfigs(cfg.Managers)
+		},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -540,6 +543,24 @@ func loadManagerConfig(cfg *Config, mgr *ManagerConfig) error {
 		managercfg.VM, err = config.MergeJSONs(managercfg.VM, cfg.PatchVMConfigs[managercfg.Type])
 		if err != nil {
 			return fmt.Errorf("failed to patch manager %v's VM: %w", mgr.Name, err)
+		}
+	}
+	return nil
+}
+
+// checkManagerConfigs validates that all manager configs are compatible with the current syzkaller
+// revision, in particular that enable_syscalls and disable_syscalls only reference syscalls that
+// exist in the current build. This is run as part of the syzkaller build process so that syscall
+// renames are caught as build errors rather than runtime failures during patch testing.
+func checkManagerConfigs(managers []*ManagerConfig) error {
+	for _, mgr := range managers {
+		cfg := mgr.managercfg
+		if cfg == nil {
+			continue
+		}
+		if _, err := mgrconfig.ParseEnabledSyscalls(cfg.Target, cfg.EnabledSyscalls,
+			cfg.DisabledSyscalls, mgrconfig.AnyDescriptions); err != nil {
+			return fmt.Errorf("manager %v: %w", cfg.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When syscalls are renamed between syzkaller revisions, manager configs that reference the old names
in `enable_syscalls` cause `#syz test` to fail immediately with "unknown enabled syscall" before any
VM is started. The failure comes from `mgrconfig.Complete` in `instance.Test()`, which validates
syscall names against the current process's compiled-in `prog.Target`—even though the old names
would be valid for the target `SyzkallerCommit` being tested.

The fix adds a `CheckConfigs` callback to `pkg/updater.Config` that is invoked after a successful
syzkaller build in `Updater.build()`. In `syz-ci`, this callback calls `checkManagerConfigs`, which
runs `mgrconfig.ParseEnabledSyscalls` for every manager config against the current revision's
syscall table. If a syscall name was renamed in the new revision, the build is rejected before it
is deployed, and `uploadSyzkallerBuildError` reports the failure to the dashboard. This turns a
silent runtime failure into a proactive build-time error so CI operators know to update manager
configs before the new revision goes live.

Fixes #7025
