### PR TITLE
dashboard/app: only forward emails if syzbot is directly CC'd

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -1446,6 +1446,32 @@ Author: default@sender.com
 `)
 }
 
+func TestForwardNotDirect(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.makeClient(clientPublicEmail, keyPublicEmail, true)
+	c.updateReporting("access-public-email", "access-public-email-reporting1",
+		func(r Reporting) Reporting {
+			r.Config = &forwardEmailConfig
+			return r
+		})
+
+	build := testBuild(1)
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+
+	sender := c.pollEmailBug().Sender
+
+	// Send to one of the mailing lists, but only include the bug ID in the body.
+	c.incomingEmail("test@syzkaller.com", "Reported-by: "+sender+"\n\n#syz fix: some: commit title",
+		EmailOptCC(nil), EmailOptSubject("fix bug title"))
+
+	c.expectNoEmail()
+}
+
 func TestForwardEmailInbox(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -750,7 +750,8 @@ func processIncomingEmail(ctx context.Context, msg *email.Email) error {
 			replies = append(replies, handleBugCommand(ctx, bugInfo, msg, nil))
 		}
 		reply := groupEmailReplies(replies)
-		if reply == "" && len(msg.Commands) > 0 && len(missingLists) > 0 && !unCc {
+		if reply == "" && len(msg.Commands) > 0 && len(missingLists) > 0 &&
+			!unCc && msg.DirectlyAddressedTo(bugInfo.bugReporting.ID) {
 			return forwardEmail(ctx, msg, missingLists, nil, bugInfo.bugReporting.ID, bugInfo.bugReporting.ExtID)
 		}
 		if reply != "" {


### PR DESCRIPTION
Currently, syzbot forwards incoming command emails for archival purposes if a command is found but the mailing list is missing from the CC list. However, this forwarding also triggers if the bug ID is merely mentioned in the email body (e.g., via `Reported-by:`) rather than syzbot being explicitly addressed in the To/Cc headers. This happens with AI patches that mention syzbot bugs in the body, causing syzbot to incorrectly trigger and forward the emails.

Use `Email.DirectlyAddressedTo` in both `processIncomingEmail` and `processInboxEmail` to ensure archival forwarding only occurs if the bug ID was explicitly addressed in the email headers.

A test has been added to verify that command emails are not forwarded if the bug ID is not directly addressed.