### PR TITLE
ci: enable coverage collection from gvisor smoke tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -25,7 +25,7 @@ coverage:
 
 comment:
   layout: "files"
-  after_n_builds: 2
+  after_n_builds: 3
 
 github_checks:
   annotations: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,16 @@ jobs:
           path: /syzkaller/.cache
           key: ${{ runner.os }}-syzenv-
       - name: run
+        env:
+          SyzCoverDir: ${{ github.workspace }}/gvisor_gocover
+          SyzCoverProfile: ${{ github.workspace }}/gvisor.coverprofile
         run: |
           cd gopath/src/github.com/google/syzkaller
-          make
+          make GO_COVER_FLAGS=-cover
           .github/workflows/run.sh bash -xe tools/gvisor-smoke-test.sh
+      - name: upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-gvisor
+          path: gvisor.coverprofile
+          include-hidden-files: true

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -100,3 +100,16 @@ jobs:
           override_pr: ${{ steps.pr.outputs.number }}
           verbose: true
           disable_search: true
+
+      - name: upload gvisor coverage
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          codecov_yml_path: base-repo/.github/codecov.yml
+          files: coverage-reports/coverage-gvisor/gvisor.coverprofile
+          flags: gvisor
+          slug: ${{ github.event.workflow_run.repository.full_name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_pr: ${{ steps.pr.outputs.number }}
+          verbose: true
+          disable_search: true

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ ifeq ("$(DEBUG)", "true")
 else
 	GLFLAGS := -s -w
 endif
-GOFLAGS := -ldflags="$(GLFLAGS) -X github.com/google/syzkaller/prog.GitRevision=$(REV) -X github.com/google/syzkaller/prog.gitRevisionDate=$(GITREVDATE)" $(GGFLAGS)
+GO_COVER_FLAGS ?=
+GOFLAGS := -ldflags="$(GLFLAGS) -X github.com/google/syzkaller/prog.GitRevision=$(REV) -X github.com/google/syzkaller/prog.gitRevisionDate=$(GITREVDATE)" $(GGFLAGS) $(GO_COVER_FLAGS)
 ifneq ("$(GOTAGS)", "")
 	GOFLAGS += " -tags=$(GOTAGS)"
 endif

--- a/tools/gvisor-smoke-test.sh
+++ b/tools/gvisor-smoke-test.sh
@@ -7,10 +7,16 @@ set -xeuo pipefail
 workdir="$(mktemp -d /tmp/syzkaller-gvisor-test.XXXXXX)"
 
 cleanup() {
-  sudo -E rm -rf "$workdir"
+  rm -rf "$workdir"
 }
 
 trap cleanup EXIT
+
+# Setup coverage directory if requested
+if [[ -n "${SyzCoverDir:-}" ]]; then
+  mkdir -p "${SyzCoverDir}"
+  export GOCOVERDIR="$(cd "${SyzCoverDir}" && pwd)"
+fi
 
 syzdir="$(pwd)"
 cat > "$workdir/config" <<EOF
@@ -18,7 +24,7 @@ cat > "$workdir/config" <<EOF
         "name": "gvisor",
         "target": "linux/amd64",
         "http": ":54321",
-        "workdir": "/$workdir/workdir/",
+        "workdir": "$workdir/workdir",
         "image": "$workdir/kernel/vmlinux",
         "kernel_obj": "$workdir/kernel/",
         "syzkaller": "$syzdir",
@@ -27,7 +33,7 @@ cat > "$workdir/config" <<EOF
         "type": "gvisor",
         "vm": {
                 "count": 1,
-                "runsc_args": "--ignore-cgroups --network none"
+                "runsc_args": "--ignore-cgroups --network none --rootless"
         }
 }
 EOF
@@ -42,4 +48,14 @@ else
   install -m555 "$GVISOR_VMLINUX_PATH" "$workdir/kernel/vmlinux"
 fi
 
-sudo -E ./bin/syz-manager -config "$workdir/config" --mode smoke-test
+./bin/syz-manager -config "$workdir/config" --mode smoke-test
+
+if [[ -n "${GOCOVERDIR:-}" ]]; then
+  if [[ -n "${SyzCoverProfile:-}" ]]; then
+    if ls "${GOCOVERDIR}"/covmeta.* >/dev/null 2>&1; then
+      go tool covdata textfmt -i="${GOCOVERDIR}" -o="${SyzCoverProfile}"
+    else
+      echo "No coverage data found in ${GOCOVERDIR}"
+    fi
+  fi
+fi


### PR DESCRIPTION
We can't see the actual coverage before the final integration because it requires codecov config change in the upstream syzkaller.