### PR TITLE
pkg/aflow/tool/syzlang: extend coverage retrieval tools

### DIFF
--- a/pkg/aflow/tool/syzlang/coverage.go
+++ b/pkg/aflow/tool/syzlang/coverage.go
@@ -22,8 +22,10 @@ The list is deduplicated and sorted, presenting a high-level summary of the cove
 
 	FileCoverage = aflow.NewFuncTool("get-file-coverage", getFileCoverage, `
 Tool evaluates code coverage for a specific file and returns coverage snippets highlighting the executed lines.
-For each function that had hits in the file, it will dump the executed source lines with short context
-around them. Covered lines are prefixed with '* '.
+By default, it will dump the executed source lines with short context for each function that had hits.
+You can use the 'Functions' argument to request snippets for a specific subset of functions.
+Covered lines are prefixed with '* '.
+If the total output exceeds the maximum line limit, it will be truncated. Use 'Functions' to narrow down your request.
 `)
 
 	Coverage = []aflow.Tool{CoverageFiles, FileCoverage}
@@ -58,12 +60,93 @@ func getCoverageFiles(ctx *aflow.Context, state reproduceState, args CoverageFil
 }
 
 type FileCoverageArgs struct {
-	ExecutionCachedID string `jsonschema:"Cached ID returned by the reproduce-crash tool."`
-	Filename          string `jsonschema:"Name of the source file to inspect."`
+	ExecutionCachedID string   `jsonschema:"Cached ID returned by the reproduce-crash tool."`
+	Filename          string   `jsonschema:"Name of the source file to inspect."`
+	Functions         []string `jsonschema:"Optional list of functions. If empty, returns all."`
 }
 
 type FileCoverageResult struct {
-	Snippets []string `jsonschema:"List of formatted code snippets for each executed function in the requested file."`
+	CoveredFunctions []string `jsonschema:"List of all executed functions in the requested file."`
+	Snippets         []string `jsonschema:"List of formatted code snippets for the requested functions."`
+}
+
+const (
+	fileCoverageMaxTotalLines = 1000
+	fileCoverageCtxPadding    = 10
+)
+
+type coverageFormatter struct {
+	srcLines       []string
+	remainingLines int
+	snippets       []string
+	truncated      bool
+}
+
+func newCoverageFormatter(srcLines []string, maxLines int) *coverageFormatter {
+	return &coverageFormatter{
+		srcLines:       srcLines,
+		remainingLines: maxLines,
+	}
+}
+
+// addFunction adds a snippet for the given function. Returns true if the global
+// limit was reached (truncated).
+func (f *coverageFormatter) addFunction(fnName string, coveredLines []int) bool {
+	start, end := f.calculateBounds(coveredLines)
+
+	actualEnd := f.applyLimits(start, end)
+	snippet := f.buildSnippet(fnName, start, actualEnd, coveredLines)
+	if snippet != "" {
+		f.snippets = append(f.snippets, snippet)
+	}
+
+	return f.truncated
+}
+
+// calculateBounds determines the starting and ending lines by adding context
+// padding around the minimum and maximum covered lines.
+func (f *coverageFormatter) calculateBounds(lines []int) (start, end int) {
+	minLine := lines[0]
+	maxLine := lines[len(lines)-1]
+	end = min(len(f.srcLines), maxLine+fileCoverageCtxPadding)
+	start = min(end, max(1, minLine-fileCoverageCtxPadding))
+	return start, end
+}
+
+// applyLimits computes how many lines can actually be rendered based on the
+// remaining lines allowed. It updates the remainingLines state and returns the
+// actual end line. It sets f.truncated if truncation occurred.
+func (f *coverageFormatter) applyLimits(start, end int) int {
+	linesInSnippet := end - start + 1
+	consumedLines := linesInSnippet
+	if linesInSnippet > f.remainingLines {
+		consumedLines = max(0, f.remainingLines)
+		f.truncated = true
+	}
+	f.remainingLines -= consumedLines
+	return start + consumedLines - 1
+}
+
+// buildSnippet constructs the final formatted snippet string using a
+// strings.Builder, prefixing covered lines with a marker and appending a
+// truncation message if f.truncated is true.
+func (f *coverageFormatter) buildSnippet(fnName string, start, end int, lines []int) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "Function: %v\n", fnName)
+
+	for i := start; i <= end; i++ {
+		prefix := "  "
+		if _, hit := slices.BinarySearch(lines, i); hit {
+			prefix = "* "
+		}
+		fmt.Fprintf(&out, "%s%4d: %s\n", prefix, i, f.srcLines[i-1])
+	}
+
+	if f.truncated {
+		fmt.Fprintf(&out, "[Truncated due to reaching maximum line limit. Use 'Functions' to narrow your query]\n")
+	}
+
+	return out.String()
 }
 
 func getFileCoverage(ctx *aflow.Context, state reproduceState, args FileCoverageArgs) (FileCoverageResult, error) {
@@ -98,31 +181,39 @@ func getFileCoverage(ctx *aflow.Context, state reproduceState, args FileCoverage
 
 	var res FileCoverageResult
 
-	for fnName, lines := range funcLines {
+	for fnName := range funcLines {
+		res.CoveredFunctions = append(res.CoveredFunctions, fnName)
+	}
+	slices.Sort(res.CoveredFunctions)
+
+	formatter := newCoverageFormatter(srcLines, fileCoverageMaxTotalLines)
+
+	for _, fnName := range res.CoveredFunctions {
+		lines := funcLines[fnName]
+		if len(args.Functions) > 0 && !slices.Contains(args.Functions, fnName) {
+			continue
+		}
 		if len(lines) == 0 {
 			continue
 		}
 		slices.Sort(lines)
 		lines = slices.Compact(lines)
-		minLine := lines[0]
-		maxLine := lines[len(lines)-1]
 
-		ctxPadding := 10
-		start := max(1, minLine-ctxPadding)
-		end := min(len(srcLines), maxLine+ctxPadding)
-
-		var out strings.Builder
-		fmt.Fprintf(&out, "Function: %v\n", fnName)
-		for i := start; i <= end; i++ {
-			prefix := "  "
-			if _, hit := slices.BinarySearch(lines, i); hit {
-				prefix = "* "
-			}
-			fmt.Fprintf(&out, "%s%4d: %s\n", prefix, i, srcLines[i-1])
+		if formatter.addFunction(fnName, lines) {
+			break
 		}
-		res.Snippets = append(res.Snippets, out.String())
 	}
-	slices.Sort(res.Snippets)
+
+	res.Snippets = formatter.snippets
+
+	if len(args.Functions) > 0 {
+		for _, fn := range args.Functions {
+			if !slices.Contains(res.CoveredFunctions, fn) {
+				msg := fmt.Sprintf("%v: [No coverage found or function does not exist]\n", fn)
+				res.Snippets = append(res.Snippets, msg)
+			}
+		}
+	}
 
 	return res, nil
 }

--- a/pkg/aflow/tool/syzlang/coverage_test.go
+++ b/pkg/aflow/tool/syzlang/coverage_test.go
@@ -6,6 +6,7 @@ package syzlang
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -91,4 +92,81 @@ void foo(void) {
      9: 
 `
 	require.Equal(t, expectedSnippet, res.Snippets[0])
+
+	// Test truncation limit using the formatter directly.
+	lines := []int{5, 6, 7}
+	srcLines := strings.Split(srcContent, "\n")
+	formatter := newCoverageFormatter(srcLines, 5)
+	truncated := formatter.addFunction("foo", lines)
+
+	require.True(t, truncated)
+	require.Len(t, formatter.snippets, 1)
+	require.Equal(t, 0, formatter.remainingLines)
+
+	expectedSnippetTrunc := `Function: foo
+     1: 1
+     2: 2
+     3: 3
+     4: 4
+*    5: void foo(void) {
+[Truncated due to reaching maximum line limit. Use 'Functions' to narrow your query]
+`
+	require.Equal(t, expectedSnippetTrunc, formatter.snippets[0])
+}
+
+func TestFileCoverageNoCoverage(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	// Provide empty coverage for this test.
+	_, reproExecCachedID, err := aflow.CacheObject(ctx, "repro", "dummy-desc-3", func() (map[string]any, error) {
+		return map[string]any{"Coverage": [][]symbolizer.Frame{}}, nil
+	})
+	require.NoError(t, err)
+
+	_, err = getFileCoverage(ctx, reproduceState{}, FileCoverageArgs{
+		ExecutionCachedID: reproExecCachedID,
+		Filename:          "nonexistent.c",
+	})
+	require.IsType(t, aflow.BadCallError(""), err)
+}
+
+func TestFileCoverageMissingFunction(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	dummyCov := [][]symbolizer.Frame{
+		{
+			{File: "foo.c", Func: "foo", Line: 5},
+		},
+	}
+
+	_, reproExecCachedID, err := aflow.CacheObject(ctx, "repro", "dummy-desc-4", func() (map[string]any, error) {
+		return map[string]any{"Coverage": dummyCov}, nil
+	})
+	require.NoError(t, err)
+
+	kernelSrc := t.TempDir()
+	err = osutil.MkdirAll(kernelSrc)
+	require.NoError(t, err)
+
+	srcContent := `1
+2
+3
+4
+void foo(void) {
+    int a = 1;
+    a++;
+}
+`
+	err = os.WriteFile(filepath.Join(kernelSrc, "foo.c"), []byte(srcContent), 0644)
+	require.NoError(t, err)
+
+	res, err := getFileCoverage(ctx, reproduceState{KernelSrc: kernelSrc}, FileCoverageArgs{
+		ExecutionCachedID: reproExecCachedID,
+		Filename:          "foo.c",
+		Functions:         []string{"foo", "nonexistent_function"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.Snippets, 2)
+	require.Contains(t, res.Snippets[1], "nonexistent_function: [No coverage found or function does not exist]")
 }


### PR DESCRIPTION
Currently, getFileCoverage returns the coverage of the entire file, which could blow up LLM context for certain Linux kernel files with several thousands lines. Add an array Functions as argument to allow the LLM to grep only coverage for certain functions it's interested in. We also add a hard line number limit to getFileCoverage.