### PR TITLE
dashboard/app/aidb: optimize slow spanner queries for ai jobs

### DIFF
--- a/dashboard/app/aidb/migrations/20_add_job_indices.down.sql
+++ b/dashboard/app/aidb/migrations/20_add_job_indices.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX JobsQueue;
+DROP INDEX JobsPendingFixes;

--- a/dashboard/app/aidb/migrations/20_add_job_indices.up.sql
+++ b/dashboard/app/aidb/migrations/20_add_job_indices.up.sql
@@ -1,0 +1,5 @@
+-- Optimizes LoadBugIDsWithPendingPatch.
+CREATE INDEX JobsPendingFixes ON Jobs(Namespace, Type, Correct);
+
+-- Optimizes StartJob (the agent queue).
+CREATE INDEX JobsQueue ON Jobs(Namespace, Started);


### PR DESCRIPTION
Add two Spanner indices to fix high CPU usage from full table scans.

1. LoadBugIDsWithPendingPatch: Scans for successful patching jobs waiting for evaluation. Add JobsPendingFixes index on (Namespace, Type, Correct) to quickly isolate these few pending jobs.

2. StartJob: Polled constantly by agents looking for unstarted jobs (Started IS NULL). Add JobsQueue index on (Namespace, Started) to instantly locate unstarted jobs without scanning the entire history.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
