### PR TITLE
pkg/aflow/action/crash: pass TargetArch in RunCReproFunc

### DIFF
--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -11,6 +11,7 @@ import (
 )
 
 type RunCReproArgs struct {
+	TargetArch      string
 	Syzkaller       string
 	Image           string
 	Type            string
@@ -40,6 +41,9 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	if args.FormattedReproC == "" {
 		return RunCReproResult{}, fmt.Errorf("no C reproducer provided")
 	}
+	if args.TargetArch == "" {
+		return RunCReproResult{}, fmt.Errorf("TargetArch must not be empty")
+	}
 
 	workdir, err := ctx.TempDir()
 	if err != nil {
@@ -47,6 +51,7 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	}
 
 	reproduceArgs := ReproduceArgs{
+		TargetArch:   args.TargetArch,
 		Syzkaller:    args.Syzkaller,
 		Image:        args.Image,
 		Type:         args.Type,


### PR DESCRIPTION
Add TargetArch to RunCReproArgs and propagate it to ReproduceArgs. This ensures that the reproduction step correctly locates the compiled kernel image for the target guest architecture.

This is a follow-up to aff979495 ('pkg/aflow: support dynamic target architectures'), which introduced dynamic architectures but omitted this propagation path in RunCReproFunc.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
