### PR TITLE
pkg/corpus: fix focus area stats tracking

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -46,6 +46,8 @@ type FocusArea struct {
 	Weight   float64
 }
 
+const allFocusAreaName = "all"
+
 func NewCorpus(ctx context.Context) *Corpus {
 	return NewMonitoredCorpus(ctx, nil)
 }
@@ -69,10 +71,11 @@ func NewFocusedCorpus(ctx context.Context, updates chan<- NewItemEvent, areas []
 		stat.Link("/cover"), stat.Prometheus("syz_corpus_cover"), stat.LenOf(&corpus.cover, &corpus.mu))
 	for _, area := range areas {
 		obj := &ProgramsList{}
-		if len(areas) > 1 && area.Name != "" {
+		statName := area.statName()
+		if len(areas) > 1 && statName != "" {
 			// Only show extra statistics if there's more than one area.
-			stat.New("corpus ["+area.Name+"]",
-				fmt.Sprintf("Corpus programs of the focus area %q", area.Name),
+			stat.New("corpus ["+statName+"]",
+				fmt.Sprintf("Corpus programs of the focus area %q", statName),
 				stat.Console, stat.Graph("corpus"),
 				stat.LenOf(&obj.progs, &corpus.mu))
 		}
@@ -191,22 +194,30 @@ func (corpus *Corpus) Save(inp NewInput) {
 
 func (corpus *Corpus) applyFocusAreas(item *Item, coverDelta []uint64) {
 	for _, area := range corpus.focusAreas {
-		matches := false
-		for _, pc := range coverDelta {
-			if _, ok := area.CoverPCs[pc]; ok {
-				matches = true
-				break
-			}
+		if _, ok := item.areas[area]; ok {
+			continue
 		}
-		if !matches {
+		if !area.containsAny(coverDelta) {
 			continue
 		}
 		area.saveProgram(item.Prog, item.Signal)
 		if item.areas == nil {
 			item.areas = make(map[*focusAreaState]struct{})
-			item.areas[area] = struct{}{}
+		}
+		item.areas[area] = struct{}{}
+	}
+}
+
+func (area FocusArea) containsAny(pcs []uint64) bool {
+	if area.CoverPCs == nil {
+		return true
+	}
+	for _, pc := range pcs {
+		if _, ok := area.CoverPCs[pc]; ok {
+			return true
 		}
 	}
+	return false
 }
 
 func (corpus *Corpus) Signal() signal.Signal {
@@ -257,9 +268,21 @@ func (corpus *Corpus) ProgsPerArea() map[string]int {
 	defer corpus.mu.RUnlock()
 	ret := map[string]int{}
 	for _, item := range corpus.focusAreas {
-		ret[item.Name] = len(item.progs)
+		if name := item.statName(); name != "" {
+			ret[name] = len(item.progs)
+		}
 	}
 	return ret
+}
+
+func (area FocusArea) statName() string {
+	if area.Name != "" {
+		return area.Name
+	}
+	if area.CoverPCs == nil {
+		return allFocusAreaName
+	}
+	return ""
 }
 
 func (corpus *Corpus) Cover() []uint64 {

--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -76,6 +76,106 @@ func TestCorpusCoverage(t *testing.T) {
 	assert.Equal(t, corpus.StatCover.Val(), 3)
 }
 
+func TestFocusAreaStatsIncludeAllArea(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{
+		{
+			Name: "dummy",
+			CoverPCs: map[uint64]struct{}{
+				42: {},
+			},
+			Weight: 10,
+		},
+		{
+			Weight: 1,
+		},
+		{
+			CoverPCs: map[uint64]struct{}{
+				42: {},
+			},
+			Weight: 1,
+		},
+	})
+	rs := rand.NewSource(0)
+
+	inp := generateInput(target, rs, 5)
+	inp.Cover = []uint64{42}
+	corpus.Save(inp)
+
+	inp = generateInput(target, rs, 5)
+	inp.Cover = []uint64{100}
+	corpus.Save(inp)
+
+	assert.Equal(t, map[string]int{
+		"dummy":          1,
+		allFocusAreaName: 2,
+	}, corpus.ProgsPerArea())
+}
+
+func TestFocusAreaStatsDoNotDuplicateExistingProgram(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{
+		{
+			Name: "area",
+			CoverPCs: map[uint64]struct{}{
+				1: {},
+				2: {},
+			},
+			Weight: 1,
+		},
+	})
+	rs := rand.NewSource(0)
+
+	inp := generateInput(target, rs, 5)
+	inp.Cover = []uint64{1}
+	corpus.Save(inp)
+	assert.Equal(t, map[string]int{"area": 1}, corpus.ProgsPerArea())
+
+	inp.Cover = []uint64{2}
+	inp.Signal = signal.FromRaw([]uint64{2}, 0)
+	corpus.Save(inp)
+
+	assert.Equal(t, map[string]int{"area": 1}, corpus.ProgsPerArea())
+}
+
+func TestFocusAreaStatsSurviveMinimize(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{
+		{
+			Name: "first",
+			CoverPCs: map[uint64]struct{}{
+				1: {},
+				2: {},
+			},
+			Weight: 1,
+		},
+		{
+			Name: "second",
+			CoverPCs: map[uint64]struct{}{
+				2: {},
+				3: {},
+			},
+			Weight: 1,
+		},
+	})
+	rs := rand.NewSource(0)
+
+	inp := generateInput(target, rs, 5)
+	inp.Cover = []uint64{2}
+	corpus.Save(inp)
+	assert.Equal(t, map[string]int{
+		"first":  1,
+		"second": 1,
+	}, corpus.ProgsPerArea())
+
+	corpus.Minimize(true)
+
+	assert.Equal(t, map[string]int{
+		"first":  1,
+		"second": 1,
+	}, corpus.ProgsPerArea())
+}
+
 func TestCorpusSaveConcurrency(t *testing.T) {
 	target := getTarget(t, targets.TestOS, targets.TestArch64)
 	corpus := NewCorpus(context.Background())


### PR DESCRIPTION
Fixes #7206.

Summary:
- Treat a focus area with nil CoverPCs as the catch-all area, so it is counted and shown as `corpus [all]`.
- Record every matching focus area on each corpus item, so `Minimize()` can rebuild all per-area program lists instead of only the first match.
- Add regression coverage for the catch-all area and for multi-area stats after minimization.

Tests:
- `GOBIN=$(pwd)/bin go install ./sys/syz-sysgen && ./bin/syz-sysgen`
- `go test ./pkg/corpus`
- `go test ./pkg/corpus ./pkg/manager/... ./pkg/mgrconfig`
- `go test ./pkg/corpus -run 'TestFocusAreaStats' -count=10`\n- `git diff --check`