### PR TITLE
use constant-time comparison for manager key in syz-hub

### DIFF
--- a/syz-hub/hub.go
+++ b/syz-hub/hub.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"flag"
 	"fmt"
 	"net/http"
@@ -146,13 +148,17 @@ func (hub *Hub) verifyKey(key, expectedKey string) error {
 		if err != nil {
 			return err
 		}
-		if subj != expectedKey {
+		subjHash := sha256.Sum256([]byte(subj))
+		expectedHash := sha256.Sum256([]byte(expectedKey))
+		if subtle.ConstantTimeCompare(subjHash[:], expectedHash[:]) != 1 {
 			return fmt.Errorf("bad token")
 		}
 		// Success due to correct token.
 		return nil
 	}
-	if key != expectedKey {
+	keyHash := sha256.Sum256([]byte(key))
+	expectedHash := sha256.Sum256([]byte(expectedKey))
+	if subtle.ConstantTimeCompare(keyHash[:], expectedHash[:]) != 1 {
 		return fmt.Errorf("bad password")
 	}
 	// Success due to correct password.


### PR DESCRIPTION
verifyKey in syz-hub authenticates managers connecting over RPC (Connect/Sync) by comparing the supplied key against the expected pre-shared key with plain string equality, which returns on the first mismatching byte and leaks the key through response timing. The dashboard already uses subtle.ConstantTimeCompare for the equivalent client-key check in checkClient, so this brings the hub in line for both the token and password branches.