### PR TITLE
pkg/aflow/tool/gitlog: fix handling of invalid grep expressions

### DIFF
--- a/pkg/aflow/test_tool.go
+++ b/pkg/aflow/test_tool.go
@@ -18,6 +18,7 @@ type TestToolOption func(*Context)
 // return struct. In the latter case, the function is executed with the actual results,
 // and is supposed to do assertions on the value.
 func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wantError string, opts ...TestToolOption) {
+	t.Helper()
 	type tester interface {
 		testVerify(t *testing.T, ctx *verifyContext, state, args, results any) (
 			map[string]any, map[string]any, func(map[string]any))

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -202,6 +202,10 @@ func gitBadCallError(err error, name, advice string) error {
 		bytes.Contains(verr.Output, []byte("no such path"))) {
 		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
 	}
+	// This should mean an invalid grep expression.
+	if verr.ExitCode == 128 && bytes.Contains(verr.Output, []byte("fatal:")) {
+		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
+	}
 	if verr.ExitCode == 1 && len(verr.Output) == 0 {
 		return nil // No matches is a valid result.
 	}

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestGitShow(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	repo := vcs.MakeTestRepo(t, filepath.Join(tmpDir, "repo", "linux"))
 	c1 := repo.CommitChangeset("initial commit", vcs.FileContent{
@@ -54,6 +55,7 @@ diff --git a/foo\.c b/foo\.c
 }
 
 func TestGitBlame(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	repoDir := filepath.Join(tmpDir, "repo", "linux")
 	repo := vcs.MakeTestRepo(t, repoDir)
@@ -105,6 +107,7 @@ $`, c1.Hash[:12], c2.Hash[:12])
 }
 
 func TestGitLog(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	repoDir := filepath.Join(tmpDir, "repo", "linux")
 	repo := vcs.MakeTestRepo(t, repoDir)
@@ -220,5 +223,21 @@ void foo() {
 		logArgs{SymbolName: "non_existing_symbol", SourcePath: "foo.c"},
 		logResult{},
 		"git log failed: fatal: -L parameter 'non_existing_symbol' starting at line 1: no match",
+		aflow.TestWorkdir(tmpDir))
+
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{CodeRegexp: `foo\(`, SourcePath: "foo.c"},
+		logResult{Output: fmt.Sprintf("%s second commit\n%s initial commit\n",
+			c2.Hash[:12], c1.Hash[:12])},
+		``,
+		aflow.TestWorkdir(tmpDir))
+
+	// Bad grep expression.
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{CodeRegexp: `foo(`, SourcePath: "foo.c"},
+		logResult{},
+		`git log failed: fatal: invalid regex: Unmatched ( or \(`,
 		aflow.TestWorkdir(tmpDir))
 }


### PR DESCRIPTION
Some workflows now fail with:

failed to run ["git" "log" "--format=%h %s" "--abbrev=12" "--no-patch" "-n" "10"
	"-G" "tso_start(" "master"]: exit status 128 args: ...
	fatal: invalid regex: Unmatched ( or \(

Fix that.
