### PR TITLE
dashboard/app: enforce authorization for AI commands

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -56,7 +56,6 @@ func apiAIReportCommand(ctx context.Context, req *dashapi.SendExternalCommandReq
 	return resp, nil
 }
 
-// nolint: dupl
 func handleUpstreamCommand(ctx context.Context, req *dashapi.SendExternalCommandReq,
 ) (*dashapi.SendExternalCommandResp, error) {
 	reporting, job, err := lookupJobByExtReq(ctx, req)
@@ -66,28 +65,35 @@ func handleUpstreamCommand(ctx context.Context, req *dashapi.SendExternalCommand
 
 	err = processUpstreamSubcommand(ctx, job, reporting, req)
 	if err != nil {
-		var cannotUpstreamErr *aidb.ErrCannotUpstream
-		if errors.As(err, &cannotUpstreamErr) {
-			// We log logical rejection errors to the Journal so that IsCommandProcessed
-			// returns true on subsequent retries (e.g., if lore-relay restarts). This prevents
-			// lore-relay from sending duplicate "Command failed" emails to the user.
-			if req.Source != "" && req.MessageExtID != "" {
-				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
-					JobID:         job.ID,
-					ReportingID:   reporting.ID,
-					CommandSource: string(req.Source),
-					CommandExtID:  req.MessageExtID,
-					User:          req.Author,
-					Action:        aidb.ActionApprove,
-					Error:         cannotUpstreamErr.Reason,
-				})
-			}
-			return &dashapi.SendExternalCommandResp{Error: cannotUpstreamErr.Reason}, nil
-		}
-		return nil, err
+		return handleCommandError(ctx, job, reporting, req, aidb.ActionApprove, err)
 	}
 
 	return &dashapi.SendExternalCommandResp{}, nil
+}
+
+func checkActionAuthorized(ctx context.Context, job *aidb.Job, req *dashapi.SendExternalCommandReq) error {
+	nsCfg := getNsConfig(ctx, job.Namespace)
+	if nsCfg.AI == nil || len(nsCfg.AI.AllowedCommandAuthors) == 0 {
+		return nil
+	}
+
+	// Verify the request came through an authenticated channel (DKIM must be OK).
+	if !req.DKIM {
+		return &aidb.ErrNotAuthorized{
+			Reason: "Command ignored: sender identity could not be verified (DKIM failed or missing).",
+		}
+	}
+
+	author := email.CanonicalEmail(req.Author)
+	for _, allowed := range nsCfg.AI.AllowedCommandAuthors {
+		allowed = strings.ToLower(allowed)
+		if allowed == author || strings.HasSuffix(author, "@"+allowed) {
+			return nil
+		}
+	}
+	return &aidb.ErrNotAuthorized{
+		Reason: "You are not authorized to send this command. Please contact the system administrators.",
+	}
 }
 
 func formatUpstreamedBy(name, email string) string {
@@ -99,6 +105,9 @@ func formatUpstreamedBy(name, email string) string {
 
 func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	currentReporting *aidb.JobReporting, req *dashapi.SendExternalCommandReq) error {
+	if err := checkActionAuthorized(ctx, job, req); err != nil {
+		return err
+	}
 	if err := checkJobUpstreamable(job); err != nil {
 		return err
 	}
@@ -201,7 +210,6 @@ func determineNextStage(ctx context.Context, cfg *AIConfig, job *aidb.Job,
 	return &cfg.Stages[currentIndex+1], nil
 }
 
-// nolint: dupl
 func handleRejectCommand(ctx context.Context,
 	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
 	reporting, job, err := lookupJobByExtReq(ctx, req)
@@ -214,31 +222,19 @@ func handleRejectCommand(ctx context.Context,
 		reason = req.Reject.Reason
 	}
 
-	err = aidb.RejectReportCommand(ctx, aidb.RejectReportArgs{
-		Job:           job,
-		ReportingID:   reporting.ID,
-		CommandSource: string(req.Source),
-		CommandExtID:  req.MessageExtID,
-		User:          req.Author,
-		Reason:        reason,
-	})
+	err = checkActionAuthorized(ctx, job, req)
+	if err == nil {
+		err = aidb.RejectReportCommand(ctx, aidb.RejectReportArgs{
+			Job:           job,
+			ReportingID:   reporting.ID,
+			CommandSource: string(req.Source),
+			CommandExtID:  req.MessageExtID,
+			User:          req.Author,
+			Reason:        reason,
+		})
+	}
 	if err != nil {
-		var cannotRejectErr *aidb.ErrCannotReject
-		if errors.As(err, &cannotRejectErr) {
-			if req.Source != "" && req.MessageExtID != "" {
-				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
-					JobID:         job.ID,
-					ReportingID:   reporting.ID,
-					CommandSource: string(req.Source),
-					CommandExtID:  req.MessageExtID,
-					User:          req.Author,
-					Action:        aidb.ActionReject,
-					Error:         cannotRejectErr.Reason,
-				})
-			}
-			return &dashapi.SendExternalCommandResp{Error: cannotRejectErr.Reason}, nil
-		}
-		return nil, err
+		return handleCommandError(ctx, job, reporting, req, aidb.ActionReject, err)
 	}
 
 	return &dashapi.SendExternalCommandResp{}, nil
@@ -451,6 +447,36 @@ func apiAIConfirmReport(ctx context.Context, req *dashapi.ConfirmPublishedReq) (
 	return nil, nil
 }
 
+func handleCommandError(ctx context.Context, job *aidb.Job, reporting *aidb.JobReporting,
+	req *dashapi.SendExternalCommandReq, action string, err error) (*dashapi.SendExternalCommandResp, error) {
+	var cannotUpstreamErr *aidb.ErrCannotUpstream
+	var cannotRejectErr *aidb.ErrCannotReject
+	var cannotUnrejectErr *aidb.ErrCannotUnreject
+	var notAuthorizedErr *aidb.ErrNotAuthorized
+
+	switch {
+	case errors.As(err, &cannotUpstreamErr),
+		errors.As(err, &cannotRejectErr),
+		errors.As(err, &cannotUnrejectErr),
+		errors.As(err, &notAuthorizedErr):
+		errReason := err.Error()
+		if req.Source != "" && req.MessageExtID != "" {
+			_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
+				JobID:         job.ID,
+				ReportingID:   reporting.ID,
+				CommandSource: string(req.Source),
+				CommandExtID:  req.MessageExtID,
+				User:          req.Author,
+				Action:        action,
+				Error:         errReason,
+			})
+		}
+		return &dashapi.SendExternalCommandResp{Error: errReason}, nil
+	default:
+		return nil, err
+	}
+}
+
 func lookupJobByExtReq(ctx context.Context, req *dashapi.SendExternalCommandReq) (
 	*aidb.JobReporting, *aidb.Job, error) {
 	extID := req.RootExtID
@@ -476,7 +502,6 @@ func lookupJobByExtReq(ctx context.Context, req *dashapi.SendExternalCommandReq)
 	return reporting, job, nil
 }
 
