### PR TITLE
pkg/aflow: preserve system instructions in context compression

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -262,7 +262,7 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 	if err := ctx.startSpan(span); err != nil {
 		return "", nil, err
 	}
-	reply, outputs, err := a.chat(ctx, cfg, tools, span.Prompt, candidate)
+	reply, outputs, err := a.chat(ctx, cfg, tools, instruction, span.Prompt, candidate)
 	if err == nil {
 		span.Reply = reply
 		span.Results = outputs
@@ -284,7 +284,7 @@ func (a *LLMAgent) handleOverflowError(cfg *genai.GenerateContentConfig, req []*
 }
 
 func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools map[string]Tool,
-	prompt string, candidate int) (string, map[string]any, error) {
+	instruction, prompt string, candidate int) (string, map[string]any, error) {
 	var outputs map[string]any
 	answerNow := false
 	req := []*genai.Content{genai.NewContentFromText(prompt, genai.RoleUser)}
@@ -296,7 +296,7 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 	for {
 		var err error
 		var newSummaryMessage *genai.Content
-		req, newSummaryMessage, lastInputTokens, err = a.maybeCompressContext(ctx, req, lastInputTokens)
+		req, newSummaryMessage, lastInputTokens, err = a.maybeCompressContext(ctx, req, instruction, lastInputTokens)
 		if err != nil {
 			return "", nil, err
 		}
@@ -388,8 +388,12 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 const tokenCompressionInstruction = `
 You are an expert technical assistant acting as a memory compressor.
 Review the following execution history of an AI agent.
-The first message contains the original system instructions and the main goal.
-It will be preserved in the history, so DO NOT duplicate its contents in your summary.
+
+The first message begins with the original system instructions enclosed in
+<system_instructions> tags, and then continues with the initial prompt.
+These are provided for your information and will be preserved in the history
+anyway, so DO NOT duplicate their contents in your summary.
+
 Write a comprehensive and substantial summary of the current state of the workspace
 and the investigation based on the SUBSEQUENT messages. Do NOT write a very short summary.
 Include:
@@ -405,7 +409,7 @@ You MUST provide the summary in your final response text. Do not use tools.
 // deterministic summarizer of facts without hallucinating or adding creative leaps.
 const tokenCompressionTemperature = 0.1
 
-func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.Content, error) {
+func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content, instruction string) (*genai.Content, error) {
 	// Lightweight config targeting the Flash model.
 	cfg := &genai.GenerateContentConfig{
 		Temperature:       genai.Ptr[float32](tokenCompressionTemperature),
@@ -425,9 +429,19 @@ func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.C
 		return nil, err
 	}
 
+	compressReq := slices.Clone(req)
+	if instruction != "" && len(compressReq) > 0 {
+		compressReq[0] = osutil.JSONDeepCopy(compressReq[0])
+		if len(compressReq[0].Parts) > 0 {
+			compressReq[0].Parts[0] = &genai.Part{
+				Text: "<system_instructions>\n" + instruction + "\n</system_instructions>\n\n" + compressReq[0].Parts[0].Text,
+			}
+		}
+	}
+
 	// We append a final prompt to ensure the model knows it must summarize now,
 	// rather than trying to continue the original conversation.
-	compressReq := append(slices.Clone(req), genai.NewContentFromText(
+	compressReq = append(compressReq, genai.NewContentFromText(
 		"Task: Provide the comprehensive summary of the above execution history now.\n"+
 			"Important: You must output the actual summary text in your final response. "+
 			"Do NOT use any tools.",
@@ -464,14 +478,14 @@ func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content) (*genai.C
 	return newSummary, ctx.finishSpan(span, nil)
 }
 
-func (a *LLMAgent) maybeCompressContext(ctx *Context, req []*genai.Content, lastInputTokens int) (
+func (a *LLMAgent) maybeCompressContext(ctx *Context, req []*genai.Content, instruction string, lastInputTokens int) (
 	[]*genai.Content, *genai.Content, int, error) {
 	if a.CompressTokens == 0 || lastInputTokens <= a.CompressTokens {
 		// Return existing state unchanged.
 		return req, nil, lastInputTokens, nil
 	}
 
-	newSummary, err := a.compressContext(ctx, req)
+	newSummary, err := a.compressContext(ctx, req, instruction)
 	if err != nil {
 		return req, nil, lastInputTokens, fmt.Errorf("context compression failed: %w", err)
 	}

--- a/pkg/aflow/testdata/TestTokenCompression.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompression.llm.json
@@ -63,7 +63,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "\nYou are an expert technical assistant acting as a memory compressor.\nReview the following execution history of an AI agent.\nThe first message contains the original system instructions and the main goal.\nIt will be preserved in the history, so DO NOT duplicate its contents in your summary.\nWrite a comprehensive and substantial summary of the current state of the workspace\nand the investigation based on the SUBSEQUENT messages. Do NOT write a very short summary.\nInclude:\n1. A detailed list of what approaches have been tried so far and their results (including dead-ends).\n2. The current hypotheses, theories, or active lines of investigation.\n3. Any specific file paths, code snippets, or configuration values that are critical to remember.\n4. Watch out for potential reasoning loops or repetitive tool calls and explicitly note them.\n\nYou MUST provide the summary in your final response text. Do not use tools.\n"
+						"text": "\nYou are an expert technical assistant acting as a memory compressor.\nReview the following execution history of an AI agent.\n\nThe first message begins with the original system instructions enclosed in\n\u003csystem_instructions\u003e tags, and then continues with the initial prompt.\nThese are provided for your information and will be preserved in the history\nanyway, so DO NOT duplicate their contents in your summary.\n\nWrite a comprehensive and substantial summary of the current state of the workspace\nand the investigation based on the SUBSEQUENT messages. Do NOT write a very short summary.\nInclude:\n1. A detailed list of what approaches have been tried so far and their results (including dead-ends).\n2. The current hypotheses, theories, or active lines of investigation.\n3. Any specific file paths, code snippets, or configuration values that are critical to remember.\n4. Watch out for potential reasoning loops or repetitive tool calls and explicitly note them.\n\nYou MUST provide the summary in your final response text. Do not use tools.\n"
 					}
 				],
 				"role": "user"
@@ -78,7 +78,7 @@
 			{
 				"parts": [
 					{
-						"text": "Initial Prompt"
+						"text": "\u003csystem_instructions\u003e\nInstructions\nPrefer calling several tools at the same time to save round-trips.\n\n\u003c/system_instructions\u003e\n\nInitial Prompt"
 					}
 				],
 				"role": "user"


### PR DESCRIPTION
Currently, when pkg/aflow compresses the execution history to save tokens, the original system instructions are lost.

Pass the system instructions down into the compression step and prepend them to the first message of the history specifically for the compressor LLM. Wrap them in <system_instructions> tags, and update the compressor's own system prompt to explicitly inform it that these instructions are for its information only and should not be summarized.
