### PR TITLE
dashboard: decouple C and Syz reproducer levels

### DIFF
--- a/dashboard/app/admin.go
+++ b/dashboard/app/admin.go
@@ -318,22 +318,16 @@ func updateHeadReproLevel(ctx context.Context, w http.ResponseWriter, r *http.Re
 		if len(bug.Commits) > 0 {
 			return nil
 		}
-		actual := ReproLevelNone
 		reproCrashes, _, err := queryCrashesForBug(ctx, key, 2)
 		if err != nil {
 			return fmt.Errorf("failed to fetch crashes with repro: %w", err)
 		}
+		actual := ReproLevelNone
 		for _, crash := range reproCrashes {
 			if crash.ReproIsRevoked {
 				continue
 			}
-			if crash.ReproC > 0 {
-				actual = ReproLevelC
-				break
-			}
-			if crash.ReproSyz > 0 {
-				actual = ReproLevelSyz
-			}
+			actual = actual.Combine(dashapi.ReproLevelFromCAndSyz(crash.ReproC > 0, crash.ReproSyz > 0))
 		}
 		if actual != bug.HeadReproLevel {
 			fmt.Fprintf(w, "%v: HeadReproLevel mismatch, actual=%d db=%d\n",

--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -872,12 +872,7 @@ func reportCrash(ctx context.Context, build *Build, req *dashapi.Crash) (*Bug, e
 
 	bugKey := bug.key(ctx)
 	now := timeNow(ctx)
-	reproLevel := ReproLevelNone
-	if len(req.ReproC) != 0 {
-		reproLevel = ReproLevelC
-	} else if len(req.ReproSyz) != 0 {
-		reproLevel = ReproLevelSyz
-	}
+	reproLevel := dashapi.ReproLevelFromCAndSyz(len(req.ReproC) != 0, len(req.ReproSyz) != 0)
 	save := reproLevel != ReproLevelNone ||
 		bug.NumCrashes < int64(maxCrashes()) ||
 		now.Sub(bug.LastSavedCrash) > time.Hour ||
@@ -922,8 +917,8 @@ func reportCrash(ctx context.Context, build *Build, req *dashapi.Crash) (*Bug, e
 			bug.NumRepro++
 			bug.LastReproTime = now
 		}
-		bug.ReproLevel = max(bug.ReproLevel, reproLevel)
-		bug.HeadReproLevel = max(bug.HeadReproLevel, reproLevel)
+		bug.ReproLevel = bug.ReproLevel.Combine(reproLevel)
+		bug.HeadReproLevel = bug.HeadReproLevel.Combine(reproLevel)
 		if len(req.Report) != 0 {
 			bug.HasReport = true
 		}
@@ -1598,7 +1593,14 @@ func needReproForBug(ctx context.Context, bug *Bug) bool {
 	if syzErrorTitleRe.MatchString(bug.Title) {
 		bestReproLevel = ReproLevelSyz
 	}
-	if bug.HeadReproLevel < bestReproLevel {
+	hasBest := false
+	switch bestReproLevel {
+	case ReproLevelC:
+		hasBest = bug.HeadReproLevel.HasC()
+	case ReproLevelSyz:
+		hasBest = bug.HeadReproLevel.HasSyz()
+	}
+	if !hasBest {
 		// We have not found a best-level repro yet, try until we do.
 		return bug.NumRepro < maxReproPerBug || timeSince(ctx, bug.LastReproTime) >= reproRetryPeriod
 	}

--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -692,9 +692,10 @@ const (
 )
 
 const (
-	ReproLevelNone = dashapi.ReproLevelNone
-	ReproLevelSyz  = dashapi.ReproLevelSyz
-	ReproLevelC    = dashapi.ReproLevelC
+	ReproLevelNone  = dashapi.ReproLevelNone
+	ReproLevelSyz   = dashapi.ReproLevelSyz
+	ReproLevelC     = dashapi.ReproLevelC
+	ReproLevelCOnly = dashapi.ReproLevelCOnly
 )
 
 type BuildType int

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -644,9 +644,13 @@ func handleRetestForBug(ctx context.Context, bug *Bug, bugKey *db.Key,
 
 func createBisectJob(ctx context.Context, managers map[string]dashapi.ManagerJobs) (*Job, *db.Key, error) {
 	// We need both C and syz repros, but the crazy datastore query restrictions
-	// do not allow to use ReproLevel>ReproLevelNone in the query. So we do 2 separate queries.
+	// do not allow to use ReproLevel>ReproLevelNone in the query. So we do 3 separate queries.
 	// C repros tend to be of higher reliability so maybe it's not bad.
 	job, jobKey, err := createBisectJobRepro(ctx, managers, ReproLevelC)
+	if job != nil || err != nil {
+		return job, jobKey, err
+	}
+	job, jobKey, err = createBisectJobRepro(ctx, managers, ReproLevelCOnly)
 	if job != nil || err != nil {
 		return job, jobKey, err
 	}
@@ -754,7 +758,7 @@ func bisectCrashForBug(ctx context.Context, bug *Bug, bugKey *db.Key, managers m
 		return nil, nil, err
 	}
 	for ci, crash := range crashes {
-		if crash.ReproSyz == 0 || !managers[crash.Manager] {
+		if (crash.ReproSyz == 0 && crash.ReproC == 0) || !managers[crash.Manager] {
 			continue
 		}
 		if jobType == JobBisectFix &&
@@ -967,11 +971,8 @@ func handleRetestedRepro(ctx context.Context, now time.Time, job *Job, jobKey *d
 		if bestCrash.ReproIsRevoked {
 			continue
 		}
-		if bestCrash.ReproC > 0 {
-			bug.HeadReproLevel = ReproLevelC
-		} else if bug.HeadReproLevel != ReproLevelC && bestCrash.ReproSyz > 0 {
-			bug.HeadReproLevel = ReproLevelSyz
-		}
+		bug.HeadReproLevel = bug.HeadReproLevel.Combine(
+			dashapi.ReproLevelFromCAndSyz(bestCrash.ReproC > 0, bestCrash.ReproSyz > 0))
 	}
 	if stringInList(allTitles, bug.Title) || stringListsIntersect(bug.AltTitles, allTitles) {
 		// We don't want to confuse users, so only update LastTime if the generated crash

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -489,6 +489,70 @@ func TestReproRetestJob(t *testing.T) {
 	c.expectEQ(bug.StatusReason, dashapi.InvalidatedByRevokedRepro)
 }
 
+func TestCOnlyReproRetestJob(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+	oldBuild := testBuild(1)
+	oldBuild.KernelRepo = "git://mygit.com/git.git"
+	oldBuild.KernelBranch = "main"
+	client.UploadBuild(oldBuild)
+
+	crash := testCrash(oldBuild, 1)
+	crash.ReproOpts = []byte("repro opts")
+	crash.ReproC = []byte("repro C")
+	client.ReportCrash(crash)
+	sender := c.pollEmailBug().Sender
+	_, extBugID, err := email.RemoveAddrContext(sender)
+	c.expectOK(err)
+
+	c.advanceTime(time.Minute)
+	build := testBuild(1)
+	build.ID = "new-build"
+	build.KernelRepo = "git://mygit.com/new-git.git"
+	build.KernelBranch = "new-main"
+	build.KernelConfig = []byte{0xAB, 0xCD, 0xEF}
+	client.UploadBuild(build)
+
+	c.advanceTime(time.Hour)
+	bug, _, _ := c.loadBug(extBugID)
+	c.expectEQ(bug.ReproLevel, ReproLevelCOnly)
+	c.expectEQ(bug.HeadReproLevel, ReproLevelCOnly)
+
+	// Let's say that the C repro testing has failed.
+	c.advanceTime(c.config().Obsoleting.ReproRetestStart + time.Hour)
+	resp := c.globalClient.pollSpecificJobs(build.Manager, dashapi.ManagerJobs{TestPatches: true})
+	c.expectEQ(resp.Type, dashapi.JobTestPatch)
+	c.expectEQ(resp.KernelRepo, build.KernelRepo)
+	c.expectEQ(resp.KernelBranch, build.KernelBranch)
+	c.expectEQ(resp.KernelConfig, build.KernelConfig)
+	c.expectEQ(resp.Patch, []uint8(nil))
+	c.expectNE(resp.ReproC, []uint8(nil))
+	c.expectEQ(resp.ReproSyz, []uint8(nil))
+
+	// Pretend that the C repro fails.
+	done := &dashapi.JobDoneReq{
+		ID: resp.ID,
+	}
+	client.expectOK(c.globalClient.JobDone(done))
+
+	// Expect that the repro level is now ReproLevelNone.
+	bug, _, _ = c.loadBug(extBugID)
+	c.expectEQ(bug.HeadReproLevel, ReproLevelNone)
+	c.expectEQ(bug.ReproLevel, ReproLevelCOnly)
+
+	// Expect that the bug gets deprecated.
+	c.advanceTime(c.config().Obsoleting.MaxPeriod + time.Hour)
+	notif := c.pollEmailBug()
+	if !strings.Contains(notif.Body, "Auto-closing this bug as obsolete") {
+		t.Fatalf("bad notification text: %q", notif.Body)
+	}
+	// Expect that the right obsoletion reason was set.
+	bug, _, _ = c.loadBug(extBugID)
+	c.expectEQ(bug.StatusReason, dashapi.InvalidatedByRevokedRepro)
+}
+
 func TestDelegatedManagerReproRetest(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()

--- a/dashboard/app/local_ui_test.go
+++ b/dashboard/app/local_ui_test.go
@@ -259,12 +259,7 @@ func populateLocalUIDB(t *testing.T, c *Ctx) {
 			}
 			if !isFixed {
 				t.Logf("acknowledging bug %q without fixing it", rep.Title)
-				reproLevel := dashapi.ReproLevelNone
-				if len(rep.ReproC) != 0 {
-					reproLevel = dashapi.ReproLevelC
-				} else if len(rep.ReproSyz) != 0 {
-					reproLevel = dashapi.ReproLevelSyz
-				}
+				reproLevel := dashapi.ReproLevelFromCAndSyz(len(rep.ReproC) != 0, len(rep.ReproSyz) != 0)
 				_, err := globalClient.ReportingUpdate(&dashapi.BugUpdate{
 					ID:         rep.ID,
 					Status:     dashapi.BugStatusOpen,

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -2239,7 +2239,7 @@ func mergeUIBug(ctx context.Context, bug *uiBug, dup *Bug) {
 	if bug.LastTime.Before(dup.LastTime) {
 		bug.LastTime = dup.LastTime
 	}
-	bug.ReproLevel = max(bug.ReproLevel, dup.ReproLevel)
+	bug.ReproLevel = bug.ReproLevel.Combine(dup.ReproLevel)
 	updateBugBadness(ctx, bug)
 }
 

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -107,7 +107,7 @@ func needReport(ctx context.Context, typ string, state *ReportingState, bug *Bug
 		return
 	}
 	link = bugReporting.Link
-	if !bugReporting.Reported.IsZero() && bugReporting.ReproLevel >= bug.HeadReproLevel {
+	if !bugReporting.Reported.IsZero() && bug.HeadReproLevel.CoveredBy(bugReporting.ReproLevel) {
 		status = fmt.Sprintf("%v: reported%v on %v",
 			reporting.DisplayTitle, reproStr(bugReporting.ReproLevel),
 			html.FormatTime(bugReporting.Reported))
@@ -121,7 +121,7 @@ func needReport(ctx context.Context, typ string, state *ReportingState, bug *Bug
 		reporting, bugReporting = nil, nil
 		return
 	}
-	if crashNeedsRepro(bug.Title) && bug.ReproLevel < ReproLevelC &&
+	if crashNeedsRepro(bug.Title) && !bug.ReproLevel.HasC() &&
 		timeSince(ctx, bug.FirstTime) < cfg.WaitForRepro {
 		status = fmt.Sprintf("%v: waiting for C repro", reporting.DisplayTitle)
 		reporting, bugReporting = nil, nil
@@ -481,7 +481,7 @@ func reproStr(level dashapi.ReproLevel) string {
 	switch level {
 	case ReproLevelSyz:
 		return " syz repro"
-	case ReproLevelC:
+	case ReproLevelC, ReproLevelCOnly:
 		return " C repro"
 	default:
 		return ""
@@ -1049,7 +1049,7 @@ func incomingCommandUpdate(ctx context.Context, now time.Time, cmd *dashapi.BugU
 		merged := email.MergeEmailLists(strings.Split(bugReporting.CC, "|"), cmd.CC)
 		bugReporting.CC = strings.Join(merged, "|")
 	}
-	bugReporting.ReproLevel = max(bugReporting.ReproLevel, cmd.ReproLevel)
+	bugReporting.ReproLevel = bugReporting.ReproLevel.Combine(cmd.ReproLevel)
 	if bug.Status != BugStatusDup {
 		bug.DupOf = ""
 	}
@@ -1088,7 +1088,7 @@ func incomingCommandCmd(ctx context.Context, now time.Time, cmd *dashapi.BugUpda
 				bug.Reporting[i].Closed = now
 			}
 		}
-		if bug.ReproLevel < cmd.ReproLevel {
+		if !cmd.ReproLevel.CoveredBy(bug.ReproLevel) {
 			return false, internalError,
 				fmt.Errorf("bug update with invalid repro level: %v/%v",
 					bug.ReproLevel, cmd.ReproLevel)
@@ -1300,15 +1300,11 @@ func findCrashForBug(ctx context.Context, bug *Bug) (*Crash, *db.Key, error) {
 		return nil, nil, fmt.Errorf("no crashes")
 	}
 	crash, key := crashes[0], keys[0]
-	switch bug.HeadReproLevel {
-	case ReproLevelC:
-		if crash.ReproC == 0 {
-			log.Errorf(ctx, "bug '%v': has C repro, but crash without C repro", bug.Title)
-		}
-	case ReproLevelSyz:
-		if crash.ReproSyz == 0 {
-			log.Errorf(ctx, "bug '%v': has syz repro, but crash without syz repro", bug.Title)
-		}
+	if bug.HeadReproLevel.HasC() && crash.ReproC == 0 {
+		log.Errorf(ctx, "bug '%v': has C repro, but crash without C repro", bug.Title)
+	}
+	if bug.HeadReproLevel.HasSyz() && crash.ReproSyz == 0 {
+		log.Errorf(ctx, "bug '%v': has syz repro, but crash without syz repro", bug.Title)
 	}
 	return crash, key, nil
 }
@@ -1528,7 +1524,7 @@ func (a bugReportSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 func (a bugReportSorter) Less(i, j int) bool {
 	if a[i].ReproLevel != a[j].ReproLevel {
-		return a[i].ReproLevel > a[j].ReproLevel
+		return a[i].ReproLevel.Rank() > a[j].ReproLevel.Rank()
 	}
 	if a[i].HasReport != a[j].HasReport {
 		return a[i].HasReport

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -296,13 +296,8 @@ func emailSendBugReport(ctx context.Context, rep *dashapi.BugReport) error {
 	cmd := &dashapi.BugUpdate{
 		ID:         rep.ID,
 		Status:     dashapi.BugStatusOpen,
-		ReproLevel: dashapi.ReproLevelNone,
+		ReproLevel: dashapi.ReproLevelFromCAndSyz(len(rep.ReproC) != 0, len(rep.ReproSyz) != 0),
 		CrashID:    rep.CrashID,
-	}
-	if len(rep.ReproC) != 0 {
-		cmd.ReproLevel = dashapi.ReproLevelC
-	} else if len(rep.ReproSyz) != 0 {
-		cmd.ReproLevel = dashapi.ReproLevelSyz
 	}
 	for label := range rep.LabelMessages {
 		cmd.Labels = append(cmd.Labels, label)

--- a/dashboard/app/repro_test.go
+++ b/dashboard/app/repro_test.go
@@ -253,6 +253,16 @@ func TestNeedReproIsolated(t *testing.T) {
 			needRepro: false,
 		},
 		{
+			// A bug for which we have recently found a C-only repro.
+			bug: &Bug{
+				Title:          "some bug with C-only repro",
+				ReproLevel:     ReproLevelCOnly,
+				HeadReproLevel: ReproLevelCOnly,
+				LastReproTime:  nowTime.Add(-time.Hour * 24),
+			},
+			needRepro: false,
+		},
+		{
 			// A bug which has an old C repro.
 			bug: &Bug{
 				Title:          "some normal bug with old repro",

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -697,12 +697,7 @@ func (client *apiClient) pollBugs(expect int) []*dashapi.BugReport {
 		client.t.Fatalf("want %v reports, got %v", expect, len(resp.Reports))
 	}
 	for _, rep := range resp.Reports {
-		reproLevel := dashapi.ReproLevelNone
-		if len(rep.ReproC) != 0 {
-			reproLevel = dashapi.ReproLevelC
-		} else if len(rep.ReproSyz) != 0 {
-			reproLevel = dashapi.ReproLevelSyz
-		}
+		reproLevel := dashapi.ReproLevelFromCAndSyz(len(rep.ReproC) != 0, len(rep.ReproSyz) != 0)
 		reply, _ := client.ReportingUpdate(&dashapi.BugUpdate{
 			ID:         rep.ID,
 			JobID:      rep.JobID,

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -946,9 +946,61 @@ const (
 
 const (
 	ReproLevelNone ReproLevel = iota
+	// Has syz repro only.
 	ReproLevelSyz
+	// Has both syz and C repros.
 	ReproLevelC
+	// Has C repro only.
+	ReproLevelCOnly
 )
+
+func ReproLevelFromCAndSyz(hasC, hasSyz bool) ReproLevel {
+	if hasC && hasSyz {
+		return ReproLevelC
+	}
+	if hasC {
+		return ReproLevelCOnly
+	}
+	if hasSyz {
+		return ReproLevelSyz
+	}
+	return ReproLevelNone
+}
+
+func (level ReproLevel) HasSyz() bool {
+	return level == ReproLevelSyz || level == ReproLevelC
+}
+
+func (level ReproLevel) HasC() bool {
+	return level == ReproLevelC || level == ReproLevelCOnly
+}
+
+func (level ReproLevel) Combine(other ReproLevel) ReproLevel {
+	return ReproLevelFromCAndSyz(level.HasC() || other.HasC(), level.HasSyz() || other.HasSyz())
+}
+
+func (level ReproLevel) CoveredBy(reported ReproLevel) bool {
+	if reported.HasC() {
+		return true
+	}
+	if reported.HasSyz() {
+		return !level.HasC()
+	}
+	return level == ReproLevelNone
+}
+
+func (level ReproLevel) Rank() int {
+	switch level {
+	case ReproLevelC:
+		return 3
+	case ReproLevelCOnly:
+		return 2
+	case ReproLevelSyz:
+		return 1
+	default:
+		return 0
+	}
+}
 
 const (
 	ReportNew         ReportType = iota // First report for this bug in the reporting stage.

--- a/dashboard/dashapi/dashapi_test.go
+++ b/dashboard/dashapi/dashapi_test.go
@@ -45,3 +45,106 @@ func TestNewOpts(t *testing.T) {
 		})
 	}
 }
+
+func TestReproLevelCoveredBy(t *testing.T) {
+	check := func(level, reported ReproLevel, want bool) {
+		t.Helper()
+		if got := level.CoveredBy(reported); got != want {
+			t.Errorf("%v.CoveredBy(%v) = %v; want %v", level, reported, got, want)
+		}
+	}
+
+	check(ReproLevelNone, ReproLevelNone, true)
+	check(ReproLevelNone, ReproLevelSyz, true)
+	check(ReproLevelNone, ReproLevelCOnly, true)
+	check(ReproLevelNone, ReproLevelC, true)
+
+	check(ReproLevelSyz, ReproLevelNone, false)
+	check(ReproLevelSyz, ReproLevelSyz, true)
+	check(ReproLevelSyz, ReproLevelCOnly, true)
+	check(ReproLevelSyz, ReproLevelC, true)
+
+	check(ReproLevelCOnly, ReproLevelNone, false)
+	check(ReproLevelCOnly, ReproLevelSyz, false)
+	check(ReproLevelCOnly, ReproLevelCOnly, true)
+	check(ReproLevelCOnly, ReproLevelC, true)
+
+	check(ReproLevelC, ReproLevelNone, false)
+	check(ReproLevelC, ReproLevelSyz, false)
+	check(ReproLevelC, ReproLevelCOnly, true) // COnly has C repro, which covers C (both C and Syz)
+	check(ReproLevelC, ReproLevelC, true)
+}
+
+func TestReproLevelFromCAndSyz(t *testing.T) {
+	tests := []struct {
+		hasC   bool
+		hasSyz bool
+		want   ReproLevel
+	}{
+		{false, false, ReproLevelNone},
+		{false, true, ReproLevelSyz},
+		{true, false, ReproLevelCOnly},
+		{true, true, ReproLevelC},
+	}
+
+	for _, test := range tests {
+		got := ReproLevelFromCAndSyz(test.hasC, test.hasSyz)
+		if got != test.want {
+			t.Errorf("reproLevelFromCAndSyz(%t, %t) = %v; want %v", test.hasC, test.hasSyz, got, test.want)
+		}
+	}
+}
+
+func TestReproLevelCombine(t *testing.T) {
+	tests := []struct {
+		level ReproLevel
+		other ReproLevel
+		want  ReproLevel
+	}{
+		{ReproLevelNone, ReproLevelNone, ReproLevelNone},
+		{ReproLevelNone, ReproLevelSyz, ReproLevelSyz},
+		{ReproLevelNone, ReproLevelCOnly, ReproLevelCOnly},
+		{ReproLevelNone, ReproLevelC, ReproLevelC},
+
+		{ReproLevelSyz, ReproLevelNone, ReproLevelSyz},
+		{ReproLevelSyz, ReproLevelSyz, ReproLevelSyz},
+		{ReproLevelSyz, ReproLevelCOnly, ReproLevelC},
+		{ReproLevelSyz, ReproLevelC, ReproLevelC},
+
+		{ReproLevelCOnly, ReproLevelNone, ReproLevelCOnly},
+		{ReproLevelCOnly, ReproLevelSyz, ReproLevelC},
+		{ReproLevelCOnly, ReproLevelCOnly, ReproLevelCOnly},
+		{ReproLevelCOnly, ReproLevelC, ReproLevelC},
+
+		{ReproLevelC, ReproLevelNone, ReproLevelC},
+		{ReproLevelC, ReproLevelSyz, ReproLevelC},
+		{ReproLevelC, ReproLevelCOnly, ReproLevelC},
+		{ReproLevelC, ReproLevelC, ReproLevelC},
+	}
+
+	for _, test := range tests {
+		got := test.level.Combine(test.other)
+		if got != test.want {
+			t.Errorf("%v.Combine(%v) = %v; want %v", test.level, test.other, got, test.want)
+		}
+	}
+}
+
+func TestReproLevelRank(t *testing.T) {
+	tests := []struct {
+		level ReproLevel
+		want  int
+	}{
+		{ReproLevelNone, 0},
+		{ReproLevelSyz, 1},
+		{ReproLevelCOnly, 2},
+		{ReproLevelC, 3},
+	}
+
+	for _, test := range tests {
+		got := test.level.Rank()
+		if got != test.want {
+			t.Errorf("%v.Rank() = %v; want %v", test.level, got, test.want)
+		}
+	}
+}

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -165,6 +165,8 @@ func formatReproLevel(l dashapi.ReproLevel) string {
 	case dashapi.ReproLevelSyz:
 		return "syz"
 	case dashapi.ReproLevelC:
+		return "syz, C"
+	case dashapi.ReproLevelCOnly:
 		return "C"
 	default:
 		return ""

--- a/pkg/html/html_test.go
+++ b/pkg/html/html_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package html
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/dashboard/dashapi"
+)
+
+func TestFormatReproLevel(t *testing.T) {
+	tests := []struct {
+		level dashapi.ReproLevel
+		want  string
+	}{
+		{dashapi.ReproLevelNone, ""},
+		{dashapi.ReproLevelSyz, "syz"},
+		{dashapi.ReproLevelC, "syz, C"},
+		{dashapi.ReproLevelCOnly, "C"},
+	}
+
+	for _, test := range tests {
+		got := formatReproLevel(test.level)
+		if got != test.want {
+			t.Errorf("formatReproLevel(%v) = %q; want %q", test.level, got, test.want)
+		}
+	}
+}

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -409,12 +409,11 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 		{"kernel branch", req.KernelBranch != "" || req.Type != dashapi.JobTestPatch},
 		{"kernel config", len(req.KernelConfig) != 0},
 		{"syzkaller commit", req.SyzkallerCommit != ""},
-		// We either want a normal repro (with options and syz repro text)
-		// or it's a boot time bug, in which case both are empty.
+		// We either want a normal repro (with options and syz/C repro text)
+		// or it's a boot time bug, in which case all are empty.
 		{
 			name: "reproducer consistency",
-			ok: (len(req.ReproOpts) != 0 && len(req.ReproSyz) != 0) ||
-				(len(req.ReproOpts) == 0 && len(req.ReproSyz) == 0),
+			ok:   (len(req.ReproOpts) != 0) == (len(req.ReproSyz) != 0 || len(req.ReproC) != 0),
 		},
 	}
 	for _, req := range required {


### PR DESCRIPTION
Introduce a new ReproLevel constant, ReproLevelCOnly, and transition the reproduction tracking logic to use capability-based getters (HasC and HasSyz) instead of direct comparisons.

This allows bugs to be associated with standalone C reproducers independently of Syz reproducers, enabling bisection, patch testing, and retesting of such bugs. We relax bisection eligibility and reproducer consistency checks to support this flow.

All tests in dashboard/app and syz-ci are updated to cover the new decoupled behavior and confirm database backwards compatibility.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
