### PR TITLE
dashboard: add TargetArch dropdown for repro-c jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -64,9 +64,13 @@ type ManualWorkflowField struct {
 	DefaultValue string
 	Required     bool
 	Hidden       bool
+	Options      []string
 }
 
 func manualAIWorkflows(cfg *Config) []ManualWorkflowSpec {
+	if cfg == nil || cfg.AI == nil {
+		return nil
+	}
 	defaultRepo, defaultBranch := cfg.mainRepoBranch()
 	ret := []ManualWorkflowSpec{
 		{
@@ -137,8 +141,15 @@ func manualAIWorkflows(cfg *Config) []ManualWorkflowSpec {
 			},
 			ManualWorkflowField{
 				ID:           "TargetArch",
+				Title:        "Target Arch",
 				DefaultValue: targets.AMD64,
-				Hidden:       true,
+				Required:     true,
+				Hidden:       ret[i].Type != ai.WorkflowReproC,
+				// syz-agent does not support other arches at the moment.
+				Options: []string{
+					targets.AMD64,
+					targets.ARM64,
+				},
 			},
 		)
 	}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1039,6 +1039,7 @@ func TestAIManualJobCreate(t *testing.T) {
 		"KernelCommit":   []string{"123456"},
 		"KernelConfig":   []string{".config"},
 		"BugDescription": []string{"test bug"},
+		"TargetArch":     []string{"amd64"},
 	})
 	require.NoError(t, err)
 	require.Contains(t, string(body), "Kernel repo git address is required")
@@ -1049,6 +1050,7 @@ func TestAIManualJobCreate(t *testing.T) {
 		"KernelCommit":   []string{""},
 		"KernelConfig":   []string{".config"},
 		"BugDescription": []string{"test bug"},
+		"TargetArch":     []string{"amd64"},
 	})
 	require.NoError(t, err)
 	require.Contains(t, string(body), "Kernel Commit Hash or branch name is required")
@@ -1058,6 +1060,7 @@ func TestAIManualJobCreate(t *testing.T) {
 		"KernelRepo":     []string{"https://repo.test"},
 		"KernelCommit":   []string{"123456"},
 		"BugDescription": []string{"test bug"},
+		"TargetArch":     []string{"amd64"},
 	})
 	require.NoError(t, err)
 	require.Contains(t, string(body), "either a custom kernel config or a manager is required")
@@ -1068,6 +1071,7 @@ func TestAIManualJobCreate(t *testing.T) {
 		"KernelCommit":   []string{"123456"},
 		"KernelConfig":   []string{"test config"},
 		"BugDescription": []string{"test bug"},
+		"TargetArch":     []string{"amd64"},
 	})
 	require.NoError(t, err)
 	require.Contains(t, string(body), "AI workflow repro-c is created")
@@ -1303,4 +1307,9 @@ func TestAIJobRestart(t *testing.T) {
 	require.Error(t, err)
 	c.expectBadReqest(err)
 	require.Contains(t, err.Error(), "cannot restart a patch iteration workflow")
+}
+
+func TestManualAIWorkflows(t *testing.T) {
+	assert.Nil(t, manualAIWorkflows(nil))
+	assert.Nil(t, manualAIWorkflows(&Config{}))
 }

--- a/dashboard/app/templates/ai_jobs.html
+++ b/dashboard/app/templates/ai_jobs.html
@@ -36,9 +36,17 @@ List of AI jobs page.
 					{{range $field := $spec.Fields}}
 						{{if not $field.Hidden}}
 							<label for="{{$spec.Name}}-{{$field.ID}}">{{$field.Title}}{{if $field.Required}}*{{end}}:</label><br>
-							<textarea name="{{$field.ID}}" id="{{$spec.Name}}-{{$field.ID}}" rows="4" cols="60"
-								placeholder="{{$field.Placeholder}}" {{if $field.Required}}required{{end}} disabled
-								>{{$field.DefaultValue}}</textarea>
+							{{if $field.Options}}
+								<select name="{{$field.ID}}" id="{{$spec.Name}}-{{$field.ID}}" {{if $field.Required}}required{{end}} disabled>
+									{{range $opt := $field.Options}}
+										<option value="{{$opt}}" {{if eq $opt $field.DefaultValue}}selected{{end}}>{{$opt}}</option>
+									{{end}}
+								</select>
+							{{else}}
+								<textarea name="{{$field.ID}}" id="{{$spec.Name}}-{{$field.ID}}" rows="4" cols="60"
+									placeholder="{{$field.Placeholder}}" {{if $field.Required}}required{{end}} disabled
+									>{{$field.DefaultValue}}</textarea>
+							{{end}}
 							<br><br>
 						{{end}}
 					{{end}}

--- a/pkg/html/pages/common.js
+++ b/pkg/html/pages/common.js
@@ -153,7 +153,7 @@ function showManualWorkflowFields(select) {
 
 	for (var i = 0; i < groups.length; i++) {
 		groups[i].style.display = "none";
-		var inputs = groups[i].querySelectorAll("input, textarea");
+		var inputs = groups[i].querySelectorAll("input, textarea, select");
 		for (var j = 0; j < inputs.length; j++) {
 			inputs[j].disabled = true;
 		}
@@ -163,7 +163,7 @@ function showManualWorkflowFields(select) {
 	var selected = document.getElementById("workflow-fields-" + workflowName);
 	if (selected) {
 		selected.style.display = "block";
-		var selectedInputs = selected.querySelectorAll("input, textarea");
+		var selectedInputs = selected.querySelectorAll("input, textarea, select");
 		for (var k = 0; k < selectedInputs.length; k++) {
 			selectedInputs[k].disabled = false;
 		}


### PR DESCRIPTION
Add a dropdown menu for selecting TargetArch when manually triggering a repro-c workflow from the UI. The dropdown lists all valid architectures with AMD64 selected by default.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
