### PR TITLE
pkg/aflow: harden llm_agent context compression mode

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -295,12 +295,23 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 	// a new summary.
 	var summaryMessage *genai.Content
 	var lastInputTokens int
+	var anchorTokens int
 	for range defaultMaxIterations {
 		var err error
 		var newSummaryMessage *genai.Content
-		req, newSummaryMessage, lastInputTokens, err = a.maybeCompressContext(ctx, req, instruction, lastInputTokens)
+		var compressed bool
+		tokensToCompress := max(0, lastInputTokens-anchorTokens)
+		req, newSummaryMessage, compressed, err = a.maybeCompressContext(
+			ctx, req, instruction, tokensToCompress)
 		if err != nil {
 			return "", nil, err
+		}
+		if compressed {
+			// Reset tokens to 0 so that if the main API call fails (e.g., token overflow)
+			// and the loop retries via `continue`, it doesn't immediately try to
+			// compress the already-compressed context again. The real token count
+			// will be fetched from the next successful API response.
+			lastInputTokens = 0
 		}
 		if newSummaryMessage != nil || a.CompressTokens > 0 {
 			// If compression happened, reset the existing summaryMessage to nil (or the new one)
@@ -321,6 +332,9 @@ func (a *LLMAgent) chat(ctx *Context, cfg *genai.GenerateContentConfig, tools ma
 
 		if resp != nil && resp.UsageMetadata != nil {
 			lastInputTokens = int(resp.UsageMetadata.PromptTokenCount)
+			if anchorTokens == 0 {
+				anchorTokens = lastInputTokens
+			}
 		}
 
 		if respErr != nil {
@@ -488,21 +502,21 @@ func (a *LLMAgent) compressContext(ctx *Context, req []*genai.Content, instructi
 	return newSummary, ctx.finishSpan(span, nil)
 }
 
-func (a *LLMAgent) maybeCompressContext(ctx *Context, req []*genai.Content, instruction string, lastInputTokens int) (
-	[]*genai.Content, *genai.Content, int, error) {
-	if a.CompressTokens == 0 || lastInputTokens <= a.CompressTokens {
+func (a *LLMAgent) maybeCompressContext(ctx *Context, req []*genai.Content, instruction string, tokensToCompress int) (
+	[]*genai.Content, *genai.Content, bool, error) {
+	if a.CompressTokens == 0 || tokensToCompress <= a.CompressTokens {
 		// Return existing state unchanged.
-		return req, nil, lastInputTokens, nil
+		return req, nil, false, nil
 	}
 
 	newSummary, err := a.compressContext(ctx, req, instruction)
 	if err != nil {
-		return req, nil, lastInputTokens, fmt.Errorf("context compression failed: %w", err)
+		return req, nil, false, fmt.Errorf("context compression failed: %w", err)
 	}
 
 	// Truncate history to Anchor + Summary.
 	req = []*genai.Content{req[0], newSummary}
-	return req, nil, 0, nil
+	return req, nil, true, nil
 }
 
 func (a *LLMAgent) slide(req []*genai.Content, summary *genai.Content) ([]*genai.Content, bool) {

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -260,24 +260,16 @@ func TestTokenCompression(t *testing.T) {
 			},
 		},
 		[]any{
-			// 1. Initial request. Return a tool call and claim we exceeded the token threshold (150 > 100).
-			&genai.GenerateContentResponse{
-				UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
-					PromptTokenCount:     150,
-					CandidatesTokenCount: 10,
-				},
-				Candidates: []*genai.Candidate{{
-					Content: &genai.Content{
-						Parts: []*genai.Part{
-							{FunctionCall: &genai.FunctionCall{ID: "id1", Name: "tick"}},
-						},
-						Role: genai.RoleModel,
-					}}}},
-			// 2. The loop detects threshold exceeded and invokes compressContext (Flash model).
+			// 1. Initial request. Return a tool call and establish the anchor token count.
+			createToolCallResponse(150, "id1", "tick"),
+			// 2. Second request. Return another tool call and report total tokens 260.
+			// This means delta = 260 - 150 = 110. Since 110 > CompressTokens (100), compression triggers!
+			createToolCallResponse(260, "id2", "tick"),
+			// 3. The loop detects threshold exceeded and invokes compressContext (Flash model).
 			// We return the compressed summary.
 			&genai.GenerateContentResponse{
 				UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
-					PromptTokenCount:     150,
+					PromptTokenCount:     260,
 					CandidatesTokenCount: 10,
 				},
 				Candidates: []*genai.Candidate{{
@@ -285,7 +277,7 @@ func TestTokenCompression(t *testing.T) {
 						Parts: []*genai.Part{genai.NewPartFromText("compressed summary")},
 						Role:  genai.RoleModel,
 					}}}},
-			// 3. The main agent resumes with the truncated history. We finish the workflow.
+			// 4. The main agent resumes with the truncated history. We finish the workflow.
 			func(model string, cfg *genai.GenerateContentConfig, req []*genai.Content) (*genai.GenerateContentResponse, error) {
 				// Assert that the history was correctly truncated!
 				assert.Equal(t, 2, len(req), "History should be truncated to just Anchor and Summary")
@@ -310,6 +302,22 @@ func TestTokenCompression(t *testing.T) {
 		},
 		nil,
 	)
+}
+
+func createToolCallResponse(tokens int32, id, name string) *genai.GenerateContentResponse {
+	return &genai.GenerateContentResponse{
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     tokens,
+			CandidatesTokenCount: 10,
+		},
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{FunctionCall: &genai.FunctionCall{ID: id, Name: name}},
+				},
+				Role: genai.RoleModel,
+			}}},
+	}
 }
 
 func TestSetResultsToolIsNotLast(t *testing.T) {

--- a/pkg/aflow/testdata/TestTokenCompression.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompression.llm.json
@@ -59,6 +59,44 @@
 	},
 	{
 		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Initial Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"name": "tick",
+							"response": {
+								"ResFoo": 123
+							}
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
 		"Config": {
 			"systemInstruction": {
 				"parts": [
@@ -99,6 +137,31 @@
 					{
 						"functionResponse": {
 							"id": "id1",
+							"name": "tick",
+							"response": {
+								"ResFoo": 123
+							}
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id2",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id2",
 							"name": "tick",
 							"response": {
 								"ResFoo": 123

--- a/pkg/aflow/testdata/TestTokenCompression.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompression.trajectory.json
@@ -57,38 +57,75 @@
 		"Seq": 4,
 		"Nesting": 2,
 		"Type": "llm",
-		"Name": "token_compression_agent-compressor",
-		"Model": "gemini-3-flash-preview",
+		"Name": "token_compression_agent",
+		"Model": "model",
 		"Started": "0001-01-01T00:00:07Z"
 	},
 	{
 		"Seq": 4,
 		"Nesting": 2,
 		"Type": "llm",
-		"Name": "token_compression_agent-compressor",
-		"Model": "gemini-3-flash-preview",
+		"Name": "token_compression_agent",
+		"Model": "model",
 		"Started": "0001-01-01T00:00:07Z",
 		"Finished": "0001-01-01T00:00:08Z",
-		"Reply": "compressed summary",
-		"InputTokens": 150,
+		"InputTokens": 260,
 		"OutputTokens": 10
 	},
 	{
 		"Seq": 5,
 		"Nesting": 2,
-		"Type": "llm",
-		"Name": "token_compression_agent",
-		"Model": "model",
+		"Type": "tool",
+		"Name": "tick",
 		"Started": "0001-01-01T00:00:09Z"
 	},
 	{
 		"Seq": 5,
 		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Results": {
+			"ResFoo": 123
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent-compressor",
+		"Model": "gemini-3-flash-preview",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent-compressor",
+		"Model": "gemini-3-flash-preview",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"Reply": "compressed summary",
+		"InputTokens": 260,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
 		"Type": "llm",
 		"Name": "token_compression_agent",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:09Z",
-		"Finished": "0001-01-01T00:00:10Z",
+		"Started": "0001-01-01T00:00:13Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "token_compression_agent",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
 		"InputTokens": 20,
 		"OutputTokens": 10
 	},
@@ -99,7 +136,7 @@
 		"Name": "token_compression_agent",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Finished": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:15Z",
 		"Instruction": "Instructions\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "Initial Prompt",
 		"Reply": "Done"
@@ -110,7 +147,7 @@
 		"Type": "flow",
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
-		"Finished": "0001-01-01T00:00:12Z",
+		"Finished": "0001-01-01T00:00:16Z",
 		"Results": {
 			"Reply": "Done"
 		}


### PR DESCRIPTION
The previous compression logic calculated token limits based on the total number of input tokens, which included the anchor prompt. For workflows with massive initial prompts (e.g. ones with large C reproducers), this would result in the context threshold being exceeded immediately, causing continuous and infinite context compression loops.

Update the maybeCompressContext logic to establish an 'anchorTokens' baseline from the first response. In subsequent turns, only evaluate the token delta against the CompressTokens threshold, effectively only counting tokens added after the first prompt. Update tests and golden trajectories to reflect the new delta-based tracking behavior.