### PR TITLE
pkg/vcs, pkg/aflow: explicitly fetch tags for RC base commit

### DIFF
--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -35,7 +35,7 @@ type baseCommitResult struct {
 func pickBaseCommit(ctx *aflow.Context, args baseCommitArgs) (baseCommitResult, error) {
 	commit := ""
 	err := kernel.UseLinuxRepo(ctx, func(_ string, repo vcs.Repo) error {
-		head, err := repo.Poll(args.BaseRepository, args.BaseBranch)
+		head, err := repo.CheckoutBranch(args.BaseRepository, args.BaseBranch)
 		if err != nil {
 			return err
 		}

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -43,6 +43,11 @@ func pickBaseCommit(ctx *aflow.Context, args baseCommitArgs) (baseCommitResult, 
 		case "HEAD":
 			commit = head.Hash
 		case "RC":
+			// FetchTags is called to force fetch the tags.
+			// See the discussion at https://github.com/google/syzkaller/pull/7385.
+			if err := repo.FetchTags(args.BaseRepository); err != nil {
+				return fmt.Errorf("failed to fetch tags: %w", err)
+			}
 			tag, err := repo.ReleaseTag(head.Hash)
 			if err != nil {
 				return err

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -78,6 +78,10 @@ func (ctx *fuchsia) CheckoutCommit(repo, commit string) (*Commit, error) {
 	return ctx.repo.CheckoutCommit(repo, commit)
 }
 
+func (ctx *fuchsia) FetchTags(repo string) error {
+	return ctx.repo.FetchTags(repo)
+}
+
 func (ctx *fuchsia) fetchRemote(repo, commit string) error {
 	return ctx.repo.fetchRemote(repo, commit)
 }

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -163,6 +163,17 @@ func (git *gitRepo) CheckoutCommit(repo, commit string) (*Commit, error) {
 	return git.SwitchCommit(commit)
 }
 
+func (git *gitRepo) FetchTags(repo string) error {
+	if err := git.repair(); err != nil {
+		return err
+	}
+	repoHash := hash.String([]byte(repo))
+	// Ignore error as we can double add the same remote and that will fail.
+	git.Run("remote", "add", repoHash, repo)
+	_, err := git.Run("fetch", "--force", "--tags", repoHash)
+	return err
+}
+
 func (git *gitRepo) fetchRemote(repo, commit string) error {
 	if commit != "" && gitFullHashRe.MatchString(commit) {
 		// If the commit is already present locally, we don't need to fetch it.

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -34,6 +34,9 @@ type Repo interface {
 	// CheckoutCommit checkouts the specified repository on the specified commit.
 	CheckoutCommit(repo, commit string) (*Commit, error)
 
+	// FetchTags forces the fetching of tags from the specified remote repository.
+	FetchTags(repo string) error
+
 	// SwitchCommit checkouts the specified commit without fetching.
 	SwitchCommit(commit string) (*Commit, error)
 


### PR DESCRIPTION
ReleaseTag() could fail with 'no release tags found' when called on a repo that was initialized with Poll(). Poll() does a `fetch origin <branch>` which only fetches objects, and the subsequent `fetch --force` misses tags if no new objects are downloaded.

Since ReleaseTag is used infrequently (e.g., in aflow to resolve the base commit for a patch), explicitly fetching tags unconditionally before reading them ensures that local tags are always present and up-to-date without adding polling overhead globally.