### PR TITLE
dashboard/app: patch iteration logic improvements

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1336,13 +1336,16 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 	})
 }
 
-const patchIterationDebounce = 30 * time.Minute
 const maxIterationGroupsPerPoll = 5
 
 // TODO: We could probably be more smart at avoiding looking into the specific
 // reportings each time, e.g. in case of retrials on errors.
 func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, error) {
-	var groups []*aidb.PendingCommentGroup
+	type pendingIteration struct {
+		*aidb.PendingCommentGroup
+		Debounce time.Duration
+	}
+	var groups []*pendingIteration
 
 	for ns, cfg := range getConfig(ctx).Namespaces {
 		if cfg.AI == nil || !client.AllowedNamespace(ns) {
@@ -1354,7 +1357,12 @@ func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, 
 				if err != nil {
 					return false, fmt.Errorf("failed to load pending comment groups for %v/%v: %w", ns, stage.Name, err)
 				}
-				groups = append(groups, grp...)
+				for _, g := range grp {
+					groups = append(groups, &pendingIteration{
+						PendingCommentGroup: g,
+						Debounce:            stage.IterationDebounce,
+					})
+				}
 			}
 		}
 	}
@@ -1368,10 +1376,10 @@ func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, 
 		groups = groups[:maxIterationGroupsPerPoll]
 	}
 	for _, g := range groups {
-		if timeNow(ctx).Sub(g.LatestComment) < patchIterationDebounce {
+		if timeNow(ctx).Sub(g.LatestComment) < g.Debounce {
 			continue
 		}
-		created, err := tryCreatePatchIterationJob(ctx, g)
+		created, err := tryCreatePatchIterationJob(ctx, g.PendingCommentGroup)
 		if err != nil {
 			log.Errorf(ctx, "tryCreatePatchIterationJob failed: %v", err)
 		} else if created {
@@ -1382,7 +1390,7 @@ func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, 
 }
 
 func tryCreatePatchIterationJob(ctx context.Context, g *aidb.PendingCommentGroup) (bool, error) {
-	job, err := aidb.CreatePatchIterationJob(ctx, g.ReportingID, patchIterationDebounce)
+	job, err := aidb.CreatePatchIterationJob(ctx, g.ReportingID)
 	if err != nil {
 		return false, fmt.Errorf("failed to create patch iteration job for %s: %w", g.ReportingID, err)
 	}

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -316,6 +316,31 @@ In-Reply-To: <mock@msgid-1>
 	assert.Equal(t, []string{"user@email"}, mockSnd.sent[3].To)
 	expectedBody := "> #syz upstream\n\nCommand failed:\n\nCannot upstream a rejected patch. Unreject it first.\n\n"
 	assert.Equal(t, expectedBody, string(mockSnd.sent[3].Body))
+
+	// 6. Test that a comment on a rejected patch does not trigger an iteration.
+	loreArchive.SaveMessageAt(t, `From: reviewer@email.com
+Subject: Re: [PATCH RFC] Test Subject
+Message-ID: <comment3>
+In-Reply-To: <mock@msgid-1>
+
+Here is another comment after rejection.
+`, now.Add(time.Minute*3))
+
+	err = relay.PollLoreOnce(t.Context())
+	require.NoError(t, err)
+
+	c.advanceTime(31 * time.Minute)
+
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	resp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	assert.Empty(t, resp.ID) // No job should be created.
 }
 
 func TestAILoreUnknownMessageID(t *testing.T) {

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -25,7 +25,7 @@ func TestAILoreIntegration(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
@@ -185,7 +185,7 @@ func TestAILoreIntegrationReject(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
@@ -383,9 +383,15 @@ func TestAILoreIntegrationComment(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
-			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{
+				Name:               "moderation",
+				ServingIntegration: "lore",
+				MailingList:        "moderation@test.com",
+				AddressComments:    true,
+				IterationDebounce:  10 * time.Minute,
+			},
 		},
 	})
 
@@ -518,7 +524,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 
 	// 5. Complete the iteration job to verify CC behavior on replies and Fixes passing.
 	// Advance time to pass the debounce logic so the iteration job gets created.
-	c.advanceTime(31 * time.Minute)
+	c.advanceTime(11 * time.Minute)
 
 	pollReq := &dashapi.AIJobPollReq{
 		AgentName:    "test-agent",
@@ -571,9 +577,15 @@ func TestAILoreIteration(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
-			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{
+				Name:               "moderation",
+				ServingIntegration: "lore",
+				MailingList:        "moderation@test.com",
+				AddressComments:    true,
+				IterationDebounce:  10 * time.Minute,
+			},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", AddressComments: true},
 		},
 	})
@@ -662,7 +674,7 @@ func TestAILoreIteration(t *testing.T) {
 
 	// 5. Complete the iteration job to verify CC behavior on replies and Fixes passing.
 	// Advance time to pass the debounce logic so the iteration job gets created.
-	c.advanceTime(31 * time.Minute)
+	c.advanceTime(11 * time.Minute)
 
 	pollReq := &dashapi.AIJobPollReq{
 		AgentName:    "test-agent",

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -25,7 +25,7 @@ func TestAIExternalReporting(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
@@ -274,7 +274,7 @@ func TestAINoFailedJobReported(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
 		},
@@ -327,7 +327,7 @@ func TestAINoParallelReports(t *testing.T) {
 			},
 		},
 	}
-	c.SetAIConfig(aiCfg)
+	c.SetAIConfig("ains", aiCfg)
 
 	// Report a crash to create a bug.
 	build := testBuild(1)
@@ -441,7 +441,7 @@ func TestAIUpstreamTwice(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
@@ -524,7 +524,7 @@ func TestAIUpstreamIdempotency(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
@@ -595,7 +595,7 @@ func TestAINoStages(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{})
+	c.SetAIConfig("ains", &AIConfig{})
 
 	build := testBuild(1)
 	c.aiClient.UploadBuild(build)
@@ -652,7 +652,7 @@ func TestAIUpstreamConcurrent(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
@@ -765,7 +765,7 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
@@ -1105,7 +1105,7 @@ func TestAIPatchIterationBackoff(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 		},
@@ -1230,7 +1230,7 @@ func TestAIPatchIterationAutoTriggerDisabled(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			// Explicitly disable auto-triggering.
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: false},
@@ -1310,7 +1310,7 @@ func TestAIPatchIterationStaleThread(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 		},
@@ -1409,7 +1409,7 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
@@ -1568,7 +1568,7 @@ func TestAIManualPushToReporting(t *testing.T) {
 	extID := c.aiClient.pollEmailExtID()
 
 	// 1. Finish a job with no AI stages configured (no reporting generated).
-	c.SetAIConfig(&AIConfig{})
+	c.SetAIConfig("ains", &AIConfig{})
 
 	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
 		AgentName:    "test",
@@ -1593,7 +1593,7 @@ func TestAIManualPushToReporting(t *testing.T) {
 	require.Empty(t, reportings)
 
 	// 2. Add an AI stage to the config and push the job.
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{{Name: "public", ServingIntegration: "lore"}},
 	})
 
@@ -1613,7 +1613,7 @@ func TestAIAssessmentNoReport(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
 		},
@@ -1675,7 +1675,7 @@ func TestAIPatchIterationEmptyResult(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 		},
@@ -1778,7 +1778,7 @@ func TestAIPatchFilter(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()
 
-	c.SetAIConfig(&AIConfig{
+	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
 			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -865,6 +865,7 @@ func LoadPendingCommentGroups(ctx context.Context, namespace, stage string) ([]*
               JOIN JobReporting ON JobComments.ReportingID = JobReporting.ID
               JOIN Jobs ON JobReporting.JobID = Jobs.ID
               WHERE JobComments.Processed = false AND Jobs.Namespace = @namespace AND JobReporting.Stage = @stage
+              AND (Jobs.Correct IS NULL OR Jobs.Correct = true)
               GROUP BY JobComments.ReportingID`,
 		Params: map[string]any{"namespace": namespace, "stage": stage},
 	})

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -878,7 +878,7 @@ func LoadJobReporting(ctx context.Context, id string) (*JobReporting, error) {
 	})
 }
 
-func CreatePatchIterationJob(ctx context.Context, reportingID string, debounce time.Duration) (*Job, error) {
+func CreatePatchIterationJob(ctx context.Context, reportingID string) (*Job, error) {
 	client, err := dbClient(ctx)
 	if err != nil {
 		return nil, err

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -164,8 +164,9 @@ type AIPatchStageConfig struct {
 	ServingIntegration string // e.g. "lore"
 	MailingList        string
 	NoParallelReports  bool
-	MergePatchCc       bool // If true, CC people mentioned in the patch report (authors, reviewers).
-	AddressComments    bool // If true, automatically trigger a patch iteration on new comments.
+	MergePatchCc       bool          // If true, CC people mentioned in the patch report (authors, reviewers).
+	AddressComments    bool          // If true, automatically trigger a patch iteration on new comments.
+	IterationDebounce  time.Duration // Wait time before creating a new iteration. Defaults to 30m.
 }
 
 func (cfg *AIConfig) StageIndexByName(name string) int {
@@ -724,7 +725,7 @@ func checkCoverageConfig(ns string, cfg *Config) {
 
 func checkAIConfig(ns string, cfg *AIConfig) {
 	stageNames := make(map[string]bool)
-	for _, stage := range cfg.Stages {
+	for i, stage := range cfg.Stages {
 		if stage.Name == "" {
 			panic(fmt.Sprintf("%v: AI stage name cannot be empty", ns))
 		}
@@ -732,6 +733,9 @@ func checkAIConfig(ns string, cfg *AIConfig) {
 			panic(fmt.Sprintf("%v: duplicate AI stage name %q", ns, stage.Name))
 		}
 		stageNames[stage.Name] = true
+		if stage.IterationDebounce == 0 {
+			cfg.Stages[i].IterationDebounce = 30 * time.Minute
+		}
 	}
 	if cfg.SecurityPrio == nil {
 		cfg.SecurityPrio = func(*Bug, ai.AssessmentSecurityOutputs) BugPrio {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -954,15 +954,23 @@ func replaceReporting(ctx context.Context, ns, name string, f func(Reporting) Re
 	})
 }
 
-// SetAIConfig patches the config for all namespaces to use the given AIConfig.
-func (ctx *Ctx) SetAIConfig(aiCfg *AIConfig) {
+// SetAIConfig patches the config for a specific namespace to use the given AIConfig.
+func (ctx *Ctx) SetAIConfig(ns string, aiCfg *AIConfig) {
+	if aiCfg != nil {
+		checkAIConfig(ns, aiCfg)
+	}
 	ctx.transformContext = func(ctx context.Context) context.Context {
 		cfg := getConfig(ctx)
+		if _, ok := cfg.Namespaces[ns]; !ok {
+			panic(fmt.Sprintf("SetAIConfig: unknown namespace %q", ns))
+		}
 		newCfg := *cfg
 		newCfg.Namespaces = make(map[string]*Config)
 		for k, v := range cfg.Namespaces {
 			nc := *v
-			nc.AI = aiCfg
+			if k == ns {
+				nc.AI = aiCfg
+			}
 			newCfg.Namespaces[k] = &nc
 		}
 		return contextWithConfig(ctx, &newCfg)

--- a/docs/syzbot_ai_patches.md
+++ b/docs/syzbot_ai_patches.md
@@ -33,6 +33,7 @@ version (e.g. an RFC v2) if necessary.
 #syz reject
 ```
 You can provide the reason for rejection in the email body for better accounting.
+Once a patch is rejected, the AI will stop reacting to further comments on this patch version.
 
 * If you accidentally rejected a patch, you can undo it:
 ```


### PR DESCRIPTION
* Do not do patch iteration on rejected patches.
* Make it possible to configure per-stage the time we wait before starting a patch-iteration job after new comments.