### PR TITLE
pkg/lore-relay: configure emails for replies

### DIFF
--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -113,7 +113,7 @@ In-Reply-To: <mock@msgid-1>
 	require.Len(t, mockSnd.sent, 2) // Moderation email + Public email.
 	assert.Equal(t, []string{"public@test.com", "maintainer@email.com"}, mockSnd.sent[1].To)
 	assert.Equal(t, "[PATCH] Test Description", mockSnd.sent[1].Subject)
-	assert.Equal(t, []string{"reviewer@email.com", "archive@lore.com"}, mockSnd.sent[1].Cc)
+	assert.Equal(t, []string{"archive@lore.com", "reviewer@email.com"}, mockSnd.sent[1].Cc)
 
 	bodyPublic := string(mockSnd.sent[1].Body)
 	assert.NotContains(t, bodyPublic, "Final To:")

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -116,9 +116,10 @@ type NewReportResult struct {
 }
 
 type ReplyResult struct {
-	Quote      string
-	Body       string
-	ReplyExtID string
+	Quote       string
+	Body        string
+	ReplyExtID  string
+	ReplyAuthor string
 }
 
 // ConfirmPublishedReq represents a request to confirm that a report has been published externally.

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -579,6 +579,21 @@ func RemoveFromEmailList(list []string, toRemove string) []string {
 	return result
 }
 
+// SubtractEmailLists subtracts all emails in 'toRemove' from 'list'.
+func SubtractEmailLists(list, toRemove []string) []string {
+	removeMap := make(map[string]bool)
+	for _, email := range toRemove {
+		removeMap[CanonicalEmail(email)] = true
+	}
+	var result []string
+	for _, email := range list {
+		if !removeMap[CanonicalEmail(email)] {
+			result = append(result, email)
+		}
+	}
+	return result
+}
+
 // Decode RFC 2047-encoded subjects.
 func decodeSubject(rawSubject string) string {
 	decoder := new(mime.WordDecoder)

--- a/pkg/lore-relay/relay.go
+++ b/pkg/lore-relay/relay.go
@@ -134,14 +134,34 @@ func (r *Relay) PollDashboardOnce(ctx context.Context) error {
 	}
 	subject := GenerateSubject(resp.Result)
 	cc := slices.Clone(resp.Result.Cc)
-	if r.cfg.LoreArchive != "" {
-		cc = append(cc, r.cfg.LoreArchive)
+	to := slices.Clone(resp.Result.To)
+
+	inReplyTo := ""
+	if len(resp.Result.Replies) > 0 {
+		inReplyTo = resp.Result.Replies[0].ReplyExtID
+		// If it's a reply and no patch is attached, GenerateSubject gives an empty subject.
+		// We must provide a subject for the email sender.
+		if subject == "" {
+			subject = "Aggregated Comment Reply"
+		}
+		var replyAuthors []string
+		for _, reply := range resp.Result.Replies {
+			if reply.ReplyAuthor != "" {
+				replyAuthors = append(replyAuthors, reply.ReplyAuthor)
+			}
+		}
+		to = email.MergeEmailLists(to, replyAuthors)
 	}
+	if r.cfg.LoreArchive != "" {
+		cc = email.MergeEmailLists(cc, []string{r.cfg.LoreArchive})
+	}
+	cc = email.SubtractEmailLists(cc, to)
 	email := &sender.Email{
-		To:      resp.Result.To,
-		Cc:      cc,
-		Subject: subject,
-		Body:    []byte(body),
+		To:        to,
+		Cc:        cc,
+		Subject:   subject,
+		InReplyTo: inReplyTo,
+		Body:      []byte(body),
 	}
 	r.cfg.Tracer.Logf("sending email: %s", subject)
 	msgID, err := r.emailSender.Send(ctx, email)

--- a/pkg/lore-relay/relay_test.go
+++ b/pkg/lore-relay/relay_test.go
@@ -70,7 +70,7 @@ func TestMainScenario(t *testing.T) {
 
 	require.Len(t, mockSnd.sent, 1)
 	assert.Equal(t, []string{"maintainer@email"}, mockSnd.sent[0].To)
-	assert.Equal(t, []string{"cc@email", "archive@lore.com"}, mockSnd.sent[0].Cc)
+	assert.Equal(t, []string{"archive@lore.com", "cc@email"}, mockSnd.sent[0].Cc)
 	assert.Equal(t, "[PATCH RFC] Fix bug", mockSnd.sent[0].Subject)
 
 	require.Len(t, mockDash.confirmed, 1)


### PR DESCRIPTION
For now, when we send replies to comments, include all to whom we reply into the To list, and subtract that list from Cc.

***

Taken out of #7150.