### PR TITLE
dashboard/app: prioritize aborted AI jobs during polling

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -859,16 +859,16 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 }
 
 func pollAIJob(ctx context.Context, req *dashapi.AIJobPollReq, client APIClient) (*aidb.Job, error) {
-	job, err := aidb.StartJob(ctx, req, client.AIJobNamespaces)
+	job, err := aidb.NextStaleJob(ctx, req, client.AIJobNamespaces)
 	if err != nil {
-		return nil, fmt.Errorf("failed StartJob: %w", err)
+		log.Errorf(ctx, "NextStaleJob failed: %v", err)
 	}
 	if job != nil {
 		return job, nil
 	}
-	job, err = aidb.NextStaleJob(ctx, req, client.AIJobNamespaces)
+	job, err = aidb.StartJob(ctx, req, client.AIJobNamespaces)
 	if err != nil {
-		log.Errorf(ctx, "NextStaleJob failed: %v", err)
+		return nil, fmt.Errorf("failed StartJob: %w", err)
 	}
 	if job != nil {
 		return job, nil

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -961,7 +961,12 @@ func TestAIJobNamespaces(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	pollResp3, err := unrestrictedClient.AIJobPoll(pollReq)
+	pollReq3 := &dashapi.AIJobPollReq{
+		AgentName:    "unrestricted-agent-3",
+		CodeRevision: "unknown",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowRepro, Name: "repro"}},
+	}
+	pollResp3, err := unrestrictedClient.AIJobPoll(pollReq3)
 	require.NoError(t, err)
 	require.Equal(t, jobIDAins2, pollResp3.ID)
 


### PR DESCRIPTION
Swap the order of `aidb.NextStaleJob` and `aidb.StartJob` in `pollAIJob`. This ensures that aborted (e.g., from agent restarts) and stale jobs are prioritized and retried before agents pick up completely new jobs.

Also updates `TestAIJobNamespaces` to use a unique agent name to avoid accidentally triggering the restart logic mid-test.