### PR TITLE
coveragedb: add sessions table to track active sessions for GC

### DIFF
--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -16,6 +16,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
+	"github.com/google/syzkaller/pkg/log"
 	pkgspanner "github.com/google/syzkaller/pkg/spanner"
 	"github.com/google/syzkaller/pkg/subsystem"
 	_ "github.com/google/syzkaller/pkg/subsystem/lists"
@@ -23,6 +24,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 )
+
+const oneWeekAgo = 7 * 24 * time.Hour
 
 type HistoryRecord struct {
 	Session   string
@@ -92,6 +95,15 @@ func SaveMergeResult(ctx context.Context, client *spanner.Client, descr *History
 	}
 	var rowsCreated int
 	session := uuid.New().String()
+	// Register session. We need this Apply call for referential integrity.
+	// GC will not be touching this session records.
+	_, err := client.Apply(ctx, []*spanner.Mutation{
+		spanner.Insert("sessions", []string{"session", "created"}, []any{session, time.Now()}),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to register session: %w", err)
+	}
+
 	var mutations []*spanner.Mutation
 
 	for {
@@ -288,26 +300,84 @@ func NsDataMerged(ctx context.Context, client *spanner.Client, ns string,
 	return periods, totalRows, nil
 }
 
-// DeleteGarbage removes orphaned file and function entries from the database.
+type sessionRow struct {
+	Session string
+}
+
+type activeSessionRow struct {
+	Session string
+	Created time.Time
+}
+
+type orphanFinder struct {
+	// client is the Spanner client used to execute queries.
+	client *spanner.Client
+	// validSessions is the set of completed session IDs present in merge_history.
+	validSessions map[string]bool
+	// sentSessions tracks session IDs already sent to sessionCh to avoid duplicates.
+	sentSessions map[string]bool
+	// activeSessions maps registered session IDs in the sessions table to their creation time.
+	activeSessions map[string]time.Time
+	// cutoff is the threshold time; sessions created before this time are considered expired.
+	cutoff time.Time
+	// sessionCh is the channel used to send expired session IDs to deletion workers.
+	sessionCh chan<- string
+	// sessionsToMigrate collects legacy sessions that are active but missing from the sessions table.
+	sessionsToMigrate []string
+}
+
+func (f *orphanFinder) stream(ctx context.Context, sql string) error {
+	iter := f.client.Single().Query(ctx, spanner.Statement{SQL: sql})
+	defer iter.Stop()
+	for {
+		r, err := pkgspanner.ReadRow[sessionRow](iter)
+		if err != nil {
+			return err
+		}
+		if r == nil {
+			break
+		}
+		if f.validSessions[r.Session] || f.sentSessions[r.Session] {
+			continue
+		}
+		if created, ok := f.activeSessions[r.Session]; ok {
+			if created.Before(f.cutoff) {
+				select {
+				case f.sessionCh <- r.Session:
+					f.sentSessions[r.Session] = true
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		} else {
+			f.sessionsToMigrate = append(f.sessionsToMigrate, r.Session)
+			f.sentSessions[r.Session] = true
+		}
+	}
+	return nil
+}
+
+// DeleteGarbage cleans up orphaned database entries that are no longer associated with active merge sessions.
 //
-// It identifies files in the "files" table and functions in the "functions" table
-// that are not referenced by any entries in the "merge_history" table,
-// indicating they are no longer associated with an active merge session.
+// It identifies sessions in "files" and "functions" tables that are:
+//  1. Not present in "merge_history" (i.e. they are not completed sessions).
+//  2. Either missing from "sessions" table (legacy active sessions, which will be auto-migrated)
+//     or present in "sessions" table but created more than 1 week ago (failed/abandoned sessions).
 //
-// To avoid slow anti-joins in Spanner, this function fetches all valid sessions from merge_history first,
+// Active incomplete sessions (present in "sessions" table and created within the last week)
+// are preserved to allow ongoing uploads to complete.
+//
+// To avoid slow anti-joins in Spanner, this function fetches all valid and active sessions first,
 // then streams distinct sessions from files and functions, performing the filtering in Go.
 //
 // To avoid exceeding Spanner mutation limits, entries are deleted in batches of 10,000.
 //
-// Returns the number of orphaned sessions and the total number of entries successfully deleted.
+// Returns the number of deleted sessions and the total number of deleted rows.
 func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, error) {
 	if client == nil {
 		return 0, 0, fmt.Errorf("nil spannerclient")
 	}
 
-	type sessionRow struct {
-		Session string
-	}
 	// 1. Get all valid sessions from merge_history
 	validSessions := make(map[string]bool)
 	iterHistory := client.Single().Query(ctx, spanner.Statement{
@@ -321,7 +391,20 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		validSessions[r.Session] = true
 	}
 
-	// 2. Stream distinct sessions from files and functions and feed to workers.
+	// 2. Get all active sessions from sessions
+	activeSessions := make(map[string]time.Time)
+	iterSessions := client.Single().Query(ctx, spanner.Statement{
+		SQL: `SELECT session, created FROM sessions`})
+	defer iterSessions.Stop()
+	sessionRows, err := pkgspanner.ReadRows[activeSessionRow](iterSessions)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, r := range sessionRows {
+		activeSessions[r.Session] = r.Created
+	}
+
+	// 3. Stream distinct sessions from files and functions and feed to workers.
 	var deletedRows atomic.Int64
 	var deletedSessions atomic.Int64
 	eg, gCtx := errgroup.WithContext(ctx)
@@ -342,60 +425,50 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		})
 	}
 
+	finder := &orphanFinder{
+		client:         client,
+		validSessions:  validSessions,
+		sentSessions:   make(map[string]bool),
+		activeSessions: activeSessions,
+		cutoff:         time.Now().Add(-oneWeekAgo),
+		sessionCh:      sessionCh,
+	}
+
 	eg.Go(func() error {
 		defer close(sessionCh)
-		sentSessions := make(map[string]bool)
 
-		// Stream from files.
-		iterFiles := client.Single().Query(gCtx, spanner.Statement{
-			SQL: `SELECT DISTINCT session FROM files`})
-		defer iterFiles.Stop()
-
-		for {
-			r, err := pkgspanner.ReadRow[sessionRow](iterFiles)
-			if err != nil {
-				return err
-			}
-			if r == nil {
-				break
-			}
-			if !validSessions[r.Session] {
-				select {
-				case sessionCh <- r.Session:
-					sentSessions[r.Session] = true
-				case <-gCtx.Done():
-					return gCtx.Err()
-				}
-			}
+		if err := finder.stream(gCtx, `SELECT DISTINCT session FROM files`); err != nil {
+			return err
 		}
 
-		// Stream from functions.
-		iterFuncs := client.Single().Query(gCtx, spanner.Statement{
-			SQL: `SELECT DISTINCT session FROM functions`})
-		defer iterFuncs.Stop()
-
-		for {
-			r, err := pkgspanner.ReadRow[sessionRow](iterFuncs)
-			if err != nil {
-				return err
-			}
-			if r == nil {
-				break
-			}
-			if !validSessions[r.Session] && !sentSessions[r.Session] {
-				select {
-				case sessionCh <- r.Session:
-					sentSessions[r.Session] = true
-				case <-gCtx.Done():
-					return gCtx.Err()
-				}
-			}
+		if err := finder.stream(gCtx, `SELECT DISTINCT session FROM functions`); err != nil {
+			return err
 		}
 		return nil
 	})
 
 	err = eg.Wait()
-	return deletedSessions.Load(), deletedRows.Load(), err
+	if err != nil {
+		return deletedSessions.Load(), deletedRows.Load(), err
+	}
+
+	if len(finder.sessionsToMigrate) > 0 {
+		var mutations []*spanner.Mutation
+		now := time.Now()
+		for _, s := range finder.sessionsToMigrate {
+			mutations = append(mutations, spanner.Insert("sessions",
+				[]string{"session", "created"},
+				[]any{s, now}))
+		}
+		if _, err := client.Apply(ctx, mutations); err != nil {
+			return deletedSessions.Load(), deletedRows.Load(), fmt.Errorf("failed to apply auto-migration: %w", err)
+		}
+	} else {
+		// TODO(tarasmadan): Remove this legacy migration block once we verify in logs that no legacy sessions remain.
+		log.Logf(0, "coveragedb: no legacy sessions to migrate")
+	}
+
+	return deletedSessions.Load(), deletedRows.Load(), nil
 }
 
 func processGarbageSession(ctx context.Context, client *spanner.Client, session string,
@@ -407,6 +480,11 @@ func processGarbageSession(ctx context.Context, client *spanner.Client, session 
 	if err := deleteGarbageTable(ctx, client, session, "functions",
 		`SELECT filepath, funcname FROM functions WHERE session = $1`, deletedRows); err != nil {
 		return err
+	}
+	// Delete from sessions.
+	mutation := spanner.Delete("sessions", spanner.Key{session})
+	if _, err := client.Apply(ctx, []*spanner.Mutation{mutation}); err != nil {
+		return fmt.Errorf("failed to delete session from sessions table: %w", err)
 	}
 	return nil
 }

--- a/pkg/coveragedb/coveragedb_test.go
+++ b/pkg/coveragedb/coveragedb_test.go
@@ -15,6 +15,7 @@ import (
 	pkgspanner "github.com/google/syzkaller/pkg/spanner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func setupTestDB(t *testing.T) *spanner.Client {
@@ -358,48 +359,60 @@ func TestDeleteGarbage(t *testing.T) {
 	client := setupTestDB(t)
 	ctx := t.Context()
 
-	// 1. Insert a valid session in merge_history, files, and functions.
-	histValid := &HistoryRecord{
-		Namespace: "upstream",
-		Repo:      "repo-valid",
-		Duration:  1,
-		DateTo:    civil.Date{Year: 2025, Month: 1, Day: 1},
-		Session:   "session-valid",
-		Time:      time.Now(),
-		Commit:    "commit-valid",
-		TotalRows: 1,
-	}
-	insertCoverage(t, client, "manager1", histValid, []*FileCoverageWithLineInfo{
-		{
-			FileCoverageWithDetails: FileCoverageWithDetails{
-				Filepath:     "file-valid",
-				Instrumented: 10,
-				Covered:      5,
-			},
-			LinesInstrumented: []int64{1, 2, 3},
-			HitCounts:         []int64{1, 0, 1},
-		},
-	})
-	// Insert function for valid session.
+	now := time.Now()
+	cutoff := now.Add(-oneWeekAgo)
+
+	// 1. Completed session (should NOT be deleted)
+	sessionCompleted := "session-completed"
 	_, err := client.Apply(ctx, []*spanner.Mutation{
+		spanner.Insert("sessions", []string{"session", "created"}, []any{sessionCompleted, now.Add(-2 * time.Hour)}),
+		spanner.Insert("merge_history",
+			[]string{"namespace", "repo", "duration", "dateto", "session", "time"},
+			[]any{"ns1", "repo1", int64(1), civil.Date{Year: 2025, Month: 1, Day: 1}, sessionCompleted, now}),
+		spanner.Insert("files",
+			[]string{"session", "manager", "filepath", "instrumented", "covered"},
+			[]any{sessionCompleted, "*", "file-completed", int64(10), int64(5)}),
 		spanner.InsertOrUpdate("functions", []string{"session", "filepath", "funcname", "lines"},
-			[]any{"session-valid", "file-valid", "func-valid", []int64{1, 2}}),
+			[]any{sessionCompleted, "file-completed", "func-completed", []int64{1, 2}}),
 	})
 	require.NoError(t, err)
 
-	// 2. Insert an orphaned (garbage) session only in files and functions (not in merge_history).
+	insertIncompleteSession := func(session, suffix string, created time.Time) {
+		_, err = client.Apply(ctx, []*spanner.Mutation{
+			spanner.Insert("sessions", []string{"session", "created"}, []any{session, created}),
+			spanner.Insert("files",
+				[]string{"session", "manager", "filepath", "instrumented", "covered"},
+				[]any{session, "*", "file-" + suffix, int64(10), int64(5)}),
+			spanner.InsertOrUpdate("functions", []string{"session", "filepath", "funcname", "lines"},
+				[]any{session, "file-" + suffix, "func-" + suffix, []int64{1, 2}}),
+		})
+		require.NoError(t, err)
+	}
+
+	// 2. Active incomplete session (younger than 1 week, should NOT be deleted).
+	sessionActive := "session-active"
+	insertIncompleteSession(sessionActive, "active", now.Add(-1*time.Hour))
+
+	// 3. Failed incomplete session (older than 1 week, should BE deleted).
+	sessionFailed := "session-failed"
+	insertIncompleteSession(sessionFailed, "failed", cutoff.Add(-1*time.Hour))
+
+	// 4. Old garbage session without sessions record (should BE auto-migrated, NOT deleted yet)
+	sessionOldGarbage := "session-old-garbage"
 	_, err = client.Apply(ctx, []*spanner.Mutation{
-		spanner.InsertOrUpdate("files", []string{"session", "manager", "filepath", "instrumented", "covered"},
-			[]any{"session-garbage", "manager-garbage", "file-garbage", int64(10), int64(5)}),
+		spanner.Insert("files",
+			[]string{"session", "manager", "filepath", "instrumented", "covered"},
+			[]any{sessionOldGarbage, "*", "file-old-garbage", int64(10), int64(5)}),
 		spanner.InsertOrUpdate("functions", []string{"session", "filepath", "funcname", "lines"},
-			[]any{"session-garbage", "file-garbage", "func-garbage", []int64{1, 2}}),
+			[]any{sessionOldGarbage, "file-old-garbage", "func-old-garbage", []int64{1, 2}}),
 	})
 	require.NoError(t, err)
 
-	// 3. Insert another orphaned session that only has entries in functions (not in files or merge_history).
+	// 5. Old garbage session with only functions record (should BE auto-migrated, NOT deleted yet)
+	sessionFuncsOnly := "session-funcs-only"
 	_, err = client.Apply(ctx, []*spanner.Mutation{
 		spanner.InsertOrUpdate("functions", []string{"session", "filepath", "funcname", "lines"},
-			[]any{"session-garbage-funcs-only", "file-garbage", "func-garbage", []int64{1, 2}}),
+			[]any{sessionFuncsOnly, "file-funcs-only", "func-funcs-only", []int64{1, 2}}),
 	})
 	require.NoError(t, err)
 
@@ -407,24 +420,64 @@ func TestDeleteGarbage(t *testing.T) {
 	deletedSessions, deletedRows, err := DeleteGarbage(ctx, client)
 	require.NoError(t, err)
 
-	// Expecting 2 sessions deleted (session-garbage, session-garbage-funcs-only).
-	// Expecting 3 rows deleted (1 in files, 2 in functions).
-	assert.Equal(t, int64(2), deletedSessions)
-	assert.Equal(t, int64(3), deletedRows)
+	// We expect:
+	// - sessionFailed is deleted: 1 session.
+	// - deleted rows: 1 from files + 1 from functions = 2 rows.
+	assert.Equal(t, int64(1), deletedSessions)
+	assert.Equal(t, int64(2), deletedRows)
 
-	// Verify that valid session files and functions still exist.
-	var count int64
-	err = client.Single().Query(ctx, spanner.Statement{SQL: "SELECT COUNT(1) FROM files"}).
-		Do(func(row *spanner.Row) error {
-			return row.Column(0, &count)
-		})
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), count)
+	// Verify DB state.
+	assertRowExists(t, client, "sessions", spanner.Key{sessionCompleted})
+	assertRowExists(t, client, "files", spanner.Key{sessionCompleted, "*", "file-completed"})
+	assertRowExists(t, client, "functions", spanner.Key{sessionCompleted, "file-completed", "func-completed"})
 
-	err = client.Single().Query(ctx, spanner.Statement{SQL: "SELECT COUNT(1) FROM functions"}).
-		Do(func(row *spanner.Row) error {
-			return row.Column(0, &count)
-		})
+	assertRowExists(t, client, "sessions", spanner.Key{sessionActive})
+	assertRowExists(t, client, "files", spanner.Key{sessionActive, "*", "file-active"})
+	assertRowExists(t, client, "functions", spanner.Key{sessionActive, "file-active", "func-active"})
+
+	assertRowNotExists(t, client, "sessions", spanner.Key{sessionFailed})
+	assertRowNotExists(t, client, "files", spanner.Key{sessionFailed, "*", "file-failed"})
+	assertRowNotExists(t, client, "functions", spanner.Key{sessionFailed, "file-failed", "func-failed"})
+
+	assertRowExists(t, client, "sessions", spanner.Key{sessionOldGarbage})
+	assertRowExists(t, client, "files", spanner.Key{sessionOldGarbage, "*", "file-old-garbage"})
+	assertRowExists(t, client, "functions", spanner.Key{sessionOldGarbage, "file-old-garbage", "func-old-garbage"})
+
+	assertRowExists(t, client, "sessions", spanner.Key{sessionFuncsOnly})
+	assertRowExists(t, client, "functions", spanner.Key{sessionFuncsOnly, "file-funcs-only", "func-funcs-only"})
+
+	var created time.Time
+	row, err := client.Single().ReadRow(ctx, "sessions", spanner.Key{sessionOldGarbage}, []string{"created"})
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), count)
+	err = row.Column(0, &created)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), created, 10*time.Second)
+}
+
+func assertRowExists(t *testing.T, client *spanner.Client, table string, key spanner.Key) {
+	ctx := t.Context()
+	row, err := client.Single().ReadRow(ctx, table, key, []string{tableColumns(table)[0]})
+	require.NoError(t, err)
+	require.NotNil(t, row)
+}
+
+func assertRowNotExists(t *testing.T, client *spanner.Client, table string, key spanner.Key) {
+	ctx := t.Context()
+	_, err := client.Single().ReadRow(ctx, table, key, []string{tableColumns(table)[0]})
+	assert.True(t, spanner.ErrCode(err) == codes.NotFound, "expected NotFound error, got %v", err)
+}
+
+func tableColumns(table string) []string {
+	switch table {
+	case "files":
+		return []string{"session", "manager", "filepath"}
+	case "functions":
+		return []string{"session", "filepath", "funcname"}
+	case "sessions":
+		return []string{"session", "created"}
+	case "merge_history":
+		return []string{"namespace", "repo", "duration", "dateto"}
+	default:
+		panic("unknown table")
+	}
 }

