### PR TITLE
dashboard/app: ignore commands if not explicitly addressed

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1530,3 +1530,27 @@ Author: someone@mail.com
 		assert.Contains(t, msg.Body, "I see the command but can't find the corresponding bug")
 	})
 }
+
+func TestEmailIndirectCommandIgnored(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.client2.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	c.client2.ReportCrash(crash)
+
+	msg := c.pollEmailBug()
+
+	// Simulate an email that is NOT addressed directly to syzbot, but contains
+	// a Reported-by tag (which provides the Bug ID) and a command.
+	// We expect the command to be ignored (no reply from syzbot).
+	body := "Some text\n\nReported-by: " + msg.Sender + "\n\n#syz upstream"
+	c.incomingEmail("patch-bot@kernel.org", body,
+		EmailOptFrom("someone@kernel.org"),
+		EmailOptCC([]string{"patch-bot@kernel.org", "test@syzkaller.com"}))
+
+	// No email should be sent back.
+	c.expectNoEmail()
+}

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -817,6 +817,12 @@ func handleBugCommand(ctx context.Context, bugInfo *bugInfoResult, msg *email.Em
 		CC:     msg.Cc,
 	}
 	if command != nil {
+		// If syzbot isn't explicitly CC'd (e.g., the command was sent to a mailing list
+		// and the Bug ID is only in the quoted email body), ignore all commands EXCEPT `#syz test`.
+		// This prevents dashboard/app from hijacking discussions meant for other bots (like lore-relay).
+		if command.Command != email.CmdTest && !msg.DirectlyAddressedTo(bugInfo.bugReporting.ID) {
+			return ""
+		}
 		switch command.Command {
 		case email.CmdTest:
 			return handleTestCommand(ctx, bugInfo, msg, command)

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -619,3 +619,12 @@ func extractBaseCommitHint(email string) string {
 	}
 	return ""
 }
+
+// DirectlyAddressedTo returns true if the specified bugID was explicitly mentioned
+// in the raw To/Cc headers of the email.
+func (email *Email) DirectlyAddressedTo(bugID string) bool {
+	return slices.ContainsFunc(email.RawCc, func(addr string) bool {
+		_, context, _ := RemoveAddrContext(addr)
+		return context == bugID
+	})
+}

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -1284,3 +1284,15 @@ base-commit: f8f97927abf7c12382dddc93a144fc9df7919b77 words after the hash are b
 		},
 	},
 }
+
+func TestDirectlyAddressedTo(t *testing.T) {
+	msg := &Email{
+		RawCc: []string{
+			"\"Name\" <user@example.com>",
+			"syzbot+12345hash@syzkaller.appspotmail.com",
+			"other@example.com",
+		},
+	}
+	assert.True(t, msg.DirectlyAddressedTo("12345hash"))
+	assert.False(t, msg.DirectlyAddressedTo("67890hash"))
+}


### PR DESCRIPTION
When lore-relay replies to discussions with AI patches containing `Reported-by: syzbot+hash@...`, users often reply `#syz upstream` intended for the lore-relay bot.

Because syzkaller-upstream-moderation is CC'd, dashboard/app receives the email. It finds the bug ID in the email body, assumes the command was meant for it, and then complains that it "Can't upstream, this is final destination." (or worse, might actually upstream a bug).

To prevent dashboard/app from hijacking discussions meant for other bots, ignore all commands (except `#syz test`) if syzbot is not explicitly CC'd with its unique `syzbot+hash@...` address.

Add the `pkg/email.Email.DirectlyAddressedTo` helper to correctly extract and check the address context from the RawCc headers.

Tests included.