### PR TITLE
tools/syz-aflow: introduce provider registry for custom backends

### DIFF
--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -12,20 +12,20 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/backend"
-	"github.com/google/syzkaller/pkg/aflow/backend/gemini"
 	_ "github.com/google/syzkaller/pkg/aflow/flow"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	aflowhtml "github.com/google/syzkaller/pkg/aflow/trajectory/html"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/pkg/tool"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/genai"
 )
 
 func main() {
@@ -140,46 +140,14 @@ func run(ctx context.Context, args RunArgs) error {
 	}
 
 	var provider backend.Provider
-	switch args.Provider {
-	case "gemini":
-		apiKey := os.Getenv("GOOGLE_API_KEY")
-		if apiKey == "" {
-			apiKey = os.Getenv("GEMINI_API_KEY")
-		}
-		if apiKey == "" {
-			return fmt.Errorf("gemini provider requires GOOGLE_API_KEY or GEMINI_API_KEY environment variable to be set")
-		}
-		provider, err = gemini.NewProvider(ctx, gemini.Config{
-			ModelOverride: args.Model,
-			ClientConfig: &genai.ClientConfig{
-				APIKey: apiKey,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to initialize Gemini provider: %w", err)
-		}
-	case "vertex":
-		project := os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if project == "" {
-			return fmt.Errorf("vertex provider requires GOOGLE_CLOUD_PROJECT environment variable to be set")
-		}
-		location := os.Getenv("GOOGLE_CLOUD_REGION")
-		if location == "" {
-			location = "global"
-		}
-		provider, err = gemini.NewProvider(ctx, gemini.Config{
-			ModelOverride: args.Model,
-			ClientConfig: &genai.ClientConfig{
-				Backend:  genai.BackendVertexAI,
-				Project:  project,
-				Location: location,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to initialize Vertex provider: %w", err)
-		}
-	default:
-		return fmt.Errorf("unknown provider %q (supported: gemini, vertex)", args.Provider)
+	factory, ok := providers[args.Provider]
+	if !ok {
+		supported := slices.Sorted(maps.Keys(providers))
+		return fmt.Errorf("unknown provider %q (supported: %v)", args.Provider, supported)
+	}
+	provider, err = factory(ctx, args.Model)
+	if err != nil {
+		return err
 	}
 
 	output, err := flow.Execute(ctx, provider, args.Workdir, inputs, cache, onEventFunc)

--- a/tools/syz-aflow/gemini.go
+++ b/tools/syz-aflow/gemini.go
@@ -1,0 +1,59 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/google/syzkaller/pkg/aflow/backend/gemini"
+	"google.golang.org/genai"
+)
+
+func init() {
+	RegisterProvider("gemini", func(ctx context.Context, model string) (backend.Provider, error) {
+		apiKey := os.Getenv("GOOGLE_API_KEY")
+		if apiKey == "" {
+			apiKey = os.Getenv("GEMINI_API_KEY")
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("gemini provider requires GOOGLE_API_KEY or GEMINI_API_KEY environment variable to be set")
+		}
+		provider, err := gemini.NewProvider(ctx, gemini.Config{
+			ModelOverride: model,
+			ClientConfig: &genai.ClientConfig{
+				APIKey: apiKey,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize Gemini provider: %w", err)
+		}
+		return provider, nil
+	})
+
+	RegisterProvider("vertex", func(ctx context.Context, model string) (backend.Provider, error) {
+		project := os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if project == "" {
+			return nil, fmt.Errorf("vertex provider requires GOOGLE_CLOUD_PROJECT environment variable to be set")
+		}
+		location := os.Getenv("GOOGLE_CLOUD_REGION")
+		if location == "" {
+			location = "global"
+		}
+		provider, err := gemini.NewProvider(ctx, gemini.Config{
+			ModelOverride: model,
+			ClientConfig: &genai.ClientConfig{
+				Backend:  genai.BackendVertexAI,
+				Project:  project,
+				Location: location,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize Vertex provider: %w", err)
+		}
+		return provider, nil
+	})
+}

--- a/tools/syz-aflow/registry.go
+++ b/tools/syz-aflow/registry.go
@@ -1,0 +1,22 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/aflow/backend"
+)
+
+type ProviderFactory func(ctx context.Context, model string) (backend.Provider, error)
+
+var providers = make(map[string]ProviderFactory)
+
+func RegisterProvider(name string, factory ProviderFactory) {
+	if _, ok := providers[name]; ok {
+		panic(fmt.Sprintf("provider %q is already registered", name))
+	}
+	providers[name] = factory
+}


### PR DESCRIPTION
Refactor backend initialization to use a registry pattern. This allows for easier extension and registration of new AI providers without needing to patch the main command-line parsing switch statement.