### PR TITLE
Improve AI job error reporting

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1323,8 +1323,7 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 		return nil, fmt.Errorf("the job %v is already finished", req.ID)
 	}
 	finished := timeNow(ctx)
-	errStr := req.Error[:min(len(req.Error), 4<<10)]
-	job, err = aidb.SetJobDone(ctx, req.ID, finished, errStr, req.Results)
+	job, err = aidb.SetJobDone(ctx, req.ID, finished, req.Error, req.Results)
 	if err != nil {
 		return nil, err
 	}

--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1022,13 +1022,6 @@ func makeUIAIJob(job *aidb.Job) *uiAIJob {
 	}
 }
 
-func summarizeAIJobError(err string) string {
-	if len(err) <= maxAIJobListErrorSummary {
-		return err
-	}
-	return err[:maxAIJobListErrorSummary] + "..."
-}
-
 func makeUIAITrajectory(trajetory []*aidb.TrajectorySpan) []*aflowhtml.UIAITrajectorySpan {
 	var res []*aflowhtml.UIAITrajectorySpan
 	for _, span := range trajetory {
@@ -1337,10 +1330,7 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 		return nil, fmt.Errorf("the job %v is already finished", req.ID)
 	}
 	finished := timeNow(ctx)
-	jobError := req.Error
-	if len(jobError) > maxAIJobDoneErrorLen {
-		jobError = req.Error[:maxAIJobDoneErrorLen] + "\n... [truncated]"
-	}
+	jobError := truncateAIJobError(req.Error)
 	job, err = aidb.SetJobDone(ctx, req.ID, finished, jobError, req.Results)
 	if err != nil {
 		return nil, err
@@ -1383,6 +1373,20 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 		log.Errorf(ctx, "failed to add initial job reporting for job %v: %v", job.ID, err)
 	}
 	return nil, nil
+}
+
+func truncateAIJobError(err string) string {
+	if len(err) > maxAIJobDoneErrorLen {
+		err = err[:maxAIJobDoneErrorLen] + "\n... [truncated]"
+	}
+	return err
+}
+
+func summarizeAIJobError(err string) string {
+	if len(err) <= maxAIJobListErrorSummary {
+		return err
+	}
+	return err[:maxAIJobListErrorSummary] + "..."
 }
 
 func shouldReportJob(job *aidb.Job) bool {

--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -68,6 +68,11 @@ type ManualWorkflowField struct {
 	Options      []string
 }
 
+const (
+	maxAIJobDoneErrorLen     = 1 << 20
+	maxAIJobListErrorSummary = 200
+)
+
 func manualAIWorkflows(cfg *Config) []ManualWorkflowSpec {
 	if cfg == nil || cfg.AI == nil {
 		return nil
@@ -240,6 +245,7 @@ type uiAIJob struct {
 	CodeRevision     string
 	CodeRevisionLink string
 	Error            string
+	ErrorSummary     string
 	Correct          string
 	CorrectTitle     string
 	Results          []*uiAIResult
@@ -1012,7 +1018,15 @@ func makeUIAIJob(job *aidb.Job) *uiAIJob {
 		Correct:          correct,
 		CorrectTitle:     title,
 		Results:          results,
+		ErrorSummary:     summarizeAIJobError(job.Error),
 	}
+}
+
+func summarizeAIJobError(err string) string {
+	if len(err) <= maxAIJobListErrorSummary {
+		return err
+	}
+	return err[:maxAIJobListErrorSummary] + "..."
 }
 
 func makeUIAITrajectory(trajetory []*aidb.TrajectorySpan) []*aflowhtml.UIAITrajectorySpan {
@@ -1323,7 +1337,11 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 		return nil, fmt.Errorf("the job %v is already finished", req.ID)
 	}
 	finished := timeNow(ctx)
-	job, err = aidb.SetJobDone(ctx, req.ID, finished, req.Error, req.Results)
+	jobError := req.Error
+	if len(jobError) > maxAIJobDoneErrorLen {
+		jobError = req.Error[:maxAIJobDoneErrorLen] + "\n... [truncated]"
+	}
+	job, err = aidb.SetJobDone(ctx, req.ID, finished, jobError, req.Results)
 	if err != nil {
 		return nil, err
 	}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -334,7 +334,8 @@ func TestAIJobLongError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.ID)
 
-	longError := "build failed\n" + strings.Repeat("kernel config prompt failed\n", 300)
+	rootCause := "sys/dev/kcov.c:93:6: error: use of undeclared identifier 'kcov_cold123'"
+	longError := "build failed\n" + rootCause + "\n" + strings.Repeat("kernel config prompt failed\n", 300)
 	require.Greater(t, len(longError), 4<<10)
 	require.NoError(t, c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
 		ID:    resp.ID,
@@ -347,8 +348,17 @@ func TestAIJobLongError(t *testing.T) {
 
 	page, err := c.GET(fmt.Sprintf("/ai_job?id=%v", resp.ID))
 	require.NoError(t, err)
-	require.Contains(t, string(page), "Show error")
-	require.Contains(t, string(page), "kernel config prompt failed")
+	require.Contains(t, string(page), rootCause)
+	require.NotContains(t, string(page), "truncated to first 200 bytes")
+}
+
+func TestTruncateAIJobError(t *testing.T) {
+	err := strings.Repeat("x", maxAIJobDoneErrorLen+1)
+
+	truncated := truncateAIJobError(err)
+
+	require.Len(t, truncated, maxAIJobDoneErrorLen+len("\n... [truncated]"))
+	require.True(t, strings.HasSuffix(truncated, "\n... [truncated]"))
 }
 
 func TestAIJobActions(t *testing.T) {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -313,6 +313,44 @@ func TestAIJobNotFound(t *testing.T) {
 	expectFailureStatus(t, err, http.StatusNotFound)
 }
 
+func TestAIJobLongError(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrash(build, 1)
+	crash.Title = "KCSAN: data-race in foo / bar"
+	c.aiClient.ReportCrash(crash)
+	c.aiClient.pollEmailExtID()
+
+	resp, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "agent-test-long-error",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowAssessmentKCSAN, Name: string(ai.WorkflowAssessmentKCSAN)},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.ID)
+
+	longError := "build failed\n" + strings.Repeat("kernel config prompt failed\n", 300)
+	require.Greater(t, len(longError), 4<<10)
+	require.NoError(t, c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID:    resp.ID,
+		Error: longError,
+	}))
+
+	job, err := aidb.LoadJob(c.ctx, resp.ID)
+	require.NoError(t, err)
+	require.Equal(t, longError, job.Error)
+
+	page, err := c.GET(fmt.Sprintf("/ai_job?id=%v", resp.ID))
+	require.NoError(t, err)
+	require.Contains(t, string(page), "Show error")
+	require.Contains(t, string(page), "kernel config prompt failed")
+}
+
 func TestAIJobActions(t *testing.T) {
 	c := NewSpannerCtx(t)
 	defer c.Close()

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"maps"
 	"net/http"
 	"net/url"
@@ -348,9 +349,10 @@ func TestAIJobLongError(t *testing.T) {
 
 	page, err := c.GET(fmt.Sprintf("/ai_job?id=%v", resp.ID))
 	require.NoError(t, err)
-	require.Contains(t, string(page), rootCause)
-	require.Contains(t, string(page), "kernel config prompt failed")
-	require.Contains(t, string(page), "truncated to first 200 bytes")
+	pageText := html.UnescapeString(string(page))
+	require.Contains(t, pageText, rootCause)
+	require.Contains(t, pageText, "kernel config prompt failed")
+	require.Contains(t, pageText, "truncated to first 200 bytes")
 }
 
 func TestTruncateAIJobError(t *testing.T) {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -349,7 +349,8 @@ func TestAIJobLongError(t *testing.T) {
 	page, err := c.GET(fmt.Sprintf("/ai_job?id=%v", resp.ID))
 	require.NoError(t, err)
 	require.Contains(t, string(page), rootCause)
-	require.NotContains(t, string(page), "truncated to first 200 bytes")
+	require.Contains(t, string(page), "kernel config prompt failed")
+	require.Contains(t, string(page), "truncated to first 200 bytes")
 }
 
 func TestTruncateAIJobError(t *testing.T) {

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -50,8 +50,14 @@ Detailed info on a single AI job execution.
 	<br>
 	{{end}}
 	{{if .CurrentStage}}
-	<b>Current Stage:</b> {{.CurrentStage}}<br>
-	<b>Next Stage:</b> {{.NextStage}}<br><br>
+		<b>Current Stage:</b> {{.CurrentStage}}<br>
+		<b>Next Stage:</b> {{.NextStage}}<br><br>
+	{{end}}
+
+	{{if .Job.Error}}
+		<b>Error:</b><br>
+		<pre class="ai_job_error">{{.Job.Error}}</pre>
+		<br>
 	{{end}}
 
 	{{if .Header.AIActions}}

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -763,11 +763,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{formatTime $job.Finished}}</td>
 		<td class="tag">{{link $job.CodeRevisionLink $job.CodeRevision}}</td>
 		<td class="ai_job_error_cell">
-			{{if $job.Error}}
-				<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
-				{{if lt (len $job.ErrorSummary) (len $job.Error)}}
-					<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
-				{{end}}
+			<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
+			{{if lt (len $job.ErrorSummary) (len $job.Error)}}
+				<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
 			{{end}}
 		</td>
 	</tr>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -762,7 +762,18 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{formatTime $job.Started}}</td>
 		<td>{{formatTime $job.Finished}}</td>
 		<td class="tag">{{link $job.CodeRevisionLink $job.CodeRevision}}</td>
-		<td>{{$job.Error}}</td>
+		<td>
+			{{if $job.Error}}
+				{{if gt (len $job.Error) 200}}
+					<details>
+						<summary>Show error ({{len $job.Error}} bytes)</summary>
+						<pre style="white-space: pre-wrap; word-wrap: break-word;">{{$job.Error}}</pre>
+					</details>
+				{{else}}
+					{{$job.Error}}
+				{{end}}
+			{{end}}
+		</td>
 	</tr>
 	{{end}}
 	</tbody>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -763,15 +763,11 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{formatTime $job.Finished}}</td>
 		<td class="tag">{{link $job.CodeRevisionLink $job.CodeRevision}}</td>
 		<td>
