### PR TITLE
pkg/execbackend: delay instance creation until after VM setup

### DIFF
--- a/pkg/execbackend/rpc.go
+++ b/pkg/execbackend/rpc.go
@@ -38,25 +38,6 @@ func New(cfg *rpcserver.RemoteConfig) (Server, error) {
 func (b *rpcBackend) RunRequests(ctx context.Context, inst *vm.Instance,
 	reporter *report.Reporter, updInfo dispatcher.UpdateInfo) (
 	[]*report.Report, error) {
-	injectExec := make(chan bool, 10)
-	rpcUpdInfo := func(cb func(info *rpcserver.RunnerInfo)) {
-		if updInfo != nil {
-			updInfo(func(info *dispatcher.Info) {
-				runnerInfo := &rpcserver.RunnerInfo{
-					Status:         info.Status,
-					DetailedStatus: info.DetailedStatus,
-					MachineInfo:    info.MachineInfo,
-				}
-				cb(runnerInfo)
-				info.Status = runnerInfo.Status
-				info.DetailedStatus = runnerInfo.DetailedStatus
-				info.MachineInfo = runnerInfo.MachineInfo
-			})
-		}
-	}
-
-	b.CreateInstance(inst.Index(), injectExec, rpcUpdInfo)
-
 	var err error
 	var fwdAddr string
 	if !b.cfg.VMLess {
@@ -84,6 +65,25 @@ func (b *rpcBackend) RunRequests(ctx context.Context, inst *vm.Instance,
 		}
 		cmd = fmt.Sprintf("%v runner %v %v %v", executorBin, inst.Index(), host, port)
 	}
+
+	injectExec := make(chan bool, 10)
+	rpcUpdInfo := func(cb func(info *rpcserver.RunnerInfo)) {
+		if updInfo != nil {
+			updInfo(func(info *dispatcher.Info) {
+				runnerInfo := &rpcserver.RunnerInfo{
+					Status:         info.Status,
+					DetailedStatus: info.DetailedStatus,
+					MachineInfo:    info.MachineInfo,
+				}
+				cb(runnerInfo)
+				info.Status = runnerInfo.Status
+				info.DetailedStatus = runnerInfo.DetailedStatus
+				info.MachineInfo = runnerInfo.MachineInfo
+			})
+		}
+	}
+
+	b.CreateInstance(inst.Index(), injectExec, rpcUpdInfo)
 
 	ctxTimeout, cancel := context.WithTimeout(ctx, b.cfg.Timeouts.VMRunningTime)
 	defer cancel()


### PR DESCRIPTION
If inst.Forward() or inst.Copy() failed, RunRequests returned early. Because ShutdownInstance was never reached, the manager would panic with "duplicate instance".

Fix this by moving b.CreateInstance() after all initial setup that can fail.

Linking https://github.com/google/syzkaller/pull/7502#discussion_r3436617644 for some context
*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
