### PR TITLE
dashboard/app: also populate missing job args if they are empty strings

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1178,7 +1178,8 @@ func buildAIJobPollArgs(ctx context.Context, job *aidb.Job) (map[string]any, err
 			if field.IsDBColumn {
 				continue
 			}
-			if args[field.ID] == nil {
+			val := args[field.ID]
+			if val == nil || val == "" {
 				args[field.ID] = field.DefaultValue
 			}
 		}


### PR DESCRIPTION
If an old job was created with an explicitly empty string for an argument (such as TargetArch: ""), restarting it will clone the empty string to the new job's argument map. When the agent later polls the new job, the empty string prevents the previous buildAIJobPollArgs logic from auto-populating it with the schema default (since an empty string is not nil).

This modifies buildAIJobPollArgs to populate missing arguments if they are either nil or an empty string, ensuring that jobs restarted from legacy jobs also correctly inherit the updated schema defaults (e.g. TargetArch).

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
