### PR TITLE
dashboard/app: improve To/Cc list processing for AI patches

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -364,7 +364,18 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	}
 	models := extractExecutedModels(trajectory)
 	var to, cc []string
+	seen := make(map[string]bool)
+	for _, a := range authors {
+		to = append(to, a)
+		seen[email.CanonicalEmail(a)] = true
+	}
+
 	for _, rec := range res.Recipients {
+		if seen[email.CanonicalEmail(rec.Email)] {
+			continue
+		}
+		seen[email.CanonicalEmail(rec.Email)] = true
+
 		addr := mail.Address{Name: rec.Name, Address: rec.Email}
 		if rec.To {
 			to = append(to, addr.String())

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -134,6 +134,13 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	}
 	nextStage := nextStageCfg.Name
 
+	var extraCcList []string
+	if currentReporting != nil {
+		extraCcList = currentReporting.ExtraCcList
+	}
+	extraCcList = email.MergeEmailLists(extraCcList, req.Cc)
+	extraCcList = email.SubtractEmailLists(extraCcList, ownEmails(ctx))
+
 	return aidb.UpstreamReportCommand(ctx, aidb.UpstreamReportArgs{
 		Job: job,
 		Reporting: &aidb.JobReporting{
@@ -142,6 +149,7 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 			UpstreamedAt: spanner.NullTime{Time: aidb.TimeNow(ctx), Valid: true},
 			UpstreamedBy: spanner.NullString{StringVal: upstreamedBy, Valid: upstreamedBy != ""},
 			Version:      spanner.NullInt64{Int64: 1, Valid: true},
+			ExtraCcList:  extraCcList,
 		},
 		NoParallel:    nextStageCfg.NoParallelReports,
 		CommandSource: string(req.Source),
@@ -320,6 +328,9 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 			result.To = append(result.To, result.Patch.To...)
 			result.Cc = append(result.Cc, result.Patch.Cc...)
 		}
+
+		result.Cc = append(result.Cc, r.ExtraCcList...)
+		result.Cc = email.SubtractEmailLists(unique(result.Cc), result.To)
 
 		result.CanUpstream = idx < len(nsCfg.AI.Stages)-1
 		if result.Patch == nil {
@@ -532,6 +543,7 @@ func handleCommentCommand(ctx context.Context,
 		return nil, fmt.Errorf("failed to store comment body: %w", err)
 	}
 
+	extraCc := email.SubtractEmailLists(req.Cc, ownEmails(ctx))
 	err = aidb.SaveJobComment(ctx, &aidb.JobComment{
 		ReportingID:  reporting.ID,
 		ExtID:        req.MessageExtID,
@@ -542,7 +554,7 @@ func handleCommentCommand(ctx context.Context,
 		OwnEmail:     req.OwnEmail,
 		Processed:    req.OwnEmail,
 		VerifiedDKIM: req.DKIM,
-	})
+	}, extraCc)
 	if err != nil && !errors.Is(err, aidb.ErrDuplicateComment) {
 		return nil, err
 	}

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -113,6 +113,7 @@ func TestAILoreIntegration(t *testing.T) {
 Subject: Re: [PATCH RFC] Test Subject
 Message-ID: <reply1>
 In-Reply-To: <mock@msgid-1>
+Cc: "New Reviewer" <newreviewer@email.com>
 
 #syz upstream
 `, now.Add(time.Minute))
@@ -127,7 +128,12 @@ In-Reply-To: <mock@msgid-1>
 	require.Len(t, mockSnd.sent, 2) // Moderation email + Public email.
 	assert.Equal(t, []string{"public@test.com", `"Maintainer" <maintainer@email.com>`}, mockSnd.sent[1].To)
 	assert.Equal(t, "[PATCH] Test Subject", mockSnd.sent[1].Subject)
-	assert.Equal(t, []string{"archive@lore.com", "reviewer@email.com"}, mockSnd.sent[1].Cc)
+	assert.Equal(t, []string{
+		"archive@lore.com",
+		"newreviewer@email.com",
+		"reviewer@email.com",
+		"user@email",
+	}, mockSnd.sent[1].Cc)
 
 	bodyPublic := string(mockSnd.sent[1].Body)
 	assert.NotContains(t, bodyPublic, "Final To:")
@@ -650,6 +656,7 @@ func TestAILoreIteration(t *testing.T) {
 
 	require.Len(t, mockSnd.sent, 2)
 	assert.Equal(t, "[PATCH RFC v2] Test Subject", mockSnd.sent[1].Subject)
+	assert.Contains(t, mockSnd.sent[1].Cc, "reviewer@email.com")
 	body = string(mockSnd.sent[1].Body)
 	assert.NotContains(t, body, "Test Subject")
 	assert.Contains(t, body, "Fixes: abcdefabcdef (\"introduce a bug\")")

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -126,13 +126,16 @@ Cc: "New Reviewer" <newreviewer@email.com>
 	require.NoError(t, err)
 
 	require.Len(t, mockSnd.sent, 2) // Moderation email + Public email.
-	assert.Equal(t, []string{"public@test.com", `"Maintainer" <maintainer@email.com>`}, mockSnd.sent[1].To)
+	assert.Equal(t, []string{
+		"public@test.com",
+		"User Name <user@email>",
+		`"Maintainer" <maintainer@email.com>`,
+	}, mockSnd.sent[1].To)
 	assert.Equal(t, "[PATCH] Test Subject", mockSnd.sent[1].Subject)
 	assert.Equal(t, []string{
 		"archive@lore.com",
 		"newreviewer@email.com",
 		"reviewer@email.com",
-		"user@email",
 	}, mockSnd.sent[1].Cc)
 
 	bodyPublic := string(mockSnd.sent[1].Body)

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -91,6 +91,10 @@ func TestAIExternalReporting(t *testing.T) {
 			"Hash":  "123456789012",
 			"Title": "original bug",
 		},
+		"Recipients": []map[string]any{
+			{"Name": "Test User", "Email": "test-user", "To": true},
+			{"Name": "Reviewer", "Email": "reviewer@test.com", "To": false},
+		},
 	})
 
 	// Poll for pending reports and confirm published.
@@ -154,6 +158,8 @@ func TestAIExternalReporting(t *testing.T) {
 		BaseCommit: "commit",
 		BaseTree:   "repo",
 		Authors:    []string{"test-user"},
+		To:         []string{"test-user"},
+		Cc:         []string{`"Reviewer" <reviewer@test.com>`},
 		Closes: []string{
 			appURL(c.ctx) + "/bug?extid=" + extID,
 		},
@@ -166,7 +172,8 @@ func TestAIExternalReporting(t *testing.T) {
 		},
 		ReportedBy: []string{"syzbot+" + extID + "@" + appengine.AppID(c.ctx) + ".appspotmail.com"},
 	}, pollResp.Result.Patch)
-	require.Equal(t, []string{"public@test.com"}, pollResp.Result.To)
+	require.Equal(t, []string{"public@test.com", "test-user"}, pollResp.Result.To)
+	require.Equal(t, []string{`"Reviewer" <reviewer@test.com>`}, pollResp.Result.Cc)
 
 	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
 		ReportID:       pollResp.Result.ID,
@@ -940,6 +947,63 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 	require.True(t, loadedComments[0].Processed)
 
 	testExtendedPatchIteration(t, c, resp, gotResult, pollReq)
+}
+
+func TestAIUpstreamAuthorDeduplication(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", MergePatchCc: true},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
+		},
+		AllowedCommandAuthors: []string{"upstreamer@example.com"},
+	})
+
+	_, jobID := c.setupAIPatchJob(t)
+
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	c.finishAIPatchJob(t, jobID, map[string]any{
+		"Fixes": map[string]any{
+			"Hash":  "123456789012",
+			"Title": "original bug",
+		},
+		"Recipients": []map[string]any{
+			{"Name": "Upstreamer", "Email": "upstreamer@example.com", "To": true},
+		},
+	})
+
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: "lore"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"moderation@test.com", "\"Upstreamer\" <upstreamer@example.com>"}, pollResp.Result.To)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollResp.Result.ID,
+		PublishedExtID: "moderation-msg-id",
+	})
+	require.NoError(t, err)
+
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "moderation-msg-id",
+		MessageExtID: "<upstream-cmd>",
+		Author:       "\"Upstreamer\" <upstreamer@example.com>",
+		DKIM:         true,
+		Upstream:     &dashapi.UpstreamCommand{},
+	})
+	require.NoError(t, err)
+
+	pollResp, err = c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: "lore"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"public@test.com", "\"Upstreamer\" <upstreamer@example.com>"}, pollResp.Result.To)
+	require.Empty(t, pollResp.Result.Cc)
 }
 
 func testExtendedPatchIteration(t *testing.T, c *Ctx, resp *dashapi.AIJobPollResp,

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
+	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/uuid"
 	"google.golang.org/api/iterator"
 	"google.golang.org/appengine/v2"
@@ -898,9 +899,40 @@ func LoadJobReportings(ctx context.Context, jobID string) ([]*JobReporting, erro
 	})
 }
 
-func SaveJobComment(ctx context.Context, entry *JobComment) error {
+func SaveJobComment(ctx context.Context, entry *JobComment, extraCc []string) error {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return err
+	}
 	entry.ID = uuid.NewString()
-	err := saveEntity(ctx, "JobComments", entry)
+
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		mut, err := spanner.InsertStruct("JobComments", entry)
+		if err != nil {
+			return err
+		}
+		muts := []*spanner.Mutation{mut}
+
+		if len(extraCc) > 0 {
+			stmt := spanner.Statement{
+				SQL:    selectJobReporting() + ` WHERE ID = @id`,
+				Params: map[string]any{"id": entry.ReportingID},
+			}
+			reporting, err := readRow[JobReporting](ctx, txn, stmt)
+			if err != nil {
+				return err
+			}
+			if reporting != nil {
+				reporting.ExtraCcList = email.MergeEmailLists(reporting.ExtraCcList, extraCc)
+				repMut, err := spanner.UpdateStruct("JobReporting", reporting)
+				if err != nil {
+					return err
+				}
+				muts = append(muts, repMut)
+			}
+		}
+		return txn.BufferWrite(muts)
+	})
 	if err != nil && spanner.ErrCode(err) == codes.AlreadyExists {
 		return ErrDuplicateComment
 	}
@@ -1256,6 +1288,7 @@ func IterationJobDone(ctx context.Context, jobID string, commentIDs []string,
 			Source:       parentRep.Source,
 			Version:      spanner.NullInt64{Int64: int64(nextVersion), Valid: true},
 			UpstreamedBy: parentRep.UpstreamedBy,
+			ExtraCcList:  parentRep.ExtraCcList,
 			CreatedAt:    TimeNow(ctx),
 		}
 
@@ -1446,19 +1479,6 @@ func RunInTransaction(ctx context.Context, f func(ctx context.Context, txn *span
 		return err
 	}
 	_, err = client.ReadWriteTransaction(ctx, f)
-	return err
-}
-
-func saveEntity[T any](ctx context.Context, table string, obj *T) error {
-	client, err := dbClient(ctx)
-	if err != nil {
-		return err
-	}
-	mut, err := spanner.InsertOrUpdateStruct(table, obj)
-	if err != nil {
-		return err
-	}
-	_, err = client.Apply(ctx, []*spanner.Mutation{mut})
 	return err
 }
 

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -113,6 +113,7 @@ type JobReporting struct {
 	UpstreamedBy spanner.NullString
 	ExtID        spanner.NullString
 	Version      spanner.NullInt64
+	ExtraCcList  []string
 	CreatedAt    time.Time
 }
 

--- a/dashboard/app/aidb/migrations/22_add_extracc.down.sql
+++ b/dashboard/app/aidb/migrations/22_add_extracc.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE JobReporting DROP COLUMN ExtraCcList;

--- a/dashboard/app/aidb/migrations/22_add_extracc.up.sql
+++ b/dashboard/app/aidb/migrations/22_add_extracc.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE JobReporting ADD COLUMN ExtraCcList ARRAY<STRING(MAX)>;

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -66,6 +66,7 @@ type SendExternalCommandReq struct {
 	MessageExtID string
 	Author       string
 	AuthorName   string
+	Cc           []string
 	OwnEmail     bool
 	DKIM         bool
 	// Only one must be set.

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -88,8 +88,10 @@ type PatchingOutputs struct {
 }
 
 type FixesTag struct {
-	Hash  string
-	Title string
+	Hash        string
+	Title       string
+	AuthorName  string
+	AuthorEmail string
 }
 
 type Recipient struct {

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/vcs"
 )
@@ -78,6 +79,7 @@ var getMaintainers = aflow.NewFuncAction("get-maintainers", maintainers)
 type maintainersArgs struct {
 	KernelCommit string
 	PatchDiff    string
+	Fixes        ai.FixesTag
 }
 
 type maintainersResult struct {
@@ -106,6 +108,23 @@ func maintainers(ctx *aflow.Context, args maintainersArgs) (maintainersResult, e
 				Email: recipient.Address.Address,
 				To:    recipient.Type == vcs.To,
 			})
+		}
+		if args.Fixes.Hash != "" && args.Fixes.AuthorEmail != "" {
+			found := false
+			canonicalFixesEmail := email.CanonicalEmail(args.Fixes.AuthorEmail)
+			for i, rec := range res.Recipients {
+				if email.CanonicalEmail(rec.Email) == canonicalFixesEmail {
+					res.Recipients[i].To = true
+					found = true
+				}
+			}
+			if !found {
+				res.Recipients = append(res.Recipients, ai.Recipient{
+					Name:  args.Fixes.AuthorName,
+					Email: args.Fixes.AuthorEmail,
+					To:    true,
+				})
+			}
 		}
 		return nil
 	})

--- a/pkg/aflow/flow/patching/actions_test.go
+++ b/pkg/aflow/flow/patching/actions_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,5 +62,41 @@ pkg/aflow/flow/assessment: add UAF moderation workflow
 dashboard/app: add support for AI workflows
 syz-cluster: rewrite fuzz config generation
 `,
+	}, "")
+}
+
+func TestMaintainers(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
+	require.NoError(t, osutil.MkdirAll(filepath.Join(repoDir, "scripts")))
+
+	// Write a fake get_maintainer.pl.
+	scriptContent := `#!/bin/bash
+echo "Maintainer 1 <m1@example.com> (maintainer:SUBSYSTEM)"
+echo "Fixes Author <fixes@example.com> (reviewer:SUBSYSTEM)"
+`
+	require.NoError(t, osutil.MkdirAll(filepath.Join(repoDir, "scripts")))
+	repo.CommitChangeset("init", vcs.FileContent{
+		File:    "scripts/get_maintainer.pl",
+		Content: scriptContent,
+	})
+	repo.Git("update-index", "--chmod=+x", "scripts/get_maintainer.pl")
+	commit := repo.CommitChangeset("make executable")
+
+	aflow.TestAction(t, getMaintainers, dir, maintainersArgs{
+		KernelCommit: commit.Hash,
+		PatchDiff:    "fake patch diff",
+		Fixes: ai.FixesTag{
+			Hash:        "123456789",
+			Title:       "some fix",
+			AuthorName:  "Fixes Author",
+			AuthorEmail: "fixes@example.com",
+		},
+	}, maintainersResult{
+		Recipients: []ai.Recipient{
+			{Name: "Fixes Author", Email: "fixes@example.com", To: true},
+			{Name: "Maintainer 1", Email: "m1@example.com", To: true},
+		},
 	}, "")
 }

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -461,8 +461,10 @@ func queryFixesTag(ctx *aflow.Context, hash string) (ai.FixesTag, error) {
 			return fmt.Errorf("failed to get commit %q: %w", hash, err)
 		}
 		fix = ai.FixesTag{
-			Hash:  commit.Hash,
-			Title: commit.Title,
+			Hash:        commit.Hash,
+			Title:       commit.Title,
+			AuthorName:  commit.AuthorName,
+			AuthorEmail: commit.Author,
 		}
 		return nil
 	})

