### PR TITLE
pkg/aflow: implement token-based context compression

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -41,7 +41,7 @@ type PatchIterationInputs struct {
 	BaseCommit     string
 }
 
-func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {
+func createPatchIterationFlow(name string, summaryWindow, compressTokens int) *aflow.Flow {
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(
@@ -62,11 +62,12 @@ func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {
 					NeedNewVersion bool   `jsonschema:"True if any comment suggests or requires a code change to the patch, or if a rebase is requested. False otherwise."`
 					VerdictReason  string `jsonschema:"Brief explanation of why a new version is or is not needed."`
 				}](),
-				TaskType:      aflow.FormalReasoningTask,
-				Instruction:   verdictInstruction,
-				Prompt:        verdictPrompt,
-				Tools:         aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools),
-				SummaryWindow: summaryWindow,
+				TaskType:       aflow.FormalReasoningTask,
+				Instruction:    verdictInstruction,
+				Prompt:         verdictPrompt,
+				Tools:          aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools),
+				SummaryWindow:  summaryWindow,
+				CompressTokens: compressTokens,
 			},
 
 			// If the verdict agent decides a new patch is needed, generate it by applying the previous
@@ -76,7 +77,7 @@ func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {
 				Do: aflow.Pipeline(
 					extractLatestPatchInfo,
 					kernel.CheckoutScratch,
-					PatchGenerationLoop(summaryWindow, applyGitPatch, patchIterationInstruction, patchIterationPrompt),
+					PatchGenerationLoop(summaryWindow, compressTokens, applyGitPatch, patchIterationInstruction, patchIterationPrompt),
 					getRecentCommits,
 					&aflow.LLMAgent{
 						Name:  "changelog-generator",
@@ -86,10 +87,11 @@ func createPatchIterationFlow(name string, summaryWindow int) *aflow.Flow {
 							PatchDescriptionRaw string `jsonschema:"The updated full commit message for the new patch."`
 							NewChangeLog        string `jsonschema:"A bulleted list of changes made in this new version compared to the previous version."`
 						}](),
-						TaskType:      aflow.FormalReasoningTask,
-						Instruction:   changelogInstruction,
-						Prompt:        changelogPrompt,
-						SummaryWindow: summaryWindow,
+						TaskType:       aflow.FormalReasoningTask,
+						Instruction:    changelogInstruction,
+						Prompt:         changelogPrompt,
+						SummaryWindow:  summaryWindow,
+						CompressTokens: compressTokens,
 					},
 					formatPatchDescription,
 					getMaintainers,
@@ -185,7 +187,8 @@ func init() {
 	aflow.Register[PatchIterationInputs, ai.PatchIterationOutputs](
 		ai.WorkflowPatchIteration,
 		"address iterative feedback on generated patches",
-		createPatchIterationFlow("", 0),
+		createPatchIterationFlow("", 0, 0),
+		createPatchIterationFlow("compressed", 0, 200_000),
 	)
 }
 

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -44,8 +44,8 @@ type Inputs struct {
 	BaseCommit     string
 }
 
-func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
-	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools)
+func createPatchingFlow(name string, summaryWindow, compressTokens int) *aflow.Flow {
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools)
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(
@@ -57,39 +57,42 @@ func createPatchingFlow(name string, summaryWindow int) *aflow.Flow {
 			crash.Reproduce,
 			codesearcher.PrepareIndex,
 			&aflow.LLMAgent{
-				Name:          "debugger",
-				Model:         aflow.BestExpensiveModel,
-				Reply:         "BugExplanation",
-				TaskType:      aflow.FormalReasoningTask,
-				Instruction:   debuggingInstruction,
-				Prompt:        debuggingPrompt,
-				Tools:         commonTools,
-				SummaryWindow: summaryWindow,
+				Name:           "debugger",
+				Model:          aflow.BestExpensiveModel,
+				Reply:          "BugExplanation",
+				TaskType:       aflow.FormalReasoningTask,
+				Instruction:    debuggingInstruction,
+				Prompt:         debuggingPrompt,
+				Tools:          commonTools,
+				SummaryWindow:  summaryWindow,
+				CompressTokens: compressTokens,
 			},
 			kernel.CheckoutScratch,
-			PatchGenerationLoop(summaryWindow, nil, patchInstruction, patchPrompt),
+			PatchGenerationLoop(summaryWindow, compressTokens, nil, patchInstruction, patchPrompt),
 			&aflow.LLMAgent{
-				Name:          "fixes-finder",
-				Model:         aflow.BestExpensiveModel,
-				Outputs:       aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
-				TaskType:      aflow.FormalReasoningTask,
-				Instruction:   fixesInstruction,
-				Prompt:        fixesPrompt,
-				Tools:         commonTools,
-				SummaryWindow: summaryWindow,
+				Name:           "fixes-finder",
+				Model:          aflow.BestExpensiveModel,
+				Outputs:        aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
+				TaskType:       aflow.FormalReasoningTask,
+				Instruction:    fixesInstruction,
+				Prompt:         fixesPrompt,
+				Tools:          commonTools,
+				SummaryWindow:  summaryWindow,
+				CompressTokens: compressTokens,
 			},
 			formatFixes,
 			getMaintainers,
 			getRecentCommits,
 			&aflow.LLMAgent{
-				Name:          "description-generator",
-				Model:         aflow.BestExpensiveModel,
-				Reply:         "PatchDescriptionRaw",
-				TaskType:      aflow.FormalReasoningTask,
-				Instruction:   descriptionInstruction,
-				Prompt:        descriptionPrompt,
-				Tools:         commonTools,
-				SummaryWindow: summaryWindow,
+				Name:           "description-generator",
+				Model:          aflow.BestExpensiveModel,
+				Reply:          "PatchDescriptionRaw",
+				TaskType:       aflow.FormalReasoningTask,
+				Instruction:    descriptionInstruction,
+				Prompt:         descriptionPrompt,
+				Tools:          commonTools,
+				SummaryWindow:  summaryWindow,
+				CompressTokens: compressTokens,
 			},
 			formatPatchDescription,
 		),
@@ -100,8 +103,9 @@ func init() {
 	aflow.Register[Inputs, ai.PatchingOutputs](
 		ai.WorkflowPatching,
 		"generate a kernel patch fixing a provided bug reproducer",
-		createPatchingFlow("", 0),
-		createPatchingFlow("summary", 10),
+		createPatchingFlow("", 0, 0),
+		createPatchingFlow("summary", 10, 0),
+		createPatchingFlow("compressed", 0, 200_000),
 	)
 }
 
@@ -254,8 +258,9 @@ should be used instead if necessary.
 {{end}}
 `
 
-func PatchGenerationLoop(summaryWindow int, beforeEach aflow.Action, instruction, prompt string) aflow.Action {
-	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.Tool, gitlog.Tools)
+func PatchGenerationLoop(summaryWindow, compressTokens int,
+	beforeEach aflow.Action, instruction, prompt string) aflow.Action {
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools)
 
 	doPipeline := []aflow.Action{}
 	if beforeEach != nil {
@@ -264,14 +269,15 @@ func PatchGenerationLoop(summaryWindow int, beforeEach aflow.Action, instruction
 
 	doPipeline = append(doPipeline,
 		&aflow.LLMAgent{
-			Name:          "patch-generator",
-			Model:         aflow.BestExpensiveModel,
-			Reply:         "PatchExplanation",
-			TaskType:      aflow.FormalReasoningTask,
-			Instruction:   instruction,
-			Prompt:        prompt,
-			Tools:         aflow.Tools(commonTools, codeeditor.Tool),
-			SummaryWindow: summaryWindow,
+			Name:           "patch-generator",
+			Model:          aflow.BestExpensiveModel,
+			Reply:          "PatchExplanation",
+			TaskType:       aflow.FormalReasoningTask,
+			Instruction:    instruction,
+			Prompt:         prompt,
+			Tools:          aflow.Tools(commonTools, codeeditor.Tool),
+			SummaryWindow:  summaryWindow,
+			CompressTokens: compressTokens,
 		},
 		crash.TestPatch, // -> PatchDiff or TestError
 	)

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -51,7 +52,13 @@ type LLMAgent struct {
 	Tools []Tool
 	// Number of historical message (sliding window) to keep. If zero, we don't enable the sliding
 	// window summary feature (don't toss old messages).
+	// Mutually exclusive with CompressTokens.
 	SummaryWindow int
+	// Token limit for historical messages. If > 0, when the total input tokens exceed this limit,
+	// the agent will pause, call a cheaper model to summarize the entire history, and then drop
+	// all intermediate messages, leaving only the anchor prompt and the new summary.
+	// Mutually exclusive with SummaryWindow.
+	CompressTokens int
 
 	// Track recent tool calls for loop detection.
 	toolHistory []toolCallRecord
@@ -201,6 +208,9 @@ type llmOutputs struct {
 }
 
 func (a *LLMAgent) execute(ctx *Context) error {
+	if a.SummaryWindow > 0 && a.CompressTokens > 0 {
+		return errors.New("SummaryWindow and CompressTokens are mutually exclusive")
+	}
 	if a.Candidates <= 1 {
 		reply, outputs, err := a.executeOne(ctx, 0)
 		if err != nil {
@@ -260,6 +270,19 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 	return reply, outputs, ctx.finishSpan(span, err)
 }
 
+func (a *LLMAgent) handleOverflowError(cfg *genai.GenerateContentConfig, req []*genai.Content, answerNow bool) bool {
+	if a.Reply == llmToolReply && len(req) >= 3 && !answerNow {
+		cfg.ToolConfig = &genai.ToolConfig{
+			FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode: genai.FunctionCallingConfigModeNone,
+			},
+		}
+		req[len(req)-1] = genai.NewContentFromText(llmAnswerNow, genai.RoleUser)
+		return true
+	}
+	return false
+}
+
 func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools map[string]Tool,
 	prompt string, candidate int) (string, map[string]any, error) {
 	var outputs map[string]any
@@ -269,7 +292,19 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 	// We need it to check if the message-to-be-popped is a summary - if so, we need to add
 	// a new summary.
 	var summaryMessage *genai.Content
+	var lastInputTokens int
 	for {
+		var err error
+		var newSummaryMessage *genai.Content
+		req, newSummaryMessage, lastInputTokens, err = a.maybeCompressContext(ctx, req, lastInputTokens)
+		if err != nil {
+			return "", nil, err
+		}
+		if newSummaryMessage != nil || a.CompressTokens > 0 {
+			// If compression happened, reset the existing summaryMessage to nil (or the new one)
+			summaryMessage = newSummaryMessage
+		}
+
 		span := &trajectory.Span{
 			Type:  trajectory.SpanLLM,
 			Name:  a.Name,
@@ -281,6 +316,11 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 		addNewSummary := false
 		req, addNewSummary = a.slide(req, summaryMessage)
 		resp, respErr := a.generateContent(ctx, cfg, req, candidate)
+
+		if resp != nil && resp.UsageMetadata != nil {
+			lastInputTokens = int(resp.UsageMetadata.PromptTokenCount)
+		}
+
 		if respErr != nil {
 			span.Error = respErr.Error()
 			if err := ctx.finishSpan(span, nil); err != nil {
@@ -289,18 +329,11 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 			// Input overflows maximum number of tokens.
 			// If this is an LLMTool, we remove the last tool reply,
 			// and replace it with an order to answer right now.
-			if isInputTokenOverflowError(respErr) &&
-				a.Reply == llmToolReply &&
-				len(req) >= 3 &&
-				!answerNow {
-				answerNow = true
-				cfg.ToolConfig = &genai.ToolConfig{
-					FunctionCallingConfig: &genai.FunctionCallingConfig{
-						Mode: genai.FunctionCallingConfigModeNone,
-					},
+			if isInputTokenOverflowError(respErr) {
+				if a.handleOverflowError(cfg, req, answerNow) {
+					answerNow = true
+					continue
 				}
-				req[len(req)-1] = genai.NewContentFromText(llmAnswerNow, genai.RoleUser)
-				continue
 			}
 			return "", nil, respErr
 		}
@@ -350,6 +383,101 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 		}
 		req = append(req, responses)
 	}
+}
+
+const tokenCompressionInstruction = `
+You are an expert technical assistant acting as a memory compressor.
+Review the following execution history of an AI agent.
+The first message contains the original system instructions and the main goal.
+It will be preserved in the history, so DO NOT duplicate its contents in your summary.
+Write a comprehensive and substantial summary of the current state of the workspace
+and the investigation based on the SUBSEQUENT messages. Do NOT write a very short summary.
+Include:
+1. A detailed list of what approaches have been tried so far and their results (including dead-ends).
+2. The current hypotheses, theories, or active lines of investigation.
+3. Any specific file paths, code snippets, or configuration values that are critical to remember.
+4. Watch out for potential reasoning loops or repetitive tool calls and explicitly note them.
+
+You MUST provide the summary in your final response text. Do not use tools.
+`
+
+// We use a very low temperature for the compressor to ensure it acts as a strict,
+// deterministic summarizer of facts without hallucinating or adding creative leaps.
+const tokenCompressionTemperature = 0.1
+
+func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.Content, error) {
+	// Lightweight config targeting the Flash model.
+	cfg := &genai.GenerateContentConfig{
+		Temperature:       genai.Ptr[float32](tokenCompressionTemperature),
+		SystemInstruction: genai.NewContentFromText(tokenCompressionInstruction, genai.RoleUser),
+		ThinkingConfig: &genai.ThinkingConfig{
+			IncludeThoughts: true,
+		},
+	}
+
+	span := &trajectory.Span{
+		Type:  trajectory.SpanLLM,
+		Name:  a.Name + "-compressor",
+		Model: ctx.modelName(GoodBalancedModel),
+	}
+	if err := ctx.startSpan(span); err != nil {
+		return nil, err
+	}
+
+	// We append a final prompt to ensure the model knows it must summarize now,
+	// rather than trying to continue the original conversation.
+	compressReq := append(slices.Clone(req), genai.NewContentFromText(
+		"Task: Provide the comprehensive summary of the above execution history now.\n"+
+			"Important: You must output the actual summary text in your final response. "+
+			"Do NOT use any tools.",
+		genai.RoleUser,
+	))
+
+	resp, err := a.generateContentCached(ctx, cfg, compressReq, 0, 0)
+	if err != nil {
+		return nil, ctx.finishSpan(span, err)
+	}
+
+	reply, _, respErr := a.parseResponse(resp, span)
+
+	// We want the model to "think" for better reasoning during compression,
+	// but we don't want to clutter the trajectory UI with those thoughts.
+	span.Thoughts = ""
+
+	if respErr != nil {
+		return nil, ctx.finishSpan(span, respErr)
+	}
+
+	reply = strings.TrimSpace(reply)
+	if reply == "" {
+		reply = "(The summarizer agent returned an empty summary)"
+	}
+
+	span.Reply = reply
+
+	newSummary := genai.NewContentFromText(
+		"Here is the summary of the previous execution history:\n\n"+reply,
+		genai.RoleUser,
+	)
+
+	return newSummary, ctx.finishSpan(span, nil)
+}
+
+func (a *LLMAgent) maybeCompressContext(ctx *Context, req []*genai.Content, lastInputTokens int) (
+	[]*genai.Content, *genai.Content, int, error) {
+	if a.CompressTokens == 0 || lastInputTokens <= a.CompressTokens {
+		// Return existing state unchanged.
+		return req, nil, lastInputTokens, nil
+	}
+
+	newSummary, err := a.compressContext(ctx, req)
+	if err != nil {
+		return req, nil, lastInputTokens, fmt.Errorf("context compression failed: %w", err)
+	}
+
+	// Truncate history to Anchor + Summary.
+	req = []*genai.Content{req[0], newSummary}
+	return req, nil, 0, nil
 }
 
 func (a *LLMAgent) slide(req []*genai.Content, summary *genai.Content) ([]*genai.Content, bool) {

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -206,6 +206,93 @@ func TestSummaryWindow(t *testing.T) {
 	)
 }
 
+func TestSummaryWindowMutualExclusion(t *testing.T) {
+	ctx := &Context{}
+	agent := &LLMAgent{
+		Name:           "mutually_exclusive",
+		SummaryWindow:  3,
+		CompressTokens: 100,
+	}
+	err := agent.execute(ctx)
+	assert.ErrorContains(t, err, "SummaryWindow and CompressTokens are mutually exclusive")
+}
+
+func TestTokenCompression(t *testing.T) {
+	type flowOutputs struct {
+		Reply string
+	}
+	type toolResults struct {
+		ResFoo int `jsonschema:"foo"`
+	}
+	testFlow[struct{}, flowOutputs](t, nil,
+		map[string]any{"Reply": "Done"},
+		&LLMAgent{
+			Name:           "token_compression_agent",
+			Model:          "model",
+			Reply:          "Reply",
+			CompressTokens: 100,
+			TaskType:       FormalReasoningTask,
+			Instruction:    "Instructions",
+			Prompt:         "Initial Prompt",
+			Tools: []Tool{
+				NewFuncTool("tick", func(ctx *Context, state struct{}, args struct{}) (toolResults, error) {
+					return toolResults{123}, nil
+				}, "logic ticker"),
+			},
+		},
+		[]any{
+			// 1. Initial request. Return a tool call and claim we exceeded the token threshold (150 > 100).
+			&genai.GenerateContentResponse{
+				UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+					PromptTokenCount:     150,
+					CandidatesTokenCount: 10,
+				},
+				Candidates: []*genai.Candidate{{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{FunctionCall: &genai.FunctionCall{ID: "id1", Name: "tick"}},
+						},
+						Role: genai.RoleModel,
+					}}}},
+			// 2. The loop detects threshold exceeded and invokes compressContext (Flash model).
+			// We return the compressed summary.
+			&genai.GenerateContentResponse{
+				UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+					PromptTokenCount:     150,
+					CandidatesTokenCount: 10,
+				},
+				Candidates: []*genai.Candidate{{
+					Content: &genai.Content{
+						Parts: []*genai.Part{genai.NewPartFromText("compressed summary")},
+						Role:  genai.RoleModel,
+					}}}},
+			// 3. The main agent resumes with the truncated history. We finish the workflow.
+			func(model string, cfg *genai.GenerateContentConfig, req []*genai.Content) (*genai.GenerateContentResponse, error) {
+				// Assert that the history was correctly truncated!
+				assert.Equal(t, 2, len(req), "History should be truncated to just Anchor and Summary")
+
+				// Assert Anchor Message remains untouched.
+				assert.Equal(t, "Initial Prompt", req[0].Parts[0].Text)
+
+				// Assert Summary is correctly formatted.
+				assert.Equal(t, "Here is the summary of the previous execution history:\n\ncompressed summary",
+					req[1].Parts[0].Text)
+				return &genai.GenerateContentResponse{
+					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+						PromptTokenCount:     20, // tokens dropped after compression
+						CandidatesTokenCount: 10,
+					},
+					Candidates: []*genai.Candidate{{
+						Content: &genai.Content{
+							Parts: []*genai.Part{genai.NewPartFromText("Done")},
+							Role:  genai.RoleModel,
+						}}}}, nil
+			},
+		},
+		nil,
+	)
+}
+
 func TestSetResultsToolIsNotLast(t *testing.T) {
 	type flowOutputs struct {
 		Reply  string

--- a/pkg/aflow/llm_tool.go
+++ b/pkg/aflow/llm_tool.go
@@ -21,9 +21,10 @@ type LLMTool struct {
 	Model    string
 	TaskType TaskType
 	// Description of the tool exposed to the parent LLM.
-	Description string
-	Instruction string
-	Tools       []Tool
+	Description    string
+	Instruction    string
+	Tools          []Tool
+	CompressTokens int
 
 	agent *LLMAgent
 }
@@ -72,13 +73,14 @@ const (
 
 func (t *LLMTool) verify(ctx *verifyContext) {
 	t.agent = &LLMAgent{
-		Name:        t.Name,
-		Model:       t.Model,
-		Reply:       llmToolReply,
-		TaskType:    t.TaskType,
-		Instruction: t.Instruction,
-		Prompt:      fmt.Sprintf("{{.%v}}", llmToolPrompt),
-		Tools:       t.Tools,
+		Name:           t.Name,
+		Model:          t.Model,
+		Reply:          llmToolReply,
+		TaskType:       t.TaskType,
+		Instruction:    t.Instruction,
+		Prompt:         fmt.Sprintf("{{.%v}}", llmToolPrompt),
+		Tools:          t.Tools,
+		CompressTokens: t.CompressTokens,
 	}
 	t.agent.verify(ctx)
 }

--- a/pkg/aflow/testdata/TestTokenCompression.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompression.llm.json
@@ -1,0 +1,186 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "logic ticker",
+							"name": "tick",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"ResFoo": {
+										"description": "foo",
+										"type": "integer"
+									}
+								},
+								"required": [
+									"ResFoo"
+								],
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"responseModalities": [
+				"TEXT"
+			],
+			"thinkingConfig": {
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "\nYou are an expert technical assistant acting as a memory compressor.\nReview the following execution history of an AI agent.\nThe first message contains the original system instructions and the main goal.\nIt will be preserved in the history, so DO NOT duplicate its contents in your summary.\nWrite a comprehensive and substantial summary of the current state of the workspace\nand the investigation based on the SUBSEQUENT messages. Do NOT write a very short summary.\nInclude:\n1. A detailed list of what approaches have been tried so far and their results (including dead-ends).\n2. The current hypotheses, theories, or active lines of investigation.\n3. Any specific file paths, code snippets, or configuration values that are critical to remember.\n4. Watch out for potential reasoning loops or repetitive tool calls and explicitly note them.\n\nYou MUST provide the summary in your final response text. Do not use tools.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.1,
+			"thinkingConfig": {
+				"includeThoughts": true
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"name": "tick",
+							"response": {
+								"ResFoo": 123
+							}
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"text": "Task: Provide the comprehensive summary of the above execution history now.\nImportant: You must output the actual summary text in your final response. Do NOT use any tools."
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "logic ticker",
+							"name": "tick",
+							"parametersJsonSchema": {
+								"additionalProperties": false,
+								"type": "object"
+							},
+							"responseJsonSchema": {
+								"additionalProperties": false,
+								"properties": {
+									"ResFoo": {
+										"description": "foo",
+										"type": "integer"
+									}
+								},
+								"required": [
+									"ResFoo"
+								],
+								"type": "object"
+							}
+						}
+					]
+				}
+			],
+			"responseModalities": [
+				"TEXT"
+			],
+			"thinkingConfig": {
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"text": "Here is the summary of the previous execution history:\n\ncompressed summary"
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestTokenCompression.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompression.trajectory.json
@@ -1,0 +1,118 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Initial Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"InputTokens": 150,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"ResFoo": 123
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent-compressor",
+		"Model": "gemini-3-flash-preview",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent-compressor",
+		"Model": "gemini-3-flash-preview",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"Reply": "compressed summary",
+		"InputTokens": 150,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:09Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"InputTokens": 20,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:11Z",
+		"Instruction": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Initial Prompt",
+		"Reply": "Done"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"Results": {
+			"Reply": "Done"
+		}
+	}
+]

--- a/pkg/aflow/tool/codeexpert/codeexpert.go
+++ b/pkg/aflow/tool/codeexpert/codeexpert.go
@@ -8,13 +8,16 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 )
 
-var Tool = &aflow.LLMTool{
-	Name:        "codeexpert",
-	Model:       aflow.GoodBalancedModel,
-	TaskType:    aflow.FormalReasoningTask,
-	Description: description,
-	Instruction: instruction,
-	Tools:       codesearcher.Tools,
+func NewTool(compressTokens int) *aflow.LLMTool {
+	return &aflow.LLMTool{
+		Name:           "codeexpert",
+		Model:          aflow.GoodBalancedModel,
+		TaskType:       aflow.FormalReasoningTask,
+		Description:    description,
+		Instruction:    instruction,
+		Tools:          codesearcher.Tools,
+		CompressTokens: compressTokens,
+	}
 }
 
 const description = `

--- a/pkg/aflow/trajectory/trajectory.go
+++ b/pkg/aflow/trajectory/trajectory.go
@@ -100,6 +100,9 @@ func (span *Span) String() string {
 			if span.Thoughts != "" {
 				fmt.Fprintf(sb, "thoughts:\n%v\n", span.Thoughts)
 			}
+			if span.Reply != "" {
+				fmt.Fprintf(sb, "reply:\n%v\n", span.Reply)
+			}
 		case SpanTool:
 			printMap(sb, span.Results, "results")
 		case SpanLoop:


### PR DESCRIPTION
Introduce CompressTokens to dynamically truncate agent context histories based on token count rather than message count.

Unlike the existing SummaryWindow (which relies on a fixed number of messages), CompressTokens handles the massive variance in message sizes (e.g., small tool replies vs. massive source code searches) predictably. When the threshold is exceeded, the agent uses a cheaper model (GoodBalancedModel) to summarize the history, truncating it down to just the anchor prompt and the new summary.

Also add a `patching-compressed` workflow registration (with a 250k token threshold) to allow experimenting with this mechanism.