### PR TITLE
Makefile: move fast static analysis checks to lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ tidy: descriptions
 		--extra-arg=-std=c++17 \
 		executor/*.cc
 
-lint:
+lint: check_whitespace check_sql_newlines check_links check_html check_shebang
 	CGO_ENABLED=1 $(HOSTGO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	CGO_ENABLED=1 $(HOSTGO) build -buildmode=plugin -o bin/syz-linter.so ./tools/syz-linter
 	bin/golangci-lint run ./...
@@ -316,7 +316,7 @@ presubmit:
 
 presubmit_aux:
 	$(MAKE) generate
-	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_whitespace check_sql_newlines check_links check_html check_shebang check_k8s tidy
+	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_k8s tidy
 	$(GO) mod tidy
 
 presubmit_build: descriptions


### PR DESCRIPTION
Move check_whitespace, check_sql_newlines, check_html, check_links, and check_shebang from the presubmit_aux target to the lint target.

These are fast, simple static analysis checks that cover frequent mistakes made by developers and coding agents alike. Moving them to the standard `make lint` target makes it easier and more intuitive to catch these issues early in the development cycle, rather than waiting for presubmit tests.