### PR TITLE
vm, pkg/mgrconfig: make scp protocol configurable

### DIFF
--- a/pkg/mgrconfig/config.go
+++ b/pkg/mgrconfig/config.go
@@ -66,6 +66,8 @@ type Config struct {
 	SSHKey string `json:"sshkey,omitempty"`
 	// SSH user ("root" by default).
 	SSHUser string `json:"ssh_user,omitempty"`
+	// Use SFTP protocol instead of legacy SCP.
+	SFTP bool `json:"sftp,omitempty"`
 
 	HubClient string `json:"hub_client,omitempty"`
 	HubAddr   string `json:"hub_addr,omitempty"`

--- a/vm/bhyve/bhyve.go
+++ b/vm/bhyve/bhyve.go
@@ -50,6 +50,7 @@ type instance struct {
 	forwardPort int
 	image       string
 	debug       bool
+	sftp        bool
 	os          string
 	merger      *vmimpl.OutputMerger
 	vmName      string
@@ -92,6 +93,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 			Key:  pool.env.SSHKey,
 			User: pool.env.SSHUser,
 		},
+		sftp:   pool.env.SFTP,
 		vmName: fmt.Sprintf("syzkaller-%v-%v", pool.env.Name, index),
 	}
 
@@ -323,6 +325,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		User:         inst.User,
 		Addr:         inst.Addr,
 		Timeout:      10 * time.Minute,
