### PR TITLE
pkg/aflow: add structured IsProbe flag to guide Oracle classification

### DIFF
--- a/pkg/aflow/docs/c-repro-from-description.md
+++ b/pkg/aflow/docs/c-repro-from-description.md
@@ -23,22 +23,27 @@ The workflow is registered as `repro-c` and consists of a preprocessing phase fo
 3.  **Initial Research**: The `initial-researcher` agent analyzes the bug description and generates an initial reproduction strategy (`InitialReproStrategy`). It has access to codesearch and grep tools, as well as the toolkit query tool.
 
 ### Iterative Loop
-The workflow enters a `DoWhile` loop with a maximum of 5 iterations. The loop condition is controlled by `ContinueSignal`.
+The workflow enters a `DoWhile` loop with a maximum of 20 iterations. The loop condition is controlled by `ContinueSignal`.
 
 In each iteration, the following steps are executed:
 1.  **Strategy Refinement**: If `OracleFeedback` is available (from previous iterations), the `strategy-refiner` agent is invoked to update the strategy, producing `RefinedReproStrategy`.
 2.  **Strategy Merge**: `MergeStrategy` merges `InitialReproStrategy` and `RefinedReproStrategy` into `CurrentReproStrategy`. If a refined strategy exists, it is preferred.
-3.  **Code Generation**: The `repro-generator` agent generates C code (`RawCandidateReproC`) based on `CurrentReproStrategy`.
-    *   **Probe Strategy**: On the very first attempt, the generator is instructed to prioritize a simple "probe" program to check if necessary devices or syscalls are available, rather than attempting full reproduction immediately.
+3.  **Code Generation**: The `repro-generator` agent generates C code (`RawCandidateReproC`) and a boolean `IsProbe` flag based on `CurrentReproStrategy`.
+    *   **Structured Probe Strategy**: The generator is instructed to prioritize a simple "probe" program to verify subsystem availability and kernel privileges (both on the very first attempt, or if a previous probe failed). It sets `IsProbe` to `true` for environment probes, and `false` for full reproducer candidates attempting to trigger the crash.
 4.  **Self-Repair & Toolkit Expansion**: The workflow enters a nested `DoWhile` loop (max 3 iterations) to handle compilation failures:
-    *   **Toolkit Expansion & Compilation**: `CompileCProg` action replaces `#include "race_toolkit.h"` with the actual content of the race toolkit and attempts to compile the program.
+    *   **Toolkit Expansion & Compilation**: `CompileCProg` action replaces `#include "race_toolkit.h"` with the
+        actual content of the race toolkit and attempts to compile the program.
+        *   **Race Condition Toolkit**: The toolkit (`race_toolkit.h`) provides pre-defined C snippets and macros
+            for advanced race setups: CPU pinning (`PIN_TO_CPU`), memory barriers (`MB`), spin-wait barriers
+            (`WAIT_ON`/`SIGNAL`), userfaultfd (`setup_uffd`), and robust timing primitives (`TIMER_START`,
+            `TIMER_NOT_EXPIRED`) designed to survive clock resets/drifts in minimal QEMU VM environments.
     *   **Success**: If compilation succeeds, it outputs `FormattedReproC` and clears `CompilerError` to exit the repair loop.
     *   **Repair**: If compilation fails, the `repro-repairer` agent is invoked to fix the code based on the compiler error, updating `RawCandidateReproC` for the next attempt.
 5.  **Execution**: `crash.RunCRepro` runs the candidate reproducer in the VM. It returns whether it reproduced the crash, the console output, and crash report details if successful.
 6.  **Log Truncation**: `TruncateLog` keeps the last 200 lines of console output to fit LLM context limits.
