### PR TITLE
dashboard/app: fix idempotency bug in AI report commands

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -21,6 +21,16 @@ import (
 const SourceWebUI = "web ui"
 
 func apiAIReportCommand(ctx context.Context, req *dashapi.SendExternalCommandReq) (any, error) {
+	if req.Source != "" && req.MessageExtID != "" {
+		processed, err := aidb.IsCommandProcessed(ctx, string(req.Source), req.MessageExtID)
+		if err != nil {
+			return nil, err
+		}
+		if processed {
+			return &dashapi.SendExternalCommandResp{}, nil // Idempotent no-op.
+		}
+	}
+
 	var resp *dashapi.SendExternalCommandResp
 	var err error
 	if req.Upstream != nil {

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -448,6 +448,77 @@ func TestAIUpstreamTwice(t *testing.T) {
 	require.Contains(t, resp.Error, "a later stage public was already reported")
 }
 
+func TestAIUpstreamIdempotency(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
+		},
+	})
+
+	// Report a crash to create a bug.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// Register workflow and create a job.
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+	jobID := c.createAIJob(extID, string(ai.WorkflowPatching), "")
+
+	// Mark job as done.
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"PatchDescription": "Test Subject\n\nTest Body",
+			"PatchDiff":        "diff",
+		},
+	})
+	require.NoError(t, err)
+
+	// Poll and confirm report for "moderation" stage.
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{
+		Source: "lore",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pollResp.Result)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollResp.Result.ID,
+		PublishedExtID: "msg-id-moderation",
+	})
+	require.NoError(t, err)
+
+	// Upstream the result.
+	resp, err := c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID:    "msg-id-moderation",
+		MessageExtID: "command-msg-id",
+		Source:       "lore",
+		Upstream:     &dashapi.UpstreamCommand{},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Error)
+
+	// Upstream the result again with the same MessageExtID. Should be an idempotent success.
+	resp, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID:    "msg-id-moderation",
+		MessageExtID: "command-msg-id",
+		Source:       "lore",
+		Upstream:     &dashapi.UpstreamCommand{},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Error)
+}
+
 func TestAINoStages(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -1100,6 +1100,23 @@ func AddJournalEntry(ctx context.Context, entry *Journal) error {
 	return err
 }
 
+func IsCommandProcessed(ctx context.Context, source, sourceExtID string) (bool, error) {
+	if source == "" || sourceExtID == "" {
+		return false, nil
+	}
+	res, err := selectAll[Journal](ctx, spanner.Statement{
+		SQL: selectJournal() + `WHERE Source = @source AND SourceExtID = @sourceExtID LIMIT 1`,
+		Params: map[string]any{
+			"source":      source,
+			"sourceExtID": sourceExtID,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(res) > 0, nil
+}
+
 func LoadJobJournal(ctx context.Context, jobID string) ([]*Journal, error) {
 	return selectAll[Journal](ctx, spanner.Statement{
 		SQL: selectJournal() + `WHERE JobID = @jobID ORDER BY Date DESC`,


### PR DESCRIPTION
When handling external AI report commands (e.g. #syz upstream), the idempotency logic previously resided inside individual database transactions (e.g. aidb.UpstreamReportCommand). This meant that state checks—such as determining if a bug had already advanced to the next stage—were performed *before* checking if the exact command was a duplicate retry.

As a result, if lore-relay restarted and retried an identical command, the dashboard threw a "cannot proceed to next stage" error rather than correctly ignoring it as an idempotent no-op.

Move the idempotency check up to the apiAIReportCommand entry point. By querying the Journal for the specific Source and SourceExtID first, the system now safely returns early for all duplicate AI commands, preventing spurious failure replies.