### PR TITLE
pkg/aflow/flow/patching: use Consts instead of a custom action

### DIFF
--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -53,6 +53,11 @@ func init() {
 		&aflow.Flow{
 			Consts: map[string]any{
 				"NeedStrace": false,
+				// For convenience of the patch-iteration workflow.
+				"ReviewedBy": []string{},
+				"AckedBy":    []string{},
+				"TestedBy":   []string{},
+				"ReportedBy": []string{},
 			},
 			Root: aflow.Pipeline(
 				baseCommitPicker,
@@ -95,7 +100,6 @@ func init() {
 					Tools:       commonTools,
 				},
 				formatPatchDescription,
-				emptyTagsAction,
 			),
 		})
 }

--- a/pkg/aflow/flow/patching/tags.go
+++ b/pkg/aflow/flow/patching/tags.go
@@ -136,20 +136,6 @@ var tagExtractor = &aflow.LLMAgent{
 	Prompt:      tagExtractorPrompt,
 }
 
-var emptyTagsAction = aflow.NewFuncAction("empty-tags", func(ctx *aflow.Context, args struct{}) (struct {
-	ReviewedBy []string
-	AckedBy    []string
-	TestedBy   []string
-	ReportedBy []string
-}, error) {
-	return struct {
-		ReviewedBy []string
-		AckedBy    []string
-		TestedBy   []string
-		ReportedBy []string
-	}{}, nil
-})
-
 const tagExtractorInstruction = `
 You are an expert Linux kernel maintainer. Your task is to extract review tags from comments on a proposed patch.
 Reviewers may provide tags to add to the commit.


### PR DESCRIPTION
This is a simpler solution that achieves the same,
and scales better if we need more of these empty outputs in the future.
