### PR TITLE
Revert "tools/clang: support clang-22"

### DIFF
--- a/tools/clang/build.go
+++ b/tools/clang/build.go
@@ -28,9 +28,6 @@ package clangtoolimpl
 //// The compiler will search in all of them in order, and pick the first
 //// that is actually present and contains files.
 //
-// #cgo CXXFLAGS: -I/usr/include/llvm-22 -I/usr/lib/llvm-22/include -I/usr/include/llvm-c-22
-// #cgo LDFLAGS: -L/usr/lib/llvm-22/lib
-//
 // #cgo CXXFLAGS: -I/usr/include/llvm-21 -I/usr/lib/llvm-21/include -I/usr/include/llvm-c-21
 // #cgo LDFLAGS: -L/usr/lib/llvm-21/lib
 //


### PR DESCRIPTION
This reverts commit a19d6d0824f5e7a9dd2b90d90635306f7c8d4ee5. Unfortunately the switch to Clang 22 broke declextract.cpp

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
