### PR TITLE
Add a script which can create FreeBSD GCE images

### DIFF
--- a/executor/executor_bsd.h
+++ b/executor/executor_bsd.h
@@ -143,6 +143,8 @@ static void cover_protect(cover_t* cov)
 
 static void cover_unprotect(cover_t* cov)
 {
+	if (cov == nullptr)
+		fail("cover_unprotect invoked without cover_t");
 	if (cov->mmap_alloc_ptr == NULL)
 		fail("cover_unprotect invoked on an unmapped cover_t object");
 #if GOOS_freebsd

--- a/pkg/aflow/test_tool.go
+++ b/pkg/aflow/test_tool.go
@@ -5,12 +5,18 @@ package aflow
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type TestToolOption func(*Context)
+type TestToolOption func(*testToolContext)
+
+type testToolContext struct {
+	ctx           Context
+	errorIsPrefix bool
+}
 
 // TestTool runs the given tool on provided initState/initArgs and compares results/error
 // with the provided wantResults/wantError.
@@ -28,20 +34,25 @@ func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wan
 	require.NoError(t, vctx.finalize())
 	// Just ensure it does not crash.
 	_ = tool.declaration()
-	// We don't init all fields, init more, if necessary.
-	ctx := &Context{
-		state: state,
+	tctx := &testToolContext{
+		// We don't init all fields, init more, if necessary.
+		ctx: Context{state: state},
 	}
 	for _, opt := range opts {
-		opt(ctx)
+		opt(tctx)
 	}
-	defer ctx.Close()
-	gotResults, err := tool.execute(ctx, args)
+	defer tctx.ctx.Close()
+	gotResults, err := tool.execute(&tctx.ctx, args)
 	gotError := ""
 	if err != nil {
 		gotError = err.Error()
 	}
-	require.Equal(t, wantError, gotError)
+	if tctx.errorIsPrefix {
+		require.True(t, strings.HasPrefix(gotError, wantError),
+			"error %q does not have prefix %q", gotError, wantError)
+	} else {
+		require.Equal(t, wantError, gotError)
+	}
 	if wantError != "" {
 		var badCallErr *badCallError
 		if !errors.As(err, &badCallErr) {
@@ -51,9 +62,15 @@ func TestTool(t *testing.T, tool Tool, initState, initArgs, wantResults any, wan
 	resultChecker(gotResults)
 }
 
+func TestErrorPrefix() TestToolOption {
+	return func(tctx *testToolContext) {
+		tctx.errorIsPrefix = true
+	}
+}
+
 func TestWorkdir(dir string) TestToolOption {
-	return func(ctx *Context) {
-		ctx.Workdir = dir
+	return func(tctx *testToolContext) {
+		tctx.ctx.Workdir = dir
 	}
 }
 

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -268,6 +268,6 @@ void foo() {
 		state{KernelCommit: "HEAD"},
 		logArgs{CodeRegexp: `foo(`, SourcePath: "foo.c"},
 		logResult{},
-		`git log failed: fatal: invalid regex: Unmatched ( or \(`,
-		aflow.TestWorkdir(tmpDir))
+		`git log failed: fatal: invalid regex: `,
+		aflow.TestErrorPrefix(), aflow.TestWorkdir(tmpDir))
 }

--- a/pkg/flatrpc/conn_test.go
+++ b/pkg/flatrpc/conn_test.go
@@ -132,7 +132,7 @@ func BenchmarkConn(b *testing.B) {
 		Files:      []string{"file1"},
 	}
 
-	serv, err := Listen(":0")
+	serv, err := Listen("127.0.0.1:0")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/image/fsck.go
+++ b/pkg/image/fsck.go
@@ -37,7 +37,9 @@ func Fsck(r io.Reader, fsckCmd string) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
-	osutil.SandboxChown(tempFile.Name())
+	if err := osutil.SandboxChown(tempFile.Name()); err != nil {
+		return nil, false, fmt.Errorf("failed to change ownership of temporary file: %w", err)
+	}
 
 	// And run the provided fsck command on it.
 	fsck := append(strings.Fields(fsckCmd), tempFile.Name())

--- a/pkg/kcov/cdefs.go
+++ b/pkg/kcov/cdefs.go
@@ -1,5 +1,8 @@
 // Copyright 2025 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux
+
 package kcov
 
 // This file defines values required for KCOV ioctl calls. More information on

--- a/tools/check-html.sh
+++ b/tools/check-html.sh
@@ -9,7 +9,7 @@ for F in $(find . -name "*.html"); do
 	TABS=`cat $F | grep "	"  | wc -l`
 	# templates.html uses several spaces to format commit info using fixed-width font.
 	SPACES=`cat $F | grep -v "Commit.Date" | grep "  "  | wc -l`
-	if [ "$TABS" = "0" ] || [ "$SPACES" = "0" ]; then continue; fi
+	if [ "$TABS" -eq "0" ] || [ "$SPACES" -eq "0" ]; then continue; fi
 	# Ignore untracked files.
 	git ls-files --error-unmatch $F >/dev/null 2>&1
 	if [ $? -ne 0 ]; then continue; fi

--- a/tools/check-k8s.sh
+++ b/tools/check-k8s.sh
@@ -22,6 +22,10 @@ run_checks() {
 	local dir=$3
 	echo "Checking $name $target..."
 	local yaml
+	if [ "$(uname)" != "Linux" ]; then
+		echo "SKIPPED: Skipping checks for $name $target (not running on Linux)"
+		return
+	fi
 	yaml=$(make -C "$dir" -s "$target" KUSTOMIZE="$KUSTOMIZE")
 	if [ $? -ne 0 ]; then
 		echo "FAILED: $name $target (make failed)"

--- a/tools/check-syzos.sh
+++ b/tools/check-syzos.sh
@@ -28,6 +28,11 @@ if [ "$TARGETOS" != "linux" ]; then
     exit 0
 fi
 
+if [ "$TARGETOS" != "$BUILDOS" ]; then
+    echo "[INFO] TARGETOS is '$TARGETOS', not '$BUILDOS'. Skipping check."
+    exit 0
+fi
+
 if [ -z "$TARGETARCH" ]; then
     echoerr "Error: \$TARGETARCH environment variable is not set."
     exit 1

--- a/tools/create-freebsd-gce-ci.sh
+++ b/tools/create-freebsd-gce-ci.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+# Produces GCE image of syz-ci running on FreeBSD 15.1.  Based on create-openbsd-gce-ci.sh.
+
+set -eux -o pipefail
+
+readonly ARCH=amd64
+readonly VERSION=15.1-RC1
+readonly IMAGE="FreeBSD-${VERSION}-${ARCH}-ufs.raw.xz"
+
+if [ "$(uname)" = FreeBSD ]; then
+  readonly TAR=gtar
+else
+  readonly TAR=tar
+fi
+
+if [ ! -f disk.raw ]; then
+  if [ ! -f $IMAGE ]; then
+    curl -o $IMAGE "https://download.freebsd.org/ftp/releases/VM-IMAGES/${VERSION}/amd64/Latest/${IMAGE}"
+  fi
+  cp -f "$IMAGE" disk.raw.xz
+  unxz disk.raw.xz
+  truncate -s 20g disk.raw
+fi
+
+cat >setup.sh <<EOF
+#!/bin/sh
+
+set -e
+
+cp -f /mnt/rc.local /etc/rc.local
+mkdir -p /root/.ssh
+cp -f /mnt/id_ed25519.pub /root/.ssh/authorized_keys
+
+echo 'console=comconsole' >> /boot/loader.conf
+
+echo 'PasswordAuthentication no' >> /etc/ssh/sshd_config
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+echo 'UsePAM no' >> /etc/ssh/sshd_config
+
+echo 'hostname=ci-freebsd'
+echo 'sshd_enable=YES' >> /etc/rc.conf
+
+echo 'debug.debugger_on_panic=0' >> /etc/sysctl.conf
+
+sed -i -e '/KEYWORD: firstboot/d' /etc/rc.d/growfs
+
+PKGS="bash gcc git gmake go llvm wget"
+for pkg in \$PKGS; do
+  pkg install -y \$pkg
+done
+
+mkdir /syzkaller
+EOF
+
+cat >rc.local <<EOF
+nc metadata.google.internal 80 <<EOF2 | tail -n1 > /etc/myname.gce \
+  && echo >> /etc/myname.gce \
+  && mv /etc/myname.gce /etc/myname \
+  && hostname \$(cat /etc/myname)
+GET /computeMetadata/v1/instance/hostname HTTP/1.0
+Host: metadata.google.internal
+Metadata-Flavor: Google
+
+EOF2
+
+cd /syzkaller
+export HOME=/syzkaller
+export PATH=${PATH}:/usr/local/sbin:/usr/local/bin
+set -eux
+mkdir -p /syzkaller/go-cache
+export GOCACHE=/syzkaller/go-cache
+test -d /syzkaller/gopath/src/github.com/google/syzkaller || (
+  mkdir -p /syzkaller/gopath/src/github.com/google && \
+  git clone https://github.com/google/syzkaller.git && \
+  mv syzkaller /syzkaller/gopath/src/github.com/google)
+(cd /syzkaller/gopath/src/github.com/google/syzkaller && \
+  gmake ci && \
+  install bin/syz-ci /syzkaller)
+./syz-ci -config /syzkaller/gopath/src/github.com/google/syzkaller/dashboard/config/freebsd/config.ci 2>&1 | tee /syzkaller/syz-ci.log &
+EOF
+
+mkisofs -o image.iso -V SYZCI -J -R setup.sh rc.local id_ed25519.pub
+
+expect 2>&1 <<EOF | tee install_log
+set timeout 1800
+set send_slow {1 0.05}
+
+spawn qemu-system-x86_64 -nographic -smp 2 \
+  -drive if=virtio,file=disk.raw,format=raw \
+  -net nic,model=virtio -net user -boot once=d -m 4000 -cdrom image.iso
+
+expect timeout { exit 1 } -exact {[Space] to pause}
+send -s "\x1b"
+expect timeout { exit 1 } "OK "
+send -s "set console=comconsole\n"
+expect timeout { exit 1 } "OK "
+send "boot\n"
+
+expect timeout { exit 1 } "login:"
+send -s "root\n"
+expect "# "
+send -s "mount -t cd9660 /dev/cd0 /mnt\n"
+expect "# "
+send -s "sh /mnt/setup.sh\n"
+expect "# "
+send -s "poweroff\n"
+expect eof
+EOF
+
+i="freebsd-${ARCH}-snapshot-gce.tar.gz"
+$TAR -Szcf "$i" disk.raw
+
+cat <<EOF
+Done.
+
+To create GCE image run the following commands:
+
+gcloud storage cp --billing-project=syzkaller --predefined-acl=publicRead "$i" gs://syzkaller/
+gcloud compute images create ci-freebsd-root --source-uri gs://syzkaller/"$i"
+
+EOF

--- a/tools/syz-imagegen/combinations.go
+++ b/tools/syz-imagegen/combinations.go
@@ -1,6 +1,8 @@
 // Copyright 2025 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build linux
+
 package main
 
 import (

--- a/tools/syz-imagegen/combinations_test.go
+++ b/tools/syz-imagegen/combinations_test.go
@@ -1,6 +1,8 @@
 // Copyright 2025 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+//go:build linux
+
 package main
 
 import (


### PR DESCRIPTION
To try and address #6910 I wrote a script which can be used to create a suitable CI host from a FreeBSD release. The rest of the commits fix various issues with the presubmit target on non-Linux.
