### PR TITLE
pkg/codesearch: fix reference name interning

### DIFF
--- a/pkg/codesearch/database.go
+++ b/pkg/codesearch/database.go
@@ -188,8 +188,8 @@ func (db *Database) Merge(other *Database, v *clangtool.Verifier) {
 		db.intern(&def.Type)
 		db.intern(&def.Body.File)
 		db.intern(&def.Comment.File)
-		for _, ref := range def.Refs {
-			db.intern(&ref.Name)
+		for i := range def.Refs {
+			db.intern(&def.Refs[i].Name)
 		}
 		for i := range def.Fields {
 			db.intern(&def.Fields[i].Name)

--- a/pkg/codesearch/database_test.go
+++ b/pkg/codesearch/database_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package codesearch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/google/syzkaller/pkg/clangtool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseIntern(t *testing.T) {
+	tempDir := t.TempDir()
+	cFile := "main.c"
+	err := os.WriteFile(filepath.Join(tempDir, cFile), []byte("line1\nline2\nline3\nline4\nline5\n"), 0644)
+	require.NoError(t, err)
+
+	v := clangtool.NewVerifier(tempDir)
+
+	db1 := &Database{
+		Definitions: []*Definition{
+			{
+				Name: "my_func",
+				Body: LineRange{File: cFile, StartLine: 1, EndLine: 3},
+				Refs: []Reference{
+					{Name: strings.Clone("some_symbol")},
+					{Name: strings.Clone("another_symbol")},
+				},
+			},
+		},
+	}
+
+	db2 := &Database{
+		Definitions: []*Definition{
+			{
+				Name: "my_func2",
+				Body: LineRange{File: cFile, StartLine: 2, EndLine: 4},
+				Refs: []Reference{
+					{Name: strings.Clone("some_symbol")},
+					{Name: strings.Clone("another_symbol")},
+				},
+			},
+		},
+	}
+
+	mergedDB := &Database{}
+	mergedDB.Merge(db1, v)
+	mergedDB.Merge(db2, v)
+	mergedDB.Finalize(v)
+
+	require.NoError(t, v.Error())
+
+	require.Len(t, mergedDB.Definitions, 2)
+
+	ref1Name := mergedDB.Definitions[0].Refs[0].Name
+	ref2Name := mergedDB.Definitions[1].Refs[0].Name
+	require.Equal(t, "some_symbol", ref1Name)
+	require.Equal(t, "some_symbol", ref2Name)
+
+	ptr1 := unsafe.StringData(ref1Name)
+	ptr2 := unsafe.StringData(ref2Name)
+
+	// We must cast the *byte pointers to uintptr before comparing them.
+	// require.Equal uses reflect.DeepEqual, which dereferences pointers and
+	// compares their values (the characters). Comparing the pointers directly
+	// would pass as long as they point to the same character, but casting to
+	// uintptr forces it to verify that they share the exact same memory address.
+	require.Equal(t, uintptr(unsafe.Pointer(ptr1)), uintptr(unsafe.Pointer(ptr2)), "reference names were not interned")
+}


### PR DESCRIPTION
Taking the address of a range loop variable in Go gets the address of a temporary stack copy, causing in-place string interning modifications to be discarded. Use index-based iteration instead. This ensures all duplicate reference names are correctly merged into a single canonical string instance in memory to reduce memory usage during database merges.
