### PR TITLE
pkg/codesearch: fix find-references for static functions

### DIFF
--- a/pkg/codesearch/codesearch.go
+++ b/pkg/codesearch/codesearch.go
@@ -317,7 +317,8 @@ func (index *Index) FindReferences(contextFile, name, srcPrefix string, contextL
 			// the reference is in another file and refers to a static 'foo'
 			// defined in that file (which is not the target 'foo').
 			if ref.Name != name || !isField && (ref.EntityKind != target.Kind ||
-				target.IsStatic && target.Body.File != def.Body.File) {
+				target.IsStatic && !strings.HasSuffix(target.Body.File, ".h") &&
+					target.Body.File != def.Body.File) {
 				continue
 			}
 			totalCount++

--- a/pkg/codesearch/testdata/query-file-index-source
+++ b/pkg/codesearch/testdata/query-file-index-source
@@ -8,4 +8,5 @@ function func_accepting_a_struct
 function function_with_comment_in_header
 function function_with_quotes_in_type
 function open
+function reference_to_header_static
 struct struct_in_c_file

--- a/pkg/codesearch/testdata/query-find-references-static
+++ b/pkg/codesearch/testdata/query-find-references-static
@@ -1,0 +1,10 @@
+find-references "" func_in_header "" 1 10
+
+func_in_header has 1 references:
+
+function reference_to_header_static calls it at source0.c:50
+  49:	{
+  50:		func_in_header();
+  51:	}
+
+

--- a/pkg/codesearch/testdata/source0.c
+++ b/pkg/codesearch/testdata/source0.c
@@ -45,6 +45,11 @@ int field_refs(struct some_struct* p, union some_union* u)
 	return p->x;
 }
 
+void reference_to_header_static()
+{
+	func_in_header();
+}
+
 // compile_commands.json we create for tests defines KBUILD_BASENAME.
 // If it's not defined, compile_commands.json is not properly loaded.
 // This is supposed to fail builds, if that happens.

--- a/pkg/codesearch/testdata/source0.c.json
+++ b/pkg/codesearch/testdata/source0.c.json
@@ -185,6 +185,25 @@
 			}
 		},
 		{
+			"name": "reference_to_header_static",
+			"type": "void ()",
+			"kind": "function",
+			"body": {
+				"file": "source0.c",
+				"start_line": 48,
+				"end_line": 51
+			},
+			"comment": {},
+			"refs": [
+				{
+					"name": "func_in_header",
+					"kind": "calls",
+					"entity_kind": "function",
+					"line": 50
+				}
+			]
+		},
+		{
 			"name": "another_struct",
 			"kind": "struct",
 			"body": {


### PR DESCRIPTION
Currently find-references fails to find references to static functions
defined in header files. Fix that.
