### PR TITLE
syz-manager, pkg: move snapshot functionality to a separate package

### DIFF
--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -533,8 +533,7 @@ private:
 			// to the caller for analysis. Don't print SYZFAIL in these requests,
 			// otherwise it will be detected as a bug.
 			if (msg_ && IsSet(msg_->flags, rpc::RequestFlag::ReturnError)) {
-				char* syzfail = strstr(output, "SYZFAIL");
-				if (syzfail)
+				while (char* syzfail = strstr(output, "SYZFAIL"))
 					memcpy(syzfail, "NOTFAIL", strlen("NOTFAIL"));
 			}
 			debug("proc %d: got output: %s%s", id_, output, has_nl ? "" : "\n");

--- a/pkg/execbackend/local.go
+++ b/pkg/execbackend/local.go
@@ -1,0 +1,207 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package execbackend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/rpcserver"
+	"github.com/google/syzkaller/pkg/signal"
+	"github.com/google/syzkaller/pkg/vminfo"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/google/syzkaller/vm"
+	"github.com/google/syzkaller/vm/vmimpl"
+	"golang.org/x/sync/errgroup"
+)
+
+type LocalConfig struct {
+	Target      *prog.Target
+	ExecutorBin string
+	Dir         string
+	Source      queue.Source
+}
+
+type localManager struct {
+	backend Server
+	source  queue.Source
+}
+
+func (m *localManager) BugFrames() ([]string, []string) { return nil, nil }
+
+func (m *localManager) MaxSignal() signal.Signal { return signal.Signal{} }
+
+func (m *localManager) CoverageFilter([]*vminfo.KernelModule) ([]uint64, error) {
+	return nil, nil
+}
+
+func (m *localManager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error {
+	if m.source != nil {
+		m.backend.SetSource(m.source)
+	}
+	return nil
+}
+
+// RunLocal is a convenience wrapper for running a local mock VM via the execbackend abstraction.
+// It executes the syz-executor binary as a standard host process, returning its output reports.
+func RunLocal(ctx context.Context, cfg LocalConfig) ([]*report.Report, error) {
+	sysTarget := targets.Get(cfg.Target.OS, cfg.Target.Arch)
+	timeouts := sysTarget.Timeouts(1)
+	timeouts.VMRunningTime = time.Minute
+	timeouts.Scale = 1
+
+	mgrCfg := &mgrconfig.Config{
+		Type:    "local",
+		Sandbox: "none",
+		Cover:   true,
+		Procs:   4,
+		Workdir: cfg.Dir,
+		Derived: mgrconfig.Derived{
+			TargetOS:     cfg.Target.OS,
+			TargetVMArch: cfg.Target.Arch,
+			SysTarget:    sysTarget,
+			Timeouts:     timeouts,
+			ExecutorBin:  cfg.ExecutorBin,
+			Target:       cfg.Target,
+		},
+		RPC: ":0",
+	}
+
+	pool, err := vm.Create(mgrCfg, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vm pool: %w", err)
+	}
+
+	inst, err := pool.Create(ctx, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vm instance: %w", err)
+	}
+	defer inst.Close()
+
+	mgrWrapper := &localManager{
+		source: cfg.Source,
+	}
+
+	rpcCfg := &rpcserver.RemoteConfig{
+		Config:  mgrCfg,
+		Manager: mgrWrapper,
+		Stats:   rpcserver.NewStats(),
+		Debug:   true,
+	}
+
+	backend, err := New(rpcCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create execbackend: %w", err)
+	}
+	mgrWrapper.backend = backend
+
+	if err := backend.Setup(); err != nil {
+		return nil, fmt.Errorf("failed to setup execbackend: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return backend.Serve(egCtx)
+	})
+
+	reporter, err := report.NewReporter(&mgrconfig.Config{
+		Type: "qemu",
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetVMArch: cfg.Target.Arch,
+			SysTarget:    sysTarget,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reporter: %w", err)
+	}
+
+	reps, err := backend.RunRequests(egCtx, inst, reporter, nil)
+	cancel()
+	if serveErr := eg.Wait(); serveErr != nil {
+		return nil, serveErr
+	}
+
+	return reps, err
+}
+
+func init() {
+	vmimpl.Register("local", vmimpl.Type{
+		Ctor: func(env *vmimpl.Env) (vmimpl.Pool, error) {
+			return &localPool{env: env}, nil
+		},
+	})
+}
+
+type localPool struct {
+	env *vmimpl.Env
+}
+
+func (p *localPool) Count() int {
+	return 1
+}
+
+func (p *localPool) Create(ctx context.Context, workdir string, index int) (vmimpl.Instance, error) {
+	return &localVM{workdir: workdir}, nil
+}
+
+type localVM struct {
+	workdir string
+}
+
+func (v *localVM) Copy(hostSrc string) (string, error) {
+	return hostSrc, nil
+}
+
+func (v *localVM) Forward(port int) (string, error) {
+	return fmt.Sprintf("localhost:%v", port), nil
+}
+
+func (v *localVM) Run(ctx context.Context, command string) (<-chan vmimpl.Chunk, <-chan error, error) {
+	parts := strings.Fields(command)
+	cmd := osutil.CommandContext(ctx, parts[0], parts[1:]...)
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		pw.Close()
+		return nil, nil, err
+	}
+
+	// Close our copy of the write end so the pipe closes when the child exits.
+	pw.Close()
+
+	merger := vmimpl.NewOutputMerger(nil)
+	merger.Add("output", vmimpl.OutputStdout, pr)
+
+	return vmimpl.Multiplex(ctx, cmd, merger, vmimpl.MultiplexConfig{
+		Scale: 1, // we don't have a slowdown factor in local config, so scale=1 is safe
+	})
+}
+
+func (v *localVM) Diagnose(rep *report.Report) ([]byte, bool) {
+	return nil, false
+}
+
+func (v *localVM) Close() error {
+	return nil
+}

--- a/pkg/execbackend/rpc.go
+++ b/pkg/execbackend/rpc.go
@@ -1,0 +1,129 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package execbackend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/rpcserver"
+	"github.com/google/syzkaller/vm"
+	"github.com/google/syzkaller/vm/dispatcher"
+	"github.com/google/syzkaller/vm/vmimpl"
+)
+
+type rpcBackend struct {
+	rpcserver.Server
+	cfg *mgrconfig.Config
+}
+
+func New(cfg *rpcserver.RemoteConfig) (Server, error) {
+	rpcServ, err := rpcserver.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &rpcBackend{
+		Server: rpcServ,
+		cfg:    cfg.Config,
+	}, nil
+}
+
+func (b *rpcBackend) RunRequests(ctx context.Context, inst *vm.Instance,
+	reporter *report.Reporter, updInfo dispatcher.UpdateInfo) (
+	[]*report.Report, error) {
+	injectExec := make(chan bool, 10)
+	rpcUpdInfo := func(cb func(info *rpcserver.RunnerInfo)) {
+		if updInfo != nil {
+			updInfo(func(info *dispatcher.Info) {
+				runnerInfo := &rpcserver.RunnerInfo{
+					Status:         info.Status,
+					DetailedStatus: info.DetailedStatus,
+					MachineInfo:    info.MachineInfo,
+				}
+				cb(runnerInfo)
+				info.Status = runnerInfo.Status
+				info.DetailedStatus = runnerInfo.DetailedStatus
+				info.MachineInfo = runnerInfo.MachineInfo
+			})
+		}
+	}
+
+	b.CreateInstance(inst.Index(), injectExec, rpcUpdInfo)
+
+	var err error
+	var fwdAddr string
+	if !b.cfg.VMLess {
+		fwdAddr, err = inst.Forward(b.Port())
+		if err != nil {
+			return nil, fmt.Errorf("failed to setup port forwarding: %w", err)
+		}
+	}
+
+	executorBin := b.cfg.SysTarget.ExecutorBin
+	if executorBin == "" {
+		executorBin, err = inst.Copy(b.cfg.ExecutorBin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to copy binary: %w", err)
+		}
+	}
+
+	var cmd string
+	if b.cfg.VMLess {
+		// Just a placeholder, actually VMLess uses local.go.
+	} else {
+		host, port, err := net.SplitHostPort(fwdAddr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse manager's address")
+		}
+		cmd = fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
+	}
+
+	ctxTimeout, cancel := context.WithTimeout(ctx, b.cfg.Timeouts.VMRunningTime)
+	defer cancel()
+
+	start := time.Now()
+	_, reps, err := inst.Run(ctxTimeout, reporter, cmd,
+		vm.WithExitCondition(vm.ExitTimeout),
+		vm.WithInjectExecuting(injectExec),
+		vm.WithEarlyFinishCb(func() {
+			b.StopFuzzing(inst.Index())
+		}))
+
+	if err != nil {
+		if errors.Is(err, vmimpl.ErrPreempted) {
+			log.Logf(0, "VM %v: preempted while executing", inst.Index())
+		} else {
+			err = fmt.Errorf("failed to run fuzzer: %w", err)
+		}
+	} else if len(reps) == 0 {
+		log.Logf(0, "VM %v: running for %v, restarting", inst.Index(), time.Since(start))
+	}
+
+	// Fetch executor info and clean up instance.
+	var extraExecs []report.ExecutorInfo
+	if len(reps) != 0 && reps[0] != nil && reps[0].Executor != nil {
+		extraExecs = []report.ExecutorInfo{*reps[0].Executor}
+	}
+	execRecords, machineInfo := b.ShutdownInstance(inst.Index(), len(reps) != 0, extraExecs...)
+
+	if len(reps) != 0 && reps[0] != nil {
+		vmInfo, infoErr := inst.Info()
+		if infoErr != nil {
+			vmInfo = []byte(fmt.Sprintf("error getting VM info: %v\n", infoErr))
+		}
+		if len(vmInfo) != 0 {
+			machineInfo = append(append(vmInfo, '\n'), machineInfo...)
+		}
+		rpcserver.PrependExecuting(reps[0], execRecords)
+		reps[0].MachineInfo = machineInfo
+	}
+
+	return reps, err
+}