-// nolint: dupl
 func handleUnrejectCommand(ctx context.Context,
 	req *dashapi.SendExternalCommandReq) (*dashapi.SendExternalCommandResp, error) {
 	reporting, job, err := lookupJobByExtReq(ctx, req)
@@ -484,30 +509,18 @@ func handleUnrejectCommand(ctx context.Context,
 		return nil, err
 	}
 
-	err = aidb.UnrejectReportCommand(ctx, aidb.UnrejectReportArgs{
-		Job:           job,
-		ReportingID:   reporting.ID,
-		CommandSource: string(req.Source),
-		CommandExtID:  req.MessageExtID,
-		User:          req.Author,
-	})
+	err = checkActionAuthorized(ctx, job, req)
+	if err == nil {
+		err = aidb.UnrejectReportCommand(ctx, aidb.UnrejectReportArgs{
+			Job:           job,
+			ReportingID:   reporting.ID,
+			CommandSource: string(req.Source),
+			CommandExtID:  req.MessageExtID,
+			User:          req.Author,
+		})
+	}
 	if err != nil {
-		var cannotUnrejectErr *aidb.ErrCannotUnreject
-		if errors.As(err, &cannotUnrejectErr) {
-			if req.Source != "" && req.MessageExtID != "" {
-				_ = aidb.LogCommandError(ctx, aidb.LogCommandErrorArgs{
-					JobID:         job.ID,
-					ReportingID:   reporting.ID,
-					CommandSource: string(req.Source),
-					CommandExtID:  req.MessageExtID,
-					User:          req.Author,
-					Action:        aidb.ActionUnreject,
-					Error:         cannotUnrejectErr.Reason,
-				})
-			}
-			return &dashapi.SendExternalCommandResp{Error: cannotUnrejectErr.Reason}, nil
-		}
-		return nil, err
+		return handleCommandError(ctx, job, reporting, req, aidb.ActionUnreject, err)
 	}
 
 	return &dashapi.SendExternalCommandResp{}, nil

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1867,3 +1867,126 @@ func TestAIManualIteration(t *testing.T) {
 	require.Len(t, gotPatchHistory[0].Comments, 1)
 	assert.Contains(t, gotPatchHistory[0].Comments[0].Body, "This is a review comment.")
 }
+
+func TestAIActionEmailsAuth(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com"},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
+		},
+		AllowedCommandAuthors: []string{
+			"exact@email.com",
+			"domain.com",
+		},
+	})
+
+	// Report a crash to create a bug.
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// Register workflow and create a job.
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	// Create and finish a job.
+	jobID := c.createAIJob(extID, string(ai.WorkflowPatching), "")
+	c.finishAIPatchJob(t, jobID, map[string]any{})
+
+	pollResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{
+		Source: "lore",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pollResp.Result)
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       pollResp.Result.ID,
+		PublishedExtID: "msg_ext_id",
+	})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		author string
+		dkim   bool
+		cmd    *dashapi.SendExternalCommandReq
+		errMsg string
+	}{
+		{
+			name:   "unauthorized_email",
+			author: "fake@email.com",
+			dkim:   true,
+			cmd:    &dashapi.SendExternalCommandReq{Upstream: &dashapi.UpstreamCommand{}},
+			errMsg: "You are not authorized to send this command. Please contact the system administrators.",
+		},
+		{
+			name:   "unauthorized_domain",
+			author: "exact@other.com",
+			dkim:   true,
+			cmd:    &dashapi.SendExternalCommandReq{Upstream: &dashapi.UpstreamCommand{}},
+			errMsg: "You are not authorized to send this command. Please contact the system administrators.",
+		},
+		{
+			name:   "authorized_but_no_dkim",
+			author: "exact@email.com",
+			dkim:   false,
+			cmd:    &dashapi.SendExternalCommandReq{Upstream: &dashapi.UpstreamCommand{}},
+			errMsg: "Command ignored: sender identity could not be verified (DKIM failed or missing).",
+		},
+		{
+			name:   "authorized_domain_unreject",
+			author: "user@domain.com",
+			dkim:   true,
+			cmd:    &dashapi.SendExternalCommandReq{Unreject: &dashapi.UnrejectCommand{}},
+			errMsg: "Cannot unreject a patch that is not rejected.", // Auth passed!
+		},
+		{
+			name:   "authorized_exact_reject",
+			author: "exact@email.com",
+			dkim:   true,
+			cmd:    &dashapi.SendExternalCommandReq{Reject: &dashapi.RejectCommand{Reason: "bad"}},
+			errMsg: "", // Auth passed and successfully rejected!
+		},
+		{
+			name:   "authorized_exact_upstream_rejected",
+			author: "exact@email.com",
+			dkim:   true,
+			cmd:    &dashapi.SendExternalCommandReq{Upstream: &dashapi.UpstreamCommand{}},
+			errMsg: "Cannot upstream a rejected patch. Unreject it first.", // Auth passed!
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.Source = dashapi.AIJobSourceLore
+			tc.cmd.RootExtID = "msg_ext_id"
+			tc.cmd.MessageExtID = "msg_ext_" + tc.name
+			tc.cmd.Author = tc.author
+			tc.cmd.DKIM = tc.dkim
+
+			// First attempt should return the error (if any) and journal it.
+			resp, err := c.globalClient.AIReportCommand(tc.cmd)
+			require.NoError(t, err)
+			if tc.errMsg != "" {
+				assert.Equal(t, tc.errMsg, resp.Error)
+			} else {
+				assert.Empty(t, resp.Error)
+			}
+
+			// Second attempt with the exact same Source and MessageExtID should be treated as
+			// an idempotent no-op (because it was already journaled), returning no error.
+			resp2, err2 := c.globalClient.AIReportCommand(tc.cmd)
+			require.NoError(t, err2)
+			assert.Empty(t, resp2.Error, "duplicate command should not return an error")
+		})
+	}
+}

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -56,6 +56,14 @@ func (e *ErrCannotUnreject) Error() string {
 	return e.Reason
 }
 
+type ErrNotAuthorized struct {
+	Reason string
+}
+
+func (e *ErrNotAuthorized) Error() string {
+	return e.Reason
+}
+
 func init() {
 	// This forces unmarshalling of JSON integers into json.Number rather than float64.
 	spanner.UseNumberWithJSONDecoderEncoder(true)

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -152,6 +152,9 @@ type AIConfig struct {
 	Stages                []AIPatchStageConfig
 	SecurityPrio          func(*Bug, ai.AssessmentSecurityOutputs) BugPrio `json:"-"`
 
+	// Emails or domains allowed to execute external AI commands (#syz upstream, reject, etc).
+	AllowedCommandAuthors []string
+
 	// These are passed to the patching workflow, see the workflow inputs for details.
 	BaseRepository string
 	BaseBranch     string


### PR DESCRIPTION
Restrict the list of users allowed to send AI patch report moderation commands. Since DKIM alone only verifies the domain, it leaves the system vulnerable to spoofing via shared email providers.

Add AllowedCommandAuthors to configure permitted emails and domains. Ensure this allowlist is strictly checked alongside a valid DKIM signature before processing any AI command. Notify unauthorized senders and journal the failure to prevent duplicate replies.