### PR TITLE
pkg/rpcserver: inject keepalive requests when VM is idle

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -568,6 +568,7 @@ func (serv *server) CreateInstance(id int, injectExec chan<- bool, updInfo Updat
 		filterSignal:  serv.cfg.FilterSignal,
 		debug:         serv.cfg.Debug,
 		debugTimeouts: serv.cfg.DebugTimeouts,
+		progTarget:    serv.target,
 		sysTarget:     serv.sysTarget,
 		injectExec:    injectExec,
 		infoc:         make(chan chan []byte),

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -24,27 +24,29 @@ import (
 )
 
 type Runner struct {
-	id            int
-	source        *queue.Distributor
-	procs         int
-	cover         bool
-	coverEdges    bool
-	filterSignal  bool
-	debug         bool
-	debugTimeouts bool
-	sysTarget     *targets.Target
-	stats         *runnerStats
-	finished      chan bool
-	injectExec    chan<- bool
-	infoc         chan chan []byte
-	canonicalizer *cover.CanonicalizerInstance
-	nextRequestID int64
-	requests      map[int64]*queue.Request
-	executing     map[int64]bool
-	hanged        map[int64]bool
-	lastExec      *LastExecuting
-	updInfo       UpdateInfo
-	resultCh      chan error
+	id              int
+	source          *queue.Distributor
+	procs           int
+	cover           bool
+	coverEdges      bool
+	filterSignal    bool
+	debug           bool
+	debugTimeouts   bool
+	progTarget      *prog.Target
+	sysTarget       *targets.Target
+	stats           *runnerStats
+	finished        chan bool
+	injectExec      chan<- bool
+	infoc           chan chan []byte
+	canonicalizer   *cover.CanonicalizerInstance
+	nextRequestID   int64
+	requests        map[int64]*queue.Request
+	executing       map[int64]bool
+	hanged          map[int64]bool
+	lastExec        *LastExecuting
+	updInfo         UpdateInfo
+	resultCh        chan error
+	lastRequestTime time.Time
 
 	// The mutex protects all the fields below.
 	mu          sync.Mutex
@@ -162,6 +164,8 @@ func (runner *Runner) ConnectionLoop() error {
 			infoc <- []byte("VM has crashed")
 		}
 	}()
+
+	runner.lastRequestTime = time.Now()
 	for {
 		if infoc == nil {
 			select {
@@ -181,13 +185,15 @@ func (runner *Runner) ConnectionLoop() error {
 			if err := runner.sendRequest(req); err != nil {
 				return err
 			}
+			runner.lastRequestTime = time.Now()
 		}
 		if len(runner.requests) == 0 {
 			if !runner.Alive() {
 				return nil
 			}
-			// The runner has no new requests, so don't wait to receive anything from it.
-			time.Sleep(10 * time.Millisecond)
+			if err := runner.handleIdle(); err != nil {
+				return err
+			}
 			continue
 		}
 		raw, err := wrappedRecv[*flatrpc.ExecutorMessageRaw](runner)
@@ -224,6 +230,34 @@ func (runner *Runner) ConnectionLoop() error {
 			return err
 		}
 	}
+}
+
+// handleIdle is called when the VM has no pending requests.
+// It sends a dummy keepalive request if the queue has been empty for a while.
+// This proves both the OS and the C++ executor's fork server are still responsive,
+// and importantly triggers the ExecutingMessage to update lastExecuteTime in the VM monitor.
+func (runner *Runner) handleIdle() error {
+	if time.Since(runner.lastRequestTime) > 10*time.Second {
+		dummyReq := &queue.Request{
+			Type: flatrpc.RequestTypeProgram,
+			Prog: &prog.Prog{
+				Target: runner.progTarget,
+				Calls:  []*prog.Call{},
+			},
+			ExecOpts: flatrpc.ExecOpts{
+				EnvFlags: flatrpc.ExecEnvSandboxNone,
+			},
+		}
+		if err := runner.sendRequest(dummyReq); err != nil {
+			return err
+		}
+		runner.lastRequestTime = time.Now()
+		return nil
+	}
+
+	// The runner has no new requests, so don't wait to receive anything from it.
+	time.Sleep(10 * time.Millisecond)
+	return nil
 }
 
 func wrappedRecv[Raw flatrpc.RecvType[T], T any](runner *Runner) (*T, error) {

--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/sys"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/require"
 )
 
 // Find the corresponding QEMU binary for the target arch, if needed.
@@ -178,4 +179,35 @@ func TestExecutorCommonExt(t *testing.T) {
 	if call := res.Info.Calls[0]; call.Flags&flatrpc.CallFlagFinished == 0 || call.Error != 0 {
 		t.Fatalf("bad call result: flags=%x errno=%v", call.Flags, call.Error)
 	}
+}
+
+func TestExecutorZeroCalls(t *testing.T) {
+	t.Parallel()
+	target, err := prog.GetTarget("test", "64_fork")
+	require.NoError(t, err)
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken cross-compiler: %v", sysTarget.BrokenCompiler)
+	}
+	executor := csource.BuildExecutor(t, target, "../..")
+
+	source := queue.Plain()
+	startRPCServer(t, target, executor, source, rpcParams{})
+
+	req := &queue.Request{
+		Type: flatrpc.RequestTypeProgram,
+		Prog: &prog.Prog{
+			Target: target,
+			Calls:  []*prog.Call{},
+		},
+		ReturnError:  true,
+		ReturnOutput: true,
+		ExecOpts: flatrpc.ExecOpts{
+			EnvFlags: flatrpc.ExecEnvSandboxNone,
+		},
+	}
+	source.Submit(req)
+	res := req.Wait(context.Background())
+	require.NoError(t, res.Err, "zero-call program execution failed:\n%s", res.Output)
+	require.Empty(t, res.Info.Calls, "expected 0 call info")
 }


### PR DESCRIPTION
When the fuzzer queue is empty and executions are rare, the host side timeout in vm.go ("no output from test machine") can falsely trigger. This happens because lastExecuteTime is only updated when the host receives an ExecutingMessage from the VM, which never occurs if no programs are being sent.

Add an explicit handleIdle routine in Runner.ConnectionLoop. If the queue is completely empty for more than 10 seconds, send a dummy program (0 calls) to the VM. This forces the executor's fork server to spawn a process, reply with an ExecutingMessage, and bump the monitor's timer. This safely proves the VM and the executor pipeline are alive without creating false timeouts.