### PR TITLE
syz-cluster: unconditionally ignore unknown polled emails

### DIFF
--- a/syz-cluster/email-reporter/email_workflow_test.go
+++ b/syz-cluster/email-reporter/email_workflow_test.go
@@ -167,6 +167,8 @@ From: Another User <c@example.com>
 To: Bot <bot@syzbot.com>
 Content-Type: text/plain
 
+Reported-by: bot+1234567890abcdef@syzbot.com
+
 #syz upstream
 `)
 		assert.NoError(t, poller.Poll(ctx, writeTo))

--- a/syz-cluster/email-reporter/handler.go
+++ b/syz-cluster/email-reporter/handler.go
@@ -205,9 +205,7 @@ func (h *Handler) ProcessPolledEmail(ctx context.Context, polled *lore.PolledEma
 		return fmt.Errorf("failed to record reply: %w", err)
 	}
 	if res.ReportID == "" {
-		if len(parsed.BugIDs) == 0 {
-			return ErrUnknownReport
-		}
+		return ErrUnknownReport
 	} else if !res.New {
 		log.Printf("email %q: already seen, skipping", parsed.MessageID)
 		return nil


### PR DESCRIPTION
When polling mailing lists, pkg/email extracts any BugIDs from the email body (e.g., upstream syzbot hashes). Since stripContextPrefix leaves unrecognized IDs intact, parsed.BugIDs can be non-empty for unrelated emails.

Previously, ProcessPolledEmail mistakenly proceeded if parsed.BugIDs was not empty. This caused syz-cluster to react to commands under AI patches submitted by lore-relay with "Failed to process the command", even though those patches were not tracked by syz-cluster.

Fix this by unconditionally returning ErrUnknownReport whenever RecordReply cannot find the report in the database.