### PR TITLE
all: fix dead code and unused struct fields

### DIFF
--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -385,7 +385,6 @@ type uiCommit struct {
 	Link       string
 	Author     string
 	AuthorName string
-	CC         []string
 	Date       time.Time
 }
 

--- a/pkg/spanner/ddl.go
+++ b/pkg/spanner/ddl.go
@@ -57,9 +57,6 @@ func sortMigrationFiles(files []string, forward bool) ([]string, error) {
 	for _, file := range files {
 		basename := path.Base(file)
 		parts := strings.Split(basename, "_")
-		if len(parts) == 0 {
-			return nil, fmt.Errorf("invalid migration filename: %v", basename)
-		}
 		num, err := strconv.Atoi(parts[0])
 		if err != nil {
 			return nil, fmt.Errorf("migration file %v must start with a number: %w", file, err)

--- a/vm/qemu/qmp.go
+++ b/vm/qemu/qmp.go
@@ -14,21 +14,6 @@ import (
 	"github.com/google/syzkaller/pkg/log"
 )
 
-type qmpVersion struct {
-	Package string
-	QEMU    struct {
-		Major int
-		Micro int
-		Minor int
-	}
-}
-
-type qmpBanner struct {
-	QMP struct {
-		Version qmpVersion
-	}
-}
-
 type qmpCommand struct {
 	Execute   string `json:"execute"`
 	Arguments any    `json:"arguments,omitempty"`
@@ -68,7 +53,11 @@ func (inst *instance) qmpConnCheck() error {
 	monDec := json.NewDecoder(conn)
 	monEnc := json.NewEncoder(conn)
 
-	var banner qmpBanner
+	// QEMU sends a greeting banner (containing version and capability details)
+	// immediately upon connection. We must decode and discard it from the TCP
+	// stream first, otherwise subsequent command responses (e.g. to qmp_capabilities)
+	// will be misread as the banner. We decode into an empty struct to avoid allocation.
+	var banner struct{}
 	if err := monDec.Decode(&banner); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix various dead code issues and unused struct fields detected by the custom static analysis tools:

1. spanner: remove unreachable `len(parts) == 0` check in `sortMigrationFiles` as `strings.Split` always returns at least one element.
2. dashboard/app: remove unused `CC` field from `uiCommit` struct.
3. vm/qemu: remove unused `qmpBanner` and `qmpVersion` structs and simplify QMP banner decoding.
