### PR TITLE
syz-agent: use a smaller disk cache size

### DIFF
--- a/syz-agent/k8s/overlays/prod-agent/agent-config.json
+++ b/syz-agent/k8s/overlays/prod-agent/agent-config.json
@@ -13,5 +13,5 @@
     "cmdline": "root=/dev/sda1",
     "qemu_args": "-machine q35 -enable-kvm -smp 2,sockets=2,cores=1"
   },
-  "cache_size": 500000000000
+  "cache_size": 350000000000
 }


### PR DESCRIPTION
The previous limit was too close to the total disk capacity. Also, the way we calculate it seems to be not 100% precise, so let's have a larger margin.