### PR TITLE
vm/dispatcher: prevent launching jobs with canceled context

### DIFF
--- a/vm/dispatcher/pool.go
+++ b/vm/dispatcher/pool.go
@@ -150,6 +150,8 @@ func (p *Pool[T]) runInstance(ctx context.Context, inst *poolInstance[T]) {
 		case <-ctx.Done():
 			return
 		}
+	} else if ctx.Err() != nil {
+		return
 	}
 
 	inst.status(StateRunning)


### PR DESCRIPTION
If the dispatcher's global context is canceled during teardown while a VM instance finishes booting, the dispatcher loop currently fails to check for the cancellation if a default job has already been assigned. This results in the job being executed with an already-canceled context, causing the underlying executor command (e.g. an SSH session) to immediately abort. The backend mistakenly interprets this sudden timeout as a clean, rapid execution run and logs confusing "VM restarting" messages while the program is trying to shut down. Checking the context state guarantees that we safely abort execution and avoid performing unnecessary or confusing work during the shutdown sequence.

