### PR TITLE
executor: support preloaded crash kernels

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -160,3 +160,4 @@ Nikolay Ivchenko
 Oleg Kulachenko
 Daniel Bransky
 Matan Kalina
+Xianjun Zeng

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -368,10 +368,8 @@ static const char* setup_kcov_reset_ioctl()
 
 static const char* setup_kdump()
 {
-	if (access("/boot/bzImageKexec", F_OK) != 0)
-		return "/boot/bzImageKexec is missing";
-	if (access("/usr/sbin/makedumpfile", F_OK) != 0)
-		return "/usr/sbin/makedumpfile is missing";
+	if (access("/usr/sbin/makedumpfile", X_OK) != 0 && access("/usr/bin/makedumpfile", X_OK) != 0)
+		return "makedumpfile is missing";
 	char cmdline[4096];
 	int fd = open("/proc/cmdline", O_RDONLY);
 	if (fd < 0)
@@ -383,6 +381,19 @@ static const char* setup_kdump()
 	cmdline[n] = 0;
 	if (strstr(cmdline, "crashkernel=") == NULL)
 		return "crashkernel= is not present in /proc/cmdline";
+
+	// kdump-tools may have already loaded a crash kernel for full-disk images.
+	int s_fd = open("/sys/kernel/kexec_crash_loaded", O_RDONLY);
+	if (s_fd >= 0) {
+		char loaded_status[1];
+		ssize_t sn = read(s_fd, loaded_status, sizeof(loaded_status));
+		close(s_fd);
+		if (sn == 1 && loaded_status[0] == '1')
+			return NULL;
+	}
+
+	if (access("/boot/bzImageKexec", F_OK) != 0)
+		return "/boot/bzImageKexec is missing";
 
 	// Current default values
 	char root[128] = "/dev/sda1";
@@ -397,7 +408,7 @@ static const char* setup_kdump()
 
 	if (system(cmd) != 0)
 		return "kexec failed";
-	int s_fd = open("/sys/kernel/kexec_crash_loaded", O_RDONLY);
+	s_fd = open("/sys/kernel/kexec_crash_loaded", O_RDONLY);
 	if (s_fd >= 0) {
 		char loaded_status[1];
 		ssize_t sn = read(s_fd, loaded_status, sizeof(loaded_status));

--- a/pkg/instance/dump.go
+++ b/pkg/instance/dump.go
@@ -26,7 +26,7 @@ func ExtractMemoryDump(inst *vm.Instance, target *targets.Target, path string) e
 		maxRetries = 100
 		retrySleep = 3 * time.Second
 		// Using more restrictive masks somhow causes the crash utility to fail.
-		cmd = "/usr/sbin/makedumpfile -F -c -d 0 /proc/vmcore"
+		cmd = "makedumpfile -F -c -d 0 /proc/vmcore"
 	)
 	if target.OS != targets.Linux {
 		return fmt.Errorf("memory dump collection is only supported on linux")


### PR DESCRIPTION
## Summary

Support memory dump collection when a full-disk guest uses kdump-tools
to preload the crash kernel.

The executor now accepts an already loaded crash kernel by checking
`/sys/kernel/kexec_crash_loaded` before falling back to the existing
`/boot/bzImageKexec` flow. This keeps the original syzkaller-managed
kexec path intact while allowing full-disk guest images to provide their
own kdump setup.

This also allows `makedumpfile` to live in either `/usr/sbin` or
`/usr/bin`, matching different distro image layouts.

## Testing

Verified on v5.15 and v6.6 full-disk QEMU guests with `memory_dump: true`:

- `kdump-tools` preloads the crash kernel in the guest
- forced panic boots into the crash kernel
- SSH reconnects to the crash kernel
- `/proc/vmcore` is present
- `makedumpfile -F -c -d 0 /proc/vmcore` streams dump data successfully
