### PR TITLE
dashboard/app: cache AI pending patches query

### DIFF
--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/appengine/v2/memcache"
 )
 
 func (ctx *Ctx) setupAIPatchJob(t *testing.T) (string, string) {
@@ -1740,6 +1741,10 @@ func TestAIPatchFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bugIDs, 1)
 
+	c.advanceTime(6 * time.Minute)
+
+	memcache.Flush(c.ctx)
+
 	// Now it should be visible!
 	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")
 	c.expectOK(err)
@@ -1766,6 +1771,8 @@ func TestAIPatchFilter(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, respCmd.Error)
+
+	memcache.Flush(c.ctx)
 
 	// Now it should no longer be visible!
 	reply, err = c.AuthGET(AccessAdmin, "/ains?with_ai_patch=true")

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -509,6 +509,19 @@ type userBugFilter struct {
 	BugsWithPendingAIPatches map[string]bool
 }
 
+func cachedBugIDsWithPendingPatch(ctx context.Context, ns string) ([]string, error) {
+	return cachedObjectList(ctx,
+		fmt.Sprintf("%s-ai-pending-patches", ns),
+		5*time.Minute,
+		func(ctx context.Context) ([]string, error) {
+			return aidb.LoadBugIDsWithPendingPatch(ctx, ns, []ai.WorkflowType{
+				ai.WorkflowPatching,
+				ai.WorkflowPatchIteration,
+			})
+		},
+	)
+}
+
 func (filter *userBugFilter) InitializeAI(ctx context.Context, ns string) error {
 	if filter == nil {
 		return nil
@@ -517,10 +530,7 @@ func (filter *userBugFilter) InitializeAI(ctx context.Context, ns string) error 
 	if !filter.WithAIPatch {
 		return nil
 	}
-	bugIDs, err := aidb.LoadBugIDsWithPendingPatch(ctx, ns, []ai.WorkflowType{
-		ai.WorkflowPatching,
-		ai.WorkflowPatchIteration,
-	})
+	bugIDs, err := cachedBugIDsWithPendingPatch(ctx, ns)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The aidb.LoadBugIDsWithPendingPatch Spanner query is expensive and slows down the UI. Wrap it in cachedObjectList to cache the result for 5 minutes, similar to how we cache other queries in the dashboard.