### PR TITLE
pkg/aflow: convert model configurations to ModelType enum

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -314,11 +314,21 @@ type stubContext struct {
 		*genai.GenerateContentResponse, error)
 }
 
-func (ctx *Context) modelName(model string) string {
+// modelName resolves the abstract ModelType enum configuration to a concrete model name.
+// If a workflow-level model override is configured (via ctx.llmModel), it takes precedence.
+func (ctx *Context) modelName(model ModelType) string {
 	if ctx.llmModel != "" {
 		return ctx.llmModel
 	}
-	return model
+	switch model {
+	case GoodBalancedModel:
+		return gemini3FlashPreview
+	case BestExpensiveModel:
+		return gemini31ProPreview
+	default:
+		// E.g. when an explicit model name or test stub is passed directly.
+		return string(model)
+	}
 }
 
 func (ctx *Context) Cache(typ, desc string, populate func(string) error) (string, error) {

--- a/pkg/aflow/execute_test.go
+++ b/pkg/aflow/execute_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"testing"
+)
+
+func TestModelNameResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		llmModel string
+		model    ModelType
+		want     string
+	}{
+		{
+			name:  "resolves good balanced model",
+			model: GoodBalancedModel,
+			want:  gemini3FlashPreview,
+		},
+		{
+			name:  "resolves best expensive model",
+			model: BestExpensiveModel,
+			want:  gemini31ProPreview,
+		},
+		{
+			name:  "falls back to raw string for unrecognized model type",
+			model: "custom-model",
+			want:  "custom-model",
+		},
+		{
+			name:     "respects context level override",
+			llmModel: "override-model",
+			model:    GoodBalancedModel,
+			want:     "override-model",
+		},
+		{
+			name:     "respects context level override even for unrecognized model type",
+			llmModel: "override-model",
+			model:    "custom-model",
+			want:     "override-model",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &Context{
+				llmModel: tc.llmModel,
+			}
+			got := ctx.modelName(tc.model)
+			if got != tc.want {
+				t.Errorf("ctx.modelName(%q) = %q, want %q", tc.model, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -28,7 +28,7 @@ type LLMAgent struct {
 	Name string
 	// The default Gemini model name to execute this workflow.
 	// Use the consts defined below.
-	Model string
+	Model ModelType
 	// Name of the state variable to store the final reply of the agent.
 	// These names can be used in subsequent action instructions/prompts,
 	// and as final workflow outputs.
@@ -88,11 +88,18 @@ type toolCallRecord struct {
 	Args map[string]any
 }
 
+type ModelType string
+
 const (
 	// Consts to use for LLMAgent.Model.
 	// See https://ai.google.dev/gemini-api/docs/models
-	BestExpensiveModel = "gemini-3.1-pro-preview"
-	GoodBalancedModel  = "gemini-3-flash-preview"
+	BestExpensiveModel ModelType = "best-expensive"
+	GoodBalancedModel  ModelType = "good-balanced"
+)
+
+const (
+	gemini3FlashPreview = "gemini-3-flash-preview"
+	gemini31ProPreview  = "gemini-3.1-pro-preview"
 
 	// Default limit for consecutive identical tool calls.
 	defaultLoopDetectionLimit = 3
@@ -760,7 +767,7 @@ func (a *LLMAgent) parseResponse(resp *genai.GenerateContentResponse, span *traj
 }
 
 func (a *LLMAgent) generateContent(ctx *Context, cfg *genai.GenerateContentConfig,
-	req []*genai.Content, candidate int, model string) (*genai.GenerateContentResponse, error) {
+	req []*genai.Content, candidate int, model ModelType) (*genai.GenerateContentResponse, error) {
 	// Copy the config in case we modify it below.
 	cfg = osutil.JSONDeepCopy(cfg)
 	for try := 0; ; try++ {
@@ -792,18 +799,18 @@ func (a *LLMAgent) generateContent(ctx *Context, cfg *genai.GenerateContentConfi
 }
 
 func (a *LLMAgent) generateContentCached(ctx *Context, cfg *genai.GenerateContentConfig,
-	req []*genai.Content, candidate, try int, model string) (*genai.GenerateContentResponse, error) {
+	req []*genai.Content, candidate, try int, model ModelType) (*genai.GenerateContentResponse, error) {
 	type Cached struct {
 		Config  *genai.GenerateContentConfig
 		Request []*genai.Content
 		Reply   *genai.GenerateContentResponse
 	}
-	model = ctx.modelName(model)
+	modelStr := ctx.modelName(model)
 	desc := fmt.Sprintf("model %v, config hash %v, request hash %v, candidate %v",
-		model, hash.String(cfg), hash.String(req), candidate)
+		modelStr, hash.String(cfg), hash.String(req), candidate)
 	cached, _, err := CacheObject(ctx, "llm", desc, func() (Cached, error) {
-		resp, err := ctx.generateContent(model, cfg, req)
-		err = parseLLMError(resp, err, model, try)
+		resp, err := ctx.generateContent(modelStr, cfg, req)
+		err = parseLLMError(resp, err, modelStr, try)
 		return Cached{
 			Config:  cfg,
 			Request: req,
@@ -954,7 +961,7 @@ func (a *LLMAgent) verify(ctx *verifyContext) {
 		a.compressTokens = 150_000
 	}
 	ctx.requireNotEmpty(a.Name, "Name", a.Name)
-	ctx.requireNotEmpty(a.Name, "Model", a.Model)
+	ctx.requireNotEmpty(a.Name, "Model", string(a.Model))
 	if a.ValidatedReply != nil {
 		if a.Reply != "" {
 			ctx.errorf(a.Name, "both Reply and ValidatedReply are specified")

--- a/pkg/aflow/llm_tool.go
+++ b/pkg/aflow/llm_tool.go
@@ -18,7 +18,7 @@ type LLMTool struct {
 	// Most fields match that of LLMAgent.
 	// The prompt is not specified here, and is provided by the parent LLM.
 	Name     string
-	Model    string
+	Model    ModelType
 	TaskType TaskType
 	// Description of the tool exposed to the parent LLM.
 	Description string


### PR DESCRIPTION
Introduces the ModelType enum to represent model tier configurations (BestExpensiveModel and GoodBalancedModel) instead of raw strings. This provides typing for LLMAgent and LLMTool model configurations.

Unrecognized/concrete model names (e.g. from tests or overrides) are resolved via the default case in modelName.
