### PR TITLE
dashboard/app: reuse comment Subject when replying to comments

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -422,6 +422,7 @@ func handleCommentCommand(ctx context.Context, req *dashapi.SendExternalCommandR
 	err = aidb.SaveJobComment(ctx, &aidb.JobComment{
 		ReportingID: reporting.ID,
 		ExtID:       req.MessageExtID,
+		Subject:     req.Comment.Subject,
 		Author:      req.Author,
 		BodyURI:     fmt.Sprintf("text://%v", textID),
 		Date:        aidb.TimeNow(ctx),

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -216,12 +216,13 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 			return nil, fmt.Errorf("unsupported job type: %s", job.Type)
 		}
 
-		var patchResult *dashapi.NewReportResult
-		var replies []*dashapi.ReplyResult
-
 		version := 1
 		if r.Version.Valid {
 			version = int(r.Version.Int64)
+		}
+
+		result := &dashapi.ReportPollResult{
+			ID: r.ID,
 		}
 
 		switch job.Type {
@@ -230,51 +231,48 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast job results: %w", err)
 			}
-			patchResult, err = makeNewReportResult(ctx, job, &res, version)
+			result.Patch, err = makeNewReportResult(ctx, job, &res, version)
 			if err != nil {
 				return nil, err
 			}
 		case ai.WorkflowPatchIteration:
-			patchResult, replies, err = makeIterationReportResult(ctx, job, version, r.Stage)
+			err = populateIterationReportResult(ctx, job, version, r.Stage, result)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		if patchResult != nil {
+		if result.Patch != nil {
 			var links []string
 			if job.BugID.Valid {
 				link, reporter := jobBugInfo(ctx, job.BugID)
 				links = append(links, link)
 				if reporter != "" {
-					patchResult.ReportedBy = []string{reporter}
+					result.Patch.ReportedBy = []string{reporter}
 				}
 			}
 			links = append(links, fmt.Sprintf("%s/ai_job?id=%s", appURL(ctx), job.ID))
-			patchResult.Links = links
+			result.Patch.Links = links
 		}
 
 		to := []string{stageCfg.MailingList}
 		var cc []string
-		if stageCfg.MergePatchCc && patchResult != nil {
-			to = append(to, patchResult.To...)
-			cc = append(cc, patchResult.Cc...)
+		if stageCfg.MergePatchCc && result.Patch != nil {
+			to = append(to, result.Patch.To...)
+			cc = append(cc, result.Patch.Cc...)
 		}
 
 		canUpstream := idx < len(nsCfg.AI.Stages)-1
-		if patchResult == nil {
+		if result.Patch == nil {
 			canUpstream = false
 		}
 
+		result.CanUpstream = canUpstream
+		result.To = to
+		result.Cc = cc
+
 		return &dashapi.PollExternalReportResp{
-			Result: &dashapi.ReportPollResult{
-				ID:          r.ID,
-				CanUpstream: canUpstream,
-				To:          to,
-				Cc:          cc,
-				Patch:       patchResult,
-				Replies:     replies,
-			},
+			Result: result,
 		}, nil
 	}
 	return &dashapi.PollExternalReportResp{}, nil
@@ -327,17 +325,15 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	}, nil
 }
 
-func makeIterationReportResult(ctx context.Context, job *aidb.Job, version int,
-	currentStage string) (*dashapi.NewReportResult, []*dashapi.ReplyResult, error) {
+func populateIterationReportResult(ctx context.Context, job *aidb.Job, version int,
+	currentStage string, result *dashapi.ReportPollResult) error {
 	res, err := castJobResults[ai.PatchIterationOutputs](job)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to cast job results: %w", err)
+		return fmt.Errorf("failed to cast job results: %w", err)
 	}
-	var patchResult *dashapi.NewReportResult
-	var replies []*dashapi.ReplyResult
 
 	if res.PatchDiff != "" {
-		patchResult, err = makeNewReportResult(ctx, job, &ai.PatchingOutputs{
+		result.Patch, err = makeNewReportResult(ctx, job, &ai.PatchingOutputs{
 			KernelRepo:       res.KernelRepo,
 			KernelBranch:     res.KernelBranch,
 			KernelCommit:     res.KernelCommit,
@@ -347,9 +343,9 @@ func makeIterationReportResult(ctx context.Context, job *aidb.Job, version int,
 			Fixes:            res.Fixes,
 		}, version)
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
-		patchResult.Changelog = collectChangelog(ctx, job.ID, currentStage)
+		result.Patch.Changelog = collectChangelog(ctx, job.ID, currentStage)
 	} else if len(res.Replies) > 0 {
 		var comments []*aidb.JobComment
 		if job.ParentReportingID.Valid {
@@ -361,10 +357,13 @@ func makeIterationReportResult(ctx context.Context, job *aidb.Job, version int,
 			for _, c := range comments {
 				if c.ExtID == r.ReplyTo {
 					author = c.Author
+					if result.ThreadSubject == "" && c.Subject != "" {
+						result.ThreadSubject = c.Subject
+					}
 					break
 				}
 			}
-			replies = append(replies, &dashapi.ReplyResult{
+			result.Replies = append(result.Replies, &dashapi.ReplyResult{
 				Quote:       r.Quote,
 				Body:        r.Text,
 				ReplyExtID:  r.ReplyTo,
@@ -372,7 +371,7 @@ func makeIterationReportResult(ctx context.Context, job *aidb.Job, version int,
 			})
 		}
 	}
-	return patchResult, replies, nil
+	return nil
 }
 
 func apiAIConfirmReport(ctx context.Context, req *dashapi.ConfirmPublishedReq) (any, error) {

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -450,7 +450,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	assert.Equal(t, []string{"moderation@test.com", "reviewer@email.com"}, mockSnd.sent[1].To)
 	// And they should be completely subtracted from the CC list.
 	assert.Equal(t, []string{"archive@lore.com"}, mockSnd.sent[1].Cc)
-	assert.Equal(t, "Aggregated Comment Reply", mockSnd.sent[1].Subject)
+	assert.Equal(t, "Re: [PATCH RFC] Test Subject", mockSnd.sent[1].Subject)
 	assert.Equal(t, "<comment1>", mockSnd.sent[1].InReplyTo)
 }
 

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1307,7 +1307,7 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 		RootExtID:    "<message-id-1>",
 		MessageExtID: "<comment-id-1>",
 		Author:       "reviewer@email.com",
-		Comment:      &dashapi.CommentCommand{Body: "This is a comment"},
+		Comment:      &dashapi.CommentCommand{Subject: "Re: [PATCH RFC] Test Subject", Body: "This is a comment"},
 	})
 	require.NoError(t, err)
 
@@ -1333,7 +1333,7 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 		RootExtID:    "<message-id-1>",
 		MessageExtID: "<comment-id-2>",
 		Author:       "reviewer@email.com",
-		Comment:      &dashapi.CommentCommand{Body: "This is a concurrent comment"},
+		Comment:      &dashapi.CommentCommand{Subject: "Re: [PATCH RFC] Test Subject", Body: "This is a concurrent comment"},
 	})
 	require.NoError(t, err)
 
@@ -1360,7 +1360,9 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 		To:          []string{"moderation@test.com"},
 		Replies: []*dashapi.ReplyResult{
 			{Body: "I will fix it.", ReplyExtID: "<comment-id-1>", ReplyAuthor: "reviewer@email.com"},
-		}}
+		},
+		ThreadSubject: "Re: [PATCH RFC] Test Subject",
+	}
 	require.Equal(t, wantResult, gotResult)
 
 	// Confirm the reply-only report so it has a PublishedExtID in the database.

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -126,6 +126,7 @@ type JobComment struct {
 	ID          string
 	ReportingID string
 	ExtID       string
+	Subject     string
 	Author      string
 	BodyURI     string
 	Date        time.Time

--- a/dashboard/app/aidb/migrations/15_comment_subject.down.sql
+++ b/dashboard/app/aidb/migrations/15_comment_subject.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE JobComments DROP COLUMN Subject;

--- a/dashboard/app/aidb/migrations/15_comment_subject.up.sql
+++ b/dashboard/app/aidb/migrations/15_comment_subject.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE JobComments ADD COLUMN Subject STRING(MAX);

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -80,7 +80,8 @@ type RejectCommand struct {
 }
 
 type CommentCommand struct {
-	Body string
+	Subject string
+	Body    string
 }
 
 type SendExternalCommandResp struct {
@@ -97,12 +98,13 @@ type PollExternalReportResp struct {
 }
 
 type ReportPollResult struct {
-	ID          string // JobReporting ID
-	CanUpstream bool
-	To          []string
-	Cc          []string
-	Patch       *NewReportResult `json:",omitempty"`
-	Replies     []*ReplyResult   `json:",omitempty"`
+	ID            string // JobReporting ID
+	CanUpstream   bool
+	To            []string
+	Cc            []string
+	Patch         *NewReportResult `json:",omitempty"`
+	Replies       []*ReplyResult   `json:",omitempty"`
+	ThreadSubject string           `json:",omitempty"` // Used as the email subject when replying without a new patch.
 }
 
 type NewReportResult struct {

--- a/pkg/lore-relay/commands.go
+++ b/pkg/lore-relay/commands.go
@@ -46,7 +46,8 @@ func extractCommands(polled *lore.PolledEmail) ([]*dashapi.SendExternalCommandRe
 			Author:       polled.Email.Author,
 			OwnEmail:     polled.Email.OwnEmail,
 			Comment: &dashapi.CommentCommand{
-				Body: polled.Email.Body,
+				Subject: polled.Email.Subject,
+				Body:    polled.Email.Body,
 			},
 		})
 	}

--- a/pkg/lore-relay/relay_test.go
+++ b/pkg/lore-relay/relay_test.go
@@ -439,7 +439,8 @@ func mockMainScenarioCommands() []*dashapi.SendExternalCommandReq {
 			MessageExtID: "<reply1>",
 			Author:       "user@email",
 			Comment: &dashapi.CommentCommand{
-				Body: "This looks interesting.\n",
+				Subject: "Re: [PATCH] Fix bug",
+				Body:    "This looks interesting.\n",
 			},
 		},
 		{

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -86,6 +86,12 @@ func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 // GenerateSubject generates the email subject based on the poll result.
 func GenerateSubject(res *dashapi.ReportPollResult) string {
 	if res.Patch == nil {
+		if res.ThreadSubject != "" {
+			if strings.HasPrefix(strings.ToLower(res.ThreadSubject), "re:") {
+				return res.ThreadSubject
+			}
+			return "Re: " + res.ThreadSubject
+		}
 		return ""
 	}
 	prefix := "PATCH"


### PR DESCRIPTION
It's not enough to just set the right In-Reply-To, we also need to use a correct Subject when we send AI-generated comments replies. Otherwise GMail fails to connect the discussion in a single thread.

Remember subjects of user comments in the DB. Since we (for now) send an aggregated reply, take the subject from one of the comments we reply to.