--- a/pkg/execbackend/rpc_test.go
+++ b/pkg/execbackend/rpc_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package execbackend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+func TestRPCBackendLocal(t *testing.T) {
+	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)
+	require.NoError(t, err)
+
+	executorBin := csource.BuildExecutor(t, target, "../..")
+
+	p, err := target.Deserialize([]byte("syz_test_fuzzer1(0, 0, 0)"), prog.Strict)
+	require.NoError(t, err)
+
+	done := make(chan *queue.Result)
+	req := &queue.Request{
+		Prog: p,
+		ExecOpts: flatrpc.ExecOpts{
+			EnvFlags: flatrpc.ExecEnvSandboxNone,
+		},
+		ReturnOutput: true,
+	}
+	req.OnDone(func(r *queue.Request, res *queue.Result) bool {
+		done <- res
+		return true
+	})
+
+	q := queue.Plain()
+	q.Submit(req)
+
+	cfg := LocalConfig{
+		Target:      target,
+		ExecutorBin: executorBin,
+		Dir:         t.TempDir(),
+		Source:      q,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		select {
+		case res := <-done:
+			t.Logf("got execution result: status=%v output=%q", res.Status, res.Output)
+			cancel() // successfully executed, stop the backend
+		case <-ctx.Done():
+		}
+	}()
+
+	reps, err := RunLocal(ctx, cfg)
+
+	if err != nil && err != context.Canceled {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Logf("reps: %v, err: %v", reps, err)
+}

--- a/pkg/execbackend/server.go
+++ b/pkg/execbackend/server.go
@@ -1,0 +1,48 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package execbackend
+
+import (
+	"context"
+
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/signal"
+	"github.com/google/syzkaller/vm"
+	"github.com/google/syzkaller/vm/dispatcher"
+)
+
+type Server interface {
+	// Setup performs initial one-time configuration for the backend (e.g. starting a TCP listener).
+	// It is called synchronously before any VM instances are started.
+	Setup() error
+
+	// Serve runs the global background loops for the backend (e.g. accepting connections).
+	// It is called asynchronously and runs until the provided context is canceled.
+	Serve(ctx context.Context) error
+
+	// Close forcefully cleans up any global resources held by the backend.
+	Close() error
+
+	// TriagedCorpus notifies the backend that the initial seed corpus has been fully evaluated.
+	TriagedCorpus()
+
+	// DistributeSignalDelta sends newly discovered max signal down to all connected executors
+	// so they can use it for subsequent coverage feedback filtering.
+	DistributeSignalDelta(plus signal.Signal)
+
+	// SetSource updates the source of execution requests for the backend.
+	// This is typically called after the initial machine check is complete.
+	SetSource(source queue.Source)
+
+	// Features returns the enabled features. It is only valid after the machine check is complete.
+	Features() flatrpc.Feature
+
+	// RunRequests handles the lifecycle of a single VM instance. It copies the executor
+	// binary, establishes communication, continuously polls Source() for execution requests,
+	// and returns when the VM crashes, hangs, or the context is canceled.
+	RunRequests(ctx context.Context, inst *vm.Instance, reporter *report.Reporter,
+		updInfo dispatcher.UpdateInfo) ([]*report.Report, error)
+}

--- a/pkg/execbackend/snapshot.go
+++ b/pkg/execbackend/snapshot.go
@@ -1,62 +1,123 @@
-// Copyright 2024 syzkaller project authors. All rights reserved.
+// Copyright 2026 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
-package main
+package execbackend
 
 import (
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
-	"github.com/google/syzkaller/pkg/log"
-	"github.com/google/syzkaller/pkg/manager"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/rpcserver"
 	"github.com/google/syzkaller/vm"
 	"github.com/google/syzkaller/vm/dispatcher"
 )
 
-func (mgr *Manager) snapshotInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
-	mgr.servStats.StatNumFuzzing.Add(1)
-	defer mgr.servStats.StatNumFuzzing.Add(-1)
+type SnapshotConfig struct {
+	*mgrconfig.Config
+	Stats rpcserver.Stats
+}
+
+type snapshotServer struct {
+	Server
+	cfg      SnapshotConfig
+	source   *queue.DynamicSourceCtl
+	dist     *queue.Distributor
+	bootDone chan struct{}
+	bootOnce sync.Once
+}
+
+func NewSnapshotBackend(base Server, cfg SnapshotConfig) Server {
+	source := queue.DynamicSource(queue.Plain())
+	return &snapshotServer{
+		Server:   base,
+		cfg:      cfg,
+		source:   source,
+		dist:     queue.Distribute(queue.Retry(source)),
+		bootDone: make(chan struct{}),
+	}
+}
+
+func (serv *snapshotServer) SetSource(source queue.Source) {
+	serv.source.Store(source)
+	serv.bootOnce.Do(func() {
+		close(serv.bootDone)
+	})
+	serv.Server.Close()
+}
+
+func (serv *snapshotServer) RunRequests(ctx context.Context, inst *vm.Instance,
+	reporter *report.Reporter, updInfo dispatcher.UpdateInfo) (
+	[]*report.Report, error) {
+	select {
+	case <-serv.bootDone:
+		// Machine check has already completed. Proceed to snapshot mode.
+	default:
+		// Machine check has not completed yet. We must boot the VM normally using the base RPC server
+		// so that it connects, exchanges capabilities, and triggers MachineChecked.
+		bootCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			select {
+			case <-bootCtx.Done():
+			case <-serv.bootDone:
+				cancel()
+			}
+		}()
+		reps, err := serv.Server.RunRequests(bootCtx, inst, reporter, updInfo)
+		if errors.Is(err, context.Canceled) {
+			err = nil
+		}
+		return reps, err
+	}
 
 	updInfo(func(info *dispatcher.Info) {
 		info.Status = "snapshot fuzzing"
 	})
 
