### PR TITLE
pkg/cover: fix incorrect SUMMARY percentage in function coverage HTML

### DIFF
--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -870,13 +870,13 @@ func mergeLine(chunks []lineCoverChunk, start, end int, covered bool) []lineCove
 func addFunctionCoverage(file *file, data *templateData) {
 	var buf bytes.Buffer
 	var coveredTotal int
-	var TotalInCoveredFunc int
+	var totalPCs int
 	for _, function := range file.functions {
 		percentage := ""
 		coveredTotal += function.covered
+		totalPCs += function.pcs
 		if function.covered > 0 {
 			percentage = fmt.Sprintf("%v%%", Percent(function.covered, function.pcs))
-			TotalInCoveredFunc += function.pcs
 		} else {
 			percentage = "---"
 		}
@@ -888,13 +888,13 @@ func addFunctionCoverage(file *file, data *templateData) {
 	buf.WriteString("-----------<br>\n")
 	buf.WriteString("<span class='hover'>SUMMARY")
 	percentInCoveredFunc := ""
-	if TotalInCoveredFunc > 0 {
-		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, TotalInCoveredFunc))
+	if totalPCs > 0 {
+		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, totalPCs))
 	} else {
 		percentInCoveredFunc = "---"
 	}
 	buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentInCoveredFunc))
-	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(TotalInCoveredFunc)))
+	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(totalPCs)))
 	buf.WriteString("</span></span></span><br>\n")
 	data.Functions = append(data.Functions, template.HTML(buf.String()))
 }


### PR DESCRIPTION
fixes #7209


## Summary

- `addFunctionCoverage` accumulated `function.pcs` into the denominator only for functions with non-zero coverage
- This inflated the SUMMARY percentage by ignoring uncovered functions entirely
- Fix: move `totalPCs += function.pcs` outside the `if function.covered > 0` block so all functions contribute to the denominator

**Example:** file with `funcA` (10 PCs, 8 covered) and `funcB` (10 PCs, 0 covered):
- Before: SUMMARY showed `80%` of `10`
- After: SUMMARY shows `40%` of `20`

Fixes #7209

## Test plan

- [ ] Verify coverage HTML report SUMMARY percentage matches the actual ratio of covered PCs to total PCs across all functions in a file
- [ ] Confirm files with all-zero-coverage functions show `0%` instead of `---` in SUMMARY