### PR TITLE
pkg/vcs: fix maintainers role parsing

### DIFF
--- a/pkg/vcs/linux.go
+++ b/pkg/vcs/linux.go
@@ -246,7 +246,7 @@ func (ctx *linux) getMaintainers(hash string, blame bool) Recipients {
 
 func ParseMaintainersLinux(text []byte) Recipients {
 	lines := strings.Split(string(text), "\n")
-	reRole := regexp.MustCompile(` \([^)]+\)$`)
+	reRole := regexp.MustCompile(` \([^()]*(?:\([^()]*\)[^()]*)*\)$`)
 	var mtrs Recipients
 	// LMKL is To by default, but it changes to Cc if there's also a subsystem list.
 	lkmlType := To

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -307,7 +307,7 @@ linux-input@vger.kernel.org (open list:INPUT (KEYBOARD, MOUSE, JOYSTICK, TOUCHSC
 				{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
 				{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
 				{mail.Address{Name: "Supporter Foo (Company)", Address: "c@email.com"}, To},
-				{mail.Address{Name: "open list:INPUT (KEYBOARD, MOUSE, JOYSTICK, TOUCHSCREEN)...", Address: "linux-input@vger.kernel.org"}, Cc},
+				{mail.Address{Name: "", Address: "linux-input@vger.kernel.org"}, To},
 				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, Cc},
 				{mail.Address{Name: "", Address: "somelist@list.com"}, To},
 			},

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -299,14 +299,18 @@ func TestParseMaintainersLinux(t *testing.T) {
 Foo Bar <a@email.com> (maintainer:KERNEL)
 Foo Bar<b@email.com> (reviewer:KERNEL)
 <somelist@list.com> (open list:FOO)
-"Supporter Foo" <c@email.com> (supporter:KERNEL)
+"Supporter Foo (Company)" <c@email.com> (supporter:KERNEL)
 linux-kernel@vger.kernel.org (open list)
+linux-input@vger.kernel.org (open list:INPUT (KEYBOARD, MOUSE, JOYSTICK, TOUCHSCREEN)...)
 		`,
-			Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+			Recipients{
+				{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
 				{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
-				{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
+				{mail.Address{Name: "Supporter Foo (Company)", Address: "c@email.com"}, To},
+				{mail.Address{Name: "open list:INPUT (KEYBOARD, MOUSE, JOYSTICK, TOUCHSCREEN)...", Address: "linux-input@vger.kernel.org"}, Cc},
 				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, Cc},
-				{mail.Address{Name: "", Address: "somelist@list.com"}, To}},
+				{mail.Address{Name: "", Address: "somelist@list.com"}, To},
+			},
 		},
 		{
 			`
@@ -315,10 +319,12 @@ Foo Bar<b@email.com> (reviewer:KERNEL)
 "Supporter Foo" <c@email.com> (supporter:KERNEL)
 linux-kernel@vger.kernel.org (open list)
 			`,
-			Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+			Recipients{
+				{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
 				{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
 				{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
-				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, To}},
+				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, To},
+			},
 		},
 	}
 	for i, test := range tests {

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -284,28 +284,46 @@ func TestFileLink(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
-	test1 := []byte(`Foo Bar <a@email.com> (maintainer:KERNEL)
-	Foo Bar<b@email.com> (reviewer:KERNEL)
-	<somelist@list.com> (open list:FOO)
-	"Supporter Foo" <c@email.com> (supporter:KERNEL)
-	linux-kernel@vger.kernel.org (open list)`)
-	test2 := []byte(`Foo Bar <a@email.com> (maintainer:KERNEL)
-	Foo Bar<b@email.com> (reviewer:KERNEL)
-	"Supporter Foo" <c@email.com> (supporter:KERNEL)
-	linux-kernel@vger.kernel.org (open list)`)
-
-	maintainers1 := Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
-		{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
-		{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
-		{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, Cc},
-		{mail.Address{Name: "", Address: "somelist@list.com"}, To}}
-	maintainers2 := Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
-		{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
-		{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
-		{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, To}}
-
-	require.Equal(t, maintainers1, ParseMaintainersLinux(test1))
-	require.Equal(t, maintainers2, ParseMaintainersLinux(test2))
-	require.Equal(t, Recipients(nil), ParseMaintainersLinux([]byte("")))
+func TestParseMaintainersLinux(t *testing.T) {
+	type Test struct {
+		Input string
+		Want  Recipients
+	}
+	tests := []Test{
+		{
+			"",
+			Recipients(nil),
+		},
+		{
+			`
+Foo Bar <a@email.com> (maintainer:KERNEL)
+Foo Bar<b@email.com> (reviewer:KERNEL)
+<somelist@list.com> (open list:FOO)
+"Supporter Foo" <c@email.com> (supporter:KERNEL)
+linux-kernel@vger.kernel.org (open list)
+		`,
+			Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+				{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
+				{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
+				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, Cc},
+				{mail.Address{Name: "", Address: "somelist@list.com"}, To}},
+		},
+		{
+			`
+Foo Bar <a@email.com> (maintainer:KERNEL)
+Foo Bar<b@email.com> (reviewer:KERNEL)
+"Supporter Foo" <c@email.com> (supporter:KERNEL)
+linux-kernel@vger.kernel.org (open list)
+			`,
+			Recipients{{mail.Address{Name: "Foo Bar", Address: "a@email.com"}, To},
+				{mail.Address{Name: "Foo Bar", Address: "b@email.com"}, Cc},
+				{mail.Address{Name: "Supporter Foo", Address: "c@email.com"}, To},
+				{mail.Address{Name: "", Address: "linux-kernel@vger.kernel.org"}, To}},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			require.Equal(t, test.Want, ParseMaintainersLinux([]byte(test.Input)), test.Input)
+		})
+	}
 }


### PR DESCRIPTION
- **pkg/vcs: convert TestParseMaintainersLinux to proper table test**
- **pkg/vcs: extend TestParseMaintainersLinux test**
- **pkg/vcs: fix maintainers role parsing**
