### PR TITLE
dashboard/app: add with_repro and with_ai_patch filters

### DIFF
--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1681,3 +1681,99 @@ func TestAIPatchIterationEmptyResult(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, resp2.ID)
 }
+
+func TestAIPatchFilter(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig(&AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
+		},
+	})
+
+	// 1. Setup bug and job.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	crash.Title = "test crash title"
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	reply, err := c.AuthGET(AccessAdmin, "/ains")
+	c.expectOK(err)
+	require.Contains(t, string(reply), crash.Title)
+
+	// Initially, the bug shouldn't be visible in the with_ai_patch filter.
+	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")
+	c.expectOK(err)
+	require.NotContains(t, string(reply), crash.Title)
+
+	_, err = c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	jobID := c.createAIJob(extID, "patching", "")
+
+	// Poll to mark the job as started.
+	_, err = c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"PatchDescription": "Test Subject\n\nTest Body",
+			"PatchDiff":        "diff",
+			"KernelRepo":       "exact-repo",
+			"KernelBranch":     "exact-branch",
+			"KernelCommit":     "exact-commit",
+		},
+	})
+	require.NoError(t, err)
+
+	job, err := aidb.LoadJob(c.ctx, jobID)
+	require.NoError(t, err)
+	bugIDs, err := aidb.LoadBugIDsWithPendingPatch(c.ctx, job.Namespace, []ai.WorkflowType{ai.WorkflowPatching})
+	require.NoError(t, err)
+	require.Len(t, bugIDs, 1)
+
+	// Now it should be visible!
+	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")
+	c.expectOK(err)
+	require.Contains(t, string(reply), crash.Title)
+
+	// Poll and confirm report for "moderation" stage.
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{
+		Source: "lore",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pollResp.Result)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollResp.Result.ID,
+		PublishedExtID: "msg-id-moderation",
+	})
+	require.NoError(t, err)
+
+	// Issue an upstream command.
+	respCmd, err := c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID: "msg-id-moderation",
+		Upstream:  &dashapi.UpstreamCommand{},
+		Source:    "lore",
+	})
+	require.NoError(t, err)
+	require.Empty(t, respCmd.Error)
+
+	// Now it should no longer be visible!
+	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")
+	c.expectOK(err)
+	require.NotContains(t, string(reply), crash.Title)
+}

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -324,6 +324,40 @@ func LoadBugJobs(ctx context.Context, bugID string) ([]*Job, error) {
 	})
 }
 
