### PR TITLE
dashboard: add button to restart failed AI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  PYTHONWARNINGS: ignore
+
 jobs:
   aux:
     runs-on: ubuntu-latest

--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -165,6 +165,7 @@ type uiAIJobPage struct {
 	CanPushToReporting bool
 	CanSetCorrectness  bool
 	Reportings         []*uiJobReporting
+	CanRestart         bool
 }
 
 type uiAIJobDetails struct {
@@ -439,32 +440,50 @@ func getJobStageInfo(ctx context.Context, job *aidb.Job) (*aidb.JobReporting, *A
 	return latest, nextStageCfg, nil
 }
 
-func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hdr *uiHeader) error {
+func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hdr *uiHeader) (string, error) {
 	if r.Method != http.MethodPost {
-		return nil
+		return "", nil
 	}
 
-	correct := r.FormValue("correct")
-	pushToReporting := r.FormValue("push_to_reporting") == "1"
-
-	if correct == "" && !pushToReporting {
-		return nil
+	action := r.FormValue("action")
+	if action == "" {
+		return "", nil
 	}
 	if !hdr.AIActions {
-		return ErrAccess
-	}
-	if !job.Finished.Valid || job.Error != "" {
-		return fmt.Errorf("job is in wrong state to be modified")
+		return "", ErrAccess
 	}
 	user := currentUser(ctx)
 	if user == nil {
-		return ErrAccess
+		return "", ErrAccess
 	}
 
-	if pushToReporting {
-		return handleAIJobPagePushToReporting(ctx, job, "", user.Email)
+	switch action {
+	case "restart":
+		if err := checkJobRestartable(job, hdr.AIActions); err != nil {
+			return "", err
+		}
+		newJobID, err := aidb.RestartJob(ctx, job.ID)
+		if err != nil {
+			return "", err
+		}
+		return newJobID, nil
+
+	case "push_to_reporting":
+		if !job.Finished.Valid || job.Error != "" {
+			return "", fmt.Errorf("job is in wrong state to be modified")
+		}
+		return "", handleAIJobPagePushToReporting(ctx, job, "", user.Email)
+
+	case "set_correctness":
+		if !job.Finished.Valid || job.Error != "" {
+			return "", fmt.Errorf("job is in wrong state to be modified")
+		}
+		correct := r.FormValue("correct")
+		return "", handleAIJobPageCorrectness(ctx, job, correct, "", user.Email)
+
+	default:
+		return "", fmt.Errorf("%w: unknown action %q", ErrClientBadRequest, action)
 	}
-	return handleAIJobPageCorrectness(ctx, job, correct, "", user.Email)
 }
 
 func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userName, userEmail string) error {
@@ -593,26 +612,72 @@ func buildUIJobChain(ctx context.Context, r *http.Request, job *aidb.Job, uiJob 
 	return []*uiAIJob{uiJob}, nil
 }
 
-func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func loadAndFilterJob(ctx context.Context, r *http.Request) (*aidb.Job, error) {
 	job, err := aidb.LoadJob(ctx, r.FormValue("id"))
 	if err != nil {
 		if errors.Is(err, aidb.ErrNotFound) {
-			return fmt.Errorf("failed to query the job: %w", ErrClientNotFound)
+			return nil, fmt.Errorf("failed to query the job: %w", ErrClientNotFound)
 		}
-		return err
+		return nil, err
 	}
 	if jobs, err := filterJobsAccess(ctx, r, []*aidb.Job{job}); err != nil {
-		return err
+		return nil, err
 	} else if len(jobs) == 0 {
+		return nil, ErrAccess
+	}
+	return job, nil
+}
+
+func checkJobRestartable(job *aidb.Job, userHasAIActions bool) error {
+	if !userHasAIActions {
 		return ErrAccess
+	}
+	if job.Type == ai.WorkflowPatchIteration {
+		return fmt.Errorf("%w: cannot restart a patch iteration workflow", ErrClientBadRequest)
+	}
+	if !job.Finished.Valid {
+		return fmt.Errorf("%w: cannot restart a running job", ErrClientBadRequest)
+	}
+	if job.Error == "" {
+		return fmt.Errorf("%w: cannot restart a successful job", ErrClientBadRequest)
+	}
+	return nil
+}
+
+func determineJobActions(ctx context.Context, job *aidb.Job, hdr *uiHeader,
+	uiReportings []*uiJobReporting) (bool, bool, bool) {
+	usesReportingStages := aiJobUsesReportingStages(ctx, job)
+
+	canPushToReporting := false
+	if len(uiReportings) == 0 && job.Type == ai.WorkflowPatching && job.Finished.Valid && job.Error == "" {
+		if usesReportingStages && checkJobUpstreamable(job) == nil {
+			canPushToReporting = true
+		}
+	}
+
+	canSetCorrectness := !usesReportingStages
+	canRestart := checkJobRestartable(job, hdr.AIActions) == nil
+
+	return canPushToReporting, canSetCorrectness, canRestart
+}
+
+func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	job, err := loadAndFilterJob(ctx, r)
+	if err != nil {
+		return err
 	}
 	hdr, err := commonHeader(ctx, r, w, job.Namespace)
 	if err != nil {
 		return err
 	}
 
-	if err := handleAIJobPagePost(ctx, job, r, hdr); err != nil {
+	newJobID, err := handleAIJobPagePost(ctx, job, r, hdr)
+	if err != nil {
 		return err
+	}
+	if newJobID != "" {
+		http.Redirect(w, r, "/ai_job?id="+newJobID, http.StatusFound)
+		return nil
 	}
 
 	trajectory, err := aidb.LoadTrajectory(ctx, job.ID)
@@ -663,17 +728,7 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		return err
 	}
 
-	usesReportingStages := aiJobUsesReportingStages(ctx, job)
-
-	canPushToReporting := false
-	if len(uiReportings) == 0 && job.Type == ai.WorkflowPatching && job.Finished.Valid && job.Error == "" {
-		if usesReportingStages && checkJobUpstreamable(job) == nil {
-			canPushToReporting = true
-		}
-	}
-
-	// Disable manual correctness for stage-reported jobs to avoid duplicating moderation functionality.
-	canSetCorrectness := !usesReportingStages
+	canPushToReporting, canSetCorrectness, canRestart := determineJobActions(ctx, job, hdr, uiReportings)
 
 	page := &uiAIJobPage{
 		Header:             hdr,
@@ -688,6 +743,7 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		CanPushToReporting: canPushToReporting,
 		CanSetCorrectness:  canSetCorrectness,
 		Reportings:         uiReportings,
+		CanRestart:         canRestart,
 	}
 	if handled, err := handleAIJobPageJSON(ctx, w, r, job, uiJob, uiTrajectory, uiArgs); handled {
 		return err

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -631,6 +631,7 @@ func TestAINoStages(t *testing.T) {
 	require.False(t, job.Correct.Valid)
 
 	values := url.Values{}
+	values.Set("action", "set_correctness")
 	values.Set("correct", aiCorrectnessCorrect)
 	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", jobID), values)
 	require.NoError(t, err)
@@ -1527,7 +1528,7 @@ func TestAIManualPushToReporting(t *testing.T) {
 	})
 
 	values := url.Values{}
-	values.Set("push_to_reporting", "1")
+	values.Set("action", "push_to_reporting")
 	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", jobID), values)
 	require.NoError(t, err)
 
@@ -1589,6 +1590,7 @@ func TestAIAssessmentNoReport(t *testing.T) {
 	require.NoError(t, err)
 
 	values := url.Values{}
+	values.Set("action", "set_correctness")
 	values.Set("correct", aiCorrectnessCorrect)
 	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", jobID), values)
 	require.NoError(t, err)

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -377,6 +377,7 @@ func TestAIJobActions(t *testing.T) {
 
 	jobAssessURL := fmt.Sprintf("/ai_job?id=%v", resp.ID)
 	values = url.Values{}
+	values.Set("action", "set_correctness")
 	values.Set("correct", aiCorrectnessCorrect)
 	_, err = c.AuthPOSTForm(AccessPublic, jobAssessURL, values)
 	require.Error(t, err)
@@ -466,6 +467,7 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 
 	// Since the job is not completed, setting correctness must fail.
 	values := url.Values{}
+	values.Set("action", "set_correctness")
 	values.Set("correct", aiCorrectnessCorrect)
 	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", resp.ID), values)
 	require.Error(t, err)
@@ -498,6 +500,7 @@ func TestAIAssessmentKCSAN(t *testing.T) {
 
 	// Re-mark the result as incorrect, this should remove the label.
 	valuesIncorrect := url.Values{}
+	valuesIncorrect.Set("action", "set_correctness")
 	valuesIncorrect.Set("correct", aiCorrectnessIncorrect)
 	_, err = c.POSTForm(fmt.Sprintf("/ai_job?id=%v", resp.ID), valuesIncorrect)
 	require.NoError(t, err)
@@ -1167,4 +1170,137 @@ func TestAIReproCJobCreateFromBugPage(t *testing.T) {
 	require.Equal(t, "repro-c", resp.Workflow)
 
 	require.Equal(t, "title1\n\nreport1", resp.Args["BugDescription"])
+}
+
+func TestAIJobRestart(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+		},
+	})
+
+	// 1. Setup bug and patching job 1.
+	extID, jobID1 := c.setupAIPatchJob(t)
+
+	// Poll job 1 (now it is RUNNING).
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatching, Name: "patching"},
+		},
+	}
+	resp1, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, jobID1, resp1.ID)
+
+	jobURL1 := fmt.Sprintf("/ai_job?id=%v", jobID1)
+	values := url.Values{}
+	values.Set("action", "restart")
+
+	// Try to restart RUNNING job -> should fail with 400
+	_, err = c.AuthPOSTForm(AccessUser, jobURL1, values)
+	require.Error(t, err)
+	c.expectBadReqest(err)
+	require.Contains(t, err.Error(), "cannot restart a running job")
+
+	// Mark job 1 as SUCCESSFUL.
+	c.finishAIPatchJob(t, jobID1, nil)
+
+	// Try to restart SUCCESSFUL job -> should fail with 400
+	_, err = c.AuthPOSTForm(AccessUser, jobURL1, values)
+	require.Error(t, err)
+	c.expectBadReqest(err)
+	require.Contains(t, err.Error(), "cannot restart a successful job")
+
+	// Create job 2 (a failed patching job).
+	jobID2 := c.createAIJob(extID, "patching", "")
+	resp2, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, jobID2, resp2.ID)
+
+	// Mark job 2 as FAILED.
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID:    jobID2,
+		Error: "some workflow error",
+	})
+	require.NoError(t, err)
+
+	jobURL2 := fmt.Sprintf("/ai_job?id=%v", jobID2)
+
+	// Public user cannot restart.
+	_, err = c.AuthPOSTForm(AccessPublic, jobURL2, values)
+	require.Error(t, err)
+
+	// User can restart FAILED job, and it should redirect to the new job.
+	_, err = c.AuthPOSTForm(AccessUser, jobURL2, values)
+	require.Error(t, err)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusFound, httpErr.Code)
+	loc := httpErr.Headers.Get("Location")
+	require.True(t, strings.HasPrefix(loc, "/ai_job?id="))
+	newJobID := strings.TrimPrefix(loc, "/ai_job?id=")
+	require.NotEmpty(t, newJobID)
+	require.NotEqual(t, jobID2, newJobID)
+
+	// Verify the new job is polled and has same arguments.
+	pollResp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.Equal(t, newJobID, pollResp.ID)
+	require.Equal(t, "patching", pollResp.Workflow)
+	require.NotEmpty(t, pollResp.Args["BugTitle"])
+
+	// 2. Setup patch iteration job to test it cannot be restarted.
+	// Confirm published report for job 1 (moderation stage).
+	pollReportResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: "lore"})
+	require.NoError(t, err)
+	require.NotNil(t, pollReportResp.Result)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollReportResp.Result.ID,
+		PublishedExtID: "msg-id-moderation",
+	})
+	require.NoError(t, err)
+
+	// Simulate comment arrival on the thread.
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "msg-id-moderation",
+		MessageExtID: "<comment-1>",
+		Author:       "reviewer@email.com",
+		Comment:      &dashapi.CommentCommand{Body: "Please fix this"},
+	})
+	require.NoError(t, err)
+
+	c.advanceTime(31 * time.Minute)
+
+	// Poll for patch iteration job.
+	pollReqIteration := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	respIteration, err := c.agentClient.AIJobPoll(pollReqIteration)
+	require.NoError(t, err)
+	require.NotEmpty(t, respIteration.ID)
+
+	// Mark patch iteration job as FAILED.
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID:    respIteration.ID,
+		Error: "iteration failed",
+	})
+	require.NoError(t, err)
+
+	// Try to restart FAILED patch-iteration job -> should fail with 400.
+	patchIterationJobURL := fmt.Sprintf("/ai_job?id=%v", respIteration.ID)
+	_, err = c.AuthPOSTForm(AccessUser, patchIterationJobURL, values)
+	require.Error(t, err)
+	c.expectBadReqest(err)
+	require.Contains(t, err.Error(), "cannot restart a patch iteration workflow")
 }

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -171,6 +171,37 @@ func cloneJob(ctx context.Context, orig *Job) *Job {
 	}
 }
 
