### PR TITLE
pkg/corpus: fix focusArea stats missing and stale after minimization

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -69,10 +69,14 @@ func NewFocusedCorpus(ctx context.Context, updates chan<- NewItemEvent, areas []
 		stat.Link("/cover"), stat.Prometheus("syz_corpus_cover"), stat.LenOf(&corpus.cover, &corpus.mu))
 	for _, area := range areas {
 		obj := &ProgramsList{}
-		if len(areas) > 1 && area.Name != "" {
+		if len(areas) > 1 {
 			// Only show extra statistics if there's more than one area.
-			stat.New("corpus ["+area.Name+"]",
-				fmt.Sprintf("Corpus programs of the focus area %q", area.Name),
+			name := area.Name
+			if name == "" {
+				name = "all"
+			}
+			stat.New("corpus ["+name+"]",
+				fmt.Sprintf("Corpus programs of the focus area %q", name),
 				stat.Console, stat.Graph("corpus"),
 				stat.LenOf(&obj.progs, &corpus.mu))
 		}
@@ -204,8 +208,8 @@ func (corpus *Corpus) applyFocusAreas(item *Item, coverDelta []uint64) {
 		area.saveProgram(item.Prog, item.Signal)
 		if item.areas == nil {
 			item.areas = make(map[*focusAreaState]struct{})
-			item.areas[area] = struct{}{}
 		}
+		item.areas[area] = struct{}{}
 	}
 }
 

--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -870,13 +870,13 @@ func mergeLine(chunks []lineCoverChunk, start, end int, covered bool) []lineCove
 func addFunctionCoverage(file *file, data *templateData) {
 	var buf bytes.Buffer
 	var coveredTotal int
-	var TotalInCoveredFunc int
+	var totalPCs int
 	for _, function := range file.functions {
 		percentage := ""
 		coveredTotal += function.covered
+		totalPCs += function.pcs
 		if function.covered > 0 {
 			percentage = fmt.Sprintf("%v%%", Percent(function.covered, function.pcs))
-			TotalInCoveredFunc += function.pcs
 		} else {
 			percentage = "---"
 		}
@@ -888,13 +888,13 @@ func addFunctionCoverage(file *file, data *templateData) {
 	buf.WriteString("-----------<br>\n")
 	buf.WriteString("<span class='hover'>SUMMARY")
 	percentInCoveredFunc := ""
-	if TotalInCoveredFunc > 0 {
-		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, TotalInCoveredFunc))
+	if totalPCs > 0 {
+		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, totalPCs))
 	} else {
 		percentInCoveredFunc = "---"
 	}
 	buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentInCoveredFunc))
-	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(TotalInCoveredFunc)))
+	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(totalPCs)))
 	buf.WriteString("</span></span></span><br>\n")
 	data.Functions = append(data.Functions, template.HTML(buf.String()))
 }


### PR DESCRIPTION
Fixes #7206

## Summary

Two bugs in focus area corpus statistics:

**Bug 1 - catch-all area always shows 0 entries:**
The `[all]` focus area (empty `Name`) was excluded from getting a stat by the `area.Name != ""` guard in `NewFocusedCorpus`. It always reported 0 entries. Fix: remove the name guard and use `"all"` as the display name for unnamed areas.

**Bug 2 - stats freeze after minimization:**
`applyFocusAreas` only tracked the **first** matching focus area in `item.areas` because the map insert was inside the `if item.areas == nil` block. Subsequent matching areas were silently dropped. After `Minimize()` rebuilt focus-area lists by iterating `inp.areas`, those dropped areas stayed at 0. Fix: move the map insert outside the nil-init block so all matching areas are recorded.

## Test plan

- [ ] Configure multiple focus areas including a catch-all (empty filter/name) and verify the `corpus [all]` stat appears and tracks the correct count
- [ ] Confirm focus area stats continue updating after the "minimized corpus: X -> Y" log message
- [ ] Verify programs matching multiple focus areas are counted in all of them after minimization