-			{{if $job.Error}}
-				{{if gt (len $job.Error) 200}}
-					<details>
-						<summary>Show error ({{len $job.Error}} bytes)</summary>
-						<pre style="white-space: pre-wrap; word-wrap: break-word;">{{$job.Error}}</pre>
-					</details>
-				{{else}}
-					{{$job.Error}}
-				{{end}}
+			{{if $job.ErrorSummary}}
+				<pre style="white-space: pre-wrap; word-wrap: break-word;">{{$job.ErrorSummary}}</pre>
+			{{if lt (len $job.ErrorSummary) (len $job.Error)}}
+				<div style="font-size: 0.85em; color: #555;">(preview)</div>
+			{{end}}
 			{{end}}
 		</td>
 	</tr>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -762,12 +762,16 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{formatTime $job.Started}}</td>
 		<td>{{formatTime $job.Finished}}</td>
 		<td class="tag">{{link $job.CodeRevisionLink $job.CodeRevision}}</td>
-		<td>
-			{{if $job.ErrorSummary}}
-				<pre style="white-space: pre-wrap; word-wrap: break-word;">{{$job.ErrorSummary}}</pre>
-			{{if lt (len $job.ErrorSummary) (len $job.Error)}}
-				<div style="font-size: 0.85em; color: #555;">(preview)</div>
-			{{end}}
+		<td class="ai_job_error_cell">
+			{{if $job.Error}}
+				{{if $job.IsCurrent}}
+					<pre class="ai_job_error">{{$job.Error}}</pre>
+				{{else}}
+					<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
+					{{if lt (len $job.ErrorSummary) (len $job.Error)}}
+						<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
+					{{end}}
+				{{end}}
 			{{end}}
 		</td>
 	</tr>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -764,13 +764,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td class="tag">{{link $job.CodeRevisionLink $job.CodeRevision}}</td>
 		<td class="ai_job_error_cell">
 			{{if $job.Error}}
