### PR TITLE
pkg/aflow: increase LLM backoff duration

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -600,13 +600,13 @@ func parseLLMErrorImpl(resp *genai.GenerateContentResponse, err error, model str
 	if !errors.As(err, &apiErr) {
 		return err
 	}
-	if try < maxLLMRetryIters && (apiErr.Code == http.StatusServiceUnavailable ||
+	if apiErr.Code == http.StatusServiceUnavailable ||
 		apiErr.Code == http.StatusBadGateway ||
 		apiErr.Code == http.StatusGatewayTimeout ||
 		// 499 has server-dependent meaning, but for genapi we observed these
 		// when a request was cancelled on some internal error.
-		apiErr.Code == 499) {
-		return &retryError{min(time.Duration(try+1)*time.Second, maxLLMBackoff), err}
+		apiErr.Code == 499 {
+		return &retryError{llmBackoffDuration(try), err}
 	}
 	if apiErr.Code == http.StatusTooManyRequests &&
 		strings.Contains(apiErr.Message, "Quota exceeded for metric") {
@@ -633,6 +633,18 @@ func parseLLMErrorImpl(resp *genai.GenerateContentResponse, err error, model str
 		return &retryError{time.Second, err}
 	}
 	return err
+}
+
+func llmBackoffDuration(try int) time.Duration {
+	backoff := time.Second
+	// Use loop instead of math.Pow to properly handle overflow.
+	for range try {
+		backoff *= 2
+		if backoff >= maxLLMBackoff {
+			return maxLLMBackoff
+		}
+	}
+	return backoff
 }
 
 func parseLLMResp(resp *genai.GenerateContentResponse) error {
@@ -672,7 +684,7 @@ func parseLLMResp(resp *genai.GenerateContentResponse) error {
 
 const (
 	maxLLMRetryIters = 100
-	maxLLMBackoff    = 10 * time.Second
+	maxLLMBackoff    = 5 * time.Minute
 )
 
 var rePleaseRetry = regexp.MustCompile("Please retry in ([0-9]+)[.s]")

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -140,14 +140,18 @@ func TestParseLLMError(t *testing.T) {
 }
 
 func TestParseLLMErrorBackoff(t *testing.T) {
+	var totalBackoff time.Duration
 	err0 := genai.APIError{Code: http.StatusServiceUnavailable}
 	for try := range maxLLMRetryIters {
-		wantDelay := min(maxLLMBackoff, time.Duration(try+1)*time.Second)
+		wantBackoff := llmBackoffDuration(try)
+		t.Logf("iter %v: %v", try, wantBackoff)
 		err := parseLLMError(nil, err0, "model", try)
-		require.Equal(t, err, &retryError{wantDelay, err0})
+		require.Equal(t, err, &retryError{wantBackoff, err0})
+		totalBackoff += wantBackoff
 	}
 	err := parseLLMError(nil, err0, "model", maxLLMRetryIters)
 	require.Equal(t, err, err0)
+	t.Logf("total backoff: %v", totalBackoff)
 }
 
 func TestSummaryWindow(t *testing.T) {


### PR DESCRIPTION
In one case we did 100 retries, but still got 503 error.
Currently the total backoff for 100 interations is only 16 min,
which is not enough to handle temporal model overload on the server side.
Increase backoff so that total backoff duration is 7h40m.

Fixes #7210
