### PR TITLE
dashboard/app: add optional ExternalBugID to AI jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -64,6 +64,7 @@ type ManualWorkflowField struct {
 	DefaultValue string
 	Required     bool
 	Hidden       bool
+	IsDBColumn   bool
 	Options      []string
 }
 
@@ -151,6 +152,12 @@ func manualAIWorkflows(cfg *Config) []ManualWorkflowSpec {
 					targets.ARM64,
 				},
 			},
+			ManualWorkflowField{
+				ID:          "ExternalBugID",
+				Title:       "External Bug ID",
+				Placeholder: "e.g. b/12345",
+				IsDBColumn:  true,
+			},
 		)
 	}
 	return ret
@@ -217,6 +224,7 @@ type uiAIJob struct {
 	Workflow         string
 	Description      string
 	DescriptionLink  string
+	ExternalBugID    string
 	AgentName        string
 	Created          time.Time
 	Started          time.Time
@@ -409,13 +417,19 @@ func handleAIJobCreate(ctx context.Context, r *http.Request, hdr *uiHeader) erro
 		if field.Required && val == "" {
 			return fmt.Errorf("%w: %v is required", ErrClientBadRequest, field.Title)
 		}
+		if field.IsDBColumn {
+			continue
+		}
 		args[field.ID] = val
 	}
+
+	externalBugID := strings.TrimSpace(r.FormValue("ExternalBugID"))
 	_, err := aidb.CreateJob(ctx, &aidb.Job{
-		Type:      spec.Type,
-		Workflow:  workflow,
-		Namespace: hdr.Namespace,
-		Args:      spanner.NullJSON{Valid: true, Value: args},
+		Type:          spec.Type,
+		Workflow:      workflow,
+		Namespace:     hdr.Namespace,
+		ExternalBugID: spanner.NullString{StringVal: externalBugID, Valid: externalBugID != ""},
+		Args:          spanner.NullJSON{Valid: true, Value: args},
 	})
 	return err
 }
@@ -985,6 +999,7 @@ func makeUIAIJob(job *aidb.Job) *uiAIJob {
 		Workflow:         job.Workflow,
 		Description:      desc,
 		DescriptionLink:  job.Link,
+		ExternalBugID:    job.ExternalBugID.StringVal,
 		AgentName:        nullString(job.AgentName),
 		Created:          job.Created,
 		Started:          nullTime(job.Started),

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -46,11 +46,12 @@ type Agent struct {
 }
 
 type Job struct {
-	ID        string
-	Type      ai.WorkflowType
-	Workflow  string
-	Namespace string
-	BugID     spanner.NullString // set if the job related to some bug
+	ID            string
+	Type          ai.WorkflowType
+	Workflow      string
+	Namespace     string
+	BugID         spanner.NullString // set if the job related to some bug
+	ExternalBugID spanner.NullString // set if manually provided via UI
 	// Arbitrary description/link shown in the UI list of jobs.
 	Description       string
 	Link              string

--- a/dashboard/app/aidb/migrations/19_add_external_bug_id.down.sql
+++ b/dashboard/app/aidb/migrations/19_add_external_bug_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX JobExternalBugID;
+ALTER TABLE Jobs DROP COLUMN ExternalBugID;

--- a/dashboard/app/aidb/migrations/19_add_external_bug_id.up.sql
+++ b/dashboard/app/aidb/migrations/19_add_external_bug_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Jobs ADD COLUMN ExternalBugID STRING(1000);
+CREATE INDEX JobExternalBugID ON Jobs(Namespace, ExternalBugID, Created DESC);

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -16,7 +16,8 @@ Detailed info on a single AI job execution.
 	{{template "header" .Header}}
 	{{template "ai_job_list" .Jobs}}
 
-	<b>Agent:</b> {{if .Job.AgentName}}{{.Job.AgentName}}{{else}}---{{end}}<br><br>
+	<b>Agent:</b> {{if .Job.AgentName}}{{.Job.AgentName}}{{else}}---{{end}}<br>
+	<b>External Bug ID:</b> {{if .Job.ExternalBugID}}{{.Job.ExternalBugID}}{{else}}---{{end}}<br><br>
 
 	{{if .CanRestart}}
 	<form method="POST" class="restart-form">

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -737,6 +737,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Workflow', textSort)" href="#">Workflow</a></th>
 		<th><a onclick="return sortTable(this, 'Result', textSort)" href="#">Result</a></th>
 		<th><a onclick="return sortTable(this, 'Correct', textSort)" href="#">Correct</a></th>
+		<th><a onclick="return sortTable(this, 'Ext Bug ID', textSort)" href="#">Ext Bug ID</a></th>
 		<th><a onclick="return sortTable(this, 'Bug', textSort)" href="#">Bug</a></th>
 		<th><a onclick="return sortTable(this, 'Created', textSort)" href="#">Created</a></th>
 		<th><a onclick="return sortTable(this, 'Started', textSort)" href="#">Started</a></th>
@@ -757,6 +758,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			{{end}}
 		</td>
 		<td class="ai_correct" title="{{$job.CorrectTitle}}">{{$job.Correct}}</td>
+		<td>{{$job.ExternalBugID}}</td>
 		<td class="title">{{link $job.DescriptionLink $job.Description}}</td>
 		<td>{{formatTime $job.Created}}</td>
 		<td>{{formatTime $job.Started}}</td>


### PR DESCRIPTION
Introduce an optional ExternalBugID field that can be populated when creating an AI job manually. The field is added to the Spanner schema and is parsed from the manual workflow UI.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
