### PR TITLE
dashboard/app: fix 500 error on duplicate AI report comments

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -411,7 +411,7 @@ func handleCommentCommand(ctx context.Context, req *dashapi.SendExternalCommandR
 		OwnEmail:    req.OwnEmail,
 		Processed:   req.OwnEmail,
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, aidb.ErrDuplicateComment) {
 		return nil, err
 	}
 

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -361,6 +361,16 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	// Verify that NO error reply was sent, meaning sent length is still exactly 1!
 	require.Len(t, mockSnd.sent, 1)
 
+	// 3.5. Duplicate comment (e.g. from another list) should be ignored without 500 error.
+	loreArchive.SaveMessageAt(t, "From: reviewer@email.com\n"+
+		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Message-ID: <comment1>\n"+
+		"In-Reply-To: <mock@msgid-1>\n\n"+
+		"This is just a normal review comment with some context.\n", now.Add(time.Minute*2))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
 	// 4. Send a reply from the bot itself.
 	loreArchive.SaveMessageAt(t, "From: syzbot@testapp.appspotmail.com\n"+
 		"Subject: Re: [PATCH RFC] Test Description\n"+

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -29,6 +29,7 @@ const (
 )
 
 var ErrNotFound = errors.New("entity not found")
+var ErrDuplicateComment = errors.New("duplicate job comment")
 
 type ErrCannotUpstream struct {
 	Reason string
@@ -658,7 +659,11 @@ func LoadJobReportings(ctx context.Context, jobID string) ([]*JobReporting, erro
 
 func SaveJobComment(ctx context.Context, entry *JobComment) error {
 	entry.ID = uuid.NewString()
-	return saveEntity(ctx, "JobComments", entry)
+	err := saveEntity(ctx, "JobComments", entry)
+	if err != nil && spanner.ErrCode(err) == codes.AlreadyExists {
+		return ErrDuplicateComment
+	}
+	return err
 }
 
 func LoadJobComments(ctx context.Context, jobID string) ([]*JobComment, error) {


### PR DESCRIPTION
Make the SaveJobComment function idempotent by ignoring spanner codes.AlreadyExists errors. This prevents unique index violations on JobCommentsByExtID when email pollers (like lore-relay) submit the same comment multiple times, ensuring smooth external AI reporting.

Add a test case in ai_report_lore_test.go to verify this behavior.