-7.  **Oracle Analysis**: The `repro-oracle` agent analyzes the execution results. It checks if the crash title matches the expected bug and provides feedback (`OracleFeedback`).
-    *   If it was a successful probe, it provides feedback to proceed to generate the full reproducer.
-    *   If failed due to environmental issues, it suggests modifications.
+7.  **Oracle Analysis**: The `repro-oracle` agent analyzes the execution results using the structured `IsProbe` flag to branch its logic:
+    *   **If `IsProbe` is true**: A successful run (all capability checks passed) confirms the environment is ready, and the Oracle instructs the generator to proceed to the full reproducer. A failed run prompts feedback on which capabilities failed to help the generator adjust its setups.
+    *   **If `IsProbe` is false**: A successful execution (exit 0) WITHOUT a crash means reproduction failed to trigger the bug (NOT a successful probe). The Oracle analyzes strace/console output to tighten the race window or adjust input parameters.
 8.  **Loop Control**: `LoopController` determines if the loop should continue:
     *   If successful reproduction occurred and the title matches, it promotes the candidate to the final output and stops (`ContinueSignal` becomes empty).
     *   If a collision is detected (different crash), it provides feedback and continues.

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -175,6 +175,7 @@ type OracleResult struct {
 
 type GeneratorResult struct {
 	RawCandidateReproC string `jsonschema:"The C reproducer code"`
+	IsProbe            bool   `jsonschema:"True if minimal capability probe, false otherwise."`
 }
 
 type LoopControllerArgs struct {
@@ -420,15 +421,16 @@ major step in the reproduction sequence.
         exit(1);
     }
     printf("[+] do_something successful.\n");
-6. For the very first attempt at generating a reproducer (when no previous feedback is provided),
-prioritize generating a simple 'probe' program. This program's sole purpose is to verify that the
-test environment has the necessary kernel capabilities. It should focus on probing the specific
-kernel subsystems, device files, or syscalls required for the reproduction (for example: opening
-/dev/vhci to check if the virtual Bluetooth controller is accessible, loading a minimal dummy BPF
-program to check if BPF_SYSCALL is enabled and permitted, or making a specific socket/ioctl call
-to verify subsystem availability). Print clear messages indicating success or failure of these
-specific kernel/subsystem probes, and exit with 0 only if all relevant subsystem checks pass.
-Do not attempt complex race conditions or heavy logic in this first version.`
+6. Prioritize generating a simple 'probe' program first to verify that the test environment has the
+necessary kernel capabilities (e.g., on the very first attempt, or if a previous probe failed). This
+program's sole purpose is to verify subsystem availability and privileges by probing specific device
+files, subsystems, or syscalls (for example: opening /dev/vhci to check if the virtual Bluetooth
+controller is accessible, loading a minimal dummy BPF program, or making a specific socket/ioctl call).
+Print clear messages indicating success or failure of these probes, and exit with 0 only if all checks pass.
+Do not attempt complex logic or try to trigger the actual bug/crash until you have confirmed
+a successful probe run in the environment.
+7. You must set the IsProbe output field to true if the generated C program is a minimal capability probe.
+Set it to false if the C program is a full reproducer candidate attempting to trigger the target bug/crash.`
 
 const generatorPrompt = `Bug Description: {{.BugDescription}}
 Strategy: {{.CurrentReproStrategy}}`
@@ -442,9 +444,22 @@ to provide detailed feedback on why it failed and how to fix it.
 The Strace Output will contain the syscall trace if the run was successful and strace was supported.
 Use this trace to identify which syscall failed or behaved unexpectedly.
 
-If the output indicates that this was a successful probe execution (all probes passed),
-set Reproduced to false but provide feedback indicating that the environment is ready
-and the agent should now proceed to generate the full reproducer in the next iteration.
+The input variable 'IsProbe' indicates whether the executed program was a simple environment
+probe (true) or a full reproducer candidate (false).
+Use this to guide your classification and feedback:
+
+1. If 'IsProbe' is true:
+   - If the execution was successful (all environment/subsystem probes passed), provide feedback
+     explicitly indicating that the environment is ready and the agent should now proceed to
+     generate the full reproducer in the next iteration.
+   - If the probe failed (e.g., missing permissions, missing devices, or sandbox restrictions),
+     explain what failed so the generator can adjust its environment setups.
+
+2. If 'IsProbe' is false:
+   - A successful execution (exit 0) WITHOUT a crash means the reproduction attempt failed to trigger
+     the bug. Do NOT classify this as a successful probe. Instead, analyze the console/strace output
+     to understand why the bug did not trigger (e.g., timing, input arguments, environment setup)
+     and provide feedback on how to improve the reproducer logic to trigger the crash.
 
 If reproduction failed due to environmental issues (e.g., missing permissions, missing devices,
 or sandbox restrictions), assume execution might succeed with a different approach or more
@@ -452,7 +467,8 @@ robust code (e.g., adding namespace setup or better error handling), and suggest
 to the C code.`
 
 const oraclePrompt = `Bug Description: {{.BugDescription}}
-Reproduced: {{.Reproduced}}
+IsProbe: {{.IsProbe}}
+Reproduced: {{.CandidateReproduced}}
 Console Output: {{.TruncatedConsoleOutput}}
 Strace Output: {{.TruncatedStraceOutput}}
 Crash Report: {{.TruncatedCrashReport}}


### PR DESCRIPTION
Introduce the IsProbe field to GeneratorResult to deterministically track whether a candidate is a minimal environment probe or a full reproducer.

Update the generator instructions to set this flag and to continue prioritizing simple capability probes if a previous probe attempt failed. The agent is now explicitly instructed not to generate a full reproducer candidate targeting the actual bug/crash until a successful environment probe run is confirmed.

Update the Oracle prompt and instructions to branch its feedback logic depending on the value of IsProbe. This prevents the Oracle from misclassifying failed reproduction runs as successful environment probes, breaking the "probe loop" trap.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
