### PR TITLE
pkg/aflow: restrict strace usage to c-repro workflow

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -45,6 +45,7 @@ type ReproduceArgs struct {
 	KernelCommit string
 	KernelConfig string
 	StraceBin    string
+	NeedStrace   bool
 }
 
 type reproduceResult struct {
@@ -100,7 +101,7 @@ func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestR
 	cfg.Image = args.Image
 	cfg.Type = args.Type
 	cfg.VM = vmCfg
-	if args.StraceBin != "" {
+	if args.NeedStrace && args.StraceBin != "" {
 		cfg.StraceBin = args.StraceBin
 		cfg.StraceBinOnTarget = false
 	}

--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -21,6 +21,7 @@ type RunCReproArgs struct {
 	KernelConfig    string
 	FormattedReproC string
 	StraceBin       string
+	NeedStrace      bool
 }
 
 type RunCReproResult struct {
@@ -59,7 +60,6 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	}
 
 	// Run 1: without strace.
-	reproduceArgs.StraceBin = ""
 	res1, err1 := RunTest(reproduceArgs, workdir, false)
 	if err1 != nil {
 		return RunCReproResult{}, err1
@@ -79,8 +79,8 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	}
 
 	// Run 2: with strace (only if first run didn't crash and didn't have boot error)
-	if !result.CandidateReproduced && result.TestError == "" && args.StraceBin != "" {
-		reproduceArgs.StraceBin = args.StraceBin
+	if !result.CandidateReproduced && result.TestError == "" && args.NeedStrace && args.StraceBin != "" {
+		reproduceArgs.NeedStrace = true
 		res2, err2 := RunTest(reproduceArgs, workdir, false)
 		if err2 != nil {
 			return result, err2 // Return what we had from Run 1, plus the error.

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -66,6 +66,9 @@ func createPatchIterationFlow(name string, summaryWindow, compressTokens int) *a
 	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools)
 	return &aflow.Flow{
 		Name: name,
+		Consts: map[string]any{
+			"NeedStrace": false,
+		},
 		Root: aflow.Pipeline(
 			// Setup base kernel for code tools.
 			baseCommitPicker,

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -50,6 +50,9 @@ func createPatchingFlow(name string, summaryWindow, compressTokens int) *aflow.F
 	commonTools := aflow.Tools(codesearcher.Tools, grepper.Tool, codeexpert.NewTool(compressTokens), gitlog.Tools)
 	return &aflow.Flow{
 		Name: name,
+		Consts: map[string]any{
+			"NeedStrace": false,
+		},
 		Root: aflow.Pipeline(
 			baseCommitPicker,
 			actionsyzlang.CreateSimplifiedCRepro,

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -42,6 +42,7 @@ func init() {
 				"DocProgramSyntax":             docs.ProgramSyntax,
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"ReproC":                       "", // is needed by crash.Reproduce
+				"NeedStrace":                   false,
 			},
 			Root: aflow.Pipeline(
 				kernel.Checkout,

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -286,7 +286,9 @@ func init() {
 		ai.WorkflowReproC,
 		"reproduce a kernel crash and generate a C reproducer",
 		&aflow.Flow{
-
+			Consts: map[string]any{
+				"NeedStrace": true,
+			},
 			Root: aflow.Pipeline(
 				kernel.Checkout,
 				kernel.Build,


### PR DESCRIPTION
The recent addition of strace to pkg/aflow enabled it for all workflows that run reproducers. However, we don't want strace enabled for patching and patch-iteration workflows since it blows up the LLM context and brings nothing of value to those workflows.

Introduce a NeedStrace boolean parameter to the Reproduce and RunCRepro actions. Explicitly set it to true in the c-repro workflow's Consts, and false in all other workflows (patching, patch-iteration, syz-repro). This ensures strace is only used when it's actively beneficial.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
