### PR TITLE
pkg/email: limit Fixes tag commit hash to 12 characters

### DIFF
--- a/pkg/email/patch.go
+++ b/pkg/email/patch.go
@@ -83,7 +83,11 @@ func FormatPatchDescription(description string, data PatchTemplateData) string {
 	}
 	var fixesStr string
 	if data.Fixes.Hash != "" {
-		fixesStr = fmt.Sprintf("%v (\"%v\")", data.Fixes.Hash, data.Fixes.Title)
+		hash := data.Fixes.Hash
+		if len(hash) > 12 {
+			hash = hash[:12]
+		}
+		fixesStr = fmt.Sprintf("%v (\"%v\")", hash, data.Fixes.Title)
 	}
 	err := patchTemplate.Execute(buf, map[string]any{
 		"description": strings.TrimSpace(description),

--- a/pkg/email/patch_test.go
+++ b/pkg/email/patch_test.go
@@ -549,7 +549,7 @@ Something was broken. This fixes it.
 `,
 			baseCommit: "f5e343a447510a663fbf6215584a9bf8e03bfd5c",
 			fixes: ai.FixesTag{
-				Hash:  "9320daf2018f",
+				Hash:  "9320daf2018f12345678",
 				Title: "some old bug",
 			},
 			authors: []string{"syzbot@kernel.org"},


### PR DESCRIPTION
In AI patches generated and sent via lore-relay, the commit hash in the Fixes tag should be limited to 12 characters.

Update FormatPatchDescription to truncate the hash string if it exceeds this length to ensure consistent formatting. Update existing tests to verify the truncation behavior.

Closes https://github.com/google/syzkaller/issues/7306
