### PR TITLE
pkg/lore-relay: include changelog into the templates

### DIFF
--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -109,10 +109,17 @@ type NewReportResult struct {
 	Body       string
 	Version    int
 	GitDiff    string
+	Changelog  []ChangelogEntry
 	To         []string
 	Cc         []string
 	BaseCommit string
 	BaseTree   string
+}
+
+type ChangelogEntry struct {
+	Version int
+	Link    string
+	Text    string
 }
 
 type ReplyResult struct {

--- a/pkg/lore-relay/templates/new_patch.txt
+++ b/pkg/lore-relay/templates/new_patch.txt
@@ -1,7 +1,12 @@
 {{.Patch.Body}}
 
 ---
-{{.Patch.GitDiff}}
+{{if .Patch.Changelog}}{{range $i, $c := .Patch.Changelog}}{{if $i}}
+{{end}}v{{$c.Version}}:
+{{if $c.Text}}{{$c.Text}}
+{{end}}{{if $c.Link}}{{$c.Link}}
+{{end}}{{end}}---
+{{end}}{{.Patch.GitDiff}}
 
 base-commit: {{.Patch.BaseCommit}}
 -- 

--- a/pkg/lore-relay/testdata/patch_v2.in.json
+++ b/pkg/lore-relay/testdata/patch_v2.in.json
@@ -1,9 +1,25 @@
 {
   "Patch": {
     "Subject": "Fix another bug",
-    "Body": "This is v2 of the patch with fixed z.",
-    "Version": 2,
+    "Body": "This is v3 of the patch with fixed z.",
+    "Version": 3,
     "GitDiff": "diff --git a/file2 b/file2\n--- a/file2\n+++ b/file2\n@@ -1 +1 @@\n-old2\n+new2",
-    "BaseCommit": "123456abcdef"
+    "BaseCommit": "123456abcdef",
+    "Changelog": [
+      {
+        "Version": 3,
+        "Text": "- Fixed ABCD.\n- Improved documentation."
+      },
+      {
+        "Version": 2,
+        "Link": "https://lore.kernel.org/all/message-id-2/T/",
+        "Text": "- Fixed EFG.\n- Adjusted formatting."
+      },
+      {
+        "Version": 1,
+        "Link": "https://lore.kernel.org/all/message-id-1/T/",
+        "Text": ""
+      }
+    ]
   }
 }

--- a/pkg/lore-relay/testdata/patch_v2.out.txt
+++ b/pkg/lore-relay/testdata/patch_v2.out.txt
@@ -1,7 +1,19 @@
-Subject: [PATCH v2] Fix another bug
+Subject: [PATCH v3] Fix another bug
 
-This is v2 of the patch with fixed z.
+This is v3 of the patch with fixed z.
 
+---
+v3:
+- Fixed ABCD.
+- Improved documentation.
+
+v2:
+- Fixed EFG.
+- Adjusted formatting.
+https://lore.kernel.org/all/message-id-2/T/
+
+v1:
+https://lore.kernel.org/all/message-id-1/T/
 ---
 diff --git a/file2 b/file2
 --- a/file2


### PR DESCRIPTION
Render the changelog as it should be listed for Linux kernel patches.

***

Taken out of #7150.