### PR TITLE
dashboard/app: allow manual triggering of AI patch iterations

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -173,12 +173,14 @@ type uiJobReviewHistory struct {
 }
 
 type uiPatchVersion struct {
-	Version  int
-	Stage    string
-	Reported time.Time
-	Link     string
-	JobID    string
-	JobLink  string
+	Version     int
+	Stage       string
+	Reported    time.Time
+	Link        string
+	JobID       string
+	JobLink     string
+	ReportingID string
+	CanIterate  bool
 }
 
 type uiAIJob struct {

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/syzkaller/dashboard/app/aidb"
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1768,4 +1769,101 @@ func TestAIPatchFilter(t *testing.T) {
 	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")
 	c.expectOK(err)
 	require.NotContains(t, string(reply), crash.Title)
+}
+
+func TestAIManualIteration(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{
+				Name:               "moderation",
+				ServingIntegration: "lore",
+				MailingList:        "moderation@test.com",
+				AddressComments:    false, // Automatic reaction disabled.
+			},
+		},
+	})
+
+	// Create a bug and AI job.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// Register workflow and create a job.
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+	jobID := c.createAIJob(extID, string(ai.WorkflowPatching), "")
+
+	c.finishAIPatchJob(t, jobID, nil)
+
+	// Confirm report published.
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{
+		Source: "lore",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pollResp.Result)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollResp.Result.ID,
+		PublishedExtID: "moderation-msg-id",
+	})
+	require.NoError(t, err)
+
+	// Simulate a comment.
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "moderation-msg-id",
+		MessageExtID: "<comment-1>",
+		Author:       "reviewer@email.com",
+		Comment:      &dashapi.CommentCommand{Body: "This is a review comment."},
+	})
+	require.NoError(t, err)
+
+	// Verify autoCreatePatchIterationJobs does NOT create a job because AddressComments = false.
+	created, err := autoCreatePatchIterationJobs(c.ctx, APIClient{AIJobNamespaces: []string{"ains"}})
+	require.NoError(t, err)
+	assert.False(t, created, "should not create job when AddressComments=false")
+
+	bug, _, err := findBugByReportingID(c.ctx, extID)
+	require.NoError(t, err)
+
+	reportings, err := aidb.LoadJobReportings(c.ctx, jobID)
+	require.NoError(t, err)
+	require.Len(t, reportings, 1)
+
+	// Trigger the manual iteration job.
+	values := url.Values{}
+	values.Set("ai-job-iteration", reportings[0].ID)
+	_, err = c.AuthPOSTForm(AccessAdmin, fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx)), values)
+	require.NoError(t, err)
+
+	// Poll the job and verify the comment text is passed in PatchHistory.
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	resp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.ID)
+
+	var gotPatchHistory []ai.PatchHistoryEntry
+	data, err := json.Marshal(resp.Args["PatchHistory"])
+	require.NoError(t, err)
+	err = json.Unmarshal(data, &gotPatchHistory)
+	require.NoError(t, err)
+
+	require.Len(t, gotPatchHistory, 1)
+	require.Len(t, gotPatchHistory[0].Comments, 1)
+	assert.Contains(t, gotPatchHistory[0].Comments[0].Body, "This is a review comment.")
 }

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -330,12 +330,14 @@ func TestAIJobActions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	jobCreateURL := fmt.Sprintf("/bug?id=%v&ai-job-create=patching", bug.keyHash(c.ctx))
-	_, err = c.AuthGET(AccessPublic, jobCreateURL)
+	jobCreateURL := fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx))
+	values := url.Values{}
+	values.Set("ai-job-create", "patching")
+	_, err = c.AuthPOSTForm(AccessPublic, jobCreateURL, values)
 	require.Error(t, err)
 	// Redirect to login page.
 	require.Contains(t, err.Error(), fmt.Sprint(http.StatusTemporaryRedirect))
-	_, err = c.AuthGET(AccessUser, jobCreateURL)
+	_, err = c.AuthPOSTForm(AccessUser, jobCreateURL, values)
 	require.NoError(t, err)
 
 	resp, err := c.globalClient.AIJobPoll(&dashapi.AIJobPollReq{
@@ -369,7 +371,7 @@ func TestAIJobActions(t *testing.T) {
 	}))
 
 	jobAssessURL := fmt.Sprintf("/ai_job?id=%v", resp.ID)
-	values := url.Values{}
+	values = url.Values{}
 	values.Set("correct", aiCorrectnessCorrect)
 	_, err = c.AuthPOSTForm(AccessPublic, jobAssessURL, values)
 	require.Error(t, err)
