### PR TITLE
pkg/coveragedb: implement global lock for write and cleanup operations

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -25,8 +25,8 @@ cron:
 - url: /cron/batch_coverage?days=true&months=true&steps=10
   schedule: every day 00:00
 # Clean up coverage db every week.
-# We're adding data w/o transactions.
-# It is important to run clean operation when there are no batch_coverage in progress.
+# This uses a global lock in Spanner to coordinate with batch coverage writers,
+# but we schedule it separately to minimize contention.
 - url: /cron/batch_coverage_clean
   schedule: every saturday 12:00
 # Export reproducers every week.

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
 )
 
 type HistoryRecord struct {
@@ -88,8 +89,14 @@ func SaveMergeResult(ctx context.Context, client *spanner.Client, descr *History
 	if client == nil {
 		return 0, fmt.Errorf("nil spannerclient")
 	}
-	var rowsCreated int
 	session := uuid.New().String()
+	release, err := Lock(ctx, client, "coveragedb", 15*time.Minute, 30*time.Minute)
+	if err != nil {
+		return 0, fmt.Errorf("failed to acquire coveragedb lock: %w", err)
+	}
+	defer release()
+
+	var rowsCreated int
 	var mutations []*spanner.Mutation
 
 	for {
@@ -312,6 +319,12 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		return 0, 0, fmt.Errorf("nil spannerclient")
 	}
 
+	release, err := Lock(ctx, client, "coveragedb", 15*time.Minute, 30*time.Minute)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to acquire coveragedb lock: %w", err)
+	}
+	defer release()
+
 	// 1. Get all valid sessions from merge_history
 	validSessions := make(map[string]bool)
 	iterHistory := client.Single().Query(ctx, spanner.Statement{
@@ -386,7 +399,7 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		return nil
 	})
 
-	err := eg.Wait()
+	err = eg.Wait()
 	return deletedSessions.Load(), deletedRows.Load(), err
 }
 
@@ -771,4 +784,103 @@ order by files.filepath
 		res = append(res, r.Filepath)
 	}
 	return res, nil
+}
+
+type ErrLockHeld struct {
+	Owner string
+}
+
+func (e *ErrLockHeld) Error() string {
+	return fmt.Sprintf("lock is held by %q", e.Owner)
+}
+
+// Lock acquires a global lock with the given lockID.
+// It will block and retry until it either acquires the lock or the acquireTimeout is exceeded.
+// On success, it returns a release function and no error.
+func Lock(ctx context.Context, client *spanner.Client, lockID string,
+	acquireTimeout, lockTimeout time.Duration) (func() error, error) {
+	owner := uuid.New().String()
+	deadline := time.Now().Add(acquireTimeout)
+	for {
+		err := tryAcquireLock(ctx, client, lockID, owner, lockTimeout)
+		if err == nil {
+			release := func() error {
+				return releaseLock(context.Background(), client, lockID, owner)
+			}
+			return release, nil
+		}
+		var lockHeldErr *ErrLockHeld
+		if !errors.As(err, &lockHeldErr) {
+			return nil, err
+		}
+		timeLeft := time.Until(deadline)
+		if timeLeft <= 0 {
+			return nil, fmt.Errorf("failed to acquire lock %q: %w", lockID, err)
+		}
+		sleepDur := min(10*time.Second, timeLeft)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(sleepDur):
+		}
+	}
+}
+
+func tryAcquireLock(ctx context.Context, client *spanner.Client, lockID, owner string,
+	lockTimeout time.Duration) error {
+	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		row, err := txn.ReadRow(ctx, "locks", spanner.Key{lockID}, []string{"owner", "last_acquired"})
+		if err != nil {
+			if spanner.ErrCode(err) == codes.NotFound {
+				// Lock doesn't exist, create it.
+				return txn.BufferWrite([]*spanner.Mutation{
+					spanner.InsertOrUpdate("locks", []string{"lock_id", "owner", "last_acquired"}, []any{lockID, owner, time.Now()}),
+				})
+			}
+			return err
+		}
+		var s struct {
+			Owner        spanner.NullString `spanner:"owner"`
+			LastAcquired spanner.NullTime   `spanner:"last_acquired"`
+		}
+		if err := row.ToStruct(&s); err != nil {
+			return err
+		}
+		currentOwner := s.Owner
+		lastAcquired := s.LastAcquired
+		if currentOwner.Valid && currentOwner.StringVal != "" {
+			if !lastAcquired.Valid || time.Since(lastAcquired.Time) < lockTimeout {
+				return &ErrLockHeld{Owner: currentOwner.StringVal}
+			}
+			// Lock has timed out, we can overwrite it.
+		}
+		return txn.BufferWrite([]*spanner.Mutation{
+			spanner.InsertOrUpdate("locks", []string{"lock_id", "owner", "last_acquired"}, []any{lockID, owner, time.Now()}),
+		})
+	})
+	return err
+}
+
+func releaseLock(ctx context.Context, client *spanner.Client, lockID, owner string) error {
+	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		row, err := txn.ReadRow(ctx, "locks", spanner.Key{lockID}, []string{"owner"})
+		if err != nil {
+			return err
+		}
+		var s struct {
+			Owner spanner.NullString `spanner:"owner"`
+		}
+		if err := row.ToStruct(&s); err != nil {
+			return err
+		}
+		currentOwner := s.Owner
+		if !currentOwner.Valid || currentOwner.StringVal != owner {
+			return fmt.Errorf("lock is not held by %q", owner)
+		}
+		// Clear the lock.
+		return txn.BufferWrite([]*spanner.Mutation{
+			spanner.InsertOrUpdate("locks", []string{"lock_id", "owner", "last_acquired"}, []any{lockID, nil, nil}),
+		})
+	})
+	return err
 }

