### PR TITLE
syz-agent: enable nested virtualization in prod QEMU args

### DIFF
--- a/syz-agent/k8s/overlays/prod-agent/agent-config.json
+++ b/syz-agent/k8s/overlays/prod-agent/agent-config.json
@@ -15,7 +15,7 @@
         "cpu": 2,
         "mem": 8192,
         "cmdline": "root=/dev/sda1",
-        "qemu_args": "-machine q35 -enable-kvm -smp 2,sockets=2,cores=1"
+        "qemu_args": "-machine q35 -enable-kvm -cpu max,migratable=off -smp 2,sockets=2,cores=1"
       }
     },
     "linux/arm64": {


### PR DESCRIPTION
Add `-cpu max,migratable=off` to the linux/amd64 QEMU args in the prod-agent config. We need this to expose KVM to the guest VM.