### PR TITLE
pkg/aflow: do context compression by default for patching jobs

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -245,8 +245,7 @@ func init() {
 	aflow.Register[PatchIterationInputs, ai.PatchIterationOutputs](
 		ai.WorkflowPatchIteration,
 		"address iterative feedback on generated patches",
-		createPatchIterationFlow("", 0, 0),
-		createPatchIterationFlow("compressed", 0, 200_000),
+		createPatchIterationFlow("", 0, 200_000),
 	)
 }
 

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -109,9 +109,8 @@ func init() {
 	aflow.Register[Inputs, ai.PatchingOutputs](
 		ai.WorkflowPatching,
 		"generate a kernel patch fixing a provided bug reproducer",
-		createPatchingFlow("", 0, 0),
+		createPatchingFlow("", 0, 200_000),
 		createPatchingFlow("summary", 10, 0),
-		createPatchingFlow("compressed", 0, 200_000),
 	)
 }
 


### PR DESCRIPTION
So far it seems to work reliably, plus it's our only change to prevent jobs from failing due to exhausting all context window. Let's make it the default.