### PR TITLE
dashboard/app: skip empty AI reports for patch iterations

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -982,11 +982,14 @@ func finishIterationJob(ctx context.Context, job *aidb.Job) error {
 		}
 	}
 
-	res, _ := job.Results.Value.(map[string]any)
-	diff, _ := res["PatchDiff"].(string)
-	hasPatch := diff != ""
+	res, err := castJobResults[ai.PatchIterationOutputs](job)
+	if err != nil {
+		return fmt.Errorf("failed to cast job results: %w", err)
+	}
+	hasPatch := res.PatchDiff != ""
+	hasReplies := len(res.Replies) > 0
 
-	err := aidb.IterationJobDone(ctx, job.ID, args.TargetCommentIDs, job.ParentReportingID.StringVal, hasPatch)
+	err = aidb.IterationJobDone(ctx, job.ID, args.TargetCommentIDs, job.ParentReportingID.StringVal, hasPatch, hasReplies)
 	if err != nil {
 		log.Errorf(ctx, "failed to finalize iteration job %v: %v", job.ID, err)
 	}

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1501,3 +1501,106 @@ func TestAIAssessmentNoReport(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, pollResp.Result)
 }
+
+func TestAIPatchIterationEmptyResult(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+		},
+	})
+
+	// 1. Setup bug and job.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	jobID := c.createAIJob(extID, "patching", "")
+
+	// Poll to mark the job as started.
+	_, err = c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"PatchDescription": "Test Description",
+			"PatchDiff":        "diff",
+			"KernelRepo":       "repo",
+			"KernelCommit":     "commit",
+		},
+	})
+	require.NoError(t, err)
+
+	reportings, err := aidb.LoadJobReportings(c.ctx, jobID)
+	require.NoError(t, err)
+	require.Len(t, reportings, 1)
+	reporting := reportings[0]
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       reporting.ID,
+		PublishedExtID: "<message-id-1>",
+	})
+	require.NoError(t, err)
+
+	// 2. Simulate comment arrival.
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "<message-id-1>",
+		MessageExtID: "<comment-id-1>",
+		Author:       "reviewer@email.com",
+		Comment:      &dashapi.CommentCommand{Body: "This is a comment"},
+	})
+	require.NoError(t, err)
+
+	// 3. Advance time to pass debounce (30 mins).
+	c.advanceTime(31 * time.Minute)
+
+	// 4. Poll should return the job.
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	resp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.ID)
+
+	// 5. Complete the job with no output (empty diff, no replies).
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: resp.ID,
+		Results: map[string]any{
+			"PatchDiff": "",
+			"Replies":   []any{},
+		},
+	})
+	require.NoError(t, err)
+
+	// 6. Verify AIPollReport returns nothing because the job had no output.
+	pollRepResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: dashapi.AIJobSourceLore})
+	require.NoError(t, err)
+	require.Nil(t, pollRepResp.Result)
+
+	// 7. Advance time again to ensure the comment doesn't re-trigger a job (it should be marked as processed).
+	c.advanceTime(31 * time.Minute)
+	resp2, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Empty(t, resp2.ID)
+}

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -940,7 +940,7 @@ func markCommentsProcessedTx(txn *spanner.ReadWriteTransaction, ids []string) er
 }
 
 func IterationJobDone(ctx context.Context, jobID string, commentIDs []string,
-	parentReportingID string, hasPatch bool) error {
+	parentReportingID string, hasPatch, hasReplies bool) error {
 	client, err := dbClient(ctx)
 	if err != nil {
 		return err
@@ -995,6 +995,11 @@ func IterationJobDone(ctx context.Context, jobID string, commentIDs []string,
 
 		if err := markCommentsProcessedTx(tx, commentIDs); err != nil {
 			return err
+		}
+
+		// If the job didn't generate a patch or replies, we don't need to report it externally.
+		if !hasPatch && !hasReplies {
+			return nil
 		}
 
 		reporting := &JobReporting{


### PR DESCRIPTION
When a patch iteration job finishes without producing a new patch or replies, do not create a JobReporting entry. This prevents the dashboard from returning an empty report result, which causes the lore-relay poller to fail and log an "empty report result" error.

Also add a test case to cover this scenario.