### PR TITLE
tools/clang/declextract: fix enum extraction for clang-22

### DIFF
--- a/tools/clang/declextract/declextract.cpp
+++ b/tools/clang/declextract/declextract.cpp
@@ -346,16 +346,9 @@ std::string Extractor::extractEnum(QualType QT, const EnumDecl* Decl) {
   if (Name.empty()) {
     // This is an unnamed enum declared with a typedef:
     //   typedef enum {...} enum_name;
-    auto Elaborated = dyn_cast<ElaboratedType>(QT.getTypePtr());
-    if (Elaborated) {
-      auto Typedef = dyn_cast<TypedefType>(Elaborated->getNamedType().getTypePtr());
-      if (Typedef)
-        Name = Typedef->getDecl()->getNameAsString();
-    }
-    // This is the code we will need for one of future versions (past 21).
-    // auto Typedef = dyn_cast<TypedefType>(QT.getTypePtr());
-    // if (Typedef)
-    //   Name = Typedef->getDecl()->getNameAsString();
+    auto Typedef = QT->getAs<TypedefType>();
+    if (Typedef)
+      Name = Typedef->getDecl()->getNameAsString();
     if (Name.empty()) {
       QT.dump();
       llvm::report_fatal_error("enum with empty name");


### PR DESCRIPTION
Adjust extractEnum to handle an AST API change in clang-22 where ElaboratedType is no longer used for unnamed enums declared with a typedef. Add conditional compilation based on CLANG_VERSION_MAJOR to maintain compatibility with clang-21 and older versions.