### PR TITLE
pkg/aflow/toolkit: limit C toolkit test to Linux

### DIFF
--- a/pkg/aflow/tool/toolkit/toolkit_test.go
+++ b/pkg/aflow/tool/toolkit/toolkit_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build linux
+
 package toolkit
 
 import (


### PR DESCRIPTION
## Summary
- limit the aflow toolkit C compilation test to Linux
- avoid compiling `race_toolkit.h` on platforms without Linux UAPI headers such as OpenBSD

Closes #7238.

## Testing
- `git diff --check`