### PR TITLE
syz-cluster: integrate with pkg/aflow

### DIFF
--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -148,6 +148,10 @@ type PatchTriageArgs struct {
 }
 
 type PatchTriageResult struct {
-	WorthFuzzing bool   `jsonschema:"True if functional. False if only docs/comments/unreachable."`
-	Reasoning    string `jsonschema:"A concise explanation of why this patch should or shouldn't be fuzzed."`
+	WorthFuzzing bool `jsonschema:"True if functional. False if only docs/comments/unreachable."`
+	// TODO: this is temporarily here. We should do it at the beginning of the fuzzing step,
+	// where we do have the built binary and can extract exact symbol names / KCOV coverage points.
+	FocusSymbols  []string `jsonschema:"List of specific kernel functions to focus fuzzing on. Should avoid hot-path functions."`                                               // nolint:lll
+	EnableConfigs []string `jsonschema:"List of kernel config flags that must be explicitly enabled to compile and test the modified code. Do not include 'CONFIG_' prefixes."` // nolint:lll
+	Reasoning     string   `jsonschema:"A concise explanation of why this patch should or shouldn't be fuzzed."`
 }

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -18,6 +18,7 @@ const (
 	WorkflowAssessmentSecurity = WorkflowType("assessment-security")
 	WorkflowRepro              = WorkflowType("repro")
 	WorkflowReproC             = WorkflowType("repro-c")
+	WorkflowPatchTriage        = WorkflowType("patch-triage")
 )
 
 // Outputs of various workflow types.
