### PR TITLE
pkg/aflow/backend: add Close() to Provider interface

### DIFF
--- a/pkg/aflow/backend/backend.go
+++ b/pkg/aflow/backend/backend.go
@@ -116,6 +116,8 @@ type Provider interface {
 	Models(ctx context.Context) ([]string, error)
 	// DefaultModel returns the provider-specific model name for a given category.
 	ResolveModels(category ModelCategory) []string
+	// Close cleans up the provider's resources.
+	Close() error
 }
 
 // RetryError indicates that the request failed but should be retried.

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -149,6 +149,10 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 	}
 }
 
+func (p *Provider) Close() error {
+	return nil
+}
+
 type client struct {
 	p *Provider
 }

--- a/pkg/aflow/runner_test.go
+++ b/pkg/aflow/runner_test.go
@@ -213,3 +213,7 @@ func (p *dummyProvider) ResolveModels(category backend.ModelCategory) []string {
 	}
 	return []string{string(category)}
 }
+
+func (p *dummyProvider) Close() error {
+	return nil
+}

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -353,6 +353,7 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ou
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM provider: %w", err)
 	}
+	defer provider.Close()
 	return flow.Execute(ctx, provider, s.workdir, false, inputs, s.cache, onEvent)
 }
 

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -103,6 +103,7 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM provider: %w", err)
 	}
+	defer provider.Close()
 
 	outputs, err := workflowDesc.Execute(aiCtx, provider, "/tmp/aflow-cache", false, initialState, cache, onEvent)
 

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -152,6 +152,7 @@ func run(ctx context.Context, args RunArgs) error {
 	if err != nil {
 		return err
 	}
+	defer provider.Close()
 
 	output, err := flow.Execute(ctx, provider, args.Workdir, args.Debug, inputs, cache, onEventFunc)
 	if err != nil {


### PR DESCRIPTION
Allow aflow providers to clean up their resources. Add a Close() method to the backend.Provider interface and call it where a provider is initialized.