### PR TITLE
dashboard/app: hide manual correctness for stage-reported AI jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -141,6 +141,7 @@ type uiAIJobPage struct {
 	CurrentStage       string
 	NextStage          string
 	CanPushToReporting bool
+	CanSetCorrectness  bool
 	Reportings         []*uiJobReporting
 }
 
@@ -381,6 +382,12 @@ func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hd
 }
 
 func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userEmail string) error {
+	if !aiJobUsesReportingStages(ctx, job) {
+		return fmt.Errorf("job is not configured to use AI reporting stages")
+	}
+	if job.Type != ai.WorkflowPatching {
+		return fmt.Errorf("only patching jobs can be manually pushed to reporting")
+	}
 	if err := checkJobUpstreamable(job); err != nil {
 		return err
 	}
@@ -394,10 +401,6 @@ func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userEmai
 	}
 
 	nsCfg := getNsConfig(ctx, job.Namespace)
-	if nsCfg.AI == nil || len(nsCfg.AI.Stages) == 0 {
-		return fmt.Errorf("no AI stages configured")
-	}
-
 	stageCfg, err := determineNextStage(ctx, nsCfg.AI, job, "")
 	if err != nil {
 		return err
@@ -427,6 +430,10 @@ func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userEmai
 }
 
 func handleAIJobPageCorrectness(ctx context.Context, job *aidb.Job, correct, userEmail string) error {
+	if aiJobUsesReportingStages(ctx, job) {
+		return fmt.Errorf("correctness cannot be set manually for jobs reported via stages")
+	}
+
 	switch correct {
 	case aiCorrectnessCorrect:
 		currentReporting, _, err := getJobStageInfo(ctx, job)
@@ -535,15 +542,17 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		return err
 	}
 
+	usesReportingStages := aiJobUsesReportingStages(ctx, job)
+
 	canPushToReporting := false
-	nsCfg := getNsConfig(ctx, job.Namespace)
-	if len(uiReportings) == 0 && nsCfg.AI != nil && len(nsCfg.AI.Stages) > 0 {
-		if job.Type == ai.WorkflowPatching && job.Finished.Valid && job.Error == "" {
-			if checkJobUpstreamable(job) == nil {
-				canPushToReporting = true
-			}
+	if len(uiReportings) == 0 && job.Type == ai.WorkflowPatching && job.Finished.Valid && job.Error == "" {
+		if usesReportingStages && checkJobUpstreamable(job) == nil {
+			canPushToReporting = true
 		}
 	}
+
+	// Disable manual correctness for stage-reported jobs to avoid duplicating moderation functionality.
+	canSetCorrectness := !usesReportingStages
 
 	page := &uiAIJobPage{
 		Header:             hdr,
@@ -556,6 +565,7 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		CurrentStage:       currentStageStr,
 		NextStage:          nextStageStr,
 		CanPushToReporting: canPushToReporting,
+		CanSetCorrectness:  canSetCorrectness,
 		Reportings:         uiReportings,
 	}
 	if r.FormValue("json") == "1" {

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -104,6 +104,14 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	})
 }
 
+func aiJobUsesReportingStages(ctx context.Context, job *aidb.Job) bool {
+	nsCfg := getNsConfig(ctx, job.Namespace)
+	if nsCfg.AI == nil || len(nsCfg.AI.Stages) == 0 {
+		return false
+	}
+	return job.Type == ai.WorkflowPatching || job.Type == ai.WorkflowPatchIteration
+}
+
 func checkJobUpstreamable(job *aidb.Job) error {
 	if job.Type != ai.WorkflowPatching && job.Type != ai.WorkflowPatchIteration {
 		return &aidb.ErrCannotUpstream{Reason: fmt.Sprintf("cannot upstream job of type %v", job.Type)}

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -49,7 +49,7 @@ Detailed info on a single AI job execution.
 	{{end}}
 
 	{{if .Header.AIActions}}
-		{{if and (ne .Job.Correct "⏳") (ne .Job.Correct "💥") (ne .Job.Correct "🏃")}}
+		{{if and .CanSetCorrectness (ne .Job.Correct "⏳") (ne .Job.Correct "💥") (ne .Job.Correct "🏃")}}
 			<form method="POST">
 				<fieldset>
 					<legend>Result correct:</legend>


### PR DESCRIPTION
Stage-reported jobs (like patching and patch-iteration workflows) undergo an explicit moderation flow via external commands (e.g., email replies). Allowing users to manually set correctness on the web UI can bypass this flow and lead to unexpected behavior, such as upstreaming an empty report.

Extract a helper aiJobUsesReportingStages() to determine if a job uses reporting stages. Use this helper to hide the Correct/Incorrect buttons in the UI and to reject manual correctness updates in the backend. Also, reuse this helper in the manual "push to reporting" logic for consistency.