### PR TITLE
pkg/aflow: Fix compilation of WAIT_ON() on non-x86 arches

### DIFF
--- a/pkg/aflow/tool/toolkit/race_toolkit.h
+++ b/pkg/aflow/tool/toolkit/race_toolkit.h
@@ -42,11 +42,10 @@
 
 // Spin-wait Barrier: Wait until a memory location has a specific value.
 // Best for tight race windows (low latency, no context switches).
-#define WAIT_ON(addr, val)                                                 \
-	do {                                                               \
-		while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) != (val)) { \
-			__builtin_ia32_pause();                            \
-		}                                                          \
+#define WAIT_ON(addr, val)                                               \
+	do {                                                             \
+		while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) != (val)) \
+			;                                                \
 	} while (0)
 
 // Signal: Set a memory location to a specific value to release a WAIT_ON.


### PR DESCRIPTION
The compiler built-in __builtin_ia32_pause() is only available on x86 arches.

ok  	github.com/google/syzkaller/pkg/aflow/tool/syzlang	(cached) --- FAIL: TestToolkitsInTestData (0.11s)
    --- FAIL: TestToolkitsInTestData/toolkit_functional_test.c (0.05s)
        toolkit_test.go:33: compilation failed: exit status 1
            In file included from testdata/toolkit_functional_test.c:2:
            testdata/toolkit_functional_test.c: In function 'wait_thread':
            testdata/../race_toolkit.h:48:25: error: implicit declaration of function '__builtin_ia32_pause'; did you mean '__builtin_isspace'? [-Wimplicit-function-declaration]
               48 |                         __builtin_ia32_pause();                            \
                  |                         ^~~~~~~~~~~~~~~~~~~~
            testdata/toolkit_functional_test.c:14:9: note: in expansion of macro 'WAIT_ON'
               14 |         WAIT_ON(&flag, 1);
                  |         ^~~~~~~
FAIL
FAIL	github.com/google/syzkaller/pkg/aflow/tool/toolkit	0.151s


Fixes: 5f81e509a046 ("pkg/aflow: implement Race Condition Toolkit for C reproducers")

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