+func RestartJob(ctx context.Context, jobID string) (string, error) {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	var newJobID string
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		iter := txn.Query(ctx, spanner.Statement{
+			SQL:    selectJobs() + `WHERE ID = @id`,
+			Params: map[string]any{"id": jobID},
+		})
+		defer iter.Stop()
+		var jobs []*Job
+		if err := spanner.SelectAll(iter, &jobs); err != nil {
+			return err
+		}
+		if len(jobs) == 0 {
+			return ErrNotFound
+		}
+		orig := jobs[0]
+		newJob := cloneJob(ctx, orig)
+		newJobID = newJob.ID
+		mut, err := spanner.InsertStruct("Jobs", newJob)
+		if err != nil {
+			return err
+		}
+		return txn.BufferWrite([]*spanner.Mutation{mut})
+	})
+	return newJobID, err
+}
+
 func StartJob(ctx context.Context, req *dashapi.AIJobPollReq, namespaces []string) (*Job, error) {
 	var workflows []string
 	for _, flow := range req.Workflows {

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -16,8 +16,13 @@ Detailed info on a single AI job execution.
 	{{template "header" .Header}}
 	{{template "ai_job_list" .Jobs}}
 
-	{{if .Job.AgentName}}
-	<b>Agent:</b> {{.Job.AgentName}}<br><br>
+	<b>Agent:</b> {{if .Job.AgentName}}{{.Job.AgentName}}{{else}}---{{end}}<br><br>
+
+	{{if .CanRestart}}
+	<form method="POST" class="restart-form">
+		<input type="hidden" name="action" value="restart">
+		<button type="submit">Restart Workflow</button>
+	</form>
 	{{end}}
 
 	{{if .Args}}
@@ -51,6 +56,7 @@ Detailed info on a single AI job execution.
 	{{if .Header.AIActions}}
 		{{if and .CanSetCorrectness (ne .Job.Correct "⏳") (ne .Job.Correct "💥") (ne .Job.Correct "🏃")}}
 			<form method="POST">
+				<input type="hidden" name="action" value="set_correctness">
 				<fieldset>
 					<legend>Result correct:</legend>
 					<input type="radio" name="correct" id="✅" value="✅" {{if eq .Job.Correct "✅" }}checked{{end}} title="Correct">
@@ -66,7 +72,7 @@ Detailed info on a single AI job execution.
 		{{end}}
 		{{if .CanPushToReporting}}
 			<form method="POST">
-				<input type="hidden" name="push_to_reporting" value="1">
+				<input type="hidden" name="action" value="push_to_reporting">
 				<button type="submit">Push to {{.NextStage}}</button>
 			</form>
 			<br>

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -605,3 +605,8 @@ aside {
 .ai_current_job {
 	background-color: lightgreen;
 }
+
+.restart-form {
+	margin-top: 5px;
+	margin-bottom: 15px;
+}


### PR DESCRIPTION
Allow restarting failed AI workflows with the same inputs. Added a 'Restart Workflow' button to the single AI job page, which is visible when the job has finished with an error and the user has AI action permissions. Clicking the button clones the job and creates a new pending job with the same inputs, then redirects the user to the new job page. Implemented backend validation to prevent restarting running or successful jobs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
