### PR TITLE
pkg/lore-relay: stay silent on unsupported/multiple commands

### DIFF
--- a/pkg/lore-relay/relay.go
+++ b/pkg/lore-relay/relay.go
@@ -195,14 +195,17 @@ func (r *Relay) HandleIncomingEmail(ctx context.Context, polled *lore.PolledEmai
 	r.cfg.Tracer.Logf("handling incoming email from %s", polled.Email.Author)
 	reqs, err := extractCommands(polled)
 	if err != nil {
-		// TODO: include instructions with the list of supported commands.
-		return r.replyError(ctx, polled, err.Error())
+		// TODO: for tracked threads we may want to reply with an error (#7199).
+		r.cfg.Tracer.Logf("ignoring email %s: %v", polled.Email.MessageID, err)
+		return nil
 	}
 	if len(reqs) == 0 {
 		return nil
 	}
 	if len(reqs) > 1 {
-		return r.replyError(ctx, polled, "multiple commands in a single message are not supported")
+		// TODO: for tracked threads we may want to reply with an error (#7199).
+		r.cfg.Tracer.Logf("ignoring email %s: multiple commands in a single message", polled.Email.MessageID)
+		return nil
 	}
 	var resp *dashapi.SendExternalCommandResp
 	backoffs := r.backoffs

--- a/pkg/lore-relay/relay_test.go
+++ b/pkg/lore-relay/relay_test.go
@@ -309,10 +309,12 @@ This is just a normal comment.
 	require.Len(t, mockSnd.sent, 0)
 }
 
-func testCommandReplyError(t *testing.T, incomingBody, expectedReply string) {
+func testCommandSilent(t *testing.T, incomingBody string, mockDash *mockDashboard) {
 	loreArchive := lore.NewTestLoreArchive(t, t.TempDir())
 	cfg := &Config{LorePollInterval: time.Hour}
-	mockDash := &mockDashboard{}
+	if mockDash == nil {
+		mockDash = &mockDashboard{}
+	}
 	mockSnd := &mockSender{}
 	lorePoller, err := lore.NewPoller(lore.PollerConfig{
 		RepoDir: t.TempDir(),
@@ -327,9 +329,7 @@ func testCommandReplyError(t *testing.T, incomingBody, expectedReply string) {
 	err = relay.PollLoreOnce(context.Background())
 	require.NoError(t, err)
 
-	require.Len(t, mockSnd.sent, 1)
-	assert.Equal(t, []string{"user@email"}, mockSnd.sent[0].To)
-	assert.Equal(t, expectedReply, string(mockSnd.sent[0].Body))
+	require.Len(t, mockSnd.sent, 0)
 }
 
 func TestMultipleCommandsReply(t *testing.T) {
@@ -340,9 +340,7 @@ Message-ID: <msg1>
 #syz upstream
 #syz reject
 `
-	expected := "> #syz upstream\n> #syz reject\n\n" +
-		"Command failed:\n\nmultiple commands in a single message are not supported\n\n"
-	testCommandReplyError(t, incoming, expected)
+	testCommandSilent(t, incoming, nil)
 }
 
 func TestUnsupportedCommandReply(t *testing.T) {
@@ -352,9 +350,19 @@ Message-ID: <msg1>
 
 #syz fix
 `
-	expected := "> #syz fix\n\n" +
-		"Command failed:\n\nunsupported command: fix\n\n"
-	testCommandReplyError(t, incoming, expected)
+	testCommandSilent(t, incoming, nil)
+}
+
+func TestUnsupportedCommandUntracked(t *testing.T) {
+	incoming := `From: user@email
+Subject: [PATCH] Fix bug
+Message-ID: <msg1>
+
+#syz fix
+`
+	testCommandSilent(t, incoming, &mockDashboard{
+		cmdErr: dashapi.ErrReportNotFound,
+	})
 }
 
 func TestBackoff(t *testing.T) {


### PR DESCRIPTION
Currently, lore-relay attempts to send an error reply via email when it encounters an unsupported or multiple syzkaller commands. This can lead to unwanted spam on unrelated mailing list threads and can trigger SMTP errors if the relay is not fully configured.

Stay silent for now in these cases, logging the Message ID and reason for skipping instead. Added TODOs to reconsider this behavior for tracked threads in the future.

Updated the related tests to expect the new silent behavior.