### PR TITLE
pkg/aflow: query the historical context during bug patching 

### DIFF
--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -78,6 +78,15 @@ func init() {
 					Prompt:      debuggingPrompt,
 					Tools:       common.CodeAccessTools,
 				},
+				&aflow.LLMAgent{
+					Name:        "history-explorer",
+					Model:       aflow.BestExpensiveModel,
+					Reply:       "HistoricalContext",
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: historyExplorerInstruction,
+					Prompt:      historyExplorerPrompt,
+					Tools:       common.CodeAccessTools,
+				},
 				kernel.CheckoutScratch,
 				patchGenerationLoop(nil, patchInstruction, patchPrompt),
 				&aflow.LLMAgent{
@@ -134,6 +143,34 @@ it may lack the precise threading, sandboxing, and some arguments of a working r
 {{.SimplifiedCRepro}}
 ` + commonFaultInjectionPrompt
 
+const historyExplorerInstruction = `
+You are an experienced Linux kernel developer researching prior art for fixing a kernel bug.
+You are given a bug explanation. This explanation details the root cause of the bug resulting
+from debugging, but does not provide the final fix strategy. Your goal is to explore how
+similar bugs were fixed in the past in the same subsystem or files.
+
+CRITICAL: Do NOT attempt to debug the issue further or write a patch for it yourself.
+Your ONLY objective is to research and provide the necessary historical context.
+
+Use the {{.toolGitLog}} tool with the Since parameter set to "3 years" to focus on recent history.
+Search for commits that address issues with similar root causes (e.g. similar missing locks,
+incorrect refcounting, or similar error path bugs) in the affected files.
+
+Your final reply must summarize your findings: what idioms, locking rules, or common patterns
+should be followed when writing a fix for this bug based on how previous similar bugs were addressed.
+If you find no relevant past fixes, clearly state that.
+` + common.InstructionDontMakeAssumptionsAboutSourceCode
+
+const historyExplorerPrompt = `
+The crash is:
+
+{{.ReproducedCrashReport}}
+
+The explanation of the root cause of the bug is:
+
+{{.BugExplanation}}
+`
+
 // This part is shared between patching and patch-iteration.
 const commonFaultInjectionPrompt = `
 
@@ -149,8 +186,8 @@ The following fault injection report(s) show what was injected:
 
 const patchInstruction = `
 You are an experienced Linux kernel developer tasked with creating a fix for a kernel bug.
-You will be given a crash report, and an initial explanation of the root cause done by another
-kernel expert.
+You will be given a crash report, an initial explanation of the root cause done by another
+kernel expert, and a summary of how similar bugs were fixed in the past.
 
 Use the {{.toolCodeeditor}} tool to do code edits.
 Note: you will not see your changes when looking at the code using codesearch tools.
@@ -195,6 +232,12 @@ The crash that corresponds to the bug is:
 The explanation of the root cause of the bug is:
 
 {{.BugExplanation}}
+
+{{if .HistoricalContext}}
+Historical context on how similar bugs were fixed in the past:
+
+{{.HistoricalContext}}
+{{end}}
 
 {{if .TestError}}
 

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -16,6 +17,12 @@ import (
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/vcs"
 )
+
+var sinceRegex = regexp.MustCompile(`^\d+\s+(years?|months?|weeks?|days?)$`)
+
+func isValidSince(since string) bool {
+	return sinceRegex.MatchString(strings.TrimSpace(since))
+}
 
 var (
 	ToolLog = aflow.NewFuncTool("git-log", gitLog, `
@@ -31,6 +38,8 @@ Supported search modes (you must provide at least one):
    The search is case-insensitive.
  - File history: use 'PathPrefix' to explore the history of a single file or directory.
    Example: PathPrefix="mm/slub.c".
+
+Use 'Since' to limit how far back to search. It accepts duration strings like "3 years", "1 month", "2 weeks", "5 days".
 `)
 	ToolShow = aflow.NewFuncTool("git-show", gitShow, `
 Tool provides full information about a specific git commit, including its title,
@@ -59,6 +68,8 @@ type logArgs struct {
 	MessageRegexps []string `jsonschema:"Regexps to search in the commit messages. All regexps must match." json:",omitempty"`
 	PathPrefix     string   `jsonschema:"Restrict search to this directory or file path." json:",omitempty"`
 	Count          int      `jsonschema:"Max number of commits to return." json:",omitempty"`
+	// nolint: lll
+	Since string `jsonschema:"Optional duration string (e.g. '3 years') to limit how far back to search." json:",omitempty"`
 }
 
 type logResult struct {
@@ -80,6 +91,13 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 	args.Count = min(args.Count, 100)
 
 	gitArgs := []string{"log", "--format=%h %s", "--abbrev=12", "--no-patch", "-n", fmt.Sprint(args.Count)}
+
+	if args.Since != "" {
+		if !isValidSince(args.Since) {
+			return logResult{}, aflow.BadCallError("invalid Since parameter format, must be like '3 years', '1 month', '5 days'")
+		}
+		gitArgs = append(gitArgs, "--since="+args.Since)
+	}
 
 	if args.CodeRegexp != "" {
 		gitArgs = append(gitArgs, "-G", args.CodeRegexp)

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -270,4 +270,41 @@ void foo() {
 		logResult{},
 		`git log failed: fatal: invalid regex: `,
 		aflow.TestErrorPrefix(), aflow.TestWorkdir(tmpDir))
+
+	// Test git-log with valid Since parameter.
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}, Since: "3 years"},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
+			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
+		"", aflow.TestWorkdir(tmpDir))
+
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}, Since: "1 day"},
+		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
+			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test git-log with invalid Since parameter.
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}, Since: "yesterday"},
+		logResult{},
+		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",
+		aflow.TestWorkdir(tmpDir))
+
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}, Since: "3 decades"},
+		logResult{},
+		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",
+		aflow.TestWorkdir(tmpDir))
+
+	aflow.TestTool(t, ToolLog,
+		state{KernelCommit: "HEAD"},
+		logArgs{MessageRegexps: []string{"commit"}, Since: "some years"},
+		logResult{},
+		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",
+		aflow.TestWorkdir(tmpDir))
 }


### PR DESCRIPTION
Explicitly look at how similar bugs have been fixes in the past. This
should help syz-aflow produce more conventional patches.