### PR TITLE
dashboard/app: say "default" instead of "latest RC" for patch creation

### DIFF
--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -99,6 +99,9 @@ var localUIConfig = &GlobalConfig{
 			DisplayTitle: "Linux",
 			AccessLevel:  AccessPublic,
 			AI: &AIConfig{
+				BaseRepository: "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+				BaseBranch:     "master",
+				BaseCommit:     "RC",
 				Stages: []AIPatchStageConfig{
 					{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 					{Name: "public", ServingIntegration: "lore", MailingList: "test@syzkaller.com"},
@@ -488,6 +491,21 @@ func populateLocalUIDB(t *testing.T, c *Ctx) {
 			PublishedExtID: "<mock-msg-2>",
 		})
 	}
+
+	// This should be last so that the app allows creation of all job types.
+	globalClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "agent-local-ui",
+		CodeRevision: "xxx",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatching, Name: string(ai.WorkflowPatching)},
+			{Type: ai.WorkflowModeration, Name: string(ai.WorkflowModeration)},
+			{Type: ai.WorkflowAssessmentKCSAN, Name: string(ai.WorkflowAssessmentKCSAN)},
+			{Type: ai.WorkflowPatchIteration, Name: string(ai.WorkflowPatchIteration)},
+			{Type: ai.WorkflowAssessmentSecurity, Name: string(ai.WorkflowAssessmentSecurity)},
+			{Type: ai.WorkflowRepro, Name: string(ai.WorkflowRepro)},
+			{Type: ai.WorkflowReproC, Name: string(ai.WorkflowReproC)},
+		},
+	})
 }
 
 // Advance the timer with random duration. Return the (copied) old time.

--- a/dashboard/app/templates/bug.html
+++ b/dashboard/app/templates/bug.html
@@ -47,9 +47,9 @@ Page with details about a single bug.
 				{{end}}
 			</select>
 			<span id="ai-set-base-commit" class="ai-create-job-args" style="display: none">
-				<input type="radio" name="base_commit_type" id="base_commit_latest" value="latest" checked
+				<input type="radio" name="base_commit_type" id="base_commit_default" value="default" checked
 					onchange="displayAICreateJobArgs()">
-				<label for="base_commit_latest">Latest RC</label>
+				<label for="base_commit_default">Default</label>
 				<input type="radio" name="base_commit_type" id="base_commit_custom" value="custom"
 					onchange="displayAICreateJobArgs()">
 				<label for="base_commit_custom">Custom commit</label>


### PR DESCRIPTION
- **pkg/aflow: restrict strace usage to c-repro workflow**
- **dashboard/app: say "default" instead of "latest RC" for patch creation**
