### PR TITLE
pkg/email: add support for Closes tag

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1746,10 +1746,11 @@ func createGerritChange(ctx context.Context, job *aidb.Job) error {
 	res.Recipients = append(res.Recipients, ai.Recipient{Email: "stable@vger.kernel.org"})
 	// TODO: add a human who reviewed the patch to authors.
 	var links []string
+	var closes []string
 	var reportedBy []string
 	if job.BugID.Valid {
 		link, reporter := jobBugInfo(ctx, job.BugID)
-		links = append(links, link)
+		closes = append(closes, link)
 		if reporter != "" {
 			reportedBy = append(reportedBy, reporter)
 		}
@@ -1760,6 +1761,7 @@ func createGerritChange(ctx context.Context, job *aidb.Job) error {
 		Tools:      slices.Collect(maps.Keys(models)),
 		Recipients: res.Recipients,
 		Links:      links,
+		Closes:     closes,
 		ReportedBy: reportedBy,
 	})
 	changeID, link, err := gerrit.CreateChange(ctx, res.KernelRepo, res.KernelBranch,

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -283,15 +283,17 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 
 		if result.Patch != nil {
 			var links []string
+			var closes []string
 			if job.BugID.Valid {
 				link, reporter := jobBugInfo(ctx, job.BugID)
-				links = append(links, link)
+				closes = append(closes, link)
 				if reporter != "" && !slices.Contains(result.Patch.ReportedBy, reporter) {
 					result.Patch.ReportedBy = append([]string{reporter}, result.Patch.ReportedBy...)
 				}
 			}
 			links = append(links, fmt.Sprintf("%s/ai_job?id=%s", appURL(ctx), job.ID))
 			result.Patch.Links = links
+			result.Patch.Closes = closes
 		}
 
 		to := []string{stageCfg.MailingList}

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -107,7 +107,7 @@ func TestAILoreIntegration(t *testing.T) {
 	assert.Contains(t, body, "Fixes: 123456789012 (\"original bug\")")
 	assert.Contains(t, body, "Assisted-by: Gemini:gemini-3.1-pro-preview")
 	assert.NotContains(t, body, "Signed-off-by")
-	assert.Contains(t, body, "Link: "+appURL(c.ctx)+"/bug?extid="+extID)
+	assert.Contains(t, body, "Closes: "+appURL(c.ctx)+"/bug?extid="+extID)
 	assert.Contains(t, body, "Link: "+appURL(c.ctx)+"/ai_job?id="+jobID)
 	assert.Contains(t, body, "To: <maintainer@email.com>")
 	assert.Contains(t, body, "Cc: <reviewer@email.com>")

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -125,8 +125,10 @@ func TestAIExternalReporting(t *testing.T) {
 		BaseCommit: "commit",
 		BaseTree:   "repo",
 		Authors:    []string{"test-user"},
-		Links: []string{
+		Closes: []string{
 			appURL(c.ctx) + "/bug?extid=" + extID,
+		},
+		Links: []string{
 			appURL(c.ctx) + "/ai_job?id=" + jobID,
 		},
 		Fixes: ai.FixesTag{
@@ -864,8 +866,10 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 			BaseCommit: "repo_commit",
 			BaseTree:   "repo_url",
 			ReviewedBy: []string{"Test Reviewer <test@reviewer.com>"},
-			Links: []string{
+			Closes: []string{
 				appURL(c.ctx) + "/bug?extid=" + extID,
+			},
+			Links: []string{
 				appURL(c.ctx) + "/ai_job?id=" + resp.ID,
 			},
 		},

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -123,6 +123,7 @@ type NewReportResult struct {
 	BaseTree   string
 	Fixes      ai.FixesTag
 	Links      []string
+	Closes     []string
 	ReportedBy []string
 
 	ReviewedBy []string

--- a/pkg/email/patch.go
+++ b/pkg/email/patch.go
@@ -63,6 +63,7 @@ type PatchTemplateData struct {
 	Authors    []string
 	Recipients []ai.Recipient
 	Links      []string
+	Closes     []string
 	ReportedBy []string
 
 	ReviewedBy []string
@@ -97,6 +98,7 @@ func FormatPatchDescription(description string, data PatchTemplateData) string {
 		"to":          to,
 		"cc":          cc,
 		"links":       data.Links,
+		"closes":      data.Closes,
 		"reportedBy":  data.ReportedBy,
 		"reviewedBy":  data.ReviewedBy,
 		"ackedBy":     data.AckedBy,
@@ -127,6 +129,8 @@ Acked-by: {{$addr}}{{end}}
 Tested-by: {{$addr}}{{end}}
 {{- range $addr := .reportedBy}}
 Reported-by: {{$addr}}{{end}}
+{{- range $link := .closes}}
+Closes: {{$link}}{{end}}
 {{- range $link := .links}}
 Link: {{$link}}{{end}}
 {{- range $addr := .authors}}

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -64,6 +64,7 @@ func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 				Authors:    res.Patch.Authors,
 				Recipients: recipients,
 				Links:      res.Patch.Links,
+				Closes:     res.Patch.Closes,
 				ReportedBy: res.Patch.ReportedBy,
 				ReviewedBy: res.Patch.ReviewedBy,
 				AckedBy:    res.Patch.AckedBy,


### PR DESCRIPTION
Add a Closes field to PatchTemplateData in pkg/email/patch.go and render it before Link fields in the patch template.

Update dashboard/app and dashapi to pass the bug report link in the new Closes field instead of the existing Links array, which is now used only for the AI job link. This ensures generated patches properly use the "Closes:" tag for bug reports.