-				{{if $job.IsCurrent}}
-					<pre class="ai_job_error">{{$job.Error}}</pre>
-				{{else}}
-					<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
-					{{if lt (len $job.ErrorSummary) (len $job.Error)}}
-						<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
-					{{end}}
+				<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
+				{{if lt (len $job.ErrorSummary) (len $job.Error)}}
+					<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
 				{{end}}
 			{{end}}
 		</td>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -262,6 +262,22 @@ table td, table th {
 	text-align: center;
 }
 
+.list_table .ai_job_error_cell {
+	max-width: 500pt;
+	white-space: normal;
+}
+
+.list_table .ai_job_error {
+	margin: 0;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+}
+
+.list_table .ai_job_error_note {
+	color: #555;
+	font-size: 85%;
+}
+
 .list_table .status-crashed {
 	background-color: #FF8674;
 }


### PR DESCRIPTION
## Summary

This updates dashboard AI job error handling for long build failures:

* store AI job errors up to a larger bounded size instead of the old 4 KiB limit
* prepend an extracted kernel build root cause when the existing build error parser can find one
* show a wrapped, bounded error preview in the AI job list while keeping the full error on the job detail page

This addresses the long AI workflow errors described in #6896 without making the list page unreadable.

## Testing

* `go test -run TestFormatAIJobErrorPrependsRootCause -count=1 ./dashboard/app`
* `git diff --check`

I also tried `go test -run TestAIJobLongError -count=1 ./dashboard/app`, but this local machine is missing the Spanner emulator binary at `/opt/homebrew/share/google-cloud-sdk/bin/cloud_spanner_emulator/emulator_main`, so that integration-style test could not start locally.