### PR TITLE
pkg/aflow: be more specific about source code viewing tools

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -197,8 +197,9 @@ You are an experienced Linux kernel developer tasked with updating a kernel patc
 based on reviewer feedback. You will be given the original bug title, a previous
 patch that reviewers commented on, and the reviewers' comments.
 
-Use the codeedit tool to do code edits.
-Note: you will not see your changes when looking at the code using codesearch tools.
+Use the {{.toolCodeeditor}} tool to do code edits.
+IMPORTANT: You will not see your changes when looking at the code using
+{{.toolGrepper}}, {{.toolReadFile}}, or any codesearch tools.
 
 Your objective is to address the reviewers' feedback and refine the existing patch.
 While addressing the feedback, you must also ensure the patch is technically sound,

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -153,7 +153,8 @@ You will be given a crash report, and an initial explanation of the root cause d
 kernel expert.
 
 Use the {{.toolCodeeditor}} tool to do code edits.
-Note: you will not see your changes when looking at the code using codesearch tools.
+IMPORTANT: You will not see your changes when looking at the code using
+{{.toolGrepper}}, {{.toolReadFile}}, or any codesearch tools.
 
 Your final reply should contain explanation of what you did in the patch and why
 (details not present in the initial explanation of the bug).

--- a/pkg/aflow/tool/codeeditor/codeeditor.go
+++ b/pkg/aflow/tool/codeeditor/codeeditor.go
@@ -21,7 +21,7 @@ with new provided lines. If new code is empty, current lines will be deleted.
 Provide full lines of code including new line characters.
 The tool should be called mutiple times to do all required changes one-by-one,
 but avoid changing the same lines multiple times.
-Note: You will not see your edits via the codesearch tool.
+IMPORTANT: You will not see your edits via {{.toolGrepper}}, {{.toolReadFile}}, or any codesearch tools.
 Note: The current code snippet should reflect the previous changes.
 `)
 

--- a/pkg/aflow/tool/codesearcher/codesearcher.go
+++ b/pkg/aflow/tool/codesearcher/codesearcher.go
@@ -23,6 +23,9 @@ Tool provides list of source files and subdirectories in the given directory in 
 Tool provides full contents of a single source file as is. Avoid using this tool if there are better
 and more specialized tools for the job, because source files may be large and contain lots
 of unrelated information.
+
+IMPORTANT: This tool reads from the original, unmodified source tree.
+It will NOT show any changes you have made using codeeditor.
 `)
 	ToolFileIndex = aflow.NewFuncTool("codesearch-file-index", fileIndex, `
 Tool provides list of entities defined in the given source file.
@@ -48,6 +51,9 @@ Tool provides full source code for an entity with the given name.
 Entity can be function, struct, or global variable.
 Use it to understand implementation details of an entity.
 For example, how a function works, what precondition error checks it has, etc.
+
+IMPORTANT: This tool reads from the original, unmodified source tree.
+It will NOT show any changes you have made using codeeditor.
 `)
 
 	ToolFindReferences = aflow.NewFuncTool("codesearch-find-references", findReferences, `

--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -20,6 +20,9 @@ The tool executes git grep on the kernel sources and returns the output.
 The codesearch set of tools provide more precise results,
 use them instead of this tool if they can answer your question.
 
+IMPORTANT: This tool reads from the original, unmodified source tree.
+It will NOT show any changes you have made using codeeditor.
+
 The following git grep flags are used:
 --extended-regexp: you need to provide expression in extended regexp syntax
 --line-number: line numbers are shown in the output


### PR DESCRIPTION
None of our current tools provides the information about the patched version of the kernel. Let's be more loud about this to not confuse the agent.

Context: https://github.com/google/syzkaller/issues/7247