### PR TITLE
dashboard/app: make JobComment.Subject nullable

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -373,8 +373,8 @@ func populateIterationReportResult(ctx context.Context, job *aidb.Job, version i
 			for _, c := range comments {
 				if c.ExtID == r.ReplyTo {
 					author = c.Author
-					if result.ThreadSubject == "" && c.Subject != "" {
-						result.ThreadSubject = c.Subject
+					if result.ThreadSubject == "" && c.Subject.Valid && c.Subject.StringVal != "" {
+						result.ThreadSubject = c.Subject.StringVal
 					}
 					break
 				}
@@ -437,7 +437,7 @@ func handleCommentCommand(ctx context.Context, req *dashapi.SendExternalCommandR
 	err = aidb.SaveJobComment(ctx, &aidb.JobComment{
 		ReportingID: reporting.ID,
 		ExtID:       req.MessageExtID,
-		Subject:     req.Comment.Subject,
+		Subject:     spanner.NullString{StringVal: req.Comment.Subject, Valid: req.Comment.Subject != ""},
 		Author:      req.Author,
 		BodyURI:     fmt.Sprintf("text://%v", textID),
 		Date:        aidb.TimeNow(ctx),

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -127,7 +127,7 @@ type JobComment struct {
 	ID          string
 	ReportingID string
 	ExtID       string
-	Subject     string
+	Subject     spanner.NullString
 	Author      string
 	BodyURI     string
 	Date        time.Time


### PR DESCRIPTION
Change the type of the Subject field in the JobComment struct from string to spanner.NullString. This fixes a decoding error when Spanner returns a NULL value for the Subject column ("failed to decode column 3, destination *string cannot support NULL SQL values").