### PR TITLE
pkg/vcs: disable gc.auto in test repositories

### DIFF
--- a/pkg/vcs/git_test_util.go
+++ b/pkg/vcs/git_test_util.go
@@ -56,6 +56,10 @@ func MakeTestRepo(t *testing.T, dir string) *TestRepo {
 	repo.Git("init")
 	repo.Git("config", "--add", "user.email", userEmail)
 	repo.Git("config", "--add", "user.name", userName)
+	repo.Git("config", "--add", "gc.auto", "0")
+	repo.Git("config", "--add", "gc.autoDetach", "false")
+	repo.Git("config", "--add", "maintenance.auto", "false")
+	repo.Git("config", "--add", "maintenance.autoDetach", "false")
 	return repo
 }
 


### PR DESCRIPTION
Git 2.54 introduced the "geometric" maintenance strategy by default, which frequently spawns detached background `git gc` processes after `git commit`.

In our parallel bisection tests, this caused flaky ENOENT errors because background GC raced with concurrent `git commit` invocations by deleting loose object directories. These detached processes also leaked out of the test environment.

Set `gc.auto=0` to prevent Git from spawning background maintenance processes during tests.

***

Hopefully closes https://github.com/google/syzkaller/issues/7117