-	err := mgr.snapshotLoop(ctx, inst)
+	executorBin, err := inst.Copy(serv.cfg.ExecutorBin)
 	if err != nil {
-		log.Error(err)
+		return nil, err
 	}
-}
 
-func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
-	executor, err := inst.Copy(mgr.cfg.ExecutorBin)
-	if err != nil {
-		return err
-	}
 	// All network connections (including ssh) will break once we start restoring snapshots.
 	// So we start a background process and log to /dev/kmsg.
-	cmd := fmt.Sprintf("nohup %v exec snapshot 1>/dev/null 2>/dev/kmsg </dev/null &", executor)
+	cmd := fmt.Sprintf("nohup %v exec snapshot 1>/dev/null 2>/dev/kmsg </dev/null &", executorBin)
 	ctxTimeout, cancel := context.WithTimeout(ctx, time.Hour)
 	defer cancel()
-	if _, _, err := inst.Run(ctxTimeout, mgr.reporter, cmd); err != nil {
-		return err
+	if _, _, err := inst.Run(ctxTimeout, reporter, cmd); err != nil {
+		return nil, err
 	}
 
 	builder := flatbuffers.NewBuilder(0)
 	var envFlags flatrpc.ExecEnv
+
+	if serv.cfg.Stats.StatNumFuzzing != nil {
+		serv.cfg.Stats.StatNumFuzzing.Add(1)
+		defer serv.cfg.Stats.StatNumFuzzing.Add(-1)
+	}
+
 	for first := true; ctx.Err() == nil; first = false {
-		mgr.servStats.StatExecs.Add(1)
-		req := mgr.snapshotSource.Next(inst.Index())
+		if serv.cfg.Stats.StatExecs != nil {
+			serv.cfg.Stats.StatExecs.Add(1)
+		}
+		req := serv.dist.Next(inst.Index())
+		if req == nil {
+			return nil, nil
+		}
 		if first {
 			envFlags = req.ExecOpts.EnvFlags
-			if err := mgr.snapshotSetup(inst, builder, envFlags); err != nil {
+			if err := serv.snapshotSetup(inst, builder, envFlags); err != nil {
 				req.Done(&queue.Result{Status: queue.Crashed})
-				return err
+				return nil, err
 			}
 		}
 		if envFlags != req.ExecOpts.EnvFlags {
@@ -64,44 +125,54 @@ func (mgr *Manager) snapshotLoop(ctx context.Context, inst *vm.Instance) error {
 				envFlags, req.ExecOpts.EnvFlags))
 		}
 
-		res, output, err := mgr.snapshotRun(inst, builder, req)
+		res, output, err := serv.snapshotRun(inst, builder, req)
 		if err != nil {
-			req.Done(&queue.Result{Status: queue.Crashed})
-			return err
+			req.Done(&queue.Result{
+				Status: queue.Crashed,
+			})
+			return nil, err
 		}
 
-		if mgr.reporter.ContainsCrash(output) {
+		if reporter.ContainsCrash(output) {
 			res.Status = queue.Crashed
-			rep := mgr.reporter.Parse(output)
+			rep := reporter.Parse(output)
+			if rep == nil {
+				rep = &report.Report{
+					Title:  "unknown crash",
+					Output: output,
+				}
+			}
 			buf := new(bytes.Buffer)
 			fmt.Fprintf(buf, "program:\n%s\n", req.Prog.Serialize())
 			buf.Write(rep.Output)
 			rep.Output = buf.Bytes()
-			mgr.crashes <- &manager.Crash{Report: rep}
+
+			req.Done(res)
+			return []*report.Report{rep}, nil
 		}
 
 		req.Done(res)
 	}
-	return nil
+	return nil, nil
 }
 
-func (mgr *Manager) snapshotSetup(inst *vm.Instance, builder *flatbuffers.Builder, env flatrpc.ExecEnv) error {
+func (serv *snapshotServer) snapshotSetup(inst *vm.Instance, builder *flatbuffers.Builder, env flatrpc.ExecEnv) error {
 	msg := flatrpc.SnapshotHandshakeT{
-		CoverEdges:       mgr.cfg.Experimental.CoverEdges,
-		Kernel64Bit:      mgr.cfg.SysTarget.PtrSize == 8,
-		Slowdown:         int32(mgr.cfg.Timeouts.Slowdown),
-		SyscallTimeoutMs: int32(mgr.cfg.Timeouts.Syscall / time.Millisecond),
-		ProgramTimeoutMs: int32(mgr.cfg.Timeouts.Program / time.Millisecond),
-		Features:         mgr.enabledFeatures,
+		CoverEdges:       serv.cfg.Experimental.CoverEdges,
+		Kernel64Bit:      serv.cfg.SysTarget.PtrSize == 8,
+		Slowdown:         int32(serv.cfg.Timeouts.Slowdown),
+		SyscallTimeoutMs: int32(serv.cfg.Timeouts.Syscall / time.Millisecond),
+		ProgramTimeoutMs: int32(serv.cfg.Timeouts.Program / time.Millisecond),
+		Features:         serv.Server.Features(),
 		EnvFlags:         env,
-		SandboxArg:       mgr.cfg.SandboxArg,
+		SandboxArg:       serv.cfg.SandboxArg,
 	}
 	builder.Reset()
 	builder.Finish(msg.Pack(builder))
 	return inst.SetupSnapshot(builder.FinishedBytes())
 }
 
-func (mgr *Manager) snapshotRun(inst *vm.Instance, builder *flatbuffers.Builder, req *queue.Request) (
+func (serv *snapshotServer) snapshotRun(inst *vm.Instance, builder *flatbuffers.Builder, req *queue.Request) (
 	*queue.Result, []byte, error) {
 	progData, err := req.Prog.SerializeForExec()
 	if err != nil {
@@ -153,6 +224,9 @@ func (mgr *Manager) snapshotRun(inst *vm.Instance, builder *flatbuffers.Builder,
 	}
 
 	ret := &queue.Result{
+		Executor: queue.ExecutorID{
+			VM: inst.Index(),
+		},
 		Status: queue.Success,
 		Info:   res.Info,
 	}

--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -19,11 +19,10 @@ import (
 
 	"github.com/google/syzkaller/pkg/corpus"
 	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/execbackend"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
-	"github.com/google/syzkaller/pkg/rpcserver"
 	"github.com/google/syzkaller/pkg/testutil"
-	"github.com/google/syzkaller/pkg/vminfo"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
@@ -157,30 +156,22 @@ func (f *testFuzzer) run() {
 	f.crashes = make(map[string]int)
 	ctx, done := context.WithCancel(context.Background())
 	f.done = done
-	var output bytes.Buffer
-	cfg := &rpcserver.LocalConfig{
-		Config: rpcserver.Config{
-			Config: vminfo.Config{
-				Debug:    true,
-				Cover:    true,
-				Target:   f.target,
-				Features: flatrpc.FeatureSandboxNone | flatrpc.FeatureCoverage,
-				Sandbox:  flatrpc.ExecEnvSandboxNone,
-			},
-			Procs:    4,
-			Slowdown: 1,
-		},
-		Executor:     f.executor,
-		Dir:          f.t.TempDir(),
-		OutputWriter: &output,
+
+	cfg := execbackend.LocalConfig{
+		Target:      f.target,
+		ExecutorBin: f.executor,
+		Dir:         f.t.TempDir(),
+		Source:      f,
 	}
-	cfg.MachineChecked = func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {
-		return f
-	}
-	if err := rpcserver.RunLocal(ctx, cfg); err != nil {
-		f.t.Logf("executor output:\n%s", output.String())
+
+	reps, err := execbackend.RunLocal(ctx, cfg)
+	if err != nil && err != context.Canceled {
 		f.t.Fatal(err)
 	}
+	if len(reps) > 0 {
+		f.t.Logf("crash: %s\noutput:\n%s", reps[0].Title, reps[0].Output)
+	}
+
 	assert.Equal(f.t, len(f.expectedCrashes), len(f.crashes), "not all expected crashes were found")
 	assert.NotEmpty(f.t, f.fuzzer.Config.Corpus.StatProgs.Val(), "must have non-empty corpus")
 	assert.NotEmpty(f.t, f.fuzzer.Config.Corpus.StatSignal.Val(), "must have non-empty signal")

--- a/pkg/manager/diff/kernel.go
+++ b/pkg/manager/diff/kernel.go
@@ -140,9 +140,9 @@ func (kc *kernelContext) BugFrames() (leaks, races []string) {
 }
 
 func (kc *kernelContext) MachineChecked(features flatrpc.Feature,
-	syscalls map[*prog.Syscall]bool) (queue.Source, error) {
+	syscalls map[*prog.Syscall]bool) error {
 	if len(syscalls) == 0 {
-		return nil, fmt.Errorf("all system calls are disabled")
+		return fmt.Errorf("all system calls are disabled")
 	}
 	log.Logf(0, "%s: machine check complete", kc.name)
 	kc.features = features
@@ -154,7 +154,8 @@ func (kc *kernelContext) MachineChecked(features flatrpc.Feature,
 		source = kc.source
 	}
 	opts := fuzzer.DefaultExecOpts(kc.cfg, features, kc.debug)
-	return queue.DefaultOpts(source, opts), nil
+	kc.serv.SetSource(queue.DefaultOpts(source, opts))
+	return nil
 }
 
 func (kc *kernelContext) setupFuzzer(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) queue.Source {

--- a/pkg/manager/diff/kernel.go
+++ b/pkg/manager/diff/kernel.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net"
 	"sync/atomic"
 	"time"
 
 	"github.com/google/syzkaller/pkg/corpus"
+	"github.com/google/syzkaller/pkg/execbackend"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
@@ -37,7 +37,7 @@ type kernelContext struct {
 	cfg        *mgrconfig.Config
 	reporter   *report.Reporter
 	fuzzer     atomic.Pointer[fuzzer.Fuzzer]
-	serv       rpcserver.Server
+	serv       execbackend.Server
 	servStats  rpcserver.Stats
 	crashes    chan *report.Report
 	pool       *vm.Dispatcher
@@ -73,7 +73,7 @@ func setup(name string, cfg *mgrconfig.Config, debug bool) (*kernelContext, erro
 		return nil, fmt.Errorf("failed to create reporter for %q: %w", name, err)
 	}
 
-	kernelCtx.serv, err = rpcserver.New(&rpcserver.RemoteConfig{
+	kernelCtx.serv, err = execbackend.New(&rpcserver.RemoteConfig{
 		Config:  cfg,
 		Manager: kernelCtx,
 		Stats:   kernelCtx.servStats,
@@ -95,7 +95,7 @@ func setup(name string, cfg *mgrconfig.Config, debug bool) (*kernelContext, erro
 func (kc *kernelContext) Loop(ctx context.Context) error {
 	defer log.Logf(1, "%s: kernel context loop terminated", kc.name)
 
-	if err := kc.serv.Listen(); err != nil {
+	if err := kc.serv.Setup(); err != nil {
 		return fmt.Errorf("failed to start rpc server: %w", err)
 	}
 	eg, groupCtx := errgroup.WithContext(ctx)
@@ -247,54 +247,16 @@ func (kc *kernelContext) CoverageFilter(modules []*vminfo.KernelModule) ([]uint6
 }
 
 func (kc *kernelContext) fuzzerInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
-	index := inst.Index()
-	injectExec := make(chan bool, 10)
-	kc.serv.CreateInstance(index, injectExec, updInfo)
-	rep, err := kc.runInstance(ctx, inst, injectExec)
-	lastExec, _ := kc.serv.ShutdownInstance(index, rep != nil)
-	if rep != nil {
-		rpcserver.PrependExecuting(rep, lastExec)
+	reps, err := kc.serv.RunRequests(ctx, inst, kc.reporter, updInfo)
+	if len(reps) > 0 {
 		select {
-		case kc.crashes <- rep:
+		case kc.crashes <- reps[0]:
 		case <-ctx.Done():
 		}
 	}
 	if err != nil {
 		log.Errorf("#%d run failed: %s", inst.Index(), err)
 	}
-}
-
-func (kc *kernelContext) runInstance(ctx context.Context, inst *vm.Instance,
-	injectExec <-chan bool) (*report.Report, error) {
-	fwdAddr, err := inst.Forward(kc.serv.Port())
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup port forwarding: %w", err)
-	}
-	executorBin, err := inst.Copy(kc.cfg.ExecutorBin)
-	if err != nil {
-		return nil, fmt.Errorf("failed to copy binary: %w", err)
-	}
-	host, port, err := net.SplitHostPort(fwdAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse manager's address")
-	}
-	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
-	ctxTimeout, cancel := context.WithTimeout(ctx, kc.cfg.Timeouts.VMRunningTime)
-	defer cancel()
-	_, reps, err := inst.Run(ctxTimeout, kc.reporter, cmd,
-		vm.WithExitCondition(vm.ExitTimeout),
-		vm.WithInjectExecuting(injectExec),
-		vm.WithEarlyFinishCb(func() {
-			// Depending on the crash type and kernel config, fuzzing may continue
-			// running for several seconds even after kernel has printed a crash report.
-			// This litters the log and we want to prevent it.
-			kc.serv.StopFuzzing(inst.Index())
-		}),
-	)
-	if len(reps) > 0 {
-		return reps[0], err
-	}
-	return nil, err
 }
 
 func (kc *kernelContext) TriageProgress() float64 {

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -114,10 +114,19 @@ type local struct {
 	setupDone chan bool
 }
 
-func (l *local) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) (queue.Source, error) {
+func (l *local) SetSource(source queue.Source) {
+	l.serv.SetSource(source)
+}
+
+func (l *local) Features() flatrpc.Feature {
+	return l.serv.Features()
+}
+
+func (l *local) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error {
 	<-l.setupDone
 	l.serv.TriagedCorpus()
-	return l.cfg.MachineChecked(features, syscalls), nil
+	l.serv.SetSource(l.cfg.MachineChecked(features, syscalls))
+	return nil
 }
 
 func (l *local) BugFrames() ([]string, []string) {

--- a/pkg/rpcserver/local.go
+++ b/pkg/rpcserver/local.go
@@ -79,7 +79,7 @@ func setupLocal(ctx context.Context, cfg *LocalConfig) (*local, context.Context,
 		setupDone: make(chan bool),
 	}
 	serv := newImpl(&cfg.Config, localCtx)
-	if err := serv.Listen(); err != nil {
+	if err := serv.Setup(); err != nil {
 		return nil, nil, err
 	}
 	localCtx.serv = serv
@@ -110,16 +110,8 @@ func cancelOnInterrupts(ctx context.Context) context.Context {
 
 type local struct {
 	cfg       *LocalConfig
-	serv      Server
+	serv      *server
 	setupDone chan bool
-}
-
-func (l *local) SetSource(source queue.Source) {
-	l.serv.SetSource(source)
-}
-
-func (l *local) Features() flatrpc.Feature {
-	return l.serv.Features()
 }
 
 func (l *local) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error {

--- a/pkg/rpcserver/mocks/Manager.go
+++ b/pkg/rpcserver/mocks/Manager.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	"github.com/google/syzkaller/pkg/flatrpc"
-	"github.com/google/syzkaller/pkg/fuzzer/queue"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/vminfo"
 	"github.com/google/syzkaller/prog"
@@ -160,31 +159,20 @@ func (_c *Manager_CoverageFilter_Call) RunAndReturn(run func(modules []*vminfo.K
 }
 
 // MachineChecked provides a mock function for the type Manager
-func (_mock *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) (queue.Source, error) {
+func (_mock *Manager) MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error {
 	ret := _mock.Called(features, syscalls)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MachineChecked")
 	}
 
-	var r0 queue.Source
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(flatrpc.Feature, map[*prog.Syscall]bool) (queue.Source, error)); ok {
-		return returnFunc(features, syscalls)
-	}
-	if returnFunc, ok := ret.Get(0).(func(flatrpc.Feature, map[*prog.Syscall]bool) queue.Source); ok {
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(flatrpc.Feature, map[*prog.Syscall]bool) error); ok {
 		r0 = returnFunc(features, syscalls)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(queue.Source)
-		}
+		r0 = ret.Error(0)
 	}
-	if returnFunc, ok := ret.Get(1).(func(flatrpc.Feature, map[*prog.Syscall]bool) error); ok {
-		r1 = returnFunc(features, syscalls)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+	return r0
 }
 
 // Manager_MachineChecked_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MachineChecked'
@@ -217,12 +205,12 @@ func (_c *Manager_MachineChecked_Call) Run(run func(features flatrpc.Feature, sy
 	return _c
 }
 
-func (_c *Manager_MachineChecked_Call) Return(source queue.Source, err error) *Manager_MachineChecked_Call {
-	_c.Call.Return(source, err)
+func (_c *Manager_MachineChecked_Call) Return(err error) *Manager_MachineChecked_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *Manager_MachineChecked_Call) RunAndReturn(run func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) (queue.Source, error)) *Manager_MachineChecked_Call {
+func (_c *Manager_MachineChecked_Call) RunAndReturn(run func(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error) *Manager_MachineChecked_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -67,7 +67,7 @@ type RemoteConfig struct {
 type Manager interface {
 	MaxSignal() signal.Signal
 	BugFrames() (leaks []string, races []string)
-	MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) (queue.Source, error)
+	MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error
 	CoverageFilter(modules []*vminfo.KernelModule) ([]uint64, error)
 }
 
@@ -77,6 +77,14 @@ type Server interface {
 	Port() int
 	TriagedCorpus()
 	Serve(context.Context) error
+
+	// SetSource updates the source of execution requests for the backend.
+	// This is typically called after the initial machine check is complete.
+	SetSource(source queue.Source)
+
+	// Features returns the enabled features. It is only valid after the machine check is complete.
+	Features() flatrpc.Feature
+
 	CreateInstance(id int, injectExec chan<- bool, updInfo dispatcher.UpdateInfo) chan error
 	ShutdownInstance(id int, crashed bool, extraExecs ...report.ExecutorInfo) ([]ExecRecord, []byte)
 	StopFuzzing(id int)
@@ -97,6 +105,7 @@ type server struct {
 	checkFailures    int
 	onHandshake      chan *handshakeResult
 	baseSource       *queue.DynamicSourceCtl
+	enabledFeatures  flatrpc.Feature
 	setupFeatures    flatrpc.Feature
 	canonicalModules *cover.Canonicalizer
 	coverFilter      []uint64
@@ -226,6 +235,11 @@ func newImpl(cfg *Config, mgr Manager) *server {
 }
 
 func (serv *server) Close() error {
+	// Unset the source so that we don't hold references to it (allowing GC)
+	// and don't serve any new requests from lingering connections.
+	serv.baseSource.Store(queue.Callback(func() *queue.Request {
+		return nil
+	}))
 	return serv.serv.Close()
 }
 
@@ -478,12 +492,12 @@ func (serv *server) runCheck(ctx context.Context, info *handshakeResult) error {
 		return checkErr
 	}
 	enabledFeatures := features.Enabled()
+	serv.enabledFeatures = enabledFeatures
 	serv.setupFeatures = features.NeedSetup()
-	newSource, err := serv.mgr.MachineChecked(enabledFeatures, enabledCalls)
+	err := serv.mgr.MachineChecked(enabledFeatures, enabledCalls)
 	if err != nil {
 		return err
 	}
-	serv.baseSource.Store(newSource)
 	serv.checkDone.Store(true)
 	return nil
 }
@@ -596,6 +610,14 @@ func (serv *server) DistributeSignalDelta(plus signal.Signal) {
 	serv.foreachRunnerAsync(func(runner *Runner) {
 		runner.SendSignalUpdate(plusRaw)
 	})
+}
+
+func (serv *server) SetSource(source queue.Source) {
+	serv.baseSource.Store(source)
+}
+
+func (serv *server) Features() flatrpc.Feature {
+	return serv.enabledFeatures
 }
 
 func (serv *server) TriagedCorpus() {

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -28,9 +28,30 @@ import (
 	"github.com/google/syzkaller/pkg/vminfo"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
-	"github.com/google/syzkaller/vm/dispatcher"
 	"golang.org/x/sync/errgroup"
 )
+
+type RunnerInfo struct {
+	Status         string
+	DetailedStatus func() []byte
+	MachineInfo    func() []byte
+}
+
+type UpdateInfo func(func(*RunnerInfo))
+
+type Server interface {
+	Setup() error
+	Close() error
+	Port() int
+	TriagedCorpus()
+	Serve(context.Context) error
+	SetSource(source queue.Source)
+	Features() flatrpc.Feature
+	CreateInstance(id int, injectExec chan<- bool, updInfo UpdateInfo) chan error
+	ShutdownInstance(id int, crashed bool, extraExecs ...report.ExecutorInfo) ([]ExecRecord, []byte)
+	StopFuzzing(id int)
+	DistributeSignalDelta(plus signal.Signal)
+}
 
 type Config struct {
 	vminfo.Config
@@ -50,6 +71,8 @@ type Config struct {
 	DebugTimeouts bool
 	Procs         int
 	Slowdown      int
+	ExecutorBin   string
+	Timeouts      targets.Timeouts
 	pcBase        uint64
 	localModules  []*vminfo.KernelModule
 
@@ -69,26 +92,6 @@ type Manager interface {
 	BugFrames() (leaks []string, races []string)
 	MachineChecked(features flatrpc.Feature, syscalls map[*prog.Syscall]bool) error
 	CoverageFilter(modules []*vminfo.KernelModule) ([]uint64, error)
-}
-
-type Server interface {
-	Listen() error
-	Close() error
-	Port() int
-	TriagedCorpus()
-	Serve(context.Context) error
-
-	// SetSource updates the source of execution requests for the backend.
-	// This is typically called after the initial machine check is complete.
-	SetSource(source queue.Source)
-
-	// Features returns the enabled features. It is only valid after the machine check is complete.
-	Features() flatrpc.Feature
-
-	CreateInstance(id int, injectExec chan<- bool, updInfo dispatcher.UpdateInfo) chan error
-	ShutdownInstance(id int, crashed bool, extraExecs ...report.ExecutorInfo) ([]ExecRecord, []byte)
-	StopFuzzing(id int)
-	DistributeSignalDelta(plus signal.Signal)
 }
 
 type server struct {
@@ -195,8 +198,11 @@ func New(cfg *RemoteConfig) (Server, error) {
 		// gVisor/Starnix are not Linux, so filtering against Linux ranges won't work.
 		FilterSignal:      cfg.Type != targets.GVisor && cfg.Type != targets.Starnix,
 		PrintMachineCheck: true,
+		DebugTimeouts:     cfg.Debug,
 		Procs:             cfg.Procs,
 		Slowdown:          cfg.Timeouts.Slowdown,
+		ExecutorBin:       cfg.ExecutorBin,
+		Timeouts:          cfg.Timeouts,
 		pcBase:            pcBase,
 		localModules:      cfg.LocalModules,
 	}, cfg.Manager), nil
@@ -243,12 +249,13 @@ func (serv *server) Close() error {
 	return serv.serv.Close()
 }
 
-func (serv *server) Listen() error {
+func (serv *server) Setup() error {
 	s, err := flatrpc.Listen(serv.cfg.RPC)
 	if err != nil {
 		return err
 	}
 	serv.serv = s
+	log.Logf(0, "serving rpc on tcp://%v", serv.Port())
 	return nil
 }
 
@@ -552,7 +559,7 @@ func (serv *server) printMachineCheck(checkFilesInfo []*flatrpc.FileInfo, enable
 	log.Logf(0, "machine check:\n%s", buf.Bytes())
 }
 
-func (serv *server) CreateInstance(id int, injectExec chan<- bool, updInfo dispatcher.UpdateInfo) chan error {
+func (serv *server) CreateInstance(id int, injectExec chan<- bool, updInfo UpdateInfo) chan error {
 	runner := &Runner{
 		id:            id,
 		source:        serv.execSource,
@@ -590,7 +597,7 @@ func (serv *server) StopFuzzing(id int) {
 	runner := serv.runners[id]
 	serv.mu.Unlock()
 	if runner.updInfo != nil {
-		runner.updInfo(func(info *dispatcher.Info) {
+		runner.updInfo(func(info *RunnerInfo) {
 			info.Status = "fuzzing is stopped"
 		})
 	}

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -38,7 +38,7 @@ func getTestDefaultCfg() mgrconfig.Config {
 func TestNew(t *testing.T) {
 	defaultCfg := getTestDefaultCfg()
 
-	nilServer := func(s Server) {
+	nilBackend := func(s Server) {
 		assert.Nil(t, s)
 	}
 
@@ -57,7 +57,7 @@ func TestNew(t *testing.T) {
 				cfg.Sandbox = "unknown"
 				return &cfg
 			},
-			expectedServCheck: nilServer,
+			expectedServCheck: nilBackend,
 			expectsErr:        true,
 		},
 		{

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/syzkaller/pkg/stat"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
-	"github.com/google/syzkaller/vm/dispatcher"
 )
 
 type Runner struct {
@@ -44,7 +43,7 @@ type Runner struct {
 	executing     map[int64]bool
 	hanged        map[int64]bool
 	lastExec      *LastExecuting
-	updInfo       dispatcher.UpdateInfo
+	updInfo       UpdateInfo
 	resultCh      chan error
 
 	// The mutex protects all the fields below.
@@ -86,7 +85,7 @@ type handshakeResult struct {
 
 func (runner *Runner) Handshake(conn *flatrpc.Conn, cfg *handshakeConfig) (handshakeResult, error) {
 	if runner.updInfo != nil {
-		runner.updInfo(func(info *dispatcher.Info) {
+		runner.updInfo(func(info *RunnerInfo) {
 			info.Status = "handshake"
 		})
 	}
@@ -129,7 +128,7 @@ func (runner *Runner) Handshake(conn *flatrpc.Conn, cfg *handshakeConfig) (hands
 	runner.mu.Unlock()
 
 	if runner.updInfo != nil {
-		runner.updInfo(func(info *dispatcher.Info) {
+		runner.updInfo(func(info *RunnerInfo) {
 			info.MachineInfo = runner.MachineInfo
 			info.DetailedStatus = runner.QueryStatus
 		})
@@ -139,7 +138,7 @@ func (runner *Runner) Handshake(conn *flatrpc.Conn, cfg *handshakeConfig) (hands
 
 func (runner *Runner) ConnectionLoop() error {
 	if runner.updInfo != nil {
-		runner.updInfo(func(info *dispatcher.Info) {
+		runner.updInfo(func(info *RunnerInfo) {
 			info.Status = "executing"
 		})
 	}

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/syzkaller/pkg/asset"
 	"github.com/google/syzkaller/pkg/corpus"
 	"github.com/google/syzkaller/pkg/db"
+	"github.com/google/syzkaller/pkg/execbackend"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
@@ -52,7 +53,6 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm"
 	"github.com/google/syzkaller/vm/dispatcher"
-	"github.com/google/syzkaller/vm/vmimpl"
 )
 
 var (
@@ -72,7 +72,7 @@ type Manager struct {
 	sysTarget       *targets.Target
 	reporter        *report.Reporter
 	crashStore      *manager.CrashStore
-	serv            rpcserver.Server
+	serv            execbackend.Server
 	http            *manager.HTTPServer
 	servStats       rpcserver.Stats
 	corpus          *corpus.Corpus
@@ -92,10 +92,9 @@ type Manager struct {
 	// cfg.DashboardOnlyRepro is set, so that we don't accidentially use dash for anything.
 	dashRepro *dashapi.Dashboard
 
-	mu             sync.Mutex
-	fuzzer         atomic.Pointer[fuzzer.Fuzzer]
-	snapshotSource *queue.Distributor
-	phase          int
+	mu     sync.Mutex
+	fuzzer atomic.Pointer[fuzzer.Fuzzer]
+	phase  int
 
 	disabledHashes   map[string]struct{}
 	newRepros        [][]byte
@@ -320,29 +319,8 @@ func RunManager(mode *Mode, cfg *mgrconfig.Config) {
 		close(mgr.corpusPreload)
 	}
 
-	// Create RPC server for fuzzers.
-	mgr.servStats = rpcserver.NewStats()
-	rpcCfg := &rpcserver.RemoteConfig{
-		Config:  mgr.cfg,
-		Manager: mgr,
-		Stats:   mgr.servStats,
-		Debug:   *flagDebug,
-	}
-	mgr.serv, err = rpcserver.New(rpcCfg)
-	if err != nil {
-		log.Fatalf("failed to create rpc server: %v", err)
-	}
-	if err := mgr.serv.Listen(); err != nil {
-		log.Fatalf("failed to start rpc server: %v", err)
-	}
 	ctx := vm.ShutdownCtx()
-	go func() {
-		err := mgr.serv.Serve(ctx)
-		if err != nil {
-			log.Fatalf("%s", err)
-		}
-	}()
-	log.Logf(0, "serving rpc on tcp://%v", mgr.serv.Port())
+	mgr.initRPCServer(ctx)
 
 	if cfg.DashboardAddr != "" {
 		opts := []dashapi.DashboardOpts{}
@@ -377,7 +355,7 @@ func RunManager(mode *Mode, cfg *mgrconfig.Config) {
 	if mgr.vmPool == nil {
 		log.Logf(0, "no VMs started (type=none)")
 		log.Logf(0, "you are supposed to start syz-executor manually as:")
-		log.Logf(0, "syz-executor runner local manager.ip %v", mgr.serv.Port())
+		log.Logf(0, "you are supposed to start syz-executor manually")
 		<-vm.Shutdown
 		return
 	}
@@ -408,6 +386,38 @@ func (mgr *Manager) exit(reason string) {
 	close(vm.Shutdown)
 	time.Sleep(10 * time.Second)
 	os.Exit(0)
+}
+
+func (mgr *Manager) initRPCServer(ctx context.Context) {
+	var err error
+	mgr.servStats = rpcserver.NewStats()
+	rpcCfg := &rpcserver.RemoteConfig{
+		Config:  mgr.cfg,
+		Manager: mgr,
+		Stats:   mgr.servStats,
+		Debug:   *flagDebug,
+	}
+	mgr.serv, err = execbackend.New(rpcCfg)
+	if err != nil {
+		log.Fatalf("failed to create rpcserver: %v", err)
+	}
+
+	if mgr.cfg.Snapshot {
+		snapCfg := execbackend.SnapshotConfig{
+			Config: mgr.cfg,
+			Stats:  mgr.servStats,
+		}
+		mgr.serv = execbackend.NewSnapshotBackend(mgr.serv, snapCfg)
+	}
+	if err := mgr.serv.Setup(); err != nil {
+		log.Fatalf("failed to start rpc server: %v", err)
+	}
+	go func() {
+		err := mgr.serv.Serve(ctx)
+		if err != nil {
+			log.Fatalf("%s", err)
+		}
+	}()
 }
 
 func (mgr *Manager) heartbeatLoop() {
@@ -632,37 +642,16 @@ func (mgr *Manager) fuzzerInstance(ctx context.Context, inst *vm.Instance, updIn
 		// We're in the process of switching off the RPCServer.
 		return
 	}
-	injectExec := make(chan bool, 10)
-	serv.CreateInstance(inst.Index(), injectExec, updInfo)
 
-	reps, vmInfo, err := mgr.runInstanceInner(ctx, inst,
-		vm.WithExitCondition(vm.ExitTimeout),
-		vm.WithInjectExecuting(injectExec),
-		vm.WithEarlyFinishCb(func() {
-			// Depending on the crash type and kernel config, fuzzing may continue
-			// running for several seconds even after kernel has printed a crash report.
-			// This litters the log, and we want to prevent it.
-			serv.StopFuzzing(inst.Index())
-		}))
-	var extraExecs []report.ExecutorInfo
+	reps, err := serv.RunRequests(ctx, inst, mgr.reporter, updInfo)
+
 	var rep *report.Report
 	if len(reps) != 0 {
 		rep = reps[0]
 	}
-	if rep != nil && rep.Executor != nil {
-		extraExecs = []report.ExecutorInfo{*rep.Executor}
-	}
 	var memoryDump string
 	if mgr.cfg.MemoryDump && rep != nil {
 		memoryDump = mgr.extractMemoryDump(inst, rep)
-	}
-	lastExec, machineInfo := serv.ShutdownInstance(inst.Index(), rep != nil, extraExecs...)
-	if rep != nil {
-		rpcserver.PrependExecuting(rep, lastExec)
-		if len(vmInfo) != 0 {
-			machineInfo = append(append(vmInfo, '\n'), machineInfo...)
-		}
-		rep.MachineInfo = machineInfo
 	}
 	if err == nil && rep != nil {
 		mgr.crashes <- &manager.Crash{
@@ -675,52 +664,6 @@ func (mgr *Manager) fuzzerInstance(ctx context.Context, inst *vm.Instance, updIn
 	if err != nil {
 		log.Logf(1, "VM %v: failed with error: %v", inst.Index(), err)
 	}
-}
-
-func (mgr *Manager) runInstanceInner(ctx context.Context, inst *vm.Instance, opts ...func(*vm.RunOptions),
-) ([]*report.Report, []byte, error) {
-	fwdAddr, err := inst.Forward(mgr.serv.Port())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to setup port forwarding: %w", err)
-	}
-
-	// If ExecutorBin is provided, it means that syz-executor is already in the image,
-	// so no need to copy it.
-	executorBin := mgr.sysTarget.ExecutorBin
-	if executorBin == "" {
-		executorBin, err = inst.Copy(mgr.cfg.ExecutorBin)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to copy binary: %w", err)
-		}
-	}
-
-	// Run the fuzzer binary.
-	start := time.Now()
-
-	host, port, err := net.SplitHostPort(fwdAddr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse manager's address")
-	}
-	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
-	ctxTimeout, cancel := context.WithTimeout(ctx, mgr.cfg.Timeouts.VMRunningTime)
-	defer cancel()
-	_, reps, err := inst.Run(ctxTimeout, mgr.reporter, cmd, opts...)
-	if err != nil {
-		if errors.Is(err, vmimpl.ErrPreempted) {
-			log.Logf(0, "VM %v: preempted while executing", inst.Index())
-		}
-		return nil, nil, fmt.Errorf("failed to run fuzzer: %w", err)
-	}
-	if len(reps) == 0 {
-		// This is the only "OK" outcome.
-		log.Logf(0, "VM %v: running for %v, restarting", inst.Index(), time.Since(start))
-		return nil, nil, nil
-	}
-	vmInfo, err := inst.Info()
-	if err != nil {
-		vmInfo = []byte(fmt.Sprintf("error getting VM info: %v\n", err))
-	}
-	return reps, vmInfo, nil
 }
 
 func (mgr *Manager) emailCrash(crash *manager.Crash) {
@@ -1181,8 +1124,8 @@ func (mgr *Manager) BugFrames() (leaks, races []string) {
 	return
 }
 
-// nolint: funlen
-func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map[*prog.Syscall]bool) error {
+func (mgr *Manager) MachineChecked(features flatrpc.Feature,
+	enabledSyscalls map[*prog.Syscall]bool) error {
 	if len(enabledSyscalls) == 0 {
 		return fmt.Errorf("all system calls are disabled")
 	}
@@ -1269,17 +1212,6 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map
 			}
 		}
 		source := queue.DefaultOpts(fuzzerObj, opts)
-		if mgr.cfg.Snapshot {
-			log.Logf(0, "restarting VMs for snapshot mode")
-			mgr.snapshotSource = queue.Distribute(source)
-			mgr.pool.SetDefault(mgr.snapshotInstance)
-			mgr.serv.SetSource(queue.Callback(func() *queue.Request {
-				return nil
-			}))
-			mgr.serv.Close()
-			mgr.serv = nil
-			return nil
-		}
 		mgr.serv.SetSource(source)
 		return nil
 	case ModeCorpusRun:

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1181,10 +1181,10 @@ func (mgr *Manager) BugFrames() (leaks, races []string) {
 	return
 }
 
-func (mgr *Manager) MachineChecked(features flatrpc.Feature,
-	enabledSyscalls map[*prog.Syscall]bool) (queue.Source, error) {
+// nolint: funlen
+func (mgr *Manager) MachineChecked(features flatrpc.Feature, enabledSyscalls map[*prog.Syscall]bool) error {
 	if len(enabledSyscalls) == 0 {
-		return nil, fmt.Errorf("all system calls are disabled")
+		return fmt.Errorf("all system calls are disabled")
 	}
 	if mgr.mode.ExitAfterMachineCheck {
 		mgr.exit(mgr.mode.Name)
@@ -1199,7 +1199,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 		}
 		data, err := kfuzztest.ExtractData(path.Join(mgr.cfg.KernelObj, "vmlinux"))
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, call := range data.Calls {
 			enabledSyscalls[call] = true
@@ -1273,19 +1273,22 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 			log.Logf(0, "restarting VMs for snapshot mode")
 			mgr.snapshotSource = queue.Distribute(source)
 			mgr.pool.SetDefault(mgr.snapshotInstance)
+			mgr.serv.SetSource(queue.Callback(func() *queue.Request {
+				return nil
+			}))
 			mgr.serv.Close()
 			mgr.serv = nil
-			return queue.Callback(func() *queue.Request {
-				return nil
-			}), nil
+			return nil
 		}
-		return source, nil
+		mgr.serv.SetSource(source)
+		return nil
 	case ModeCorpusRun:
 		ctx := &corpusRunner{
 			candidates: candidates,
 			rnd:        rand.New(rand.NewSource(time.Now().UnixNano())),
 		}
-		return queue.DefaultOpts(ctx, opts), nil
+		mgr.serv.SetSource(queue.DefaultOpts(ctx, opts))
+		return nil
 	case ModeRunTests:
 		ctx := &runtest.Context{
 			Dir:      filepath.Join(mgr.cfg.Syzkaller, "sys", mgr.cfg.Target.OS, "test"),
@@ -1307,7 +1310,8 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 			}
 			mgr.exit("tests")
 		}()
-		return ctx, nil
+		mgr.serv.SetSource(ctx)
+		return nil
 	case ModeIfaceProbe:
 		exec := queue.Plain()
 		go func() {
@@ -1321,7 +1325,8 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 			}
 			mgr.exit("interface probe")
 		}()
-		return exec, nil
+		mgr.serv.SetSource(exec)
+		return nil
 	}
 	panic(fmt.Sprintf("unexpected mode %q", mgr.mode.Name))
 }

--- a/syz-verifier/main.go
+++ b/syz-verifier/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/syzkaller/pkg/execbackend"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
 	"github.com/google/syzkaller/pkg/log"
@@ -45,7 +46,7 @@ func Setup(name string, cfg *mgrconfig.Config, debug bool) (*Kernel, error) {
 	// Executor process restarts between program executions to clear accumulated kernel/VM stat.
 	cfg.Experimental.ResetAccState = true
 
-	kernel.serv, err = rpcserver.New(&rpcserver.RemoteConfig{
+	kernel.serv, err = execbackend.New(&rpcserver.RemoteConfig{
 		Config:  cfg,
 		Manager: kernel,
 		Stats:   kernel.servStats,

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"net"
 	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/google/syzkaller/pkg/execbackend"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
@@ -56,7 +56,7 @@ type Kernel struct {
 	reporter        *report.Reporter
 	queueConfigured bool
 
-	serv      rpcserver.Server
+	serv      execbackend.Server
 	servStats rpcserver.Stats
 
 	pool    *vm.Dispatcher
@@ -423,11 +423,8 @@ func (vrf *Verifier) createRequests(prog *prog.Prog) (map[int]*queue.Request, []
 // Kernel
 // =============================================================================.
 func (kernel *Kernel) FuzzerInstance(ctx context.Context, inst *vm.Instance, updInfo dispatcher.UpdateInfo) {
-	index := inst.Index()
-	injectExec := make(chan bool, 10)
-	kernel.serv.CreateInstance(index, injectExec, updInfo)
-	reps, err := kernel.runInstance(ctx, inst, injectExec)
-	_, _ = kernel.serv.ShutdownInstance(index, len(reps) > 0)
+	reps, err := kernel.serv.RunRequests(ctx, inst, kernel.reporter, updInfo)
+
 	if len(reps) > 0 {
 		// Just log crashes - syz-verifier focuses on behavioral differences, not crashes.
 		select {
@@ -439,36 +436,6 @@ func (kernel *Kernel) FuzzerInstance(ctx context.Context, inst *vm.Instance, upd
 	if err != nil {
 		log.Errorf("#%d run failed: %s", inst.Index(), err)
 	}
-}
-
-func (kernel *Kernel) runInstance(ctx context.Context, inst *vm.Instance,
-	injectExec <-chan bool) ([]*report.Report, error) {
-	fwdAddr, err := inst.Forward(kernel.serv.Port())
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup port forwarding: %w", err)
-	}
-	executorBin, err := inst.Copy(kernel.cfg.ExecutorBin)
-	if err != nil {
-		return nil, fmt.Errorf("failed to copy binary: %w", err)
-	}
-	host, port, err := net.SplitHostPort(fwdAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse manager's address")
-	}
-	cmd := fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
-	ctxTimeout, cancel := context.WithTimeout(ctx, kernel.cfg.Timeouts.VMRunningTime)
-	defer cancel()
-	_, rep, err := inst.Run(ctxTimeout, kernel.reporter, cmd,
-		vm.WithExitCondition(vm.ExitTimeout),
-		vm.WithInjectExecuting(injectExec),
-		vm.WithEarlyFinishCb(func() {
-			// Depending on the crash type and kernel config, fuzzing may continue
-			// running for several seconds even after kernel has printed a crash report.
-			// This litters the log and we want to prevent it.
-			kernel.serv.StopFuzzing(inst.Index())
-		}),
-	)
-	return rep, err
 }
 
 func (kernel *Kernel) MachineChecked(features flatrpc.Feature,
@@ -494,7 +461,7 @@ func (kernel *Kernel) MachineChecked(features flatrpc.Feature,
 
 func (kernel *Kernel) loop(ctx context.Context) {
 	defer log.Logf(1, "syz-verifier (%s): kernel context loop terminated", kernel.cfg.Name)
-	if err := kernel.serv.Listen(); err != nil {
+	if err := kernel.serv.Setup(); err != nil {
 		log.Fatalf("failed to start rpc server: %v", err)
 	}
 	// Respect both the caller-provided context and global shutdown.
@@ -510,7 +477,6 @@ func (kernel *Kernel) loop(ctx context.Context) {
 			log.Fatalf("%s", err)
 		}
 	}()
-	log.Logf(0, "serving rpc on tcp://%v", kernel.serv.Port())
 	kernel.pool.Loop(runCtx)
 }
 

--- a/syz-verifier/verifier.go
+++ b/syz-verifier/verifier.go
@@ -472,10 +472,10 @@ func (kernel *Kernel) runInstance(ctx context.Context, inst *vm.Instance,
 }
 
 func (kernel *Kernel) MachineChecked(features flatrpc.Feature,
-	enabledSyscalls map[*prog.Syscall]bool) (queue.Source, error) {
+	enabledSyscalls map[*prog.Syscall]bool) error {
 	if len(enabledSyscalls) == 0 {
 		log.Logf(0, "no syscalls enabled for kernel %s", kernel.cfg.Name)
-		return nil, nil
+		return nil
 	}
 	log.Logf(0, "kernel %s: sending enabled syscalls: %v", kernel.cfg.Name, enabledSyscalls)
 	kernel.enabledSyscalls <- enabledSyscalls
@@ -488,7 +488,8 @@ func (kernel *Kernel) MachineChecked(features flatrpc.Feature,
 	kernel.mu.Lock()
 	kernel.queueConfigured = true
 	kernel.mu.Unlock()
-	return kernel.source, nil
+	kernel.serv.SetSource(kernel.source)
+	return nil
 }
 
 func (kernel *Kernel) loop(ctx context.Context) {


### PR DESCRIPTION
Abstract the fuzzer execution logic into a new pkg/execbackend.Server
interface to put snapshot and non-snapshot implementations under the
same umbrella. This abstracts the underlying execution mechanism, allowing
syz-manager, syz-verifier, and patch fuzzing (pkg/manager/diff) to easily
reuse snapshot functionality without managing the two-phase boot process
and queue resets.