### PR TITLE
tools: add a linter to check trailing newlines in .sql files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ endif
 	extract generate generate_go generate_rpc generate_sys \
 	format format_go format_cpp format_sys \
 	tidy test test_race \
-	check_copyright check_language check_whitespace check_links check_diff check_commits check_shebang check_html \
+	check_copyright check_language check_whitespace check_sql_newlines check_links check_diff check_commits check_shebang check_html \
 	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd \
 	presubmit_arch_netbsd presubmit_arch_openbsd presubmit_arch_darwin presubmit_arch_windows \
 	presubmit_arch_executor presubmit_dashboard presubmit_race presubmit_race_dashboard presubmit_old
@@ -316,7 +316,7 @@ presubmit:
 
 presubmit_aux:
 	$(MAKE) generate
-	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_whitespace check_links check_html check_shebang check_k8s tidy
+	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_whitespace check_sql_newlines check_links check_html check_shebang check_k8s tidy
 	$(GO) mod tidy
 
 presubmit_build: descriptions
@@ -430,6 +430,9 @@ check_language:
 
 check_whitespace:
 	./tools/check-whitespace.sh
+
+check_sql_newlines:
+	./tools/check-sql-newlines.sh
 
 check_commits:
 	./tools/check-commits.sh

--- a/tools/check-sql-newlines.sh
+++ b/tools/check-sql-newlines.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Copyright 2026 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+FAILED=""
+for f in $(find . -name "*.sql"); do
+	if [ -s "$f" ] && [ -n "$(tail -c 1 "$f")" ]; then
+		echo "$f:1:1: No newline at the end of the file."
+		FAILED="1"
+	fi
+done
+
+if [ "$FAILED" != "" ]; then exit 1; fi


### PR DESCRIPTION
We prefer migration files (like those in dashboard/app/aidb/migrations and syz-cluster) to end with a newline character, but some tools/agents often omit them.

Add tools/check-sql-newlines.sh to enforce this on all .sql files across the repository.
Integrate this check into the make presubmit target.
