### PR TITLE
pkg/fuzzer: use RWMutex for choice table

### DIFF
--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -37,7 +37,7 @@ type Fuzzer struct {
 
 	ct           *prog.ChoiceTable
 	ctProgs      int
-	ctMu         sync.Mutex // TODO: use RWLock.
+	ctMu         sync.RWMutex
 	ctRegenerate chan struct{}
 
 	execQueues
@@ -409,8 +409,8 @@ func (fuzzer *Fuzzer) choiceTableUpdater() {
 func (fuzzer *Fuzzer) ChoiceTable() *prog.ChoiceTable {
 	progs := fuzzer.Config.Corpus.Programs()
 
-	fuzzer.ctMu.Lock()
-	defer fuzzer.ctMu.Unlock()
+	fuzzer.ctMu.RLock()
+	defer fuzzer.ctMu.RUnlock()
 
 	// There were no deep ideas nor any calculations behind these numbers.
 	regenerateEveryProgs := 333


### PR DESCRIPTION
The ChoiceTable() method is called concurrently by fuzzer worker goroutines when mutating or generating programs. Using a standard Mutex forces sequential access and causes lock contention.

Switching to RWMutex allows concurrent workers to read the table simultaneously, only locking exclusively when the choice table is regenerated by the background updater.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
