### PR TITLE
pkg/instance: fix select race on context cancellation

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -367,6 +367,11 @@ func runStreamAndCollectStdout(ctx context.Context, inst *vm.Instance, command s
 					return err
 				}
 			}
+			// In case of race between context cancellation and receiving
+			// command error, prioritize context error.
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			outc = nil
 			return err
 		case <-ctx.Done():


### PR DESCRIPTION
In runStreamAndCollectStdout, when the parent context is cancelled, the VM run implementation stops and (in some cases) closes both outc and errc channels. Because select statement cases are chosen pseudo-randomly when multiple channels are ready, Go would occasionally select <-errc and return nil instead of returning context.Canceled.

Fix this by prioritizing the context cancellation error when reading from the errc channel.

