### PR TITLE
pkg/lore-relay: report own emails as such

### DIFF
--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -65,6 +65,7 @@ type SendExternalCommandReq struct {
 	RootExtID    string
 	MessageExtID string
 	Author       string
+	OwnEmail     bool
 	// Only one must be set.
 	Upstream *UpstreamCommand `json:",omitempty"`
 	Reject   *RejectCommand   `json:",omitempty"`

--- a/pkg/lore-relay/commands.go
+++ b/pkg/lore-relay/commands.go
@@ -21,6 +21,7 @@ func extractCommands(polled *lore.PolledEmail) ([]*dashapi.SendExternalCommandRe
 			RootExtID:    polled.RootMessageID,
 			MessageExtID: polled.Email.MessageID,
 			Author:       polled.Email.Author,
+			OwnEmail:     polled.Email.OwnEmail,
 		}
 
 		switch cmd.Command {
@@ -43,6 +44,7 @@ func extractCommands(polled *lore.PolledEmail) ([]*dashapi.SendExternalCommandRe
 			RootExtID:    polled.RootMessageID,
 			MessageExtID: polled.Email.MessageID,
 			Author:       polled.Email.Author,
+			OwnEmail:     polled.Email.OwnEmail,
 			Comment: &dashapi.CommentCommand{
 				Body: polled.Email.Body,
 			},


### PR DESCRIPTION
Pass on the flag whether the email was coming from our own addresses.

***

Taken out of #7150.