### PR TITLE
pkg/instance: Fix coverage retrieval via SSH cat

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"slices"
 	"strconv"
 	"time"
 
@@ -238,13 +236,24 @@ func (inst *ExecProgInstance) RunCProgRaw(src []byte, target *prog.Target, opts 
 
 func (inst *ExecProgInstance) RunSyzProgFile(progFile string, opts RunOptions) (*RunResult, error) {
 	coverFile := ""
+	ncalls := 0
+	if opts.CollectCoverage && inst.mgrCfg.TargetOS != "linux" {
+		return nil, fmt.Errorf("coverage collection via ssh cat is only supported on Linux")
+	}
+
 	if opts.CollectCoverage {
-		coverDir, err := os.MkdirTemp("", "syz-cover")
-		if err != nil {
-			return nil, err
+		if opts.Opts.Repeat {
+			return nil, fmt.Errorf("coverage retrieval is not supported when repeat is enabled")
 		}
-		defer osutil.RemoveAll(coverDir)
-		coverFile = filepath.Join(coverDir, "cover")
+		progData, err := os.ReadFile(progFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read prog file: %w", err)
+		}
+		_, ncalls, err = prog.CallSet(progData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse prog: %w", err)
+		}
+		coverFile = fmt.Sprintf("/tmp/syz-cover-%d", time.Now().UnixNano())
 	}
 	vmProgFile, err := inst.VMInstance.Copy(progFile)
 	if err != nil {
@@ -257,18 +266,11 @@ func (inst *ExecProgInstance) RunSyzProgFile(progFile string, opts RunOptions) (
 		return nil, err
 	}
 	if coverFile != "" {
-		files, err := filepath.Glob(coverFile + "*")
+		coverage, err := inst.retrieveCoverageFiles(coverFile, ncalls)
 		if err != nil {
-			return nil, fmt.Errorf("failed to glob cover files: %w", err)
+			return nil, err
 		}
-		slices.Sort(files)
-		for _, f := range files {
-			cover, err := parseCoverageFile(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse cover file: %w", err)
-			}
-			res.Coverage = append(res.Coverage, cover)
-		}
+		res.Coverage = coverage
 	}
 	return res, nil
 }
@@ -286,14 +288,10 @@ func (inst *ExecProgInstance) RunSyzProg(syzProg []byte, opts RunOptions) (*RunR
 	return inst.RunSyzProgFile(progFile, opts)
 }
 
-func parseCoverageFile(filename string) ([]uint64, error) {
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
+func parseCoverageData(data []byte) ([]uint64, error) {
 	var res []uint64
 	for s := bufio.NewScanner(bytes.NewReader(data)); s.Scan(); {
-		v, err := strconv.ParseUint(s.Text(), 16, 64)
+		v, err := strconv.ParseUint(s.Text(), 0, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -378,4 +376,41 @@ func runStreamAndCollectStdout(ctx context.Context, inst *vm.Instance, command s
 			return ctx.Err()
 		}
 	}
+}
+
+func (inst *ExecProgInstance) runStreamAndCollectStdoutToBuf(ctx context.Context, command string) ([]byte, error) {
+	var buf bytes.Buffer
+	err := runStreamAndCollectStdout(ctx, inst.VMInstance, command, &buf)
+	return buf.Bytes(), err
+}
+
+func (inst *ExecProgInstance) retrieveCoverageFiles(vmCoverFilePrefix string, ncalls int) ([][]uint64, error) {
+	// syz-execprog generates these coverage files during execution (see tools/syz-execprog/execprog.go).
+	// Because we run a single program exactly once (opts.Repeat is false), it generates:
+	// - Per-call coverage: <prefix>_prog1.<call_index>
+	// - Extra coverage (background threads): <prefix>_prog1.extra
+	var files []string
+	for i := range ncalls {
+		files = append(files, fmt.Sprintf("%s_prog1.%d", vmCoverFilePrefix, i))
+	}
+	files = append(files, fmt.Sprintf("%s_prog1.extra", vmCoverFilePrefix))
+
+	coverage := make([][]uint64, 0, ncalls)
+	for _, file := range files {
+		catCmd := "cat " + file + " 2>/dev/null || true"
+		catCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		catOutput, err := inst.runStreamAndCollectStdoutToBuf(catCtx, catCmd)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read coverage file %s in VM: %w", file, err)
+		}
+
+		cover, err := parseCoverageData(catOutput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cover data from %s: %w", file, err)
+		}
+		coverage = append(coverage, cover)
+	}
+
+	return coverage, nil
 }

--- a/pkg/instance/execprog_test.go
+++ b/pkg/instance/execprog_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +65,162 @@ func init() {
 			return globalMockPool, nil
 		},
 	})
+}
+
+func TestRetrieveCoverageFiles_Success(t *testing.T) {
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetArch:   targets.AMD64,
+			TargetVMArch: targets.AMD64,
+			SysTarget:    targets.Get(targets.Linux, targets.AMD64),
+			Timeouts: targets.Timeouts{
+				Scale: 1,
+			},
+		},
+		Type:    "mock-vm",
+		Workdir: t.TempDir(),
+	}
+	pool, err := vm.Create(cfg, false)
+	require.NoError(t, err)
+
+	vmInst, err := pool.Create(t.Context(), 0)
+	require.NoError(t, err)
+
+	execProgInst := &ExecProgInstance{
+		VMInstance: vmInst,
+		mgrCfg:     cfg,
+	}
+
+	prefix := "/tmp/syz-cover-123"
+
+	globalMockPool.inst.runFunc = func(ctx context.Context, command string) (<-chan vmimpl.Chunk, <-chan error, error) {
+		outc := make(chan vmimpl.Chunk, 10)
+		errc := make(chan error, 1)
+
+		go func() {
+			defer close(outc)
+			defer close(errc)
+
+			if file, ok := strings.CutPrefix(command, "cat "); ok {
+				file = strings.TrimSpace(strings.TrimSuffix(file, " 2>/dev/null || true"))
+				switch file {
+				case prefix + "_prog1.0":
+					outc <- vmimpl.Chunk{Data: []byte("0x123\n0x456\n"), Type: vmimpl.OutputStdout}
+				case prefix + "_prog1.1":
+					outc <- vmimpl.Chunk{Data: []byte("0x789\n"), Type: vmimpl.OutputStdout}
+				}
+				errc <- nil
+			}
+		}()
+
+		return outc, errc, nil
+	}
+
+	coverage, err := execProgInst.retrieveCoverageFiles(prefix, 2)
+	require.NoError(t, err)
+	require.Len(t, coverage, 3)
+	require.Equal(t, []uint64{0x123, 0x456}, coverage[0])
+	require.Equal(t, []uint64{0x789}, coverage[1])
+	require.Nil(t, coverage[2])
+}
+
+func TestRetrieveCoverageFiles_EmptyList(t *testing.T) {
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetArch:   targets.AMD64,
+			TargetVMArch: targets.AMD64,
+			SysTarget:    targets.Get(targets.Linux, targets.AMD64),
+			Timeouts: targets.Timeouts{
+				Scale: 1,
+			},
+		},
+		Type:    "mock-vm",
+		Workdir: t.TempDir(),
+	}
+	pool, err := vm.Create(cfg, false)
+	require.NoError(t, err)
+
+	vmInst, err := pool.Create(t.Context(), 0)
+	require.NoError(t, err)
+
+	execProgInst := &ExecProgInstance{
+		VMInstance: vmInst,
+		mgrCfg:     cfg,
+	}
+
+	prefix := "/tmp/syz-cover-123"
+
+	globalMockPool.inst.runFunc = func(ctx context.Context, command string) (<-chan vmimpl.Chunk, <-chan error, error) {
+		outc := make(chan vmimpl.Chunk, 10)
+		errc := make(chan error, 1)
+
+		go func() {
+			defer close(outc)
+			defer close(errc)
+
+			if strings.HasPrefix(command, "cat ") {
+				errc <- nil // Empty output.
+			}
+		}()
+
+		return outc, errc, nil
+	}
+
+	coverage, err := execProgInst.retrieveCoverageFiles(prefix, 2)
+	require.NoError(t, err)
+	require.Len(t, coverage, 3)
+	require.Nil(t, coverage[0])
+	require.Nil(t, coverage[1])
+	require.Nil(t, coverage[2])
+}
+
+func TestRetrieveCoverageFiles_ReadError(t *testing.T) {
+	cfg := &mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetArch:   targets.AMD64,
+			TargetVMArch: targets.AMD64,
+			SysTarget:    targets.Get(targets.Linux, targets.AMD64),
+			Timeouts: targets.Timeouts{
+				Scale: 1,
+			},
+		},
+		Type:    "mock-vm",
+		Workdir: t.TempDir(),
+	}
+	pool, err := vm.Create(cfg, false)
+	require.NoError(t, err)
+
+	vmInst, err := pool.Create(t.Context(), 0)
+	require.NoError(t, err)
+
+	execProgInst := &ExecProgInstance{
+		VMInstance: vmInst,
+		mgrCfg:     cfg,
+	}
+
+	prefix := "/tmp/syz-cover-123"
+
+	globalMockPool.inst.runFunc = func(ctx context.Context, command string) (<-chan vmimpl.Chunk, <-chan error, error) {
+		outc := make(chan vmimpl.Chunk, 10)
+		errc := make(chan error, 1)
+
+		go func() {
+			defer close(outc)
+			defer close(errc)
+
+			if strings.HasPrefix(command, "cat ") {
+				errc <- errors.New("read error")
+			}
+		}()
+
+		return outc, errc, nil
+	}
+
+	_, err = execProgInst.retrieveCoverageFiles(prefix, 1)
+	require.Error(t, err)
 }
 
 func TestRunStreamAndCollectStdout_Success(t *testing.T) {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -508,7 +508,7 @@ func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Optio
 	}
 	coverArg := ""
 	if coverFile != "" {
-		coverArg = " -cover=%v -coverfile=" + coverFile
+		coverArg = " -cover=true -coverfile=" + coverFile
 	}
 	return fmt.Sprintf("%v -executor=%v -arch=%v%v -sandbox=%v"+
 		" -procs=%v -repeat=%v -threaded=%v -collide=%v%v%v %v",


### PR DESCRIPTION
Use `ls` and `cat` streamed over the execution channel (`RunStream`) to retrieve coverage information from the VM. This removes the previous dependency on a shared filesystem between the host and the VM, making coverage collection more robust.

Add tests for coverage retrieval.

