### PR TITLE
pkg/aflow: handle Vertex AI specific 429 quota errors

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -777,6 +777,12 @@ func parseLLMErrorImpl(resp *genai.GenerateContentResponse, err error, model str
 		// (see the test for exact error message). But presumably this is some per-minute quota.
 		return &retryError{time.Minute, err}
 	}
+	if apiErr.Code == http.StatusTooManyRequests &&
+		(strings.Contains(apiErr.Message, "Resource exhausted. Please try again later.") ||
+			strings.Contains(apiErr.Message, "Resource has been exhausted")) {
+		// Vertex AI specific rate limit error (e.g. RPM/TPM exhausted).
+		return &retryError{time.Minute, err}
+	}
 	if apiErr.Code == http.StatusBadRequest &&
 		strings.Contains(apiErr.Message, "The input token count exceeds the maximum") {
 		return &inputTokenOverflowError{err}

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -31,6 +31,15 @@ func TestParseLLMError(t *testing.T) {
 		// nolint:lll
 		Message: `You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit.`,
 	}
+	vertexError1 := genai.APIError{
+		Code: 429,
+		// nolint:lll
+		Message: `Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.`,
+	}
+	vertexError2 := genai.APIError{
+		Code:    429,
+		Message: `Resource has been exhausted (e.g. check quota).`,
+	}
 	rpdError := genai.APIError{
 		Code: 429,
 		// nolint:lll
@@ -84,6 +93,16 @@ func TestParseLLMError(t *testing.T) {
 			resp:      nil,
 			inputErr:  tpmError2,
 			outputErr: &retryError{time.Minute, tpmError2},
+		},
+		{
+			resp:      nil,
+			inputErr:  vertexError1,
+			outputErr: &retryError{time.Minute, vertexError1},
+		},
+		{
+			resp:      nil,
+			inputErr:  vertexError2,
+			outputErr: &retryError{time.Minute, vertexError2},
 		},
 		{
 			resp:      nil,


### PR DESCRIPTION
Vertex AI returns a specific 'Resource exhausted. Please try again later.' message for its 429 errors (e.g., when RPM/TPM limits are hit). This commit explicitly parses that error to trigger the correct short (1-minute) retry behavior, ensuring the agent doesn't fail immediately.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
