### PR TITLE
dashboard/app: limit ai result column width

### DIFF
--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -696,10 +696,10 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	<tr>
 		<td class="tag">{{link $job.Link $job.ID}}</td>
 		<td>{{$job.Workflow}}</td>
-		<td>
+		<td class="ai_result">
 			{{range $res := $job.Results}}
 				{{if $res.IsBool}}
-					{{$res.Name}}: {{if $res.Value}}✅{{else}}❌{{end}}&nbsp;
+					<span>{{$res.Name}}: {{if $res.Value}}✅{{else}}❌{{end}}</span>
 				{{end}}
 			{{end}}
 		</td>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -244,6 +244,15 @@ table td, table th {
 	font-size: 75%;
 }
 
+.list_table .ai_result {
+	max-width: 400pt;
+	white-space: normal;
+}
+
+.list_table .ai_result span {
+	white-space: nowrap;
+}
+
 .list_table .ai_correct {
 	text-align: center;
 }


### PR DESCRIPTION
With the addition of assessment-security workflow, the table with the AI jobs has become unreadable.

Fix it by setting max width for the results column.