### PR TITLE
executor: retry posix_spawnp without SETPGROUP on EPERM

### DIFF
--- a/executor/subprocess.h
+++ b/executor/subprocess.h
@@ -56,9 +56,19 @@ public:
 		    "GLIBC_TUNABLES=glibc.pthread.rseq=0",
 		    nullptr};
 
-		if (posix_spawnp(&pid_, argv[0], &actions, &attr,
-				 const_cast<char**>(argv), const_cast<char**>(child_envp)))
-			fail("posix_spawnp failed");
+		int err = posix_spawnp(&pid_, argv[0], &actions, &attr,
+				 const_cast<char**>(argv), const_cast<char**>(child_envp));
+		if (err) {
+			if (err != EPERM)
+				fail("posix_spawnp failed");
+			debug("posix_spawnp failed with EPERM, retrying without SETPGROUP\n");
+			if (posix_spawnattr_setflags(&attr, 0))
+				fail("posix_spawnattr_setflags failed");
+			if (posix_spawnp(&pid_, argv[0], &actions, &attr,
+					 const_cast<char**>(argv), const_cast<char**>(child_envp)))
+				fail("posix_spawnp failed");
+			new_pgroup_ = false;
+		}
 
 		if (posix_spawn_file_actions_destroy(&actions))
 			fail("posix_spawn_file_actions_destroy failed");
@@ -101,7 +111,8 @@ public:
 			if (waitpid(pid_, &wstatus, WNOHANG | WAIT_FLAGS) == pid_)
 				break;
 			if (current_time_ms() - start > timeout_ms) {
-				kill(-pid_, SIGKILL);
+				if (new_pgroup_)
+					kill(-pid_, SIGKILL);
 				kill(pid_, SIGKILL);
 			}
 		}
@@ -111,6 +122,7 @@ public:
 
 private:
 	int pid_ = 0;
+	bool new_pgroup_ = true;
 
 	static int ExitStatus(int wstatus)
 	{

--- a/executor/subprocess.h
+++ b/executor/subprocess.h
@@ -57,7 +57,7 @@ public:
 		    nullptr};
 
 		int err = posix_spawnp(&pid_, argv[0], &actions, &attr,
-				 const_cast<char**>(argv), const_cast<char**>(child_envp));
+				       const_cast<char**>(argv), const_cast<char**>(child_envp));
 		if (err) {
 			if (err != EPERM) {
 				errno = err;
@@ -70,13 +70,13 @@ public:
 				fail("posix_spawnattr_setflags failed");
 			}
 			err = posix_spawnp(&pid_, argv[0], &actions, &attr,
-				 const_cast<char**>(argv), const_cast<char**>(child_envp));
+					   const_cast<char**>(argv), const_cast<char**>(child_envp));
 			if (err) {
 				errno = err;
 				fail("posix_spawnp failed");
 			}
 			new_pgroup_ = false;
-        }
+		}
 
 		if (posix_spawn_file_actions_destroy(&actions))
 			fail("posix_spawn_file_actions_destroy failed");

--- a/executor/subprocess.h
+++ b/executor/subprocess.h
@@ -59,16 +59,24 @@ public:
 		int err = posix_spawnp(&pid_, argv[0], &actions, &attr,
 				 const_cast<char**>(argv), const_cast<char**>(child_envp));
 		if (err) {
-			if (err != EPERM)
+			if (err != EPERM) {
+				errno = err;
 				fail("posix_spawnp failed");
+			}
 			debug("posix_spawnp failed with EPERM, retrying without SETPGROUP\n");
-			if (posix_spawnattr_setflags(&attr, 0))
+			err = posix_spawnattr_setflags(&attr, 0);
+			if (err) {
+				errno = err;
 				fail("posix_spawnattr_setflags failed");
-			if (posix_spawnp(&pid_, argv[0], &actions, &attr,
-					 const_cast<char**>(argv), const_cast<char**>(child_envp)))
+			}
+			err = posix_spawnp(&pid_, argv[0], &actions, &attr,
+				 const_cast<char**>(argv), const_cast<char**>(child_envp));
+			if (err) {
+				errno = err;
 				fail("posix_spawnp failed");
+			}
 			new_pgroup_ = false;
-		}
+        }
 
 		if (posix_spawn_file_actions_destroy(&actions))
 			fail("posix_spawn_file_actions_destroy failed");


### PR DESCRIPTION
posix_spawnp with `POSIX_SPAWN_SETPGROUP` fails with EPERM on the gVisor ptrace platform (the emulated `setpgid(0, 0)` is rejected), causing the executor to `fail()` and crash the VM (#7478).
The SETPGROUP flag is only an optimization for killing the whole process tree on timeout. On EPERM, retry the spawn without it instead of aborting. Track whether the child was actually spawned in a new process group (new_pgroup_), and only use` kill(-pid_, SIGKILL)` in WaitAndKill when it was.

resolves: #7478 