### PR TITLE
pkg/aflow: support auto-generated syscalls during crash reproduction 

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -121,6 +121,7 @@ func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestR
 	cfg.Image = args.Image
 	cfg.Type = args.Type
 	cfg.VM = vmCfg
+	cfg.Experimental.DescriptionsMode = mgrconfig.AnyDescriptionsMode
 	if args.NeedStrace && args.StraceBin != "" {
 		cfg.StraceBin = args.StraceBin
 		cfg.StraceBinOnTarget = false

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -104,7 +104,7 @@ func DefaultValues() *Config {
 		Experimental: Experimental{
 			RemoteCover:      true,
 			CoverEdges:       true,
-			DescriptionsMode: manualDescriptions,
+			DescriptionsMode: ManualDescriptionsMode,
 		},
 	}
 }
@@ -119,12 +119,16 @@ const (
 	AnyDescriptions = ManualDescriptions | AutoDescriptions
 )
 
-const manualDescriptions = "manual"
+const (
+	ManualDescriptionsMode = "manual"
+	AutoDescriptionsMode   = "auto"
+	AnyDescriptionsMode    = "any"
+)
 
 var strToDescriptionsMode = map[string]DescriptionsMode{
-	manualDescriptions: ManualDescriptions,
-	"auto":             AutoDescriptions,
-	"any":              AnyDescriptions,
+	ManualDescriptionsMode: ManualDescriptions,
+	AutoDescriptionsMode:   AutoDescriptions,
+	AnyDescriptionsMode:    AnyDescriptions,
 }
 
 func SetTargets(cfg *Config) error {

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -6,10 +6,12 @@ package mgrconfig
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/google/syzkaller/pkg/config"
@@ -187,7 +189,12 @@ func Complete(cfg *Config) error {
 		return fmt.Errorf("fuzzing_vms cannot be less than 0")
 	}
 
-	descriptionsMode := strToDescriptionsMode[cfg.Experimental.DescriptionsMode]
+	descriptionsMode, ok := strToDescriptionsMode[cfg.Experimental.DescriptionsMode]
+	if !ok {
+		allowed := slices.Sorted(maps.Keys(strToDescriptionsMode))
+		return fmt.Errorf("invalid descriptions_mode %q, must be one of: %s",
+			cfg.Experimental.DescriptionsMode, strings.Join(allowed, ", "))
+	}
 	if cfg.Snapshot {
 		descriptionsMode |= SnapshotDescriptions
 	}

--- a/pkg/mgrconfig/load_test.go
+++ b/pkg/mgrconfig/load_test.go
@@ -97,3 +97,18 @@ func TestParseEnabledSyscalls(t *testing.T) {
 		})
 	}
 }
+
+func TestCompleteDescriptionsMode(t *testing.T) {
+	data := []byte(`{
+		"target": "linux/amd64",
+		"type": "none",
+		"workdir": "/tmp",
+		"syzkaller": "testdata/syzkaller",
+		"experimental": {
+			"descriptions_mode": "invalid"
+		}
+	}`)
+	_, err := LoadData(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid descriptions_mode "invalid", must be one of: any, auto, manual`)
+}


### PR DESCRIPTION
Set cfg.Experimental.DescriptionsMode to mgrconfig.AnyDescriptionsMode
when setting up the reproducer environment in the crash reproducing
action. This fixes an issue where the patching workflow could not
reproduce crashes if the reproducer relied on syscalls from auto.txt.