### PR TITLE
docs: add AI patches documentation

### DIFF
--- a/docs/syzbot_ai_patches.md
+++ b/docs/syzbot_ai_patches.md
@@ -1,0 +1,107 @@
+# syzbot AI patches
+
+`syzbot` automatically generates and sends patches for found bugs using AI.
+
+## The Intended Workflow
+
+syzbot's AI patch reporting follows a two-stage pipeline to refine the patch
+before publishing it to the wider community.
+
+### 1. Moderation Stage
+
+Newly generated patches are first sent to an internal moderation mailing list
+(`syzkaller-upstream-moderation@googlegroups.com`) where the bot actively
+listens and participates. You can:
+
+* Reply to the patch email with text comments to provide feedback and request
+changes. The AI model will read the comments and reply or send a new patch
+version (e.g. an RFC v2) if necessary.
+
+* Reject a fundamentally flawed patch:
+```
+#syz reject
+```
+You can provide the reason for rejection in the email body for better accounting.
+
+* Approve a patch and send it to the public list:
+```
+#syz upstream
+```
+
+### 2. Linux Kernel Mailing List (LKML)
+
+Once a patch is upstreamed from the moderation list, it is sent to the public
+LKML.
+
+**Note**: in this stage, the syzbot AI's automatic reaction to code review
+comments is currently disabled to avoid spamming the public mailing
+list. However, syzbot administrators actively monitor these patches and can
+manually force the agent to incorporate mailing list feedback and send newer
+versions.
+
+## System Invariants and Rules
+
+`syzbot` maintains strict rules about tracking and handling AI patches based on
+email replies.
+
+### Which patch version am I interacting with?
+
+Each patch version (e.g., v1, v2) is sent as a separate email thread. `syzbot`
+uses the `In-Reply-To` email header to identify exactly which version of the
+patch you are interacting with.
+
+You can reply to any patch version's thread, not just the latest one. Commands
+like `#syz upstream` or `#syz reject` will only apply to the specific version
+you are replying to.
+
+### Can I upstream multiple versions of the same patch?
+
+No. `syzbot` prevents upstreaming multiple patch iterations for the same bug
+simultaneously to avoid spamming the upstream list.
+
+If you upstream "v1" and later decide "v2" is better, an attempt to
+`#syz upstream` "v2" will be blocked. You must first reply to the previously
+upstreamed version ("v1") with:
+```
+#syz reject
+```
+Once rejected, the system clears the conflict, and you can successfully
+`#syz upstream` the new version.
+
+### What happens to my tags (Reviewed-by, Acked-by)?
+
+During the review process, reviewers often provide standard tags like
+`Reviewed-by:`, `Acked-by:`, `Tested-by:`, or `Reported-by:`.
+
+`syzbot` automatically parses and accumulates these tags from review comments.
+When a newer iteration of the patch is generated, these tags are reliably
+preserved and appended to the commit message's trailer.
+
+### Who gets the Signed-off-by tag?
+
+When you approve a patch by replying with `#syz upstream`, `syzbot` incorporates
+your email and name into a standard `Signed-off-by:` tag and appends it to the
+commit message when sending the patch to the next stage (e.g., LKML).
+
+If the patch goes through further iterations on the public list, this
+`Signed-off-by:` tag is preserved.
+
+### What happens if I reply without a command?
+
+If you reply to the patch without `#syz upstream` or `#syz reject`, your reply
+is simply recorded as a comment on that specific AI patch job in the dashboard.
+It does not advance or reject the patch on its own.
+
+**Note**: AI will evaluate your comment to decide if a new version is needed.
+Simply providing a tag (like `Reviewed-by`) will not trigger the generation of
+a new patch version on its own.
+
+### What are the requirements for upstreaming?
+
+The AI job must have successfully produced a patch. You cannot use
+`#syz upstream` on an AI run that only replied with a textual comment and no
+code changes.
+
+If you send `#syz upstream` and do not receive a reply, the command was
+processed successfully. The system does not reply back to confirm; it simply
+pushes the patch to the next reporting stage.

--- a/syz-agent/k8s/overlays/prod-lore/lore-relay-config.yaml
+++ b/syz-agent/k8s/overlays/prod-lore/lore-relay-config.yaml
@@ -10,6 +10,7 @@ own_emails:
   - "syzbot@kernel.org"
 lore_archive: "syzbot@lists.linux.dev"
 verify_dkim: true
+docs_link: "https://github.com/google/syzkaller/blob/master/docs/syzbot_ai_patches.md"
 smtp:
   host: "gcp-secret:lore-relay-smtp-host"
   port: "gcp-secret:lore-relay-smtp-port"


### PR DESCRIPTION
An initial version of the documentation we'll refer to at the bottom of
our patches.