### PR TITLE
dashboard/app: allow manual push of AI jobs to reporting

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -133,14 +133,15 @@ type uiAIJobPage struct {
 	Header *uiHeader
 	Job    *uiAIJob
 	// The slice contains the same single Job, just for HTML templates convenience.
-	Jobs           []*uiAIJob
-	Args           []*uiAIJobArg
-	CrashReport    template.HTML
-	TrajectoryHTML template.HTML
-	History        []*uiJobReviewHistory
-	CurrentStage   string
-	NextStage      string
-	Reportings     []*uiJobReporting
+	Jobs               []*uiAIJob
+	Args               []*uiAIJobArg
+	CrashReport        template.HTML
+	TrajectoryHTML     template.HTML
+	History            []*uiJobReviewHistory
+	CurrentStage       string
+	NextStage          string
+	CanPushToReporting bool
+	Reportings         []*uiJobReporting
 }
 
 type uiAIJobDetails struct {
@@ -352,22 +353,80 @@ func getJobStageInfo(ctx context.Context, job *aidb.Job) (*aidb.JobReporting, *A
 }
 
 func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hdr *uiHeader) error {
+	if r.Method != http.MethodPost {
+		return nil
+	}
+
 	correct := r.FormValue("correct")
-	if correct == "" {
+	pushToReporting := r.FormValue("push_to_reporting") == "1"
+
+	if correct == "" && !pushToReporting {
 		return nil
 	}
 	if !hdr.AIActions {
 		return ErrAccess
 	}
 	if !job.Finished.Valid || job.Error != "" {
-		return fmt.Errorf("job is in wrong state to set correct status")
+		return fmt.Errorf("job is in wrong state to be modified")
 	}
 	user := currentUser(ctx)
 	if user == nil {
 		return ErrAccess
 	}
-	userEmail := user.Email
 
+	if pushToReporting {
+		return handleAIJobPagePushToReporting(ctx, job, user.Email)
+	}
+	return handleAIJobPageCorrectness(ctx, job, correct, user.Email)
+}
+
+func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userEmail string) error {
+	if err := checkJobUpstreamable(job); err != nil {
+		return err
+	}
+
+	reportings, err := aidb.LoadJobReportings(ctx, job.ID)
+	if err != nil {
+		return err
+	}
+	if len(reportings) > 0 {
+		return fmt.Errorf("job already has reportings")
+	}
+
+	nsCfg := getNsConfig(ctx, job.Namespace)
+	if nsCfg.AI == nil || len(nsCfg.AI.Stages) == 0 {
+		return fmt.Errorf("no AI stages configured")
+	}
+
+	stageCfg, err := determineNextStage(ctx, nsCfg.AI, job, "")
+	if err != nil {
+		return err
+	}
+	if stageCfg == nil {
+		return fmt.Errorf("no valid next stage found")
+	}
+
+	args := aidb.UpstreamReportArgs{
+		Job: job,
+		Reporting: &aidb.JobReporting{
+			Stage:        stageCfg.Name,
+			Source:       stageCfg.ServingIntegration,
+			Version:      spanner.NullInt64{Int64: 1, Valid: true},
+			UpstreamedAt: spanner.NullTime{Time: aidb.TimeNow(ctx), Valid: true},
+		},
+		NoParallel:    stageCfg.NoParallelReports,
+		CommandSource: SourceWebUI,
+		CommandExtID:  "",
+		User:          userEmail,
+		Reason:        "Manual push to reporting",
+	}
+	if err := aidb.UpstreamReportCommand(ctx, args); err != nil {
+		return fmt.Errorf("failed to upstream job: %w", err)
+	}
+	return nil
+}
+
+func handleAIJobPageCorrectness(ctx context.Context, job *aidb.Job, correct, userEmail string) error {
 	switch correct {
 	case aiCorrectnessCorrect:
 		currentReporting, _, err := getJobStageInfo(ctx, job)
@@ -466,17 +525,29 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return err
 	}
+
+	canPushToReporting := false
+	nsCfg := getNsConfig(ctx, job.Namespace)
+	if len(uiReportings) == 0 && nsCfg.AI != nil && len(nsCfg.AI.Stages) > 0 {
+		if job.Type == ai.WorkflowPatching && job.Finished.Valid && job.Error == "" {
+			if checkJobUpstreamable(job) == nil {
+				canPushToReporting = true
+			}
+		}
+	}
+
 	page := &uiAIJobPage{
-		Header:         hdr,
-		Job:            uiJob,
-		Jobs:           []*uiAIJob{uiJob},
-		Args:           uiArgs,
-		CrashReport:    crashReport,
-		History:        uiHistory,
-		TrajectoryHTML: trajectoryHTML,
-		CurrentStage:   currentStageStr,
-		NextStage:      nextStageStr,
-		Reportings:     uiReportings,
+		Header:             hdr,
+		Job:                uiJob,
+		Jobs:               []*uiAIJob{uiJob},
+		Args:               uiArgs,
+		CrashReport:        crashReport,
+		History:            uiHistory,
+		TrajectoryHTML:     trajectoryHTML,
+		CurrentStage:       currentStageStr,
+		NextStage:          nextStageStr,
+		CanPushToReporting: canPushToReporting,
+		Reportings:         uiReportings,
 	}
 	if r.FormValue("json") == "1" {
 		w.Header().Set("Content-Type", "application/json")

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -63,14 +63,8 @@ func handleUpstreamCommand(ctx context.Context, req *dashapi.SendExternalCommand
 
 func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	currentReporting *aidb.JobReporting, req *dashapi.SendExternalCommandReq) error {
-	// Prevent upstreaming if the job didn't actually produce a patch (e.g. reply-only iteration).
-	if job.Results.Valid {
-		if res, ok := job.Results.Value.(map[string]any); ok {
-			diff, _ := res["PatchDiff"].(string)
-			if diff == "" && (job.Type == ai.WorkflowPatching || job.Type == ai.WorkflowPatchIteration) {
-				return &aidb.ErrCannotUpstream{Reason: "Cannot upstream a job that did not produce a patch."}
-			}
-		}
+	if err := checkJobUpstreamable(job); err != nil {
+		return err
 	}
 
 	nsCfg := getNsConfig(ctx, job.Namespace)
@@ -108,6 +102,19 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 		User:          req.Author,
 		Reason:        "",
 	})
+}
+
+func checkJobUpstreamable(job *aidb.Job) error {
+	// Prevent upstreaming if the job didn't actually produce a patch (e.g. reply-only iteration).
+	if job.Results.Valid {
+		if res, ok := job.Results.Value.(map[string]any); ok {
+			diff, _ := res["PatchDiff"].(string)
+			if diff == "" && (job.Type == ai.WorkflowPatching || job.Type == ai.WorkflowPatchIteration) {
+				return &aidb.ErrCannotUpstream{Reason: "Cannot upstream a job that did not produce a patch."}
+			}
+		}
+	}
+	return nil
 }
 
 func determineNextStage(ctx context.Context, cfg *AIConfig, job *aidb.Job,

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1374,3 +1374,52 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 	require.NotEmpty(t, resp2.ID)
 	require.NotEqual(t, resp.ID, resp2.ID) // Must be a new job.
 }
+
+func TestAIManualPushToReporting(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// 1. Finish a job with no AI stages configured (no reporting generated).
+	c.SetAIConfig(&AIConfig{})
+
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName: "test", CodeRevision: "test-rev", Workflows: []dashapi.AIWorkflow{{Type: "patching", Name: "patching"}},
+	})
+	require.NoError(t, err)
+	jobID := c.createAIJob(extID, "patching", "")
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID, Results: map[string]any{
+			"PatchDiff":        "diff",
+			"PatchDescription": "Subject\n\nBody",
+			"KernelCommit":     "abcd",
+			"KernelRepo":       "git://repo",
+		},
+	})
+	require.NoError(t, err)
+
+	reportings, err := aidb.LoadJobReportings(c.ctx, jobID)
+	require.NoError(t, err)
+	require.Empty(t, reportings)
+
+	// 2. Add an AI stage to the config and push the job.
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{{Name: "public", ServingIntegration: "lore"}},
+	})
+
+	values := url.Values{}
+	values.Set("push_to_reporting", "1")
+	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", jobID), values)
+	require.NoError(t, err)
+
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: "lore"})
+	require.NoError(t, err)
+	require.NotNil(t, pollResp.Result)
+	// Make sure the poll returns our manually pushed job.
+	require.Equal(t, "Subject", pollResp.Result.Patch.Subject)
+}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -368,12 +368,14 @@ func TestAIJobActions(t *testing.T) {
 		Results: map[string]any{"PatchDiff": "diff", "PatchDescription": "description"},
 	}))
 
