### PR TITLE
tools/clang/codesearch: fix tracking context for global variable initializers

### DIFF
--- a/pkg/codesearch/testdata/query-find-references-global-init
+++ b/pkg/codesearch/testdata/query-find-references-global-init
@@ -1,0 +1,9 @@
+find-references refs.c global_init_target "" 1 10
+
+global_init_target has 1 references:
+
+global_variable my_global_ops takes-address-of it at refs.c:45
+  44:	struct global_ops my_global_ops[] = {
+  45:	    {.prep = global_init_target}};
+
+

--- a/pkg/codesearch/testdata/refs.c
+++ b/pkg/codesearch/testdata/refs.c
@@ -32,3 +32,14 @@ void long_func_with_ref()
 	refs0();
 	refs1();
 }
+
+struct global_ops {
+	void (*prep)(void);
+};
+
+void global_init_target(void)
+{
+}
+
+struct global_ops my_global_ops[] = {
+    {.prep = global_init_target}};

--- a/pkg/codesearch/testdata/refs.c.json
+++ b/pkg/codesearch/testdata/refs.c.json
@@ -1,6 +1,16 @@
 {
 	"definitions": [
 		{
+			"name": "global_init_target",
+			"type": "void (void)",
+			"kind": "function",
+			"body": {
+				"file": "refs.c",
+				"start_line": 40,
+				"end_line": 42
+			}
+		},
+		{
 			"name": "long_func_with_ref",
 			"type": "void ()",
 			"kind": "function",
@@ -146,6 +156,46 @@
 					"kind": "takes-address-of",
 					"entity_kind": "function",
 					"line": 20
+				}
+			]
+		},
+		{
+			"name": "global_ops",
+			"kind": "struct",
+			"body": {
+				"file": "refs.c",
+				"start_line": 36,
+				"end_line": 38
+			},
+			"fields": [
+				{
+					"name": "prep",
+					"offset": 0,
+					"size": 64
+				}
+			]
+		},
+		{
+			"name": "my_global_ops",
+			"type": "struct global_ops[1]",
+			"kind": "global_variable",
+			"body": {
+				"file": "refs.c",
+				"start_line": 44,
+				"end_line": 45
+			},
+			"refs": [
+				{
+					"name": "global_ops",
+					"kind": "uses",
+					"entity_kind": "struct",
+					"line": 44
+				},
+				{
+					"name": "global_init_target",
+					"kind": "takes-address-of",
+					"entity_kind": "function",
+					"line": 45
 				}
 			]
 		}

--- a/tools/clang/codesearch/codesearch.cpp
+++ b/tools/clang/codesearch/codesearch.cpp
@@ -232,6 +232,8 @@ bool Indexer::VisitDeclRefExpr(const DeclRefExpr* DeclRef) {
 }
 
 bool Indexer::TraverseVarDecl(VarDecl* Decl) {
+  ScopedState<SourceLocation> Scoped(&TypeRefingLocation, Decl->getBeginLoc());
+
   if (Decl->isFileVarDecl() && Decl->isThisDeclarationADefinition() == VarDecl::Definition) {
     // Preserves whether this variable can be referenced from other translation
     // units. A static global (internal linkage) is only referenceable within
@@ -239,9 +241,13 @@ bool Indexer::TraverseVarDecl(VarDecl* Decl) {
     // referenced from anywhere in the kernel.
     const bool IsInternalLinkage = Decl->getStorageClass() == SC_Static;
     NamedDeclEmitter Emitter(this, Decl, EntityKindGlobalVariable, Decl->getType().getAsString(), IsInternalLinkage);
+    // We must return here to trigger the base traversal before this if-block
+    // ends. Otherwise, the Emitter's destructor will run and clear the tracking
+    // context, causing references to functions inside global arrays to be
+    // silently dropped.
+    return Base::TraverseVarDecl(Decl);
   }
 
-  ScopedState<SourceLocation> Scoped(&TypeRefingLocation, Decl->getBeginLoc());
   return Base::TraverseVarDecl(Decl);
 }
 


### PR DESCRIPTION
Fix a bug in the AST traversal where references to functions inside global variable initializers were being silently dropped from the codesearch database by moving the base traversal call inside the `if` block. This ensures the base traversal occurs while the `NamedDeclEmitter` is still alive in scope, allowing references in global variable initializers (like kernel operation tables) to be properly captured and indexed.

## Current behaviour

When the `codesearch-find-references` tool was queried for the function `io_epoll_ctl_prep` (which is assigned to `.prep` inside the global `io_issue_defs` array in `io_uring/opdef.c`), 

```cpp
// io_uring/opdef.c
const struct io_issue_def io_issue_defs[] = {
    // ...
	[IORING_OP_EPOLL_CTL] = {
		.unbound_nonreg_file	= 1,
		.audit_skip		= 1,
#if defined(CONFIG_EPOLL)
		.prep			= io_epoll_ctl_prep,  // <--- The missing reference!
		.issue			= io_epoll_ctl,
#else
        // ...
#endif
	},
    // ...
};
```

the query returned `null` references:
```
{
  "ContextFile": "io_uring/epoll.c",
  "Name": "io_epoll_ctl_prep",
  ...
} -> {"References": null, "TruncatedOutput": false}
```

## Expected behaviour

```
io_epoll_ctl_prep has 1 references:

global_variable io_issue_defs takes-address-of it at io_uring/opdef.c:317
 312:           },
 313:           [IORING_OP_EPOLL_CTL] = {
 314:                   .unbound_nonreg_file    = 1,
 315:                   .audit_skip             = 1,
 316:   #if defined(CONFIG_EPOLL)
 317:                   .prep                   = io_epoll_ctl_prep,
 318:                   .issue                  = io_epoll_ctl,
 319:   #else
 320:                   .prep                   = io_eopnotsupp_prep,
 321:   #endif
 322:           },
```