### PR TITLE
pkg/aflow: don't ValidatedLLMOutputs State generic arg

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -90,7 +90,7 @@ func init() {
 				&aflow.LLMAgent{
 					Name:        "verdict-agent",
 					Model:       aflow.BestExpensiveModel,
-					Outputs:     aflow.ValidatedLLMOutputs[struct{}, verdictAgentArgs](validateVerdictArgs),
+					Outputs:     aflow.ValidatedLLMOutputs[verdictAgentArgs](validateVerdictArgs),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: verdictInstruction,
 					Prompt:      verdictPrompt,
@@ -117,7 +117,7 @@ func init() {
 								&aflow.LLMAgent{
 									Name:        "fixes-finder",
 									Model:       aflow.BestExpensiveModel,
-									Outputs:     aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
+									Outputs:     aflow.ValidatedLLMOutputs[fixesFinderArgs](validateFixesHashes),
 									TaskType:    aflow.FormalReasoningTask,
 									Instruction: fixesIterationInstruction,
 									Prompt:      fixesIterationPrompt,

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -79,7 +79,7 @@ func init() {
 				&aflow.LLMAgent{
 					Name:        "fixes-finder",
 					Model:       aflow.BestExpensiveModel,
-					Outputs:     aflow.ValidatedLLMOutputs[fixesFinderState, fixesFinderArgs](validateFixesHashes),
+					Outputs:     aflow.ValidatedLLMOutputs[fixesFinderArgs](validateFixesHashes),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: fixesInstruction,
 					Prompt:      fixesPrompt,

--- a/pkg/aflow/flow/patching/tags.go
+++ b/pkg/aflow/flow/patching/tags.go
@@ -130,7 +130,7 @@ var tagsMergerAction = aflow.NewFuncAction("tags-merger", mergeTags)
 var tagExtractor = &aflow.LLMAgent{
 	Name:        "tag-extractor",
 	Model:       aflow.GoodBalancedModel,
-	Outputs:     aflow.ValidatedLLMOutputs[tagExtractorState, tagExtractorArgs](validateTagExtractorOutputs),
+	Outputs:     aflow.ValidatedLLMOutputs[tagExtractorArgs](validateTagExtractorOutputs),
 	TaskType:    aflow.FormalReasoningTask,
 	Instruction: tagExtractorInstruction,
 	Prompt:      tagExtractorPrompt,

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -35,7 +35,7 @@ type LLMAgent struct {
 	// Reply should not be empty unless Outputs are specified.
 	Reply string
 	// Optional additional structured outputs besides the final text reply.
-	// Use LLMOutputs function to create it.
+	// Use LLMOutputs or ValidatedLLMOutputs functions to create it.
 	Outputs *llmOutputs
 	// Task type controls various LLM parameters, see TaskType consts below.
 	TaskType TaskType
@@ -147,14 +147,14 @@ func Tools(tools ...any) []Tool {
 
 // LLMOutputs creates a special tool that can be used by LLM to provide structured outputs.
 func LLMOutputs[Args any]() *llmOutputs {
-	return ValidatedLLMOutputs[struct{}, Args](nil)
+	return ValidatedLLMOutputs[Args, struct{}](nil)
 }
 
 // ValidatedLLMOutputs is like LLMOutputs but allows to validate the outputs before accepting them.
 // The validate function may return modified Args, which will be used as the final result.
 // If the validate function returns an error, it will be returned to the LLM agent,
 // so that it can retry the call. Use BadCallError if LLM must retry.
-func ValidatedLLMOutputs[State, Args any](validate func(*Context, State, Args) (Args, error)) *llmOutputs {
+func ValidatedLLMOutputs[Args, State any](validate func(*Context, State, Args) (Args, error)) *llmOutputs {
 	return &llmOutputs{
 		tool: NewFuncTool(llmSetResultsTool, func(ctx *Context, state State, args Args) (Args, error) {
 			if validate != nil {

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -548,7 +548,7 @@ func TestValidatedLLMOutputs(t *testing.T) {
 		&LLMAgent{
 			Name:  "smarty",
 			Model: "model",
-			Outputs: ValidatedLLMOutputs[subState, flowResults](
+			Outputs: ValidatedLLMOutputs[flowResults](
 				func(ctx *Context, state subState, args flowResults) (flowResults, error) {
 					if state.StateValue != 42 {
 						return args, fmt.Errorf("bad state value: %v", state.StateValue)
@@ -596,7 +596,7 @@ func TestValidatedLLMOutputsVerify(t *testing.T) {
 			Root: &LLMAgent{
 				Name:  "smarty",
 				Model: "model",
-				Outputs: ValidatedLLMOutputs[missingState, flowResults](
+				Outputs: ValidatedLLMOutputs[flowResults](
 					func(ctx *Context, state missingState, args flowResults) (flowResults, error) {
 						return args, nil
 					}),


### PR DESCRIPTION
Make the State arg inferrable, and don't spell it out to avoid clutter and duplication.
The Args arg is also inferrable, but keep it spelled out explicitly for consistencty
with LLMOutputs and to make it easier for workflow declaration readers to understand
what are the outputs.
