### PR TITLE
pkg/aflow: baseline implementation for determining the guilty commit

### DIFF
--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -66,6 +66,12 @@ type PatchingOutputs struct {
 	PatchDescription string
 	PatchDiff        string
 	Recipients       []Recipient
+	Fixes            FixesTag
+}
+
+type FixesTag struct {
+	Hash  string
+	Title string
 }
 
 type Recipient struct {

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codeexpert"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/gitlog"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
@@ -64,7 +65,7 @@ func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {
 				TaskType:      aflow.FormalReasoningTask,
 				Instruction:   verdictInstruction,
 				Prompt:        verdictPrompt,
-				Tools:         aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool),
+				Tools:         aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools),
 				SummaryWindow: summaryWindow,
 			},
 

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -5,6 +5,7 @@ package patching
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/actionsyzlang"
@@ -16,6 +17,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/gitlog"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 type Inputs struct {
@@ -66,6 +68,17 @@ func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
 			},
 			kernel.CheckoutScratch,
 			PatchGenerationLoop(summaryWindow, nil, patchInstruction, patchPrompt),
+			&aflow.LLMAgent{
+				Name:          "fixes-finder",
+				Model:         aflow.BestExpensiveModel,
+				Outputs:       aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
+				TaskType:      aflow.FormalReasoningTask,
+				Instruction:   fixesInstruction,
+				Prompt:        fixesPrompt,
+				Tools:         commonTools,
+				SummaryWindow: summaryWindow,
+			},
+			formatFixes,
 			getMaintainers,
 			getRecentCommits,
 			&aflow.LLMAgent{
@@ -242,7 +255,7 @@ should be used instead if necessary.
 `
 
 func PatchGenerationLoop(summaryWindow int, beforeEach aflow.Action, instruction, prompt string) aflow.Action {
-	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool)
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools)
 
 	doPipeline := []aflow.Action{}
 	if beforeEach != nil {
@@ -269,3 +282,100 @@ func PatchGenerationLoop(summaryWindow int, beforeEach aflow.Action, instruction
 		MaxIterations: 10,
 	}
 }
+
+const fixesInstruction = `
+You are an experienced Linux kernel developer tasked with identifying the commit
+that introduced the bug being fixed. Identifying the correct buggy commit is crucial
+for proper kernel maintenance (backporting to stable trees, etc.).
+
+Your investigation strategy:
+1. Examine the patch that fixes the bug. Use git tools (like git-log or git-blame)
+   to trace the history of the lines or functions modified by the patch.
+2. Analyze the stack trace in the crash report. Identify the key files and functions
+   involved in the crash and investigate their history to see when the problematic
+   logic was introduced.
+3. Compare the bug explanation with the commit history to find the point where
+   the described logic error first appeared.
+
+A bug is typically introduced when a piece of code is first written, or when
+a refactoring changed its logic in a way that introduced the bug.
+Trace the history of relevant symbols or find when specific code patterns were introduced/removed.
+
+You must provide exactly one bug-introducing commit hash.
+If you are unable to confidently determine the bug-introducing commit after investigation,
+return an empty string rather than guessing.
+`
+
+const fixesPrompt = `
+The crash is:
+
+{{.ReproducedCrashReport}}
+
+The explanation of the root cause is:
+
+{{.BugExplanation}}
+
+The patch that fixes the bug is:
+
+{{.PatchDiff}}
+
+Search for the commit(s) that introduced this bug.
+`
+
+type fixesFinderState struct {
+	KernelSrc    string
+	KernelCommit string
+}
+
+type fixesFinderArgs struct {
+	FixesHash string `jsonschema:"The commit hash that introduced the bug."`
+}
+
+func validateFixesHashes(ctx *aflow.Context, state fixesFinderState, args fixesFinderArgs) (fixesFinderArgs, error) {
+	if args.FixesHash == "" {
+		return args, nil
+	}
+	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
+		commit, err := repo.Commit(args.FixesHash)
+		if err != nil {
+			return aflow.BadCallError("commit hash %q not found in the repository", args.FixesHash)
+		}
+		// LLM can provide a commit from a different branch.
+		// We want to ensure it is actually reachable from the current commit.
+		if _, err := repo.SwitchCommit(state.KernelCommit); err != nil {
+			return err
+		}
+		reachable, err := repo.Contains(commit.Hash)
+		if err != nil || !reachable {
+			return aflow.BadCallError("commit %q is not reachable from the current commit",
+				args.FixesHash)
+		}
+		args.FixesHash = commit.Hash
+		return nil
+	})
+	return args, err
+}
+
+type formatFixesResult struct {
+	Fixes ai.FixesTag
+}
+
+var formatFixes = aflow.NewFuncAction("format-fixes",
+	func(ctx *aflow.Context, args fixesFinderArgs) (formatFixesResult, error) {
+		var fix ai.FixesTag
+		if args.FixesHash == "" {
+			return formatFixesResult{}, nil
+		}
+		err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
+			commit, err := repo.Commit(args.FixesHash)
+			if err != nil {
+				return fmt.Errorf("failed to get commit %q: %w", args.FixesHash, err)
+			}
+			fix = ai.FixesTag{
+				Hash:  commit.Hash,
+				Title: commit.Title,
+			}
+			return nil
+		})
+		return formatFixesResult{Fixes: fix}, err
+	})

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codeeditor"
 	"github.com/google/syzkaller/pkg/aflow/tool/codeexpert"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/gitlog"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
@@ -42,7 +43,7 @@ type Inputs struct {
 }
 
 func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
-	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool)
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools)
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -122,8 +122,22 @@ func Tools(tools ...any) []Tool {
 
 // LLMOutputs creates a special tool that can be used by LLM to provide structured outputs.
 func LLMOutputs[Args any]() *llmOutputs {
+	return ValidatedLLMOutputs[struct{}, Args](nil)
+}
+
+// ValidatedLLMOutputs is like LLMOutputs but allows to validate the outputs before accepting them.
+// The validate function may return modified Args, which will be used as the final result.
+// If the validate function returns an error, it will be returned to the LLM agent,
+// so that it can retry the call. Use BadCallError if LLM must retry.
+func ValidatedLLMOutputs[State, Args any](validate func(*Context, State, Args) (Args, error)) *llmOutputs {
 	return &llmOutputs{
-		tool: NewFuncTool(llmSetResultsTool, func(ctx *Context, state struct{}, args Args) (Args, error) {
+		tool: NewFuncTool(llmSetResultsTool, func(ctx *Context, state State, args Args) (Args, error) {
+			if validate != nil {
+				var err error
+				if args, err = validate(ctx, state, args); err != nil {
+					return args, err
+				}
+			}
 			return args, nil
 		}, "Use this tool to provide results of the analysis."),
 		provideOutputs: func(ctx *verifyContext, who string, many bool) {
@@ -707,6 +721,7 @@ func (a *LLMAgent) verify(ctx *verifyContext) {
 			ctx.provideOutput(a.Name, a.Reply, replyType)
 		}
 		if a.Outputs != nil {
+			a.Outputs.tool.verify(ctx)
 			a.Outputs.provideOutputs(ctx, a.Name, a.Candidates > 1)
 		}
 	}

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -381,3 +381,82 @@ func TestOutputOverflow(t *testing.T) {
 		nil,
 	)
 }
+
+func TestValidatedLLMOutputs(t *testing.T) {
+	type flowOutputs struct {
+		Result    int
+		Unrelated int
+	}
+	type flowInputs struct {
+		StateValue int
+		Unrelated  int
+	}
+	type subState struct {
+		StateValue int
+	}
+	type flowResults struct {
+		Result int `jsonschema:"Result"`
+	}
+	testFlow[flowInputs, flowOutputs](t, map[string]any{"StateValue": 42, "Unrelated": 123},
+		map[string]any{"Result": 43, "Unrelated": 123},
+		&LLMAgent{
+			Name:  "smarty",
+			Model: "model",
+			Outputs: ValidatedLLMOutputs[subState, flowResults](
+				func(ctx *Context, state subState, args flowResults) (flowResults, error) {
+					if state.StateValue != 42 {
+						return args, fmt.Errorf("bad state value: %v", state.StateValue)
+					}
+					if args.Result == 42 {
+						return args, BadCallError("result cannot be 42")
+					}
+					if args.Result == 100 {
+						args.Result = 43
+					}
+					return args, nil
+				}),
+			TaskType:    FormalReasoningTask,
+			Instruction: "Instructions",
+			Prompt:      "Initial Prompt with {{.StateValue}} and {{.Unrelated}}",
+		},
+		[]any{
+			// First try returns an invalid result.
+			&genai.Part{FunctionCall: &genai.FunctionCall{Name: "set-results", Args: map[string]any{"Result": 42}}},
+			// Second try returns a result that is modified by the validation function.
+			&genai.Part{FunctionCall: &genai.FunctionCall{Name: "set-results", Args: map[string]any{"Result": 100}}},
+		},
+		nil,
+	)
+}
+
+func TestValidatedLLMOutputsVerify(t *testing.T) {
+	type flowInputs struct {
+		StateValue int
+	}
+	type flowOutputs struct {
+		Result int
+	}
+	type missingState struct {
+		MissingValue int
+	}
+	type flowResults struct {
+		Result int `jsonschema:"Result"`
+	}
+
+	testRegistrationError[flowInputs, flowOutputs](t,
+		"flow test-test: action set-results: no input MissingValue, available inputs: [StateValue]",
+		&Flow{
+			Name: "test",
+			Root: &LLMAgent{
+				Name:  "smarty",
+				Model: "model",
+				Outputs: ValidatedLLMOutputs[missingState, flowResults](
+					func(ctx *Context, state missingState, args flowResults) (flowResults, error) {
+						return args, nil
+					}),
+				TaskType:    FormalReasoningTask,
+				Instruction: "Instructions",
+				Prompt:      "Initial Prompt",
+			},
+		})
+}

--- a/pkg/aflow/testdata/TestValidatedLLMOutputs.llm.json
+++ b/pkg/aflow/testdata/TestValidatedLLMOutputs.llm.json
@@ -1,0 +1,108 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instructions\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"Result": {
+										"description": "Result",
+										"type": "integer"
+									}
+								},
+								"required": [
+									"Result"
+								],
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"Result": {
+										"description": "Result",
+										"type": "integer"
+									}
+								},
+								"required": [
+									"Result"
+								],
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"responseModalities": [
+				"TEXT"
+			],
+			"thinkingConfig": {
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt with 42 and 123"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt with 42 and 123"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"args": {
+								"Result": 42
+							},
+							"name": "set-results"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"name": "set-results",
+							"response": {
+								"error": "result cannot be 42"
+							}
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestValidatedLLMOutputs.trajectory.json
+++ b/pkg/aflow/testdata/TestValidatedLLMOutputs.trajectory.json
@@ -1,0 +1,128 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instructions\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Initial Prompt with 42 and 123"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:05Z",
+		"Args": {
+			"Result": 42
+		}
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Error": "result cannot be 42",
+		"Args": {
+			"Result": 42
+		},
+		"Results": {
+			"Result": 42
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:09Z",
+		"Args": {
+			"Result": 100
+		}
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Args": {
+			"Result": 100
+		},
+		"Results": {
+			"Result": 43
+		}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:11Z",
+		"Results": {
+			"Result": 43
+		},
+		"Instruction": "Instructions\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Initial Prompt with 42 and 123"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"Results": {
+			"Result": 43,
+			"Unrelated": 123
+		}
+	}
+]

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -1,0 +1,181 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package gitlog
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+var (
+	ToolLog = aflow.NewFuncTool("git-log", gitLog, `
+The tool executes git log on the kernel sources and returns the output.
+Use it to find commits that introduced or modified specific code, symbols, or matched a message.
+
+Supported search modes (you must provide at least one):
+ - Code search (-G): use 'CodeRegexp' to find commits that introduced or removed code matching the regexp.
+ - Symbol search (-L): use 'SymbolName' and 'SourcePath' to trace the history of a specific function or struct.
+   Example: SymbolName="tcp_v4_rcv", SourcePath="net/ipv4/tcp_ipv4.c".
+ - Message search: use 'MessageRegexps' (array of regexps) to find commits with matching titles or descriptions.
+   If multiple regexps are provided, only commits matching ALL of them are returned.
+   The search is case-insensitive.
+ - File history: use 'PathPrefix' to explore the history of a single file or directory.
+   Example: PathPrefix="mm/slub.c".
+`)
+	ToolShow = aflow.NewFuncTool("git-show", gitShow, `
+Tool provides full information about a specific git commit, including its title,
+full description, and the diff.
+`)
+	ToolBlame = aflow.NewFuncTool("git-blame", gitBlame, `
+Tool provides git blame for a given file and line range.
+It helps to identify which commit last modified specific lines of code.
+`)
+
+	Tools = []aflow.Tool{ToolLog, ToolShow, ToolBlame}
+)
+
+const maxOutputLines = 1000
+
+type state struct {
+	KernelSrc    string
+	KernelCommit string
+}
+
+type logArgs struct {
+	CodeRegexp string `jsonschema:"Regexp to search in the code diffs (-G)." json:",omitempty"`
+	SymbolName string `jsonschema:"Name of the function or struct to trace (-L)." json:",omitempty"`
+	// nolint: lll
+	SourcePath string `jsonschema:"Source path for the symbol search (-L). Required if SymbolName is set." json:",omitempty"`
+	// nolint: lll
+	MessageRegexps []string `jsonschema:"Regexps to search in the commit messages. All regexps must match." json:",omitempty"`
+	PathPrefix     string   `jsonschema:"Restrict search to this directory or file path." json:",omitempty"`
+	Count          int      `jsonschema:"Max number of commits to return." json:",omitempty"`
+}
+
+type logResult struct {
+	Output string `jsonschema:"Output of the git log command."`
+}
+
+func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
+	if args.CodeRegexp == "" && args.SymbolName == "" && len(args.MessageRegexps) == 0 &&
+		args.PathPrefix == "" {
+		return logResult{}, aflow.BadCallError("at least one of CodeRegexp, SymbolName, " +
+			"MessageRegexps, or PathPrefix must be set")
+	}
+	if args.Count <= 0 {
+		args.Count = 10
+	}
+	args.Count = min(args.Count, 100)
+
+	gitArgs := []string{"log", "--format=%h %s", "--abbrev=12", "--no-patch", "-n", fmt.Sprint(args.Count)}
+
+	if args.CodeRegexp != "" {
+		gitArgs = append(gitArgs, "-G", args.CodeRegexp)
+	}
+	if args.SymbolName != "" {
+		if args.SourcePath == "" {
+			return logResult{}, aflow.BadCallError("SourcePath is required when SymbolName is set")
+		}
+		gitArgs = append(gitArgs, fmt.Sprintf("-L:%s:%s", args.SymbolName, args.SourcePath))
+	}
+	if len(args.MessageRegexps) != 0 {
+		gitArgs = append(gitArgs, "--regexp-ignore-case", "--all-match")
+		for _, re := range args.MessageRegexps {
+			gitArgs = append(gitArgs, "--grep", re)
+		}
+	}
+
+	if args.CodeRegexp == "" && args.SymbolName == "" {
+		gitArgs = append(gitArgs, "--no-merges")
+	}
+
+	gitArgs = append(gitArgs, state.KernelCommit)
+
+	if args.PathPrefix != "" {
+		gitArgs = append(gitArgs, "--", args.PathPrefix)
+	}
+
+	output, err := osutil.RunCmd(5*time.Minute, state.KernelSrc, "git", gitArgs...)
+	if err != nil {
+		return logResult{}, gitBadCallError(err, "git log")
+	}
+	return logResult{Output: string(output)}, nil
+}
+
+type showArgs struct {
+	Commit string `jsonschema:"Commit hash or reference."`
+}
+
+type showResult struct {
+	Output string `jsonschema:"Full commit information including diff."`
+}
+
+func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error) {
+	if args.Commit == "" {
+		return showResult{}, aflow.BadCallError("commit hash is required")
+	}
+	output, err := osutil.RunCmd(time.Minute, state.KernelSrc, "git", "show", "--no-color", args.Commit)
+	if err != nil {
+		return showResult{}, gitBadCallError(err, "git show")
+	}
+	return showResult{Output: truncate(output, maxOutputLines)}, nil
+}
+
+type blameArgs struct {
+	File  string `jsonschema:"Source file path."`
+	Start int    `jsonschema:"Start line number (1-based)."`
+	End   int    `jsonschema:"End line number (inclusive)."`
+}
+
+type blameResult struct {
+	Output string `jsonschema:"Output of the git blame command."`
+}
+
+func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, error) {
+	args.Start = max(args.Start, 1)
+	args.End = max(args.End, args.Start)
+	args.End = min(args.End, args.Start+maxOutputLines)
+	lineRange := fmt.Sprintf("%d,%d", args.Start, args.End)
+	output, err := osutil.RunCmd(time.Minute, state.KernelSrc, "git",
+		"blame", "-s", "-L", lineRange, "--abbrev=12", state.KernelCommit, "--", args.File)
+	if err != nil {
+		return blameResult{}, gitBadCallError(err, "git blame")
+	}
+	return blameResult{Output: truncate(output, maxOutputLines)}, nil
+}
+
+func gitBadCallError(err error, name string) error {
+	var verr *osutil.VerboseError
+	if !errors.As(err, &verr) {
+		return err
+	}
+	if verr.ExitCode == 128 && (bytes.Contains(verr.Output, []byte("bad object")) ||
+		bytes.Contains(verr.Output, []byte("bad revision")) ||
+		bytes.Contains(verr.Output, []byte("unknown revision")) ||
+		bytes.Contains(verr.Output, []byte("ambiguous argument"))) {
+		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
+	}
+	if verr.ExitCode == 1 && len(verr.Output) == 0 {
+		return nil // No matches is a valid result.
+	}
+	return err
+}
+
+func truncate(output []byte, maxLines int) string {
+	lines := slices.Collect(bytes.Lines(output))
+	if len(lines) <= maxLines {
+		return string(output)
+	}
+	return fmt.Sprintf(`
+Full output is too long, showing %v out of %v lines.
+
+%s
+`, maxLines, len(lines), slices.Concat(lines[:maxLines]))
+}

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package gitlog
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitShow(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := vcs.MakeTestRepo(t, filepath.Join(tmpDir, "repo", "linux"))
+	c1 := repo.CommitChangeset("initial commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+void foo() {
+	// BUG HERE
+}
+`,
+	})
+
+	// Test git-show.
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repo.Dir},
+		showArgs{Commit: c1.Hash},
+		func(res showResult) {
+			expected := fmt.Sprintf(`(?s)^commit %s
+Author: Test Syzkaller <test@syzkaller\.com>
+Date:   .*
+
+    initial commit
+
+diff --git a/foo\.c b/foo\.c
+.*
+\+void foo\(\) {
+\+	// BUG HERE
+\+}`, c1.Hash)
+			assert.Regexp(t, expected, res.Output)
+		},
+		"")
+
+	// Test git-show with non-existing commit.
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repo.Dir},
+		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567"},
+		showResult{},
+		"git show failed: fatal: bad object 0123456789abcdef0123456789abcdef01234567")
+}
+
+func TestGitBlame(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
+	c1 := repo.CommitChangeset("initial commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+void foo() {
+	// BUG HERE
+}
+`,
+	})
+	c2 := repo.CommitChangeset("third commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+void foo() {
+	// BUG HERE
+	// fixed!
+}
+`,
+	})
+
+	// Test git-blame.
+	aflow.TestTool(t, ToolBlame,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		blameArgs{File: "foo.c", Start: 3, End: 4},
+		func(res blameResult) {
+			expected := fmt.Sprintf(`(?m)^\^%s.* 3\) 	// BUG HERE
+%s.* 4\) 	// fixed!
+$`, c1.Hash[:12], c2.Hash[:12])
+			assert.Regexp(t, expected, res.Output)
+		},
+		"")
+}
+
+func TestGitLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
+	c1 := repo.CommitChangeset("initial commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+void foo() {
+	// BUG HERE
+}
+`,
+	})
+	c2 := repo.CommitChangeset("second commit", vcs.FileContent{
+		File: "bar.c",
+		Content: `
+void bar() {
+	foo();
+}
+`,
+	})
+	c3 := repo.CommitChangeset("third commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+void foo() {
+	// BUG HERE
+	// fixed!
+}
+`,
+	})
+
+	// Test git-log message search.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
+			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
+		"")
+
+	// Test git-log multiple message regexps.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"third", "commit"}},
+		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
+		"")
+
+	// Test git-log message search case-insensitive.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"COMMIT"}},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
+			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
+		"")
+
+	// Test git-log code search (-G).
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{CodeRegexp: "fixed"},
+		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
+		"")
+
+	// Test git-log symbol search (-L).
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{SymbolName: "foo", SourcePath: "foo.c"},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
+		"")
+
+	// Test git-log path prefix.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{PathPrefix: "foo.c"},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
+		"")
+
+	// Test git-log no matches.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"non-existing"}},
+		logResult{},
+		"")
+
+	// Test git-log code search (-G) no matches.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{CodeRegexp: "non-existing"},
+		logResult{},
+		"")
+
+	// Test git-log error: missing SourcePath for symbol search.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{SymbolName: "foo"},
+		logResult{},
+		"SourcePath is required when SymbolName is set")
+
+	// Test git-log error: no filters provided.
+	aflow.TestTool(t, ToolLog,
+		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		logArgs{},
+		logResult{},
+		"at least one of CodeRegexp, SymbolName, MessageRegexps, or PathPrefix must be set")
+}


### PR DESCRIPTION
As part of the `patching` workflow, determine the commit(s) to be used in the future `Fixes: ` tag.
See individual commits.

Cc #7185