### PR TITLE
pkg/osutil: fix DiskUsage to report actual disk usage

### DIFF
--- a/pkg/aflow/cache.go
+++ b/pkg/aflow/cache.go
@@ -4,7 +4,6 @@
 package aflow
 
 import (
-	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -90,6 +89,7 @@ func (c *Cache) Create(typ, desc string, populate func(string) error) (string, e
 			return "", err
 		}
 		meta := cacheMeta{
+			Version:     currentCacheVersion,
 			Description: desc,
 			DiskUsage:   size,
 		}
@@ -194,16 +194,15 @@ func (c *Cache) init() error {
 			}
 			return err
 		}
-		var meta cacheMeta
-		if err := json.Unmarshal(data, &meta); err != nil {
-			// Assume the old format that contained just the description.
-			// This code can be removed after 2027-06-01,
-			// and the code above can use osutil.ReadJSON.
+		meta, err := osutil.ParseJSON[cacheMeta](data)
+		if err != nil || meta.Version != currentCacheVersion {
+			// An older metadata format, update it to the current version.
 			size, err := osutil.DiskUsage(dir)
 			if err != nil {
 				return err
 			}
-			meta.Description = string(data)
+			// Assume meta.Description is present.
+			meta.Version = currentCacheVersion
 			meta.DiskUsage = size
 			if err := osutil.WriteJSON(metaFile, meta); err != nil {
 				return err
@@ -263,8 +262,12 @@ func (c *Cache) logf(msg string, args ...any) {
 }
 
 type cacheMeta struct {
+	Version     int
 	Description string
 	DiskUsage   uint64
 }
 
-const cacheMetaFile = "aflow-meta"
+const (
+	cacheMetaFile       = "aflow-meta"
+	currentCacheVersion = 1
+)

--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -165,5 +165,14 @@ func prolongPipe(r, w *os.File) {
 
 func sysDiskUsage(info fs.FileInfo) uint64 {
 	stat := info.Sys().(*syscall.Stat_t)
-	return uint64(max(0, stat.Size, stat.Blocks*512))
+	blocks := uint64(max(0, stat.Blocks))
+	if blocks == 0 && stat.Size > 0 && (info.Mode().IsRegular() || info.IsDir()) {
+		// This is what du does in this case: small files stored inline, still take some blocks.
+		blksize := uint64(stat.Blksize)
+		if blksize == 0 {
+			blksize = 4096
+		}
+		return (uint64(stat.Size) + blksize - 1) / blksize * blksize
+	}
+	return blocks * 512
 }

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -162,15 +162,16 @@ func TestDiskUsage(t *testing.T) {
 	dir := t.TempDir()
 	var currentUsage uint64
 	expectUsage := func(minIncrease, maxIncrease uint64) {
+		t.Helper()
 		usage, err := DiskUsage(dir)
 		if err != nil {
 			t.Fatal(err)
 		}
 		expectMin := currentUsage + minIncrease
 		expectMax := currentUsage + maxIncrease
-		t.Logf("got usage %v when expected (%v, %v)", usage, expectMin, expectMax)
-		if usage <= expectMin || usage >= expectMax {
-			t.Fatalf("bad usage %v, expect (%v, %v)", usage, expectMin, expectMax)
+		t.Logf("got usage %v when expected [%v, %v]", usage, expectMin, expectMax)
+		if usage < expectMin || usage > expectMax {
+			t.Fatalf("bad usage %v, expect [%v, %v]", usage, expectMin, expectMax)
 		}
 		currentUsage = usage
 	}
@@ -191,12 +192,12 @@ func TestDiskUsage(t *testing.T) {
 	if err := os.Symlink(filepath.Join(dir, "nested"), filepath.Join(dir, "dirlink")); err != nil {
 		t.Fatal(err)
 	}
-	expectUsage(1, 1<<10)
+	expectUsage(0, 1<<10)
 
 	if err := os.Symlink(filepath.Join(dir, "nested", "bar"), filepath.Join(dir, "filelink")); err != nil {
 		t.Fatal(err)
 	}
-	expectUsage(1, 1<<10)
+	expectUsage(0, 1<<10)
 }
 
 func TestVerboseMessage(t *testing.T) {


### PR DESCRIPTION
Update osutil.DiskUsage on Linux to match the size calculation logic of the du utility.

Previously, the disk usage logic incorrectly computed the size by using max(stat.Size, stat.Blocks * 512). For files where stat.Blocks is 0 (e.g. inline files on btrfs or some pseudo-filesystems), this would return stat.Size instead of the allocated block size.

To accurately match GNU du's fallback behavior, we check if Blocks is 0 and the file is a regular file or directory. If so, we round up the apparent size to the filesystem's block size. Otherwise, we strictly use stat.Blocks * 512.

Also update TestDiskUsage to correctly reflect that fast symlinks may consume 0 allocated blocks.

Also update pkg/aflow cache metadata to reflect updated size.
