### PR TITLE
pkg/vcs: use git apply

### DIFF
--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -233,17 +233,17 @@ func NewLKMLRepo(dir string) Repo {
 }
 
 func Patch(dir string, patch []byte) error {
-	// Do --dry-run first to not mess with partially consistent state.
-	cmd := osutil.Command("patch", "-p1", "--force", "--ignore-whitespace", "--dry-run")
+	// Do --check first to not mess with partially consistent state.
+	args := []string{"apply", "-p1", "--ignore-whitespace", "--check", "-"}
+	cmd := osutil.Command("git", args...)
 	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return err
 	}
 	cmd.Stdin = bytes.NewReader(patch)
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
-		// If it reverses clean, then it's already applied
-		// (seems to be the easiest way to detect it).
-		cmd = osutil.Command("patch", "-p1", "--force", "--ignore-whitespace", "--reverse", "--dry-run")
+		// If it reverses clean, then it's already applied.
+		cmd = osutil.Command("git", "apply", "-p1", "--ignore-whitespace", "--reverse", "--check", "-")
 		if err := osutil.Sandbox(cmd, true, true); err != nil {
 			return err
 		}
@@ -255,7 +255,8 @@ func Patch(dir string, patch []byte) error {
 		return fmt.Errorf("failed to apply patch:\n%s", output)
 	}
 	// Now apply for real.
-	cmd = osutil.Command("patch", "-p1", "--force", "--ignore-whitespace")
+	args = []string{"apply", "-p1", "--ignore-whitespace", "-"}
+	cmd = osutil.Command("git", args...)
 	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return err
 	}

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -4,11 +4,52 @@
 package vcs
 
 import (
+	"fmt"
 	"net/mail"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestPatch(t *testing.T) {
+	for _, repo := range []bool{false, true} {
+		t.Run(fmt.Sprintf("repo=%v", repo), func(t *testing.T) {
+			dir := t.TempDir()
+			if repo {
+				MakeTestRepo(t, dir)
+			}
+			file := filepath.Join(dir, "file.txt")
+			err := os.WriteFile(file, []byte("line1\nline2\n"), 0644)
+			require.NoError(t, err)
+
+			patch := []byte("--- a/file.txt\n+++ b/file.txt\n@@ -1,2 +1,3 @@\n line1\n+injected\n line2\n")
+			err = Patch(dir, patch)
+			require.NoError(t, err)
+
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+			require.Equal(t, "line1\ninjected\nline2\n", string(content))
+
+			err = Patch(dir, patch)
+			require.ErrorContains(t, err, "patch is already applied")
+		})
+	}
+}
+
+func TestPatchForbidden(t *testing.T) {
+	dir := t.TempDir()
+	MakeTestRepo(t, dir)
+
+	// Modification of .git/ directory must be blocked.
+	patch1 := []byte("--- /dev/null\n+++ b/.git/file.txt\n@@ -0,0 +1 @@\n+injected\n")
+	require.Error(t, Patch(dir, patch1))
+
+	// Path traversal must be blocked.
+	patch2 := []byte("--- a/../file.txt\n+++ b/../file.txt\n@@ -0,0 +1 @@\n+injected\n")
+	require.Error(t, Patch(dir, patch2))
+}
 
 func TestCanonicalizeCommit(t *testing.T) {
 	tests := map[string]string{


### PR DESCRIPTION
Unlike patch, it prohibits modifying .git or parent directory files. Add tests.