### PR TITLE
pkg/instance: detect crash kernel boots for dumps

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -52,6 +53,25 @@ type RunResult struct {
 	// It's populated after a crash if MemoryDump was enabled in RunOptions.
 	// Empty if no dump was extracted.
 	MemoryDump string
+}
+
+var crashKernelCmdlineRe = regexp.MustCompile(`(?i)command line:.*elfcorehdr=`)
+
+// CanExtractMemoryDump returns true if /proc/vmcore may be available in the VM.
+func CanExtractMemoryDump(rep *report.Report) bool {
+	return rep != nil && (rep.Panicked || crashKernelCmdlineAfterReport(rep))
+}
+
+func crashKernelCmdlineAfterReport(rep *report.Report) bool {
+	if rep.EndPos < 0 || rep.EndPos > len(rep.Output) {
+		return false
+	}
+	for _, line := range bytes.Split(rep.Output[rep.EndPos:], []byte{'\n'}) {
+		if crashKernelCmdlineRe.Match(line) {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -176,7 +196,7 @@ func (inst *ExecProgInstance) runCommand(command string, opts RunOptions) (*RunR
 
 func (inst *ExecProgInstance) extractDump(rep *report.Report,
 	opts RunOptions) (string, error) {
-	if rep == nil || !rep.Panicked {
+	if !CanExtractMemoryDump(rep) {
 		return "", nil
 	}
 	dumpPath, err := osutil.TempFileIn(opts.MemoryDumpDir, "syz-dump-*")

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/report"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -141,5 +142,42 @@ func TestRunnerCmd(t *testing.T) {
 
 	if got, want := *flagEnv, false; got != want {
 		t.Errorf("bad new-env: %t, want: %t", got, want)
+	}
+}
+
+func TestCanExtractMemoryDump(t *testing.T) {
+	tests := []struct {
+		name string
+		rep  *report.Report
+		want bool
+	}{
+		{
+			name: "no report",
+		},
+		{
+			name: "no panic",
+			rep:  &report.Report{},
+		},
+		{
+			name: "panic",
+			rep:  &report.Report{Panicked: true},
+			want: true,
+		},
+		{
+			name: "crash kernel command line",
+			rep: &report.Report{
+				Output: []byte("general protection fault\n" +
+					"Kernel command line: BOOT_IMAGE=/vmlinux elfcorehdr=123K"),
+				EndPos: len("general protection fault\n"),
+			},
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := CanExtractMemoryDump(test.rep); got != test.want {
+				t.Fatalf("CanExtractMemoryDump() = %v, want %v", got, test.want)
+			}
+		})
 	}
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -964,8 +964,9 @@ func (mgr *Manager) uploadReproAssets(repro *repro.Result) []dashapi.NewAsset {
 }
 
 func (mgr *Manager) extractMemoryDump(inst *vm.Instance, rep *report.Report) string {
-	if !rep.Panicked {
-		// We can only collect a memory dump from a kernel that panicked.
+	if !instance.CanExtractMemoryDump(rep) {
+		// We can only collect a memory dump after a panic, or after the crash
+		// kernel has booted far enough to expose /proc/vmcore.
 		return ""
 	}
 	if mgr.crashStore.HasMemoryDump(rep.Title) {


### PR DESCRIPTION
## Summary
Crashs like `general protection fault` may collect dump after the crash kernel has already booted. In that case the original `Kernel panic - not syncing` line may be missing from the saved report, so `rep.Panicked` is false even though `/proc/vmcore` is available.

Detect this case by looking for `elfcorehdr=` in the report output, which indicates that the crash kernel was booted.

## Changes
- Add a shared `CanExtractMemoryDump()` predicate.
- Make syz-manager and syz-execprog use the same check before extracting a dump.
- Add tests for `elfcorehdr=` dump detection.

## Testing
- `go test ./pkg/instance`