### PR TITLE
Makefile: use go tool for goyacc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ generate_rpc:
 
 generate_trace2syz:
 	(cd tools/syz-trace2syz/parser; ragel -Z -G2 -o lex.go straceLex.rl)
-	(cd tools/syz-trace2syz/parser; goyacc -o strace.go -p Strace -v="" strace.y)
+	(cd tools/syz-trace2syz/parser; $(HOSTGO) tool goyacc -o strace.go -p Strace -v="" strace.y)
 
 format: format_go format_cpp format_sys format_keep_sorted
 
@@ -428,7 +428,6 @@ install_prerequisites: act
 	sudo apt-get install -y -q clang-tidy || true
 	sudo apt-get install -y -q clang clang-format ragel
 	sudo apt-get install -y -q flatbuffers-compiler libflatbuffers-dev
-	GO111MODULE=off go get -u golang.org/x/tools/cmd/goyacc
 
 check_copyright:
 	./tools/check-copyright.sh

--- a/go.mod
+++ b/go.mod
@@ -355,5 +355,6 @@ tool (
 	github.com/google/keep-sorted
 	github.com/vektra/mockery/v3
 	golang.org/x/tools/cmd/deadcode
+	golang.org/x/tools/cmd/goyacc
 	golang.org/x/tools/cmd/stringer
 )


### PR DESCRIPTION
When running `sudo make install_prerequisites` with Go 1.26.0, the `G0111MODULE=off go get -u golang.org/x/tools/cmd/goyacc` command would return error:

<img width="540" height="55" alt="Screenshot 2026-05-25 at 11 17 22" src="https://github.com/user-attachments/assets/2bd118ed-9dfb-4f0d-a5bd-648b7ce6d5f6" />

The root cause may be that newer Go no longer supports installing tools with `go get`: https://go.dev/doc/go-get-install-deprecation.
