### PR TITLE
pkg/clangtool: pass kernel object dir to clang tool

### DIFF
--- a/pkg/clangtool/clangtool.go
+++ b/pkg/clangtool/clangtool.go
@@ -63,7 +63,7 @@ func Run[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config) (OutputPtr, e
 	for range runtime.NumCPU() {
 		go func() {
 			for file := range files {
-				out, err := runTool[Output, OutputPtr](cfg, dbFile, file)
+				out, err := runTool[Output, OutputPtr](cfg, file)
 				results <- &result{out, err}
 			}
 		}()
@@ -153,7 +153,7 @@ func (v *Verifier) LineRange(file string, start, end int) {
 	}
 }
 
-func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, dbFile, file string) (OutputPtr, error) {
+func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, file string) (OutputPtr, error) {
 	relFile := strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(filepath.Clean(file),
 		cfg.KernelSrc), cfg.KernelObj), "/")
 	// Suppress warning since we may build the tool on a different clang
@@ -166,7 +166,7 @@ func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, dbFile, f
 	} else {
 		bin, _ = exec.LookPath(bin)
 	}
-	cmd := exec.Command(bin, "-p", dbFile,
+	cmd := exec.Command(bin, "-p", cfg.KernelObj,
 		"--extra-arg=-w", "--extra-arg=-fparse-all-comments", file)
 	cmd.Dir = cfg.KernelObj
 	// This tells the C++ clang tool to execute in a constructor.


### PR DESCRIPTION
Update runTool to pass the kernel object directory (cfg.KernelObj) instead of the compile_commands.json file path to the clang tool's -p argument, because the clang tool actually expects a directory. Remove the now-unused dbFile parameter from the runTool signature.