### PR TITLE
pkg/aflow: add patch-diff tool

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -259,8 +259,9 @@ You are an experienced Linux kernel developer tasked with updating a kernel patc
 based on reviewer feedback. You will be given the original bug title, a previous
 patch that reviewers commented on, and the reviewers' comments.
 
-Use the codeedit tool to do code edits.
+Use the {{.toolCodeeditor}} tool to do code edits.
 Note: you will not see your changes when looking at the code using codesearch tools.
+Use the {{.toolPatchDiff}} tool to review the modifications you applied (and to view the previously applied patch).
 
 Your objective is to address the reviewers' feedback and refine the existing patch.
 While addressing the feedback, you must also ensure the patch is technically sound,

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/gitlog"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/aflow/tool/patchdiff"
 	"github.com/google/syzkaller/pkg/vcs"
 )
 
@@ -154,6 +155,7 @@ kernel expert.
 
 Use the {{.toolCodeeditor}} tool to do code edits.
 Note: you will not see your changes when looking at the code using codesearch tools.
+Use the {{.toolPatchDiff}} tool to review the modifications you applied.
 
 Your final reply should contain explanation of what you did in the patch and why
 (details not present in the initial explanation of the bug).
@@ -277,7 +279,7 @@ func PatchGenerationLoop(summaryWindow, compressTokens int,
 			TaskType:       aflow.FormalReasoningTask,
 			Instruction:    instruction,
 			Prompt:         prompt,
-			Tools:          aflow.Tools(commonTools, codeeditor.Tool),
+			Tools:          aflow.Tools(commonTools, codeeditor.Tool, patchdiff.Tool),
 			SummaryWindow:  summaryWindow,
 			CompressTokens: compressTokens,
 		},

--- a/pkg/aflow/tool/patchdiff/patchdiff.go
+++ b/pkg/aflow/tool/patchdiff/patchdiff.go
@@ -1,0 +1,64 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patchdiff
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+var Tool = aflow.NewFuncTool("patch-diff", patchDiff, `
+The tool executes 'git diff' to show the changes you have made so far.
+Because other source code viewing tools only show the original code,
+you can use this tool to review the modifications you applied using code
+editing tools.
+`)
+
+type state struct {
+	KernelScratchSrc string
+}
+
+type args struct {
+	// Let's add an optional File parameter to restrict the diff output.
+	File string `jsonschema:"Optional: restrict diff to a specific file. If empty, shows all changes."`
+}
+
+type result struct {
+	Output string `jsonschema:"Output of the git diff command."`
+}
+
+func patchDiff(ctx *aflow.Context, state state, args args) (result, error) {
+	if state.KernelScratchSrc == "" {
+		return result{}, aflow.BadCallError("KernelScratchSrc is not set")
+	}
+
+	// Compare working tree to HEAD with expanded context.
+	gitArgs := []string{"diff", "HEAD", "--function-context", "-U10"}
+	if args.File != "" {
+		gitArgs = append(gitArgs, "--", args.File)
+	}
+
+	cmd := osutil.Command("git", gitArgs...)
+	cmd.Dir = state.KernelScratchSrc
+
+	output, err := osutil.Run(1*time.Minute, cmd)
+	if err != nil {
+		var verr *osutil.VerboseError
+		if errors.As(err, &verr) {
+			if bytes.Contains(verr.Output, []byte("outside repository")) {
+				return result{}, aflow.BadCallError("git diff failed: the file is outside the repository")
+			}
+		}
+		if errors.Is(err, osutil.ErrTimeout) {
+			return result{}, aflow.BadCallError("git diff timed out")
+		}
+		return result{}, err
+	}
+
+	return result{Output: string(output)}, nil
+}

--- a/pkg/aflow/tool/patchdiff/patchdiff_test.go
+++ b/pkg/aflow/tool/patchdiff/patchdiff_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patchdiff
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatchDiff(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
+
+	repo.CommitChangeset("initial commit", vcs.FileContent{
+		File: "foo.c",
+		Content: `
+#include <stdio.h>
+
+void helper() {
+	printf("helper\n");
+}
+
+void foo() {
+	// BUG HERE
+	printf("foo\n");
+}
+
+void bar() {
+	printf("bar\n");
+}
+
+int main() {
+	foo();
+	bar();
+	return 0;
+}
+`,
+	})
+
+	// Make an uncommitted change in the middle of a longer file.
+	osutil.WriteFile(filepath.Join(repoDir, "foo.c"), []byte(`
+#include <stdio.h>
+
+void helper() {
+	printf("helper\n");
+}
+
+void foo() {
+	// fixed!
+	printf("foo\n");
+}
+
+void bar() {
+	printf("bar\n");
+}
+
+int main() {
+	foo();
+	bar();
+	return 0;
+}
+`))
+
+	// Test a successful diff with expanded context.
+	aflow.TestTool(t, Tool,
+		state{KernelScratchSrc: repoDir},
+		args{},
+		func(res result) {
+			// Strip the dynamic index line to do a clean string comparison.
+			output := regexp.MustCompile(`(?m)^index [0-9a-f]+\.\.[0-9a-f]+ 100644\n`).ReplaceAllString(res.Output, "")
+			expected := `diff --git a/foo.c b/foo.c
+--- a/foo.c
++++ b/foo.c
+@@ -1,19 +1,19 @@
+ 
+ #include <stdio.h>
+ 
+ void helper() {
+ 	printf("helper\n");
+ }
+ 
+ void foo() {
+-	// BUG HERE
++	// fixed!
+ 	printf("foo\n");
+ }
+ 
+ void bar() {
+ 	printf("bar\n");
+ }
+ 
+ int main() {
+ 	foo();
+ 	bar();
+`
+			assert.Equal(t, expected, output)
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test restricting diff to a specific file.
+	aflow.TestTool(t, Tool,
+		state{KernelScratchSrc: repoDir},
+		args{File: "foo.c"},
+		func(res result) {
+			assert.Regexp(t, `-\s*// BUG HERE`, res.Output)
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test a non-existent file, it should just return an empty diff without erroring.
+	aflow.TestTool(t, Tool,
+		state{KernelScratchSrc: repoDir},
+		args{File: "nonexistent.c"},
+		func(res result) {
+			assert.Empty(t, res.Output)
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test an out-of-bounds file, should return an aflow.BadCallError from git.
+	aflow.TestTool(t, Tool,
+		state{KernelScratchSrc: repoDir},
+		args{File: "../outside.c"},
+		result{},
+		"git diff failed: the file is outside the repository",
+		aflow.TestWorkdir(tmpDir))
+}


### PR DESCRIPTION
Context: https://github.com/google/syzkaller/issues/7247

It would be best to make existing code exploration tools include the newly patched code, but it may take a while to figure out and implement the right approach.

I suggest that we introduce a new `patch-diff` tool for the time being so that the agent could still see what's been changed in the repository.

***

The LLM agent previously lacked a reliable way to view its own modifications after applying them. Because the codesearch and grepper tools only expose the pristine, original source tree, the agent would sometimes become confused and assume its code edits had failed when re-verifying the file contents.

Introduce a new patch-diff tool that runs git diff with expanded function context (-U10) in the scratch repository. This gives the agent a mechanism to review its applied changes. Update the prompt instructions in both the patching and iteration workflows to explicitly direct the agent to use this new tool to verify its modifications.

