### PR TITLE
syz-agent: keep lore-relay in a separate namespace

### DIFF
--- a/syz-agent/k8s/overlays/prod-lore/kustomization.yaml
+++ b/syz-agent/k8s/overlays/prod-lore/kustomization.yaml
@@ -4,7 +4,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: syz-agent
+namespace: lore-relay
 namePrefix: prod-
 
 resources:


### PR DESCRIPTION
It was put into syz-agent one by mistake.