### PR TITLE
dashboard/app: fix patch subject duplication in report body

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -277,8 +277,12 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	if res.PatchDescription == "" {
 		return nil, fmt.Errorf("patch generation result can't be empty")
 	}
-	lines := strings.Split(res.PatchDescription, "\n")
-	if lines[0] == "" {
+
+	subject, body, _ := strings.Cut(res.PatchDescription, "\n")
+	subject = strings.TrimSpace(subject)
+	body = strings.Trim(body, "\n\r")
+
+	if subject == "" {
 		return nil, fmt.Errorf("title line can't be empty")
 	}
 
@@ -292,7 +296,6 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 			models[span.Model] = true
 		}
 	}
-	subject := lines[0]
 	var to, cc []string
 	for _, rec := range res.Recipients {
 		if rec.To {
@@ -304,7 +307,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 
 	return &dashapi.NewReportResult{
 		Subject:    subject,
-		Body:       res.PatchDescription,
+		Body:       body,
 		GitDiff:    res.PatchDiff,
 		BaseCommit: res.KernelCommit,
 		BaseTree:   res.KernelRepo,

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -76,7 +76,7 @@ func TestAILoreIntegration(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -98,7 +98,7 @@ func TestAILoreIntegration(t *testing.T) {
 
 	require.Len(t, mockSnd.sent, 1)
 	assert.Equal(t, []string{"moderation@test.com"}, mockSnd.sent[0].To)
-	assert.Equal(t, "[PATCH RFC] Test Description", mockSnd.sent[0].Subject)
+	assert.Equal(t, "[PATCH RFC] Test Subject", mockSnd.sent[0].Subject)
 	assert.Equal(t, []string{"archive@lore.com"}, mockSnd.sent[0].Cc)
 
 	body := string(mockSnd.sent[0].Body)
@@ -110,7 +110,7 @@ func TestAILoreIntegration(t *testing.T) {
 	assert.Contains(t, body, "Cc: <reviewer@email.com>")
 	// 3. Approval (#syz upstream).
 	loreArchive.SaveMessageAt(t, `From: user@email
-Subject: Re: [PATCH RFC] Test Description
+Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply1>
 In-Reply-To: <mock@msgid-1>
 
@@ -126,7 +126,7 @@ In-Reply-To: <mock@msgid-1>
 
 	require.Len(t, mockSnd.sent, 2) // Moderation email + Public email.
 	assert.Equal(t, []string{"public@test.com", "maintainer@email.com"}, mockSnd.sent[1].To)
-	assert.Equal(t, "[PATCH] Test Description", mockSnd.sent[1].Subject)
+	assert.Equal(t, "[PATCH] Test Subject", mockSnd.sent[1].Subject)
 	assert.Equal(t, []string{"archive@lore.com", "reviewer@email.com"}, mockSnd.sent[1].Cc)
 
 	bodyPublic := string(mockSnd.sent[1].Body)
@@ -134,7 +134,7 @@ In-Reply-To: <mock@msgid-1>
 
 	// 5. Duplicate Approval (#syz upstream) - should fail because already upstreamed.
 	loreArchive.SaveMessageAt(t, `From: user@email
-Subject: Re: [PATCH RFC] Test Description
+Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply2>
 In-Reply-To: <mock@msgid-2>
 
@@ -210,7 +210,7 @@ func TestAILoreIntegrationReject(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -224,12 +224,12 @@ func TestAILoreIntegrationReject(t *testing.T) {
 
 	require.Len(t, mockSnd.sent, 1)
 	assert.Equal(t, []string{"moderation@test.com"}, mockSnd.sent[0].To)
-	assert.Equal(t, "[PATCH RFC] Test Description", mockSnd.sent[0].Subject)
+	assert.Equal(t, "[PATCH RFC] Test Subject", mockSnd.sent[0].Subject)
 	assert.Equal(t, []string{"archive@lore.com"}, mockSnd.sent[0].Cc)
 
 	// 3. Reject (#syz reject).
 	loreArchive.SaveMessageAt(t, `From: user@email
-Subject: Re: [PATCH RFC] Test Description
+Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply1>
 In-Reply-To: <mock@msgid-1>
 
@@ -269,7 +269,7 @@ func TestAILoreUnknownMessageID(t *testing.T) {
 
 	now := time.Now()
 	loreArchive.SaveMessageAt(t, `From: user@email
-Subject: Re: [PATCH RFC] Test Description
+Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply_err>
 In-Reply-To: <non-existent-msg-id>
 
@@ -331,7 +331,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -350,7 +350,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 
 	// 3. Send a plain comment.
 	loreArchive.SaveMessageAt(t, "From: reviewer@email.com\n"+
-		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Subject: Re: [PATCH RFC] Test Subject\n"+
 		"Message-ID: <comment1>\n"+
 		"In-Reply-To: <mock@msgid-1>\n\n"+
 		"This is just a normal review comment with some context.\n", now.Add(time.Minute))
@@ -363,7 +363,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 
 	// 3.5. Duplicate comment (e.g. from another list) should be ignored without 500 error.
 	loreArchive.SaveMessageAt(t, "From: reviewer@email.com\n"+
-		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Subject: Re: [PATCH RFC] Test Subject\n"+
 		"Message-ID: <comment1>\n"+
 		"In-Reply-To: <mock@msgid-1>\n\n"+
 		"This is just a normal review comment with some context.\n", now.Add(time.Minute*2))
@@ -373,7 +373,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 
 	// 4. Send a reply from the bot itself.
 	loreArchive.SaveMessageAt(t, "From: syzbot@testapp.appspotmail.com\n"+
-		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Subject: Re: [PATCH RFC] Test Subject\n"+
 		"Message-ID: <bot-reply>\n"+
 		"In-Reply-To: <comment1>\n\n"+
 		"This is a generated bot reply.\n", now.Add(time.Minute*2))
@@ -512,7 +512,7 @@ func TestAILoreIteration(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -531,7 +531,7 @@ func TestAILoreIteration(t *testing.T) {
 
 	// 3. Send a plain comment.
 	loreArchive.SaveMessageAt(t, "From: reviewer@email.com\n"+
-		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Subject: Re: [PATCH RFC] Test Subject\n"+
 		"Message-ID: <comment1>\n"+
 		"In-Reply-To: <mock@msgid-1>\n\n"+
 		"This is just a normal review comment with some context.\n", now.Add(time.Minute))
@@ -541,7 +541,7 @@ func TestAILoreIteration(t *testing.T) {
 
 	// 4. Send a reply from the bot itself.
 	loreArchive.SaveMessageAt(t, "From: syzbot@testapp.appspotmail.com\n"+
-		"Subject: Re: [PATCH RFC] Test Description\n"+
+		"Subject: Re: [PATCH RFC] Test Subject\n"+
 		"Message-ID: <bot-reply>\n"+
 		"In-Reply-To: <comment1>\n\n"+
 		"This is a generated bot reply.\n", now.Add(time.Minute*2))
@@ -570,7 +570,7 @@ func TestAILoreIteration(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: resp.ID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff v2",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -587,8 +587,9 @@ func TestAILoreIteration(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, mockSnd.sent, 2)
-	assert.Equal(t, "[PATCH v2] Test Description", mockSnd.sent[1].Subject)
+	assert.Equal(t, "[PATCH v2] Test Subject", mockSnd.sent[1].Subject)
 	body := string(mockSnd.sent[1].Body)
+	assert.NotContains(t, body, "Test Subject")
 	assert.Contains(t, body, "Fixes: abcdefabcdef (\"introduce a bug\")")
 
 	// 7. But nothing else.

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -52,7 +52,7 @@ func TestAIExternalReporting(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -118,8 +118,8 @@ func TestAIExternalReporting(t *testing.T) {
 	require.NotNil(t, pollResp.Result)
 	require.False(t, pollResp.Result.CanUpstream)
 	require.Equal(t, &dashapi.NewReportResult{
-		Subject:    "Test Description",
-		Body:       "Test Description",
+		Subject:    "Test Subject",
+		Body:       "Test Body",
 		Version:    1,
 		GitDiff:    "diff",
 		BaseCommit: "commit",
@@ -279,7 +279,7 @@ func TestAINoParallelReports(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID1,
 		Results: map[string]any{
-			"PatchDescription": "Job 1 Description",
+			"PatchDescription": "Job 1 Subject\n\nJob 1 Body",
 			"PatchDiff":        "diff1",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit1",
@@ -290,7 +290,7 @@ func TestAINoParallelReports(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID2,
 		Results: map[string]any{
-			"PatchDescription": "Job 2 Description",
+			"PatchDescription": "Job 2 Subject\n\nJob 2 Body",
 			"PatchDiff":        "diff2",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit2",
@@ -395,7 +395,7 @@ func TestAIUpstreamTwice(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 		},
 	})
@@ -470,7 +470,7 @@ func TestAINoStages(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -533,7 +533,7 @@ func TestAIUpstreamConcurrent(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID1,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -588,7 +588,7 @@ func TestAIUpstreamConcurrent(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: resp.ID,
 		Results: map[string]any{
-			"PatchDescription": "New Description",
+			"PatchDescription": "New Subject\n\nNew Body",
 			"PatchDiff":        "new diff",
 		},
 	})
@@ -655,7 +655,7 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "exact-repo",
 			"KernelBranch":     "exact-branch",
@@ -736,7 +736,7 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 		{
 			Version:     1,
 			Diff:        "diff",
-			Description: "Test Description",
+			Description: "Test Subject\n\nTest Body",
 			Comments: []ai.ExternalComment{
 				{
 					ExtID:  "<comment-id-1>",
@@ -753,7 +753,7 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: resp.ID,
 		Results: map[string]any{
-			"PatchDescription": "New Description",
+			"PatchDescription": "New Subject\n\nNew Body",
 			"PatchDiff":        "new diff",
 			"NewChangeLog":     "- Fixed ABCD.",
 			"KernelRepo":       "repo_url",
@@ -773,8 +773,8 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 		CanUpstream: true,
 		To:          []string{"moderation@test.com"},
 		Patch: &dashapi.NewReportResult{
-			Subject:    "New Description",
-			Body:       "New Description",
+			Subject:    "New Subject",
+			Body:       "New Body",
 			Version:    2,
 			GitDiff:    "new diff",
 			ReportedBy: []string{"syzbot+" + extID + "@" + appengine.AppID(c.ctx) + ".appspotmail.com"},
@@ -860,7 +860,7 @@ func testExtendedPatchIteration(t *testing.T, c *Ctx, resp *dashapi.AIJobPollRes
 		{
 			Version:     2,
 			Diff:        "new diff",
-			Description: "New Description",
+			Description: "New Subject\n\nNew Body",
 			Comments: []ai.ExternalComment{
 				{
 					ExtID:  "<comment-id-2>",
@@ -877,7 +877,7 @@ func testExtendedPatchIteration(t *testing.T, c *Ctx, resp *dashapi.AIJobPollRes
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: resp.ID,
 		Results: map[string]any{
-			"PatchDescription": "Description V3",
+			"PatchDescription": "Subject V3\n\nBody V3",
 			"PatchDiff":        "diff V3",
 			"NewChangeLog":     "- Reverted to standard formatting.",
 		},
@@ -978,7 +978,7 @@ func TestAIPatchIterationBackoff(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Desc",
+			"PatchDescription": "Desc Subject\n\nDesc Body",
 			"PatchDiff":        "diff",
 			"KernelCommit":     "exact-commit-hash",
 			"KernelRepo":       "exact-repo",
@@ -1102,7 +1102,7 @@ func TestAIPatchIterationAutoTriggerDisabled(t *testing.T) {
 
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:      jobID,
-		Results: map[string]any{"PatchDescription": "Desc1", "PatchDiff": "diff1"},
+		Results: map[string]any{"PatchDescription": "Desc1 Subject\n\nDesc1 Body", "PatchDiff": "diff1"},
 	})
 	require.NoError(t, err)
 
@@ -1182,7 +1182,7 @@ func TestAIPatchIterationStaleThread(t *testing.T) {
 	// Complete V1 job.
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:      jobID1,
-		Results: map[string]any{"PatchDescription": "Desc1", "PatchDiff": "diff1"},
+		Results: map[string]any{"PatchDescription": "Desc1 Subject\n\nDesc1 Body", "PatchDiff": "diff1"},
 	})
 	require.NoError(t, err)
 
@@ -1222,7 +1222,7 @@ func TestAIPatchIterationStaleThread(t *testing.T) {
 	// Complete V2 job.
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:      jobID2,
-		Results: map[string]any{"PatchDescription": "Desc2", "PatchDiff": "diff2"},
+		Results: map[string]any{"PatchDescription": "Desc2 Subject\n\nDesc2 Body", "PatchDiff": "diff2"},
 	})
 	require.NoError(t, err)
 
@@ -1282,7 +1282,7 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",
@@ -1542,7 +1542,7 @@ func TestAIPatchIterationEmptyResult(t *testing.T) {
 	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID,
 		Results: map[string]any{
-			"PatchDescription": "Test Description",
+			"PatchDescription": "Test Subject\n\nTest Body",
 			"PatchDiff":        "diff",
 			"KernelRepo":       "repo",
 			"KernelCommit":     "commit",

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -364,7 +364,7 @@ func TestAIJobActions(t *testing.T) {
 	})
 	require.NoError(t, c.globalClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:      resp.ID,
-		Results: map[string]any{"PatchDiff": "diff", "PatchDescription": "description"},
+		Results: map[string]any{"PatchDiff": "diff", "PatchDescription": "description subject\n\ndescription body"},
 	}))
 
 	jobAssessURL := fmt.Sprintf("/ai_job?id=%v", resp.ID)

--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -430,7 +430,7 @@ func populateLocalUIDB(t *testing.T, c *Ctx) {
 	globalClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: jobID2,
 		Results: map[string]any{
-			"PatchDescription": "Test Patch Description",
+			"PatchDescription": "Test Patch Subject\n\nTest Patch Body",
 			"PatchDiff":        "diff --git a/test b/test",
 		},
 	})
@@ -472,7 +472,7 @@ func populateLocalUIDB(t *testing.T, c *Ctx) {
 	globalClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID: iterResp.ID,
 		Results: map[string]any{
-			"PatchDescription": "Test Patch V2",
+			"PatchDescription": "Test Patch V2 Subject\n\nTest Patch V2 Body",
 			"PatchDiff":        "diff --git a/test b/test\n+v2 changes",
 			"NewChangeLog":     "Fixed reviewer comment",
 		},


### PR DESCRIPTION
The makeNewReportResult function extracts the first line of the patch description for the subject but inadvertently includes the full description in the body, causing the subject to be duplicated.

Fix this by using strings.Cut to split the description into distinct subject and body parts. Updated test mock data to reflect realistic multi-line patch descriptions and added assertions to verify the body no longer contains the subject.

Cc https://github.com/google/syzkaller/issues/6766