### PR TITLE
dashboard/app: avoid syzbot error email loops

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -612,6 +612,13 @@ func TestEmailErrors(t *testing.T) {
 	c.incomingEmail("syzbot@testapp.appspotmail.com", "Investment Proposal")
 	c.expectNoEmail()
 
+	// Do not reply to syzbot's own context-address replies. Otherwise an error
+	// reply that quotes a stale syzbot+HASH address can start a mail loop.
+	c.incomingEmail("syzbot@testapp.appspotmail.com", "#syz upstream\n\n"+
+		"On Thu, syzbot ci <syzbot+cidbb9f477452b5813@testapp.appspotmail.com> wrote:",
+		EmailOptFrom("syzbot+cidbb9f477452b5813@testapp.appspotmail.com"))
+	c.expectNoEmail()
+
 	// If email contains a command we need to reply.
 	c.incomingEmail("syzbot@testapp.appspotmail.com", "#syz invalid")
 	reply := c.pollEmailBug()

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -692,8 +692,9 @@ func processInboxEmail(ctx context.Context, msg *email.Email, inbox *PerInboxCon
 }
 
 func processIncomingEmail(ctx context.Context, msg *email.Email) error {
-	// Ignore any incoming emails from syzbot itself.
-	if ownEmail(ctx) == msg.Author {
+	// Ignore any incoming emails from syzbot itself, including context
+	// addresses such as syzbot+HASH@domain.
+	if msg.OwnEmail {
 		// But we still want to remember the id of our own message, so just neutralize the command.
 		msg.Commands = nil
 	}
@@ -1225,6 +1226,10 @@ func loadBugInfo(ctx context.Context, msg *email.Email) *bugInfoResult {
 	bug, bugKey, err := findBugByReportingID(ctx, bugID)
 	if err != nil {
 		log.Errorf(ctx, "can't find bug: %v", err)
+		if msg.OwnEmail {
+			log.Infof(ctx, "ignoring own email with unknown bug ID")
+			return nil
+		}
 		from, err := email.AddAddrContext(ownEmail(ctx), "HASH")
 		if err != nil {
 			log.Errorf(ctx, "failed to format sender email address: %v", err)


### PR DESCRIPTION
Fixes #7415.

`email.Parse` already marks context-address senders such as `syzbot+HASH@...` as `OwnEmail`, but `processIncomingEmail` only neutralized commands when the author exactly matched the base syzbot address. That let syzbot react to its own context-address error replies, including stale bug hashes quoted in the body.

This uses `msg.OwnEmail` for the self-email check and skips bad-hash error replies for syzbot's own messages, while still allowing valid own-message IDs to be remembered. The regression covers a self-reply with a quoted stale `syzbot+HASH` address.

Validation:
- `go test ./dashboard/app -run TestEmailErrors -count=1`
- `git diff --check`