### PR TITLE
syz-cluster: fix local kernel fetcher SA permissions

### DIFF
--- a/syz-cluster/overlays/local/common/service-accounts.yaml
+++ b/syz-cluster/overlays/local/common/service-accounts.yaml
@@ -46,3 +46,18 @@ kind: ServiceAccount
 metadata:
   name: kernel-fetcher-ksa
   namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kernel-fetcher-workflowtasks-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflowtasks-role
+subjects:
+- kind: ServiceAccount
+  name: kernel-fetcher-ksa
+  namespace: default


### PR DESCRIPTION
We were missing a few essential permissions to run inside Argo workflow steps.
For prod environments, these are defined elsewhere, but for minikube it must be specified in the k8s overlays.