### PR TITLE
pkg/aflow: add grep, pagination & .const to read-description

### DIFF
--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/syzlang"
 	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type ReproInputs struct {
@@ -41,7 +42,7 @@ func init() {
 		&aflow.Flow{
 			Consts: map[string]any{
 				"SyzkallerCommit":              prog.GitRevisionBase,
-				"DescriptionFiles":             syzlang.DescriptionFiles(),
+				"DescriptionFilesPrompt":       syzlang.DescriptionFilesPrompt(targets.Linux),
 				"DocProgramSyntax":             docs.ProgramSyntax,
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"ReproC":                       "", // is needed by crash.Reproduce
@@ -105,7 +106,5 @@ Bug title: {{.BugTitle}}
 The bug report to reproduce:
 {{.CrashReport}}
 
-The list of existing description files:
-{{range $file := .DescriptionFiles}}{{$file}}
-{{end}}
+{{.DescriptionFilesPrompt}}
 `

--- a/pkg/aflow/tool/syzlang/descriptions.go
+++ b/pkg/aflow/tool/syzlang/descriptions.go
@@ -4,43 +4,346 @@
 package syzlang
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"path"
+	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/sys"
 	"github.com/google/syzkaller/sys/targets"
 )
 
-func DescriptionFiles() []string {
-	entries, err := sys.Files.ReadDir(targets.Linux)
+func DescriptionFiles(osTarget string) []string {
+	entries, err := sys.Files.ReadDir(osTarget)
 	if err != nil {
 		panic(err)
 	}
 	var files []string
 	for _, ent := range entries {
+		if ent.Name() == "auto.txt" || ent.Name() == "auto.txt.const" {
+			continue
+		}
 		files = append(files, ent.Name())
 	}
+	slices.Sort(files)
 	return files
 }
 
-var ReadDescription = aflow.NewFuncTool("read-description", readDescription, `
+// DescriptionFilesPrompt returns a formatted section for the prompt listing description files,
+// excluding ".const" files, and appending a note about where constant values are defined.
+func DescriptionFilesPrompt(osTarget string) string {
+	files := DescriptionFiles(osTarget)
+	var filtered []string
+	for _, f := range files {
+		if !strings.HasSuffix(f, ".const") {
+			filtered = append(filtered, f)
+		}
+	}
+	sb := new(strings.Builder)
+	sb.WriteString("Available Syscall Description Files:\n")
+	for _, f := range filtered {
+		sb.WriteString(f)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("\nNote that the constant values for the descriptions are defined " +
+		"in the file suffixed with .const (e.g. sys.txt.const for sys.txt).\n")
+	return sb.String()
+}
+
+var ReadDescription = aflow.NewFuncTool("read-description", readDescription, fmt.Sprintf(`
 The tool reads the content of a syzlang description file (e.g. sys.txt, socket.txt, etc).
 Description files contain syscall definitions and related types.
-`)
 
+You can read a specific file sequentially by providing File and FirstLine (it will return a window of %d lines).
+You can also grep across a specific File or all description files by providing a regular expression in Expression. 
+If Expression is provided, FirstLine is ignored. The grep results will automatically
+include up to %d surrounding context lines for each match to help you understand the definition.
+You can read and grep both .txt and .const files.
+`, paginateLinesWindow, grepContextLines))
+
+const (
+	maxGrepLines          = 500
+	maxLineLen            = 500
+	paginateLinesWindow   = 200
+	maxOutputBytes        = 256 * 1024
+	defaultScanBufferSize = 64 * 1024
+	maxScanBufferSize     = 10 * 1024 * 1024
+	grepContextLines      = 10
+)
+
+// nolint: lll
 type readDescArgs struct {
-	File string `jsonschema:"the name of the syzlang description file to read, e.g. sys.txt or socket.txt"`
+	File       string `jsonschema:"the name of the syzlang description file to read, e.g. sys.txt or socket.txt. Can be empty if Expression is provided to search all files." json:",omitempty"`
+	FirstLine  int    `jsonschema:"First source line to return, 1-based." json:",omitempty"`
+	Expression string `jsonschema:"Regular expression to search in the description file(s)." json:",omitempty"`
 }
 
 type readDescResults struct {
 	Output string `jsonschema:"Content of the description file."`
 }
 
-func readDescription(ctx *aflow.Context, state struct{}, args readDescArgs) (readDescResults, error) {
-	// sys.Files always uses a slash as a file separator.
-	data, err := sys.Files.ReadFile(path.Join(targets.Linux, args.File))
-	if err != nil {
-		return readDescResults{}, aflow.BadCallError("failed to read file %q: %v", args.File, err)
+type readDescState struct {
+	TargetOS string
+}
+
+func readDescription(ctx *aflow.Context, state readDescState, args readDescArgs) (readDescResults, error) {
+	if args.Expression != "" && args.FirstLine != 0 {
+		return readDescResults{}, aflow.BadCallError("Expression cannot be used together with FirstLine")
 	}
-	return readDescResults{string(data)}, nil
+	osTarget := strings.ToLower(state.TargetOS)
+	if osTarget == "" {
+		osTarget = targets.Linux
+	}
+	if _, err := sys.Files.ReadDir(osTarget); err != nil {
+		return readDescResults{}, aflow.BadCallError("invalid OS %q: %v", osTarget, err)
+	}
+	if args.Expression != "" {
+		return grepDescriptions(osTarget, args.Expression, args.File)
+	}
+	return paginateDescription(osTarget, args.File, args.FirstLine)
+}
+
+func validateFilePath(file string) error {
+	if file != "" {
+		cleaned := strings.TrimPrefix(file, "test/")
+		if strings.Contains(cleaned, "/") || strings.Contains(cleaned, "\\") || strings.HasPrefix(cleaned, ".") {
+			return aflow.BadCallError("invalid file path %q", file)
+		}
+		if cleaned == "auto.txt" || cleaned == "auto.txt.const" {
+			return aflow.BadCallError("access to auto.txt or auto.txt.const is disallowed")
+		}
+	}
+	return nil
+}
+
+func newScanner(f io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, defaultScanBufferSize)
+	scanner.Buffer(buf, maxScanBufferSize)
+	return scanner
+}
+
+func grepDescriptions(osTarget, expression, file string) (readDescResults, error) {
+	if err := validateFilePath(file); err != nil {
+		return readDescResults{}, err
+	}
+
+	re, err := regexp.Compile(expression)
+	if err != nil {
+		return readDescResults{}, aflow.BadCallError("bad expression: %v", err)
+	}
+	var targetFiles []string
+	if file != "" {
+		targetFiles = []string{file}
+	} else {
+		targetFiles = DescriptionFiles(osTarget)
+	}
+
+	state := grepState{
+		b:           new(strings.Builder),
+		targetFiles: targetFiles,
+	}
+
+	for _, fname := range targetFiles {
+		f, err := sys.Files.Open(path.Join(osTarget, fname))
+		if err != nil {
+			return readDescResults{}, aflow.BadCallError("failed to read file %q: %v", fname, err)
+		}
+
+		scanner := newScanner(f)
+		state.fname = fname
+		state.beforeBuf = nil
+		state.remainingAfterCtxLines = 0
+		state.lastPrintedLineNum = 0
+		lineNum := 1
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			matched := re.MatchString(line)
+			state.processLine(line, lineNum, matched)
+			if state.truncated {
+				break
+			}
+			lineNum++
+		}
+		f.Close()
+		if err := scanner.Err(); err != nil {
+			return readDescResults{}, aflow.BadCallError("failed to scan file %q: %v", fname, err)
+		}
+		if state.truncated {
+			break
+		}
+	}
+
+	if state.linesCount == 0 {
+		return readDescResults{Output: "No matches found."}, nil
+	}
+
+	res := state.b.String()
+	if state.truncated {
+		res = fmt.Sprintf("%s\n... (Output truncated because it reached the maximum "+
+			"line count limit. Use a stricter Expression.)", res)
+	}
+	return readDescResults{limitOutputBytes(res)}, nil
+}
+
+type ctxLine struct {
+	num  int
+	text string
+}
+
+type grepState struct {
+	// File-local state (reset for every target file).
+	beforeBuf              []ctxLine
+	remainingAfterCtxLines int
+	lastPrintedLineNum     int
+
+	// Global state (retained across all files).
+	linesCount  int
+	truncated   bool
+	b           *strings.Builder
+	fname       string
+	targetFiles []string
+}
+
+func (s *grepState) appendLine(num int, text, sep string) {
+	if s.truncated {
+		return
+	}
+	var prefix string
+	if len(s.targetFiles) == 1 {
+		prefix = fmt.Sprintf("%4d%s\t", num, sep)
+	} else {
+		prefix = fmt.Sprintf("%s:%d%s\t", s.fname, num, sep)
+	}
+	truncatedLine := truncateLine(text)
+	s.b.WriteString(prefix)
+	s.b.WriteString(truncatedLine)
+	s.b.WriteByte('\n')
+}
+
+func (s *grepState) appendSeparator(lineNum int) {
+	if s.lastPrintedLineNum <= 0 || s.lastPrintedLineNum >= lineNum-len(s.beforeBuf)-1 {
+		return
+	}
+	if s.b.Len() == 0 || s.truncated {
+		return
+	}
+	s.b.WriteString("--\n")
+}
+
+func (s *grepState) processMatched(line string, lineNum int) {
+	s.appendSeparator(lineNum)
+
+	for _, cl := range s.beforeBuf {
+		s.appendLine(cl.num, cl.text, "-")
+	}
+	s.beforeBuf = nil
+
+	s.appendLine(lineNum, line, ":")
+	s.lastPrintedLineNum = lineNum
+
+	s.linesCount++
+	if s.linesCount >= maxGrepLines {
+		s.truncated = true
+	}
+	s.remainingAfterCtxLines = grepContextLines
+}
+
+func (s *grepState) processUnmatched(line string, lineNum int) {
+	if s.remainingAfterCtxLines > 0 {
+		s.appendLine(lineNum, line, "-")
+		s.remainingAfterCtxLines--
+		s.lastPrintedLineNum = lineNum
+		return
+	}
+	s.beforeBuf = append(s.beforeBuf, ctxLine{num: lineNum, text: line})
+	if len(s.beforeBuf) > grepContextLines {
+		s.beforeBuf = s.beforeBuf[1:]
+	}
+}
+
+func (s *grepState) processLine(line string, lineNum int, matched bool) {
+	if matched {
+		s.processMatched(line, lineNum)
+	} else {
+		s.processUnmatched(line, lineNum)
+	}
+}
+
+func paginateDescription(osTarget, file string, firstLine int) (readDescResults, error) {
+	if file == "" {
+		return readDescResults{}, aflow.BadCallError("File must be provided when not using Expression")
+	}
+	if err := validateFilePath(file); err != nil {
+		return readDescResults{}, err
+	}
+
+	f, err := sys.Files.Open(path.Join(osTarget, file))
+	if err != nil {
+		return readDescResults{}, aflow.BadCallError("failed to read file %q: %v", file, err)
+	}
+	defer f.Close()
+
+	firstLine = max(1, firstLine)
+
+	scanner := newScanner(f)
+	lineNum := 1
+
+	// Skip until firstLine.
+	for lineNum < firstLine && scanner.Scan() {
+		lineNum++
+	}
+	if err := scanner.Err(); err != nil {
+		return readDescResults{}, aflow.BadCallError("failed to scan file %q: %v", file, err)
+	}
+	// If EOF reached before firstLine.
+	if lineNum < firstLine {
+		return readDescResults{}, aflow.BadCallError("file %s does not have line %d, it has only %d lines",
+			file, firstLine, lineNum-1)
+	}
+
+	b := new(strings.Builder)
+	count := 0
+
+	for count < paginateLinesWindow && scanner.Scan() {
+		line := scanner.Text()
+		truncatedLine := truncateLine(line)
+
+		lineStr := fmt.Sprintf("%4d:\t%s\n", lineNum, truncatedLine)
+		b.WriteString(lineStr)
+		lineNum++
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return readDescResults{}, aflow.BadCallError("failed to scan file %q: %v", file, err)
+	}
+
+	res := b.String()
+	return readDescResults{limitOutputBytes(res)}, nil
+}
+
+func limitOutputBytes(res string) string {
+	if len(res) > maxOutputBytes {
+		return res[:maxOutputBytes] + "\nWARNING: Output truncated as it exceeded the 256KB limit."
+	}
+	return res
+}
+
+func truncateLine(line string) string {
+	if len(line) <= maxLineLen {
+		return line
+	}
+	count := 0
+	for i := range line {
+		if count == maxLineLen {
+			return line[:i] + "... <truncated>"
+		}
+		count++
+	}
+	return line
 }

--- a/pkg/aflow/tool/syzlang/descriptions_test.go
+++ b/pkg/aflow/tool/syzlang/descriptions_test.go
@@ -6,20 +6,104 @@ package syzlang
 import (
 	"testing"
 
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDescriptionFiles(t *testing.T) {
-	files := DescriptionFiles()
+	files := DescriptionFiles(targets.Linux)
 	require.Greater(t, len(files), 50)
 	require.Contains(t, files, "sys.txt")
 }
 
-func TestReadDescription(t *testing.T) {
-	res, err := readDescription(nil, struct{}{}, readDescArgs{File: "sys.txt"})
-	require.NoError(t, err)
-	require.Contains(t, res.Output, "meta")
+func TestDescriptionFilesPrompt(t *testing.T) {
+	prompt := DescriptionFilesPrompt(targets.Linux)
+	require.Contains(t, prompt, "sys.txt\n")
+	require.NotContains(t, prompt, "sys.txt.const\n")
+}
 
-	_, err2 := readDescription(nil, struct{}{}, readDescArgs{File: "non_existent_file.txt"})
+func TestReadDescription(t *testing.T) {
+	// Test pagination.
+	res, err := readDescription(nil, readDescState{}, readDescArgs{
+		File:      "sys.txt",
+		FirstLine: 1,
+	})
+	require.NoError(t, err)
+	require.Contains(t, res.Output, "Copyright")
+
+	// Test missing file without expression.
+	_, err2 := readDescription(nil, readDescState{}, readDescArgs{File: "non_existent_file.txt"})
 	require.Error(t, err2)
+
+	// Test invalid file paths.
+	_, errInvalid := readDescription(nil, readDescState{}, readDescArgs{File: "../sys.txt"})
+	require.ErrorContains(t, errInvalid, "invalid file path")
+	_, errInvalid2 := readDescription(nil, readDescState{}, readDescArgs{File: "/etc/passwd"})
+	require.ErrorContains(t, errInvalid2, "invalid file path")
+
+	// Test reading auto.txt or auto.txt.const is disallowed.
+	_, errAuto := readDescription(nil, readDescState{}, readDescArgs{File: "auto.txt"})
+	require.ErrorContains(t, errAuto, "access to auto.txt or auto.txt.const is disallowed")
+	_, errAutoConst := readDescription(nil, readDescState{}, readDescArgs{File: "auto.txt.const"})
+	require.ErrorContains(t, errAutoConst, "access to auto.txt or auto.txt.const is disallowed")
+
+	// Test reading const file works.
+	resConst, errConst := readDescription(nil, readDescState{}, readDescArgs{File: "aio.txt.const", FirstLine: 1})
+	require.NoError(t, errConst)
+	require.NotEmpty(t, resConst.Output)
+
+	// Test grep with a file.
+	resGrep, errGrep := readDescription(nil, readDescState{}, readDescArgs{
+		File:       "sys.txt",
+		Expression: "^type ",
+	})
+	require.NoError(t, errGrep)
+	require.Contains(t, resGrep.Output, "type ")
+	require.Contains(t, resGrep.Output, ":\ttype")
+
+	// Test grep across all files.
+	resGrepAll, errGrepAll := readDescription(nil, readDescState{}, readDescArgs{
+		Expression: "^type ",
+	})
+	require.NoError(t, errGrepAll)
+	require.Contains(t, resGrepAll.Output, ".txt:")
+	require.Contains(t, resGrepAll.Output, "type")
+
+	// Test grep with no matches (should return success, not error).
+	resEmpty, errEmpty := readDescription(nil, readDescState{}, readDescArgs{
+		File:       "sys.txt",
+		Expression: "THIS_STRING_SHOULD_NOT_EXIST_IN_SYS_TXT",
+	})
+	require.NoError(t, errEmpty)
+	require.Equal(t, "No matches found.", resEmpty.Output)
+
+	// Test conflicting arguments.
+	_, errConflict := readDescription(nil, readDescState{}, readDescArgs{
+		Expression: "^type ",
+		FirstLine:  1,
+	})
+	require.ErrorContains(t, errConflict, "Expression cannot be used together")
+
+	// Test pagination boundary violation.
+	_, errBound := readDescription(nil, readDescState{}, readDescArgs{
+		File:      "sys.txt",
+		FirstLine: 9999999, // Way out of bounds.
+	})
+	require.ErrorContains(t, errBound, "does not have line")
+
+	// Test reading test seed file.
+	resSeed, errSeed := readDescription(nil, readDescState{}, readDescArgs{
+		File:      "test/syz_mount_image_btrfs_0",
+		FirstLine: 1,
+	})
+	require.NoError(t, errSeed)
+	require.NotEmpty(t, resSeed.Output)
+
+	// Test grep across test seed file.
+	resSeedGrep, errSeedGrep := readDescription(nil, readDescState{}, readDescArgs{
+		File:       "test/syz_mount_image_btrfs_0",
+		Expression: "syz_mount_image",
+	})
+	require.NoError(t, errSeedGrep)
+	require.Contains(t, resSeedGrep.Output, "syz_mount_image")
 }

--- a/sys/syz-sysgen/sysgen.go
+++ b/sys/syz-sysgen/sysgen.go
@@ -372,7 +372,7 @@ import (
 // For simplicity we embed them here for now, since go:embed patterns can't contain "..".
 // Ideally we move this to a separate package, but this will require some restructuring.
 
-//go:embed linux/*.txt
+//go:embed linux/*.txt linux/*.const linux/test
 var Files embed.FS
 
 //go:embed gen/*.gob.flate


### PR DESCRIPTION
Previously, the read-description tool loaded the entire contents of a syzlang description file into the agent's context window. This resulted in massive token consumption and often exceeded context limits, making it impossible for the agent to safely read large autogenerated files.

Introduce regex-based grep searching and line-by-line pagination to the tool, allowing the agent to precisely query the specific syscall signatures and struct definitions it needs. To further guarantee token safety, strict per-line character limits and global byte caps are enforced on the output.

<del>Embed the linux/test directory inside sys/syz-sysgen, and update the
read-description tool to allow listing and reading test seeds (e.g. from
the test/ subdirectory).</del> -> in another PR later