### PR TITLE
strip CRLF from email headers in smtp rawEmail

### DIFF
--- a/pkg/email/sender/smtp.go
+++ b/pkg/email/sender/smtp.go
@@ -92,23 +92,30 @@ func (s *smtpSender) Send(ctx context.Context, item *Email) (string, error) {
 	return msgID, nil
 }
 
+// stripCRLF removes CR and LF from a header value. The Subject and In-Reply-To
+// can originate from an incoming email (e.g. a #syz command reply), and an
+// RFC 2047 encoded-word Subject decodes to arbitrary bytes including CRLF, so
+// writing it verbatim lets a sender inject extra headers into the outgoing mail.
+func stripCRLF(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+}
+
 func (s *smtpSender) rawEmail(item *Email, id string) []byte {
 	var msg bytes.Buffer
 
-	fmt.Fprintf(&msg, "From: %s\r\n", s.cfg.From.String())
-	fmt.Fprintf(&msg, "To: %s\r\n", strings.Join(item.To, ", "))
+	fmt.Fprintf(&msg, "From: %s\r\n", stripCRLF(s.cfg.From.String()))
+	fmt.Fprintf(&msg, "To: %s\r\n", stripCRLF(strings.Join(item.To, ", ")))
 	if len(item.Cc) > 0 {
-		fmt.Fprintf(&msg, "Cc: %s\r\n", strings.Join(item.Cc, ", "))
+		fmt.Fprintf(&msg, "Cc: %s\r\n", stripCRLF(strings.Join(item.Cc, ", ")))
 	}
-	fmt.Fprintf(&msg, "Subject: %s\r\n", item.Subject)
-	if item.InReplyTo != "" {
-		inReplyTo := item.InReplyTo
+	fmt.Fprintf(&msg, "Subject: %s\r\n", stripCRLF(item.Subject))
+	if inReplyTo := stripCRLF(item.InReplyTo); inReplyTo != "" {
 		if inReplyTo[0] != '<' {
 			inReplyTo = "<" + inReplyTo + ">"
 		}
 		fmt.Fprintf(&msg, "In-Reply-To: %s\r\n", inReplyTo)
 	}
-	if id != "" {
+	if id = stripCRLF(id); id != "" {
 		if id[0] != '<' {
 			id = "<" + id + ">"
 		}

--- a/pkg/email/sender/smtp_test.go
+++ b/pkg/email/sender/smtp_test.go
@@ -37,6 +37,26 @@ func TestRawEmail(t *testing.T) {
 				"Content-Transfer-Encoding: 8bit\r\n\r\n" +
 				"Email body",
 		},
+		{
+			// CRLF in the (attacker-controlled) Subject and In-Reply-To must not
+			// inject additional headers into the outgoing message.
+			item: &Email{
+				To:        []string{"1@to.com"},
+				InReplyTo: "<reply@domain>\r\nBcc: victim@evil.com",
+				Subject:   "subject\r\nBcc: victim@evil.com",
+				Body:      []byte("Email body"),
+			},
+			id: "<id@domain>",
+			result: "From: \"name\" <a@b.com>\r\n" +
+				"To: 1@to.com\r\n" +
+				"Subject: subjectBcc: victim@evil.com\r\n" +
+				"In-Reply-To: <reply@domain>Bcc: victim@evil.com\r\n" +
+				"Message-ID: <id@domain>\r\n" +
+				"MIME-Version: 1.0\r\n" +
+				"Content-Type: text/plain; charset=UTF-8\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n\r\n" +
+				"Email body",
+		},
 	}
 
 	cfg := SMTPConfig{


### PR DESCRIPTION
rawEmail in pkg/email/sender/smtp.go writes the Subject and In-Reply-To verbatim, but an RFC 2047 encoded-word Subject from an incoming #syz reply decodes to arbitrary bytes including CRLF, so the sender can inject extra headers (e.g. Bcc) into the outgoing mail. Strip CR/LF from the header values before writing them.