### PR TITLE
pkg/aflow: fix error types for maps and slices

### DIFF
--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -217,6 +217,17 @@ func setSliceField(val any, field reflect.Value, name string, f any, targetType 
 	res := reflect.MakeSlice(targetType, 0, len(slice))
 	for i, item := range slice {
 		elem := reflect.New(elemType).Elem()
+		if item == nil {
+			switch elemType.Kind() {
+			case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
+				res = reflect.Append(res, elem)
+				continue
+			}
+			if tool {
+				return BadCallError("item %d in field %q cannot be null", i, name)
+			}
+			return fmt.Errorf("item %d in field %q cannot be null", i, name)
+		}
 		if err := setField(elem, val, item, fmt.Sprintf("%s[%d]", name, i), tool); err != nil {
 			if tool {
 				return BadCallError("item %d in field %q: %v", i, name, err)

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -176,6 +176,9 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 	if targetType.Kind() == reflect.Struct {
 		mm, ok := f.(map[string]any)
 		if !ok {
+			if tool {
+				return BadCallError("field %q must be a map, got %T", name, f)
+			}
 			return fmt.Errorf("field %q must be a map, got %T", name, f)
 		}
 		var structVal reflect.Value
@@ -205,6 +208,9 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 func setSliceField(val any, field reflect.Value, name string, f any, targetType reflect.Type, tool bool) error {
 	slice, ok := f.([]any)
 	if !ok {
+		if tool {
+			return BadCallError("field %q must be a slice, got %T", name, f)
+		}
 		return fmt.Errorf("field %q must be a slice, got %T", name, f)
 	}
 	elemType := targetType.Elem()
@@ -212,6 +218,9 @@ func setSliceField(val any, field reflect.Value, name string, f any, targetType 
 	for i, item := range slice {
 		elem := reflect.New(elemType).Elem()
 		if err := setField(elem, val, item, fmt.Sprintf("%s[%d]", name, i), tool); err != nil {
+			if tool {
+				return BadCallError("item %d in field %q: %v", i, name, err)
+			}
 			return fmt.Errorf("item %d in field %q: %w", i, name, err)
 		}
 		res = reflect.Append(res, elem)

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -190,6 +190,32 @@ func TestConvertFromMap(t *testing.T) {
 		`item 0 in field "Arr": missing argument "B"`,
 		`item 0 in field "Arr": struct { A int; B string }: field "B" is not present when converting map`)
 
+	testConvertFromMap(t, true, map[string]any{
+		"Nested": "not a map",
+	}, struct {
+		Nested struct {
+			A int
+		}
+	}{},
+		`field "Nested" must be a map, got string`,
+		`field "Nested" must be a map, got string`)
+
+	testConvertFromMap(t, true, map[string]any{
+		"Strs": "not a slice",
+	}, struct {
+		Strs []string
+	}{},
+		`field "Strs" must be a slice, got string`,
+		`field "Strs" must be a slice, got string`)
+
+	testConvertFromMap(t, true, map[string]any{
+		"Strs": []any{1, 2},
+	}, struct {
+		Strs []string
+	}{},
+		`item 0 in field "Strs": argument "Strs[0]" has wrong type: got int, want string`,
+		`item 0 in field "Strs": struct { Strs []string }: field "Strs[0]" has wrong type: got int, want string`)
+
 	t1, _ := time.Parse(time.RFC3339, "2026-04-16T14:26:33Z")
 	testConvertFromMap(t, true, map[string]any{
 		"T": "2026-04-16T14:26:33Z",

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -216,6 +216,22 @@ func TestConvertFromMap(t *testing.T) {
 		`item 0 in field "Strs": argument "Strs[0]" has wrong type: got int, want string`,
 		`item 0 in field "Strs": struct { Strs []string }: field "Strs[0]" has wrong type: got int, want string`)
 
+	testConvertFromMap(t, true, map[string]any{
+		"Strs": []any{nil, "a"},
+	}, struct {
+		Strs []string
+	}{},
+		`item 0 in field "Strs" cannot be null`,
+		`item 0 in field "Strs" cannot be null`)
+
+	testConvertFromMap(t, true, map[string]any{
+		"Ptrs": []any{nil},
+	}, struct {
+		Ptrs []*string
+	}{
+		Ptrs: []*string{nil},
+	}, "", "")
+
 	t1, _ := time.Parse(time.RFC3339, "2026-04-16T14:26:33Z")
 	testConvertFromMap(t, true, map[string]any{
 		"T": "2026-04-16T14:26:33Z",


### PR DESCRIPTION
Fix setSliceField and setField in pkg/aflow/schema.go to always return BadCallError if tool == true. Currently, they fail to do so for maps and slices, and when setSliceField recursively calls setField. Add corresponding tests.

Currently some workflows fail with:
git-log failed: error: field "MessageRegexps" must be a slice, got string
