### PR TITLE
pkg/build: implement shell builder support

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -82,7 +82,7 @@ func sanitize(params *Params) {
 func Image(params Params) (details ImageDetails, err error) {
 	sanitize(&params)
 	var builder builder
-	builder, err = getBuilder(params.TargetOS, params.TargetArch, params.VMType)
+	builder, err = getBuilder(params)
 	if err != nil {
 		return
 	}
@@ -119,7 +119,7 @@ func Image(params Params) (details ImageDetails, err error) {
 
 func Clean(params Params) error {
 	sanitize(&params)
-	builder, err := getBuilder(params.TargetOS, params.TargetArch, params.VMType)
+	builder, err := getBuilder(params)
 	if err != nil {
 		return err
 	}
@@ -154,9 +154,13 @@ type builder interface {
 	clean(params Params) error
 }
 
-func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
-	if targetOS == targets.Linux {
-		switch vmType {
+func getBuilder(params Params) (builder, error) {
+	const shellPrefix = "SHELL:"
+	if strings.HasPrefix(params.Make, shellPrefix) {
+		return shell{script: params.Make[len(shellPrefix):]}, nil
+	}
+	if params.TargetOS == targets.Linux {
+		switch params.VMType {
 		case targets.GVisor:
 			return gvisor{}, nil
 		case "cuttlefish":
@@ -176,10 +180,10 @@ func getBuilder(targetOS, targetArch, vmType string) (builder, error) {
 		targets.Darwin:  darwin{},
 		targets.TestOS:  test{},
 	}
-	if builder, ok := builders[targetOS]; ok {
+	if builder, ok := builders[params.TargetOS]; ok {
 		return builder, nil
 	}
-	return nil, fmt.Errorf("unsupported image type %v/%v/%v", targetOS, targetArch, vmType)
+	return nil, fmt.Errorf("unsupported image type %v/%v/%v", params.TargetOS, params.TargetArch, params.VMType)
 }
 
 func compilerIdentity(compiler string) (string, error) {

--- a/pkg/build/shell.go
+++ b/pkg/build/shell.go
@@ -1,0 +1,67 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type shell struct {
+	script string
+}
+
+func (s shell) build(params Params) (ImageDetails, error) {
+	return s.run(params, "build")
+}
+
+func (s shell) clean(params Params) error {
+	_, err := s.run(params, "clean")
+	return err
+}
+
+func (s shell) run(params Params, action string) (ImageDetails, error) {
+	cmd := osutil.Command("sh", "-c", s.script)
+	cmd.Dir = params.KernelDir
+	cmd.Env = slices.Clone(os.Environ())
+	cmd.Env = append(cmd.Env,
+		"SYZ_TARGET_OS="+params.TargetOS,
+		"SYZ_TARGET_ARCH="+params.TargetArch,
+		"SYZ_VM_TYPE="+params.VMType,
+		"SYZ_KERNEL_DIR="+params.KernelDir,
+		"SYZ_OUTPUT_DIR="+params.OutputDir,
+		"SYZ_COMPILER="+params.Compiler,
+		"SYZ_LINKER="+params.Linker,
+		"SYZ_CCACHE="+params.Ccache,
+		"SYZ_USERSPACE_DIR="+params.UserspaceDir,
+		"SYZ_CMDLINE_FILE="+params.CmdlineFile,
+		"SYZ_SYSCTL_FILE="+params.SysctlFile,
+		"SYZ_BUILD_CPUS="+fmt.Sprint(params.BuildCPUs),
+		"SYZ_BUILD_ACTION="+action,
+	)
+	if _, err := osutil.Run(2*time.Hour, cmd); err != nil {
+		return ImageDetails{}, fmt.Errorf("%v", osutil.VerboseMessage(err))
+	}
+	if action == "clean" {
+		return ImageDetails{}, nil
+	}
+	sysTarget := targets.Get(params.TargetOS, params.TargetArch)
+	required := []string{"image", filepath.Join("obj", sysTarget.KernelObject)}
+	for _, file := range required {
+		if !osutil.IsExist(filepath.Join(params.OutputDir, file)) {
+			return ImageDetails{}, fmt.Errorf("build did not produce required file %v", file)
+		}
+	}
+	sig, err := elfBinarySignature(filepath.Join(params.OutputDir, "obj", sysTarget.KernelObject), params.Tracer)
+	if err != nil {
+		return ImageDetails{}, err
+	}
+	return ImageDetails{Signature: sig}, err
+}

--- a/pkg/build/shell_test.go
+++ b/pkg/build/shell_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellBuild(t *testing.T) {
+	kernelDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	script := filepath.Join(kernelDir, "build.sh")
+	err := osutil.WriteExecFile(script, []byte(`#!/bin/sh
+echo $SYZ_BUILD_ACTION > action
+mkdir -p $SYZ_OUTPUT_DIR/obj
+touch $SYZ_OUTPUT_DIR/image
+cp $SYZ_LINKER $SYZ_OUTPUT_DIR/obj/vmlinux
+`))
+	require.NoError(t, err)
+
+	params := Params{
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+		KernelDir:  kernelDir,
+		OutputDir:  outputDir,
+		Linker:     osutil.Abs(os.Args[0]),
+		Make:       "SHELL: " + script,
+	}
+
+	_, err = Image(params)
+	require.NoError(t, err)
+
+	action, err := os.ReadFile(filepath.Join(kernelDir, "action"))
+	require.NoError(t, err)
+	require.Equal(t, "build\n", string(action))
+
+	require.True(t, osutil.IsExist(filepath.Join(outputDir, "image")))
+	require.True(t, osutil.IsExist(filepath.Join(outputDir, "obj", "vmlinux")))
+
+	err = Clean(params)
+	require.NoError(t, err)
+
+	action, err = os.ReadFile(filepath.Join(kernelDir, "action"))
+	require.NoError(t, err)
+	require.Equal(t, "clean\n", string(action))
+}
+
+func TestShellBuildFail(t *testing.T) {
+	kernelDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	params := Params{
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+		KernelDir:  kernelDir,
+		OutputDir:  outputDir,
+		Make:       "SHELL: exit 1",
+	}
+
+	_, err := Image(params)
+	require.Error(t, err)
+}
+
+func TestShellBuildMissingFile(t *testing.T) {
+	kernelDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	params := Params{
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+		KernelDir:  kernelDir,
+		OutputDir:  outputDir,
+		Make:       "SHELL: touch $SYZ_OUTPUT_DIR/image", // missing obj/vmlinux
+	}
+
+	_, err := Image(params)
+	require.ErrorContains(t, err, "build did not produce required file obj/vmlinux")
+}


### PR DESCRIPTION
Implement ability to pass a string prefixed with 'SHELL:' in Params.Make. This allows to script out the build procedure using a shell script. The script receives all build parameters as environment variables. Verification of produced files is performed after the script execution.
