### PR TITLE
dashboard/app: limit global emails per hour

### DIFF
--- a/dashboard/app/email_test.go
+++ b/dashboard/app/email_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	aemail "google.golang.org/appengine/v2/mail"
 )
 
 // nolint: funlen
@@ -1623,4 +1624,35 @@ func TestEmailIndirectCommandIgnored(t *testing.T) {
 
 	// No email should be sent back.
 	c.expectNoEmail()
+}
+
+func TestEmailRateLimit(t *testing.T) {
+	MaxGlobalEmailsPerHour = 3
+	c := NewCtx(t)
+	defer c.Close()
+
+	msg := &aemail.Message{
+		Sender:  "syzbot@testapp.appspotmail.com",
+		To:      []string{"test@syzkaller.com"},
+		Subject: "Test subject",
+		Body:    "Test body",
+	}
+
+	for i := range MaxGlobalEmailsPerHour {
+		// Calling the checker directly is easier than modifying the sender mock.
+		err := checkEmailRateLimit(c.ctx, msg)
+		require.NoError(t, err, "failed to send email %d", i)
+	}
+
+	// Max + 1 should fail.
+	err := checkEmailRateLimit(c.ctx, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "global email rate limit exceeded")
+
+	// Advance time by 1 hour.
+	c.advanceTime(time.Hour)
+
+	// Now we should be able to send emails again.
+	err = checkEmailRateLimit(c.ctx, msg)
+	require.NoError(t, err)
 }

--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -483,6 +483,12 @@ type DiscussionMessage struct {
 // ReportingState holds dynamic info associated with reporting.
 type ReportingState struct {
 	Entries []ReportingStateEntry
+	Emails  EmailState
+}
+
+type EmailState struct {
+	Count int
+	Time  time.Time
 }
 
 type ReportingStateEntry struct {

--- a/dashboard/app/reporting_email.go
+++ b/dashboard/app/reporting_email.go
@@ -1539,8 +1539,37 @@ func replyError(ctx context.Context, msg *email.Email, bugID, reply string) erro
 	return replyTo(ctx, msg, bugID, reply)
 }
 
+// Exported to use in test.
+var MaxGlobalEmailsPerHour = 60
+
+func checkEmailRateLimit(ctx context.Context, msg *aemail.Message) error {
+	tx := func(txCtx context.Context) error {
+		state, err := loadReportingState(txCtx)
+		if err != nil {
+			return err
+		}
+		now := timeNow(txCtx)
+		currentHour := now.Truncate(time.Hour)
+		lastHour := state.Emails.Time.Truncate(time.Hour)
+		if !currentHour.Equal(lastHour) {
+			state.Emails.Count = 0
+		}
+		if state.Emails.Count >= MaxGlobalEmailsPerHour {
+			return fmt.Errorf("global email rate limit exceeded (%v >= %v)",
+				state.Emails.Count, MaxGlobalEmailsPerHour)
+		}
+		state.Emails.Count++
+		state.Emails.Time = now
+		return saveReportingState(txCtx, state)
+	}
+	return runInTransaction(ctx, tx, nil)
+}
+
 // Sends email, can be stubbed for testing.
 var sendEmail = func(ctx context.Context, msg *aemail.Message) error {
+	if err := checkEmailRateLimit(ctx, msg); err != nil {
+		return fmt.Errorf("email rate limit exceeded: %w", err)
+	}
 	if err := aemail.Send(ctx, msg); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}


### PR DESCRIPTION
Introduce checkEmailRateLimit to restrict outgoing emails to a maximum of 240 per hour globally. The limit is tracked via App Engine's memcache using the current hour as the key.
