### PR TITLE
pkg/email: fix SMTP header injection vulnerability

### DIFF
--- a/pkg/email/sender/smtp.go
+++ b/pkg/email/sender/smtp.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"mime"
 	"net/mail"
 	"net/smtp"
 	"slices"
@@ -42,6 +43,12 @@ func (s *smtpSender) Send(ctx context.Context, item *Email) (string, error) {
 	recipients := slices.Concat(item.To, item.Cc)
 	slices.Sort(recipients)
 	recipients = slices.Compact(recipients)
+
+	for _, addr := range recipients {
+		if _, err := mail.ParseAddress(addr); err != nil {
+			return "", fmt.Errorf("invalid recipient address %q: %w", addr, err)
+		}
+	}
 
 	if s.cfg.Port == 465 {
 		// Implicit TLS.
@@ -100,7 +107,7 @@ func (s *smtpSender) rawEmail(item *Email, id string) []byte {
 	if len(item.Cc) > 0 {
 		fmt.Fprintf(&msg, "Cc: %s\r\n", strings.Join(item.Cc, ", "))
 	}
-	fmt.Fprintf(&msg, "Subject: %s\r\n", item.Subject)
+	fmt.Fprintf(&msg, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", item.Subject))
 	if item.InReplyTo != "" {
 		inReplyTo := item.InReplyTo
 		if inReplyTo[0] != '<' {

--- a/pkg/email/sender/smtp.go
+++ b/pkg/email/sender/smtp.go
@@ -39,16 +39,17 @@ func (s *smtpSender) Send(ctx context.Context, item *Email) (string, error) {
 	auth := smtp.PlainAuth("", s.cfg.User, s.cfg.Password, s.cfg.Host)
 	smtpAddr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 
-	// Create a slice of recipients (To + Cc) without duplicates.
-	recipients := slices.Concat(item.To, item.Cc)
-	slices.Sort(recipients)
-	recipients = slices.Compact(recipients)
-
-	for _, addr := range recipients {
-		if _, err := mail.ParseAddress(addr); err != nil {
+	// Extract bare email addresses for the SMTP envelope.
+	var envRecipients []string
+	for _, addr := range slices.Concat(item.To, item.Cc) {
+		parsed, err := mail.ParseAddress(addr)
+		if err != nil {
 			return "", fmt.Errorf("invalid recipient address %q: %w", addr, err)
 		}
+		envRecipients = append(envRecipients, parsed.Address)
 	}
+	slices.Sort(envRecipients)
+	envRecipients = slices.Compact(envRecipients)
 
 	if s.cfg.Port == 465 {
 		// Implicit TLS.
@@ -71,7 +72,7 @@ func (s *smtpSender) Send(ctx context.Context, item *Email) (string, error) {
 		if err = client.Mail(s.cfg.From.Address); err != nil {
 			return "", fmt.Errorf("client.Mail failed: %w", err)
 		}
-		for _, addr := range recipients {
+		for _, addr := range envRecipients {
 			if err = client.Rcpt(addr); err != nil {
 				return "", fmt.Errorf("client.Rcpt failed for %v: %w", addr, err)
 			}
@@ -90,7 +91,7 @@ func (s *smtpSender) Send(ctx context.Context, item *Email) (string, error) {
 		}
 		client.Quit()
 	} else {
-		err := smtp.SendMail(smtpAddr, auth, s.cfg.From.Address, recipients, msg)
+		err := smtp.SendMail(smtpAddr, auth, s.cfg.From.Address, envRecipients, msg)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/email/sender/smtp_test.go
+++ b/pkg/email/sender/smtp_test.go
@@ -4,6 +4,7 @@
 package sender
 
 import (
+	"context"
 	"fmt"
 	"net/mail"
 	"testing"
@@ -37,6 +38,38 @@ func TestRawEmail(t *testing.T) {
 				"Content-Transfer-Encoding: 8bit\r\n\r\n" +
 				"Email body",
 		},
+		{
+			item: &Email{
+				To:      []string{"1@to.com"},
+				Subject: "subject\r\nBcc: attacker@evil.com",
+				Body:    []byte("body"),
+			},
+			id: "<id@domain>",
+			result: "From: \"name\" <a@b.com>\r\n" +
+				"To: 1@to.com\r\n" +
+				"Subject: =?utf-8?q?subject=0D=0ABcc:_attacker@evil.com?=\r\n" +
+				"Message-ID: <id@domain>\r\n" +
+				"MIME-Version: 1.0\r\n" +
+				"Content-Type: text/plain; charset=UTF-8\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n\r\n" +
+				"body",
+		},
+		{
+			item: &Email{
+				To:      []string{"\"=?utf-8?q?Attacker=0D=0ABcc:_evil@evil.com?=\" <attacker@example.com>"},
+				Subject: "subject",
+				Body:    []byte("body"),
+			},
+			id: "<id@domain>",
+			result: "From: \"name\" <a@b.com>\r\n" +
+				"To: \"=?utf-8?q?Attacker=0D=0ABcc:_evil@evil.com?=\" <attacker@example.com>\r\n" +
+				"Subject: subject\r\n" +
+				"Message-ID: <id@domain>\r\n" +
+				"MIME-Version: 1.0\r\n" +
+				"Content-Type: text/plain; charset=UTF-8\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n\r\n" +
+				"body",
+		},
 	}
 
 	cfg := SMTPConfig{
@@ -53,4 +86,17 @@ func TestRawEmail(t *testing.T) {
 			assert.Equal(t, test.result, string(ret))
 		})
 	}
+}
+
+func TestSendInvalidRecipients(t *testing.T) {
+	s := &smtpSender{cfg: SMTPConfig{}}
+	_, err := s.Send(context.Background(), &Email{
+		To: []string{"valid@to.com"},
+		Cc: []string{"invalid\r\nemail@to.com"},
+	})
+	assert.ErrorContains(t, err, "invalid recipient address")
+	_, err = s.Send(context.Background(), &Email{
+		To: []string{"just name"},
+	})
+	assert.ErrorContains(t, err, "invalid recipient address")
 }


### PR DESCRIPTION
The SMTP sender manually constructs raw email headers. Previously, if untrusted data (such as fuzzer-generated bug titles) was provided to the Subject or recipient fields, it could be exploited to inject arbitrary SMTP headers via CRLF injection or raw RFC 2047 payload injection.

Fix this by:
1. MIME-encoding the Subject header using mime.QEncoding.
2. Validating all To and Cc recipient addresses using mail.ParseAddress before sending, failing immediately if invalid characters (like CRLF) are present.

Thanks to @alhudz for discovering this issue and proposing a fix in https://github.com/google/syzkaller/pull/7436.
