### PR TITLE
pkg/aflow/tool/gitlog: handle out-of-bounds lines in git blame

### DIFF
--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -198,6 +198,7 @@ func gitBadCallError(err error, name, advice string) error {
 		bytes.Contains(verr.Output, []byte("unknown revision")) ||
 		bytes.Contains(verr.Output, []byte("ambiguous argument")) ||
 		bytes.Contains(verr.Output, []byte("no match")) ||
+		bytes.Contains(verr.Output, []byte("has only")) ||
 		bytes.Contains(verr.Output, []byte("no such path"))) {
 		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
 	}

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -94,6 +94,14 @@ $`, c1.Hash[:12], c2.Hash[:12])
 		blameResult{},
 		"git blame failed: fatal: no such path non_existing.c in HEAD",
 		aflow.TestWorkdir(tmpDir))
+
+	// Test git-blame out of bounds line range.
+	aflow.TestTool(t, ToolBlame,
+		state{KernelCommit: "HEAD"},
+		blameArgs{File: "foo.c", Start: 1000, End: 1001},
+		blameResult{},
+		"git blame failed: fatal: file foo.c has only 5 lines",
+		aflow.TestWorkdir(tmpDir))
 }
 
 func TestGitLog(t *testing.T) {


### PR DESCRIPTION
When the git-blame tool was invoked with a line range that exceeded the actual number of lines in the target file, it failed with a generic exit code 128. This was previously treated as an unhandled execution error.

Add the "has only" error string to the list of acceptable git errors so that this condition is properly surfaced as an aflow.BadCallError, allowing LLM agents to understand the failure and self-correct their requests.

***

Failed in https://syzkaller.appspot.com/ai_job?id=b33339a8-524d-413e-868b-d9e9a9299b09