### PR TITLE
dashboard/app: prevent JobReporting creation for non-patching AI jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -433,12 +433,21 @@ func handleAIJobPageCorrectness(ctx context.Context, job *aidb.Job, correct, use
 		if err != nil {
 			return err
 		}
-		err = processUpstreamSubcommand(ctx, job, currentReporting, &dashapi.SendExternalCommandReq{
-			Source: SourceWebUI,
-			Author: userEmail,
-		})
-		if err != nil {
-			return err
+		var cmdErr error
+		if err := checkJobUpstreamable(job); err == nil {
+			cmdErr = processUpstreamSubcommand(ctx, job, currentReporting, &dashapi.SendExternalCommandReq{
+				Source: SourceWebUI,
+				Author: userEmail,
+			})
+		} else {
+			cmdErr = aidb.UpstreamReportCommand(ctx, aidb.UpstreamReportArgs{
+				Job:           job,
+				CommandSource: SourceWebUI,
+				User:          userEmail,
+			})
+		}
+		if cmdErr != nil {
+			return cmdErr
 		}
 	case aiCorrectnessIncorrect:
 		err := aidb.RejectReportCommand(ctx, aidb.RejectReportArgs{

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -105,11 +105,14 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 }
 
 func checkJobUpstreamable(job *aidb.Job) error {
+	if job.Type != ai.WorkflowPatching && job.Type != ai.WorkflowPatchIteration {
+		return &aidb.ErrCannotUpstream{Reason: fmt.Sprintf("cannot upstream job of type %v", job.Type)}
+	}
 	// Prevent upstreaming if the job didn't actually produce a patch (e.g. reply-only iteration).
 	if job.Results.Valid {
 		if res, ok := job.Results.Value.(map[string]any); ok {
 			diff, _ := res["PatchDiff"].(string)
-			if diff == "" && (job.Type == ai.WorkflowPatching || job.Type == ai.WorkflowPatchIteration) {
+			if diff == "" {
 				return &aidb.ErrCannotUpstream{Reason: "Cannot upstream a job that did not produce a patch."}
 			}
 		}

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1423,3 +1423,65 @@ func TestAIManualPushToReporting(t *testing.T) {
 	// Make sure the poll returns our manually pushed job.
 	require.Equal(t, "Subject", pollResp.Result.Patch.Subject)
 }
+
+func TestAIAssessmentNoReport(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
+		},
+		SecurityPrio: func(*Bug, ai.AssessmentSecurityOutputs) BugPrio { return "" },
+	})
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrash(build, 1)
+	crash.Title = "WARNING: any type of bug"
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+	// Register the workflow first.
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowAssessmentSecurity, Name: string(ai.WorkflowAssessmentSecurity)},
+		},
+	})
+	require.NoError(t, err)
+
+	// Manually create the job since it's not automatically created for generic bugs.
+	jobID := c.createAIJob(extID, string(ai.WorkflowAssessmentSecurity), "")
+
+	// Poll again to pick up the job and assign it to the agent.
+	pollResp2, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowAssessmentSecurity, Name: string(ai.WorkflowAssessmentSecurity)},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, jobID, pollResp2.ID)
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"Explanation": "Test",
+			"Exploitable": false,
+		},
+	})
+	require.NoError(t, err)
+
+	values := url.Values{}
+	values.Set("correct", aiCorrectnessCorrect)
+	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", jobID), values)
+	require.NoError(t, err)
+
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{
+		Source: "lore",
+	})
+	require.NoError(t, err)
+	require.Nil(t, pollResp.Result)
+}


### PR DESCRIPTION
When a non-patching job (e.g. assessment-security) was manually marked as correct via the UI, handleAIJobPageCorrectness attempted to upstream it. Because checkJobUpstreamable did not explicitly forbid non-patching workflows, a bogus JobReporting entity was created, which subsequently broke the lore-relay poller.

This updates checkJobUpstreamable to explicitly reject any job type other than WorkflowPatching and WorkflowPatchIteration. handleAIJobPageCorrectness now handles this gracefully, recording the manual approval without spawning a JobReporting stage.