### PR TITLE
pkg/cover: include uncovered functions in HTML summary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ International Business Machines Corporation
 Institute of Software Chinese Academy of Sciences
 Berk Cem Goksel
 Nikolay Ivchenko
+cyphercodes

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -160,3 +160,4 @@ Nikolay Ivchenko
 Oleg Kulachenko
 Daniel Bransky
 Matan Kalina
+cyphercodes

--- a/pkg/cover/cover_test.go
+++ b/pkg/cover/cover_test.go
@@ -110,3 +110,19 @@ func TestPerLineCoverage(t *testing.T) {
 	got := perLineCoverage(covered, uncovered)
 	require.Equal(t, want, got)
 }
+
+func TestAddFunctionCoverageSummary(t *testing.T) {
+	data := &templateData{}
+	addFunctionCoverage(&file{
+		functions: []*function{
+			{name: "covered", pcs: 2, covered: 1},
+			{name: "uncovered", pcs: 2},
+		},
+	}, data)
+
+	require.Len(t, data.Functions, 1)
+	got := string(data.Functions[0])
+	require.Contains(t, got, "<span class='hover'>covered<span class='cover hover'>50%<span class='cover-right'>of 2")
+	require.Contains(t, got, "<span class='hover'>uncovered<span class='cover hover'>---<span class='cover-right'>of 2")
+	require.Contains(t, got, "<span class='hover'>SUMMARY<span class='cover hover'>25%<span class='cover-right'>of 4")
+}

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -870,13 +870,13 @@ func mergeLine(chunks []lineCoverChunk, start, end int, covered bool) []lineCove
 func addFunctionCoverage(file *file, data *templateData) {
 	var buf bytes.Buffer
 	var coveredTotal int
-	var TotalInCoveredFunc int
+	var totalInFunc int
 	for _, function := range file.functions {
 		percentage := ""
 		coveredTotal += function.covered
+		totalInFunc += function.pcs
 		if function.covered > 0 {
 			percentage = fmt.Sprintf("%v%%", Percent(function.covered, function.pcs))
-			TotalInCoveredFunc += function.pcs
 		} else {
 			percentage = "---"
 		}
@@ -888,13 +888,13 @@ func addFunctionCoverage(file *file, data *templateData) {
 	buf.WriteString("-----------<br>\n")
 	buf.WriteString("<span class='hover'>SUMMARY")
 	percentInCoveredFunc := ""
-	if TotalInCoveredFunc > 0 {
-		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, TotalInCoveredFunc))
+	if totalInFunc > 0 {
+		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, totalInFunc))
 	} else {
 		percentInCoveredFunc = "---"
 	}
 	buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentInCoveredFunc))
-	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(TotalInCoveredFunc)))
+	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(totalInFunc)))
 	buf.WriteString("</span></span></span><br>\n")
 	data.Functions = append(data.Functions, template.HTML(buf.String()))
 }


### PR DESCRIPTION
Fixes #7209

The HTML function summary used only functions with covered PCs as the denominator. This overstates coverage when a file contains fully uncovered functions.

This counts all function PCs in the summary denominator and adds a unit test for zero-covered functions.

Testing:
- go test ./pkg/cover
- git diff --check