### PR TITLE
tools/docker: install bindgen using cargo

### DIFF
--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -145,10 +145,10 @@ ENV SOURCEDIR_NETBSD /syzkaller/netbsd
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-ENV RUST_VERSION=1.91.1
+ENV RUST_VERSION=1.96.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_VERSION
 RUN rustup component add rust-src
-RUN apt-get install -y bindgen
+RUN cargo install --version 0.72.1 bindgen-cli && rm -rf /usr/local/cargo/registry/cache /usr/local/cargo/registry/src
 
 # Use the latest libdw-dev release, otherwise we get compilation error when CONFIG_RUST=y.
 RUN apt-get install -y --no-install-recommends libdw-dev libelf-dev

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -103,10 +103,10 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-ENV RUST_VERSION=1.91.1
+ENV RUST_VERSION=1.96.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_VERSION
 RUN rustup component add rust-src
-RUN apt-get install -y bindgen
+RUN cargo install --version 0.72.1 bindgen-cli && rm -rf /usr/local/cargo/registry/cache /usr/local/cargo/registry/src
 
 RUN apt-get install -y --no-install-recommends libdw-dev libelf-dev
 


### PR DESCRIPTION
The bindgen binary available in apt is old and might be causing linux-next to fail to build as reported in https://groups.google.com/g/syzkaller/c/BiV5kr3xonY/m/gIItKk5TAAAJ. Install using cargo to get the newest version.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
