### PR TITLE
dashboard/app: add export=1 parameter to export AI job inputs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -573,15 +573,35 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		CanSetCorrectness:  canSetCorrectness,
 		Reportings:         uiReportings,
 	}
+	if handled, err := handleAIJobPageJSON(ctx, w, r, job, uiJob, uiTrajectory, uiArgs); handled {
+		return err
+	}
+	return serveTemplate(w, "ai_job.html", page)
+}
+
+func handleAIJobPageJSON(ctx context.Context, w http.ResponseWriter, r *http.Request,
+	job *aidb.Job, uiJob *uiAIJob, uiTrajectory []*aflowhtml.UIAITrajectorySpan, uiArgs []*uiAIJobArg) (bool, error) {
 	if r.FormValue("json") == "1" {
 		w.Header().Set("Content-Type", "application/json")
-		return writeJSONVersionOf(w, &uiAIJobDetails{
+		return true, writeJSONVersionOf(w, &uiAIJobDetails{
 			Job:        uiJob,
 			Trajectory: uiTrajectory,
 			Args:       uiArgs,
 		})
 	}
-	return serveTemplate(w, "ai_job.html", page)
+	if r.FormValue("export") == "1" {
+		w.Header().Set("Content-Type", "application/json")
+		pollArgs, err := buildAIJobPollArgs(ctx, job)
+		if err != nil {
+			return true, err
+		}
+		return true, json.NewEncoder(w).Encode(&dashapi.AIJobPollResp{
+			ID:       job.ID,
+			Workflow: job.Workflow,
+			Args:     pollArgs,
+		})
+	}
+	return false, nil
 }
 
 func formatUIJobArgs(ctx context.Context, args map[string]any) ([]*uiAIJobArg, template.HTML, error) {
@@ -902,8 +922,21 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 	if job == nil {
 		return &dashapi.AIJobPollResp{}, nil
 	}
+	args, err := buildAIJobPollArgs(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dashapi.AIJobPollResp{
+		ID:       job.ID,
+		Workflow: job.Workflow,
+		Args:     args,
+	}, nil
+}
+
+func buildAIJobPollArgs(ctx context.Context, job *aidb.Job) (map[string]any, error) {
 	if !job.Args.Valid {
-		job.Args.Value = map[string]any{}
+		return map[string]any{}, nil
 	}
 	args := make(map[string]any)
 	var textErr error
@@ -954,11 +987,7 @@ func apiAIJobPoll(ctx context.Context, req *dashapi.AIJobPollReq) (any, error) {
 		args["PatchHistory"] = history
 	}
 
-	return &dashapi.AIJobPollResp{
-		ID:       job.ID,
-		Workflow: job.Workflow,
-		Args:     args,
-	}, nil
+	return args, nil
 }
 
 func pollAIJob(ctx context.Context, req *dashapi.AIJobPollReq, client APIClient) (*aidb.Job, error) {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -443,6 +444,14 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 	respJSON, err := c.GET(fmt.Sprintf("/ai_job?id=%v&json=1", resp.ID))
 	require.NoError(t, err)
 	require.Contains(t, string(respJSON), `"Trajectory"`)
+
+	// Verify export output.
+	respExportJSON, err := c.GET(fmt.Sprintf("/ai_job?id=%v&export=1", resp.ID))
+	require.NoError(t, err)
+	var exportResp dashapi.AIJobPollResp
+	require.NoError(t, json.Unmarshal(respExportJSON, &exportResp))
+	require.Equal(t, resp.ID, exportResp.ID)
+	require.Equal(t, string(ai.WorkflowAssessmentKCSAN), exportResp.Workflow)
 
 	// Since the job is not completed, setting correctness must fail.
 	values := url.Values{}


### PR DESCRIPTION
To re-run AI jobs locally (e.g. using tools/syz-aflow), we need a way to extract the full inputs exactly as they are passed to syz-agent. Currently, the "inputs" shown on the web dashboard don't include the fully resolved data, such as the full loaded comments or the complete patch history for patch-iteration jobs.

Extract the logic that constructs the syz-agent inputs from apiAIJobPoll into a reusable buildAIJobPollArgs function. Then, add support for an export=1 query parameter in handleAIJobPage. When this parameter is provided, the endpoint will now return the fully resolved job inputs in JSON format.