### PR TITLE
dashboard/app/aidb: add indexes to speed up AI job lists

### DIFF
--- a/dashboard/app/aidb/migrations/21_add_job_list_indices.down.sql
+++ b/dashboard/app/aidb/migrations/21_add_job_list_indices.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX JobsBugIDCreated;
+DROP INDEX JobsNamespaceCreated;

--- a/dashboard/app/aidb/migrations/21_add_job_list_indices.up.sql
+++ b/dashboard/app/aidb/migrations/21_add_job_list_indices.up.sql
@@ -1,0 +1,5 @@
+-- Optimizes LoadNamespaceJobs for the /ns/ai page.
+CREATE INDEX JobsNamespaceCreated ON Jobs(Namespace, Created DESC);
+
+-- Optimizes LoadBugJobs.
+CREATE INDEX JobsBugIDCreated ON Jobs(BugID, Created DESC);


### PR DESCRIPTION
Add Spanner indexes for (Namespace, Created DESC) and (BugID, Created DESC). This avoids slow full-table scans and in-memory sorting when paginating the /ns/ai dashboard or querying jobs for a specific bug.