### PR TITLE
syz-agent: disable CGO for lore-relay container build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ agent: descriptions
 	CGO_ENABLED=1 GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-agent github.com/google/syzkaller/syz-agent/agent
 
 lore-relay: descriptions
-	CGO_ENABLED=1 GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-lore-relay github.com/google/syzkaller/syz-agent/lore-relay
+	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-lore-relay github.com/google/syzkaller/syz-agent/lore-relay
 
 repro: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-repro github.com/google/syzkaller/tools/syz-repro

--- a/syz-agent/lore-relay/Dockerfile
+++ b/syz-agent/lore-relay/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN make lore-relay
+RUN CGO_ENABLED=0 make lore-relay
 
 FROM alpine:latest
 


### PR DESCRIPTION
The syz-lore-relay binary was previously built with CGO_ENABLED=1, which produced a dynamically linked binary depending on glibc. When deployed to the Alpine-based container, this caused a "no such file or directory" error on startup since Alpine uses musl.

Fix this by explicitly setting CGO_ENABLED=0 in the Dockerfile when building the binary. Also remove the hardcoded CGO_ENABLED=1 from the main Makefile's lore-relay target so it can be controlled by the environment.