-	jobAssessURL := fmt.Sprintf("/ai_job?id=%v&correct=%v", resp.ID, aiCorrectnessCorrect)
-	_, err = c.AuthGET(AccessPublic, jobAssessURL)
+	jobAssessURL := fmt.Sprintf("/ai_job?id=%v", resp.ID)
+	values := url.Values{}
+	values.Set("correct", aiCorrectnessCorrect)
+	_, err = c.AuthPOSTForm(AccessPublic, jobAssessURL, values)
 	require.Error(t, err)
 	// Redirect to login page.
 	require.Contains(t, err.Error(), fmt.Sprint(http.StatusTemporaryRedirect))
-	_, err = c.AuthGET(AccessUser, jobAssessURL)
+	_, err = c.AuthPOSTForm(AccessUser, jobAssessURL, values)
 	require.NoError(t, err)
 
 	// Test crash w/o C repro.
@@ -444,7 +446,9 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 	require.Contains(t, string(respJSON), `"Trajectory"`)
 
 	// Since the job is not completed, setting correctness must fail.
-	_, err = c.GET(fmt.Sprintf("/ai_job?id=%v&correct=%v", resp.ID, aiCorrectnessCorrect))
+	values := url.Values{}
+	values.Set("correct", aiCorrectnessCorrect)
+	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", resp.ID), values)
 	require.Error(t, err)
 
 	require.NoError(t, c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
@@ -457,7 +461,7 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 	}))
 
 	// Now setting correctness must not fail.