@@ -385,8 +387,10 @@ func TestAIJobActions(t *testing.T) {
 	extID2 := c.aiClient.pollEmailExtID()
 	bug2, _, _ := c.loadBug(extID2)
 
-	jobCreateURL2 := fmt.Sprintf("/bug?id=%v&ai-job-create=patching", bug2.keyHash(c.ctx))
-	_, err = c.AuthGET(AccessUser, jobCreateURL2)
+	jobCreateURL2 := fmt.Sprintf("/bug?id=%v", bug2.keyHash(c.ctx))
+	values = url.Values{}
+	values.Set("ai-job-create", "patching")
+	_, err = c.AuthPOSTForm(AccessUser, jobCreateURL2, values)
 	require.NoError(t, err)
 
 	resp2, err := c.globalClient.AIJobPoll(&dashapi.AIJobPollReq{
@@ -1140,8 +1144,10 @@ func TestAIReproCJobCreateFromBugPage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	jobCreateURL := fmt.Sprintf("/bug?id=%v&ai-job-create=repro-c", bug.keyHash(c.ctx))
-	_, err = c.AuthGET(AccessUser, jobCreateURL)
+	jobCreateURL := fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx))
+	values := url.Values{}
+	values.Set("ai-job-create", "repro-c")
+	_, err = c.AuthPOSTForm(AccessUser, jobCreateURL, values)
 	require.NoError(t, err)
 
 	resp, err := c.globalClient.AIJobPoll(&dashapi.AIJobPollReq{

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1227,7 +1227,7 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 			aiJobs = append(aiJobs, makeUIAIJob(job))
 		}
 
-		patchVersions, err = getPatchVersions(ctx, bug, jobs)
+		patchVersions, err = getPatchVersions(ctx, bug, jobs, hdr.AIActions)
 		if err != nil {
 			return err
 		}
@@ -1247,17 +1247,13 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 		data.DebugSubsystems = urlutil.SetParam(data.Bug.Link, "debug_subsystems", "1")
 	}
 	if workflow := r.FormValue("ai-job-create"); workflow != "" {
-		if !hdr.AIActions {
-			return ErrAccess
+		if err := handleBugJobCreate(ctx, r, hdr, bug, aiWorkflows, workflow); err != nil {
+			return err
 		}
-		args, err := parseAIJobArgs(r, workflow, aiWorkflows)
-		if err != nil {
-			hdr.Message = err.Error()
-		} else {
-			if _, err := aiBugJobCreate(ctx, workflow, bug, args); err != nil {
-				return err
-			}
-			hdr.Message = fmt.Sprintf("AI workflow %v is created", workflow)
+	}
+	if reportingID := r.FormValue("ai-job-iteration"); reportingID != "" {
+		if err := handleManualIterationJob(ctx, r, hdr, reportingID); err != nil {
+			return err
 		}
 	}
 	if r.FormValue("json") == "1" {
@@ -1266,6 +1262,45 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 	}
 
 	return serveTemplate(w, "bug.html", data)
+}
+
+func handleBugJobCreate(ctx context.Context, r *http.Request, hdr *uiHeader,
+	bug *Bug, aiWorkflows []*uiWorkflow, workflow string) error {
+	if !hdr.AIActions {
+		return ErrAccess
+	}
+	if r.Method != http.MethodPost {
+		return ErrAccess
+	}
+	args, err := parseAIJobArgs(r, workflow, aiWorkflows)
+	if err != nil {
+		hdr.Message = err.Error()
+		return nil
+	}
+	if _, err := aiBugJobCreate(ctx, workflow, bug, args); err != nil {
+		return fmt.Errorf("failed to create AI job %q: %w", workflow, err)
+	}
+	hdr.Message = fmt.Sprintf("AI workflow %v is created", workflow)
+	return nil
+}
+
+func handleManualIterationJob(ctx context.Context, r *http.Request,
+	hdr *uiHeader, reportingID string) error {
+	if !hdr.AIActions {
+		return ErrAccess
+	}
+	if r.Method != http.MethodPost {
+		return ErrAccess
+	}
+	job, err := aidb.CreatePatchIterationJob(ctx, reportingID)
+	if err != nil {
+		return fmt.Errorf("failed to create patch iteration job for %v: %w", reportingID, err)
+	} else if job == nil {
+		hdr.Message = "Iteration job is already running or in backoff."
+		return nil
+	}
+	hdr.Message = "Patch iteration job triggered successfully."
+	return nil
 }
 
 func parseAIJobArgs(r *http.Request, workflow string, aiWorkflows []*uiWorkflow) (map[string]any, error) {
@@ -2758,7 +2793,7 @@ func bugLink(id string) string {
 	return "/bug?id=" + id
 }
 
-func getPatchVersions(ctx context.Context, bug *Bug, jobs []*aidb.Job) ([]*uiPatchVersion, error) {
+func getPatchVersions(ctx context.Context, bug *Bug, jobs []*aidb.Job, aiActions bool) ([]*uiPatchVersion, error) {
 	reportings, err := aidb.LoadBugJobReportings(ctx, bug.keyHash(ctx))
 	if err != nil {
 		return nil, err
@@ -2768,6 +2803,7 @@ func getPatchVersions(ctx context.Context, bug *Bug, jobs []*aidb.Job) ([]*uiPat
 		jobMap[job.ID] = job
 	}
 	var patchVersions []*uiPatchVersion
+	latestFound := false
 	for _, r := range reportings {
 		if !r.Version.Valid {
 			continue
@@ -2779,14 +2815,33 @@ func getPatchVersions(ctx context.Context, bug *Bug, jobs []*aidb.Job) ([]*uiPat
 				continue
 			}
 		}
+
+		canIterate := false
+		if !latestFound {
+			latestFound = true
+			canIterate = aiActions && hasUnprocessedComments(ctx, r.ID)
+		}
+
 		patchVersions = append(patchVersions, &uiPatchVersion{
-			Version:  int(r.Version.Int64),
-			Stage:    r.Stage,
-			Reported: r.CreatedAt,
-			Link:     r.ExternalLink(),
-			JobID:    r.JobID,
-			JobLink:  fmt.Sprintf("/ai_job?id=%s", r.JobID),
+			Version:     int(r.Version.Int64),
+			Stage:       r.Stage,
+			Reported:    r.CreatedAt,
+			Link:        r.ExternalLink(),
+			JobID:       r.JobID,
+			JobLink:     fmt.Sprintf("/ai_job?id=%s", r.JobID),
+			ReportingID: r.ID,
+			CanIterate:  canIterate,
 		})
 	}
 	return patchVersions, nil
+}
+
+func hasUnprocessedComments(ctx context.Context, reportingID string) bool {
+	comments, err := aidb.LoadJobCommentsByReporting(ctx, reportingID)
+	if err != nil {
+		return false
+	}
+	return slices.ContainsFunc(comments, func(c *aidb.JobComment) bool {
+		return !c.Processed
+	})
 }

--- a/dashboard/app/templates/bug.html
+++ b/dashboard/app/templates/bug.html
@@ -76,7 +76,7 @@ Page with details about a single bug.
 				<span>✨ AI Patch Versions ({{len .PatchVersions}})</span>
 			</div>
 			<div class="content">
-				{{template "patch_version_list" .PatchVersions}}
+				{{template "patch_version_list" .}}
 			</div>
 		</div>
 	{{end}}

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -692,7 +692,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 {{end}}
 {{end}}
 
-{{/* List of AI patch versions, invoked with []*uiPatchVersion */}}
+{{/* List of AI patch versions, invoked with *uiBugPage */}}
 {{define "patch_version_list"}}
 <table class="list_table">
 	<thead><tr>
@@ -701,9 +701,10 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			<th><a onclick="return sortTable(this, 'Reported', textSort)" href="#">Reported</a></th>
 			<th><a onclick="return sortTable(this, 'Report Link', textSort)" href="#">Report Link</a></th>
 			<th><a onclick="return sortTable(this, 'Job', textSort)" href="#">Job</a></th>
+			{{if .Header.AIActions}}<th>Actions</th>{{end}}
 	</tr></thead>
 	<tbody>
-	{{range $v := .}}
+	{{range $v := .PatchVersions}}
 	<tr>
 			<td>{{$v.Version}}</td>
 			<td>{{$v.Stage}}</td>
@@ -712,6 +713,16 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 				{{if $v.Link}}<a href="{{$v.Link}}">Discussion</a>{{else}}Not reported{{end}}
 			</td>
 			<td class="tag">{{link $v.JobLink $v.JobID}}</td>
+			{{if $.Header.AIActions}}
+			<td>
+				{{if $v.CanIterate}}
+					<form method="POST" style="display:inline;">
+						<input type="hidden" name="ai-job-iteration" value="{{$v.ReportingID}}">
+						<button class="button" type="submit">Process Comments</button>
+					</form>
+				{{end}}
+			</td>
+			{{end}}
 	</tr>
 	{{end}}
 	</tbody>


### PR DESCRIPTION
Add a "Process Comments" button to the bug page to allow authorized users to manually trigger iterations for pending comments. This is needed for stages where AddressComments is false, as incoming comments are stored but do not automatically trigger a new patch iteration.