### PR TITLE
pkg/aflow: do multiple reproducer runs

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -4,6 +4,7 @@
 package crash
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,12 +49,15 @@ type ReproduceArgs struct {
 type reproduceResult struct {
 	ReproducedBugTitle       string
 	ReproducedCrashReport    string
+	OtherCrashReports        []string
 	ReproducedFaultInjection string
 }
 
 type RunTestResult struct {
 	// Returned if the program caused a kernel crash.
 	Report *report.Report
+	// Other crash reports triggered during reproduction, excluding the main Report.
+	OtherReports []*report.Report
 	// Returned if the kernel failed to boot or function properly
 	// (Report is not returned in this case).
 	BootError string
@@ -108,42 +112,112 @@ func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestR
 	if err != nil {
 		return res, err
 	}
-	// TODO: run multiple instances, handle TestError.Infra, and aggregate results.
-	results, err := env.Test(1, []byte(args.ReproSyz), []byte(args.ReproOpts), []byte(args.ReproC), collectCoverage)
-	if err != nil {
-		return res, err
-	}
-	if len(results) == 0 {
-		return res, fmt.Errorf("env.Test returned no results")
-	}
-	res.ConsoleOutput = string(results[0].RawOutput)
 	crashReporter, err := report.NewReporter(cfg)
 	if err != nil {
 		return res, fmt.Errorf("failed to create crash reporter: %w", err)
 	}
-	res.FaultInjection, err = crashReporter.ExtractFaultInjectionInfo(results[0].RawOutput)
-	if err != nil {
-		return res, fmt.Errorf("failed to extract fault injection info: %w", err)
+
+	runner := &reproRunner{
+		env:             env,
+		args:            args,
+		collectCoverage: collectCoverage,
 	}
-	if err := results[0].Error; err != nil {
-		if crashErr := new(instance.CrashError); errors.As(err, &crashErr) {
-			res.Report = crashErr.Report
-		} else if testErr := new(instance.TestError); errors.As(err, &testErr) {
-			if testErr.Infra {
-				// No point in showing this to LLM and asking to fix.
-				return res, fmt.Errorf("%v\n%v\n%s",
-					testErr.Error(), testErr.Title, testErr.Output)
+
+	validResults, err := instance.CollectRuns(runner.Test, instance.CollectRunsOpts{
+		WantValid: 3,
+		MaxTotal:  6,
+		MaxVMs:    3,
+	})
+	if err != nil {
+		return res, err
+	}
+
+	return aggregateTestResults(validResults, crashReporter, args.KernelObj)
+}
+
+type reproRunner struct {
+	env             instance.Env
+	args            ReproduceArgs
+	collectCoverage bool
+}
+
+func (r *reproRunner) Test(numVMs int) ([]instance.EnvTestResult, error) {
+	results, err := r.env.Test(numVMs, []byte(r.args.ReproSyz), []byte(r.args.ReproOpts),
+		[]byte(r.args.ReproC), r.collectCoverage)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("env.Test returned no results")
+	}
+	return results, nil
+}
+
+func aggregateTestResults(validResults []instance.EnvTestResult,
+	crashReporter *report.Reporter, kernelObj string) (RunTestResult, error) {
+	var res RunTestResult
+	if len(validResults) > 0 {
+		res.ConsoleOutput = string(validResults[0].RawOutput)
+	}
+
+	type crashStat struct {
+		report *report.Report
+		count  int
+	}
+	crashes := make(map[string]*crashStat)
+	var firstCoverage [][]uint64
+
+	for _, result := range validResults {
+		if result.Error == nil {
+			if len(result.Coverage) > 0 && firstCoverage == nil {
+				firstCoverage = result.Coverage
 			}
+			continue
+		}
+
+		var crashErr *instance.CrashError
+		if errors.As(result.Error, &crashErr) {
+			title := crashErr.Report.Title
+			if stat, ok := crashes[title]; ok {
+				stat.count++
+			} else {
+				crashes[title] = &crashStat{report: crashErr.Report, count: 1}
+				if res.FaultInjection == "" {
+					fi, _ := crashReporter.ExtractFaultInjectionInfo(result.RawOutput)
+					res.FaultInjection = fi
+				}
+			}
+			continue
+		}
+
+		var testErr *instance.TestError
+		if errors.As(result.Error, &testErr) && res.BootError == "" {
 			res.BootError = parseTestError(testErr)
-		} else {
-			res.BootError = err.Error()
 		}
 	}
-	coverage, err := symbolize(args.KernelObj, results[0].Coverage)
-	if err != nil {
-		return res, fmt.Errorf("failed to symbolize coverage: %w", err)
+
+	if len(crashes) > 0 {
+		stats := slices.Collect(maps.Values(crashes))
+		slices.SortFunc(stats, func(a, b *crashStat) int {
+			if a.count != b.count {
+				return b.count - a.count
+			}
+			return cmp.Compare(a.report.Title, b.report.Title)
+		})
+		res.Report = stats[0].report
+		for i := 1; i < len(stats); i++ {
+			res.OtherReports = append(res.OtherReports, stats[i].report)
+		}
 	}
-	res.Coverage = coverage
+
+	if res.Report == nil && res.BootError == "" && firstCoverage != nil {
+		coverage, err := symbolize(kernelObj, firstCoverage)
+		if err != nil {
+			return res, fmt.Errorf("failed to symbolize coverage: %w", err)
+		}
+		res.Coverage = coverage
+	}
+
 	return res, nil
 }
 
@@ -174,6 +248,7 @@ func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
 	type Cached struct {
 		BugTitle       string
 		Report         string
+		OtherReports   []string
 		FaultInjection string
 		Error          string
 		CoverageID     string
@@ -188,6 +263,9 @@ func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
 		if testRes.Report != nil {
 			res.BugTitle = testRes.Report.Title
 			res.Report = string(testRes.Report.Report)
+		}
+		for _, rep := range testRes.OtherReports {
+			res.OtherReports = append(res.OtherReports, string(rep.Report))
 		}
 		res.FaultInjection = testRes.FaultInjection
 		res.Error = testRes.BootError
@@ -210,12 +288,13 @@ func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
 	}
 	if cached.Error != "" {
 		return reproduceResult{}, "", errors.New(cached.Error)
-	} else if cached.Report == "" {
+	} else if cached.Report == "" && len(cached.OtherReports) == 0 {
 		return reproduceResult{}, cached.CoverageID, aflow.FlowError(ErrDidNotCrash)
 	}
 	return reproduceResult{
 		ReproducedBugTitle:       cached.BugTitle,
 		ReproducedCrashReport:    cached.Report,
+		OtherCrashReports:        cached.OtherReports,
 		ReproducedFaultInjection: cached.FaultInjection,
 	}, cached.CoverageID, nil
 }

--- a/pkg/aflow/action/crash/reproduce_test.go
+++ b/pkg/aflow/action/crash/reproduce_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/instance"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateTestResults(t *testing.T) {
+	// Dummy crash reporter for tests.
+	crashReporter, err := report.NewReporter(&mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:   "linux",
+			TargetArch: "amd64",
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		results           []instance.EnvTestResult
+		expectedReport    *report.Report
+		expectedBootError bool
+	}{
+		{
+			name: "single_crash",
+			results: []instance.EnvTestResult{
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A")}}},
+			},
+			expectedReport: &report.Report{Title: "bug A", Report: []byte("stack A")},
+		},
+		{
+			name: "multiple_crashes_same_title",
+			results: []instance.EnvTestResult{
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A1")}}},
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A2")}}},
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A3")}}},
+			},
+			expectedReport: &report.Report{Title: "bug A", Report: []byte("stack A1")},
+		},
+		{
+			name: "flaky_crash",
+			results: []instance.EnvTestResult{
+				{Error: nil},
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A")}}},
+				{Error: nil},
+			},
+			expectedReport: &report.Report{Title: "bug A", Report: []byte("stack A")},
+		},
+		{
+			name: "multiple_crash_types_majority_wins",
+			results: []instance.EnvTestResult{
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug B", Report: []byte("stack B")}}},
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug A", Report: []byte("stack A")}}},
+				{Error: nil},
+				{Error: &instance.CrashError{Report: &report.Report{Title: "bug B", Report: []byte("stack B")}}},
+			},
+			expectedReport: &report.Report{Title: "bug B", Report: []byte("stack B")},
+		},
+		{
+			name: "no_crashes_but_boot_errors",
+			results: []instance.EnvTestResult{
+				{Error: &instance.TestError{Boot: true, Title: "boot error 1"}},
+				{Error: &instance.TestError{Boot: true, Title: "boot error 2"}},
+				{Error: nil},
+			},
+			expectedBootError: true,
+		},
+		{
+			name: "all_ok",
+			results: []instance.EnvTestResult{
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := aggregateTestResults(tc.results, crashReporter, "")
+			require.NoError(t, err)
+
+			if tc.expectedReport != nil {
+				require.NotNil(t, res.Report)
+				require.Equal(t, tc.expectedReport.Title, res.Report.Title)
+				if len(tc.expectedReport.Report) > 0 {
+					require.Contains(t, string(res.Report.Report), string(tc.expectedReport.Report))
+				}
+			} else if tc.expectedBootError {
+				require.NotEmpty(t, res.BootError)
+				require.Nil(t, res.Report)
+			} else {
+				require.Nil(t, res.Report)
+				require.Empty(t, res.BootError)
+			}
+		})
+	}
+}

--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -27,6 +27,7 @@ type RunCReproResult struct {
 	ConsoleOutput        string
 	CandidateBugTitle    string
 	CandidateCrashReport string
+	OtherCrashReports    []string
 	TestError            string
 }
 
@@ -70,6 +71,11 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 		result.CandidateReproduced = true
 		result.CandidateBugTitle = res.Report.Title
 		result.CandidateCrashReport = string(res.Report.Report)
+	}
+	if len(res.OtherReports) > 0 {
+		for _, rep := range res.OtherReports {
+			result.OtherCrashReports = append(result.OtherCrashReports, string(rep.Report))
+		}
 	}
 
 	return result, nil

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -114,6 +114,7 @@ type ReproOutputs struct {
 	SyzkallerCommit       string
 	Reproduced            bool
 	ReproducedCrashReport string
+	OtherCrashReports     []string
 }
 
 type ReproCOutputs struct {
@@ -121,4 +122,5 @@ type ReproCOutputs struct {
 	Reproduced            bool
 	ReproducedBugTitle    string
 	ReproducedCrashReport string
+	OtherCrashReports     []string
 }

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -421,6 +421,13 @@ Bug title: {{jsonMarshal .ReproducedBugTitle}}
 Crash report:
 {{.ReproducedCrashReport}}
 
+{{if .OtherCrashReports}}
+Other crashes triggered:
+{{range .OtherCrashReports}}
+{{.}}
+{{end}}
+{{end}}
+
 {{if .ReproducedFaultInjection}}
 Fault injection report(s):
 {{.ReproducedFaultInjection}}

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -237,6 +237,13 @@ The crash that corresponds to the bug is:
 
 {{.ReproducedCrashReport}}
 
+{{if .OtherCrashReports}}
+Other crashes triggered:
+{{range .OtherCrashReports}}
+{{.}}
+{{end}}
+{{end}}
+
 The explanation of the root cause of the bug is:
 
 {{.BugExplanation}}

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -420,4 +420,10 @@ const oraclePrompt = `Bug Description: {{.BugDescription}}
 Reproduced: {{.Reproduced}}
 Console Output: {{.TruncatedConsoleOutput}}
 Crash Report: {{.TruncatedCrashReport}}
+{{if .OtherCrashReports}}
+Other crashes triggered:
+{{range .OtherCrashReports}}
+{{.}}
+{{end}}
+{{end}}
 {{if .TestError}}Boot/Compilation Error: {{.TestError}}{{end}}`

--- a/pkg/aflow/template.go
+++ b/pkg/aflow/template.go
@@ -98,6 +98,10 @@ func walkTemplate(n parse.Node, used map[string]bool, errp *error) {
 		walkTemplate(n.Node, used, errp)
 	case *parse.TextNode:
 	case *parse.IdentifierNode:
+	case *parse.NumberNode:
+	case *parse.StringNode:
+	case *parse.BoolNode:
+	case *parse.DotNode:
 	default:
 		noteError(errp, "unhandled node type %T", n)
 	}

--- a/pkg/aflow/template_test.go
+++ b/pkg/aflow/template_test.go
@@ -87,6 +87,13 @@ func TestTemplate(t *testing.T) {
 			},
 			used: []string{"foo"},
 		},
+		{
+			template: `{{range .foo}}{{if eq . "bar"}}{{end}}{{if eq . 1}}{{end}}{{if eq . true}}{{end}}{{end}}`,
+			vars: map[string]reflect.Type{
+				"foo": reflect.TypeFor[[]string](),
+			},
+			used: []string{"foo"},
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/instance/collect.go
+++ b/pkg/instance/collect.go
@@ -1,0 +1,69 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RunAttempt represents a single execution batch, returning results for numVMs.
+type RunAttempt func(numVMs int) ([]EnvTestResult, error)
+
+// CollectRunsOpts configures the execution of CollectRuns.
+type CollectRunsOpts struct {
+	WantValid int // Target number of valid runs to collect.
+	MaxTotal  int // Maximum total number of runs (including failed infra runs).
+	MaxVMs    int // Maximum number of VMs to run concurrently in a single batch.
+}
+
+// CollectRuns runs attempts to collect the requested number of valid test results.
+// It automatically retries on infrastructure errors.
+func CollectRuns(attempt RunAttempt, opts CollectRunsOpts) ([]EnvTestResult, error) {
+	if opts.MaxTotal < opts.WantValid {
+		return nil, fmt.Errorf("collectRuns: MaxTotal (%d) cannot be less than WantValid (%d)", opts.MaxTotal, opts.WantValid)
+	}
+	opts.MaxVMs = max(opts.MaxVMs, 1)
+
+	var validResults []EnvTestResult
+	var lastInfraErr error
+
+	totalAttempts := 0
+
+	for totalAttempts < opts.MaxTotal && len(validResults) < opts.WantValid {
+		// Run as many as we need, up to MaxVMs.
+		need := opts.WantValid - len(validResults)
+		batchSize := min(need, opts.MaxVMs)
+		// We still need to respect MaxTotal.
+		batchSize = min(batchSize, opts.MaxTotal-totalAttempts)
+
+		results, err := attempt(batchSize)
+		totalAttempts += batchSize
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, res := range results {
+			if res.Error == nil {
+				validResults = append(validResults, res)
+				continue
+			}
+
+			var crashErr *CrashError
+			var testErr *TestError
+			if errors.As(res.Error, &crashErr) || (errors.As(res.Error, &testErr) && !testErr.Infra) {
+				validResults = append(validResults, res)
+			} else {
+				lastInfraErr = res.Error
+			}
+		}
+	}
+
+	if len(validResults) < opts.WantValid {
+		return validResults, fmt.Errorf("failed to collect %d valid runs within %d total attempts. Last infra error: %w",
+			opts.WantValid, opts.MaxTotal, lastInfraErr)
+	}
+	return validResults[:opts.WantValid], nil // Trim just in case an attempt returned more than requested.
+}

--- a/pkg/instance/collect_test.go
+++ b/pkg/instance/collect_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRunner struct {
+	responses []EnvTestResult
+	idx       int
+}
+
+func (m *mockRunner) Test(numVMs int) ([]EnvTestResult, error) {
+	var batch []EnvTestResult
+	for range numVMs {
+		if m.idx >= len(m.responses) {
+			return nil, fmt.Errorf("ran out of responses")
+		}
+		batch = append(batch, m.responses[m.idx])
+		m.idx++
+	}
+	return batch, nil
+}
+
+func TestCollectRuns(t *testing.T) {
+	tests := []struct {
+		name             string
+		responses        []EnvTestResult
+		opts             CollectRunsOpts
+		expectedValid    int
+		expectErr        bool
+		expectErrMessage string
+	}{
+		{
+			name: "all_successful",
+			responses: []EnvTestResult{
+				{RawOutput: []byte("1")},
+				{RawOutput: []byte("2")},
+				{RawOutput: []byte("3")},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  6,
+				MaxVMs:    3,
+			},
+			expectedValid: 3,
+		},
+		{
+			name: "recover_from_infra_errors",
+			responses: []EnvTestResult{
+				{Error: &TestError{Infra: true}},
+				{RawOutput: []byte("1")},
+				{Error: errors.New("unknown error treated as infra")},
+				{RawOutput: []byte("2")},
+				{RawOutput: []byte("3")},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  6,
+				MaxVMs:    2,
+			},
+			expectedValid: 3,
+		},
+		{
+			name: "fail_with_too_many_infra_errors",
+			responses: []EnvTestResult{
+				{Error: &TestError{Infra: true}},
+				{Error: &TestError{Infra: true}},
+				{Error: &TestError{Infra: true}},
+				{Error: &TestError{Infra: true}},
+				{Error: &TestError{Infra: true}},
+				{Error: &TestError{Infra: true}},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  6,
+				MaxVMs:    3,
+			},
+			expectErr:     true,
+			expectedValid: 0,
+		},
+		{
+			name: "mix_of_crashes_and_infra",
+			responses: []EnvTestResult{
+				{Error: &TestError{Infra: true}},
+				{Error: &CrashError{Report: &report.Report{Title: "crash1"}}},
+				{Error: &TestError{Infra: true}},
+				{Error: &CrashError{Report: &report.Report{Title: "crash2"}}},
+				{Error: &CrashError{Report: &report.Report{Title: "crash3"}}},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  6,
+				MaxVMs:    1, // Test sequential.
+			},
+			expectedValid: 3,
+		},
+		{
+			name: "stop_at_max_total",
+			responses: []EnvTestResult{
+				{Error: &TestError{Infra: true}},
+				{RawOutput: []byte("1")},
+				{Error: &TestError{Infra: true}},
+				{RawOutput: []byte("2")},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  4, // Stop after 4 total.
+				MaxVMs:    4, // Test high parallelism.
+			},
+			expectErr:     true,
+			expectedValid: 2, // We still return what we collected so far if it errors out.
+		},
+		{
+			name: "invalid_opts_fails_fast",
+			responses: []EnvTestResult{
+				{RawOutput: []byte("1")},
+			},
+			opts: CollectRunsOpts{
+				WantValid: 3,
+				MaxTotal:  2, // Invalid: MaxTotal < WantValid.
+				MaxVMs:    1,
+			},
+			expectErr:        true,
+			expectErrMessage: "collectRuns: MaxTotal (2) cannot be less than WantValid (3)",
+			expectedValid:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &mockRunner{responses: tc.responses}
+
+			validResults, err := CollectRuns(runner.Test, tc.opts)
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.expectErrMessage != "" {
+					require.Contains(t, err.Error(), tc.expectErrMessage)
+				}
+				require.Len(t, validResults, tc.expectedValid)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, validResults, tc.expectedValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enhance reproducer execution to perform multiple runs and collect all
unique crashes. The most frequent crash is returned in RunTestResult.Report,
and the rest in RunTestResult.OtherReports.

Expose these additional crashes to the LLM agent as OtherCrashReports
to provide a better view of the reproducer's behavior, especially for
flaky crashes.

Also, update the template verifier to support `range` iterations in prompts.

Cc https://github.com/google/syzkaller/issues/7093