### PR TITLE
pkg/aflow: execute git revert with sandboxing in checkout

### DIFF
--- a/pkg/aflow/action/kernel/checkout.go
+++ b/pkg/aflow/action/kernel/checkout.go
@@ -87,8 +87,9 @@ func checkout(ctx *aflow.Context, args checkoutArgs) (checkoutResult, error) {
 				if ok, err := repo.Contains(badCommit); err != nil {
 					return err
 				} else if ok {
-					if _, err = osutil.RunCmd(time.Hour, kernelRepoDir,
-						"git", "revert", "--no-edit", badCommit); err != nil {
+					if _, err = runSandboxedGit(time.Minute, kernelRepoDir,
+						"-c", "user.name=aflow", "-c", "user.email=aflow@syzkaller.com",
+						"revert", "--no-edit", badCommit); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
Currently, the `git revert` command used to remove the bogus clang-tools commit executes as root via `osutil.RunCmd`. This creates root-owned object directories in the global, sandboxed linux checkout. If a later sandboxed operation (like `git fetch`) downloads an object that maps to the same prefix directory, it fails with "insufficient permission".

Fix this by using `runSandboxedGit` for the revert, ensuring all created objects are correctly owned by the syzkaller user.