### PR TITLE
pkg/aflow/action/actionsyzlang: truncate large hex arrays in C repros

### DIFF
--- a/pkg/aflow/action/actionsyzlang/crepro.go
+++ b/pkg/aflow/action/actionsyzlang/crepro.go
@@ -5,6 +5,7 @@ package actionsyzlang
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/csource"
@@ -23,11 +24,13 @@ type createCReproResult struct {
 	SimplifiedCRepro string
 }
 
+var stringLiteralSeq = regexp.MustCompile(`"(?:[^"\\]|\\.)*"(?:\s*"(?:[^"\\]|\\.)*")*`)
+
 func createCRepro(ctx *aflow.Context, args createCReproArgs) (createCReproResult, error) {
 	if args.ReproSyz == "" {
 		// Patching workflow may run only with C repro, if created manually (not from a syzbot bug).
 		// For these cases return the provided C repro.
-		return createCReproResult{args.ReproC}, nil
+		return createCReproResult{truncateLargeData(args.ReproC)}, nil
 	}
 	pt, err := prog.GetTarget("linux", "amd64")
 	if err != nil {
@@ -41,5 +44,16 @@ func createCRepro(ctx *aflow.Context, args createCReproArgs) (createCReproResult
 	if err != nil {
 		return createCReproResult{}, fmt.Errorf("failed to generate simplified C repro: %w", err)
 	}
-	return createCReproResult{SimplifiedCRepro: string(cData)}, nil
+	return createCReproResult{SimplifiedCRepro: truncateLargeData(string(cData))}, nil
+}
+
+const maxStringLiteralSeqLen = 128
+
+func truncateLargeData(cRepro string) string {
+	return stringLiteralSeq.ReplaceAllStringFunc(cRepro, func(match string) string {
+		if len(match) > maxStringLiteralSeqLen {
+			return `"... [truncated large byte array] ..."`
+		}
+		return match
+	})
 }

--- a/pkg/aflow/action/actionsyzlang/crepro_test.go
+++ b/pkg/aflow/action/actionsyzlang/crepro_test.go
@@ -38,3 +38,34 @@ func TestSyzlangToC_Empty(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, res.SimplifiedCRepro)
 }
+
+func TestTruncateLargeData(t *testing.T) {
+	input := `
+    memcpy(
+        (void*)0x20000001f7c0,
+        "\x78\x9c\xec\xdd\x09\x9c\x4d\xf5\xdf\x07\xf0\xdf\xd9\xf7\xfd\x5c\xd9"
+        "\x0d\x4d\x92\x90\x7d\x49\xb2\xaf\xd9\xb7\x90\xec\xfb\x9e\x2d\x24\x86"
+        "\x64\x4b\x96\x08\xc9\x96\x64\x4b\x12\x2a\x49\x22\x89\x92\xec\x92\x90"
+        "\x24\xa9\x24\xed\x92\x78\x5e\xce\xdc\x99\x66\x06\xff\x3a\x6d\xbf\x9e"
+        "\xe3\xf3\xee\xd5\xf7\xdc\x39\x73\xef\x39\xdf\xbb\x7c\xce\x66\xce\xb9"
+        "\x24\xa9\x24\xed\x92\x78\x5e\xce\xdc\x99\x66\x06\xff\x3a\x6d\xbf\x9e",
+        200);
+`
+	expectedInput := `
+    memcpy(
+        (void*)0x20000001f7c0,
+        "... [truncated large byte array] ...",
+        200);
+`
+	require.Equal(t, expectedInput, truncateLargeData(input))
+
+	singleLineInput := "memcpy((void*)0x20000, \"\\x78\\x9c\\xec\\xdd\\x09\\x9c\\x4d\\xf5\\xdf\\x07" +
+		"\\xf0\\xdf\\xd9\\xf7\\xfd\\x5c\\xd9\\x0d\\x4d\\x92\\x90\\x7d\\x49\\xb2\\xaf\\xd9\\xb7\\x90" +
+		"\\xec\\xfb\\x9e\\x2d\\x24\\x86\\x64\\x4b\\x96\\x08\\xc9\\x96\\x64\\x4b\\x12\\x2a\\x49\\x22" +
+		"\\x89\\x92\\xec\\x92\\x90\", 200);"
+	expectedSingleLineInput := `memcpy((void*)0x20000, "... [truncated large byte array] ...", 200);`
+	require.Equal(t, expectedSingleLineInput, truncateLargeData(singleLineInput))
+
+	smallInput := `memcpy((void*)0x20000, "\x11\x22", 2);`
+	require.Equal(t, smallInput, truncateLargeData(smallInput))
+}


### PR DESCRIPTION
When generating simplified C reproducers for LLM prompts, large byte sequences (like fs images) can consume hundreds of thousands of tokens, slowing down the agents and hitting token limits.

Truncate sequences of C string literals that exceed 128 bytes by replacing them with a short placeholder comment. This preserves the structural context while preventing massive token consumption.

There may be better solutions, but we need at least something for now to unbreak our prod.

Closes https://github.com/google/syzkaller/issues/7271