### PR TITLE
dashboard/app: ignore commands on mailing lists if syzbot is not CC'd

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -624,6 +624,18 @@ that is the sender of the bug report (also present in the Reported-by tag).
 
 `)
 
+	// If the command was seen on a mailing list, but syzbot was not addressed, do NOT reply.
+	// Since we receive the email, it hits our endpoint, but the To header is the mailing list.
+	c.incomingEmail("syzbot@testapp.appspotmail.com", "#syz invalid",
+		EmailOptTo("test@syzkaller.com"), EmailOptSender("test@syzkaller.com"))
+	c.expectNoEmail()
+
+	// If the command was seen on a mailing list AND syzbot was explicitly addressed (without hash), we DO reply.
+	c.incomingEmail("syzbot@testapp.appspotmail.com", "#syz invalid",
+		EmailOptSender("test@syzkaller.com"), EmailOptCC([]string{"test@syzkaller.com"}))
+	reply = c.pollEmailBug()
+	assert.Contains(t, reply.Body, "I see the command but can't find the corresponding bug")
+
 	c.incomingEmail("syzbot+123@testapp.appspotmail.com", "#syz invalid")
 	reply = c.pollEmailBug()
 	c.expectEQ(reply.Body, `> #syz invalid
@@ -1027,9 +1039,7 @@ func TestBugFromSubjectInference(t *testing.T) {
 		EmailOptOrigFrom("test@requester.com"),
 		EmailOptFrom(mailingList), EmailOptSubject(subject),
 	)
-	syzbotReply := c.pollEmailBug()
-	c.expectNE(syzbotReply.Sender, origSender)
-	c.expectEQ(strings.Contains(syzbotReply.Body, "can't find the corresponding bug"), true)
+	c.expectNoEmail()
 
 	// Now try to test the exiting bug, but with the wrong mailing list.
 	subject = "Re: " + crashTitle
@@ -1047,7 +1057,7 @@ func TestBugFromSubjectInference(t *testing.T) {
 		EmailOptFrom(mailingList), EmailOptOrigFrom("test@requester.com"),
 		EmailOptSubject(subject),
 	)
