### PR TITLE
tools/clang/codesearch: fetch comments from any redeclaration

### DIFF
--- a/pkg/codesearch/testdata/query-def-comment-header
+++ b/pkg/codesearch/testdata/query-def-comment-header
@@ -1,3 +1,8 @@
 def-comment source0.c function_with_comment_in_header
 
-function function_with_comment_in_header is defined in source0.c and is not commented
+function function_with_comment_in_header is defined in source0.c and commented as:
+
+   4:	/*
+   5:	 * Comment about the function in header.
+   6:	 * Multi-line just in case.
+   7:	 */

--- a/pkg/codesearch/testdata/source0.c.json
+++ b/pkg/codesearch/testdata/source0.c.json
@@ -144,6 +144,11 @@
 				"start_line": 24,
 				"end_line": 27
 			},
+			"comment": {
+				"file": "source0.h",
+				"start_line": 4,
+				"end_line": 7
+			},
 			"refs": [
 				{
 					"name": "same_name_in_several_files",

--- a/tools/clang/codesearch/codesearch.cpp
+++ b/tools/clang/codesearch/codesearch.cpp
@@ -150,7 +150,7 @@ Indexer::NamedDeclEmitter::NamedDeclEmitter(Indexer* Parent, const NamedDecl* De
   std::string CommentSourceFile;
   int CommentStartLine = 0;
   int CommentEndLine = 0;
-  if (auto Comment = Context.getRawCommentForDeclNoCache(Decl)) {
+  if (auto Comment = Context.getRawCommentForAnyRedecl(Decl)) {
     const auto& begin = Comment->getBeginLoc();
     const auto& end = Comment->getEndLoc();
     CommentSourceFile = std::filesystem::relative(SM.getFilename(SM.getExpansionLoc(begin)).str());


### PR DESCRIPTION
Use `getRawCommentForAnyRedecl(Decl)` instead of `getRawCommentForDeclNoCache` to retrieve comments. This allows codesearch to find comments placed on function prototypes in header files, even when querying the function definition in a C file.

Update golden test data to reflect the newly discovered comments.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
