### PR TITLE
pkg/aflow: fix rate limit retry logic in context compression

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -412,6 +412,7 @@ func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.C
 		SystemInstruction: genai.NewContentFromText(tokenCompressionInstruction, genai.RoleUser),
 		ThinkingConfig: &genai.ThinkingConfig{
 			IncludeThoughts: true,
+			ThinkingLevel:   genai.ThinkingLevelHigh,
 		},
 	}
 

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -433,7 +433,7 @@ func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.C
 		genai.RoleUser,
 	))
 
-	resp, err := a.generateContentCached(ctx, cfg, compressReq, 0, 0)
+	resp, err := a.generateContent(ctx, cfg, compressReq, 0)
 	if err != nil {
 		return nil, ctx.finishSpan(span, err)
 	}

--- a/pkg/aflow/testdata/TestTokenCompression.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompression.llm.json
@@ -70,7 +70,8 @@
 			},
 			"temperature": 0.1,
 			"thinkingConfig": {
-				"includeThoughts": true
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
 			}
 		},
 		"Request": [


### PR DESCRIPTION
LLMAgent.compressContext was directly calling generateContentCached, bypassing the retry loop implemented in generateContent. This caused context compression to fail immediately on API rate limits (e.g., 429 RESOURCE_EXHAUSTED) instead of sleeping and retrying.

Fix this by replacing generateContentCached with generateContent in compressContext.