### PR TITLE
dashboard/app/aidb: avoid overfetching large columns in LoadNamespaceJobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -286,7 +286,7 @@ func handleAIJobsPage(ctx context.Context, w http.ResponseWriter, r *http.Reques
 	reverse := r.FormValue("reverse") != ""
 	const limit = 300
 
-	jobs, err := aidb.LoadNamespaceJobs(ctx, hdr.Namespace, &aidb.JobFilter{
+	jobs, err := aidb.LoadNamespaceJobsSummary(ctx, hdr.Namespace, &aidb.JobFilter{
 		Workflow:    currentWorkflow,
 		ShowAborted: showAborted,
 		CursorTime:  cursorTime,

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -344,8 +344,8 @@ type JobFilter struct {
 	Reverse     bool
 }
 
-func LoadNamespaceJobs(ctx context.Context, ns string, filter *JobFilter) ([]*Job, error) {
-	sql := selectJobs() + "WHERE Namespace = @ns"
+func LoadNamespaceJobsSummary(ctx context.Context, ns string, filter *JobFilter) ([]*Job, error) {
+	sql := selectJobsSummary() + "WHERE Namespace = @ns"
 	params := map[string]any{
 		"ns": ns,
 	}
@@ -565,6 +565,17 @@ func selectAgents() string {
 
 func selectJobs() string {
 	return selectAllFrom[Job]("Jobs")
+}
+
+// selectJobsSummary returns a SELECT query for the Jobs table optimized for the list page.
+// It selects all columns except the large 'Args' column (which is unused on the list page)
+// and fetches a truncated version of 'Error' to reduce payload size and unmarshalling time.
+// Note: This query must be kept in sync with the aidb.Job struct definition.
+func selectJobsSummary() string {
+	return `SELECT ID, Type, Workflow, Namespace, BugID, ExternalBugID, 
+		Description, Link, Created, Started, Finished, CodeRevision, 
+		SUBSTR(Error, 1, 201) AS Error, AgentName, Results, Correct, 
+		Aborted, ParentReportingID FROM Jobs `
 }
 
 func selectTrajectorySpans() string {

--- a/dashboard/app/util_test.go
+++ b/dashboard/app/util_test.go
@@ -249,7 +249,7 @@ func (ctx *Ctx) Close() {
 		if ctx.checkAI {
 			_, err = ctx.GET("/ains/ai/")
 			ctx.expectOK(err)
-			jobs, err := aidb.LoadNamespaceJobs(ctx.ctx, "ains", nil)
+			jobs, err := aidb.LoadNamespaceJobsSummary(ctx.ctx, "ains", nil)
 			ctx.expectOK(err)
 			for _, job := range jobs {
 				_, err = ctx.GET(fmt.Sprintf("/ai_job?id=%v", job.ID))


### PR DESCRIPTION
[AI_PERF_COLUMNS] Baseline (ID): 123.632016ms | ID+Error: 3.873358383s | ID+Results: 151.864557ms | ID+Args: 167.279027ms | **Optimized Query: 722.779346ms**

Limiting the Error field data saves the most.
Alternatively we can stop writing excessive Error data. See https://github.com/google/syzkaller/issues/7532#issuecomment-4808101074 .
