### PR TITLE
pkg/lore-relay: ignore commands on DKIM failure

### DIFF
--- a/pkg/lore-relay/relay.go
+++ b/pkg/lore-relay/relay.go
@@ -227,6 +227,10 @@ func (r *Relay) HandleIncomingEmail(ctx context.Context, polled *lore.PolledEmai
 			dkimOk = true
 		}
 	}
+	if r.cfg.VerifyDKIM && !dkimOk && len(polled.Email.Commands) > 0 {
+		r.cfg.Tracer.Logf("ignoring commands from %s due to DKIM failure", polled.Email.Author)
+		return nil
+	}
 	reqs, err := extractCommands(polled, dkimOk)
 	if err != nil {
 		// TODO: for tracked threads we may want to reply with an error (#7199).


### PR DESCRIPTION
Emails containing commands sent to lore-relay from users with a failed DKIM check can pose a security risk. To address this while preventing unnecessary test failures where DKIM is not checked, silently drop any email that has both commands and a failed DKIM signature check, but only if VerifyDKIM is enabled.