### PR TITLE
dashboard/app: fix 404 handling for invalid URLs

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -46,6 +46,8 @@ import (
 // This file contains web UI http handlers.
 
 func initHTTPHandlers() {
+	// A pattern ending with a slash matches as a prefix.
+	// This makes it a greedy catch-all for any request that doesn't explicitly match a more specific route.
 	http.Handle("/", handlerWrapper(handleMain))
 	http.Handle("/bug", handlerWrapper(handleBug))
 	http.Handle("/text", handlerWrapper(handleText))
@@ -611,6 +613,13 @@ func handleMain(ctx context.Context, w http.ResponseWriter, r *http.Request) err
 	hdr, err := commonHeader(ctx, r, w, "")
 	if err != nil {
 		return err
+	}
+	// The route "/" is a greedy catch-all. Without this check, any malformed URL
+	// that doesn't match a specific route will fall through to handleMain,
+	// which can cause massive DB queries for garbage URLs.
+	cleanPath := strings.TrimSuffix(r.URL.Path, "/")
+	if cleanPath != "/"+hdr.Namespace && cleanPath != "" {
+		return ErrClientNotFound
 	}
 	accessLevel := accessLevel(ctx, r)
 	filter, err := MakeBugFilter(r)


### PR DESCRIPTION
The HTTP route '/' acts as a greedy catch-all in net/http ServeMux for any request that doesn't explicitly match a more specific route. When crawlers generate mangled URLs due to broken relative links (e.g. duplicating paths like /upstream/graph/coverage/upstream/manager/...), they bypass specific handlers and fall back to handleMain.

Previously, handleMain would ignore the extraneous path segments and still attempt to fetch all namespace bugs. This resulted in massive database queries for garbage URLs, which eventually led to context DeadlineExceeded errors.

This change adds a strict path check to handleMain. If the request URL does not match '/' or '/<namespace>', it returns a 404 (ErrClientNotFound), preventing the heavy DB fetch operations.
