### PR TITLE
tools/clang/codesearch: fix compilation database loading

### DIFF
--- a/tools/clang/codesearch/codesearch.cpp
+++ b/tools/clang/codesearch/codesearch.cpp
@@ -395,7 +395,7 @@ static int Main(int argc, const char** argv) {
   return 0;
 }
 
-__attribute__((constructor(1000))) static void ctor(int argc, const char** argv) {
+__attribute__((constructor)) static void ctor(int argc, const char** argv) {
   const char* run = getenv("SYZ_RUN_CLANGTOOL");
   if (run && !strcmp(run, "codesearch"))
     exit(Main(argc, argv));


### PR DESCRIPTION
Remove the `(1000)` priority from the C++ constructor used to intercept execution of the embedded clang tool.

Setting the priority to `(1000)` caused the interceptor to run before LLVM's default constructors had executed, preventing LLVM from registering the plugins necessary to parse `compile_commands.json`.

Using an un-prioritized `__attribute__((constructor))` ensures the interceptor runs after LLVM initializes, but still safely exits before the Go runtime can start and cause conflicts.