### PR TITLE
dashboard/app: implement cursor-based pagination for AI jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -41,6 +41,12 @@ type uiAIJobsPage struct {
 	ShowAborted     bool
 	ManualWorkflows []ManualWorkflowSpec
 	Managers        []string
+	HasNextPage     bool
+	NextCursorTime  string
+	NextCursorID    string
+	HasPrevPage     bool
+	PrevCursorTime  string
+	PrevCursorID    string
 }
 
 type ManualWorkflowSpec struct {
@@ -214,13 +220,67 @@ func handleAIJobsPage(ctx context.Context, w http.ResponseWriter, r *http.Reques
 	currentWorkflow := r.FormValue("workflow")
 	showAborted := r.FormValue("show_aborted") != ""
 
+	cursorTimeStr := r.FormValue("cursor_time")
+	var cursorTime time.Time
+	if cursorTimeStr != "" {
+		t, err := time.Parse(time.RFC3339Nano, cursorTimeStr)
+		if err != nil {
+			return fmt.Errorf("%w: invalid cursor_time %q", ErrClientBadRequest, cursorTimeStr)
+		}
+		cursorTime = t
+	}
+	cursorIDStr := r.FormValue("cursor_id")
+	reverse := r.FormValue("reverse") != ""
+	const limit = 500
+
 	jobs, err := aidb.LoadNamespaceJobs(ctx, hdr.Namespace, &aidb.JobFilter{
 		Workflow:    currentWorkflow,
 		ShowAborted: showAborted,
+		CursorTime:  cursorTime,
+		CursorID:    cursorIDStr,
+		Reverse:     reverse,
+		Limit:       limit + 1,
 	})
 	if err != nil {
 		return err
 	}
+
+	hasNextPage := false
+	hasPrevPage := false
+
+	if reverse {
+		if len(jobs) > limit {
+			hasPrevPage = true
+			jobs = jobs[1:]
+		}
+		if cursorTimeStr != "" {
+			hasNextPage = true
+		}
+	} else {
+		if len(jobs) > limit {
+			hasNextPage = true
+			jobs = jobs[:limit]
+		}
+		if cursorTimeStr != "" {
+			hasPrevPage = true
+		}
+	}
+
+	var nextCursorTime string
+	var nextCursorID string
+	var prevCursorTime string
+	var prevCursorID string
+
+	if len(jobs) > 0 {
+		firstJob := jobs[0]
+		prevCursorTime = firstJob.Created.Format(time.RFC3339Nano)
+		prevCursorID = firstJob.ID
+
+		lastJob := jobs[len(jobs)-1]
+		nextCursorTime = lastJob.Created.Format(time.RFC3339Nano)
+		nextCursorID = lastJob.ID
+	}
+
 	jobs, err = filterJobsAccess(ctx, r, jobs)
 	if err != nil {
 		return err
@@ -257,6 +317,12 @@ func handleAIJobsPage(ctx context.Context, w http.ResponseWriter, r *http.Reques
 		ShowAborted:     showAborted,
 		ManualWorkflows: manualAIWorkflows(cfg),
 		Managers:        managers,
+		HasNextPage:     hasNextPage,
+		NextCursorTime:  nextCursorTime,
+		NextCursorID:    nextCursorID,
+		HasPrevPage:     hasPrevPage,
+		PrevCursorTime:  prevCursorTime,
+		PrevCursorID:    prevCursorID,
 	}
 
 	if r.FormValue("json") == "1" {

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -302,6 +303,10 @@ func staleUnfinishedJobs(cutoff time.Time, workflows, namespaces []string) spann
 type JobFilter struct {
 	Workflow    string
 	ShowAborted bool
+	Limit       int
+	CursorTime  time.Time
+	CursorID    string
+	Reverse     bool
 }
 
 func LoadNamespaceJobs(ctx context.Context, ns string, filter *JobFilter) ([]*Job, error) {
@@ -324,11 +329,35 @@ func LoadNamespaceJobs(ctx context.Context, ns string, filter *JobFilter) ([]*Jo
 	if !filter.ShowAborted {
 		sql += " AND NOT Aborted"
 	}
-	sql += " ORDER BY Created DESC"
-	return selectAll[Job](ctx, spanner.Statement{
+	if !filter.CursorTime.IsZero() && filter.CursorID != "" {
+		if filter.Reverse {
+			sql += " AND (Created > @cursorTime OR (Created = @cursorTime AND ID > @cursorID))"
+		} else {
+			sql += " AND (Created < @cursorTime OR (Created = @cursorTime AND ID < @cursorID))"
+		}
+		params["cursorTime"] = filter.CursorTime
+		params["cursorID"] = filter.CursorID
+	}
+	if filter.Reverse {
+		sql += " ORDER BY Created ASC, ID ASC"
+	} else {
+		sql += " ORDER BY Created DESC, ID DESC"
+	}
+	if filter.Limit > 0 {
+		sql += " LIMIT @limit"
+		params["limit"] = filter.Limit
+	}
+	jobs, err := selectAll[Job](ctx, spanner.Statement{
 		SQL:    sql,
 		Params: params,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if filter.Reverse {
+		slices.Reverse(jobs)
+	}
+	return jobs, nil
 }
 
 func LoadBugJobs(ctx context.Context, bugID string) ([]*Job, error) {

--- a/dashboard/app/templates/ai_jobs.html
+++ b/dashboard/app/templates/ai_jobs.html
@@ -73,6 +73,32 @@ List of AI jobs page.
 			<label for="show_aborted" style="margin-left: 20px;">Display aborted jobs:</label>
 			<input type="checkbox" id="show_aborted" name="show_aborted" onchange="this.form.submit()" {{if .ShowAborted}}checked{{end}}> YES
 	</form>
+	<div class="pagination">
+		{{if .HasPrevPage}}
+			<a href="?workflow={{.CurrentWorkflow}}&show_aborted={{if .ShowAborted}}1{{end}}&reverse=1&cursor_time={{.PrevCursorTime}}&cursor_id={{.PrevCursorID}}">Prev</a>
+		{{else}}
+			<span class="disabled-link">Prev</span>
+		{{end}}
+		|
+		{{if .HasNextPage}}
+			<a href="?workflow={{.CurrentWorkflow}}&show_aborted={{if .ShowAborted}}1{{end}}&cursor_time={{.NextCursorTime}}&cursor_id={{.NextCursorID}}">Next</a>
+		{{else}}
+			<span class="disabled-link">Next</span>
+		{{end}}
+	</div>
 	{{template "ai_job_list" .Jobs}}
+	<div class="pagination">
+		{{if .HasPrevPage}}
+			<a href="?workflow={{.CurrentWorkflow}}&show_aborted={{if .ShowAborted}}1{{end}}&reverse=1&cursor_time={{.PrevCursorTime}}&cursor_id={{.PrevCursorID}}">Prev</a>
+		{{else}}
+			<span class="disabled-link">Prev</span>
+		{{end}}
+		|
+		{{if .HasNextPage}}
+			<a href="?workflow={{.CurrentWorkflow}}&show_aborted={{if .ShowAborted}}1{{end}}&cursor_time={{.NextCursorTime}}&cursor_id={{.NextCursorID}}">Next</a>
+		{{else}}
+			<span class="disabled-link">Next</span>
+		{{end}}
+	</div>
 </body>
 </html>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -586,3 +586,13 @@ aside {
 	border-radius: 4px;
 	margin: 10px 5px;
 }
+
+.pagination {
+	margin-top: 10px;
+	margin-bottom: 10px;
+	font-size: 16px;
+}
+
+.disabled-link {
+	color: grey;
+}


### PR DESCRIPTION
The AI jobs page previously loaded and displayed all jobs at once, which becomes prohibitively expensive and degrades performance as the number of jobs grows.

Implement efficient cursor-based pagination to limit the number of jobs returned per page (500 items). To ensure stable pagination without the performance penalty of large database offsets or costly subqueries, the implementation uses a composite cursor consisting of the job's creation timestamp and its unique ID. This allows the database to perform a simple, highly-efficient index scan to fetch the next sequential page of results.