### PR TITLE
pkg/aflow: embed timezone data to prevent initialization panics

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/pkg/osutil"


### PR DESCRIPTION
Import `time/tzdata` to embed the timezone database directly into the compiled binary. This prevents a `time.LoadLocation("US/Pacific")` panic when the `aflow` package is initialized inside minimal Docker containers that lack OS-level tzdata.
