### PR TITLE
dashboard/app: migrate error page to bootstrap

### DIFF
--- a/dashboard/app/templates/error.html
+++ b/dashboard/app/templates/error.html
@@ -1,14 +1,25 @@
 <!doctype html>
 <html>
 <head>
-	{{template "head" .Header}}
+	{{template "head_bootstrap" .Header}}
 	<title>syzbot</title>
 </head>
 <body>
-	traceID: {{.TraceID}}
-	<br>
-	{{.Error}}
-	<br>
-	<a href="javascript:history.back()">back</a>
+	{{/* .container: Centers content and provides responsive fixed width. mt-5: Adds top margin (level 5) */}}
+	<div class="container mt-5">
+		{{/* .alert, .alert-danger: Styles the box as a red/danger alert block */}}
+		<div class="alert alert-danger" role="alert">
+			{{/* .alert-heading: Styles the heading inside the alert */}}
+			<h4 class="alert-heading">Error</h4>
+			<p>{{.Error}}</p>
+			{{if .TraceID}}
+				<hr>
+				{{/* .mb-0: Removes bottom margin */}}
+				<p class="mb-0">Trace ID: {{.TraceID}}</p>
+			{{end}}
+		</div>
+		{{/* .btn, .btn-secondary: Styles the link as a standard gray secondary button */}}
+		<a href="javascript:history.back()" class="btn btn-secondary">Back</a>
+	</div>
 </body>
 </html>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -23,6 +23,32 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 	{{end}}
 {{end}}
 
+{{/* Common page head part with Bootstrap, invoked with *uiHeader */}}
+{{define "head_bootstrap"}}
+	{{/* Required meta tags for responsive design on mobile devices */}}
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	{{/* Bootstrap 5.3.3 CSS compiled styles from Google Hosted Libraries */}}
+	<link href="https://ajax.googleapis.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css"
+		rel="stylesheet"
+		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+		crossorigin="anonymous">
+	{{/* Bootstrap 5.3.3 JS Bundle from Google Hosted Libraries, deferred to load asynchronously */}}
+	<script src="https://ajax.googleapis.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js"
+		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+		crossorigin="anonymous"
+		defer></script>
+	{{/* Google Analytics tracking code, injected only if AnalyticsTrackingID is configured in production */}}
+	{{if .AnalyticsTrackingID}}
+		<script async src="https://www.googletagmanager.com/gtag/js?id={{.AnalyticsTrackingID}}"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() { dataLayer.push(arguments); }
+			gtag('js', new Date());
+			gtag('config', '{{.AnalyticsTrackingID}}');
+		</script>
+	{{end}}
+{{end}}
+
 {{/* Common page header, invoked with *uiHeader */}}
 {{define "header"}}
 	<header id="topbar">

--- a/dashboard/app/templates_compile_test.go
+++ b/dashboard/app/templates_compile_test.go
@@ -1,0 +1,19 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/html"
+)
+
+func TestTemplatesCompile(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("template parsing panicked: %v", r)
+		}
+	}()
+	html.CreateGlob("*.html")
+}


### PR DESCRIPTION
Introduce head_bootstrap template that loads Bootstrap 5.3.8 via CDN. Update error.html to use head_bootstrap and style the error message using Bootstrap's container and alert components.
Add templates_compile_test.go to verify templates compile.


<img width="1716" height="390" alt="image" src="https://github.com/user-attachments/assets/87afd2ee-7f45-4c98-9282-09ea10f92c4d" />

