### PR TITLE
vm/qemu: preserve memory dump byte streams

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -415,8 +415,9 @@ func (mon *monitor) monitorExecution() ([]*report.Report, error) {
 				mon.outc = nil
 				continue
 			}
-			mon.inst.pool.statOutputReceived.Add(len(chunk.Data))
-			if rep, done, appendErr := mon.appendOutput(chunk.Data); done {
+			output := cleanOutputForRun(chunk.Data)
+			mon.inst.pool.statOutputReceived.Add(len(output))
+			if rep, done, appendErr := mon.appendOutput(output); done {
 				return rep, appendErr
 			}
 		case <-mon.injectExecuting:
@@ -462,6 +463,13 @@ func (mon *monitor) appendOutput(out []byte) ([]*report.Report, bool, error) {
 	}
 	mon.curPos = max(mon.curPos, 0)
 	return nil, false, nil
+}
+
+func cleanOutputForRun(out []byte) []byte {
+	if bytes.IndexByte(out, '\r') == -1 {
+		return out
+	}
+	return bytes.ReplaceAll(out, []byte("\r"), nil)
 }
 
 func (mon *monitor) extractErrors(defaultError string) ([]*report.Report, error) {
@@ -546,7 +554,7 @@ func (mon *monitor) waitForOutput() {
 			if !ok {
 				return
 			}
-			mon.output = append(mon.output, chunk.Data...)
+			mon.output = append(mon.output, cleanOutputForRun(chunk.Data)...)
 		case <-timer.C:
 			return
 		case <-Shutdown:

--- a/vm/vmimpl/merger.go
+++ b/vm/vmimpl/merger.go
@@ -122,11 +122,7 @@ func (merger *OutputMerger) runDecoder(typ OutputType, r io.ReadCloser,
 					merger.Output <- Chunk{decoded, typ} // note: this can block
 				}
 			}
-			// Remove all carriage returns.
 			buf := buf[:n]
-			if bytes.IndexByte(buf, '\r') != -1 {
-				buf = bytes.ReplaceAll(buf, []byte("\r"), nil)
-			}
 			pending = append(pending, buf...)
 			if pos := bytes.LastIndexByte(pending, '\n'); pos != -1 {
 				out := pending[:pos+1]

--- a/vm/vmimpl/merger_test.go
+++ b/vm/vmimpl/merger_test.go
@@ -55,7 +55,7 @@ func TestMerger(t *testing.T) {
 
 	wp2.Write([]byte("555\r\n666\n\r\r777"))
 	got = (<-merger.Output).Data
-	if want := "222555\n666\n"; string(got) != want {
+	if want := "222555\r\n666\n"; string(got) != want {
 		t.Fatalf("bad line: '%s', want '%s'", got, want)
 	}
 	// We need to robustly read until we get what we want if we want to be safe.
@@ -64,7 +64,7 @@ func TestMerger(t *testing.T) {
 
 	wp1.Close()
 	got = (<-merger.Output).Data
-	if want := "444\n"; string(got) != want {
+	if want := "444\r\n"; string(got) != want {
 		t.Fatalf("bad line: '%s', want '%s'", got, want)
 	}
 
@@ -79,12 +79,12 @@ func TestMerger(t *testing.T) {
 
 	wp2.Close()
 	got = (<-merger.Output).Data
-	if want := "777\n"; string(got) != want {
+	if want := "\r\r777\n"; string(got) != want {
 		t.Fatalf("bad line: '%s', want '%s'", got, want)
 	}
 
 	merger.Wait()
-	want := "111333\n222555\n666\n444\n777\n"
+	want := "111333\n222555\r\n666\n444\r\n\r\r777\n"
 	if got := tee.String(); got != want {
 		t.Fatalf("bad tee: '%s', want '%s'", got, want)
 	}


### PR DESCRIPTION
## Summary

`makedumpfile -F` writes a binary vmcore stream. syzkaller used to pass that stream through `OutputMerger` as log text, which could strip `\r`, wait for newlines, or drop chunks when the output channel was full. That can corrupt the saved vmcore binary.

This change keeps raw stdout bytes in `OutputMerger`. Text consumers of `vm.Run()` still strip `\r` before log parsing, while `RunStream()` can now deliver byte-for-byte stdout data for vmcore extraction.

## Changes
- Stop stripping `\r` in `OutputMerger`.
- Strip `\r` in `vm.Run()` before crash/log parsing.
- Keep `waitForOutput()` behavior consistent with `vm.Run()`.
- Update tests to reflect that `OutputMerger` now preserves carriage returns.

## Testing
- `go test ./vm/... ./pkg/report`