### PR TITLE
syz-cluster/pkg/blob: add backward-compatible gzip compression for GCS blobs

### DIFF
--- a/syz-cluster/pkg/blob/gcs.go
+++ b/syz-cluster/pkg/blob/gcs.go
@@ -4,6 +4,7 @@
 package blob
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -34,13 +35,17 @@ func (gcs *gcsDriver) Write(source io.Reader, parts ...string) (string, error) {
 		return "", fmt.Errorf("no identifiers for the object were passed to Write")
 	}
 	object := path.Join(gcs.bucket, path.Join(parts...))
-	w, err := gcs.client.FileWriter(object, "", "")
+	w, err := gcs.client.FileWriter(object, "", "gzip")
 	if err != nil {
 		return "", err
 	}
 	defer w.Close()
-	_, err = io.Copy(w, source)
-	if err != nil {
+	gz := gzip.NewWriter(w)
+	if _, err := io.Copy(gz, source); err != nil {
+		gz.Close()
+		return "", err
+	}
+	if err := gz.Close(); err != nil {
 		return "", err
 	}
 	return "gcs://" + object, nil

--- a/syz-cluster/pkg/blob/gcs.go
+++ b/syz-cluster/pkg/blob/gcs.go
@@ -39,13 +39,17 @@ func (gcs *gcsDriver) Write(source io.Reader, parts ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer w.Close()
 	gz := gzip.NewWriter(w)
 	if _, err := io.Copy(gz, source); err != nil {
 		gz.Close()
+		w.Close()
 		return "", err
 	}
 	if err := gz.Close(); err != nil {
+		w.Close()
+		return "", err
+	}
+	if err := w.Close(); err != nil {
 		return "", err
 	}
 	return "gcs://" + object, nil


### PR DESCRIPTION
GCS blob storage handles highly compressible data, but previously stored it as raw bytes.

Implement transparent gzip compression when writing data to GCS by setting the Content-Encoding parameter to "gzip" during upload. This approach ensures seamless backward compatibility: the Go Google Cloud Storage client natively detects the Content-Encoding metadata and automatically decompresses new objects, while continuing to serve older, uncompressed objects as raw bytes without error.
