### PR TITLE
pkg/aflow: fix schema unmarshaling for primitive slices

### DIFF
--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -190,19 +190,19 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 		return convertFromMapReflect(structVal, mm, false, tool)
 	}
 
-	if targetType.Kind() == reflect.Slice && targetType.Elem().Kind() == reflect.Struct {
-		return setSliceField(field, name, f, targetType, tool)
+	if targetType.Kind() == reflect.Slice {
+		return setSliceField(val, field, name, f, targetType, tool)
 	}
 
 	if tool {
 		return BadCallError("argument %q has wrong type: got %T, want %v",
-			name, f, field.Type().Name())
+			name, f, field.Type().String())
 	}
 	return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
-		val, name, f, field.Type().Name())
+		val, name, f, field.Type().String())
 }
 
-func setSliceField(field reflect.Value, name string, f any, targetType reflect.Type, tool bool) error {
+func setSliceField(val any, field reflect.Value, name string, f any, targetType reflect.Type, tool bool) error {
 	slice, ok := f.([]any)
 	if !ok {
 		return fmt.Errorf("field %q must be a slice, got %T", name, f)
@@ -210,12 +210,8 @@ func setSliceField(field reflect.Value, name string, f any, targetType reflect.T
 	elemType := targetType.Elem()
 	res := reflect.MakeSlice(targetType, 0, len(slice))
 	for i, item := range slice {
-		mm, ok := item.(map[string]any)
-		if !ok {
-			return fmt.Errorf("item %d in field %q must be a map, got %T", i, name, item)
-		}
 		elem := reflect.New(elemType).Elem()
-		if err := convertFromMapReflect(elem, mm, false, tool); err != nil {
+		if err := setField(elem, val, item, fmt.Sprintf("%s[%d]", name, i), tool); err != nil {
 			return fmt.Errorf("item %d in field %q: %w", i, name, err)
 		}
 		res = reflect.Append(res, elem)

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -139,6 +139,14 @@ func TestConvertFromMap(t *testing.T) {
 	}, "", "")
 
 	testConvertFromMap(t, false, map[string]any{
+		"Strs": []any{"foo", "bar"},
+	}, struct {
+		Strs []string
+	}{
+		Strs: []string{"foo", "bar"},
+	}, "", "")
+
+	testConvertFromMap(t, false, map[string]any{
 		"Nested": map[string]any{"A": 1, "B": "foo"},
 	}, struct {
 		Nested struct {


### PR DESCRIPTION
The custom reflection-based unmarshaler used in the aflow framework implicitly assumed that all arrays passed from LLM responses were slices of structs. It failed when processing arguments that were arrays of primitive types (like []string for MessageRegexps).

This commit updates the unmarshaler to recursively process all slice elements by delegating to setField, which already handles primitives, structs, and custom JSON unmarshalers. It also corrects the type name formatting in the error messages by using String() instead of Name(), so that slice types correctly display their type signature instead of an empty string.

***

Observed when exploring trajectories:

```
Error:
argument "MessageRegexps" has wrong type: got []interface {}, want 

Args:
{
  "MessageRegexps": [
    "HCI_CMD_DRAIN_WORKQUEUE"
  ]
}

Results:
{
  "error": "argument \"MessageRegexps\" has wrong type: got []interface {}, want "
}
```