### PR TITLE
pkg/aflow/tool/codesearcher: wrap file access errors in BadCallError

### DIFF
--- a/pkg/aflow/tool/codesearcher/codesearcher_test.go
+++ b/pkg/aflow/tool/codesearcher/codesearcher_test.go
@@ -38,6 +38,72 @@ func TestStructLayoutNonExistent(t *testing.T) {
 	)
 }
 
+func TestReadFile(t *testing.T) {
+	aflow.TestTool(t, ToolReadFile,
+		fsState{KernelSrc: filepath.FromSlash("../../../codesearch/testdata")},
+		readFileArgs{
+			File:      "global_vars.c",
+			FirstLine: 11,
+			LineCount: 1,
+		},
+		readFileResult{
+			Contents: "  11:\tint global_var = 3;\n",
+		},
+		``,
+	)
+}
+
+func TestReadFileNonExistent(t *testing.T) {
+	aflow.TestTool(t, ToolReadFile,
+		fsState{KernelSrc: filepath.FromSlash("../../../codesearch/testdata")},
+		readFileArgs{
+			File:      "file-that-does-not-exist.c",
+			FirstLine: 1,
+			LineCount: 1,
+		},
+		readFileResult{},
+		`the file does not exist`,
+	)
+}
+
+func TestDirIndex(t *testing.T) {
+	aflow.TestTool(t, ToolDirIndex,
+		fsState{KernelSrc: filepath.FromSlash("../../../codesearch/testdata")},
+		dirIndexArgs{
+			Dir: "mm",
+		},
+		dirIndexResult{
+			Subdirs: nil,
+			Files:   []string{"refs.c", "slub.c", "slub.h"},
+		},
+		``,
+	)
+}
+
+func TestDirIndexNonExistent(t *testing.T) {
+	aflow.TestTool(t, ToolDirIndex,
+		fsState{KernelSrc: filepath.FromSlash("../../../codesearch/testdata")},
+		dirIndexArgs{
+			Dir: "dir-that-does-not-exist",
+		},
+		dirIndexResult{},
+		`the directory does not exist`,
+	)
+}
+
+func TestReadFileEmptySrc(t *testing.T) {
+	aflow.TestTool(t, ToolReadFile,
+		fsState{KernelSrc: ""},
+		readFileArgs{
+			File:      "global_vars.c",
+			FirstLine: 11,
+			LineCount: 1,
+		},
+		readFileResult{},
+		"KernelSrc is empty",
+	)
+}
+
 func createIndex(t *testing.T) prepareResult {
 	return prepareResult{
 		Index: index{codesearch.NewTestIndex(t, filepath.FromSlash("../../../codesearch/testdata"))},

--- a/pkg/aflow/tool/codesearcher/filesystem.go
+++ b/pkg/aflow/tool/codesearcher/filesystem.go
@@ -49,13 +49,16 @@ type dirIndexResult struct {
 func dirIndex(ctx *aflow.Context, state fsState, args dirIndexArgs) (dirIndexResult, error) {
 	root, err := getSrcDir(ctx, state)
 	if err != nil {
-		return dirIndexResult{}, err
+		return dirIndexResult{}, aflow.BadCallError("%v", err)
 	}
 	subdirs, files, err := codesearch.DirIndex([]string{root}, args.Dir)
+	if err != nil {
+		return dirIndexResult{}, aflow.BadCallError("%v", err)
+	}
 	return dirIndexResult{
 		Subdirs: subdirs,
 		Files:   files,
-	}, err
+	}, nil
 }
 
 type readFileArgs struct {
@@ -71,10 +74,13 @@ type readFileResult struct {
 func readFile(ctx *aflow.Context, state fsState, args readFileArgs) (readFileResult, error) {
 	root, err := getSrcDir(ctx, state)
 	if err != nil {
-		return readFileResult{}, err
+		return readFileResult{}, aflow.BadCallError("%v", err)
 	}
 	contents, err := codesearch.ReadFile([]string{root}, args.File, args.FirstLine, args.LineCount)
+	if err != nil {
+		return readFileResult{}, aflow.BadCallError("%v", err)
+	}
 	return readFileResult{
 		Contents: contents,
-	}, err
+	}, nil
 }


### PR DESCRIPTION
Wrap codesearcher file access errors in BadCallError to prevent pipeline crashes when a file or directory is missing.

Currently, if an LLM agent tries to read a non-existent file or look up a missing directory, read-file returns a standard Go error. This causes the tool invocation to fail the entire flow, resulting in an execution crash. By wrapping these in BadCallError, the tool returns a recoverable error to the agent, allowing it to adapt its strategy.
