### PR TITLE
pkg/vcs: dynamically bound commit search by date

### DIFF
--- a/pkg/bisect/bisect.go
+++ b/pkg/bisect/bisect.go
@@ -384,7 +384,7 @@ func (env *env) identifyRewrittenCommit() (string, error) {
 			"commit %v not reachable in branch '%v' and no commit title available",
 			cfg.Kernel.Commit, cfg.Kernel.Branch)
 	}
-	commit, err := env.repo.GetCommitByTitle(cfg.Kernel.CommitTitle)
+	commit, err := env.repo.GetCommitByTitle(cfg.Kernel.CommitTitle, time.Time{})
 	if err != nil {
 		return cfg.Kernel.Commit, err
 	}

--- a/pkg/bisect/bisect_test.go
+++ b/pkg/bisect/bisect_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/syzkaller/pkg/build"
 	"github.com/google/syzkaller/pkg/debugtracer"
@@ -92,7 +93,7 @@ func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collect
 
 	fixed := false
 	if env.test.fixCommit != "" {
-		commit, err := env.r.GetCommitByTitle(env.test.fixCommit)
+		commit, err := env.r.GetCommitByTitle(env.test.fixCommit, time.Time{})
 		if err != nil {
 			return ret, err
 		}
@@ -101,7 +102,7 @@ func (env *testEnv) Test(numVMs int, reproSyz, reproOpts, reproC []byte, collect
 
 	introduced := true
 	if env.test.introduced != "" {
-		commit, err := env.r.GetCommitByTitle(env.test.introduced)
+		commit, err := env.r.GetCommitByTitle(env.test.introduced, time.Time{})
 		if err != nil {
 			return ret, err
 		}
@@ -208,7 +209,7 @@ func testBisection(t *testing.T, baseDir string, test BisectionTest) {
 	} else {
 		r.SwitchCommit("master")
 	}
-	sc, err := r.GetCommitByTitle(fmt.Sprint(test.startCommit))
+	sc, err := r.GetCommitByTitle(fmt.Sprint(test.startCommit), time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/vcs/fuchsia.go
+++ b/pkg/vcs/fuchsia.go
@@ -94,12 +94,12 @@ func (ctx *fuchsia) Commit(commit string) (*Commit, error) {
 	return ctx.repo.Commit(commit)
 }
 
-func (ctx *fuchsia) GetCommitByTitle(title string) (*Commit, error) {
-	return ctx.repo.GetCommitByTitle(title)
+func (ctx *fuchsia) GetCommitByTitle(title string, since time.Time) (*Commit, error) {
+	return ctx.repo.GetCommitByTitle(title, since)
 }
 
-func (ctx *fuchsia) GetCommitsByTitles(titles []string) ([]*Commit, []string, error) {
-	return ctx.repo.GetCommitsByTitles(titles)
+func (ctx *fuchsia) GetCommitsByTitles(titles []string, since time.Time) ([]*Commit, []string, error) {
+	return ctx.repo.GetCommitsByTitles(titles, since)
 }
 
 func (ctx *fuchsia) ExtractFixTagsFromCommits(baseCommit, email string) ([]*Commit, error) {

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -341,8 +341,8 @@ func gitParseCommit(output, user, domain []byte, ignoreCC map[string]bool) (*Com
 	return com, nil
 }
 
-func (git *gitRepo) GetCommitByTitle(title string) (*Commit, error) {
-	commits, _, err := git.GetCommitsByTitles([]string{title})
+func (git *gitRepo) GetCommitByTitle(title string, since time.Time) (*Commit, error) {
+	commits, _, err := git.GetCommitsByTitles([]string{title}, since)
 	if err != nil || len(commits) == 0 {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ const (
 	fetchCommitsMaxAgeInYears = 5
 )
 
-func (git *gitRepo) GetCommitsByTitles(titles []string) ([]*Commit, []string, error) {
+func (git *gitRepo) GetCommitsByTitles(titles []string, since time.Time) ([]*Commit, []string, error) {
 	var greps []string
 	m := make(map[string]string)
 	for _, title := range titles {
@@ -361,8 +361,11 @@ func (git *gitRepo) GetCommitsByTitles(titles []string) ([]*Commit, []string, er
 		greps = append(greps, canonical)
 		m[canonical] = title
 	}
-	since := time.Now().Add(-time.Hour * 24 * 365 * fetchCommitsMaxAgeInYears).Format("01-02-2006")
-	commits, err := git.fetchCommits(since, HEAD, "", "", greps, true)
+	if since.IsZero() {
+		since = time.Now().AddDate(-fetchCommitsMaxAgeInYears, 0, 0)
+	}
+	sinceStr := since.Format("01-02-2006")
+	commits, err := git.fetchCommits(sinceStr, HEAD, "", "", greps, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -415,7 +418,7 @@ func (git *gitRepo) ExtractFixTagsFromCommits(baseCommit, emailStr string) ([]*C
 		return nil, fmt.Errorf("failed to parse email %q: %w", emailStr, err)
 	}
 	grep := user + "+.*" + domain
-	since := time.Now().Add(-time.Hour * 24 * 365 * fetchCommitsMaxAgeInYears).Format("01-02-2006")
+	since := time.Now().AddDate(-fetchCommitsMaxAgeInYears, 0, 0).Format("01-02-2006")
 	return git.fetchCommits(since, baseCommit, user, domain, []string{grep}, false)
 }
 

--- a/pkg/vcs/git_repo_test.go
+++ b/pkg/vcs/git_repo_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/stretchr/testify/assert"
@@ -166,7 +167,7 @@ func TestMetadata(t *testing.T) {
 			if title == "" {
 				continue
 			}
-			com, err := repo.repo.GetCommitByTitle(title)
+			com, err := repo.repo.GetCommitByTitle(title, time.Time{})
 			if err != nil {
 				t.Error(err)
 			} else if com == nil {

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -187,7 +187,7 @@ func TestGetCommitsByTitles(t *testing.T) {
 	repo.Git("commit", "--no-edit", "--allow-empty", "-m", "abc")
 	repo.Git("commit", "--no-edit", "--allow-empty", "-m", "target")
 	commitA, _ := repo.repo.Commit(HEAD)
-	results, missing, err := repo.repo.GetCommitsByTitles([]string{"target"})
+	results, missing, err := repo.repo.GetCommitsByTitles([]string{"target"}, time.Time{})
 	validateSuccess(commitA, results, missing, err)
 
 	// Put another commit with the title we search for in another branch.
@@ -195,12 +195,12 @@ func TestGetCommitsByTitles(t *testing.T) {
 	repo.Git("checkout", "-b", "branch-b")
 	repo.Git("commit", "--no-edit", "--allow-empty", "-m", "target")
 	repo.Git("checkout", "branch-a")
-	results, missing, err = repo.repo.GetCommitsByTitles([]string{"target"})
+	results, missing, err = repo.repo.GetCommitsByTitles([]string{"target"}, time.Time{})
 	validateSuccess(commitA, results, missing, err)
 
 	// We expect GetCommitsByTitles to only find commits in the current branch.
 	repo.Git("checkout", "branch-b")
-	results, missing, err = repo.repo.GetCommitsByTitles([]string{"xyz"})
+	results, missing, err = repo.repo.GetCommitsByTitles([]string{"xyz"}, time.Time{})
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}

--- a/pkg/vcs/linux_patches.go
+++ b/pkg/vcs/linux_patches.go
@@ -57,7 +57,9 @@ func BackportCommits(repo Repo, commits []BackportCommit, remoteRepoURL string) 
 		if err != nil {
 			return applied, fmt.Errorf("fix commit %s not found: %w", info.FixHash, err)
 		}
-		fixCommit, err := repo.GetCommitByTitle(fixCommitOrig.Title)
+		// The default commit date range limit in GetCommitByTitle may not be enough
+		// for old backports, so we set a custom cut-off date.
+		fixCommit, err := repo.GetCommitByTitle(fixCommitOrig.Title, fixCommitOrig.CommitDate.AddDate(-1, 0, 0))
 		if err != nil {
 			return applied, err
 		}

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -48,11 +48,15 @@ type Repo interface {
 	// GetCommitByTitle finds commit info by the title. If the commit is not found, nil is returned.
 	// Remote is not fetched and only commits reachable from the checked out HEAD are searched
 	// (e.g. do CheckoutBranch before).
-	GetCommitByTitle(title string) (*Commit, error)
+	// The search is limited to commits starting from the 'since' time. If 'since' is the zero
+	// value, a default limit of 5 years is used.
+	GetCommitByTitle(title string, since time.Time) (*Commit, error)
 
 	// GetCommitsByTitles is a batch version of GetCommitByTitle.
 	// Returns list of commits and titles of commits that are not found.
-	GetCommitsByTitles(titles []string) ([]*Commit, []string, error)
+	// The search is limited to commits starting from the 'since' time. If 'since' is the zero
+	// value, a default limit of 5 years is used.
+	GetCommitsByTitles(titles []string, since time.Time) ([]*Commit, []string, error)
 
 	// ExtractFixTagsFromCommits extracts fixing tags for bugs from git log.
 	// Given email = "user@domain.com", it searches for tags of the form "user+tag@domain.com"

--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -265,7 +265,7 @@ func (jp *JobProcessor) getCommitInfo(mgr *Manager, URL, branch string, commits 
 	if _, err = repo.CheckoutBranch(URL, branch); err != nil {
 		return nil, fmt.Errorf("failed to checkout kernel repo %v/%v: %w", URL, branch, err)
 	}
-	results, missing, err := repo.GetCommitsByTitles(commits)
+	results, missing, err := repo.GetCommitsByTitles(commits, time.Time{})
 	if err != nil {
 		return nil, err
 	}

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -714,7 +714,7 @@ func (mgr *Manager) pollCommits(buildCommit string) ([]string, []dashapi.Commit,
 
 	var present []string
 	if len(pendingCommits) != 0 {
-		commits, _, err := mgr.repo.GetCommitsByTitles(pendingCommits)
+		commits, _, err := mgr.repo.GetCommitsByTitles(pendingCommits, time.Time{})
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Update GetCommitByTitle to accept a `since` parameter to dynamically bound the git log search.

Currently, git log searches are hardcoded to a 5-year limit for performance, which causes the system to miss older fix backports and erroneously attempt to cherry-pick them again. This breaks bisections with errors such as:

failed building 49e02880ec0a8c378e811bc9d85da188d7c6204c: failed to run ["git" "-c" "core.hooksPath=/dev/null" "cherry-pick" "--no-commit" "1d489151e9f9d1647110277ff77282fe4d96d09b"]: exit status 1.

Fix this by passing a custom cut-off date when searching for Linux backports, set to 1 year before the original upstream commit date. All other callers continue to use the 5-year default.