### PR TITLE
pkg/aflow: ask not to format the description

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -348,6 +348,9 @@ of the most important changes (e.g., '- Fixed memory leak in error path', '- Ren
 CRITICAL: Do NOT rewrite or rephrase the existing patch description. You may only modify it
 if the previous description is now fundamentally incorrect due to the new changes. Otherwise,
 keep it exactly as it was, and document all new changes exclusively in the change log.
+
+IMPORTANT: Do not wrap lines manually (e.g., at 80 characters); we will reformat the text
+automatically, so keep paragraphs as single lines without newlines.
 `
 
 const changelogPrompt = `

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -226,6 +226,8 @@ and then include description of the bug being fixed, and how it's fixed by the p
 
 Your final reply should contain only the text of the commit description.
 Phrase the one-line summary so that it is not longer than 72 characters.
+IMPORTANT: Do not wrap lines manually (e.g., at 80 characters); we will reformat the text
+automatically, so keep paragraphs as single lines without newlines.
 `
 
 const descriptionPrompt = `


### PR DESCRIPTION
There happen to be cases when AI produces an already formatted patch description, which breaks the assumption of our auto-formatting step.

Example: https://syzkaller.appspot.com/ai_job?id=cb59c8d3-74b8-4ca8-b183-69270de54718

Let's tell the agent not to do that.
