### PR TITLE
pkg/aflow: wrap git-log and git-blame path errors as BadCallError

### DIFF
--- a/pkg/aflow/test_tool.go
+++ b/pkg/aflow/test_tool.go
@@ -4,6 +4,7 @@
 package aflow
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,12 @@ func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wan
 		gotError = err.Error()
 	}
 	require.Equal(t, wantError, gotError)
+	if wantError != "" {
+		var badCallErr *badCallError
+		if !errors.As(err, &badCallErr) {
+			t.Errorf("expected BadCallError, got %T: %v", err, err)
+		}
+	}
 	resultChecker(gotResults)
 }
 

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -196,7 +196,9 @@ func gitBadCallError(err error, name, advice string) error {
 	if verr.ExitCode == 128 && (bytes.Contains(verr.Output, []byte("bad object")) ||
 		bytes.Contains(verr.Output, []byte("bad revision")) ||
 		bytes.Contains(verr.Output, []byte("unknown revision")) ||
-		bytes.Contains(verr.Output, []byte("ambiguous argument"))) {
+		bytes.Contains(verr.Output, []byte("ambiguous argument")) ||
+		bytes.Contains(verr.Output, []byte("no match")) ||
+		bytes.Contains(verr.Output, []byte("no such path"))) {
 		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
 	}
 	if verr.ExitCode == 1 && len(verr.Output) == 0 {

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -86,6 +86,14 @@ $`, c1.Hash[:12], c2.Hash[:12])
 			assert.Regexp(t, expected, res.Output)
 		},
 		"", aflow.TestWorkdir(tmpDir))
+
+	// Test git-blame with non-existent file.
+	aflow.TestTool(t, ToolBlame,
+		state{KernelCommit: "HEAD"},
+		blameArgs{File: "non_existing.c", Start: 1, End: 1},
+		blameResult{},
+		"git blame failed: fatal: no such path non_existing.c in HEAD",
+		aflow.TestWorkdir(tmpDir))
 }
 
 func TestGitLog(t *testing.T) {
@@ -196,5 +204,13 @@ void foo() {
 		logArgs{},
 		logResult{},
 		"at least one of CodeRegexp, SymbolName, MessageRegexps, or PathPrefix must be set",
+		aflow.TestWorkdir(tmpDir))
+
+	// Test git-log error: symbol not found.
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{SymbolName: "non_existing_symbol", SourcePath: "foo.c"},
+		logResult{},
+		"git log failed: fatal: -L parameter 'non_existing_symbol' starting at line 1: no match",
 		aflow.TestWorkdir(tmpDir))
 }


### PR DESCRIPTION
When using git-log with -L (SymbolName) on a non-existent symbol, or
git-blame on a non-existent file, git exits with fatal error code 128
("no match" and "no such path").

Previously, these caused the workflow to abort entirely. Add these
substrings to gitBadCallError so they are correctly wrapped as
aflow.BadCallError, allowing the LLM agent to retry the action.

Add tests to prevent regressions.
