### PR TITLE
syz-agent: supply StraceBin to AI workflows

### DIFF
--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -327,6 +327,7 @@ func initState(cfg *Config, syzkallerDir string) map[string]any {
 		"Image":        cfg.Image,
 		"Type":         cfg.Type,
 		"VM":           cfg.VM,
+		"StraceBin":    cfg.StraceBin,
 		"KernelConfig": cfg.kernelConfigData,
 	}
 }

--- a/syz-agent/agent/config.go
+++ b/syz-agent/agent/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Image           string          `json:"image"`
 	Type            string          `json:"type"`
 	VM              json.RawMessage `json:"vm"`
+	StraceBin       string          `json:"strace_bin"`
 	CacheSize       uint64          `json:"cache_size"`
 	Model           string          `json:"model"`
 	Workflows       []string        `json:"workflows"`


### PR DESCRIPTION
dashboard/app AI jobs currently fail with 'flow inputs are missing: patching.Inputs: field "StraceBin" is not present when converting map' because the patching workflow expects StraceBin in its inputs.

Since StraceBin is an infrastructure-specific setting (similar to Image and Type), it should be supplied by syz-agent.

Add StraceBin to the syz-agent configuration and include it in the initial state used when executing AI jobs. Also add StraceBin as a hidden field in the manual AI workflow definitions in dashboard/app.

***

Closes https://github.com/google/syzkaller/issues/7290