### PR TITLE
syz-agent: return to Gemini API

### DIFF
--- a/syz-agent/k8s/overlays/prod-agent/agent-config.json
+++ b/syz-agent/k8s/overlays/prod-agent/agent-config.json
@@ -2,7 +2,7 @@
   "dashboard_addr": "https://syzbot.org",
   "dashboard_client": "gcp-secret:syz-agent-dashboard-client",
   "dashboard_key": "gcp-secret:syz-agent-dashboard-key",
-  "cloud_project": "gcp-secret:syz-agent-cloud-project",
+  "gemini_api_key": "gcp-secret:syz-agent-gemini-key",
   "target": "linux/amd64",
   "image": "/disk-images/buildroot_amd64",
   "kernel_config": "/kernel-configs/upstream-apparmor-kasan.config",


### PR DESCRIPTION
We first need to resolve quota issues for Vertex AI API. Then we can normally switch there.