### PR TITLE
vm,instance,repro: handle GCE VM preemption in reproduction runs

### DIFF
--- a/pkg/cover/html.go
+++ b/pkg/cover/html.go
@@ -870,13 +870,13 @@ func mergeLine(chunks []lineCoverChunk, start, end int, covered bool) []lineCove
 func addFunctionCoverage(file *file, data *templateData) {
 	var buf bytes.Buffer
 	var coveredTotal int
-	var TotalInCoveredFunc int
+	var totalPCs int
 	for _, function := range file.functions {
 		percentage := ""
 		coveredTotal += function.covered
+		totalPCs += function.pcs
 		if function.covered > 0 {
 			percentage = fmt.Sprintf("%v%%", Percent(function.covered, function.pcs))
-			TotalInCoveredFunc += function.pcs
 		} else {
 			percentage = "---"
 		}
@@ -888,13 +888,13 @@ func addFunctionCoverage(file *file, data *templateData) {
 	buf.WriteString("-----------<br>\n")
 	buf.WriteString("<span class='hover'>SUMMARY")
 	percentInCoveredFunc := ""
-	if TotalInCoveredFunc > 0 {
-		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, TotalInCoveredFunc))
+	if totalPCs > 0 {
+		percentInCoveredFunc = fmt.Sprintf("%v%%", Percent(coveredTotal, totalPCs))
 	} else {
 		percentInCoveredFunc = "---"
 	}
 	buf.WriteString(fmt.Sprintf("<span class='cover hover'>%v", percentInCoveredFunc))
-	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(TotalInCoveredFunc)))
+	buf.WriteString(fmt.Sprintf("<span class='cover-right'>of %v", strconv.Itoa(totalPCs)))
 	buf.WriteString("</span></span></span><br>\n")
 	data.Functions = append(data.Functions, template.HTML(buf.String()))
 }

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -51,6 +51,9 @@ type RunResult struct {
 	// It's populated after a crash if MemoryDump was enabled in RunOptions.
 	// Empty if no dump was extracted.
 	MemoryDump string
+	// Preempted is true when the VM was preempted during execution.
+	// The result should be treated as inconclusive and the run retried.
+	Preempted bool
 }
 
 const (
@@ -156,9 +159,10 @@ func (inst *ExecProgInstance) runCommand(command string, opts RunOptions) (*RunR
 		inst.Logf(2, "program crashed: %v", rep.Title)
 	}
 	res := &RunResult{
-		Output:   append(prefixOutput, output...),
-		Report:   rep,
-		Duration: time.Since(start),
+		Output:    append(prefixOutput, output...),
+		Report:    rep,
+		Duration:  time.Since(start),
+		Preempted: vm.IsPreempted(output),
 	}
 	if opts.MemoryDump {
 		res.MemoryDump, err = inst.extractDump(rep, opts)

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -689,13 +689,18 @@ func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, er
 		// and not. So let's just retry runs for all errors.
 		// If the problem is transient, it will likely go away.
 		// If the problem is permanent, it will just be the same.
+		// Also retry when the VM was preempted -- a preempted run is inconclusive
+		// and must not be treated as "did not crash", which would corrupt bisection.
 		result, err = callback()
-		if err == nil {
+		if err == nil && !result.Preempted {
 			break
 		}
 	}
 	if err != nil {
 		return verdict{}, err
+	}
+	if result.Preempted {
+		return verdict{}, fmt.Errorf("VM preempted during all %d reproduction attempts", attempts)
 	}
 	rep := result.Report
 	if rep == nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -552,6 +552,11 @@ func (mon *monitor) waitForOutput() {
 	}
 }
 
+// IsPreempted reports whether the VM output indicates the instance was preempted.
+func IsPreempted(output []byte) bool {
+	return bytes.Contains(output, []byte(executorPreemptedStr))
+}
+
 const (
 	maxErrorLength = 256
 


### PR DESCRIPTION
Fixes #7111

## Summary

When a GCE preemptible VM is preempted, the monitor detects `SYZ-EXECUTOR: PREEMPTED` in the output and returns nil reports (no crash). This nil propagated up to `repro.getVerdict()` as `Crashed=false`, silently treating a preempted run as a clean non-crashing result. This corrupts bisection by making a preempted attempt look like the kernel did not reproduce the bug.

Fix across three layers:

- **`vm/vm.go`**: Export `IsPreempted(output []byte) bool` so callers can detect preemption from raw output
- **`pkg/instance/execprog.go`**: Add `Preempted bool` to `RunResult`, set via `vm.IsPreempted`
- **`pkg/repro/repro.go`**: In `getVerdict`, retry when `result.Preempted` (same retry loop as on error); if all attempts are preempted, return an error instead of a false `Crashed=false` verdict that would corrupt bisection

## Test plan

- [ ] Simulate preemption by injecting `SYZ-EXECUTOR: PREEMPTED` into VM output during repro and verify the run is retried rather than returning `Crashed=false`
- [ ] Verify non-preempted runs are unaffected
- [ ] Confirm that after all retry attempts being preempted, an error is returned (not a silent non-crash)