### PR TITLE
pkg/lore-relay: add maintainer email to the AI patch template

### DIFF
--- a/pkg/lore-relay/relay.go
+++ b/pkg/lore-relay/relay.go
@@ -37,6 +37,8 @@ type Config struct {
 	LorePollInterval time.Duration `yaml:"lore_poll_interval"`
 	// DocsLink is the link to the documentation.
 	DocsLink string `yaml:"docs_link"`
+	// MaintainersEmail is the email address to reach the maintainers.
+	MaintainersEmail string `yaml:"maintainers_email"`
 	// Tracer is used for debug logging.
 	Tracer debugtracer.DebugTracer `yaml:"-"`
 	// LoreArchive is an optional mailing list that will be added to Cc on all sent emails.

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -21,10 +21,11 @@ var templatesFS embed.FS
 
 // TemplateData holds data for rendering email templates.
 type TemplateData struct {
-	Patch       *dashapi.NewReportResult
-	Replies     []*dashapi.ReplyResult
-	DocsLink    string
-	CanUpstream bool
+	Patch            *dashapi.NewReportResult
+	Replies          []*dashapi.ReplyResult
+	DocsLink         string
+	MaintainersEmail string
+	CanUpstream      bool
 }
 
 func renderTemplate(name, tmplStr string, data TemplateData) (string, error) {
@@ -44,8 +45,9 @@ func renderTemplate(name, tmplStr string, data TemplateData) (string, error) {
 // RenderBody renders the email body based on the poll result.
 func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 	data := TemplateData{
-		DocsLink:    cfg.DocsLink,
-		CanUpstream: res.CanUpstream,
+		DocsLink:         cfg.DocsLink,
+		MaintainersEmail: cfg.MaintainersEmail,
+		CanUpstream:      res.CanUpstream,
 	}
 	if res.Patch != nil {
 		var recipients []ai.Recipient

--- a/pkg/lore-relay/templates/new_patch.txt
+++ b/pkg/lore-relay/templates/new_patch.txt
@@ -10,8 +10,10 @@
 
 base-commit: {{.Patch.BaseCommit}}
 -- 
-{{ if .CanUpstream }}This is an AI-generated patch subject to moderation.
+This is an AI-generated patch.
+{{ if .CanUpstream }}It is subject to moderation.
 Reply with '#syz upstream' to send it to the mailing list.
 Reply with '#syz reject' to reject it (or '#syz unreject' to undo).
 
+{{ end }}{{ if .MaintainersEmail }}Maintainers can be reached at {{.MaintainersEmail}}.
 {{ end }}See {{.DocsLink}} for more information.

--- a/pkg/lore-relay/templates_test.go
+++ b/pkg/lore-relay/templates_test.go
@@ -42,7 +42,10 @@ func TestRender(t *testing.T) {
 			err = json.Unmarshal(inputData, &res)
 			require.NoError(t, err)
 
-			output, err := RenderBody(&Config{DocsLink: "http://docs.link"}, &res)
+			output, err := RenderBody(&Config{
+				DocsLink:         "http://docs.link",
+				MaintainersEmail: "test-maintainer@example.com",
+			}, &res)
 			require.NoError(t, err)
 			subject := GenerateSubject(&res)
 			fullOutput := "Subject: " + subject + "\n\n" + output

--- a/pkg/lore-relay/testdata/patch_moderation.out.txt
+++ b/pkg/lore-relay/testdata/patch_moderation.out.txt
@@ -19,8 +19,10 @@ index 123..456 100644
 
 base-commit: abcdef123456
 -- 
-This is an AI-generated patch subject to moderation.
+This is an AI-generated patch.
+It is subject to moderation.
 Reply with '#syz upstream' to send it to the mailing list.
 Reply with '#syz reject' to reject it (or '#syz unreject' to undo).
 
+Maintainers can be reached at test-maintainer@example.com.
 See http://docs.link for more information.

--- a/pkg/lore-relay/testdata/patch_v2.out.txt
+++ b/pkg/lore-relay/testdata/patch_v2.out.txt
@@ -24,4 +24,6 @@ diff --git a/file2 b/file2
 
 base-commit: 123456abcdef
 -- 
+This is an AI-generated patch.
+Maintainers can be reached at test-maintainer@example.com.
 See http://docs.link for more information.

--- a/syz-agent/k8s/overlays/prod-lore/lore-relay-config.yaml
+++ b/syz-agent/k8s/overlays/prod-lore/lore-relay-config.yaml
@@ -11,6 +11,7 @@ own_emails:
 lore_archive: "syzbot@lists.linux.dev"
 verify_dkim: true
 docs_link: "https://github.com/google/syzkaller/blob/master/docs/syzbot_ai_patches.md"
+maintainers_email: "syzkaller@googlegroups.com"
 smtp:
   host: "gcp-secret:lore-relay-smtp-host"
   port: "gcp-secret:lore-relay-smtp-port"


### PR DESCRIPTION
Make it clear in all patch templates that the patch is AI-generated, even if it cannot be upstreamed yet. Add a new maintainers_email config option to lore-relay and include a note in the patch template directing users to this email for questions. Set this email to syzkaller@googlegroups.com in the prod-lore configuration.