### PR TITLE
all: move spanner readRow/readRows helpers

### DIFF
--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -20,8 +20,8 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/pkg/email"
+	pkgspanner "github.com/google/syzkaller/pkg/spanner"
 	"github.com/google/uuid"
-	"google.golang.org/api/iterator"
 	"google.golang.org/appengine/v2"
 	"google.golang.org/grpc/codes"
 )
@@ -1490,20 +1490,7 @@ type dbQuerier interface {
 func readRow[T any](ctx context.Context, txn dbQuerier, stmt spanner.Statement) (*T, error) {
 	iter := txn.Query(ctx, stmt)
 	defer iter.Stop()
-
-	row, err := iter.Next()
-	if err == iterator.Done {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var obj T
-	err = row.ToStruct(&obj)
-	if err != nil {
-		return nil, err
-	}
-	return &obj, nil
+	return pkgspanner.ReadRow[T](iter)
 }
 
 func extractBaseCommitArgs(job *Job, argsMap map[string]any) {

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -16,6 +16,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
+	pkgspanner "github.com/google/syzkaller/pkg/spanner"
 	"github.com/google/syzkaller/pkg/subsystem"
 	_ "github.com/google/syzkaller/pkg/subsystem/lists"
 	"github.com/google/uuid"
@@ -167,16 +168,12 @@ func ReadLinesHitCount(ctx context.Context, client *spanner.Client,
 	iter := client.Single().Query(ctx, stmt)
 	defer iter.Stop()
 
-	row, err := iter.Next()
-	if err == iterator.Done {
-		return nil, nil, nil
-	}
+	r, err := pkgspanner.ReadRow[LinesCoverage](iter)
 	if err != nil {
-		return nil, nil, fmt.Errorf("iter.Next: %w", err)
+		return nil, nil, err
 	}
-	var r LinesCoverage
-	if err = row.ToStruct(&r); err != nil {
-		return nil, nil, fmt.Errorf("failed to row.ToStruct() spanner DB: %w", err)
+	if r == nil {
+		return nil, nil, nil
 	}
 	if _, err := iter.Next(); err != iterator.Done {
 		return nil, nil, fmt.Errorf("more than 1 line is available")
@@ -275,22 +272,16 @@ func NsDataMerged(ctx context.Context, client *spanner.Client, ns string,
 	defer iter.Stop()
 	var periods []TimePeriod
 	var totalRows []int64
-	for {
-		row, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to iter.Next() spanner DB: %w", err)
-		}
-		var r struct {
-			Days      int64
-			DateTo    civil.Date
-			TotalRows int64
-		}
-		if err = row.ToStruct(&r); err != nil {
-			return nil, nil, fmt.Errorf("failed to row.ToStruct() spanner DB: %w", err)
-		}
+	type nsDataMergedRow struct {
+		Days      int64
+		DateTo    civil.Date
+		TotalRows int64
+	}
+	rows, err := pkgspanner.ReadRows[nsDataMergedRow](iter)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, r := range rows {
 		periods = append(periods, TimePeriod{DateTo: r.DateTo, Days: int(r.Days)})
 		totalRows = append(totalRows, r.TotalRows)
 	}
@@ -314,25 +305,19 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		return 0, 0, fmt.Errorf("nil spannerclient")
 	}
 
+	type sessionRow struct {
+		Session string
+	}
 	// 1. Get all valid sessions from merge_history
 	validSessions := make(map[string]bool)
 	iterHistory := client.Single().Query(ctx, spanner.Statement{
 		SQL: `SELECT DISTINCT session FROM merge_history`})
 	defer iterHistory.Stop()
-	for {
-		row, err := iterHistory.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return 0, 0, fmt.Errorf("iterHistory.Next: %w", err)
-		}
-		var r struct {
-			Session string
-		}
-		if err = row.ToStruct(&r); err != nil {
-			return 0, 0, fmt.Errorf("row.ToStruct: %w", err)
-		}
+	historyRows, err := pkgspanner.ReadRows[sessionRow](iterHistory)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, r := range historyRows {
 		validSessions[r.Session] = true
 	}
 
@@ -367,18 +352,12 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		defer iterFiles.Stop()
 
 		for {
-			row, err := iterFiles.Next()
-			if err == iterator.Done {
-				break
-			}
+			r, err := pkgspanner.ReadRow[sessionRow](iterFiles)
 			if err != nil {
-				return fmt.Errorf("iterFiles.Next: %w", err)
+				return err
 			}
-			var r struct {
-				Session string
-			}
-			if err = row.ToStruct(&r); err != nil {
-				return fmt.Errorf("row.ToStruct: %w", err)
+			if r == nil {
+				break
 			}
 			if !validSessions[r.Session] {
 				select {
@@ -396,18 +375,12 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		defer iterFuncs.Stop()
 
 		for {
-			row, err := iterFuncs.Next()
-			if err == iterator.Done {
-				break
-			}
+			r, err := pkgspanner.ReadRow[sessionRow](iterFuncs)
 			if err != nil {
-				return fmt.Errorf("iterFuncs.Next: %w", err)
+				return err
 			}
-			var r struct {
-				Session string
-			}
-			if err = row.ToStruct(&r); err != nil {
-				return fmt.Errorf("row.ToStruct: %w", err)
+			if r == nil {
+				break
 			}
 			if !validSessions[r.Session] && !sentSessions[r.Session] {
 				select {
@@ -421,7 +394,7 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		return nil
 	})
 
-	err := eg.Wait()
+	err = eg.Wait()
 	return deletedSessions.Load(), deletedRows.Load(), err
 }
 
@@ -708,19 +681,15 @@ func readCoverageUniq(full, mgr *spanner.RowIterator,
 func readIterToChan[K FileCoverageWithLineInfo | FileCoverageWithDetails](
 	ctx context.Context, iter *spanner.RowIterator, ch chan<- *K) error {
 	for {
-		row, err := iter.Next()
-		if err == iterator.Done {
+		r, err := pkgspanner.ReadRow[K](iter)
+		if err != nil {
+			return err
+		}
+		if r == nil {
 			break
 		}
-		if err != nil {
-			return fmt.Errorf("iter.Next: %w", err)
-		}
-		var r K
-		if err = row.ToStruct(&r); err != nil {
-			return fmt.Errorf("row.ToStruct: %w", err)
-		}
 		select {
-		case ch <- &r:
+		case ch <- r:
 		case <-ctx.Done():
 			return nil
 		}
@@ -803,21 +772,15 @@ order by files.filepath
 	})
 	defer iter.Stop()
 
+	type filepathRow struct {
+		Filepath string
+	}
+	rows, err := pkgspanner.ReadRows[filepathRow](iter)
+	if err != nil {
+		return nil, err
+	}
 	var res []string
-	for {
-		row, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("iter.Next: %w", err)
-		}
-		var r struct {
-			Filepath string
-		}
-		if err = row.ToStruct(&r); err != nil {
-			return nil, fmt.Errorf("row.ToStruct: %w", err)
-		}
+	for _, r := range rows {
 		res = append(res, r.Filepath)
 	}
 	return res, nil

--- a/pkg/coveragedb/functions.go
+++ b/pkg/coveragedb/functions.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/spanner"
-	"google.golang.org/api/iterator"
+	pkgspanner "github.com/google/syzkaller/pkg/spanner"
 )
 
 // FuncLines represents the 'functions' table records.
@@ -39,19 +39,11 @@ where
 	defer iter.Stop()
 
 	ff := &FunctionFinder{}
-	for {
-		row, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("iter.Next(): %w", err)
-		}
-		var r FuncLines
-		if err = row.ToStruct(&r); err != nil {
-			return nil, fmt.Errorf("row.ToStruct(): %w", err)
-		}
-
+	rows, err := pkgspanner.ReadRows[FuncLines](iter)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
 		for _, val := range r.Lines {
 			ff.addLine(r.FilePath, r.FuncName, int(val))
 		}

--- a/pkg/spanner/query.go
+++ b/pkg/spanner/query.go
@@ -29,15 +29,8 @@ func ReadRow[T any](iter *spanner.RowIterator) (*T, error) {
 // ReadRows reads all remaining rows from the iterator and parses them into a slice of pointers to T.
 func ReadRows[T any](iter *spanner.RowIterator) ([]*T, error) {
 	var ret []*T
-	for {
-		obj, err := ReadRow[T](iter)
-		if err != nil {
-			return nil, err
-		}
-		if obj == nil {
-			break
-		}
-		ret = append(ret, obj)
+	if err := spanner.SelectAll(iter, &ret); err != nil {
+		return nil, err
 	}
 	return ret, nil
 }

--- a/pkg/spanner/query.go
+++ b/pkg/spanner/query.go
@@ -1,0 +1,43 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package spanner
+
+import (
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+// ReadRow reads a single row from the iterator and parses it into a struct of type T.
+// Returns nil, nil if the iterator is done.
+func ReadRow[T any](iter *spanner.RowIterator) (*T, error) {
+	row, err := iter.Next()
+	if err == iterator.Done {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var obj T
+	err = row.ToStruct(&obj)
+	if err != nil {
+		return nil, err
+	}
+	return &obj, nil
+}
+
+// ReadRows reads all remaining rows from the iterator and parses them into a slice of pointers to T.
+func ReadRows[T any](iter *spanner.RowIterator) ([]*T, error) {
+	var ret []*T
+	for {
+		obj, err := ReadRow[T](iter)
+		if err != nil {
+			return nil, err
+		}
+		if obj == nil {
+			break
+		}
+		ret = append(ret, obj)
+	}
+	return ret, nil
+}

--- a/pkg/spanner/query_test.go
+++ b/pkg/spanner/query_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package spanner
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testEntity struct {
+	ID   string
+	Val  int64
+	Text string
+}
+
+func setupTestDB(t *testing.T) (*spanner.Client, context.Context) {
+	ddl := []string{
+		`CREATE TABLE TestEntities (
+			ID STRING(MAX) NOT NULL,
+			Val INT64 NOT NULL,
+			Text STRING(MAX),
+		) PRIMARY KEY (ID)`,
+	}
+	uri := NewTestDB(t, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, ddl)
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, uri)
+	require.NoError(t, err)
+
+	// Insert some data.
+	_, err = client.Apply(ctx, []*spanner.Mutation{
+		spanner.Insert("TestEntities", []string{"ID", "Val", "Text"}, []any{"1", int64(10), "one"}),
+		spanner.Insert("TestEntities", []string{"ID", "Val", "Text"}, []any{"2", int64(20), "two"}),
+		spanner.Insert("TestEntities", []string{"ID", "Val", "Text"}, []any{"3", int64(30), "three"}),
+	})
+	require.NoError(t, err)
+
+	return client, ctx
+}
+
+func TestReadRows(t *testing.T) {
+	client, ctx := setupTestDB(t)
+	defer client.Close()
+
+	iter := client.Single().Query(ctx, spanner.Statement{SQL: "SELECT * FROM TestEntities ORDER BY ID"})
+	defer iter.Stop()
+
+	rows, err := ReadRows[testEntity](iter)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	assert.Equal(t, &testEntity{ID: "1", Val: 10, Text: "one"}, rows[0])
+	assert.Equal(t, &testEntity{ID: "2", Val: 20, Text: "two"}, rows[1])
+	assert.Equal(t, &testEntity{ID: "3", Val: 30, Text: "three"}, rows[2])
+}
+
+func TestReadRow(t *testing.T) {
+	client, ctx := setupTestDB(t)
+	defer client.Close()
+
+	t.Run("ExistingRow", func(t *testing.T) {
+		iter := client.Single().Query(ctx, spanner.Statement{SQL: "SELECT * FROM TestEntities WHERE ID = '2'"})
+		defer iter.Stop()
+
+		row, err := ReadRow[testEntity](iter)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		assert.Equal(t, &testEntity{ID: "2", Val: 20, Text: "two"}, row)
+	})
+
+	t.Run("NonexistentRow", func(t *testing.T) {
+		iter := client.Single().Query(ctx, spanner.Statement{SQL: "SELECT * FROM TestEntities WHERE ID = 'nonexistent'"})
+		defer iter.Stop()
+
+		row, err := ReadRow[testEntity](iter)
+		require.NoError(t, err)
+		assert.Nil(t, row)
+	})
+}

--- a/syz-cluster/pkg/db/spanner.go
+++ b/syz-cluster/pkg/db/spanner.go
@@ -15,7 +15,6 @@ import (
 	migrate_spanner "github.com/golang-migrate/migrate/v4/database/spanner"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	pkgspanner "github.com/google/syzkaller/pkg/spanner"
-	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -72,47 +71,16 @@ type dbQuerier interface {
 	Query(context.Context, spanner.Statement) *spanner.RowIterator
 }
 
-func readRow[T any](iter *spanner.RowIterator) (*T, error) {
-	row, err := iter.Next()
-	if err == iterator.Done {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var obj T
-	err = row.ToStruct(&obj)
-	if err != nil {
-		return nil, err
-	}
-	return &obj, nil
-}
-
-func readRows[T any](iter *spanner.RowIterator) ([]*T, error) {
-	var ret []*T
-	for {
-		obj, err := readRow[T](iter)
-		if err != nil {
-			return nil, err
-		}
-		if obj == nil {
-			break
-		}
-		ret = append(ret, obj)
-	}
-	return ret, nil
-}
-
 func readEntity[T any](ctx context.Context, txn dbQuerier, stmt spanner.Statement) (*T, error) {
 	iter := txn.Query(ctx, stmt)
 	defer iter.Stop()
-	return readRow[T](iter)
+	return pkgspanner.ReadRow[T](iter)
 }
 
 func readEntities[T any](ctx context.Context, txn dbQuerier, stmt spanner.Statement) ([]*T, error) {
 	iter := txn.Query(ctx, stmt)
 	defer iter.Stop()
-	return readRows[T](iter)
+	return pkgspanner.ReadRows[T](iter)
 }
 
 const NoLimit = 0


### PR DESCRIPTION
Export them as ReadRow/ReadRows. Refactor syz-cluster, coveragedb, and aidb to use the shared implementation.

Prerequisites:
1. #7463 