@@ -140,4 +141,13 @@ type ReproCOutputs struct {
 	ReproducedCrashReport string
 	OtherCrashReports     []string
 	EquivalenceAnalysis   string
+}
+
+type PatchTriageArgs struct {
+	KernelSrc string
+}
+
+type PatchTriageResult struct {
+	WorthFuzzing bool   `jsonschema:"True if functional. False if only docs/comments/unreachable."`
+	Reasoning    string `jsonschema:"A concise explanation of why this patch should or shouldn't be fuzzed."`
 }

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -144,7 +144,8 @@ type ReproCOutputs struct {
 }
 
 type PatchTriageArgs struct {
-	KernelSrc string
+	TargetArch string
+	KernelSrc  string
 }
 
 type PatchTriageResult struct {

--- a/pkg/aflow/flow/flows.go
+++ b/pkg/aflow/flow/flows.go
@@ -5,6 +5,7 @@ package flow
 
 import (
 	_ "github.com/google/syzkaller/pkg/aflow/flow/assessment"
+	_ "github.com/google/syzkaller/pkg/aflow/flow/fuzzing"
 	_ "github.com/google/syzkaller/pkg/aflow/flow/patching"
 	_ "github.com/google/syzkaller/pkg/aflow/flow/repro"
 	_ "github.com/google/syzkaller/pkg/aflow/flow/reproc"

--- a/pkg/aflow/flow/fuzzing/patch_triage.go
+++ b/pkg/aflow/flow/fuzzing/patch_triage.go
@@ -4,6 +4,7 @@
 package fuzzing
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -28,6 +29,12 @@ func init() {
 						func(ctx *aflow.Context, state struct{}, args ai.PatchTriageResult) (ai.PatchTriageResult, error) {
 							if args.Reasoning == "" {
 								return args, aflow.BadCallError("reasoning must be provided")
+							}
+							if !args.WorthFuzzing && len(args.FocusSymbols) > 0 {
+								return args, aflow.BadCallError("FocusSymbols must be empty if WorthFuzzing is false")
+							}
+							for i, cfg := range args.EnableConfigs {
+								args.EnableConfigs[i] = strings.TrimPrefix(cfg, "CONFIG_")
 							}
 							return args, nil
 						},
@@ -77,7 +84,16 @@ Return WorthFuzzing=false if the patch only contains:
 even when utilizing software-emulated hardware (e.g., usb gadget, mac80211_hwsim).
 
 If it modifies reachable core kernel logic, drivers, or architectures, use your code search
-tools to verify the code can be executed, then return WorthFuzzing=true.`
+tools to verify the code can be executed, then return WorthFuzzing=true.
+
+When returning WorthFuzzing=true, you MUST ALSO:
+1. Extract any specific kernel functions that should be heavily fuzzed into FocusSymbols.
+   Avoid listing generic hot-path functions to prevent skewed test distributions.
+2. Identify any specific CONFIG_ options required to properly test this new/modified feature.
+   Go and look into the Kconfig files and check for ifdefs around the code, do not make assumptions.
+   Do not list too generic configs (we already have them enabled). Only list those that
+   specifically cover the modified code. List them in the EnableConfigs output array,
+   and DO NOT add a 'CONFIG_' prefix (e.g., return "NET_IPV4" instead of "CONFIG_NET_IPV4").`
 
 const patchTriagePrompt = `For your convenience, here is the diff of the changes:
 {{.PatchDiff}}`

--- a/pkg/aflow/flow/fuzzing/patch_triage.go
+++ b/pkg/aflow/flow/fuzzing/patch_triage.go
@@ -1,0 +1,83 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+func init() {
+	aflow.Register[ai.PatchTriageArgs, ai.PatchTriageResult](
+		ai.WorkflowPatchTriage,
+		"evaluate if a kernel patch series has functional impact worth fuzzing",
+		&aflow.Flow{
+			Root: aflow.Pipeline(
+				readPatchDiff,
+				&aflow.LLMAgent{
+					Name:     "patch-evaluator",
+					Model:    aflow.BestExpensiveModel,
+					TaskType: aflow.FormalReasoningTask,
+					Outputs: aflow.ValidatedLLMOutputs[ai.PatchTriageResult](
+						func(ctx *aflow.Context, state struct{}, args ai.PatchTriageResult) (ai.PatchTriageResult, error) {
+							if args.Reasoning == "" {
+								return args, aflow.BadCallError("reasoning must be provided")
+							}
+							return args, nil
+						},
+					),
+					Tools: aflow.Tools(
+						grepper.Tool,
+						codesearcher.FilesystemTools,
+					),
+					Instruction: patchTriageInstruction,
+					Prompt:      patchTriagePrompt,
+				},
+			),
+		},
+	)
+}
+
+type readPatchDiffArgs struct {
+	KernelSrc string
+}
+
+type readPatchDiffResult struct {
+	PatchDiff string
+}
+
+var readPatchDiff = aflow.NewFuncAction("read-patch-diff",
+	func(ctx *aflow.Context, args readPatchDiffArgs) (readPatchDiffResult, error) {
+		patch, err := osutil.RunCmd(time.Minute, args.KernelSrc, "git", "show", "HEAD")
+		if err != nil {
+			return readPatchDiffResult{}, err
+		}
+		return readPatchDiffResult{PatchDiff: string(patch)}, nil
+	})
+
+const patchTriageInstruction = `You are an expert Linux kernel maintainer.
+Your job is to review a provided patch series and determine
+if it makes functional changes to the kernel that should be fuzzed.
+
+IMPORTANT: The changes have ALREADY been applied and committed as the HEAD commit in
+your workspace. Do NOT rely on your internal knowledge of the kernel. You must actively
+use your code access tools to examine the actual source code and confirm any assumptions.
+
+Return WorthFuzzing=false if the patch only contains:
+- Modifications to Documentation/, Kconfig files, or code comments.
+- Purely decorative changes, such as logging (e.g., pr_err, printk) or tracepoints.
+- Changes to numeric constants or macros that do not functionally alter execution flow.
+- Code paths that are impossible to reach in virtualized environments like GCE or QEMU,
+even when utilizing software-emulated hardware (e.g., usb gadget, mac80211_hwsim).
+
+If it modifies reachable core kernel logic, drivers, or architectures, use your code search
+tools to verify the code can be executed, then return WorthFuzzing=true.`
+
+const patchTriagePrompt = `For your convenience, here is the diff of the changes:
+{{.PatchDiff}}`

--- a/pkg/aflow/flow/fuzzing/patch_triage.go
+++ b/pkg/aflow/flow/fuzzing/patch_triage.go
@@ -4,6 +4,8 @@
 package fuzzing
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -11,7 +13,9 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/kconfig"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 func init() {
@@ -26,15 +30,17 @@ func init() {
 					Model:    aflow.BestExpensiveModel,
 					TaskType: aflow.FormalReasoningTask,
 					Outputs: aflow.ValidatedLLMOutputs[ai.PatchTriageResult](
-						func(ctx *aflow.Context, state struct{}, args ai.PatchTriageResult) (ai.PatchTriageResult, error) {
+						func(ctx *aflow.Context, state ai.PatchTriageArgs, args ai.PatchTriageResult) (ai.PatchTriageResult, error) {
 							if args.Reasoning == "" {
 								return args, aflow.BadCallError("reasoning must be provided")
 							}
 							if !args.WorthFuzzing && len(args.FocusSymbols) > 0 {
 								return args, aflow.BadCallError("FocusSymbols must be empty if WorthFuzzing is false")
 							}
-							for i, cfg := range args.EnableConfigs {
-								args.EnableConfigs[i] = strings.TrimPrefix(cfg, "CONFIG_")
+
+							args.EnableConfigs = normalizeKernelConfigs(args.EnableConfigs)
+							if err := validateKernelConfigs(state.TargetArch, state.KernelSrc, args.EnableConfigs); err != nil {
+								return args, err
 							}
 							return args, nil
 						},
@@ -49,6 +55,38 @@ func init() {
 			),
 		},
 	)
+}
+
+func normalizeKernelConfigs(configs []string) []string {
+	var normalized []string
+	for _, cfg := range configs {
+		normalized = append(normalized, strings.TrimPrefix(cfg, "CONFIG_"))
+	}
+	return normalized
+}
+
+func validateKernelConfigs(targetArch, kernelSrc string, configs []string) error {
+	if len(configs) == 0 {
+		return nil
+	}
+	target := targets.Get("linux", targetArch)
+	if target == nil {
+		return fmt.Errorf("unknown target linux/%q", targetArch)
+	}
+	kconf, err := kconfig.Parse(target, filepath.Join(kernelSrc, "Kconfig"))
+	if err != nil {
+		return fmt.Errorf("failed to parse Kconfig: %w", err)
+	}
+	var badConfigs []string
+	for _, cfg := range configs {
+		if kconf.Configs[cfg] == nil {
+			badConfigs = append(badConfigs, cfg)
+		}
+	}
+	if len(badConfigs) > 0 {
+		return aflow.BadCallError("the following configs do not exist in the kernel tree: %v", strings.Join(badConfigs, ", "))
+	}
+	return nil
 }
 
 type readPatchDiffArgs struct {

--- a/pkg/aflow/flow/fuzzing/patch_triage_test.go
+++ b/pkg/aflow/flow/fuzzing/patch_triage_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeKernelConfigs(t *testing.T) {
+	configs := []string{"CONFIG_FOO_BAR", "BAZ", "CONFIG_QUX"}
+	want := []string{"FOO_BAR", "BAZ", "QUX"}
+	got := normalizeKernelConfigs(configs)
+	require.Equal(t, want, got)
+}
+
+func TestValidateKernelConfigs(t *testing.T) {
+	dir := t.TempDir()
+	kconfigContent := `
+mainmenu "test"
+
+config FOO_BAR
+	bool "foo bar"
+
+config BAZ
+	bool "baz"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Kconfig"), []byte(kconfigContent), 0644))
+
+	tests := []struct {
+		name    string
+		configs []string
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			configs: []string{},
+		},
+		{
+			name:    "valid",
+			configs: []string{"FOO_BAR", "BAZ"},
+		},
+		{
+			name:    "single invalid",
+			configs: []string{"FOO_BAR", "INVALID"},
+			wantErr: `the following configs do not exist in the kernel tree: INVALID`,
+		},
+		{
+			name:    "multiple invalid",
+			configs: []string{"INVALID1", "FOO_BAR", "INVALID2"},
+			wantErr: `the following configs do not exist in the kernel tree: INVALID1, INVALID2`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateKernelConfigs("amd64", dir, tc.configs)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -72,6 +72,7 @@ func (h *dashboardHandler) Mux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sessions/{id}/log", errToStatus(h.sessionLog))
 	mux.HandleFunc("/sessions/{id}/triage_log", errToStatus(h.sessionTriageLog))
+	mux.HandleFunc("/sessions/{id}/triage_trajectory", errToStatus(h.sessionTriageTrajectory))
 	mux.HandleFunc("/sessions/{id}/test_logs", errToStatus(h.sessionTestLog))
 	mux.HandleFunc("/test_steps/{step_id}/log", errToStatus(h.sessionTestStepLog))
 	mux.HandleFunc("/sessions/{id}/test_artifacts", errToStatus(h.sessionTestArtifacts))
@@ -425,6 +426,17 @@ func (h *dashboardHandler) sessionTriageLog(w http.ResponseWriter, r *http.Reque
 		return fmt.Errorf("%w: session", errNotFound)
 	}
 	return h.streamBlob(w, session.TriageLogURI)
+}
+
+func (h *dashboardHandler) sessionTriageTrajectory(w http.ResponseWriter, r *http.Request) error {
+	session, err := h.sessionRepo.GetByID(r.Context(), r.PathValue("id"))
+	if err != nil {
+		return err
+	} else if session == nil {
+		return fmt.Errorf("%w: session", errNotFound)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	return h.streamBlob(w, session.TriageTrajectoryURI.StringVal)
 }
 
 // nolint:dupl

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -121,13 +121,16 @@
                     <th>Status</th>
                     <td>{{.Status}}</td>
                 </tr>
-                {{if or (not .SkipReason.IsNull) .TriageLogURI}}
+                {{if or (not .SkipReason.IsNull) .TriageLogURI .TriageTrajectoryURI.Valid}}
                 <tr>
                     <th>Triaged</th>
                     <td>
                         {{if not .SkipReason.IsNull}}Skipped: {{.SkipReason.StringVal}}{{else}}OK{{end}}
                         {{if .TriageLogURI}}
                             <a href="/sessions/{{.ID}}/triage_log">[Log]</a>
+                        {{end}}
+                        {{if .TriageTrajectoryURI.Valid}}
+                            <a href="/sessions/{{.ID}}/triage_trajectory" target="_blank">[Trajectory]</a>
                         {{end}}
                     </td>
                 </tr>

--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -31,6 +31,9 @@ emailReporting:
     from: syzbot@syzkaller.appspotmail.com
     contextPrefix: ci
 
+aiConfig:
+  geminiAPIKey: "gcp-secret:syz-cluster-gemini-key"
+
 trees:
   - name: bpf-next
     URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/bpf/bpf-next.git

--- a/syz-cluster/overlays/gke/prod/kustomization.yaml
+++ b/syz-cluster/overlays/gke/prod/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
 
 configMapGenerator:
   - name: global-config
+    options:
+      disableNameSuffixHash: true
     files:
       - config.yaml=global-config.yaml

--- a/syz-cluster/overlays/gke/staging/global-config.yaml
+++ b/syz-cluster/overlays/gke/staging/global-config.yaml
@@ -7,6 +7,9 @@ loreArchives:
   - netdev
   - linux-ext4
 
+aiConfig:
+  geminiAPIKey: "gcp-secret:syz-cluster-gemini-key"
+
 trees:
   - name: net
     URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/netdev/net.git

--- a/syz-cluster/overlays/gke/staging/kustomization.yaml
+++ b/syz-cluster/overlays/gke/staging/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
 
 configMapGenerator:
   - name: global-config
+    options:
+      disableNameSuffixHash: true
     files:
       - config.yaml=global-config.yaml

--- a/syz-cluster/overlays/local/minikube/kustomization.yaml
+++ b/syz-cluster/overlays/local/minikube/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
 
 configMapGenerator:
   - name: global-config
+    options:
+      disableNameSuffixHash: true
     files:
       - config.yaml=global-config.yaml

--- a/syz-cluster/overlays/local/test/kustomization.yaml
+++ b/syz-cluster/overlays/local/test/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
 
 configMapGenerator:
   - name: global-config
+    options:
+      disableNameSuffixHash: true
     files:
       - config.yaml=global-config.yaml

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -40,8 +40,11 @@ const (
 // FuzzConfig represents a set of parameters passed to the fuzz step.
 // The triage step aggregates multiple KernelFuzzConfig to construct FuzzConfig.
 type FuzzConfig struct {
-	Focus      []string `json:"focus" yaml:"focus"`
-	CorpusURLs []string `json:"corpus_urls" yaml:"corpus_urls"`
+	Focus []string `json:"focus" yaml:"focus"`
+	// TODO: this is temporarily here. We should do it at the beginning of the fuzzing step,
+	// where we do have the built binary and can extract exact symbol names / PC symbols.
+	FocusSymbols []string `json:"focus_symbols" yaml:"focus_symbols"`
+	CorpusURLs   []string `json:"corpus_urls" yaml:"corpus_urls"`
 	// Don't expect kernel coverage for the patched area.
 	SkipCoverCheck bool `json:"skip_cover_check" yaml:"skip_cover_check"`
 	// Only report the bugs that match the regexp.
@@ -75,13 +78,14 @@ type FuzzTriageTarget struct {
 }
 
 type BuildRequest struct {
-	Arch       string `json:"arch"`
-	TreeName   string `json:"tree_name"`
-	TreeURL    string `json:"tree_url"`
-	CommitHash string `json:"commit_hash"`
-	ConfigName string `json:"config_name"` // These are known to both the triage and build steps.
-	SeriesID   string `json:"series_id"`
-	JobID      string `json:"job_id,omitempty"`
+	Arch          string   `json:"arch"`
+	TreeName      string   `json:"tree_name"`
+	TreeURL       string   `json:"tree_url"`
+	CommitHash    string   `json:"commit_hash"`
+	ConfigName    string   `json:"config_name"` // These are known to both the triage and build steps.
+	EnableConfigs []string `json:"enable_configs,omitempty"`
+	SeriesID      string   `json:"series_id"`
+	JobID         string   `json:"job_id,omitempty"`
 }
 
 // BuildResult is returned from the build workflow step.

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -11,6 +11,8 @@ type TriageResult struct {
 	SkipReason string `json:"skip_reason"`
 	// Fuzzing configuration to try (NULL if nothing).
 	Targets []*TestTarget `json:"targets"`
+	// Aflow Trajectory.
+	Trajectory []byte `json:"trajectory,omitempty"`
 }
 
 // TestTarget groups the testing tasks that share the same base/patched builds.
@@ -274,6 +276,8 @@ type Job struct {
 }
 
 type SessionInfo struct {
-	Series *Series `json:"series"`
-	Job    *Job    `json:"job,omitempty"`
+	Series              *Series `json:"series"`
+	Job                 *Job    `json:"job,omitempty"`
+	TriageLogURI        string  `json:"triage_log_uri,omitempty"`
+	TriageTrajectoryURI string  `json:"triage_trajectory_uri,omitempty"`
 }

--- a/syz-cluster/pkg/api/client.go
+++ b/syz-cluster/pkg/api/client.go
@@ -41,6 +41,7 @@ func (client Client) GetJob(ctx context.Context, jobID string) (*Job, error) {
 type UploadTriageResultReq struct {
 	SkipReason string `json:"skip_reason"`
 	Log        []byte `json:"log"`
+	Trajectory []byte `json:"trajectory,omitempty"`
 }
 
 func (client Client) UploadTriageResult(ctx context.Context, sessionID string, req *UploadTriageResultReq) error {

--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -28,6 +28,17 @@ type AppConfig struct {
 	// Trees and Fuzzer configuration.
 	Trees       []*api.Tree             `yaml:"trees"`
 	FuzzTargets []*api.FuzzTriageTarget `yaml:"fuzz_targets"`
+	// AI configuration (e.g. LLM secrets).
+	AI *AIConfig `yaml:"aiConfig"`
+}
+
+type AIConfig struct {
+	// The name of the GCP Secret Manager secret containing the Gemini API key.
+	GeminiAPIKey string `yaml:"geminiAPIKey"`
+}
+
+func (c *AIConfig) Empty() bool {
+	return c == nil || c.GeminiAPIKey == ""
 }
 
 const (
@@ -106,6 +117,7 @@ func loadConfig(path string) (*AppConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse: %w", err)
 	}
+
 	err = obj.Validate()
 	if err != nil {
 		return nil, err

--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -71,16 +71,17 @@ const (
 )
 
 type Session struct {
-	ID           string             `spanner:"ID"`
-	SeriesID     string             `spanner:"SeriesID"`
-	CreatedAt    time.Time          `spanner:"CreatedAt"`
-	StartedAt    spanner.NullTime   `spanner:"StartedAt"`
-	FinishedAt   spanner.NullTime   `spanner:"FinishedAt"`
-	SkipReason   spanner.NullString `spanner:"SkipReason"`
-	LogURI       string             `spanner:"LogURI"`
-	TriageLogURI string             `spanner:"TriageLogURI"`
-	Tags         []string           `spanner:"Tags"`
-	JobID        spanner.NullString `spanner:"JobID"`
+	ID                  string             `spanner:"ID"`
+	SeriesID            string             `spanner:"SeriesID"`
+	CreatedAt           time.Time          `spanner:"CreatedAt"`
+	StartedAt           spanner.NullTime   `spanner:"StartedAt"`
+	FinishedAt          spanner.NullTime   `spanner:"FinishedAt"`
+	SkipReason          spanner.NullString `spanner:"SkipReason"`
+	LogURI              string             `spanner:"LogURI"`
+	TriageLogURI        string             `spanner:"TriageLogURI"`
+	TriageTrajectoryURI spanner.NullString `spanner:"TriageTrajectoryURI"`
+	Tags                []string           `spanner:"Tags"`
+	JobID               spanner.NullString `spanner:"JobID"`
 	// TODO: to accept more specific fuzzing assignment,
 	// add Triager, BaseRepo, BaseCommit, Config fields.
 }

--- a/syz-cluster/pkg/db/migrations/16_add_triage_trajectory.down.sql
+++ b/syz-cluster/pkg/db/migrations/16_add_triage_trajectory.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Sessions DROP COLUMN TriageTrajectoryURI;

--- a/syz-cluster/pkg/db/migrations/16_add_triage_trajectory.up.sql
+++ b/syz-cluster/pkg/db/migrations/16_add_triage_trajectory.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Sessions ADD COLUMN TriageTrajectoryURI STRING(512);

--- a/syz-cluster/pkg/service/session.go
+++ b/syz-cluster/pkg/service/session.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"cloud.google.com/go/spanner"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/blob"
@@ -38,6 +39,7 @@ var ErrSessionNotFound = errors.New("session not found")
 
 func (s *SessionService) TriageResult(ctx context.Context, sessionID string, req *api.UploadTriageResultReq) error {
 	var triageLogURI string
+	var triageTrajectoryURI string
 	if len(req.Log) > 0 {
 		var err error
 		triageLogURI, err = s.blobStorage.Write(bytes.NewReader(req.Log), "Session", sessionID, "triage_log")
@@ -45,8 +47,19 @@ func (s *SessionService) TriageResult(ctx context.Context, sessionID string, req
 			return fmt.Errorf("failed to save the triage log: %w", err)
 		}
 	}
+	if len(req.Trajectory) > 0 {
+		var err error
+		triageTrajectoryURI, err = s.blobStorage.Write(
+			bytes.NewReader(req.Trajectory), "Session", sessionID, "triage_trajectory")
+		if err != nil {
+			return fmt.Errorf("failed to save the triage trajectory: %w", err)
+		}
+	}
 	err := s.sessionRepo.Update(ctx, sessionID, func(session *db.Session) error {
 		session.TriageLogURI = triageLogURI
+		if triageTrajectoryURI != "" {
+			session.TriageTrajectoryURI = spanner.NullString{StringVal: triageTrajectoryURI, Valid: true}
+		}
 		if req.SkipReason != "" {
 			session.SetSkipReason(req.SkipReason)
 		}
@@ -91,7 +104,9 @@ func (s *SessionService) GetSessionInfo(ctx context.Context, sessionID string) (
 	}
 
 	info := &api.SessionInfo{
-		Series: series,
+		Series:              series,
+		TriageLogURI:        session.TriageLogURI,
+		TriageTrajectoryURI: session.TriageTrajectoryURI.StringVal,
 	}
 
 	if session.JobID.Valid {

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -1,0 +1,117 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package triage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	_ "github.com/google/syzkaller/pkg/aflow/flow"
+	"github.com/google/syzkaller/pkg/aflow/trajectory"
+	aflowhtml "github.com/google/syzkaller/pkg/aflow/trajectory/html"
+	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/gcpsecret"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
+	"github.com/google/syzkaller/syz-cluster/pkg/app"
+)
+
+type AITriageResult struct {
+	WorthFuzzing bool
+	Reasoning    string
+	Trajectory   []byte
+}
+
+const aiEvaluationTimeout = time.Hour
+
+func CommitPatchForAflow(ops *GitTreeOps) error {
+	if _, err := ops.Run("add", "-A"); err != nil {
+		return fmt.Errorf("git add failed: %v", osutil.VerboseMessage(err))
+	}
+	if _, err := ops.Run("-c", "user.name=syz-cluster", "-c", "user.email=triage@syzkaller.com",
+		"commit", "-m", "syz-cluster: applied patch under review"); err != nil {
+		return fmt.Errorf("git commit failed: %v", osutil.VerboseMessage(err))
+	}
+	return nil
+}
+
+func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Series,
+	tracer debugtracer.DebugTracer, kernelSrcDir string) (*AITriageResult, error) {
+	apiKey, err := gcpsecret.Resolve(ctx, config.AI.GeminiAPIKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Gemini API key: %w", err)
+	}
+	os.Setenv("GOOGLE_API_KEY", apiKey)
+
+	aiCtx, cancel := context.WithTimeout(ctx, aiEvaluationTimeout)
+	defer cancel()
+
+	var spans []*trajectory.Span
+	seenID := make(map[int]struct{})
+	onEvent := func(span *trajectory.Span) error {
+		// Aflow sends us the same span pointer twice: on start and on finish.
+		if _, ok := seenID[span.Seq]; ok {
+			return nil
+		}
+		seenID[span.Seq] = struct{}{}
+		spans = append(spans, span)
+		return nil
+	}
+
+	args := ai.PatchTriageArgs{
+		KernelSrc: kernelSrcDir,
+	}
+	argsBytes, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal initial args: %w", err)
+	}
+	var initialState map[string]any
+	if err := json.Unmarshal(argsBytes, &initialState); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal initial state: %w", err)
+	}
+
+	tracer.Logf("starting AI patch evaluation...")
+	workflowDesc := aflow.Flows[string(ai.WorkflowPatchTriage)]
+	if workflowDesc == nil {
+		return nil, fmt.Errorf("failed to find workflow %s", ai.WorkflowPatchTriage)
+	}
+
+	cache, err := aflow.NewCache("/tmp/aflow-cache", 1024*1024*1024)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create aflow cache: %w", err)
+	}
+
+	outputs, err := workflowDesc.Execute(aiCtx, "", "/tmp/aflow-cache", initialState, cache, onEvent)
+
+	var htmlReport []byte
+	buf := new(bytes.Buffer)
+	if renderErr := aflowhtml.RenderReport(buf, spans); renderErr == nil {
+		htmlReport = buf.Bytes()
+	} else {
+		tracer.Logf("failed to render trajectory: %v", renderErr)
+	}
+
+	if err != nil {
+		return &AITriageResult{Trajectory: htmlReport}, err
+	}
+
+	outBytes, err := json.Marshal(outputs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal outputs: %w", err)
+	}
+	var result ai.PatchTriageResult
+	if err := json.Unmarshal(outBytes, &result); err != nil {
+		return nil, fmt.Errorf("AI evaluation returned invalid data: %w", err)
+	}
+
+	tracer.Logf("AI verdict: WorthFuzzing=%v (Reason: %s)", result.WorthFuzzing, result.Reasoning)
+
+	return &AITriageResult{WorthFuzzing: result.WorthFuzzing, Reasoning: result.Reasoning, Trajectory: htmlReport}, nil
+}

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -24,9 +24,11 @@ import (
 )
 
 type AITriageResult struct {
-	WorthFuzzing bool
-	Reasoning    string
-	Trajectory   []byte
+	WorthFuzzing  bool
+	FocusSymbols  []string
+	EnableConfigs []string
+	Reasoning     string
+	Trajectory    []byte
 }
 
 const aiEvaluationTimeout = time.Hour
@@ -113,5 +115,11 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 
 	tracer.Logf("AI verdict: WorthFuzzing=%v (Reason: %s)", result.WorthFuzzing, result.Reasoning)
 
-	return &AITriageResult{WorthFuzzing: result.WorthFuzzing, Reasoning: result.Reasoning, Trajectory: htmlReport}, nil
+	return &AITriageResult{
+		WorthFuzzing:  result.WorthFuzzing,
+		FocusSymbols:  result.FocusSymbols,
+		EnableConfigs: result.EnableConfigs,
+		Reasoning:     result.Reasoning,
+		Trajectory:    htmlReport,
+	}, nil
 }

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -68,7 +68,10 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 	}
 
 	args := ai.PatchTriageArgs{
-		KernelSrc: kernelSrcDir,
+		// TODO: Set TargetArch dynamically based on the fuzzing targets for the patch.
+		// For now it's irrelevant as we only fuzz amd64 anyway.
+		TargetArch: "amd64",
+		KernelSrc:  kernelSrcDir,
 	}
 	argsBytes, err := json.Marshal(args)
 	if err != nil {

--- a/syz-cluster/workflow/build/main.go
+++ b/syz-cluster/workflow/build/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/build"
 	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/kconfig"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/vcs"
 	"github.com/google/syzkaller/sys/targets"
@@ -228,6 +229,16 @@ func buildKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest) (*BuildR
 	kernelConfig, err := os.ReadFile(filepath.Join("/kernel-configs", req.ConfigName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the kernel config: %w", err)
+	}
+	if len(req.EnableConfigs) > 0 {
+		parsed, err := kconfig.ParseConfigData(kernelConfig, req.ConfigName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kernel config: %w", err)
+		}
+		for _, cfg := range req.EnableConfigs {
+			parsed.Set(cfg, kconfig.Yes)
+		}
+		kernelConfig = parsed.Serialize()
 	}
 	if req.Arch != "amd64" {
 		// TODO: lift this restriction.

--- a/syz-cluster/workflow/fuzz/main.go
+++ b/syz-cluster/workflow/fuzz/main.go
@@ -142,6 +142,20 @@ func run(ctx context.Context, config *api.FuzzConfig, client *api.Client,
 	}
 	diff.PatchFocusAreas(patched, series.PatchBodies(), baseSymbols.Text, patchedSymbols.Text)
 
+	if len(config.FocusSymbols) > 0 {
+		var regexps []string
+		for _, name := range config.FocusSymbols {
+			regexps = append(regexps, fmt.Sprintf("^%s$", regexp.QuoteMeta(name)))
+		}
+		patched.Experimental.FocusAreas = append(patched.Experimental.FocusAreas, mgrconfig.FocusArea{
+			Name: "ai_focus",
+			Filter: mgrconfig.CovFilterCfg{
+				Functions: regexps,
+			},
+			Weight: 10.0,
+		})
+	}
+
 	if len(config.CorpusURLs) > 0 {
 		err := prepareCorpus(ctx, patched.Workdir, config.CorpusURLs, patched.Target)
 		if err != nil {

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -39,10 +39,16 @@ func main() {
 	output := new(bytes.Buffer)
 	tracer := &debugtracer.GenericTracer{WithTime: true, TraceWriter: output}
 
+	cfg, err := app.Config()
+	if err != nil {
+		app.Fatalf("failed to load app config: %v", err)
+	}
+
 	triager := &seriesTriager{
 		DebugTracer: tracer,
 		client:      client,
 		ops:         repo,
+		config:      cfg,
 	}
 	verdict, err := triager.GetVerdict(ctx, *flagSession)
 	if err != nil {
@@ -51,6 +57,7 @@ func main() {
 	err = client.UploadTriageResult(ctx, *flagSession, &api.UploadTriageResultReq{
 		SkipReason: verdict.SkipReason,
 		Log:        output.Bytes(),
+		Trajectory: verdict.Trajectory,
 	})
 	if err != nil {
 		app.Fatalf("failed to upload triage results: %v", err)
@@ -66,8 +73,10 @@ func main() {
 
 type seriesTriager struct {
 	debugtracer.DebugTracer
-	client *api.Client
-	ops    *triage.GitTreeOps
+	client    *api.Client
+	ops       *triage.GitTreeOps
+	config    *app.AppConfig
+	aiVerdict *triage.AITriageResult
 }
 
 func (triager *seriesTriager) GetVerdict(ctx context.Context, sessionID string) (*api.TriageResult, error) {
@@ -105,6 +114,9 @@ func (triager *seriesTriager) GetVerdict(ctx context.Context, sessionID string) 
 		// If we have prepared at least one fuzzing task, the series was not skipped.
 		ret.SkipReason = ""
 	}
+	if triager.aiVerdict != nil {
+		ret.Trajectory = triager.aiVerdict.Trajectory
+	}
 	return ret, nil
 }
 
@@ -130,39 +142,63 @@ func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *ap
 			return nil, fmt.Errorf("selection from the list failed: %w", err)
 		}
 	}
-	if result != nil {
-		triager.Logf("continuing with %v in %v", result.Commit, result.Tree.Name)
-		base := api.BuildRequest{
-			TreeName:   result.Tree.Name,
-			TreeURL:    result.Tree.URL,
-			ConfigName: target.KernelConfig,
-			CommitHash: result.Commit,
-			Arch:       result.Arch,
-		}
-		testTarget := &api.TestTarget{
-			Base:    base,
-			Patched: base,
-			Track:   target.Track,
-			Fuzz:    target.FuzzConfig,
-		}
-		testTarget.Patched.SeriesID = series.ID
-		retestFindings, err := triager.client.ListPreviousFindings(ctx, &api.ListPreviousFindingsReq{
-			SeriesID: series.ID,
-			Arch:     result.Arch,
-			Config:   target.KernelConfig,
-		})
-		if err != nil {
-			// This is sad, but not critical.
-			app.Errorf("failed to query previous findings: %v", err)
-		} else if len(retestFindings) > 0 {
-			triager.Logf("scheduling retest for %d findings", len(retestFindings))
-			testTarget.Retest = &api.RetestTask{
-				Findings: retestFindings,
+	if result == nil {
+		return nil, SkipError("no base commit found")
+	}
+
+	triager.Logf("continuing with %v in %v", result.Commit, result.Tree.Name)
+
+	if err := triager.ops.ApplySeries(result.Commit, series.PatchBodies()); err != nil {
+		return nil, fmt.Errorf("failed to apply series to base commit: %w", err)
+	}
+
+	if triager.aiVerdict == nil {
+		triager.aiVerdict = &triage.AITriageResult{WorthFuzzing: true}
+		if !triager.config.AI.Empty() {
+			if err := triage.CommitPatchForAflow(triager.ops); err != nil {
+				return nil, fmt.Errorf("failed to commit patch for aflow: %w", err)
+			}
+			if aiResult, err := triage.EvaluatePatch(ctx, triager.config, series, triager.DebugTracer, "/workdir"); err != nil {
+				triager.Logf("AI evaluation failed: %v", err)
+			} else if aiResult != nil {
+				triager.aiVerdict = aiResult
 			}
 		}
-		return testTarget, nil
 	}
-	return nil, SkipError("no base commit found")
+
+	if !triager.aiVerdict.WorthFuzzing {
+		return nil, SkipError("AI determined the patch has no functional impact")
+	}
+
+	base := api.BuildRequest{
+		TreeName:   result.Tree.Name,
+		TreeURL:    result.Tree.URL,
+		ConfigName: target.KernelConfig,
+		CommitHash: result.Commit,
+		Arch:       result.Arch,
+	}
+	testTarget := &api.TestTarget{
+		Base:    base,
+		Patched: base,
+		Track:   target.Track,
+		Fuzz:    target.FuzzConfig,
+	}
+	testTarget.Patched.SeriesID = series.ID
+	retestFindings, err := triager.client.ListPreviousFindings(ctx, &api.ListPreviousFindingsReq{
+		SeriesID: series.ID,
+		Arch:     result.Arch,
+		Config:   target.KernelConfig,
+	})
+	if err != nil {
+		// This is sad, but not critical.
+		app.Errorf("failed to query previous findings: %v", err)
+	} else if len(retestFindings) > 0 {
+		triager.Logf("scheduling retest for %d findings", len(retestFindings))
+		testTarget.Retest = &api.RetestTask{
+			Findings: retestFindings,
+		}
+	}
+	return testTarget, nil
 }
 
 func (triager *seriesTriager) prepareJobTask(

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -171,17 +171,23 @@ func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *ap
 	}
 
 	base := api.BuildRequest{
-		TreeName:   result.Tree.Name,
-		TreeURL:    result.Tree.URL,
-		ConfigName: target.KernelConfig,
-		CommitHash: result.Commit,
-		Arch:       result.Arch,
+		TreeName:      result.Tree.Name,
+		TreeURL:       result.Tree.URL,
+		ConfigName:    target.KernelConfig,
+		CommitHash:    result.Commit,
+		Arch:          result.Arch,
+		EnableConfigs: triager.aiVerdict.EnableConfigs,
 	}
+	fuzzCfg := new(api.FuzzConfig)
+	if target.FuzzConfig != nil {
+		*fuzzCfg = *target.FuzzConfig
+	}
+	fuzzCfg.FocusSymbols = triager.aiVerdict.FocusSymbols
 	testTarget := &api.TestTarget{
 		Base:    base,
 		Patched: base,
 		Track:   target.Track,
-		Fuzz:    target.FuzzConfig,
+		Fuzz:    fuzzCfg,
 	}
 	testTarget.Patched.SeriesID = series.ID
 	retestFindings, err := triager.client.ListPreviousFindings(ctx, &api.ListPreviousFindingsReq{

--- a/syz-cluster/workflow/triage/workflow-template.yaml
+++ b/syz-cluster/workflow/triage/workflow-template.yaml
@@ -63,6 +63,10 @@ spec:
               mountPath: /workdir
             - name: output
               mountPath: /output
+            - name: aflow-cache
+              mountPath: /tmp/aflow-cache
+            - name: config-volume
+              mountPath: /config
       volumes:
         - name: base-kernel-repo
           persistentVolumeClaim:
@@ -71,6 +75,11 @@ spec:
           emptyDir: {}
         - name: output
           emptyDir: {}
+        - name: aflow-cache
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: global-config
       outputs:
         parameters:
           - name: result


### PR DESCRIPTION
To start with, add a small AI-powered triage workflow that would determine if a give patch (series) is worth fuzzing.

Adjust the `pkg/aflow` framework to be more easily usable outside of `syz-agent`.