+		SFTP:         inst.sftp,
 	})
 	if err != nil {
 		return "", err

--- a/vm/gce/gce.go
+++ b/vm/gce/gce.go
@@ -295,6 +295,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		Addr:          inst.Addr,
 		Timeout:       time.Minute,
 		VerboseOutput: true,
+		SFTP:          inst.env.SFTP,
 	})
 	if err != nil {
 		return "", err

--- a/vm/isolated/isolated.go
+++ b/vm/isolated/isolated.go
@@ -53,6 +53,7 @@ type instance struct {
 	index       int
 	closed      chan bool
 	debug       bool
+	sftp        bool
 	forwardPort int
 	timeouts    targets.Timeouts
 }
@@ -107,6 +108,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		closed:   make(chan bool),
 		debug:    pool.env.Debug,
 		timeouts: pool.env.Timeouts,
+		sftp:     pool.env.SFTP,
 	}
 	closeInst := inst
 	defer func() {
@@ -293,6 +295,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		User:         inst.User,
 		Addr:         inst.Addr,
 		Timeout:      3 * time.Minute,
+		SFTP:         inst.sftp,
 	})
 	if err != nil {
 		return "", err

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -99,6 +99,7 @@ type instance struct {
 	args       []string
 	image      string
 	debug      bool
+	sftp       bool
 	os         string
 	workdir    string
 	vmimpl.SSHOptions
@@ -385,6 +386,7 @@ func (pool *Pool) ctor(workdir, sshkey, sshuser string, index int) (*instance, e
 		version:    pool.version,
 		image:      pool.env.Image,
 		debug:      pool.env.Debug,
+		sftp:       pool.env.SFTP,
 		os:         pool.env.OS,
 		timeouts:   pool.env.Timeouts,
 		workdir:    workdir,
@@ -684,6 +686,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		Addr:          "localhost",
 		Timeout:       10 * time.Minute * inst.timeouts.Scale,
 		VerboseOutput: true,
+		SFTP:          inst.sftp,
 	})
 	if err != nil {
 		return "", err

--- a/vm/starnix/starnix.go
+++ b/vm/starnix/starnix.go
@@ -54,6 +54,7 @@ type instance struct {
 	cfg          *Config
 	version      string
 	debug        bool
+	sftp         bool
 	workdir      string
 	port         int
 	forwardPort  int
@@ -107,6 +108,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		index:      index,
 		cfg:        pool.cfg,
 		debug:      pool.env.Debug,
+		sftp:       pool.env.SFTP,
 		workdir:    workdir,
 		timeouts:   pool.env.Timeouts,
 	}
@@ -447,6 +449,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		Addr:    "localhost",
 		Dir:     inst.fuchsiaDir,
 		Timeout: 5 * time.Minute,
+		SFTP:    inst.sftp,
 	})
 	if err == nil {
 		return vmDst, err

--- a/vm/virtualbox/virtualbox.go
+++ b/vm/virtualbox/virtualbox.go
@@ -38,6 +38,7 @@ type Pool struct {
 type instance struct {
 	cfg        *Config
 	debug      bool
+	sftp       bool
 	baseVM     string
 	vmName     string
 	rpcPort    int
@@ -77,6 +78,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 	inst := &instance{
 		cfg:        pool.cfg,
 		debug:      pool.env.Debug,
+		sftp:       pool.env.SFTP,
 		baseVM:     pool.cfg.BaseVM,
 		vmName:     vmName,
 		os:         pool.env.OS,
@@ -264,6 +266,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		User:    inst.SSHOptions.User,
 		Addr:    "127.0.0.1",
 		Timeout: 3 * time.Minute,
+		SFTP:    inst.sftp,
 	})
 	if err != nil {
 		return "", err

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -125,6 +125,7 @@ func Create(cfg *mgrconfig.Config, debug bool) (*Pool, error) {
 		Image:     cfg.Image,
 		SSHKey:    cfg.SSHKey,
 		SSHUser:   cfg.SSHUser,
+		SFTP:      cfg.SFTP,
 		Timeouts:  cfg.Timeouts,
 		Snapshot:  cfg.Snapshot,
 		Debug:     debug,

--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -76,8 +76,12 @@ func SSHArgsForward(debug bool, sshKey string, port, forwardPort int, systemSSHC
 	return sshArgs(debug, sshKey, "-p", port, forwardPort, systemSSHCfg)
 }
 
-func scpArgs(debug bool, sshKey string, port int, systemSSHCfg bool) []string {
-	return append(sshArgs(debug, sshKey, "-P", port, 0, systemSSHCfg), "-O") // Default to legacy scp protocol.
+func scpArgs(debug bool, sshKey string, port int, systemSSHCfg, sftp bool) []string {
+	args := sshArgs(debug, sshKey, "-P", port, 0, systemSSHCfg)
+	if !sftp {
+		args = append(args, "-O")
+	}
+	return args
 }
 
 func sshArgs(debug bool, sshKey, portArg string, port, forwardPort int, systemSSHCfg bool) []string {
@@ -116,10 +120,11 @@ type SCPOptions struct {
 	Timeout       time.Duration
 	Dir           string
 	VerboseOutput bool
+	SFTP          bool
 }
 
 func SCP(hostSrc, vmDst string, opts SCPOptions) error {
-	args := append(scpArgs(opts.VerboseOutput, opts.Key, opts.Port, opts.SystemSSHCfg),
+	args := append(scpArgs(opts.VerboseOutput, opts.Key, opts.Port, opts.SystemSSHCfg, opts.SFTP),
 		hostSrc, opts.User+"@"+opts.Addr+":"+vmDst)
 	if opts.Debug {
 		log.Logf(0, "running command: scp %#v", args)

--- a/vm/vmimpl/vmimpl.go
+++ b/vm/vmimpl/vmimpl.go
@@ -81,6 +81,7 @@ type Env struct {
 	Image     string
 	SSHKey    string
 	SSHUser   string
+	SFTP      bool
 	Timeouts  targets.Timeouts
 	Snapshot  bool
 	Debug     bool

--- a/vm/vmm/vmm.go
+++ b/vm/vmm/vmm.go
@@ -48,6 +48,7 @@ type instance struct {
 	cfg   *Config
 	image string
 	debug bool
+	sftp  bool
 	os    string
 	vmimpl.SSHOptions
 	merger   *vmimpl.OutputMerger
@@ -102,6 +103,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 		cfg:   pool.cfg,
 		image: filepath.Join(workdir, "disk.qcow2"),
 		debug: pool.env.Debug,
+		sftp:  pool.env.SFTP,
 		os:    pool.env.OS,
 		SSHOptions: vmimpl.SSHOptions{
 			Key:  pool.env.SSHKey,
@@ -246,6 +248,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		SystemSSHCfg: false,
 		User:         inst.User,
 		Addr:         inst.Addr,
+		SFTP:         inst.sftp,
 	})
 	if err != nil {
 		return "", err

--- a/vm/vmware/vmware.go
+++ b/vm/vmware/vmware.go
@@ -46,6 +46,7 @@ type instance struct {
 	ipAddr      string
 	closed      chan bool
 	debug       bool
+	sftp        bool
 	sshuser     string
 	sshkey      string
 	forwardPort int
@@ -85,6 +86,7 @@ func (pool *Pool) Create(_ context.Context, workdir string, index int) (vmimpl.I
 	inst := &instance{
 		cfg:      pool.cfg,
 		debug:    pool.env.Debug,
+		sftp:     pool.env.SFTP,
 		baseVMX:  pool.cfg.BaseVMX,
 		vmx:      vmx,
 		sshkey:   sshkey,
@@ -167,6 +169,7 @@ func (inst *instance) Copy(hostSrc string) (string, error) {
 		User:         inst.sshuser,
 		Addr:         inst.ipAddr,
 		Timeout:      3 * time.Minute,
+		SFTP:         inst.sftp,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Allow users to configure which scp protocol to use (Either SFTP or SCP). Defaults to SCP.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
