### PR TITLE
validate redirect target in syz-manager httpAction

### DIFF
--- a/pkg/manager/http.go
+++ b/pkg/manager/http.go
@@ -145,7 +145,23 @@ func (serv *HTTPServer) httpAction(w http.ResponseWriter, r *http.Request) {
 		serv.paused = !serv.paused
 		serv.TogglePause(serv.paused)
 	}
-	http.Redirect(w, r, r.FormValue("url"), http.StatusFound)
+	http.Redirect(w, r, localRedirectURL(r.FormValue("url")), http.StatusFound)
+}
+
+// localRedirectRe matches a same-site relative path with an optional query: a
+// single leading slash followed by an ordinary path, never "//" or "/\" that
+// browsers treat as a protocol-relative URL.
+var localRedirectRe = regexp.MustCompile(`^/[\w.-]*(\?.*)?$`)
+
+// localRedirectURL returns dest only if it is a same-site relative path,
+// otherwise "/". The action form always submits the current relative URL, so a
+// value carrying a scheme or host is an attempt to use /action as an open
+// redirector.
+func localRedirectURL(dest string) string {
+	if !localRedirectRe.MatchString(dest) {
+		return "/"
+	}
+	return dest
 }
 
 func (serv *HTTPServer) httpMain(w http.ResponseWriter, r *http.Request) {

--- a/pkg/manager/http_test.go
+++ b/pkg/manager/http_test.go
@@ -21,3 +21,20 @@ func TestHttpTemplates(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalRedirectURL(t *testing.T) {
+	tests := map[string]string{
+		"/stats?x=1":           "/stats?x=1",
+		"/":                    "/",
+		"https://evil.example": "/",
+		"//evil.example":       "/",
+		"///evil.example":      "/",
+		"/\\evil.example":      "/",
+		"javascript:alert(1)":  "/",
+	}
+	for in, want := range tests {
+		if got := localRedirectURL(in); got != want {
+			t.Errorf("localRedirectURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Noticed `/action` redirects to the raw `url` form value, but that value is only ever the current relative path: `pageHeader` builds `CurrentURL` with the scheme, host and user stripped. A request with an absolute or protocol-relative (`//host`) `url` turns the unauthenticated manager UI into an open redirector. Keep only same-site relative paths.