### PR TITLE
pkg/aflow: add iteration limit to LLMAgent

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -78,6 +78,8 @@ const (
 	// Default limit for consecutive identical tool calls.
 	defaultLoopDetectionLimit = 3
 	maxHistorySize            = 20 // Large enough to catch alternating loops.
+	// We abort execution after this many iterations to prevent infinite loops.
+	defaultMaxIterations = 250
 )
 
 type TaskType int
@@ -293,7 +295,7 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 	// a new summary.
 	var summaryMessage *genai.Content
 	var lastInputTokens int
-	for {
+	for range defaultMaxIterations {
 		var err error
 		var newSummaryMessage *genai.Content
 		req, newSummaryMessage, lastInputTokens, err = a.maybeCompressContext(ctx, req, lastInputTokens)
@@ -383,6 +385,8 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 		}
 		req = append(req, responses)
 	}
+	return "", nil, fmt.Errorf("agent reached max iterations limit (%v)",
+		defaultMaxIterations)
 }
 
 const tokenCompressionInstruction = `

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -356,14 +356,8 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 			summaryMessage = req[len(req)-1]
 		}
 		if len(calls) == 0 {
-			if a.Outputs != nil && outputs == nil {
-				// LLM did not call set-results.
-				req = append(req, genai.NewContentFromText(llmMissingOutputs, genai.RoleUser))
-				continue
-			}
-			if reply == "" {
-				// LLM did not provide any final reply.
-				req = append(req, genai.NewContentFromText(llmMissingReply, genai.RoleUser))
+			if missing := a.checkFinalReply(reply, outputs); missing != nil {
+				req = append(req, missing)
 				continue
 			}
 			// This is the final reply.
@@ -387,6 +381,18 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 	}
 	return "", nil, fmt.Errorf("agent reached max iterations limit (%v)",
 		defaultMaxIterations)
+}
+
+func (a *LLMAgent) checkFinalReply(reply string, outputs map[string]any) *genai.Content {
+	if a.Outputs != nil && outputs == nil {
+		// LLM did not call set-results.
+		return genai.NewContentFromText(llmMissingOutputs, genai.RoleUser)
+	}
+	if reply == "" {
+		// LLM did not provide any final reply.
+		return genai.NewContentFromText(llmMissingReply, genai.RoleUser)
+	}
+	return nil
 }
 
 const tokenCompressionInstruction = `


### PR DESCRIPTION
The patch-generator agent could enter an infinite loop when verifying its own successful edits. Because codesearch tools read from the pristine source tree, the LLM saw unmodified code and assumed its edits had failed. It repeatedly attempted to re-apply the patch, bypassing duplicate checks and forgetting its initial success due to context compression.

Add a MaxIterations property to LLMAgent and enforce it within the chat loop to prevent endless tool-calling loops. Set this limit to 250 for the patch-generator agent.

***

It doesn't address the underlying problem of https://github.com/google/syzkaller/issues/7247, but at least prevents the waste of tokens.