### PR TITLE
syz-ci: limit local data exposed to kernel builds

### DIFF
--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -14,7 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/syzkaller/pkg/debugtracer"
@@ -124,8 +124,7 @@ func (linux) createImage(params Params, kernelPath string) error {
 	}
 	cmd := osutil.Command(scriptFile, params.UserspaceDir, kernelPath, params.TargetArch)
 	cmd.Dir = tempDir
-	cmd.Env = slices.Clone(os.Environ())
-	cmd.Env = append(cmd.Env,
+	cmd.Env = buildEnv(
 		"SYZ_VM_TYPE="+params.VMType,
 		"SYZ_CMDLINE_FILE="+osutil.Abs(params.CmdlineFile),
 		"SYZ_SYSCTL_FILE="+osutil.Abs(params.SysctlFile),
@@ -165,12 +164,11 @@ func runMake(params Params, extraArgs ...string) error {
 		return err
 	}
 	cmd.Dir = params.KernelDir
-	cmd.Env = slices.Clone(os.Environ())
 	// This makes the build [more] deterministic:
 	// 2 builds from the same sources should result in the same vmlinux binary.
 	// Build on a release commit and on the previous one should result in the same vmlinux too.
 	// We use it for detecting no-op changes during bisection.
-	cmd.Env = append(cmd.Env,
+	cmd.Env = buildEnv(
 		"KBUILD_BUILD_VERSION=0",
 		"KBUILD_BUILD_TIMESTAMP=now",
 		"KBUILD_BUILD_USER=syzkaller",
@@ -179,6 +177,41 @@ func runMake(params Params, extraArgs ...string) error {
 	output, err := osutil.Run(time.Hour, cmd)
 	params.Tracer.Logf("build log:\n%s", output)
 	return err
+}
+
+var buildEnvPrefixes = []string{
+	// keep-sorted start
+	"CARGO_HOME=",
+	"CCACHE_",
+	"HOME=",
+	"LANG",
+	"LC_",
+	"LOGNAME=",
+	"NOT_FOR_",
+	"PATH=",
+	"RUSTUP_HOME=",
+	"SOURCE_DATE_EPOCH",
+	"TEMP",
+	"TERM",
+	"TMP",
+	"USER=",
+	// keep-sorted end
+}
+
+func buildEnv(extra ...string) []string {
+	env := make([]string, 0, len(buildEnvPrefixes)+len(extra))
+	for _, value := range os.Environ() {
+		if _, _, ok := strings.Cut(value, "="); !ok {
+			continue
+		}
+		for _, prefix := range buildEnvPrefixes {
+			if strings.HasPrefix(value, prefix) {
+				env = append(env, value)
+				break
+			}
+		}
+	}
+	return append(env, extra...)
 }
 
 func LinuxMakeArgs(target *targets.Target, compiler, linker, ccache, buildDir string, jobs int) []string {

--- a/pkg/build/linux_test.go
+++ b/pkg/build/linux_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,6 +40,35 @@ func TestQueryLinuxCompiler(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected an error, got none")
 	}
+}
+
+func TestBuildEnvFiltersUnexpectedVariables(t *testing.T) {
+	t.Setenv("CARGO_HOME", "/tmp/cargo")
+	t.Setenv("CCACHE_COMPILERCHECK", "content")
+	t.Setenv("LANGUAGE", "en_US")
+	t.Setenv("LC_SYZ_TEST", "C")
+	t.Setenv("NOT_FOR_TEST", "1")
+	t.Setenv("RUSTUP_HOME", "/tmp/rustup")
+	t.Setenv("SOURCE_DATE_EPOCH", "1")
+	t.Setenv("TMPDIR", "/tmp/syzkaller")
+	t.Setenv("CARGO_HOME_TOKEN", "secret")
+	t.Setenv("SYZ_BUILD_ENV_SECRET", "secret")
+	t.Setenv("USER_TOKEN", "secret")
+
+	env := buildEnv("SYZ_VM_TYPE=qemu")
+
+	require.Contains(t, env, "CARGO_HOME=/tmp/cargo")
+	require.Contains(t, env, "CCACHE_COMPILERCHECK=content")
+	require.Contains(t, env, "LANGUAGE=en_US")
+	require.Contains(t, env, "LC_SYZ_TEST=C")
+	require.Contains(t, env, "NOT_FOR_TEST=1")
+	require.Contains(t, env, "RUSTUP_HOME=/tmp/rustup")
+	require.Contains(t, env, "SOURCE_DATE_EPOCH=1")
+	require.Contains(t, env, "TMPDIR=/tmp/syzkaller")
+	require.Contains(t, env, "SYZ_VM_TYPE=qemu")
+	require.NotContains(t, env, "CARGO_HOME_TOKEN=secret")
+	require.NotContains(t, env, "SYZ_BUILD_ENV_SECRET=secret")
+	require.NotContains(t, env, "USER_TOKEN=secret")
 }
 
 func enumerateFlags(t *testing.T, flags, allFlags []string) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,9 +37,13 @@ func LoadData(data []byte, cfg any) error {
 }
 
 func SaveFile(filename string, cfg any) error {
+	return SaveFileMode(filename, cfg, osutil.DefaultFilePerm)
+}
+
+func SaveFileMode(filename string, cfg any, perm os.FileMode) error {
 	data, err := json.MarshalIndent(cfg, "", "\t")
 	if err != nil {
 		return err
 	}
-	return osutil.WriteFile(filename, data)
+	return osutil.WriteFileMode(filename, data, perm)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveFileMode(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "config.json")
+	err := os.WriteFile(file, []byte("{}"), 0644)
+	require.NoError(t, err)
+
+	err = SaveFileMode(file, map[string]string{"key": "value"}, 0600)
+	require.NoError(t, err)
+
+	info, err := os.Stat(file)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	var cfg map[string]string
+	err = LoadFile(file, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"key": "value"}, cfg)
+}

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -256,6 +257,46 @@ func MkdirAll(dir string) error {
 
 func WriteFile(filename string, data []byte) error {
 	return os.WriteFile(filename, data, DefaultFilePerm)
+}
+
+func WriteFileMode(filename string, data []byte, perm os.FileMode) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(filename), "."+filepath.Base(filename)+".tmp.")
+	if err != nil {
+		return err
+	}
+	tmpName := tmpFile.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(perm); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		if runtime.GOOS != "windows" {
+			return err
+		}
+		// Windows does not replace an existing destination in os.Rename.
+		// Remove the old file after the new file has the requested mode.
+		if removeErr := os.Remove(filename); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+			return removeErr
+		}
+		if err := os.Rename(tmpName, filename); err != nil {
+			return err
+		}
+	}
+	removeTmp = false
+	return nil
 }
 
 // WriteFileAtomically writes data to file filename without exposing and empty/partially-written file.

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -612,7 +612,7 @@ func (mgr *Manager) writeConfig(buildTag string) (string, error) {
 		return "", fmt.Errorf("bad manager config: %w", err)
 	}
 	configFile := filepath.Join(mgr.currentDir, "manager.cfg")
-	if err := config.SaveFile(configFile, mgrcfg); err != nil {
+	if err := config.SaveFileMode(configFile, mgrcfg, 0600); err != nil {
 		return "", err
 	}
 	return configFile, nil


### PR DESCRIPTION
This hardens syz-ci against accidental exposure of local runner state during kernel builds.

Kernel builds execute code from the checked-out kernel tree. This PR avoids forwarding the full syz-ci process environment to Linux build commands and writes generated manager configs with owner-only permissions, since those configs can contain dashboard or hub credentials.

Changes:
- pass only a small allowlist of build-related environment variables plus explicit syzkaller build variables to Linux image/build commands
- add SaveFileMode/WriteFileMode helpers that enforce the requested mode even for existing files
- write syz-ci generated manager.cfg with 0600 permissions
- add regression tests for env filtering and mode enforcement

Tests:
- go test ./pkg/build ./pkg/config ./pkg/osutil ./syz-ci