-	syzbotReply = c.pollEmailBug()
+	syzbotReply := c.pollEmailBug()
 	c.expectEQ(syzbotReply.Sender, origSender)
 	c.expectEQ(strings.Contains(syzbotReply.Body, "This crash does not have a reproducer"), true)
 

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -1256,6 +1256,11 @@ func bugInfoWithoutBugID(ctx context.Context, msg *email.Email) *bugInfoResult {
 	if len(msg.Commands) == 0 {
 		// This happens when people CC syzbot on unrelated emails.
 		log.Infof(ctx, "no bug ID (%q)", msg.Subject)
+	} else if msg.MailingList != "" && len(msg.BugIDs) == 0 && matchingErr != errAmbiguousTitle {
+		// If we received a command via a mailing list but syzbot was not explicitly CC'd,
+		// and we couldn't identify the bug (and it's not a case of an ambiguous title),
+		// don't reply with an error. It might be meant for another syzbot instance.
+		log.Infof(ctx, "no bug ID for command (%q), ignoring", msg.Subject)
 	} else {
 		log.Errorf(ctx, "no bug ID (%q)", msg.Subject)
 		from, err := email.AddAddrContext(ownEmail(ctx), "HASH")

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -1205,35 +1205,7 @@ func loadBugInfo(ctx context.Context, msg *email.Email) *bugInfoResult {
 		bugID = msg.BugIDs[0]
 	}
 	if bugID == "" {
-		var matchingErr error
-		// Give it one more try -- maybe we can determine the bug from the subject + mailing list.
-		if msg.MailingList != "" {
-			var ret *bugInfoResult
-			ret, matchingErr = matchBugFromList(ctx, msg.MailingList, msg.Subject)
-			if matchingErr == nil {
-				return ret
-			}
-			log.Infof(ctx, "mailing list matching failed: %s", matchingErr)
-		}
-		if len(msg.Commands) == 0 {
-			// This happens when people CC syzbot on unrelated emails.
-			log.Infof(ctx, "no bug ID (%q)", msg.Subject)
-		} else {
-			log.Errorf(ctx, "no bug ID (%q)", msg.Subject)
-			from, err := email.AddAddrContext(ownEmail(ctx), "HASH")
-			if err != nil {
-				log.Errorf(ctx, "failed to format sender email address: %v", err)
-				from = "ERROR"
-			}
-			message := fmt.Sprintf(replyNoBugID, from)
-			if matchingErr == errAmbiguousTitle {
-				message = fmt.Sprintf(replyAmbiguousBugID, from)
-			}
-			if err := replyTo(ctx, msg, "", message); err != nil {
-				log.Errorf(ctx, "failed to send reply: %v", err)
-			}
-		}
-		return nil
+		return bugInfoWithoutBugID(ctx, msg)
 	}
 	bug, bugKey, err := findBugByReportingID(ctx, bugID)
 	if err != nil {
@@ -1268,6 +1240,38 @@ func loadBugInfo(ctx context.Context, msg *email.Email) *bugInfoResult {
 		return nil
 	}
 	return &bugInfoResult{bug, bugKey, bugReporting, reporting}
+}
+
+func bugInfoWithoutBugID(ctx context.Context, msg *email.Email) *bugInfoResult {
+	var matchingErr error
+	// Give it one more try -- maybe we can determine the bug from the subject + mailing list.
+	if msg.MailingList != "" {
+		var ret *bugInfoResult
+		ret, matchingErr = matchBugFromList(ctx, msg.MailingList, msg.Subject)
+		if matchingErr == nil {
+			return ret
+		}
+		log.Infof(ctx, "mailing list matching failed: %s", matchingErr)
+	}
+	if len(msg.Commands) == 0 {
+		// This happens when people CC syzbot on unrelated emails.
+		log.Infof(ctx, "no bug ID (%q)", msg.Subject)
+	} else {
+		log.Errorf(ctx, "no bug ID (%q)", msg.Subject)
+		from, err := email.AddAddrContext(ownEmail(ctx), "HASH")
+		if err != nil {
+			log.Errorf(ctx, "failed to format sender email address: %v", err)
+			from = "ERROR"
+		}
+		message := fmt.Sprintf(replyNoBugID, from)
+		if matchingErr == errAmbiguousTitle {
+			message = fmt.Sprintf(replyAmbiguousBugID, from)
+		}
+		if err := replyTo(ctx, msg, "", message); err != nil {
+			log.Errorf(ctx, "failed to send reply: %v", err)
+		}
+	}
+	return nil
 }
 
 func ownMailingLists(ctx context.Context) []string {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -777,6 +777,7 @@ type (
 	EmailOptOrigFrom  string
 	EmailOptCC        []string
 	EmailOptSender    string
+	EmailOptTo        string
 )
 
 func (ctx *Ctx) incomingEmail(to, body string, opts ...any) {
@@ -786,6 +787,7 @@ func (ctx *Ctx) incomingEmail(to, body string, opts ...any) {
 	cc := []string{"test@syzkaller.com", "bugs@syzkaller.com", "bugs2@syzkaller.com"}
 	sender := ""
 	origFrom := ""
+	toHeader := to
 	for _, o := range opts {
 		switch opt := o.(type) {
 		case EmailOptMessageID:
@@ -800,6 +802,8 @@ func (ctx *Ctx) incomingEmail(to, body string, opts ...any) {
 			cc = []string(opt)
 		case EmailOptOrigFrom:
 			origFrom = fmt.Sprintf("\nX-Original-From: %v", string(opt))
+		case EmailOptTo:
+			toHeader = string(opt)
 		}
 	}
 	if sender == "" {
@@ -815,7 +819,7 @@ To: %v%v
 Content-Type: text/plain
 
 %v
-`, sender, id, subject, from, strings.Join(cc, ","), to, origFrom, body)
+`, sender, id, subject, from, strings.Join(cc, ","), toHeader, origFrom, body)
 	log.Infof(ctx.ctx, "sending %s", email)
 	_, err := ctx.POST("/_ah/mail/"+to, email)
 	ctx.expectOK(err)


### PR DESCRIPTION
If a user sends a command to a mailing list (e.g., "#syz upstream" in
reply to a patch sent by lore-relay) without explicitly addressing
syzbot, dashboard/app currently replies with an "I see the command but
can't find the corresponding bug" error.

Fix this by silently dropping unmapped commands if they arrive via a
mailing list and syzbot's own address isn't explicitly included.

Closes #7237.