--- a/pkg/lore-relay/commands.go
+++ b/pkg/lore-relay/commands.go
@@ -22,6 +22,7 @@ func extractCommands(polled *lore.PolledEmail, dkimOk bool) ([]*dashapi.SendExte
 			MessageExtID: polled.Email.MessageID,
 			Author:       polled.Email.Author,
 			AuthorName:   polled.Email.AuthorName,
+			Cc:           polled.Email.Cc,
 			OwnEmail:     polled.Email.OwnEmail,
 			DKIM:         dkimOk,
 		}
@@ -50,6 +51,7 @@ func extractCommands(polled *lore.PolledEmail, dkimOk bool) ([]*dashapi.SendExte
 			MessageExtID: polled.Email.MessageID,
 			Author:       polled.Email.Author,
 			AuthorName:   polled.Email.AuthorName,
+			Cc:           polled.Email.Cc,
 			OwnEmail:     polled.Email.OwnEmail,
 			DKIM:         dkimOk,
 			Comment: &dashapi.CommentCommand{

--- a/pkg/lore-relay/relay_test.go
+++ b/pkg/lore-relay/relay_test.go
@@ -200,6 +200,7 @@ In-Reply-To: <reply1>
 			RootExtID:    "<mock@msgid-1>",
 			MessageExtID: "<reply2>",
 			Author:       "user@email",
+			Cc:           []string{"user@email"},
 			Upstream:     &dashapi.UpstreamCommand{},
 		},
 	}, mockDash.commands)
