### PR TITLE
syz-cluster/email-reporter: ignore empty bug IDs from email parser

### DIFF
--- a/syz-cluster/email-reporter/email_workflow_test.go
+++ b/syz-cluster/email-reporter/email_workflow_test.go
@@ -155,5 +155,28 @@ Content-Type: text/plain
 		polled := <-writeTo
 		err = handler.ProcessPolledEmail(ctx, polled)
 		assert.ErrorIs(t, err, ErrUnknownReport)
+
+		assert.Nil(t, emailServer.email())
+	})
+
+	t.Run("empty-bug-id", func(t *testing.T) {
+		loreArchive.SaveMessage(t, `Date: Sun, 7 May 2017 19:57:00 -0700
+Subject: Reply to nothing
+Message-ID: <empty-bug-id>
+From: Someone Else <b@syzkaller.com>
+To: Bot <bot@syzbot.com>
+Content-Type: text/plain
+
+#syz upstream
+`)
+		err = poller.Poll(ctx, writeTo)
+		assert.NoError(t, err)
+
+		polled := <-writeTo
+		err = handler.ProcessPolledEmail(ctx, polled)
+		assert.ErrorIs(t, err, ErrUnknownReport)
+
+		// Verify no email was sent in reply (it should be ignored).
+		assert.Nil(t, emailServer.email())
 	})
 }

--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -205,7 +205,14 @@ func (h *Handler) ProcessPolledEmail(ctx context.Context, polled *lore.PolledEma
 		return fmt.Errorf("failed to record reply: %w", err)
 	}
 	if res.ReportID == "" {
-		if len(parsed.BugIDs) == 0 {
+		hasValidBugID := false
+		for _, id := range parsed.BugIDs {
+			if id != "" {
+				hasValidBugID = true
+				break
+			}
+		}
+		if !hasValidBugID {
 			return ErrUnknownReport
 		}
 	} else if !res.New {


### PR DESCRIPTION
When the email parser processes an address configured in ownEmails (e.g., syzbot@kernel.org) that lacks a +<hash> context, it returns an empty string as a Bug ID.

Previously, the handler only checked if the list was empty (len(parsed.BugIDs) == 0). Because the parser returned [""], the handler bypassed this check, attempted to process commands against a blank ID, and incorrectly replied with "Failed to process the command". This caused a conflict when an AI patch upstream command was sent: dashboard's lore-relay successfully processed it, while syz-cluster concurrently tried processing the empty ID and sent an error reply.

We must filter out these empty strings at the syz-cluster handler level rather than in the parser itself, because dashboard/app relies on the presence of this empty string in parsed.BugIDs to detect when syzbot is explicitly CC'd (to deduplicate emails arriving via mailing lists).

Update the handler to verify that the Bug IDs list contains at least one valid, non-empty ID before proceeding.