### PR TITLE
pkg/aflow: make BaseFixes optional in PatchIterationInputs

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -36,7 +36,7 @@ type PatchIterationInputs struct {
 	PatchHistory []ai.PatchHistoryEntry
 
 	// Base fixes tag from previous version.
-	BaseFixes ai.FixesTag
+	BaseFixes ai.FixesTag `json:",omitempty"`
 
 	// See patching workflow.
 	BaseRepository string


### PR DESCRIPTION
Add the `json:",omitempty"` tag to the BaseFixes field to prevent fatal errors during strict map conversion for older jobs that omit the Fixes tag in their input arguments.

The workflow prompt templates already handle an empty BaseFixes gracefully.