### PR TITLE
dashboard/app: move bisection info above AI blocks on bug page

### DIFF
--- a/dashboard/app/templates/bug.html
+++ b/dashboard/app/templates/bug.html
@@ -38,6 +38,14 @@ Page with details about a single bug.
 		{{end}}
 	{{end}}
 	First crash: {{formatLateness $.Now $.Bug.FirstTime}}, last: {{formatLateness $.Now $.Bug.LastTime}}<br>
+	{{if .Bug.FixCandidateJob}}
+		<div class="fix-candidate-block">{{template "bisect_results" .Bug.FixCandidateJob}}</div>
+	{{end}}
+	<div>
+		{{if .Bug.BisectCauseJob}}<div class="bug-bisection-info">{{template "bisect_results" .Bug.BisectCauseJob}}</div>{{end}}
+		{{if .Bug.BisectFixJob}}<div class="bug-bisection-info">{{template "bisect_results" .Bug.BisectFixJob}}</div>{{end}}
+		<div class="bug-bisection-stop"></div>
+	</div>
 	{{if .AIWorkflows}}
 		<form method="POST">
 			<select name="ai-job-create" onchange="displayAICreateJobArgs(this)">
@@ -84,14 +92,6 @@ Page with details about a single bug.
 			</div>
 		</div>
 	{{end}}
-	{{if .Bug.FixCandidateJob}}
-		<div class="fix-candidate-block">{{template "bisect_results" .Bug.FixCandidateJob}}</div>
-	{{end}}
-	<div>
-		{{if .Bug.BisectCauseJob}}<div class="bug-bisection-info">{{template "bisect_results" .Bug.BisectCauseJob}}</div>{{end}}
-		{{if .Bug.BisectFixJob}}<div class="bug-bisection-info">{{template "bisect_results" .Bug.BisectFixJob}}</div>{{end}}
-		<div class="bug-bisection-stop"></div>
-	</div>
 
 	{{range $item := .Sections}}
 	<div class="collapsible {{if $item.Show}}collapsible-show{{else}}collapsible-hide{{end}}">


### PR DESCRIPTION
Currently, on the /bug?extid= page, the bisection results are rendered below the AI-related blocks (AIWorkflows, PatchVersions, and AIJobs). This causes the bisection information to be awkwardly squeezed between these new AI collapsible blocks and the standard section collapsibles.

Reorder the HTML in dashboard/app/templates/bug.html so that the bisection information is displayed immediately after the general bug information and before any AI-related sections.