@@ -438,6 +439,7 @@ func mockMainScenarioCommands() []*dashapi.SendExternalCommandReq {
 			RootExtID:    "<mock@msgid-1>",
 			MessageExtID: "<reply1>",
 			Author:       "user@email",
+			Cc:           []string{"user@email"},
 			Comment: &dashapi.CommentCommand{
 				Subject: "Re: [PATCH] Fix bug",
 				Body:    "This looks interesting.\n",
@@ -448,6 +450,7 @@ func mockMainScenarioCommands() []*dashapi.SendExternalCommandReq {
 			RootExtID:    "<mock@msgid-1>",
 			MessageExtID: "<reply2>",
 			Author:       "user@email",
+			Cc:           []string{"user@email"},
 			Upstream:     &dashapi.UpstreamCommand{},
 		},
 		{
@@ -455,6 +458,7 @@ func mockMainScenarioCommands() []*dashapi.SendExternalCommandReq {
 			RootExtID:    "<mock@msgid-1>",
 			MessageExtID: "<reply3>",
 			Author:       "user@email",
+			Cc:           []string{"user@email"},
 			Reject: &dashapi.RejectCommand{
 				Reason: "#syz reject\n",
 			},


### PR DESCRIPTION
Assorted improvements to AI patch reporting:
* Preserve the emails of people discussing the patch.
* Include the author of the `Fixes: ` tag commit to the To list.
* Include the person who signed off the patch.

See individual commits.

Closes https://github.com/google/syzkaller/issues/7324