+func LoadBugIDsWithPendingPatch(ctx context.Context, ns string, workflows []ai.WorkflowType) ([]string, error) {
+	if len(workflows) == 0 {
+		return nil, nil
+	}
+	var types []string
+	for _, w := range workflows {
+		types = append(types, string(w))
+	}
+	type result struct {
+		BugID string
+	}
+	items, err := selectAll[result](ctx, spanner.Statement{
+		SQL: `SELECT DISTINCT BugID FROM Jobs
+	WHERE Namespace = @ns
+	AND Type IN UNNEST(@types)
+	AND Correct IS NULL AND BugID IS NOT NULL
+	AND Finished IS NOT NULL
+	AND Error = ''
+	AND JSON_VALUE(Results, '$.PatchDiff') > ''`,
+		Params: map[string]any{
+			"ns":    ns,
+			"types": types,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var ret []string
+	for _, item := range items {
+		ret = append(ret, item.BugID)
+	}
+	return ret, nil
+}
+
 func LoadBugJobReportings(ctx context.Context, bugID string) ([]*JobReporting, error) {
 	return selectAll[JobReporting](ctx, spanner.Statement{
 		SQL: selectJobReporting() + ` WHERE JobID IN (SELECT ID FROM Jobs WHERE BugID = @bugID) ORDER BY CreatedAt DESC`,

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -23,6 +23,7 @@ import (
 	"cloud.google.com/go/logging/logadmin"
 	"github.com/google/syzkaller/dashboard/app/aidb"
 	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/pkg/hash"
@@ -117,6 +118,7 @@ type uiMainPage struct {
 type uiBugFilter struct {
 	Filter  *userBugFilter
 	DropURL func(string, string) string
+	SetURL  func(string, string) string
 }
 
 func makeUIBugFilter(ctx context.Context, filter *userBugFilter) *uiBugFilter {
@@ -125,6 +127,9 @@ func makeUIBugFilter(ctx context.Context, filter *userBugFilter) *uiBugFilter {
 		Filter: filter,
 		DropURL: func(name, value string) string {
 			return urlutil.DropParam(url, name, value)
+		},
+		SetURL: func(name, value string) string {
+			return urlutil.SetParam(url, name, value)
 		},
 	}
 }
@@ -497,6 +502,33 @@ type userBugFilter struct {
 	OnlyManager string // show bugs that happened ONLY on the manager
 	Labels      []string
 	NoSubsystem bool
+	WithRepro   bool
+	WithAIPatch bool
+
+	HasAI                    bool
+	BugsWithPendingAIPatches map[string]bool
+}
+
+func (filter *userBugFilter) InitializeAI(ctx context.Context, ns string) error {
+	if filter == nil {
+		return nil
+	}
+	filter.HasAI = getNsConfig(ctx, ns).AI != nil
+	if !filter.WithAIPatch {
+		return nil
+	}
+	bugIDs, err := aidb.LoadBugIDsWithPendingPatch(ctx, ns, []ai.WorkflowType{
+		ai.WorkflowPatching,
+		ai.WorkflowPatchIteration,
+	})
+	if err != nil {
+		return err
+	}
+	filter.BugsWithPendingAIPatches = make(map[string]bool)
+	for _, id := range bugIDs {
+		filter.BugsWithPendingAIPatches[id] = true
+	}
+	return nil
 }
 
 func MakeBugFilter(r *http.Request) (*userBugFilter, error) {
@@ -508,6 +540,8 @@ func MakeBugFilter(r *http.Request) (*userBugFilter, error) {
 		Manager:     r.FormValue("manager"),
 		OnlyManager: r.FormValue("only_manager"),
 		Labels:      r.Form["label"],
+		WithRepro:   r.FormValue("with_repro") != "",
+		WithAIPatch: r.FormValue("with_ai_patch") != "",
 	}, nil
 }
 
@@ -526,9 +560,15 @@ func (filter *userBugFilter) ManagerName() string {
 	return ""
 }
 
-func (filter *userBugFilter) MatchBug(bug *Bug) bool {
+func (filter *userBugFilter) MatchBug(ctx context.Context, bug *Bug) bool {
 	if filter == nil {
 		return true
+	}
+	if filter.WithRepro && bug.ReproLevel == dashapi.ReproLevelNone {
+		return false
+	}
+	if filter.WithAIPatch && !filter.BugsWithPendingAIPatches[bug.keyHash(ctx)] {
+		return false
 	}
 	if filter.OnlyManager != "" && (len(bug.HappenedOn) != 1 || bug.HappenedOn[0] != filter.OnlyManager) {
 		return false
@@ -561,7 +601,9 @@ func (filter *userBugFilter) Any() bool {
 	if filter == nil {
 		return false
 	}
-	return len(filter.Labels) > 0 || filter.OnlyManager != "" || filter.Manager != "" || filter.NoSubsystem
+	return len(filter.Labels) > 0 || filter.OnlyManager != "" ||
+		filter.Manager != "" || filter.NoSubsystem ||
+		filter.WithRepro || filter.WithAIPatch
 }
 
 // handleMain serves main page.
@@ -574,6 +616,9 @@ func handleMain(ctx context.Context, w http.ResponseWriter, r *http.Request) err
 	filter, err := MakeBugFilter(r)
 	if err != nil {
 		return fmt.Errorf("%w: failed to parse URL parameters", ErrClientBadRequest)
+	}
+	if err := filter.InitializeAI(ctx, hdr.Namespace); err != nil {
+		return err
 	}
 	managers, err := CachedUIManagers(ctx, accessLevel, hdr.Namespace, filter)
 	if err != nil {
@@ -1899,7 +1944,7 @@ func loadVisibleBugs(ctx context.Context, ns string, bugFilter *userBugFilter) (
 	}
 	var filteredBugs []*Bug
 	for _, bug := range bugs {
-		if bugFilter.MatchBug(bug) {
+		if bugFilter.MatchBug(ctx, bug) {
 			filteredBugs = append(filteredBugs, bug)
 		}
 	}
@@ -1948,7 +1993,7 @@ func fetchTerminalBugs(ctx context.Context, accessLevel AccessLevel,
 		if accessLevel < bug.sanitizeAccess(ctx, accessLevel) {
 			continue
 		}
-		if !typ.Filter.MatchBug(bug) {
+		if !typ.Filter.MatchBug(ctx, bug) {
 			continue
 		}
 		uiBug := createUIBug(ctx, bug, state, managers)

--- a/dashboard/app/main_test.go
+++ b/dashboard/app/main_test.go
@@ -164,7 +164,7 @@ func TestSubsystemFilterTerminal(t *testing.T) {
 }
 
 func TestMainBugFilters(t *testing.T) {
-	c := NewCtx(t)
+	c := NewSpannerCtx(t)
 	defer c.Close()
 
 	client := c.client
@@ -192,6 +192,16 @@ func TestMainBugFilters(t *testing.T) {
 	reply, err = c.AuthGET(AccessAdmin, "/test1?no_subsystem=true")
 	c.expectOK(err)
 	assert.Contains(t, string(reply), crash1.Title) // the bug has no subsystems
+
+	reply, err = c.AuthGET(AccessAdmin, "/test1?with_repro=true")
+	c.expectOK(err)
+	assert.NotContains(t, string(reply), crash1.Title) // the bug has no repro
+	assert.Contains(t, string(reply), "Applied filters")
+
+	reply, err = c.AuthGET(AccessAdmin, "/test1?with_ai_patch=true")
+	c.expectOK(err)
+	assert.NotContains(t, string(reply), crash1.Title) // the bug has no pending AI patch
+	assert.Contains(t, string(reply), "Applied filters")
 }
 
 func TestSubsystemsList(t *testing.T) {

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -150,9 +150,25 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{if .Filter.NoSubsystem}}
 		NoSubsystem={{.Filter.NoSubsystem}} ({{link (call .DropURL "no_subsystem" "") "drop"}})
 	{{end}}
+	{{if .Filter.WithRepro}}
+		WithRepro ({{link (call .DropURL "with_repro" "") "drop"}})
+	{{end}}
+	{{if .Filter.WithAIPatch}}
+		WithAIPatch ({{link (call .DropURL "with_ai_patch" "") "drop"}})
+	{{end}}
 	{{$drop := .DropURL}}
 	{{range .Filter.Labels}}
 		Label={{.}} ({{link (call $drop "label" .) "drop"}})
+	{{end}}
+	<br>
+{{end}}
+{{if or (not .Filter.WithRepro) (and .Filter.HasAI (not .Filter.WithAIPatch))}}
+	<b>Extra filters: </b>
+	{{if not .Filter.WithRepro}}
+		[{{link (call .SetURL "with_repro" "true") "With Repro"}}]
+	{{end}}
+	{{if and .Filter.HasAI (not .Filter.WithAIPatch)}}
+		[{{link (call .SetURL "with_ai_patch" "true") "With AI Patch Pending Review"}}]
 	{{end}}
 	<br>
 {{end}}


### PR DESCRIPTION
Add two new filtering options for the bug list in the dashboard:
- with_repro=true to only show bugs that have a reproducer
- with_ai_patch=true to only show bugs with an AI patch pending review

For the AI patch filter, userBugFilter.Initialize() performs a Spanner query to prefetch bugs that have active patching or patch iteration jobs that have finished successfully, contain an actual patch (JSON_VALUE(Results, '$.PatchDiff') > ''), and are not marked as approved or rejected (Correct IS NULL).

The filters are displayed in the "Applied filters" and "Extra filters" sections in the UI, allowing users to easily toggle them.