### PR TITLE
dashboard/app: avoid syzbot email reply loops

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -681,6 +681,15 @@ Please double check the address.
 		EmailOptFrom("syzbot@testapp.appspotmail.com"),
 		EmailOptSender("syzkaller-upstream-moderation@googlegroups.com"))
 	c.expectNoEmail()
+
+	// A reply from a context-addressed syzbot sender is still our own email and
+	// must not trigger a new error reply from quoted commands.
+	c.incomingEmail("syzbot+123@testapp.appspotmail.com", `> #syz upstream
+
+Failed to process the command.`,
+		EmailOptFrom("syzbot+cidbb9f477452b5813@testapp.appspotmail.com"),
+		EmailOptSender("syzkaller-upstream-moderation@googlegroups.com"))
+	c.expectNoEmail()
 }
 
 func TestEmailFailedBuild(t *testing.T) {

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -689,7 +689,7 @@ func processInboxEmail(ctx context.Context, msg *email.Email, inbox *PerInboxCon
 
 func processIncomingEmail(ctx context.Context, msg *email.Email) error {
 	// Ignore any incoming emails from syzbot itself.
-	if ownEmail(ctx) == msg.Author {
+	if msg.OwnEmail {
 		// But we still want to remember the id of our own message, so just neutralize the command.
 		msg.Commands = nil
 	}


### PR DESCRIPTION
## Summary

This fixes an email loop where dashboard/app can react to syzbot's own error reply when the reply comes from a context-addressed sender such as `syzbot+cid...@...`.

The parser already marks those messages as `OwnEmail` after stripping the address context. `processIncomingEmail` now uses that parsed flag instead of comparing only against the bare syzbot address, so quoted `#syz` commands in syzbot's own replies are neutralized before processing.

Fixes #7415.

## Testing

* `PATH="/tmp/codex-python12-bin:$PATH" CLOUDSDK_PYTHON="$(command -v python3.12)" go test -run 'TestEmailLoop|TestEmailErrors|TestEmailIndirectCommandIgnored' -count=1 ./dashboard/app`\n* `PATH="/tmp/codex-python12-bin:$PATH" CLOUDSDK_PYTHON="$(command -v python3.12)" go test -run '^TestEmail' -count=1 ./dashboard/app`\n* `go test ./pkg/email`\n* `git diff --check`