### PR TITLE
pkg/aflow: assorted gitlog improvements

### DIFF
--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -323,7 +323,6 @@ Search for the commit(s) that introduced this bug.
 `
 
 type fixesFinderState struct {
-	KernelSrc    string
 	KernelCommit string
 }
 
@@ -342,10 +341,7 @@ func validateFixesHashes(ctx *aflow.Context, state fixesFinderState, args fixesF
 		}
 		// LLM can provide a commit from a different branch.
 		// We want to ensure it is actually reachable from the current commit.
-		if _, err := repo.SwitchCommit(state.KernelCommit); err != nil {
-			return err
-		}
-		reachable, err := repo.Contains(commit.Hash)
+		reachable, err := vcs.Git{Dir: kernelRepoDir}.ContainedIn(state.KernelCommit, commit.Hash)
 		if err != nil || !reachable {
 			return aflow.BadCallError("commit %q is not reachable from the current commit",
 				args.FixesHash)

--- a/pkg/aflow/test_tool.go
+++ b/pkg/aflow/test_tool.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type TestToolOption func(*Context)
+
 // TestTool runs the given tool on provided initState/initArgs and compares results/error
 // with the provided wantResults/wantError.
 // wantResults can be either the tool return struct, or a function that accepts the tool
 // return struct. In the latter case, the function is executed with the actual results,
 // and is supposed to do assertions on the value.
-func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wantError string) {
+func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wantError string, opts ...TestToolOption) {
 	type tester interface {
 		testVerify(t *testing.T, ctx *verifyContext, state, args, results any) (
 			map[string]any, map[string]any, func(map[string]any))
@@ -28,6 +30,9 @@ func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wan
 	ctx := &Context{
 		state: state,
 	}
+	for _, opt := range opts {
+		opt(ctx)
+	}
 	defer ctx.Close()
 	gotResults, err := tool.execute(ctx, args)
 	gotError := ""
@@ -36,6 +41,12 @@ func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wan
 	}
 	require.Equal(t, wantError, gotError)
 	resultChecker(gotResults)
+}
+
+func TestWorkdir(dir string) TestToolOption {
+	return func(ctx *Context) {
+		ctx.Workdir = dir
+	}
 }
 
 func FuzzTool(t *testing.T, tool Tool, initState, initArgs any) (map[string]any, error) {

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -111,11 +111,12 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 		if err := osutil.Sandbox(cmd, true, true); err != nil {
 			return err
 		}
-		output, err = osutil.Run(5*time.Minute, cmd)
+		output, err = osutil.Run(10*time.Minute, cmd)
 		return err
 	})
 	if err != nil {
-		return logResult{}, gitBadCallError(err, "git log")
+		return logResult{}, gitBadCallError(err, "git log",
+			"Please specify a tighter search scope (e.g. by providing a PathPrefix).")
 	}
 	return logResult{Output: string(output)}, nil
 }
@@ -140,11 +141,11 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 		if err := osutil.Sandbox(cmd, true, true); err != nil {
 			return err
 		}
-		output, err = osutil.Run(time.Minute, cmd)
+		output, err = osutil.Run(5*time.Minute, cmd)
 		return err
 	})
 	if err != nil {
-		return showResult{}, gitBadCallError(err, "git show")
+		return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different commit.")
 	}
 	return showResult{Output: truncate(output, maxOutputLines)}, nil
 }
@@ -172,19 +173,22 @@ func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, err
 		if err := osutil.Sandbox(cmd, true, true); err != nil {
 			return err
 		}
-		output, err = osutil.Run(time.Minute, cmd)
+		output, err = osutil.Run(5*time.Minute, cmd)
 		return err
 	})
 	if err != nil {
-		return blameResult{}, gitBadCallError(err, "git blame")
+		return blameResult{}, gitBadCallError(err, "git blame", "Consider specifying a smaller line range.")
 	}
 	return blameResult{Output: truncate(output, maxOutputLines)}, nil
 }
 
-func gitBadCallError(err error, name string) error {
+func gitBadCallError(err error, name, advice string) error {
 	var verr *osutil.VerboseError
 	if !errors.As(err, &verr) {
 		return err
+	}
+	if errors.Is(err, osutil.ErrTimeout) {
+		return aflow.BadCallError("%s timed out. %s", name, advice)
 	}
 	if verr.ExitCode == 128 && (bytes.Contains(verr.Output, []byte("bad object")) ||
 		bytes.Contains(verr.Output, []byte("bad revision")) ||

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 var (
@@ -44,7 +46,6 @@ It helps to identify which commit last modified specific lines of code.
 const maxOutputLines = 1000
 
 type state struct {
-	KernelSrc    string
 	KernelCommit string
 }
 
@@ -102,7 +103,17 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 		gitArgs = append(gitArgs, "--", args.PathPrefix)
 	}
 
-	output, err := osutil.RunCmd(5*time.Minute, state.KernelSrc, "git", gitArgs...)
+	var output []byte
+	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
+		var err error
+		cmd := osutil.Command("git", gitArgs...)
+		cmd.Dir = kernelRepoDir
+		if err := osutil.Sandbox(cmd, true, true); err != nil {
+			return err
+		}
+		output, err = osutil.Run(5*time.Minute, cmd)
+		return err
+	})
 	if err != nil {
 		return logResult{}, gitBadCallError(err, "git log")
 	}
@@ -121,7 +132,17 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 	if args.Commit == "" {
 		return showResult{}, aflow.BadCallError("commit hash is required")
 	}
-	output, err := osutil.RunCmd(time.Minute, state.KernelSrc, "git", "show", "--no-color", args.Commit)
+	var output []byte
+	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
+		var err error
+		cmd := osutil.Command("git", "show", "--no-color", args.Commit)
+		cmd.Dir = kernelRepoDir
+		if err := osutil.Sandbox(cmd, true, true); err != nil {
+			return err
+		}
+		output, err = osutil.Run(time.Minute, cmd)
+		return err
+	})
 	if err != nil {
 		return showResult{}, gitBadCallError(err, "git show")
 	}
@@ -143,8 +164,17 @@ func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, err
 	args.End = max(args.End, args.Start)
 	args.End = min(args.End, args.Start+maxOutputLines)
 	lineRange := fmt.Sprintf("%d,%d", args.Start, args.End)
-	output, err := osutil.RunCmd(time.Minute, state.KernelSrc, "git",
-		"blame", "-s", "-L", lineRange, "--abbrev=12", state.KernelCommit, "--", args.File)
+	var output []byte
+	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
+		var err error
+		cmd := osutil.Command("git", "blame", "-s", "-L", lineRange, "--abbrev=12", state.KernelCommit, "--", args.File)
+		cmd.Dir = kernelRepoDir
+		if err := osutil.Sandbox(cmd, true, true); err != nil {
+			return err
+		}
+		output, err = osutil.Run(time.Minute, cmd)
+		return err
+	})
 	if err != nil {
 		return blameResult{}, gitBadCallError(err, "git blame")
 	}

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -70,6 +70,9 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 		return logResult{}, aflow.BadCallError("at least one of CodeRegexp, SymbolName, " +
 			"MessageRegexps, or PathPrefix must be set")
 	}
+	if args.SymbolName != "" && args.PathPrefix != "" {
+		return logResult{}, aflow.BadCallError("SymbolName and PathPrefix cannot be used together")
+	}
 	if args.Count <= 0 {
 		args.Count = 10
 	}

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -27,7 +27,7 @@ void foo() {
 
 	// Test git-show.
 	aflow.TestTool(t, ToolShow,
-		state{KernelSrc: repo.Dir},
+		state{},
 		showArgs{Commit: c1.Hash},
 		func(res showResult) {
 			expected := fmt.Sprintf(`(?s)^commit %s
