### PR TITLE
grepper improvenments

### DIFF
--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -37,6 +37,7 @@ type state struct {
 
 type args struct {
 	Expression string `jsonschema:"Git grep expression in extended regexp syntax."`
+	PathPrefix string `jsonschema:"Optional path prefix or file to restrict the scope of the grep." json:",omitempty"`
 }
 
 type results struct {
@@ -44,8 +45,15 @@ type results struct {
 }
 
 func grepper(ctx *aflow.Context, state state, args args) (results, error) {
-	output, err := osutil.RunCmd(time.Hour, state.KernelSrc, "git", "grep", "--extended-regexp",
-		"--line-number", "--show-function", "-C1", "--no-color", "--", args.Expression)
+	cmdArgs := []string{
+		"grep", "--extended-regexp", "--line-number",
+		"--show-function", "-C1", "--no-color",
+		"-e", args.Expression, "--",
+	}
+	if args.PathPrefix != "" {
+		cmdArgs = append(cmdArgs, args.PathPrefix)
+	}
+	output, err := osutil.RunCmd(time.Hour, state.KernelSrc, "git", cmdArgs...)
 	if err != nil {
 		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
 			if exitErr.ExitCode() == 1 && len(output) == 0 {

--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -47,8 +47,7 @@ type results struct {
 func grepper(ctx *aflow.Context, state state, args args) (results, error) {
 	cmdArgs := []string{
 		"grep", "--extended-regexp", "--line-number",
-		"--show-function", "-C1", "--no-color",
-		"-e", args.Expression, "--",
+		"--show-function", "-C1", "-e", args.Expression, "--",
 	}
 	if args.PathPrefix != "" {
 		cmdArgs = append(cmdArgs, args.PathPrefix)
@@ -74,8 +73,33 @@ func grepper(ctx *aflow.Context, state state, args args) (results, error) {
 	// but should be bearable for syz-agent.
 	// Each match takes 3-6 lines (counting context, function lines, and -- delimiters).
 	const maxLines = 500
+	// Grep can match some effectively binary files, e.g. svg.
+	// They can contain lines >100K. We mainly intend to match source/docs files
+	// which should not contain long lines, so cap at 200 chars.
+	const maxLineLen = 200
 	lines := slices.Collect(bytes.Lines(output))
+	var truncated bool
+	for i, line := range lines {
+		hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
+		contentLen := len(line)
+		if hasNewline {
+			contentLen--
+		}
+		if contentLen > maxLineLen {
+			newLine := slices.Clone(line[:maxLineLen])
+			newLine = append(newLine, []byte("...")...)
+			if hasNewline {
+				newLine = append(newLine, '\n')
+			}
+			lines[i] = newLine
+			truncated = true
+		}
+	}
+
 	if len(lines) <= maxLines {
+		if truncated {
+			return results{string(slices.Concat(lines...))}, nil
+		}
 		return results{string(output)}, nil
 	}
 	res := fmt.Sprintf(`
@@ -83,6 +107,6 @@ Full output is too long, showing %v out of %v lines.
 Use more precise expression if possible.
 
 %s
-`, maxLines, len(lines), slices.Concat(lines[:maxLines]))
+`, maxLines, len(lines), slices.Concat(lines[:maxLines]...))
 	return results{res}, nil
 }

--- a/pkg/aflow/tool/grepper/grepper_test.go
+++ b/pkg/aflow/tool/grepper/grepper_test.go
@@ -38,6 +38,15 @@ int another_func(int) {
 			`,
 		},
 		vcs.FileContent{
+			File: "longline.c",
+			Content: `
+int long_func(void)
+{
+	` + strings.Repeat("a", 300) + `;
+}
+			`,
+		},
+		vcs.FileContent{
 			File: "overflow.c",
 			Content: strings.Repeat(`
 int some_func(int) {
@@ -60,6 +69,16 @@ foo.c-4-	line;
 foo.c:5:	foobar;
 foo.c-6-	line;
 `},
+		"")
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "aaaaa"},
+		func(got results) {
+			expectedLine := "longline.c:4:	" + strings.Repeat("a", 186) + "..."
+			assert.True(t, strings.Contains(got.Output, expectedLine),
+				"output does not contain expected truncated line: %q", got.Output)
+		},
 		"")
 
 	aflow.TestTool(t, Tool,

--- a/pkg/aflow/tool/grepper/grepper_test.go
+++ b/pkg/aflow/tool/grepper/grepper_test.go
@@ -83,7 +83,19 @@ foo.c-6-	line;
 		state{KernelSrc: repo.Dir},
 		args{Expression: "bad expression ("},
 		results{},
-		`bad expression: fatal: command line, 'bad expression (': Unmatched ( or \(`)
+		`bad expression: fatal: -e option, 'bad expression (': Unmatched ( or \(`)
+
+	aflow.TestTool(t, Tool,
+		state{KernelSrc: repo.Dir},
+		args{Expression: "foobar", PathPrefix: "foo.c"},
+		results{Output: `foo.c=2=int some_func(void)
+--
+foo.c-4-	line;
+foo.c:5:	foobar;
+foo.c-6-	line;
+`},
+		"")
+
 	aflow.TestTool(t, Tool,
 		state{KernelSrc: repo.Dir},
 		args{Expression: "->root"},


### PR DESCRIPTION
- **pkg/aflow/tool/grepper: support PathPrefix argument**
- **pkg/aflow/tool/grepper: cap matched lines to 200 characters**
