### PR TITLE
pkg/aflow: integrate Fixes tag processing into patch iteration

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -328,6 +328,7 @@ func makeIterationReportResult(ctx context.Context, job *aidb.Job, version int,
 			PatchDescription: res.PatchDescription,
 			PatchDiff:        res.PatchDiff,
 			Recipients:       res.Recipients,
+			Fixes:            res.Fixes,
 		}, version)
 		if err != nil {
 			return nil, nil, err

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -335,6 +335,10 @@ func TestAILoreIntegrationComment(t *testing.T) {
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
+			"Fixes": map[string]any{
+				"Hash":  "123456789012",
+				"Title": "original bug",
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -398,7 +402,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	// Should be automatically processed to avoid loops.
 	assert.True(t, botComment.Processed)
 
-	// 5. Complete the iteration job to verify CC behavior on replies.
+	// 5. Complete the iteration job to verify CC behavior on replies and Fixes passing.
 	// Advance time to pass the debounce logic so the iteration job gets created.
 	c.advanceTime(31 * time.Minute)
 
@@ -412,6 +416,10 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	resp, err := c.agentClient.AIJobPoll(pollReq)
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.ID)
+
+	// Verify that the original fixes hash was passed down.
+	baseFixesMap := resp.Args["BaseFixes"].(map[string]any)
+	require.Equal(t, "123456789012", baseFixesMap["Hash"])
 
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: resp.ID,
@@ -443,4 +451,138 @@ type integrationMockSender struct {
 func (m *integrationMockSender) Send(ctx context.Context, email *sender.Email) (string, error) {
 	m.sent = append(m.sent, email)
 	return fmt.Sprintf("<mock@msgid-%d>", len(m.sent)), nil
+}
+
+func TestAILoreIteration(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+		},
+	})
+
+	repoDir := t.TempDir()
+	loreArchive := lore.NewTestLoreArchive(t, repoDir)
+
+	now := time.Now()
+
+	pollerCfg := lore.PollerConfig{
+		RepoDir:   t.TempDir(),
+		URL:       loreArchive.Repo.Dir,
+		Tracer:    &debugtracer.TestTracer{T: t},
+		OwnEmails: []string{"syzbot@testapp.appspotmail.com"},
+	}
+	poller, err := lore.NewPoller(pollerCfg)
+	require.NoError(t, err)
+
+	mockSnd := &integrationMockSender{}
+
+	relay := lorerelay.NewRelay(&lorerelay.Config{
+		DocsLink:    "http://docs.link",
+		LoreArchive: "archive@lore.com",
+	}, c.globalClient, poller, mockSnd)
+
+	// 1. Create a bug and AI job.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	_, err = c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+	jobID := c.createAIJob(extID, string(ai.WorkflowPatching), "")
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"PatchDescription": "Test Description",
+			"PatchDiff":        "diff",
+			"KernelRepo":       "repo",
+			"KernelCommit":     "commit",
+			"Fixes": map[string]any{
+				"Hash":  "123456789012",
+				"Title": "original bug",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 2. Poll Dashboard - should report to moderation.
+	err = relay.PollDashboardOnce(t.Context())
+	require.NoError(t, err)
+	require.Len(t, mockSnd.sent, 1)
+
+	// 3. Send a plain comment.
+	loreArchive.SaveMessageAt(t, "From: reviewer@email.com\n"+
+		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Message-ID: <comment1>\n"+
+		"In-Reply-To: <mock@msgid-1>\n\n"+
+		"This is just a normal review comment with some context.\n", now.Add(time.Minute))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
+	// 4. Send a reply from the bot itself.
+	loreArchive.SaveMessageAt(t, "From: syzbot@testapp.appspotmail.com\n"+
+		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Message-ID: <bot-reply>\n"+
+		"In-Reply-To: <comment1>\n\n"+
+		"This is a generated bot reply.\n", now.Add(time.Minute*2))
+	err = relay.PollLoreOnce(context.Background())
+	require.NoError(t, err)
+
+	// 5. Complete the iteration job to verify CC behavior on replies and Fixes passing.
+	// Advance time to pass the debounce logic so the iteration job gets created.
+	c.advanceTime(31 * time.Minute)
+
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	resp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.ID)
+
+	// Verify that the original fixes hash was passed down.
+	baseFixesMap := resp.Args["BaseFixes"].(map[string]any)
+	require.Equal(t, "123456789012", baseFixesMap["Hash"])
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: resp.ID,
+		Results: map[string]any{
+			"PatchDescription": "Test Description",
+			"PatchDiff":        "diff v2",
+			"KernelRepo":       "repo",
+			"KernelCommit":     "commit",
+			"Fixes": map[string]any{
+				"Hash":  "abcdefabcdef",
+				"Title": "introduce a bug",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 6. Poll Dashboard again - lore-relay should send patch v2.
+	err = relay.PollDashboardOnce(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, mockSnd.sent, 2)
+	assert.Equal(t, "[PATCH v2] Test Description", mockSnd.sent[1].Subject)
+	body := string(mockSnd.sent[1].Body)
+	assert.Contains(t, body, "Fixes: abcdefabcdef (\"introduce a bug\")")
+
+	// 7. But nothing else.
+	err = relay.PollDashboardOnce(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mockSnd.sent, 2)
 }

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -55,6 +55,10 @@ func TestAIExternalReporting(t *testing.T) {
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
+			"Fixes": map[string]any{
+				"Hash":  "123456789012",
+				"Title": "original bug",
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -66,6 +70,8 @@ func TestAIExternalReporting(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pollResp.Result)
 	require.True(t, pollResp.Result.CanUpstream)
+	require.Equal(t, "123456789012", pollResp.Result.Patch.Fixes.Hash)
+	require.Equal(t, "original bug", pollResp.Result.Patch.Fixes.Title)
 
 	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
 		ReportID:       pollResp.Result.ID,
@@ -120,6 +126,10 @@ func TestAIExternalReporting(t *testing.T) {
 		Links: []string{
 			appURL(c.ctx) + "/bug?extid=" + extID,
 			appURL(c.ctx) + "/ai_job?id=" + jobID,
+		},
+		Fixes: ai.FixesTag{
+			Hash:  "123456789012",
+			Title: "original bug",
 		},
 	}, pollResp.Result.Patch)
 	require.Equal(t, []string{"public@test.com"}, pollResp.Result.To)

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -1234,5 +1234,8 @@ func extractBaseCommitArgs(job *Job, argsMap map[string]any) {
 		if commit, ok := m["KernelCommit"].(string); ok && commit != "" {
 			argsMap["BaseCommit"] = commit
 		}
+		if fixes, ok := m["Fixes"].(map[string]any); ok && fixes != nil {
+			argsMap["BaseFixes"] = fixes
+		}
 	}
 }

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -31,6 +31,7 @@ type PatchIterationOutputs struct {
 	PatchDescription string
 	PatchDiff        string
 	Recipients       []Recipient
+	Fixes            FixesTag
 
 	NewChangeLog string
 	Replies      []CommentReply

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -35,6 +35,9 @@ type PatchIterationInputs struct {
 	// Discussion history grouped by patch version.
 	PatchHistory []ai.PatchHistoryEntry
 
+	// Base fixes tag from previous version.
+	BaseFixes ai.FixesTag
+
 	// See patching workflow.
 	BaseRepository string
 	BaseBranch     string
@@ -42,6 +45,7 @@ type PatchIterationInputs struct {
 }
 
 func createPatchIterationFlow(name string, summaryWindow, compressTokens int) *aflow.Flow {
+	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools)
 	return &aflow.Flow{
 		Name: name,
 		Root: aflow.Pipeline(
@@ -59,8 +63,10 @@ func createPatchIterationFlow(name string, summaryWindow, compressTokens int) *a
 				Model: aflow.GoodBalancedModel,
 				// nolint: lll
 				Outputs: aflow.LLMOutputs[struct {
-					NeedNewVersion bool   `jsonschema:"True if any comment suggests or requires a code change to the patch, or if a rebase is requested. False otherwise."`
-					VerdictReason  string `jsonschema:"Brief explanation of why a new version is or is not needed."`
+					NeedNewVersion    bool   `jsonschema:"True if any comment suggests or requires a code change to the patch, if a rebase is requested, or if the Fixes tag needs to be updated. False otherwise."`
+					UpdateFixes       bool   `jsonschema:"True if any comment suggests that the Fixes tag is incorrect or needs to be updated. False otherwise."`
+					UpdateFixesReason string `jsonschema:"Explanation of why the Fixes tag needs to be updated, and any hints provided by reviewers."`
+					VerdictReason     string `jsonschema:"Brief explanation of why a new version is or is not needed."`
 				}](),
 				TaskType:       aflow.FormalReasoningTask,
 				Instruction:    verdictInstruction,
@@ -78,6 +84,22 @@ func createPatchIterationFlow(name string, summaryWindow, compressTokens int) *a
 					extractLatestPatchInfo,
 					kernel.CheckoutScratch,
 					PatchGenerationLoop(summaryWindow, compressTokens, applyGitPatch, patchIterationInstruction, patchIterationPrompt),
+					&aflow.If{
+						Condition: "UpdateFixes",
+						Do: aflow.Pipeline(
+							&aflow.LLMAgent{
+								Name:          "fixes-finder",
+								Model:         aflow.BestExpensiveModel,
+								Outputs:       aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
+								TaskType:      aflow.FormalReasoningTask,
+								Instruction:   fixesIterationInstruction,
+								Prompt:        fixesIterationPrompt,
+								Tools:         commonTools,
+								SummaryWindow: summaryWindow,
+							},
+						),
+					},
+					resolveFixes,
 					getRecentCommits,
 					&aflow.LLMAgent{
 						Name:  "changelog-generator",
@@ -164,6 +186,21 @@ var extractLatestPatchInfo = aflow.NewFuncAction("extract-latest-patch-info", fu
 	}, nil
 })
 
+var resolveFixes = aflow.NewFuncAction("resolve-fixes", func(ctx *aflow.Context, args struct {
+	BaseFixes   ai.FixesTag
+	FixesHash   string
+	UpdateFixes bool
+}) (formatFixesResult, error) {
+	if !args.UpdateFixes {
+		return formatFixesResult{Fixes: args.BaseFixes}, nil
+	}
+	if args.FixesHash == "" {
+		return formatFixesResult{}, nil
+	}
+	fix, err := queryFixesTag(ctx, args.FixesHash)
+	return formatFixesResult{Fixes: fix}, err
+})
+
 var appendCommentReply = aflow.NewFuncAction("append-comment-reply", func(ctx *aflow.Context, args struct {
 	Action         string
 	Reason         string
@@ -191,6 +228,31 @@ func init() {
 		createPatchIterationFlow("compressed", 0, 200_000),
 	)
 }
+
+const fixesIterationInstruction = fixesInstruction + `
+Additionally, you are provided with a previous guess for the Fixes tag and the reason reviewers asked to update it.
+Do NOT guess the same commit if it was rejected. Use the provided reason to guide your new search.
+If the reviewers explicitly provided the exact commit hash that introduced the bug, and it looks
+reasonable, trust their input and use it.
+`
+
+const fixesIterationPrompt = `
+The crash is:
+
+{{.ReproducedCrashReport}}
+
+The patch that fixes the bug is:
+
+{{.PatchDiff}}
+
+Search for the commit(s) that introduced this bug.
+
+{{if .BaseFixes.Hash}}
+Reviewers rejected our previous guess for the Fixes tag: {{.BaseFixes.Hash}} ("{{.BaseFixes.Title}}")
+The reason they asked to update it:
+{{.UpdateFixesReason}}
+{{end}}
+`
 
 const patchIterationInstruction = `
 You are an experienced Linux kernel developer tasked with updating a kernel patch

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -319,9 +319,11 @@ The crash is:
 
 {{.ReproducedCrashReport}}
 
+{{if .BugExplanation}}
 The explanation of the root cause is:
 
 {{.BugExplanation}}
+{{end}}
 
 The patch that fixes the bug is:
 
@@ -366,20 +368,25 @@ type formatFixesResult struct {
 
 var formatFixes = aflow.NewFuncAction("format-fixes",
 	func(ctx *aflow.Context, args fixesFinderArgs) (formatFixesResult, error) {
-		var fix ai.FixesTag
 		if args.FixesHash == "" {
 			return formatFixesResult{}, nil
 		}
-		err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
-			commit, err := repo.Commit(args.FixesHash)
-			if err != nil {
-				return fmt.Errorf("failed to get commit %q: %w", args.FixesHash, err)
-			}
-			fix = ai.FixesTag{
-				Hash:  commit.Hash,
-				Title: commit.Title,
-			}
-			return nil
-		})
+		fix, err := queryFixesTag(ctx, args.FixesHash)
 		return formatFixesResult{Fixes: fix}, err
 	})
+
+func queryFixesTag(ctx *aflow.Context, hash string) (ai.FixesTag, error) {
+	var fix ai.FixesTag
+	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, repo vcs.Repo) error {
+		commit, err := repo.Commit(hash)
+		if err != nil {
+			return fmt.Errorf("failed to get commit %q: %w", hash, err)
+		}
+		fix = ai.FixesTag{
+			Hash:  commit.Hash,
+			Title: commit.Title,
+		}
+		return nil
+	})
+	return fix, err
+}


### PR DESCRIPTION
Currently, the patching workflow discovers and emits a Fixes tag, but the patch-iteration workflow loses it. This commit integrates Fixes tag tracking and conditional updating into patch-iteration.

The verdict agent now evaluates whether reviewers requested a new Fixes tag. If requested, the fixes-finder agent is invoked to deduce the new guilty commit. Otherwise, the original Fixes tag is propagated to the output.

Closes https://github.com/google/syzkaller/issues/7185
