### PR TITLE
vm/vmimpl: default to legacy scp protocol

### DIFF
--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -77,7 +77,7 @@ func SSHArgsForward(debug bool, sshKey string, port, forwardPort int, systemSSHC
 }
 
 func scpArgs(debug bool, sshKey string, port int, systemSSHCfg bool) []string {
-	return sshArgs(debug, sshKey, "-P", port, 0, systemSSHCfg)
+	return append(sshArgs(debug, sshKey, "-P", port, 0, systemSSHCfg), "-O") // Default to legacy scp protocol.
 }
 
 func sshArgs(debug bool, sshKey, portArg string, port, forwardPort int, systemSSHCfg bool) []string {


### PR DESCRIPTION
Newer versions of OpenSSH scp default to using the SFTP protocol, which may not be supported by all target test VMs. Pass the -O flag to force the use of the legacy SCP protocol.

re: #7090

We can make it configurable in another PR.
I'm indecisive about which one to make the default though, SFTP, or legacy SCP?