### PR TITLE
dashboard/app, pkg/lore-relay: improve AI patch rejection logic

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -55,6 +55,7 @@ func apiAIReportCommand(ctx context.Context, req *dashapi.SendExternalCommandReq
 	return resp, nil
 }
 
+// nolint: dupl
 func handleUpstreamCommand(ctx context.Context, req *dashapi.SendExternalCommandReq,
 ) (*dashapi.SendExternalCommandResp, error) {
 	reporting, job, err := lookupJobByExtReq(ctx, req)
@@ -202,7 +203,7 @@ func determineNextStage(ctx context.Context, cfg *AIConfig, job *aidb.Job,
 // nolint: dupl
 func handleRejectCommand(ctx context.Context,
 	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
-	_, job, err := lookupJobByExtReq(ctx, req)
+	reporting, job, err := lookupJobByExtReq(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +215,7 @@ func handleRejectCommand(ctx context.Context,
 
 	err = aidb.RejectReportCommand(ctx, aidb.RejectReportArgs{
 		Job:           job,
+		ReportingID:   reporting.ID,
 		CommandSource: string(req.Source),
 		CommandExtID:  req.MessageExtID,
 		User:          req.Author,
@@ -225,6 +227,7 @@ func handleRejectCommand(ctx context.Context,
 			if req.Source != "" && req.MessageExtID != "" {
 				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
 					JobID:         job.ID,
+					ReportingID:   reporting.ID,
 					CommandSource: string(req.Source),
 					CommandExtID:  req.MessageExtID,
 					User:          req.Author,
@@ -473,13 +476,14 @@ func lookupJobByExtReq(ctx context.Context, req *dashapi.SendExternalCommandReq)
 // nolint: dupl
 func handleUnrejectCommand(ctx context.Context,
 	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
-	_, job, err := lookupJobByExtReq(ctx, req)
+	reporting, job, err := lookupJobByExtReq(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	err = aidb.UnrejectReportCommand(ctx, aidb.UnrejectReportArgs{
 		Job:           job,
+		ReportingID:   reporting.ID,
 		CommandSource: string(req.Source),
 		CommandExtID:  req.MessageExtID,
 		User:          req.Author,
@@ -490,6 +494,7 @@ func handleUnrejectCommand(ctx context.Context,
 			if req.Source != "" && req.MessageExtID != "" {
 				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
 					JobID:         job.ID,
+					ReportingID:   reporting.ID,
 					CommandSource: string(req.Source),
 					CommandExtID:  req.MessageExtID,
 					User:          req.Author,

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -38,6 +38,8 @@ func apiAIReportCommand(ctx context.Context, req *dashapi.SendExternalCommandReq
 		resp, err = handleUpstreamCommand(ctx, req)
 	} else if req.Reject != nil {
 		resp, err = handleRejectCommand(ctx, req)
+	} else if req.Unreject != nil {
+		resp, err = handleUnrejectCommand(ctx, req)
 	} else if req.Comment != nil {
 		resp, err = handleCommentCommand(ctx, req)
 	} else {
@@ -468,8 +470,43 @@ func lookupJobByExtReq(ctx context.Context, req *dashapi.SendExternalCommandReq)
 	return reporting, job, nil
 }
 
-func handleCommentCommand(ctx context.Context, req *dashapi.SendExternalCommandReq,
-) (*dashapi.SendExternalCommandResp, error) {
+// nolint: dupl
+func handleUnrejectCommand(ctx context.Context,
+	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
+	_, job, err := lookupJobByExtReq(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = aidb.UnrejectReportCommand(ctx, aidb.UnrejectReportArgs{
+		Job:           job,
+		CommandSource: string(req.Source),
+		CommandExtID:  req.MessageExtID,
+		User:          req.Author,
+	})
+	if err != nil {
+		var cannotUnrejectErr *aidb.ErrCannotUnreject
+		if errors.As(err, &cannotUnrejectErr) {
+			if req.Source != "" && req.MessageExtID != "" {
+				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
+					JobID:         job.ID,
+					CommandSource: string(req.Source),
+					CommandExtID:  req.MessageExtID,
+					User:          req.Author,
+					Action:        aidb.ActionUnreject,
+					Error:         cannotUnrejectErr.Reason,
+				})
+			}
+			return &dashapi.SendExternalCommandResp{Error: cannotUnrejectErr.Reason}, nil
+		}
+		return nil, err
+	}
+
+	return &dashapi.SendExternalCommandResp{}, nil
+}
+
+func handleCommentCommand(ctx context.Context,
+	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
 	reporting, job, err := lookupJobByExtReq(ctx, req)
 	if err != nil {
 		return nil, err

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -197,8 +197,9 @@ func determineNextStage(ctx context.Context, cfg *AIConfig, job *aidb.Job,
 	return &cfg.Stages[currentIndex+1], nil
 }
 
-func handleRejectCommand(ctx context.Context, req *dashapi.SendExternalCommandReq,
-) (*dashapi.SendExternalCommandResp, error) {
+// nolint: dupl
+func handleRejectCommand(ctx context.Context,
+	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
 	_, job, err := lookupJobByExtReq(ctx, req)
 	if err != nil {
 		return nil, err
@@ -217,6 +218,20 @@ func handleRejectCommand(ctx context.Context, req *dashapi.SendExternalCommandRe
 		Reason:        reason,
 	})
 	if err != nil {
+		var cannotRejectErr *aidb.ErrCannotReject
+		if errors.As(err, &cannotRejectErr) {
+			if req.Source != "" && req.MessageExtID != "" {
+				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
+					JobID:         job.ID,
+					CommandSource: string(req.Source),
+					CommandExtID:  req.MessageExtID,
+					User:          req.Author,
+					Action:        aidb.ActionReject,
+					Error:         cannotRejectErr.Reason,
+				})
+			}
+			return &dashapi.SendExternalCommandResp{Error: cannotRejectErr.Reason}, nil
+		}
 		return nil, err
 	}
 

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -248,6 +248,23 @@ func TestAILoreIntegrationReject(t *testing.T) {
 	assert.Equal(t, "[PATCH RFC] Test Subject", mockSnd.sent[0].Subject)
 	assert.Equal(t, []string{"archive@lore.com"}, mockSnd.sent[0].Cc)
 
+	// 2a. Unreject when not rejected (#syz unreject) - should fail.
+	loreArchive.SaveMessageAt(t, `From: user@email
+Subject: Re: [PATCH RFC] Test Subject
+Message-ID: <reply1-unreject-fail>
+In-Reply-To: <mock@msgid-1>
+
+#syz unreject
+`, now.Add(time.Second*30))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, mockSnd.sent, 2)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[1].To)
+	expectedUnrejectFailBody := "> #syz unreject\n\nCommand failed:\n\nCannot unreject a patch that is not rejected.\n\n"
+	assert.Equal(t, expectedUnrejectFailBody, string(mockSnd.sent[1].Body))
+
 	// 3. Reject (#syz reject).
 	loreArchive.SaveMessageAt(t, `From: user@email
 Subject: Re: [PATCH RFC] Test Subject
@@ -264,9 +281,9 @@ In-Reply-To: <mock@msgid-1>
 	err = relay.PollDashboardOnce(t.Context())
 	require.NoError(t, err)
 
-	require.Len(t, mockSnd.sent, 1)
+	require.Len(t, mockSnd.sent, 2)
 
-	// 4a. Reject again (#syz reject) - should fail because already rejected.
+	// 4b. Reject again (#syz reject) - should fail because already rejected.
 	loreArchive.SaveMessageAt(t, `From: user@email
 Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply1-again>
@@ -278,10 +295,10 @@ In-Reply-To: <mock@msgid-1>
 	err = relay.PollLoreOnce(t.Context())
 	require.NoError(t, err)
 
-	require.Len(t, mockSnd.sent, 2)
-	assert.Equal(t, []string{"user@email"}, mockSnd.sent[1].To)
+	require.Len(t, mockSnd.sent, 3)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[2].To)
 	expectedRejectBody := "> #syz reject\n\nCommand failed:\n\nCannot reject a patch that is already rejected.\n\n"
-	assert.Equal(t, expectedRejectBody, string(mockSnd.sent[1].Body))
+	assert.Equal(t, expectedRejectBody, string(mockSnd.sent[2].Body))
 
 	// 5. Try to upstream - should fail because it's rejected.
 	loreArchive.SaveMessageAt(t, `From: user@email
@@ -295,10 +312,10 @@ In-Reply-To: <mock@msgid-1>
 	err = relay.PollLoreOnce(t.Context())
 	require.NoError(t, err)
 
-	require.Len(t, mockSnd.sent, 3)
-	assert.Equal(t, []string{"user@email"}, mockSnd.sent[2].To)
+	require.Len(t, mockSnd.sent, 4)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[3].To)
 	expectedBody := "> #syz upstream\n\nCommand failed:\n\nCannot upstream a rejected patch. Unreject it first.\n\n"
-	assert.Equal(t, expectedBody, string(mockSnd.sent[2].Body))
+	assert.Equal(t, expectedBody, string(mockSnd.sent[3].Body))
 }
 
 func TestAILoreUnknownMessageID(t *testing.T) {

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -265,6 +265,23 @@ In-Reply-To: <mock@msgid-1>
 	require.NoError(t, err)
 
 	require.Len(t, mockSnd.sent, 1)
+
+	// 5. Try to upstream - should fail because it's rejected.
+	loreArchive.SaveMessageAt(t, `From: user@email
+Subject: Re: [PATCH RFC] Test Subject
+Message-ID: <reply2>
+In-Reply-To: <mock@msgid-1>
+
+#syz upstream
+`, now.Add(time.Minute*2))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, mockSnd.sent, 2)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[1].To)
+	expectedBody := "> #syz upstream\n\nCommand failed:\n\nCannot upstream a rejected patch. Unreject it first.\n\n"
+	assert.Equal(t, expectedBody, string(mockSnd.sent[1].Body))
 }
 
 func TestAILoreUnknownMessageID(t *testing.T) {

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -266,6 +266,23 @@ In-Reply-To: <mock@msgid-1>
 
 	require.Len(t, mockSnd.sent, 1)
 
+	// 4a. Reject again (#syz reject) - should fail because already rejected.
+	loreArchive.SaveMessageAt(t, `From: user@email
+Subject: Re: [PATCH RFC] Test Subject
+Message-ID: <reply1-again>
+In-Reply-To: <mock@msgid-1>
+
+#syz reject
+`, now.Add(time.Minute*1+time.Second*30))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, mockSnd.sent, 2)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[1].To)
+	expectedRejectBody := "> #syz reject\n\nCommand failed:\n\nCannot reject a patch that is already rejected.\n\n"
+	assert.Equal(t, expectedRejectBody, string(mockSnd.sent[1].Body))
+
 	// 5. Try to upstream - should fail because it's rejected.
 	loreArchive.SaveMessageAt(t, `From: user@email
 Subject: Re: [PATCH RFC] Test Subject
@@ -278,10 +295,10 @@ In-Reply-To: <mock@msgid-1>
 	err = relay.PollLoreOnce(t.Context())
 	require.NoError(t, err)
 
-	require.Len(t, mockSnd.sent, 2)
-	assert.Equal(t, []string{"user@email"}, mockSnd.sent[1].To)
+	require.Len(t, mockSnd.sent, 3)
+	assert.Equal(t, []string{"user@email"}, mockSnd.sent[2].To)
 	expectedBody := "> #syz upstream\n\nCommand failed:\n\nCannot upstream a rejected patch. Unreject it first.\n\n"
-	assert.Equal(t, expectedBody, string(mockSnd.sent[1].Body))
+	assert.Equal(t, expectedBody, string(mockSnd.sent[2].Body))
 }
 
 func TestAILoreUnknownMessageID(t *testing.T) {

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -185,6 +185,18 @@ func TestAIExternalReporting(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, job.Correct.Valid)
 	require.False(t, job.Correct.Bool)
+
+	c.advanceTime(time.Second)
+
+	// Try to reject the patch again - should fail.
+	resp, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID: "moderation-msg-id",
+		Reject:    &dashapi.RejectCommand{Reason: "Bad patch again"},
+		Author:    "test-user",
+		Source:    "lore",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Cannot reject a patch that is already rejected.", resp.Error)
 }
 
 func TestAIReportNotFound(t *testing.T) {

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -152,6 +152,8 @@ func TestAIExternalReporting(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, pollResp.Result)
 
+	tReject := c.mockedTime
+
 	// Reject the patch.
 	resp, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
 		RootExtID: "moderation-msg-id",
@@ -165,7 +167,7 @@ func TestAIExternalReporting(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []*uiJobReviewHistory{
 		{
-			Date:    c.mockedTime,
+			Date:    tReject,
 			User:    "test-user",
 			Correct: aiCorrectnessIncorrect,
 			Source:  "lore",
@@ -197,6 +199,62 @@ func TestAIExternalReporting(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "Cannot reject a patch that is already rejected.", resp.Error)
+
+	c.advanceTime(time.Second)
+	tUnreject := c.mockedTime
+
+	// Unreject the patch.
+	resp, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID: "moderation-msg-id",
+		Unreject:  &dashapi.UnrejectCommand{},
+		Author:    "test-user",
+		Source:    "lore",
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Error)
+
+	c.advanceTime(time.Second)
+
+	// Unreject the patch again - should fail.
+	resp, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID: "moderation-msg-id",
+		Unreject:  &dashapi.UnrejectCommand{},
+		Author:    "test-user",
+		Source:    "lore",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Cannot unreject a patch that is not rejected.", resp.Error)
+
+	uiHistory, err = LoadUIJobReviewHistory(c.ctx, jobID)
+	require.NoError(t, err)
+	require.Equal(t, []*uiJobReviewHistory{
+		{
+			Date:    tUnreject,
+			User:    "test-user",
+			Correct: "?",
+			Source:  "lore",
+			Stage:   "",
+		},
+		{
+			Date:    tReject,
+			User:    "test-user",
+			Correct: aiCorrectnessIncorrect,
+			Source:  "lore",
+			Stage:   "",
+		},
+		{
+			Date:    t0,
+			User:    "test-user",
+			Correct: aiCorrectnessCorrect,
+			Source:  "lore",
+			Stage:   "public",
+		},
+	}, uiHistory)
+
+	// Verify Job.Correct = nil (Valid = false).
+	job, err = aidb.LoadJob(c.ctx, jobID)
+	require.NoError(t, err)
+	require.False(t, job.Correct.Valid)
 }
 
 func TestAIReportNotFound(t *testing.T) {

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -171,7 +171,7 @@ func TestAIExternalReporting(t *testing.T) {
 			User:    "test-user",
 			Correct: aiCorrectnessIncorrect,
 			Source:  "lore",
-			Stage:   "", // Rejections are not per-stage.
+			Stage:   "moderation",
 		},
 		{
 			Date:    t0,
@@ -233,14 +233,14 @@ func TestAIExternalReporting(t *testing.T) {
 			User:    "test-user",
 			Correct: "?",
 			Source:  "lore",
-			Stage:   "",
+			Stage:   "moderation",
 		},
 		{
 			Date:    tReject,
 			User:    "test-user",
 			Correct: aiCorrectnessIncorrect,
 			Source:  "lore",
-			Stage:   "",
+			Stage:   "moderation",
 		},
 		{
 			Date:    t0,

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -589,6 +589,10 @@ func UpstreamReportCommand(ctx context.Context, args UpstreamReportArgs) error {
 			return ErrNotFound
 		}
 
+		if job.Correct.Valid && !job.Correct.Bool {
+			return &ErrCannotUpstream{Reason: "Cannot upstream a rejected patch. Unreject it first."}
+		}
+
 		if args.NoParallel && job.BugID.Valid && args.Reporting != nil {
 			if err := checkNoParallelConflict(ctx, txn, job, args.Reporting.Stage); err != nil {
 				return err

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -690,6 +690,7 @@ func RejectReportCommand(ctx context.Context, args RejectReportArgs) error {
 			Action:      ActionReject,
 			Source:      toNullString(args.CommandSource),
 			SourceExtID: toNullString(args.CommandExtID),
+			ReportingID: toNullString(args.ReportingID),
 		}
 		if args.Reason != "" {
 			journal.Details = spanner.NullJSON{Value: map[string]string{"reason": args.Reason}, Valid: true}
@@ -746,6 +747,7 @@ func UnrejectReportCommand(ctx context.Context, args UnrejectReportArgs) error {
 			Action:      ActionUnreject,
 			Source:      toNullString(args.CommandSource),
 			SourceExtID: toNullString(args.CommandExtID),
+			ReportingID: toNullString(args.ReportingID),
 		}
 		journalMut, err := spanner.InsertStruct("Journal", journal)
 		if err != nil {
@@ -1237,6 +1239,7 @@ type UpstreamReportArgs struct {
 
 type RejectReportArgs struct {
 	Job           *Job
+	ReportingID   string
 	CommandSource string
 	CommandExtID  string
 	User          string
@@ -1245,6 +1248,7 @@ type RejectReportArgs struct {
 
 type UnrejectReportArgs struct {
 	Job           *Job
+	ReportingID   string
 	CommandSource string
 	CommandExtID  string
 	User          string

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -47,6 +47,14 @@ func (e *ErrCannotReject) Error() string {
 	return e.Reason
 }
 
+type ErrCannotUnreject struct {
+	Reason string
+}
+
+func (e *ErrCannotUnreject) Error() string {
+	return e.Reason
+}
+
 func init() {
 	// This forces unmarshalling of JSON integers into json.Number rather than float64.
 	spanner.UseNumberWithJSONDecoderEncoder(true)
@@ -707,6 +715,59 @@ func RejectReportCommand(ctx context.Context, args RejectReportArgs) error {
 	return nil
 }
 
+func UnrejectReportCommand(ctx context.Context, args UnrejectReportArgs) error {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL:    selectJobs() + ` WHERE ID = @id`,
+			Params: map[string]any{"id": args.Job.ID},
+		}
+		job, err := readRow[Job](ctx, txn, stmt)
+		if err != nil {
+			return err
+		}
+		if job == nil {
+			return ErrNotFound
+		}
+
+		if !job.Correct.Valid || job.Correct.Bool {
+			return &ErrCannotUnreject{Reason: "Cannot unreject a patch that is not rejected."}
+		}
+
+		journal := &Journal{
+			ID:          uuid.NewString(),
+			JobID:       toNullString(args.Job.ID),
+			Date:        TimeNow(ctx),
+			User:        args.User,
+			Action:      ActionUnreject,
+			Source:      toNullString(args.CommandSource),
+			SourceExtID: toNullString(args.CommandExtID),
+		}
+		journalMut, err := spanner.InsertStruct("Journal", journal)
+		if err != nil {
+			return err
+		}
+
+		job.Correct = spanner.NullBool{Valid: false}
+		jobMut, err := spanner.UpdateStruct("Jobs", job)
+		if err != nil {
+			return err
+		}
+		return txn.BufferWrite([]*spanner.Mutation{jobMut, journalMut})
+	})
+	if err != nil {
+		if spanner.ErrCode(err) == codes.AlreadyExists {
+			return nil // Idempotent no-op.
+		}
+		return err
+	}
+	return nil
+}
+
 type LogCommandErrorArgs struct {
 	JobID         string
 	ReportingID   string
@@ -1180,6 +1241,13 @@ type RejectReportArgs struct {
 	CommandExtID  string
 	User          string
 	Reason        string
+}
+
+type UnrejectReportArgs struct {
+	Job           *Job
+	CommandSource string
+	CommandExtID  string
+	User          string
 }
 
 func LoadJobReportingByExtID(ctx context.Context, extID string) (*JobReporting, error) {

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -39,6 +39,14 @@ func (e *ErrCannotUpstream) Error() string {
 	return e.Reason
 }
 
+type ErrCannotReject struct {
+	Reason string
+}
+
+func (e *ErrCannotReject) Error() string {
+	return e.Reason
+}
+
 func init() {
 	// This forces unmarshalling of JSON integers into json.Number rather than float64.
 	spanner.UseNumberWithJSONDecoderEncoder(true)
@@ -650,6 +658,22 @@ func RejectReportCommand(ctx context.Context, args RejectReportArgs) error {
 	}
 
 	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL:    selectJobs() + ` WHERE ID = @id`,
+			Params: map[string]any{"id": args.Job.ID},
+		}
+		job, err := readRow[Job](ctx, txn, stmt)
+		if err != nil {
+			return err
+		}
+		if job == nil {
+			return ErrNotFound
+		}
+
+		if job.Correct.Valid && !job.Correct.Bool {
+			return &ErrCannotReject{Reason: "Cannot reject a patch that is already rejected."}
+		}
+
 		journal := &Journal{
 			ID:          uuid.NewString(),
 			JobID:       toNullString(args.Job.ID),
@@ -667,9 +691,11 @@ func RejectReportCommand(ctx context.Context, args RejectReportArgs) error {
 			return err
 		}
 
-		jobMut := spanner.Update("Jobs",
-			[]string{"ID", "Correct"},
-			[]any{args.Job.ID, spanner.NullBool{Bool: false, Valid: true}})
+		job.Correct = spanner.NullBool{Bool: false, Valid: true}
+		jobMut, err := spanner.UpdateStruct("Jobs", job)
+		if err != nil {
+			return err
+		}
 		return txn.BufferWrite([]*spanner.Mutation{jobMut, journalMut})
 	})
 	if err != nil {

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -16,6 +16,7 @@ const (
 	ActionJobReview = "JobReview" // Outdated. Use ActionApprove/ActionReject.
 	ActionApprove   = "Approve"
 	ActionReject    = "Reject"
+	ActionUnreject  = "Unreject"
 )
 
 const (

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -71,6 +71,7 @@ type SendExternalCommandReq struct {
 	// Only one must be set.
 	Upstream *UpstreamCommand `json:",omitempty"`
 	Reject   *RejectCommand   `json:",omitempty"`
+	Unreject *UnrejectCommand `json:",omitempty"`
 	Comment  *CommentCommand  `json:",omitempty"`
 }
 
@@ -79,6 +80,9 @@ type UpstreamCommand struct {
 
 type RejectCommand struct {
 	Reason string
+}
+
+type UnrejectCommand struct {
 }
 
 type CommentCommand struct {

--- a/docs/syzbot_ai_patches.md
+++ b/docs/syzbot_ai_patches.md
@@ -23,6 +23,11 @@ version (e.g. an RFC v2) if necessary.
 ```
 You can provide the reason for rejection in the email body for better accounting.
 
+* If you accidentally rejected a patch, you can undo it:
+```
+#syz unreject
+```
+
 * Approve a patch and send it to the public list:
 ```
 #syz upstream

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -63,6 +63,7 @@ const (
 	CmdUnset
 	CmdRegenerate
 	CmdReject
+	CmdUnreject
 
 	cmdTest5
 )
@@ -378,6 +379,8 @@ func strToCmd(str string) Command {
 		return CmdRegenerate
 	case "reject":
 		return CmdReject
+	case "unreject":
+		return CmdUnreject
 	case "test_5_arg_cmd":
 		return cmdTest5
 	}

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -409,6 +409,14 @@ baz
 			Args:    "",
 		},
 	},
+	{
+		body: `#syz unreject`,
+		cmd: &SingleCommand{
+			Command: CmdUnreject,
+			Str:     "unreject",
+			Args:    "",
+		},
+	},
 }
 
 type ParseTest struct {

--- a/pkg/lore-relay/commands.go
+++ b/pkg/lore-relay/commands.go
@@ -35,6 +35,9 @@ func extractCommands(polled *lore.PolledEmail, dkimOk bool) ([]*dashapi.SendExte
 				Reason: polled.Email.Body,
 			}
 			reqs = append(reqs, req)
+		case email.CmdUnreject:
+			req.Unreject = &dashapi.UnrejectCommand{}
+			reqs = append(reqs, req)
 		default:
 			return nil, fmt.Errorf("unsupported command: %s", cmd.Str)
 		}

--- a/pkg/lore-relay/commands_test.go
+++ b/pkg/lore-relay/commands_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint: dupl
 func TestMapCommands(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -65,6 +66,30 @@ func TestMapCommands(t *testing.T) {
 					MessageExtID: "<msg@id>",
 					Author:       "user@example.com",
 					Reject:       &dashapi.RejectCommand{Reason: "some reason"},
+				},
+			},
+		},
+		{
+			name: "unreject",
+			polled: &lore.PolledEmail{
+				RootMessageID: "<root@id>",
+				Email: &lore.Email{
+					Email: &email.Email{
+						MessageID: "<msg@id>",
+						Author:    "user@example.com",
+						Commands: []*email.SingleCommand{
+							{Command: email.CmdUnreject},
+						},
+					},
+				},
+			},
+			want: []*dashapi.SendExternalCommandReq{
+				{
+					Source:       dashapi.AIJobSourceLore,
+					RootExtID:    "<root@id>",
+					MessageExtID: "<msg@id>",
+					Author:       "user@example.com",
+					Unreject:     &dashapi.UnrejectCommand{},
 				},
 			},
 		},

--- a/pkg/lore-relay/templates/new_patch.txt
+++ b/pkg/lore-relay/templates/new_patch.txt
@@ -12,6 +12,6 @@ base-commit: {{.Patch.BaseCommit}}
 -- 
 {{ if .CanUpstream }}This is an AI-generated patch subject to moderation.
 Reply with '#syz upstream' to send it to the mailing list.
-Reply with '#syz reject' to reject it.
+Reply with '#syz reject' to reject it (or '#syz unreject' to undo).
 
 {{ end }}See {{.DocsLink}} for more information.

--- a/pkg/lore-relay/testdata/patch_moderation.out.txt
+++ b/pkg/lore-relay/testdata/patch_moderation.out.txt
@@ -21,6 +21,6 @@ base-commit: abcdef123456
 -- 
 This is an AI-generated patch subject to moderation.
 Reply with '#syz upstream' to send it to the mailing list.
-Reply with '#syz reject' to reject it.
+Reply with '#syz reject' to reject it (or '#syz unreject' to undo).
 
 See http://docs.link for more information.


### PR DESCRIPTION
* Extend the semantics of rejected AI patches: prohibit their upstreaming.
* Introduce `#syz unreject` to unmark a previously rejected AI patch.