### PR TITLE
pkg/aflow: fix panic when tool names are used in agent prompts

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -240,13 +240,13 @@ func (a *LLMAgent) executeMany(ctx *Context) error {
 }
 
 func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]any, error) {
-	cfg, instruction, tools := a.config(ctx)
+	cfg, instruction, prompt, tools := a.config(ctx)
 
 	span := &trajectory.Span{
 		Type:        trajectory.SpanAgent,
 		Name:        a.Name,
 		Instruction: instruction,
-		Prompt:      formatTemplate(a.Prompt, ctx.state),
+		Prompt:      prompt,
 		Model:       ctx.modelName(a.Model),
 	}
 	if err := ctx.startSpan(span); err != nil {
@@ -394,7 +394,7 @@ func (a *LLMAgent) slide(req []*genai.Content, summary *genai.Content) ([]*genai
 	return req, addNewSummary
 }
 
-func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, map[string]Tool) {
+func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, string, map[string]Tool) {
 	toolList := a.Tools
 	if a.Outputs != nil {
 		toolList = append(toolList, a.Outputs.tool)
@@ -418,6 +418,7 @@ func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, m
 	if a.Outputs != nil {
 		instruction += llmOutputsInstruction
 	}
+	prompt := formatTemplate(a.Prompt, state)
 	return &genai.GenerateContentConfig{
 		ResponseModalities: []string{"TEXT"},
 		Temperature:        genai.Ptr(taskParameters[a.TaskType]),
@@ -438,7 +439,7 @@ func (a *LLMAgent) config(ctx *Context) (*genai.GenerateContentConfig, string, m
 			// we use ThinkingLevel.
 			ThinkingLevel: genai.ThinkingLevelHigh,
 		},
-	}, instruction, toolMap
+	}, instruction, prompt, toolMap
 }
 
 func (a *LLMAgent) callTools(ctx *Context, tools map[string]Tool, calls []*genai.FunctionCall) (

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -290,6 +290,31 @@ func TestNilToolArg(t *testing.T) {
 	)
 }
 
+func TestToolInPrompt(t *testing.T) {
+	type flowResults struct {
+		Ignored string
+	}
+	testFlow[struct{}, flowResults](t, nil, map[string]any{"Ignored": "Ignored"},
+		&LLMAgent{
+			Name:        "prompt-tester",
+			Model:       "model",
+			Reply:       "Ignored",
+			TaskType:    FormalReasoningTask,
+			Instruction: "Use {{.toolSwissKnife}}",
+			Prompt:      "Please call {{.toolSwissKnife}} now.",
+			Tools: []Tool{
+				NewFuncTool("swiss-knife", func(ctx *Context, state struct{}, args struct{}) (struct{}, error) {
+					return struct{}{}, nil
+				}, "description"),
+			},
+		},
+		[]any{
+			genai.NewPartFromText("Ignored"),
+		},
+		nil,
+	)
+}
+
 func TestAgentRegistrationErrors(t *testing.T) {
 	testRegistrationError[struct{}, struct{}](t,
 		`flow test: action smarty: Instruction: template: :1: function "NonExistentFoo" not defined`,

--- a/pkg/aflow/testdata/TestToolInPrompt.llm.json
+++ b/pkg/aflow/testdata/TestToolInPrompt.llm.json
@@ -1,0 +1,51 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Use swiss-knife\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "description",
+							"name": "swiss-knife",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"responseModalities": [
+				"TEXT"
+			],
+			"thinkingConfig": {
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Please call swiss-knife now."
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestToolInPrompt.trajectory.json
+++ b/pkg/aflow/testdata/TestToolInPrompt.trajectory.json
@@ -1,0 +1,59 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "prompt-tester",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Use swiss-knife\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Please call swiss-knife now."
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "prompt-tester",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "prompt-tester",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "prompt-tester",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Instruction": "Use swiss-knife\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Please call swiss-knife now.",
+		"Reply": "Ignored"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"Ignored": "Ignored"
+		}
+	}
+]


### PR DESCRIPTION
LLMAgent uses two templates: Instruction and Prompt. Previously, tool names (e.g. {{.toolCodeeditor}}) were only injected into the state map during the Instruction formatting phase. If a Prompt template also referenced a tool, it would trigger a "missing key" panic during execution.

This change moves the formatting of both templates into a single config() method, ensuring they both use the same augmented state map containing all available tools.

A regression test is added to verify tool name resolution in Prompts.

Closes https://github.com/google/syzkaller/issues/7197