--- a/pkg/coveragedb/coveragedb_test.go
+++ b/pkg/coveragedb/coveragedb_test.go
@@ -5,6 +5,7 @@ package coveragedb
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -352,4 +353,48 @@ func TestMigrations(t *testing.T) {
 	require.NoError(t, pkgspanner.UpdateSpannerDDL(ctx, uri, up))
 	require.NoError(t, pkgspanner.UpdateSpannerDDL(ctx, uri, down))
 	require.NoError(t, pkgspanner.UpdateSpannerDDL(ctx, uri, up))
+}
+
+func TestLock(t *testing.T) {
+	client := setupTestDB(t)
+	ctx := t.Context()
+
+	// 1. Acquire lock successfully
+	release1, err := Lock(ctx, client, "test-lock", 1*time.Second, 10*time.Second)
+	require.NoError(t, err)
+
+	// 2. Try to acquire the same lock (should fail/timeout)
+	_, err = Lock(ctx, client, "test-lock", 1*time.Second, 10*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lock is held by")
+	var lockHeldErr *ErrLockHeld
+	require.True(t, errors.As(err, &lockHeldErr))
+	assert.NotEmpty(t, lockHeldErr.Owner)
+
+	// 3. Release first lock
+	err = release1()
+	require.NoError(t, err)
+
+	// 4. Try acquiring again (should succeed now)
+	release2, err := Lock(ctx, client, "test-lock", 1*time.Second, 10*time.Second)
+	require.NoError(t, err)
+	defer release2()
+
+	// 5. Test lock timeout (steal lock)
+	// We acquire a lock with a very short timeout (2 seconds)
+	release3, err := Lock(ctx, client, "test-lock-timeout", 1*time.Second, 2*time.Second)
+	require.NoError(t, err)
+	_ = release3
+
+	// If we try to acquire immediately, it should fail.
+	_, err = Lock(ctx, client, "test-lock-timeout", 500*time.Millisecond, 2*time.Second)
+	require.Error(t, err)
+
+	// Wait for the lock to timeout (2 seconds)
+	time.Sleep(2500 * time.Millisecond)
+
+	// Now trying to acquire should succeed (stealing the lock)
+	release4, err := Lock(ctx, client, "test-lock-timeout", 1*time.Second, 2*time.Second)
+	require.NoError(t, err)
+	defer release4()
 }

--- a/pkg/coveragedb/migrations/2_locks.down.sql
+++ b/pkg/coveragedb/migrations/2_locks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE locks;

--- a/pkg/coveragedb/migrations/2_locks.up.sql
+++ b/pkg/coveragedb/migrations/2_locks.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE locks (
+    lock_id text,
+    owner text,
+    last_acquired timestamptz,
+    PRIMARY KEY (lock_id)
+);


### PR DESCRIPTION
Currently we guarantee write and cleanup don't happen in parallel managing the cron.yml.
This PR relaxes the rules.