### PR TITLE
dashboard/app: allow resizing the 'Sample crash report' block

### DIFF
--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -391,6 +391,7 @@ aside {
 	height: 400px;
 	margin: 0 0;
 	overflow: scroll;
+	resize: vertical;
 	border: 1px solid #777;
 	padding: 0px;
 	background: transparent;


### PR DESCRIPTION
Long crashes require a lot of scrolling as crash_div is short.

Set 'resize: both;' in crash_div to allow a user to resize it, which can significantly reduce scrolling thus improve comfort.

P.S.: This was manually tested in the browser's CSS editor.

Before: fixed-size (short)
<img width="1270" height="961" alt="Screenshot From 2026-05-07 17-03-56" src="https://github.com/user-attachments/assets/5a673321-84ea-4237-902d-1ef116dd8775" />

After: resizable (compare the lower right hand corner)
<img width="1270" height="961" alt="Screenshot From 2026-05-07 17-04-39" src="https://github.com/user-attachments/assets/56082a81-6c50-4c19-b77e-2df919c8597a" />

Done: resized (tall)
<img width="1270" height="961" alt="Screenshot From 2026-05-07 17-04-58" src="https://github.com/user-attachments/assets/6054e7f8-f236-4dd2-832f-997156f632f7" />


