### PR TITLE
pkg/aflow/action/crash: add configure-runner action

### DIFF
--- a/pkg/aflow/action/crash/configure_runner.go
+++ b/pkg/aflow/action/crash/configure_runner.go
@@ -1,0 +1,61 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/log"
+)
+
+var ActionConfigureRunner = aflow.NewFuncAction("configure-runner", configureRunnerAction)
+
+type ConfigureRunnerArgs struct {
+	TargetOS   string
+	TargetArch string
+	Syzkaller  string
+	Image      string
+	Type       string
+	VM         json.RawMessage
+	KernelSrc  string
+	KernelObj  string
+}
+
+func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct{}, error) {
+	workdir, err := ctx.TempDir()
+	if err != nil {
+		return struct{}{}, fmt.Errorf("failed to create workdir for configure-runner: %w", err)
+	}
+
+	reproArgs := ReproduceArgs{
+		TargetArch: args.TargetArch,
+		Syzkaller:  args.Syzkaller,
+		Image:      args.Image,
+		Type:       args.Type,
+		VM:         args.VM,
+		KernelSrc:  args.KernelSrc,
+		KernelObj:  args.KernelObj,
+	}
+
+	if err := reproArgs.Validate(); err != nil {
+		return struct{}{}, aflow.FlowError(err)
+	}
+
+	cfg, err := buildConfig(reproArgs, workdir)
+	if err != nil {
+		return struct{}{}, fmt.Errorf("failed to build config for runner: %w", err)
+	}
+
+	// Initializes the VM pool and triggers background VM boot. Returns instantly.
+	// If it fails here, it's a hard error (e.g., vm.Create failed).
+	_, err = ctx.InitRunnerManager(cfg)
+	if err != nil {
+		return struct{}{}, aflow.FlowError(fmt.Errorf("RunnerManager init failed: %w", err))
+	}
+
+	log.Logf(1, "aflow: RunnerManager configured and background VM boot started successfully")
+	return struct{}{}, nil
+}

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -300,12 +300,17 @@ func (ctx *Context) finishSpan(span *trajectory.Span, spanErr error) error {
 	return err
 }
 
-// GetRunnerManager returns the context's continuous RunnerManager, initializing it if necessary.
-func (ctx *Context) GetRunnerManager(cfg *mgrconfig.Config) (*RunnerManager, error) {
+var (
+	ErrRunnerNotInitialized     = errors.New("RunnerManager is not initialized (requires configure-runner)")
+	ErrRunnerAlreadyInitialized = errors.New("RunnerManager is already initialized")
+)
+
+// InitRunnerManager initializes the continuous RunnerManager. It must be called exactly once per flow.
+func (ctx *Context) InitRunnerManager(cfg *mgrconfig.Config) (*RunnerManager, error) {
 	ctx.runnerMu.Lock()
 	defer ctx.runnerMu.Unlock()
 	if ctx.runnerManager != nil {
-		return ctx.runnerManager, nil
+		return nil, ErrRunnerAlreadyInitialized
 	}
 	runnerCtx, cancel := context.WithCancel(ctx.Context)
 	eg, egCtx := errgroup.WithContext(runnerCtx)
@@ -325,4 +330,14 @@ func (ctx *Context) GetRunnerManager(cfg *mgrconfig.Config) (*RunnerManager, err
 	})
 
 	return rm, nil
+}
+
+// GetRunnerManager returns the initialized RunnerManager, or an error if it hasn't been configured.
+func (ctx *Context) GetRunnerManager() (*RunnerManager, error) {
+	ctx.runnerMu.Lock()
+	defer ctx.runnerMu.Unlock()
+	if ctx.runnerManager == nil {
+		return nil, ErrRunnerNotInitialized
+	}
+	return ctx.runnerManager, nil
 }

--- a/pkg/aflow/runner.go
+++ b/pkg/aflow/runner.go
@@ -63,6 +63,11 @@ func newRunnerManager(ctx context.Context, cfg *mgrconfig.Config, debug bool) (*
 	return rm, nil
 }
 
+// Config returns the configuration used to initialize the RunnerManager.
+func (rm *RunnerManager) Config() *mgrconfig.Config {
+	return rm.cfg
+}
+
 func (rm *RunnerManager) Loop() error {
 	rpcCfg := &rpcserver.RemoteConfig{
 		Config:  rm.cfg,


### PR DESCRIPTION
This action allows us to preboot the vm at the beginning of a flow, reducing cold start penalties during the flow.

