### PR TITLE
pkg/aflow: fix tests for openbsd

### DIFF
--- a/pkg/aflow/flow/patching/actions_test.go
+++ b/pkg/aflow/flow/patching/actions_test.go
@@ -72,7 +72,7 @@ func TestMaintainers(t *testing.T) {
 	require.NoError(t, osutil.MkdirAll(filepath.Join(repoDir, "scripts")))
 
 	// Write a fake get_maintainer.pl.
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/bin/sh
 echo "Maintainer 1 <m1@example.com> (maintainer:SUBSYSTEM)"
 echo "Fixes Author <fixes@example.com> (reviewer:SUBSYSTEM)"
 `


### PR DESCRIPTION
https://github.com/google/syzkaller/pull/7436 broke openbsd: https://github.com/google/syzkaller/pull/7346#issuecomment-4895598962

It looks to me that the script should work regardless of whether it runs on openbsd or linux, but I'd appreciate a sanity check :)