### PR TITLE
pkg/report: fix data loss in Fuchsia starnix panic shortening

### DIFF
--- a/pkg/report/fuchsia.go
+++ b/pkg/report/fuchsia.go
@@ -116,7 +116,11 @@ func (ctx *fuchsia) shortenStarnixPanicReport(report []byte, maxUnrelatedLines, 
 			break
 		}
 	}
-	return append(bytes.TrimRight(out.Bytes(), "\n"), '\n')
+	trimmed := bytes.TrimRight(out.Bytes(), "\n")
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return append(trimmed, '\n')
 }
 
 func (ctx *fuchsia) shortenReport(report []byte) []byte {

--- a/pkg/report/testdata/fuchsia/report/31
+++ b/pkg/report/testdata/fuchsia/report/31
@@ -1,0 +1,16 @@
+TITLE: starnix kernel panic in foo.rs: bar
+CORRUPTED: Y
+FRAME: foo
+
+STARNIX KERNEL PANIC
+info=panicked at foo.rs:12:34:
+bar
+[123.456] starnix line 1
+[123.456] starnix line 2
+
+REPORT:
+STARNIX KERNEL PANIC
+info=panicked at foo.rs:12:34:
+bar
+[123.456] starnix line 1
+[123.456] starnix line 2


### PR DESCRIPTION
If a Fuchsia crash report has a starnix kernel panic but does not contain any matching starnix panic stack frames, the parser was discarding the entire crash log, replacing it with a single newline character '\n'.

This happened because shortenStarnixPanicReport returned []byte{'\n'} (length 1) when it could not find any frames to extract. The caller checked if the returned report was non-empty (len(report) != 0) and, since 1 != 0, overwrote the original report with the single newline.

Fix this by trimming trailing newlines from the shortened report and returning nil if the trimmed report is empty. This prevents the caller from overwriting the original report when no shortening could be performed.

Also added a test case (31) to verify starnix panic parsing.
