### PR TITLE
syz-agent: use bigger and more VMs

### DIFF
--- a/syz-agent/k8s/overlays/prod-agent/agent-config.json
+++ b/syz-agent/k8s/overlays/prod-agent/agent-config.json
@@ -9,8 +9,9 @@
   "strace_bin": "/opt/bin/strace",
   "type": "qemu",
   "vm": {
+    "count": 3,
     "cpu": 2,
-    "mem": 2048,
+    "mem": 8192,
     "cmdline": "root=/dev/sda1",
     "qemu_args": "-machine q35 -enable-kvm -smp 2,sockets=2,cores=1"
   },


### PR DESCRIPTION
Set VM count to 3 to run reproducers in parallel.
Increase RAM to 8GB to enable KMSAN kernels to boot.

Closes https://github.com/google/syzkaller/issues/7310