-	_, err = c.GET(fmt.Sprintf("/ai_job?id=%v&correct=%v", resp.ID, aiCorrectnessCorrect))
+	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", resp.ID), values)
 	require.NoError(t, err)
 
 	// Verify history via UI helper to also test parsing logic.
@@ -475,7 +479,9 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 	c.advanceTime(time.Second)
 
 	// Re-mark the result as incorrect, this should remove the label.
-	_, err = c.GET(fmt.Sprintf("/ai_job?id=%v&correct=%v", resp.ID, aiCorrectnessIncorrect))
+	valuesIncorrect := url.Values{}
+	valuesIncorrect.Set("correct", aiCorrectnessIncorrect)
+	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", resp.ID), valuesIncorrect)
 	require.NoError(t, err)
 
 	uiHistory, err = LoadUIJobReviewHistory(c.ctx, resp.ID)

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -64,6 +64,13 @@ Detailed info on a single AI job execution.
 			</form>
 			<br>
 		{{end}}
+		{{if .CanPushToReporting}}
+			<form method="POST">
+				<input type="hidden" name="push_to_reporting" value="1">
+				<button type="submit">Push to {{.NextStage}}</button>
+			</form>
+			<br>
+		{{end}}
 	{{end}}
 
 	{{if .Reportings}}

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -468,6 +468,16 @@ func (ctx *Ctx) POSTForm(url string, form url.Values) ([]byte, error) {
 	return w.Body.Bytes(), nil
 }
 
+// AuthPOSTForm sends HTTP POST form to the app with the specified authorization.
+func (ctx *Ctx) AuthPOSTForm(access AccessLevel, url string, form url.Values) ([]byte, error) {
+	w, err := ctx.httpRequest("POST", url, form.Encode(),
+		"application/x-www-form-urlencoded", access)
+	if err != nil {
+		return nil, err
+	}
+	return w.Body.Bytes(), nil
+}
+
 // ContentType returns the response Content-Type header value.
 func (ctx *Ctx) ContentType(url string) (string, error) {
 	w, err := ctx.httpRequest("HEAD", url, "", "", AccessAdmin)


### PR DESCRIPTION
There are edge cases where an AI job correctly completes, but the namespace's AI configuration did not have a reporting stage set up at the exact time of completion. Because jobs only create their first reporting stage during the `apiAIJobDone` hook, such a job gets stuck and will never be reported.

To address this, this commit adds a manual 'Push to [Stage]' button to the AI job details page. The button is strictly visible to authorized users and only displays if the job has successfully finished, but has no existing reporting stages.

When triggered, it uses the standard `UpstreamReportCommand` logic to safely create the reporting stage. It also cleans up `handleAIJobPagePost` by enforcing that mutations are only accepted via POST.