### PR TITLE
pkg/aflow: extract file-based code search tools

### DIFF
--- a/pkg/aflow/tool/codesearcher/codesearcher.go
+++ b/pkg/aflow/tool/codesearcher/codesearcher.go
@@ -15,17 +15,6 @@ import (
 )
 
 var (
-	ToolDirIndex = aflow.NewFuncTool("codesearch-dir-index", dirIndex, `
-Tool provides list of source files and subdirectories in the given directory in the source tree.
-`)
-
-	ToolReadFile = aflow.NewFuncTool("read-file", readFile, `
-Tool provides full contents of a single source file as is. Avoid using this tool if there are better
-and more specialized tools for the job. The tool returns at most 100 lines at a time.
-If you need more, you need to call the tool several times. But avoid fetching large files
-with lots of repetitive calls if possible.
-`)
-
 	ToolFileIndex = aflow.NewFuncTool("codesearch-file-index", fileIndex, `
 Tool provides list of entities defined in the given source file.
 Entity can be function, struct, or global variable.
@@ -87,26 +76,6 @@ type prepareArgs struct {
 
 type prepareResult struct {
 	Index index
-}
-
-// nolint: lll
-type dirIndexArgs struct {
-	Dir string `jsonschema:"Relative directory in the source tree. Use an empty string for the root of the tree, or paths like 'net/ipv4/' for subdirs."`
-}
-
-type dirIndexResult struct {
-	Subdirs []string `jsonschema:"List of direct subdirectories."`
-	Files   []string `jsonschema:"List of source files."`
-}
-
-type readFileArgs struct {
-	File      string `jsonschema:"Source file path."`
-	FirstLine int    `jsonschema:"First source line to return, 1-based."`
-	LineCount int    `jsonschema:"Number of lines to return, capped at 100."`
-}
-
-type readFileResult struct {
-	Contents string `jsonschema:"File contents."`
 }
 
 type fileIndexArgs struct {
@@ -179,21 +148,6 @@ func prepare(ctx *aflow.Context, args prepareArgs) (prepareResult, error) {
 	srcDirs := []string{args.KernelSrc, args.KernelObj}
 	csIndex, err := codesearch.NewIndex(filepath.Join(dir, "index.json"), srcDirs)
 	return prepareResult{index{csIndex}}, err
-}
-
-func dirIndex(ctx *aflow.Context, state prepareResult, args dirIndexArgs) (dirIndexResult, error) {
-	subdirs, files, err := state.Index.DirIndex(args.Dir)
-	return dirIndexResult{
-		Subdirs: subdirs,
-		Files:   files,
-	}, err
-}
-
-func readFile(ctx *aflow.Context, state prepareResult, args readFileArgs) (readFileResult, error) {
-	contents, err := state.Index.ReadFile(args.File, args.FirstLine, args.LineCount)
-	return readFileResult{
-		Contents: contents,
-	}, err
 }
 
 func fileIndex(ctx *aflow.Context, state prepareResult, args fileIndexArgs) (fileIndexResult, error) {

--- a/pkg/aflow/tool/codesearcher/filesystem.go
+++ b/pkg/aflow/tool/codesearcher/filesystem.go
@@ -1,0 +1,80 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package codesearcher
+
+import (
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/codesearch"
+)
+
+var (
+	ToolDirIndex = aflow.NewFuncTool("codesearch-dir-index", dirIndex, `
+Tool provides list of source files and subdirectories in the given directory in the source tree.
+`)
+
+	ToolReadFile = aflow.NewFuncTool("read-file", readFile, `
+Tool provides full contents of a single source file as is. Avoid using this tool if there are better
+and more specialized tools for the job. The tool returns at most 100 lines at a time.
+If you need more, you need to call the tool several times. But avoid fetching large files
+with lots of repetitive calls if possible.
+`)
+
+	FilesystemTools = []aflow.Tool{ToolDirIndex, ToolReadFile}
+)
+
+type fsState struct {
+	KernelSrc string
+}
+
+func getSrcDir(ctx *aflow.Context, state fsState) (string, error) {
+	if state.KernelSrc != "" {
+		return state.KernelSrc, nil
+	}
+	return "", fmt.Errorf("KernelSrc is empty")
+}
+
+// nolint: lll
+type dirIndexArgs struct {
+	Dir string `jsonschema:"Relative directory in the source tree. Use an empty string for the root of the tree, or paths like 'net/ipv4/' for subdirs."`
+}
+
+type dirIndexResult struct {
+	Subdirs []string `jsonschema:"List of direct subdirectories."`
+	Files   []string `jsonschema:"List of source files."`
+}
+
+func dirIndex(ctx *aflow.Context, state fsState, args dirIndexArgs) (dirIndexResult, error) {
+	root, err := getSrcDir(ctx, state)
+	if err != nil {
+		return dirIndexResult{}, err
+	}
+	subdirs, files, err := codesearch.DirIndex([]string{root}, args.Dir)
+	return dirIndexResult{
+		Subdirs: subdirs,
+		Files:   files,
+	}, err
+}
+
+type readFileArgs struct {
+	File      string `jsonschema:"Source file path."`
+	FirstLine int    `jsonschema:"First source line to return, 1-based."`
+	LineCount int    `jsonschema:"Number of lines to return, capped at 100."`
+}
+
+type readFileResult struct {
+	Contents string `jsonschema:"File contents."`
+}
+
+func readFile(ctx *aflow.Context, state fsState, args readFileArgs) (readFileResult, error) {
+	root, err := getSrcDir(ctx, state)
+	if err != nil {
+		return readFileResult{}, err
+	}
+	contents, err := codesearch.ReadFile([]string{root}, args.File, args.FirstLine, args.LineCount)
+	return readFileResult{
+		Contents: contents,
+	}, err
+}

--- a/pkg/codesearch/codesearch.go
+++ b/pkg/codesearch/codesearch.go
@@ -37,7 +37,7 @@ var Commands = []Command{
 		Name:  "dir-index",
 		NArgs: 1,
 		Func: func(index *Index, args []string) (string, error) {
-			subdirs, files, err := index.DirIndex(args[0])
+			subdirs, files, err := DirIndex(index.srcDirs, args[0])
 			if err != nil {
 				return "", err
 			}
@@ -64,7 +64,7 @@ var Commands = []Command{
 			if err != nil {
 				return "", fmt.Errorf("failed to parse line count %q: %w", args[2], err)
 			}
-			return index.ReadFile(args[0], firstLine, lineCount)
+			return ReadFile(index.srcDirs, args[0], firstLine, lineCount)
 		}},
 	{
 		Name:  "file-index",
@@ -207,76 +207,10 @@ type Entity struct {
 	Name string
 }
 
-func (index *Index) DirIndex(dir string) ([]string, []string, error) {
-	if err := escaping(dir); err != nil {
-		return nil, nil, err
-	}
-	exists := false
-	var subdirs, files []string
-	for _, root := range index.srcDirs {
-		exists1, subdirs1, files1, err := dirIndex(root, dir)
-		if err != nil {
-			return nil, nil, err
-		}
-		if exists1 {
-			exists = true
-		}
-		subdirs = append(subdirs, subdirs1...)
-		files = append(files, files1...)
-	}
-	if !exists {
-		return nil, nil, aflow.BadCallError("the directory does not exist")
-	}
-	slices.Sort(subdirs)
-	slices.Sort(files)
-	// Dedup dirs across src/build trees,
-	// also dedup files, but hopefully there are no duplicates.
-	subdirs = slices.Compact(subdirs)
-	files = slices.Compact(files)
-	return subdirs, files, nil
-}
-
-func (index *Index) ReadFile(file string, firstLine, lineCount int) (string, error) {
-	if err := escaping(file); err != nil {
-		return "", err
-	}
-	firstLine = max(1, firstLine)
-	lineCount = max(1, min(100, lineCount))
-	for _, dir := range index.srcDirs {
-		path := filepath.Join(dir, file)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			var errno syscall.Errno
-			if errors.As(err, &errno) && errno == syscall.EISDIR {
-				return "", aflow.BadCallError("the file is a directory")
-			}
-			return "", err
-		}
-		lines := bytes.Split(data, []byte{'\n'})
-		if last := len(lines) - 1; last >= 0 && len(lines[last]) == 0 {
-			lines = lines[:last]
-		}
-		if firstLine > len(lines) {
-			return "", aflow.BadCallError("file %v does not have line %v, it has only %v lines",
-				file, firstLine, len(lines))
-		}
-		end := min(firstLine+lineCount-1, len(lines))
-		b := new(strings.Builder)
-		for i := firstLine - 1; i < end; i++ {
-			fmt.Fprintf(b, "%4v:\t%s\n", i+1, lines[i])
-		}
-		return b.String(), nil
-	}
-	return "", aflow.BadCallError("the file does not exist")
-}
-
 func (index *Index) FileIndex(file string) ([]Entity, error) {
 	file = filepath.Clean(file)
 	// This allows to distinguish missing files from files that don't define anything.
-	if _, err := index.ReadFile(file, 1, 1); err != nil {
+	if _, err := ReadFile(index.srcDirs, file, 1, 1); err != nil {
 		return nil, err
 	}
 	var entities []Entity
@@ -504,4 +438,70 @@ func dirIndex(root, subdir string) (bool, []string, []string, error) {
 		}
 	}
 	return true, subdirs, files, err
+}
+
+func DirIndex(srcDirs []string, dir string) ([]string, []string, error) {
+	if err := escaping(dir); err != nil {
+		return nil, nil, err
+	}
+	exists := false
+	var subdirs, files []string
+	for _, root := range srcDirs {
+		exists1, subdirs1, files1, err := dirIndex(root, dir)
+		if err != nil {
+			return nil, nil, err
+		}
+		if exists1 {
+			exists = true
+		}
+		subdirs = append(subdirs, subdirs1...)
+		files = append(files, files1...)
+	}
+	if !exists {
+		return nil, nil, aflow.BadCallError("the directory does not exist")
+	}
+	slices.Sort(subdirs)
+	slices.Sort(files)
+	// Dedup dirs across src/build trees,
+	// also dedup files, but hopefully there are no duplicates.
+	subdirs = slices.Compact(subdirs)
+	files = slices.Compact(files)
+	return subdirs, files, nil
+}
+
+func ReadFile(srcDirs []string, file string, firstLine, lineCount int) (string, error) {
+	if err := escaping(file); err != nil {
+		return "", err
+	}
+	firstLine = max(1, firstLine)
+	lineCount = max(1, min(100, lineCount))
+	for _, dir := range srcDirs {
+		path := filepath.Join(dir, file)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			var errno syscall.Errno
+			if errors.As(err, &errno) && errno == syscall.EISDIR {
+				return "", aflow.BadCallError("the file is a directory")
+			}
+			return "", err
+		}
+		lines := bytes.Split(data, []byte{'\n'})
+		if last := len(lines) - 1; last >= 0 && len(lines[last]) == 0 {
+			lines = lines[:last]
+		}
+		if firstLine > len(lines) {
+			return "", aflow.BadCallError("file %v does not have line %v, it has only %v lines",
+				file, firstLine, len(lines))
+		}
+		end := min(firstLine+lineCount-1, len(lines))
+		b := new(strings.Builder)
+		for i := firstLine - 1; i < end; i++ {
+			fmt.Fprintf(b, "%4v:\t%s\n", i+1, lines[i])
+		}
+		return b.String(), nil
+	}
+	return "", aflow.BadCallError("the file does not exist")
 }


### PR DESCRIPTION
Extract DirIndex and ReadFile logic from pkg/codesearch into standalone functions so they can be run without a built compilation database (*Index).

Move the aflow wrappers for these tools into a new filesystem.go file and export them as FilesystemTools. This allows workflows like patch triage to explore directories and read files without the overhead of generating a full clang index.

***

Taken out of https://github.com/google/syzkaller/pull/7445
