### PR TITLE
dashboard/app: pass on Fixes tag

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1719,8 +1719,11 @@ func createGerritChange(ctx context.Context, job *aidb.Job) error {
 	// or priority label (don't cc stable on low prio bugs).
 	res.Recipients = append(res.Recipients, ai.Recipient{Email: "stable@vger.kernel.org"})
 	// TODO: add a human who reviewed the patch to authors.
-	description := email.FormatPatchDescription(res.PatchDescription, slices.Collect(maps.Keys(models)),
-		nil, res.Recipients)
+	description := email.FormatPatchDescription(res.PatchDescription, email.PatchTemplateData{
+		Fixes:      res.Fixes,
+		Tools:      slices.Collect(maps.Keys(models)),
+		Recipients: res.Recipients,
+	})
 	changeID, link, err := gerrit.CreateChange(ctx, res.KernelRepo, res.KernelBranch,
 		res.KernelCommit, description, res.PatchDiff)
 	if err != nil {

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -298,6 +298,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 		To:         to,
 		Cc:         cc,
 		Tools:      slices.Collect(maps.Keys(models)),
+		Fixes:      res.Fixes,
 	}, nil
 }
 

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -80,6 +80,10 @@ func TestAILoreIntegration(t *testing.T) {
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
+			"Fixes": map[string]any{
+				"Hash":  "123456789012",
+				"Title": "original bug",
+			},
 			"Recipients": []map[string]any{
 				{"Name": "Maintainer", "Email": "maintainer@email.com", "To": true},
 				{"Name": "Reviewer", "Email": "reviewer@email.com", "To": false},
@@ -98,6 +102,7 @@ func TestAILoreIntegration(t *testing.T) {
 	assert.Equal(t, []string{"archive@lore.com"}, mockSnd.sent[0].Cc)
 
 	body := string(mockSnd.sent[0].Body)
+	assert.Contains(t, body, "Fixes: 123456789012 (\"original bug\")")
 	assert.Contains(t, body, "Assisted-by: Gemini:gemini-3.1-pro-preview")
 	assert.Contains(t, body, "To: <maintainer@email.com>")
 	assert.Contains(t, body, "Cc: <reviewer@email.com>")

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -116,6 +116,7 @@ type NewReportResult struct {
 	Tools      []string
 	BaseCommit string
 	BaseTree   string
+	Fixes      ai.FixesTag
 }
 
 type ChangelogEntry struct {

--- a/pkg/email/patch.go
+++ b/pkg/email/patch.go
@@ -56,10 +56,18 @@ func ParsePatch(message []byte) (diff string) {
 	return
 }
 
-func FormatPatchDescription(description string, tools, authors []string, recipients []ai.Recipient) string {
+type PatchTemplateData struct {
+	BaseCommit string
+	Fixes      ai.FixesTag
+	Tools      []string
+	Authors    []string
+	Recipients []ai.Recipient
+}
+
+func FormatPatchDescription(description string, data PatchTemplateData) string {
 	buf := new(bytes.Buffer)
 	var to, cc []mail.Address
-	for _, recipient := range recipients {
+	for _, recipient := range data.Recipients {
 		addr := mail.Address{Name: recipient.Name, Address: recipient.Email}
 		if recipient.To {
 			to = append(to, addr)
@@ -67,10 +75,15 @@ func FormatPatchDescription(description string, tools, authors []string, recipie
 			cc = append(cc, addr)
 		}
 	}
+	var fixesStr string
+	if data.Fixes.Hash != "" {
+		fixesStr = fmt.Sprintf("%v (\"%v\")", data.Fixes.Hash, data.Fixes.Title)
+	}
 	err := patchTemplate.Execute(buf, map[string]any{
 		"description": strings.TrimSpace(description),
-		"assistedBy":  formatAssistedBy(tools),
-		"authors":     authors,
+		"fixes":       fixesStr,
+		"assistedBy":  formatAssistedBy(data.Tools),
+		"authors":     data.Authors,
 		"to":          to,
 		"cc":          cc,
 	})
@@ -80,16 +93,16 @@ func FormatPatchDescription(description string, tools, authors []string, recipie
 	return buf.String()
 }
 
-func FormatPatch(description, diff, baseCommit string, tools, authors []string,
-	recipients []ai.Recipient) string {
-	return FormatPatchDescription(description, tools, authors, recipients) +
-		fmt.Sprintf("%v\nbase-commit: %v\n", diff, baseCommit)
+func FormatPatch(description, diff string, data PatchTemplateData) string {
+	return FormatPatchDescription(description, data) +
+		fmt.Sprintf("%v\nbase-commit: %v\n", diff, data.BaseCommit)
 }
 
 // Note: the patches we generate should comply to:
 // https://docs.kernel.org/process/coding-assistants.html
 var patchTemplate = template.Must(template.New("").Parse(`{{.description}}
-{{if .assistedBy}}
+{{if .fixes}}
+Fixes: {{.fixes}}{{end}}{{if .assistedBy}}
 Assisted-by: {{.assistedBy}}{{end}}
 {{- range $addr := .authors}}
 Signed-off-by: {{$addr}}{{end}}

--- a/pkg/email/patch_test.go
+++ b/pkg/email/patch_test.go
@@ -527,6 +527,7 @@ func TestFormatPatch(t *testing.T) {
 		description string
 		diff        string
 		baseCommit  string
+		fixes       ai.FixesTag
 		tools       []string
 		authors     []string
 		recipients  []ai.Recipient
@@ -540,16 +541,38 @@ Something was broken. This fixes it.
 
 `,
 			diff: `diff --git a/mm/slub.c b/mm/slub.c
-index f77b7407c51b..9320daf2018f 100644
---- a/mm/slub.c
-+++ b/mm/slub.c
-@@ -250,7 +250,7 @@ struct partial_context {
- 
- static inline bool kmem_cache_debug(struct kmem_cache *s)
- {
--       return kmem_cache_debug_flags(s, SLAB_DEBUG_FLAGS);
-+       return kmem_cache_debug_flags(s, 0);
- }
+`,
+			baseCommit: "f5e343a447510a663fbf6215584a9bf8e03bfd5c",
+			fixes: ai.FixesTag{
+				Hash:  "9320daf2018f",
+				Title: "some old bug",
+			},
+			authors: []string{"syzbot@kernel.org"},
+			recipients: []ai.Recipient{
+				{Name: "Foo Bar", Email: "foobar@test.com", To: true},
+				{Email: "linux-kernel@vger.kernel.org"},
+			},
+			want: `mm: fix something
+
+Something was broken. This fixes it.
+
+Fixes: 9320daf2018f ("some old bug")
+Signed-off-by: syzbot@kernel.org
+To: "Foo Bar" <foobar@test.com>
+Cc: <linux-kernel@vger.kernel.org>
+
+diff --git a/mm/slub.c b/mm/slub.c
+
+base-commit: f5e343a447510a663fbf6215584a9bf8e03bfd5c
+`,
+		},
+		{
+			description: `mm: fix something
+
+Something was broken. This fixes it.
+
+`,
+			diff: `diff --git a/mm/slub.c b/mm/slub.c
 `,
 			baseCommit: "f5e343a447510a663fbf6215584a9bf8e03bfd5c",
 			authors:    []string{"syzbot@kernel.org"},
@@ -566,16 +589,6 @@ To: "Foo Bar" <foobar@test.com>
 Cc: <linux-kernel@vger.kernel.org>
 
 diff --git a/mm/slub.c b/mm/slub.c
-index f77b7407c51b..9320daf2018f 100644
---- a/mm/slub.c
-+++ b/mm/slub.c
-@@ -250,7 +250,7 @@ struct partial_context {
- 
- static inline bool kmem_cache_debug(struct kmem_cache *s)
- {
--       return kmem_cache_debug_flags(s, SLAB_DEBUG_FLAGS);
-+       return kmem_cache_debug_flags(s, 0);
- }
 
 base-commit: f5e343a447510a663fbf6215584a9bf8e03bfd5c
 `,
@@ -612,8 +625,13 @@ base-commit: f5e343a447510a663fbf6215584a9bf8e03bfd5c
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			got := FormatPatch(test.description, test.diff, test.baseCommit,
-				test.tools, test.authors, test.recipients)
+			got := FormatPatch(test.description, test.diff, PatchTemplateData{
+				BaseCommit: test.baseCommit,
+				Fixes:      test.fixes,
+				Tools:      test.tools,
+				Authors:    test.authors,
+				Recipients: test.recipients,
+			})
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -58,7 +58,11 @@ func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 		}
 		// TODO: Figure out what Authors we want to use here.
 		res.Patch.Body = strings.TrimSpace(email.FormatPatchDescription(
-			res.Patch.Body, res.Patch.Tools, nil, recipients))
+			res.Patch.Body, email.PatchTemplateData{
+				Fixes:      res.Patch.Fixes,
+				Tools:      res.Patch.Tools,
+				Recipients: recipients,
+			}))
 		data.Patch = res.Patch
 		tmpl, err := templatesFS.ReadFile("templates/new_patch.txt")
 		if err != nil {


### PR DESCRIPTION
The previous changes added a new step to the patching workflow that determines the git commit for the Fixes: tag.

Update pkg/email to accept Fixes tag for patch template generation.

Update pkg/lore-relay and dahsboard/app to pass on the flag.

***

Note: it still needs to be integrated with the `patching-iteration` workflow, that will be done in a separate PR.