### PR TITLE
pkg/execbackend: skip TestRPCBackendLocal when compiler is broken

### DIFF
--- a/pkg/execbackend/rpc_test.go
+++ b/pkg/execbackend/rpc_test.go
@@ -21,6 +21,11 @@ func TestRPCBackendLocal(t *testing.T) {
 	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)
 	require.NoError(t, err)
 
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken compiler: %v", sysTarget.BrokenCompiler)
+	}
+
 	executorBin := csource.BuildExecutor(t, target, "../..")
 
 	p, err := target.Deserialize([]byte("syz_test_fuzzer1(0, 0, 0)"), prog.Strict)


### PR DESCRIPTION
The TestRPCBackendLocal test attempts to build the executor for TestOS without checking if the compiler is fully functional. On OpenBSD, TestOS is explicitly marked as broken due to missing syscalls, which leads to uninitialized compiler flags and subsequent build failures.

Add a check for sysTarget.BrokenCompiler and skip the test if it is set.