--- a/pkg/coveragedb/init_db.sh
+++ b/pkg/coveragedb/init_db.sh
@@ -64,6 +64,21 @@ gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
  gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
   --ddl="CREATE INDEX merge_history_session ON merge_history (session);"
 
+echo "drop table 'sessions' if exists"
+gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
+--ddl="DROP TABLE IF EXISTS sessions"
+echo "create table 'sessions'"
+create_table=$( echo -n '
+CREATE TABLE
+  sessions (
+    "session" text,
+    "created" timestamptz NOT NULL,
+  PRIMARY KEY
+    (session) );')
+gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
+ --ddl="$create_table"
+
+
 echo "drop table 'file_subsystems' if exists"
 gcloud spanner databases ddl update $db --instance=syzbot --project=syzkaller \
 --ddl="DROP TABLE IF EXISTS file_subsystems"

--- a/pkg/coveragedb/migrations/3_sessions.down.sql
+++ b/pkg/coveragedb/migrations/3_sessions.down.sql
@@ -1,0 +1,4 @@
+-- Copyright 2026 syzkaller project authors. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+DROP TABLE sessions;

--- a/pkg/coveragedb/migrations/3_sessions.up.sql
+++ b/pkg/coveragedb/migrations/3_sessions.up.sql
@@ -1,0 +1,8 @@
+-- Copyright 2026 syzkaller project authors. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+CREATE TABLE sessions (
+    session text,
+    created timestamptz NOT NULL,
+    PRIMARY KEY (session)
+);


### PR DESCRIPTION
* Introduce 'sessions' table to track active and incomplete sessions.
* SaveMergeResult leaves completed sessions in the 'sessions' table.
* DeleteGarbage deletes active sessions that are older than 1 week and not in merge_history.
* Include auto-migration logic for legacy abandoned sessions in DeleteGarbage.

Prerequisites:
1. requires #7582 to simplify the loops
2. DB migration is needed before the traffic switch