### PR TITLE
Revert "pkg/aflow: use vcs git apply helper"

### DIFF
--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -168,7 +168,10 @@ func applyGitPatchFunc(ctx *aflow.Context, args applyGitPatchArgs) (struct{}, er
 	}
 
 	// Apply the diff.
-	if err := vcs.Patch(args.KernelScratchSrc, []byte(latest.Diff)); err != nil {
+	cmd := exec.Command("git", "apply")
+	cmd.Dir = args.KernelScratchSrc
+	cmd.Stdin = strings.NewReader(latest.Diff)
+	if _, err := osutil.Run(time.Minute, cmd); err != nil {
 		return struct{}{}, aflow.FlowError(fmt.Errorf("failed to apply previous patch: %w", err))
 	}
 


### PR DESCRIPTION
This reverts commit b09ea9df3d95c21ecaf04e8423f52421c8094283.

The change has caused permission issues due to sandboxing which will likely require larger refactorings to fix properly.

Roll-back the change to unbreak the patch-iteration workflow.