@@ -43,14 +43,14 @@ diff --git a/foo\.c b/foo\.c
 \+}`, c1.Hash)
 			assert.Regexp(t, expected, res.Output)
 		},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-show with non-existing commit.
 	aflow.TestTool(t, ToolShow,
-		state{KernelSrc: repo.Dir},
+		state{},
 		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567"},
 		showResult{},
-		"git show failed: fatal: bad object 0123456789abcdef0123456789abcdef01234567")
+		"git show failed: fatal: bad object 0123456789abcdef0123456789abcdef01234567", aflow.TestWorkdir(tmpDir))
 }
 
 func TestGitBlame(t *testing.T) {
@@ -77,7 +77,7 @@ void foo() {
 
 	// Test git-blame.
 	aflow.TestTool(t, ToolBlame,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		blameArgs{File: "foo.c", Start: 3, End: 4},
 		func(res blameResult) {
 			expected := fmt.Sprintf(`(?m)^\^%s.* 3\) 	// BUG HERE
@@ -85,7 +85,7 @@ void foo() {
 $`, c1.Hash[:12], c2.Hash[:12])
 			assert.Regexp(t, expected, res.Output)
 		},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 }
 
 func TestGitLog(t *testing.T) {
@@ -120,73 +120,74 @@ void foo() {
 
 	// Test git-log message search.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{MessageRegexps: []string{"commit"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log multiple message regexps.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{MessageRegexps: []string{"third", "commit"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log message search case-insensitive.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{MessageRegexps: []string{"COMMIT"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log code search (-G).
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{CodeRegexp: "fixed"},
 		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log symbol search (-L).
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{SymbolName: "foo", SourcePath: "foo.c"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log path prefix.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{PathPrefix: "foo.c"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log no matches.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{MessageRegexps: []string{"non-existing"}},
 		logResult{},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log code search (-G) no matches.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{CodeRegexp: "non-existing"},
 		logResult{},
-		"")
+		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log error: missing SourcePath for symbol search.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{SymbolName: "foo"},
 		logResult{},
-		"SourcePath is required when SymbolName is set")
+		"SourcePath is required when SymbolName is set", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log error: no filters provided.
 	aflow.TestTool(t, ToolLog,
-		state{KernelSrc: repo.Dir, KernelCommit: "HEAD"},
+		state{KernelCommit: "HEAD"},
 		logArgs{},
 		logResult{},
-		"at least one of CodeRegexp, SymbolName, MessageRegexps, or PathPrefix must be set")
+		"at least one of CodeRegexp, SymbolName, MessageRegexps, or PathPrefix must be set",
+		aflow.TestWorkdir(tmpDir))
 }

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -183,6 +183,13 @@ void foo() {
 		logResult{},
 		"SourcePath is required when SymbolName is set", aflow.TestWorkdir(tmpDir))
 
+	// Test git-log error: SymbolName and PathPrefix conflict.
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{SymbolName: "foo", SourcePath: "foo.c", PathPrefix: "foo.c"},
+		logResult{},
+		"SymbolName and PathPrefix cannot be used together", aflow.TestWorkdir(tmpDir))
+
 	// Test git-log error: no filters provided.
 	aflow.TestTool(t, ToolLog,
 		state{KernelCommit: "HEAD"},

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -35,6 +35,8 @@ func RunCmd(timeout time.Duration, dir, bin string, args ...string) ([]byte, err
 	return Run(timeout, cmd)
 }
 
+var ErrTimeout = errors.New("timedout")
+
 // Run runs cmd with the specified timeout.
 // Returns combined output. If the command fails, err includes output.
 func Run(timeout time.Duration, cmd *exec.Cmd) ([]byte, error) {
@@ -68,7 +70,7 @@ func Run(timeout time.Duration, cmd *exec.Cmd) ([]byte, error) {
 	if err != nil {
 		retErr := fmt.Errorf("failed to run %q: %w", cmd.Args, err)
 		if <-timedout {
-			retErr = fmt.Errorf("timedout after %v %q", timeout, cmd.Args)
+			retErr = fmt.Errorf("%w after %v %q", ErrTimeout, timeout, cmd.Args)
 		}
 		exitCode := cmd.ProcessState.ExitCode()
 		var exitErr *exec.ExitError

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -255,7 +255,7 @@ func (git *gitRepo) initRepo(reason error) error {
 }
 
 func (git *gitRepo) Contains(commit string) (bool, error) {
-	return git.containedIn(HEAD, commit)
+	return git.ContainedIn(HEAD, commit)
 }
 
 const gitDateFormat = "Mon Jan 2 15:04:05 2006 -0700"
@@ -897,7 +897,7 @@ func (git Git) minimizeBaseCommits(list []*BaseCommit) ([]*BaseCommit, error) {
 			lastCommit[key] = item
 			continue
 		}
-		isNewer, err := git.containedIn(item.Hash, prev.Hash)
+		isNewer, err := git.ContainedIn(item.Hash, prev.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("topological sort step failed: %w", err)
 		}
@@ -977,7 +977,7 @@ func (git Git) verifyHash(hash string) (bool, error) {
 	return true, nil
 }
 
-func (git Git) containedIn(parent, commit string) (bool, error) {
+func (git Git) ContainedIn(parent, commit string) (bool, error) {
 	_, err := git.Run("merge-base", "--is-ancestor", commit, parent)
 	return err == nil, nil
 }


### PR DESCRIPTION
The gitlog tools (git-log, git-show, git-blame) previously failed because
they queried the shallow KernelSrc checkout, which lacks full git history.

Fix this by switching the tools to use kernel.UseLinuxRepo, which accesses
the full kernel repository cache. The KernelSrc property is removed from
gitlog state and fixesFinderState.

To support testing UseLinuxRepo, aflow.TestTool now accepts a new
aflow.TestWorkdir option to inject the test's temporary directory.

Also, simplify validateFixesHashes by using the newly exported
vcs.Git.ContainedIn instead of switching commits.