### PR TITLE
dashboard/app: hide reply-only AI patch iterations from bug page

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1227,7 +1227,7 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 			aiJobs = append(aiJobs, makeUIAIJob(job))
 		}
 
-		patchVersions, err = getPatchVersions(ctx, bug)
+		patchVersions, err = getPatchVersions(ctx, bug, jobs)
 		if err != nil {
 			return err
 		}
@@ -2758,15 +2758,26 @@ func bugLink(id string) string {
 	return "/bug?id=" + id
 }
 
-func getPatchVersions(ctx context.Context, bug *Bug) ([]*uiPatchVersion, error) {
+func getPatchVersions(ctx context.Context, bug *Bug, jobs []*aidb.Job) ([]*uiPatchVersion, error) {
 	reportings, err := aidb.LoadBugJobReportings(ctx, bug.keyHash(ctx))
 	if err != nil {
 		return nil, err
+	}
+	jobMap := make(map[string]*aidb.Job)
+	for _, job := range jobs {
+		jobMap[job.ID] = job
 	}
 	var patchVersions []*uiPatchVersion
 	for _, r := range reportings {
 		if !r.Version.Valid {
 			continue
+		}
+		if job, ok := jobMap[r.JobID]; ok && job.Type == ai.WorkflowPatchIteration {
+			res, err := castJobResults[ai.PatchIterationOutputs](job)
+			if err == nil && res.PatchDiff == "" {
+				// Only show iterations that produced a new patch.
+				continue
+			}
 		}
 		patchVersions = append(patchVersions, &uiPatchVersion{
 			Version:  int(r.Version.Int64),


### PR DESCRIPTION
Currently, the bug page displays a new patch version for every AI patch iteration job that produces a reporting. However, some patch iterations only result in a reply comment and do not generate a new code patch. Since the JobReporting table does not explicitly distinguish between these outcomes, this causes "empty" patch versions to appear in the UI.

Fix this by explicitly checking the job results when loading patch versions. If a WorkflowPatchIteration job did not produce a PatchDiff, skip it so that only actual code patches are shown in the patch history list.