### PR TITLE
tools/syz-aflow: preserve 64-bit integers in JSON input

### DIFF
--- a/pkg/aflow/jsonmap.go
+++ b/pkg/aflow/jsonmap.go
@@ -1,0 +1,21 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// DecodeJSONMap decodes JSON into map[string]any preserving integer precision
+// by storing numbers as json.Number instead of float64.
+func DecodeJSONMap(data []byte) (map[string]any, error) {
+	var m map[string]any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/pkg/aflow/jsonmap_test.go
+++ b/pkg/aflow/jsonmap_test.go
@@ -1,0 +1,47 @@
+// Copyright 2025 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJSONMapPreservesUint64(t *testing.T) {
+	const pc = uint64(18446744071636006420)
+	data := []byte(`{"PC":18446744071636006420}`)
+	m, err := DecodeJSONMap(data)
+	require.NoError(t, err)
+	require.IsType(t, json.Number(""), m["PC"])
+
+	got, err := convertFromMap[struct {
+		PC uint64
+	}](m, false, false)
+	require.NoError(t, err)
+	require.Equal(t, pc, got.PC)
+}
+
+func TestConvertFromMapJSONNumber(t *testing.T) {
+	const pc = uint64(18446744071636006420)
+	testConvertFromMap(t, false, map[string]any{
+		"PC": json.Number("18446744071636006420"),
+	}, struct {
+		PC uint64
+	}{
+		PC: pc,
+	}, "", "")
+
+	testConvertFromMap(t, false, map[string]any{
+		"I0": json.Number("-1"),
+		"I1": json.Number("2"),
+	}, struct {
+		I0 int
+		I1 int
+	}{
+		I0: -1,
+		I1: 2,
+	}, "", "")
+}

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"maps"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -131,6 +132,12 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 		field.Set(reflect.ValueOf(json.RawMessage(raw)))
 		return nil
 	}
+	if num, ok := f.(json.Number); ok {
+		if err := setJSONNumberField(field, val, num, name, targetType, tool); err != nil {
+			return err
+		}
+		return nil
+	}
 	if fType.Kind() == reflect.Float64 &&
 		(reflect.Zero(targetType).CanInt() || reflect.Zero(targetType).CanUint()) {
 		// Genai will send us integers as float64 after json conversion,
@@ -203,6 +210,68 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 	}
 	return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
 		val, name, f, field.Type().String())
+}
+
+func setJSONNumberField(field reflect.Value, val any, num json.Number, name string,
+	targetType reflect.Type, tool bool) error {
+	switch {
+	case reflect.Zero(targetType).CanInt():
+		iv, err := strconv.ParseInt(num.String(), 10, targetType.Bits())
+		if err != nil {
+			if tool {
+				return BadCallError("argument %q: invalid integer %q: %v", name, num, err)
+			}
+			return fmt.Errorf("%T: field %q: invalid integer %q: %w", val, name, num, err)
+		}
+		ivVal := reflect.ValueOf(iv).Convert(targetType)
+		if field.Kind() == reflect.Ptr {
+			ptr := reflect.New(targetType)
+			ptr.Elem().Set(ivVal)
+			field.Set(ptr)
+		} else {
+			field.Set(ivVal)
+		}
+	case reflect.Zero(targetType).CanUint():
+		uv, err := strconv.ParseUint(num.String(), 10, targetType.Bits())
+		if err != nil {
+			if tool {
+				return BadCallError("argument %q: invalid unsigned integer %q: %v", name, num, err)
+			}
+			return fmt.Errorf("%T: field %q: invalid unsigned integer %q: %w", val, name, num, err)
+		}
+		uvVal := reflect.ValueOf(uv).Convert(targetType)
+		if field.Kind() == reflect.Ptr {
+			ptr := reflect.New(targetType)
+			ptr.Elem().Set(uvVal)
+			field.Set(ptr)
+		} else {
+			field.Set(uvVal)
+		}
+	case targetType.Kind() == reflect.Float32 || targetType.Kind() == reflect.Float64:
+		fv, err := num.Float64()
+		if err != nil {
+			if tool {
+				return BadCallError("argument %q: invalid float %q: %v", name, num, err)
+			}
+			return fmt.Errorf("%T: field %q: invalid float %q: %w", val, name, num, err)
+		}
+		fvVal := reflect.ValueOf(fv).Convert(targetType)
+		if field.Kind() == reflect.Ptr {
+			ptr := reflect.New(targetType)
+			ptr.Elem().Set(fvVal)
+			field.Set(ptr)
+		} else {
+			field.Set(fvVal)
+		}
+	default:
+		if tool {
+			return BadCallError("argument %q has wrong type: got json.Number, want %v",
+				name, field.Type().String())
+		}
+		return fmt.Errorf("%T: field %q has wrong type: got json.Number, want %v",
+			val, name, field.Type().String())
+	}
+	return nil
 }
 
 func setSliceField(val any, field reflect.Value, name string, f any, targetType reflect.Type, tool bool) error {

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -96,8 +96,8 @@ func run(ctx context.Context, args RunArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to open -input file: %w", err)
 	}
-	var inputs map[string]any
-	if err := json.Unmarshal(inputData, &inputs); err != nil {
+	inputs, err := aflow.DecodeJSONMap(inputData)
+	if err != nil {
 		return err
 	}
 	cache, err := aflow.NewCache(filepath.Join(args.Workdir, "cache"), args.CacheSize)


### PR DESCRIPTION
## Summary
- Decode `syz-aflow` workflow input with `json.Decoder.UseNumber()` so large integers stay as `json.Number` instead of lossy `float64`
- Teach `pkg/aflow` `convertFromMap` to convert `json.Number` into integer and float struct fields
- Add regression tests for a kernel PC address (`18446744071636006420`) that previously rounded to `18446744071636006912`

Fixes #7452

## Test plan
- [x] `go test ./pkg/aflow -count=1`
- [ ] `syz-aflow -workflow ... -input large-pc.json` with a 64-bit PC value and verify no precision loss

/cc @a-nogikh