### PR TITLE
pkg/aflow: support model pools with fallbacks

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -2017,12 +2017,7 @@ func createGerritChange(ctx context.Context, job *aidb.Job) error {
 	if err != nil {
 		return err
 	}
-	models := make(map[string]bool)
-	for _, span := range trajectory {
-		if span.Model != "" {
-			models[span.Model] = true
-		}
-	}
+	models := extractExecutedModels(trajectory)
 	// Add Fixes tag if we have cause bisection, but we need to verify it with LLMs
 	// somehow since lots of them are wrong.
 	// Probably shouldn't cc stable for all patches (e.g. removing a WARNING)?
@@ -2043,7 +2038,7 @@ func createGerritChange(ctx context.Context, job *aidb.Job) error {
 	links = append(links, fmt.Sprintf("%s/ai_job?id=%s", appURL(ctx), job.ID))
 	description := email.FormatPatchDescription(res.PatchDescription, email.PatchTemplateData{
 		Fixes:      res.Fixes,
-		Tools:      slices.Collect(maps.Keys(models)),
+		Tools:      models,
 		Recipients: res.Recipients,
 		Links:      links,
 		Closes:     closes,
@@ -2138,4 +2133,19 @@ func jobBugInfo(ctx context.Context, bugID spanner.NullString) (string, string) 
 		return appURL(ctx) + bugExtLink(ctx, bug), reportedBy
 	}
 	return appURL(ctx) + bugLink(bugID.StringVal), ""
+}
+
+func extractExecutedModels(trajectory []*aidb.TrajectorySpan) []string {
+	models := make(map[string]bool)
+	for _, span := range trajectory {
+		// We only collect models from "llm" type spans because they represent the actual
+		// successful executions of the model. "agent" type spans represent the agent
+		// configuration and contain the full model pool (including models that might have failed).
+		if span.Type == "llm" && span.Model != "" {
+			models[span.Model] = true
+		}
+	}
+	res := slices.Collect(maps.Keys(models))
+	slices.Sort(res)
+	return res
 }

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/mail"
 	"slices"
 	"strings"
@@ -352,12 +351,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	if err != nil {
 		return nil, err
 	}
-	models := make(map[string]bool)
-	for _, span := range trajectory {
-		if span.Model != "" {
-			models[span.Model] = true
-		}
-	}
+	models := extractExecutedModels(trajectory)
 	var to, cc []string
 	for _, rec := range res.Recipients {
 		addr := mail.Address{Name: rec.Name, Address: rec.Email}
@@ -377,7 +371,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 		Version:    version,
 		To:         to,
 		Cc:         cc,
-		Tools:      slices.Collect(maps.Keys(models)),
+		Tools:      models,
 		Authors:    authors,
 		Fixes:      res.Fixes,
 		ReviewedBy: res.ReviewedBy,

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -58,7 +58,24 @@ func TestAILoreIntegration(t *testing.T) {
 
 	err = c.agentClient.AITrajectoryLog(&dashapi.AITrajectoryReq{
 		JobID: jobID,
-		Span:  &trajectory.Span{Seq: 1, Type: trajectory.SpanAgent, Name: "patch-generator", Model: "gemini-3.1-pro-preview"},
+		Span: &trajectory.Span{
+			Seq:      1,
+			Type:     trajectory.SpanAgent,
+			Name:     "patch-generator",
+			Model:    "gemini-3.0,gemini-3.1-pro-preview",
+			Finished: now,
+		},
+	})
+	require.NoError(t, err)
+	err = c.agentClient.AITrajectoryLog(&dashapi.AITrajectoryReq{
+		JobID: jobID,
+		Span: &trajectory.Span{
+			Seq:      2,
+			Type:     trajectory.SpanLLM,
+			Name:     "patch-generator",
+			Model:    "gemini-3.1-pro-preview",
+			Finished: now,
+		},
 	})
 	require.NoError(t, err)
 	c.finishAIPatchJob(t, jobID, map[string]any{

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -259,6 +259,13 @@ func loadModelList(ctx context.Context) (*genai.Client, map[string]*modelInfo, s
 				InputTokenLimit:  1048576,
 				OutputTokenLimit: 65536,
 			},
+
+			"gemini-3.5-flash": {
+				Thinking:         true,
+				MaxTemperature:   2.0,
+				InputTokenLimit:  1048576,
+				OutputTokenLimit: 65536,
+			},
 		}
 		// Vertex AI backend expects the bare model name, not prefixed with "models/".
 		// E.g. "gemini-1.5-pro" instead of "models/gemini-1.5-pro".
@@ -314,20 +321,20 @@ type stubContext struct {
 		*genai.GenerateContentResponse, error)
 }
 
-// modelName resolves the abstract ModelType enum configuration to a concrete model name.
+// modelNames resolves the abstract ModelType configurations to a flattened slice of concrete fallback model names.
 // If a workflow-level model override is configured (via ctx.llmModel), it takes precedence.
-func (ctx *Context) modelName(model ModelType) string {
+func (ctx *Context) modelNames(m ModelType) []string {
 	if ctx.llmModel != "" {
-		return ctx.llmModel
+		return []string{ctx.llmModel}
 	}
-	switch model {
+	switch m {
 	case GoodBalancedModel:
-		return gemini3FlashPreview
+		return []string{gemini3FlashPreview, gemini35Flash}
 	case BestExpensiveModel:
-		return gemini31ProPreview
+		return []string{gemini31ProPreview}
 	default:
 		// E.g. when an explicit model name or test stub is passed directly.
-		return string(model)
+		return strings.Split(string(m), ",")
 	}
 }
 

--- a/pkg/aflow/execute_test.go
+++ b/pkg/aflow/execute_test.go
@@ -4,42 +4,48 @@
 package aflow
 
 import (
+	"slices"
 	"testing"
 )
 
-func TestModelNameResolution(t *testing.T) {
+func TestContextModelNames(t *testing.T) {
 	tests := []struct {
 		name     string
 		llmModel string
 		model    ModelType
-		want     string
+		want     []string
 	}{
 		{
-			name:  "resolves good balanced model",
+			name:  "resolves good balanced model pool",
 			model: GoodBalancedModel,
-			want:  gemini3FlashPreview,
+			want:  []string{gemini3FlashPreview, gemini35Flash},
 		},
 		{
-			name:  "resolves best expensive model",
+			name:  "resolves best expensive model pool",
 			model: BestExpensiveModel,
-			want:  gemini31ProPreview,
+			want:  []string{gemini31ProPreview},
 		},
 		{
 			name:  "falls back to raw string for unrecognized model type",
 			model: "custom-model",
-			want:  "custom-model",
+			want:  []string{"custom-model"},
+		},
+		{
+			name:  "resolves comma separated mixed models",
+			model: "best-expensive,custom-model,good-balanced",
+			want:  []string{"best-expensive", "custom-model", "good-balanced"},
 		},
 		{
 			name:     "respects context level override",
 			llmModel: "override-model",
 			model:    GoodBalancedModel,
-			want:     "override-model",
+			want:     []string{"override-model"},
 		},
 		{
 			name:     "respects context level override even for unrecognized model type",
 			llmModel: "override-model",
 			model:    "custom-model",
-			want:     "override-model",
+			want:     []string{"override-model"},
 		},
 	}
 
@@ -48,9 +54,9 @@ func TestModelNameResolution(t *testing.T) {
 			ctx := &Context{
 				llmModel: tc.llmModel,
 			}
-			got := ctx.modelName(tc.model)
-			if got != tc.want {
-				t.Errorf("ctx.modelName(%q) = %q, want %q", tc.model, got, tc.want)
+			got := ctx.modelNames(tc.model)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("ctx.modelNames(%v) = %v, want %v", tc.model, got, tc.want)
 			}
 		})
 	}

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -71,6 +71,7 @@ type agentSession struct {
 	// answerNow is set to true when the input overflows and the agent must
 	// immediately respond.
 	answerNow bool
+	agentSpan *trajectory.Span
 }
 
 type llmMessage struct {
@@ -86,16 +87,18 @@ type toolCallRecord struct {
 type ModelType string
 
 const (
-	// Consts to use for LLMAgent.Model.
-	// See https://ai.google.dev/gemini-api/docs/models
 	BestExpensiveModel ModelType = "best-expensive"
 	GoodBalancedModel  ModelType = "good-balanced"
 )
 
 const (
-	gemini3FlashPreview = "gemini-3-flash-preview"
+	// See https://ai.google.dev/gemini-api/docs/models
 	gemini31ProPreview  = "gemini-3.1-pro-preview"
+	gemini3FlashPreview = "gemini-3-flash-preview"
+	gemini35Flash       = "gemini-3.5-flash"
+)
 
+const (
 	// Default limit for consecutive identical tool calls.
 	defaultLoopDetectionLimit = 3
 	hardLoopDetectionLimit    = 6
@@ -299,12 +302,12 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 		Name:        a.Name,
 		Instruction: instruction,
 		Prompt:      prompt,
-		Model:       ctx.modelName(a.Model),
+		Model:       strings.Join(ctx.modelNames(a.Model), ","),
 	}
 	if err := ctx.startSpan(span); err != nil {
 		return "", nil, err
 	}
-	s := &agentSession{LLMAgent: a}
+	s := &agentSession{LLMAgent: a, agentSpan: span}
 	reply, outputs, err := s.chat(ctx, cfg, tools, instruction, span.Prompt, candidate)
 	if err == nil {
 		span.Reply = reply
@@ -352,12 +355,15 @@ func (a *agentSession) chat(ctx *Context, cfg *genai.GenerateContentConfig, tool
 		span := &trajectory.Span{
 			Type:  trajectory.SpanLLM,
 			Name:  a.Name,
-			Model: ctx.modelName(a.Model),
+			Model: strings.Join(ctx.modelNames(a.Model), ","),
 		}
 		if err := ctx.startSpan(span); err != nil {
 			return "", nil, err
 		}
-		resp, respErr := a.generateContent(ctx, cfg, a.req, candidate, a.Model)
+		resp, respErr := a.generateContent(ctx, cfg, a.req, candidate, a.Model, span)
+		if a.agentSpan != nil {
+			a.agentSpan.Model = span.Model
+		}
 
 		if respErr != nil {
 			span.Error = respErr.Error()
@@ -506,7 +512,7 @@ func (a *agentSession) compressContext(ctx *Context, instruction string, splitIn
 	span := &trajectory.Span{
 		Type:  trajectory.SpanLLM,
 		Name:  a.Name + "-compressor",
-		Model: ctx.modelName(GoodBalancedModel),
+		Model: strings.Join(ctx.modelNames(GoodBalancedModel), ","),
 	}
 	if err := ctx.startSpan(span); err != nil {
 		return nil, 0, err
@@ -529,7 +535,7 @@ func (a *agentSession) compressContext(ctx *Context, instruction string, splitIn
 	compressReq = append(compressReq, llmMessage{
 		content: genai.NewContentFromText(tokenCompressionPrompt, genai.RoleUser),
 	})
-	resp, err := a.generateContent(ctx, cfg, compressReq, 0, GoodBalancedModel)
+	resp, err := a.generateContent(ctx, cfg, compressReq, 0, GoodBalancedModel, span)
 	if err != nil {
 		return nil, 0, ctx.finishSpan(span, err)
 	}
@@ -748,7 +754,8 @@ func (a *LLMAgent) parseResponse(resp *genai.GenerateContentResponse, span *traj
 }
 
 func (a *LLMAgent) generateContent(ctx *Context, cfg *genai.GenerateContentConfig,
-	req []llmMessage, candidate int, model ModelType) (*genai.GenerateContentResponse, error) {
+	req []llmMessage, candidate int, model ModelType,
+	span *trajectory.Span) (*genai.GenerateContentResponse, error) {
 	// Copy the config in case we modify it below.
 	cfg = osutil.JSONDeepCopy(cfg)
 
@@ -757,47 +764,63 @@ func (a *LLMAgent) generateContent(ctx *Context, cfg *genai.GenerateContentConfi
 		rawReq = append(rawReq, msg.content)
 	}
 
-	for try := 0; ; try++ {
-		resp, err := a.generateContentCached(ctx, cfg, rawReq, candidate, try, model)
-		if retryErr := new(retryError); errors.As(err, &retryErr) {
-			time.Sleep(retryErr.delay)
-			continue
+	resolvedModels := ctx.modelNames(model)
+	var lastErr error
+	for _, m := range resolvedModels {
+		if span != nil {
+			span.Model = m
 		}
-		if isOutputTokenOverflowError(err) &&
-			cfg.ThinkingConfig.ThinkingLevel != genai.ThinkingLevelMinimal {
-			// Reduce amount of thinking and try again (thinking tokens are counted against output).
-			// For non-thinking models this is effectively just a retry,
-			// but that's fine, there is some chance that retry will succeed due to randomness,
-			// or it will just fail after few retries.
-			switch cfg.ThinkingConfig.ThinkingLevel {
-			case genai.ThinkingLevelHigh:
-				cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelMedium
-			case genai.ThinkingLevelMedium:
-				cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelLow
-			case genai.ThinkingLevelLow:
-				cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelMinimal
-			default:
-				return nil, fmt.Errorf("unexpected thinking level %v", cfg.ThinkingConfig.ThinkingLevel)
+		for try := 0; ; try++ {
+			resp, err := a.generateContentCached(ctx, cfg, rawReq, candidate, try, m)
+			if retryErr := new(retryError); errors.As(err, &retryErr) {
+				time.Sleep(retryErr.delay)
+				continue
 			}
-			continue
+			if isOutputTokenOverflowError(err) &&
+				cfg.ThinkingConfig.ThinkingLevel != genai.ThinkingLevelMinimal {
+				// Reduce amount of thinking and try again (thinking tokens are counted against output).
+				// For non-thinking models this is effectively just a retry,
+				// but that's fine, there is some chance that retry will succeed due to randomness,
+				// or it will just fail after few retries.
+				switch cfg.ThinkingConfig.ThinkingLevel {
+				case genai.ThinkingLevelHigh:
+					cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelMedium
+				case genai.ThinkingLevelMedium:
+					cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelLow
+				case genai.ThinkingLevelLow:
+					cfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelMinimal
+				default:
+					return nil, fmt.Errorf("unexpected thinking level %v", cfg.ThinkingConfig.ThinkingLevel)
+				}
+				continue
+			}
+			if err != nil {
+				// This model failed, fallback to next model.
+				if m != "" {
+					lastErr = fmt.Errorf("%v: %w", m, err)
+				} else {
+					lastErr = err
+				}
+				break // break retry loop, fallback to next model
+			}
+			return resp, nil
 		}
-		return resp, err
 	}
+	return nil, lastErr
 }
 
 func (a *LLMAgent) generateContentCached(ctx *Context, cfg *genai.GenerateContentConfig,
-	req []*genai.Content, candidate, try int, model ModelType) (*genai.GenerateContentResponse, error) {
+	req []*genai.Content, candidate, try int, model string) (*genai.GenerateContentResponse, error) {
 	type Cached struct {
 		Config  *genai.GenerateContentConfig
 		Request []*genai.Content
 		Reply   *genai.GenerateContentResponse
 	}
-	modelStr := ctx.modelName(model)
 	desc := fmt.Sprintf("model %v, config hash %v, request hash %v, candidate %v",
-		modelStr, hash.String(cfg), hash.String(req), candidate)
+		model, hash.String(cfg), hash.String(req), candidate)
 	cached, _, err := CacheObject(ctx, "llm", desc, func() (Cached, error) {
-		resp, err := ctx.generateContent(modelStr, cfg, req)
-		err = parseLLMError(resp, err, modelStr, try)
+		resp, err := ctx.generateContent(model, cfg, req)
+		err = parseLLMError(resp, err, model, try)
 		return Cached{
 			Config:  cfg,
 			Request: req,

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -569,7 +569,7 @@ func TestOutputOverflow(t *testing.T) {
 			FinishReason: genai.FinishReasonMaxTokens,
 		}},
 	}
-	testFlow[struct{}, flowResults](t, nil, string(genai.FinishReasonMaxTokens),
+	testFlow[struct{}, flowResults](t, nil, "model: "+string(genai.FinishReasonMaxTokens),
 		&LLMAgent{
 			Reply: "Result",
 			Outputs: LLMOutputs[struct {
@@ -689,6 +689,43 @@ func TestValidatedLLMReply(t *testing.T) {
 		[]any{
 			genai.NewPartFromText("reply1"),
 			genai.NewPartFromText("reply2"),
+		},
+		nil,
+	)
+}
+
+// TestModelFallbackTrajectory verifies that when a workflow is configured with a model pool (fallback list),
+// and the primary model fails (e.g. returns quota limit error), the workflow engine successfully falls back
+// to the backup model and executes. It also verifies that only the successful fallback model is recorded
+// in the finished LLM span of the execution trajectory.
+func TestModelFallbackTrajectory(t *testing.T) {
+	type flowOutputs struct {
+		Reply string
+	}
+	testFlow[struct{}, flowOutputs](t, nil,
+		map[string]any{"Reply": "Done"},
+		&LLMAgent{
+			Name:     "smarty",
+			Model:    "model1,model2",
+			Reply:    "Reply",
+			TaskType: FormalReasoningTask,
+		},
+		[]any{
+			func(model string, cfg *genai.GenerateContentConfig, req []*genai.Content) (
+				*genai.GenerateContentResponse, error) {
+				if model == "model1" {
+					return nil, errors.New("model1 failed (quota limit)")
+				}
+				if model == "model2" {
+					return &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content: &genai.Content{
+								Parts: []*genai.Part{genai.NewPartFromText("Done")},
+								Role:  genai.RoleModel,
+							}}}}, nil
+				}
+				return nil, fmt.Errorf("unexpected model %q", model)
+			},
 		},
 		nil,
 	)

--- a/pkg/aflow/testdata/TestLLMTool.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMTool.trajectory.json
@@ -266,7 +266,7 @@
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:27Z",
 		"Finished": "0001-01-01T00:00:28Z",
-		"Error": "Error 400, Message: The input token count exceeds the maximum number of tokens allowed 1048576., Status: , Details: []"
+		"Error": "sub-agent-model: Error 400, Message: The input token count exceeds the maximum number of tokens allowed 1048576., Status: , Details: []"
 	},
 	{
 		"Seq": 16,

--- a/pkg/aflow/testdata/TestModelFallbackTrajectory.llm.json
+++ b/pkg/aflow/testdata/TestModelFallbackTrajectory.llm.json
@@ -1,0 +1,46 @@
+[
+	{
+		"Model": "model1",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"responseModalities": [
+				"TEXT"
+			],
+			"thinkingConfig": {
+				"includeThoughts": true,
+				"thinkingLevel": "HIGH"
+			}
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model2",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestModelFallbackTrajectory.trajectory.json
+++ b/pkg/aflow/testdata/TestModelFallbackTrajectory.trajectory.json
@@ -1,0 +1,59 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model1,model2",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model1,model2",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model2",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model2",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Instruction": "Instruction",
+		"Prompt": "Prompt",
+		"Reply": "Done"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"Reply": "Done"
+		}
+	}
+]

--- a/pkg/aflow/testdata/TestOutputOverflow.trajectory.json
+++ b/pkg/aflow/testdata/TestOutputOverflow.trajectory.json
@@ -73,7 +73,7 @@
 		"Model": "model",
 		"Started": "0001-01-01T00:00:07Z",
 		"Finished": "0001-01-01T00:00:08Z",
-		"Error": "MAX_TOKENS"
+		"Error": "model: MAX_TOKENS"
 	},
 	{
 		"Seq": 1,
@@ -83,7 +83,7 @@
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
 		"Finished": "0001-01-01T00:00:09Z",
-		"Error": "MAX_TOKENS",
+		"Error": "model: MAX_TOKENS",
 		"Instruction": "Instruction\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
 		"Prompt": "Prompt"
 	},
@@ -94,6 +94,6 @@
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
 		"Finished": "0001-01-01T00:00:10Z",
-		"Error": "MAX_TOKENS"
+		"Error": "model: MAX_TOKENS"
 	}
 ]

--- a/pkg/aflow/testdata/TestTokenCompression.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompression.trajectory.json
@@ -95,7 +95,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "gemini-3-flash-preview",
+		"Model": "gemini-3-flash-preview,gemini-3.5-flash",
 		"Started": "0001-01-01T00:00:11Z"
 	},
 	{

--- a/pkg/aflow/testdata/TestTokenCompressionPreservesSuffix.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompressionPreservesSuffix.trajectory.json
@@ -279,7 +279,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "gemini-3-flash-preview",
+		"Model": "gemini-3-flash-preview,gemini-3.5-flash",
 		"Started": "0001-01-01T00:00:27Z"
 	},
 	{

--- a/pkg/aflow/testdata/TestTokenCompressionResetsHistory.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompressionResetsHistory.trajectory.json
@@ -132,7 +132,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "gemini-3-flash-preview",
+		"Model": "gemini-3-flash-preview,gemini-3.5-flash",
 		"Started": "0001-01-01T00:00:15Z"
 	},
 	{

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -311,10 +311,18 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ou
 
 	onEvent := func(span *trajectory.Span) error {
 		log.Logf(0, "%v", span)
+
+		// The trajectory files should contain the model fallback pool, but the dashboard
+		// should not display it for start spans, so we filter it out here.
+		sendSpan := *span
+		if span.Finished.IsZero() && span.Model != "" {
+			sendSpan.Model = ""
+		}
+
 		return s.dash.AITrajectoryLog(&dashapi.AITrajectoryReq{
 			AgentName: s.cfg.DashboardClient,
 			JobID:     req.ID,
-			Span:      span,
+			Span:      &sendSpan,
 		})
 	}
 	return flow.Execute(ctx, s.cfg.Model, s.workdir, inputs, s.cache, onEvent)


### PR DESCRIPTION
See commit message.
The actual switching logic is the most interesting part. Current error processing looks heavy and relying on it long-term may not work.
The alternative I'm thinking about is to randomize the model selection.

Prerequisites:
1. #7504
2. #7506
