### PR TITLE
syz-agent: add missing lore-relay-pvc

### DIFF
--- a/syz-agent/k8s/common/lore-relay/kustomization.yaml
+++ b/syz-agent/k8s/common/lore-relay/kustomization.yaml
@@ -5,3 +5,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - lore-relay.yaml
+  - lore-relay-pvc.yaml

--- a/syz-agent/k8s/common/lore-relay/lore-relay-pvc.yaml
+++ b/syz-agent/k8s/common/lore-relay/lore-relay-pvc.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lore-relay-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 32Gi
+  storageClassName: standard


### PR DESCRIPTION
The PVC was mentioned in the pod definition, but never actually committed in. Fix it.