### PR TITLE
pkg/aflow: do full clone of local repositories

### DIFF
--- a/pkg/aflow/action/kernel/checkout.go
+++ b/pkg/aflow/action/kernel/checkout.go
@@ -72,7 +72,7 @@ func checkout(ctx *aflow.Context, args checkoutArgs) (checkoutResult, error) {
 					}
 				}
 			}
-			return shallowGitClone(dir, kernelRepoDir)
+			return localGitClone(dir, kernelRepoDir)
 		})
 		res.KernelSrc = dir
 		return err
@@ -85,20 +85,20 @@ func checkoutScratch(ctx *aflow.Context, args checkoutScratchArgs) (checkoutScra
 	if err != nil {
 		return checkoutScratchResult{}, err
 	}
-	if err := shallowGitClone(dir, args.KernelSrc); err != nil {
+	if err := localGitClone(dir, args.KernelSrc); err != nil {
 		return checkoutScratchResult{}, err
 	}
 	return checkoutScratchResult{dir}, nil
 }
 
-func shallowGitClone(dir, remoteDir string) error {
+func localGitClone(dir, remoteDir string) error {
 	if _, err := osutil.RunCmd(time.Hour, dir, "git", "init"); err != nil {
 		return err
 	}
 	if _, err := osutil.RunCmd(time.Hour, dir, "git", "remote", "add", "origin", remoteDir); err != nil {
 		return err
 	}
-	if _, err := osutil.RunCmd(time.Hour, dir, "git", "pull", "origin", "HEAD", "--depth=1",
+	if _, err := osutil.RunCmd(time.Hour, dir, "git", "pull", "origin", "HEAD",
 		"--allow-unrelated-histories"); err != nil {
 		return err
 	}

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -104,6 +104,7 @@ func maintainers(ctx *aflow.Context, args maintainersArgs) (maintainersResult, e
 var getRecentCommits = aflow.NewFuncAction("get-recent-commits", recentCommits)
 
 type recentCommitsArgs struct {
+	KernelSrc    string
 	KernelCommit string
 	PatchDiff    string
 }
@@ -121,18 +122,13 @@ func recentCommits(ctx *aflow.Context, args recentCommitsArgs) (recentCommitsRes
 	if len(files) == 0 {
 		return res, aflow.FlowError(errors.New("patch diff does not contain any modified files"))
 	}
-	// We need to run git log in the master git repo b/c out KernelSrc/KernelScratchSrc
-	// are shallow checkouts that don't have history.
-	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
-		gitArgs := append([]string{"log", "--format=%s", "--no-merges", "-n", "20", args.KernelCommit}, files...)
-		output, err := osutil.RunCmd(10*time.Minute, kernelRepoDir, "git", gitArgs...)
-		if err != nil {
-			return aflow.FlowError(err)
-		}
-		res.RecentCommits = string(output)
-		return nil
-	})
-	return res, err
+	gitArgs := append([]string{"log", "--format=%s", "--no-merges", "-n", "20", args.KernelCommit}, files...)
+	output, err := osutil.RunCmd(10*time.Minute, args.KernelSrc, "git", gitArgs...)
+	if err != nil {
+		return res, aflow.FlowError(err)
+	}
+	res.RecentCommits = string(output)
+	return res, nil
 }
 
 var formatPatchDescription = aflow.NewFuncAction("format-patch-description", formatDescription)

--- a/pkg/aflow/flow/patching/actions_test.go
+++ b/pkg/aflow/flow/patching/actions_test.go
@@ -24,6 +24,7 @@ func TestRecentCommits(t *testing.T) {
 	require.NoError(t, os.Symlink(osutil.Abs(filepath.FromSlash("../../../..")),
 		filepath.Join(dir, "repo", "linux")))
 	aflow.TestAction(t, getRecentCommits, dir, recentCommitsArgs{
+		KernelSrc:    filepath.Join(dir, "repo", "linux"),
 		KernelCommit: "e01a0ca6c12c9851ea7090f13879255ef82291e7",
 		PatchDiff: `
 diff --git a/dashboard/app/ai.go b/dashboard/app/ai.go

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -335,47 +335,49 @@ func validateFixesHashes(ctx *aflow.Context, state fixesFinderState, args fixesF
 	if args.FixesHash == "" {
 		return args, nil
 	}
-	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
-		commit, err := repo.Commit(args.FixesHash)
-		if err != nil {
-			return aflow.BadCallError("commit hash %q not found in the repository", args.FixesHash)
-		}
-		// LLM can provide a commit from a different branch.
-		// We want to ensure it is actually reachable from the current commit.
-		if _, err := repo.SwitchCommit(state.KernelCommit); err != nil {
-			return err
-		}
-		reachable, err := repo.Contains(commit.Hash)
-		if err != nil || !reachable {
-			return aflow.BadCallError("commit %q is not reachable from the current commit",
-				args.FixesHash)
-		}
-		args.FixesHash = commit.Hash
-		return nil
-	})
-	return args, err
+	git := &vcs.Git{
+		Dir: state.KernelSrc,
+	}
+	commit, err := git.Commit(args.FixesHash)
+	if err != nil {
+		return args, aflow.BadCallError("commit hash %q not found in the repository", args.FixesHash)
+	}
+	// LLM can provide a commit from a different branch.
+	// We want to ensure it is actually reachable from the current commit.
+	reachable, err := git.ContainedIn(state.KernelCommit, commit.Hash)
+	if err != nil || !reachable {
+		return args, aflow.BadCallError("commit %q is not reachable from the current commit",
+			args.FixesHash)
+	}
+	args.FixesHash = commit.Hash
+	return args, nil
 }
 
 type formatFixesResult struct {
 	Fixes ai.FixesTag
 }
 
+type formatFixesArgs struct {
+	KernelSrc string
+	FixesHash string
+}
+
 var formatFixes = aflow.NewFuncAction("format-fixes",
-	func(ctx *aflow.Context, args fixesFinderArgs) (formatFixesResult, error) {
+	func(ctx *aflow.Context, args formatFixesArgs) (formatFixesResult, error) {
 		var fix ai.FixesTag
 		if args.FixesHash == "" {
 			return formatFixesResult{}, nil
 		}
-		err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
-			commit, err := repo.Commit(args.FixesHash)
-			if err != nil {
-				return fmt.Errorf("failed to get commit %q: %w", args.FixesHash, err)
-			}
-			fix = ai.FixesTag{
-				Hash:  commit.Hash,
-				Title: commit.Title,
-			}
-			return nil
-		})
-		return formatFixesResult{Fixes: fix}, err
+		git := &vcs.Git{
+			Dir: args.KernelSrc,
+		}
+		commit, err := git.Commit(args.FixesHash)
+		if err != nil {
+			return formatFixesResult{}, fmt.Errorf("failed to get commit %q: %w", args.FixesHash, err)
+		}
+		fix = ai.FixesTag{
+			Hash:  commit.Hash,
+			Title: commit.Title,
+		}
+		return formatFixesResult{Fixes: fix}, nil
 	})

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -255,7 +255,7 @@ func (git *gitRepo) initRepo(reason error) error {
 }
 
 func (git *gitRepo) Contains(commit string) (bool, error) {
-	return git.containedIn(HEAD, commit)
+	return git.ContainedIn(HEAD, commit)
 }
 
 const gitDateFormat = "Mon Jan 2 15:04:05 2006 -0700"
@@ -897,7 +897,7 @@ func (git Git) minimizeBaseCommits(list []*BaseCommit) ([]*BaseCommit, error) {
 			lastCommit[key] = item
 			continue
 		}
-		isNewer, err := git.containedIn(item.Hash, prev.Hash)
+		isNewer, err := git.ContainedIn(item.Hash, prev.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("topological sort step failed: %w", err)
 		}
@@ -977,7 +977,7 @@ func (git Git) verifyHash(hash string) (bool, error) {
 	return true, nil
 }
 
-func (git Git) containedIn(parent, commit string) (bool, error) {
+func (git Git) ContainedIn(parent, commit string) (bool, error) {
 	_, err := git.Run("merge-base", "--is-ancestor", commit, parent)
 	return err == nil, nil
 }


### PR DESCRIPTION
Now that we perform git log operations, we need the full git history. Otherwise the recently added `Fixes` finding logic does not properly work.