### PR TITLE
syz-cluster: compact the web interface

### DIFF
--- a/syz-cluster/dashboard/static/style.css
+++ b/syz-cluster/dashboard/static/style.css
@@ -1,0 +1,24 @@
+body {
+  font-size: 0.9rem;
+}
+
+.patch-subject {
+  font-family: monospace;
+}
+
+.navbar {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.table td, .table th {
+  padding: 0.3rem 0.75rem;
+}
+
+.btn-collapse::after {
+  content: "\25BC"; /* DOWN-POINTING TRIANGLE */
+}
+
+.btn-collapse[aria-expanded="true"]::after {
+  content: "\25B2"; /* UP-POINTING TRIANGLE */
+}

--- a/syz-cluster/dashboard/templates/base.html
+++ b/syz-cluster/dashboard/templates/base.html
@@ -4,12 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/style.css">
     <script src="/static/jquery-3.7.1.min.js"></script>
     <script src="/static/bootstrap.bundle.min.js"></script>
     <title>{{.Title}}</title>
   </head>
   <body>
-    <nav class="navbar navbar-light navbar-expand-lg bg-light justify-content-start">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light justify-content-start border-bottom">
       <a class="navbar-brand px-3" href="#">{{.Title}}</a>
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav">

--- a/syz-cluster/dashboard/templates/index.html
+++ b/syz-cluster/dashboard/templates/index.html
@@ -59,7 +59,7 @@
     </nav>
     {{end}}
 
-    <table class="table">
+    <table class="table table-sm table-striped table-hover mt-3 border-top">
       <thead class="thead-light">
         <tr>
           <th scope="col">Published</th>
@@ -73,7 +73,7 @@
         {{range .List}}
         <tr>
           <td>{{.Series.PublishedAt.Format "2006-01-02 15:04 MST"}}</td>
-          <td><a href="/series/{{.Series.ID}}">{{.Series.Title}}</a></td>
+          <td class="patch-subject"><a href="/series/{{.Series.ID}}">{{.Series.Title}}</a></td>
           <td>{{.Series.Version}}</td>
           <td>{{.Series.AuthorEmail}}</td>
           <td>

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -1,12 +1,4 @@
 {{define "content"}}
-<style>
-  .btn-collapse::after {
-      content: " \25BC"; /* DOWN-POINTING TRIANGLE */
-  }
-  .btn-collapse[aria-expanded="true"]::after {
-      content: " \25B2"; /* UP-POINTING TRIANGLE */
-  }
-</style>
     <!-- Modal -->
     <div class="modal fade" tabindex="-1" id="contentModal" role="dialog" aria-labelledby="contentModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-lg" role="document">
@@ -43,13 +35,12 @@
       });
     </script>
 
-    <div class="container">
-        <h2>Patch Series</h2>
+    <div class="container-fluid px-3 mt-3">
         <table class="table table-bordered table-sm">
             <tbody>
                 <tr>
                     <th>Subject</th>
-                    <td><a href="{{.Link}}">{{.Title}}</a></td>
+                    <td class="patch-subject"><a href="{{.Link}}">{{.Title}}</a></td>
                 </tr>
                 <tr>
                     <th>Author</th>
@@ -83,8 +74,8 @@
             </tbody>
         </table>
 
-        <h3>Patches ({{.TotalPatches}})</h3>
-        <table class="table table-striped">
+        <h5 class="mt-3">Patches ({{.TotalPatches}})</h5>
+        <table class="table table-striped table-sm">
             <thead>
                 <tr>
                     <th>Name</th>
@@ -95,22 +86,22 @@
                 {{$data := .}} 
                 {{range .Patches}}
                 <tr>
-                    <td><a href="{{.Link}}">{{.Title}}</a></td>
+                    <td class="patch-subject"><a href="{{.Link}}">{{.Title}}</a></td>
                     <td><a href="/patches/{{.ID}}" class="modal-link-raw">[Body]</a></td>
                 </tr>
                 {{end}}
            </tbody>
         </table>
         {{range .Sessions}}
-        <div class="card mb-3">
-            <div class="card-header d-flex justify-content-between align-items-center">
+        <div class="card mb-2">
+            <div class="card-header d-flex justify-content-between align-items-center py-1">
                 <div>
-                    <h5 class="mb-0">
+                    <h6 class="mb-0">
                         Session {{.CreatedAt.Format "2006-01-02"}}
                         {{if .Job}}
                             <span class="badge bg-info text-dark">Job</span>
                         {{end}}
-                    </h5>
+                    </h6>
                     {{if .Job}}
                         <small class="text-muted">Job requested at: <a href="{{.JobLink}}" target="_blank">{{.JobLink}}</a></small>
                     {{end}}
@@ -149,7 +140,7 @@
                 {{end}}
             </tbody>
         </table>
-        <table class="table table-striped">
+        <table class="table table-striped table-sm">
             <thead>
                 <tr>
                     <th>Test</th>


### PR DESCRIPTION
Update the web dashboard to have a denser, more Linux-style layout. Introduce a style.css file for the custom CSS definitions.

***

The new dashboard can be seen locally e.g. by running

```
DOCKERARGS="-p 8082:8082" ./tools/syz-env go test -v ./syz-cluster/dashboard/ -run TestLocalUI -local-ui -local-ui-addr=:8082 -timeout=0
```