### PR TITLE
vm: fix blocking select on nil outc channel in instance.Run

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -541,6 +541,9 @@ func (mon *monitor) createReports(defaultError string) []*report.Report {
 }
 
 func (mon *monitor) waitForOutput() {
+	if mon.outc == nil {
+		return
+	}
 	timer := time.NewTimer(vmimpl.WaitForOutputTimeout * mon.inst.pool.timeouts.Scale)
 	defer timer.Stop()
 	for {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm/vmimpl"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testPool struct {
@@ -349,6 +350,27 @@ func TestMonitorExecution(t *testing.T) {
 			testMonitorExecution(t, test)
 		})
 	}
+}
+
+func TestNilChannelBlock(t *testing.T) {
+	inst, reporter := makeLinuxAMD64Futex(t, "test")
+	testInst := inst.impl.(*testInstance)
+
+	go func() {
+		close(testInst.outc)
+		time.Sleep(10 * time.Millisecond)
+		testInst.errc <- nil
+	}()
+
+	start := time.Now()
+	_, _, err := inst.Run(context.Background(), reporter, "", withTestRunOptionsDefaults(), WithExitCondition(ExitNormal))
+	require.NoError(t, err)
+
+	duration := time.Since(start)
+	// vmimpl.WaitForOutputTimeout is artificially set to 3s in vm_test.go init().
+	// If the bug is present, duration will be >= 3 seconds. Testing for 2s to
+	// compensate potential timer inaccuracy.
+	require.Less(t, duration, 2*time.Second, "test took %v, meaning it is waiting for a nil outc channel", duration)
 }
 
 func makeLinuxAMD64Futex(t *testing.T, poolName string) (*Instance, *report.Reporter) {


### PR DESCRIPTION
In mon.monitorExecution(), the monitor loops over a select statement reading from the errc and outc channels. If a multiplexed VM (which doesn't reuse its merger.Output, e.g. isolate or gce) finishes execution, outc is closed and errc is written to.

If the monitor reads the outc closure first, it sets mon.outc = nil. When it subsequently receives the exit status on errc, it calls extractErrors(), which triggers waitForOutput(). If mon.outc is nil, reading from it blocks permanently, causing a 10-second stall (or 3-second stall in tests) until the timeout expires.

Fix this by returning early from waitForOutput() if mon.outc is nil.

---

```mermaid
sequenceDiagram
    participant X as Multiplex() (vmimpl.go)
    participant O as OutputMerger (merger.go)
    participant OutC as mon.outc (Channel)
    participant ErrC as mon.errc (Channel)
    participant M as monitorExecution() (vm.go)

    Note over X, M: Both goroutines are running concurrently
    Note over M: monitorExecution is blocked, listening to both mon.outc and mon.errc

    Note over X: Command exits
    X->>X: config.Console.Close()

    rect rgb(255, 235, 235)
        Note over X, M: Critical Race Window
        X->>O: calls merger.Wait()
        O->>OutC: executes close(merger.Output)
        O-->>X: returns from Wait()
        
        %% Race condition: M wakes up instantly while X moves to next line
        OutC-->>M: select unblocks on closed outc (ok = false)
        M->>M: sets mon.outc = nil
        
        X->>ErrC: executes signal(err) -> pushes exit status
    end

    Note over M: monitorExecution loops back, blocks at select (outc is now nil)
    ErrC-->>M: select unblocks on mon.errc
    M->>M: extractErrors()
    M->>OutC: waitForOutput() -> reads from mon.outc
    Note over M, OutC: select blocks on nil mon.outc until timer triggers time exceed

```