### PR TITLE
k8s: fix kustomize deprecations

### DIFF
--- a/syz-cluster/overlays/common/argo/kustomization.yaml
+++ b/syz-cluster/overlays/common/argo/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - https://github.com/argoproj/argo-workflows/releases/download/v3.6.2/install.yaml
   - workflow-roles.yaml
 
-patchesStrategicMerge:
-  - patch-argo-controller.yaml
-  - patch-workflow-controller-configmap.yaml
+patches:
+  - path: patch-argo-controller.yaml
+  - path: patch-workflow-controller-configmap.yaml

--- a/syz-cluster/overlays/local/common/kustomization.yaml
+++ b/syz-cluster/overlays/local/common/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - network-policy-spanner.yaml
   - workflow-artifacts.yaml
 
-patchesStrategicMerge:
-  - patch-workflow-controller-configmap.yaml
+patches:
+  - path: patch-workflow-controller-configmap.yaml


### PR DESCRIPTION
- In syz-cluster/overlays/local/common/kustomization.yaml and syz-cluster/overlays/common/argo/kustomization.yaml, replace deprecated patchesStrategicMerge with patches as recommended by Kustomize v5.
