### PR TITLE
pkg/clangtool/tooltest: handle WalkDir errors to prevent panics

### DIFF
--- a/pkg/clangtool/tooltest/tooltest.go
+++ b/pkg/clangtool/tooltest/tooltest.go
@@ -87,10 +87,13 @@ func ForEachTestFile(t *testing.T, tool string, fn func(t *testing.T, cfg *clang
 func forEachTestFile(t *testing.T, dir string, fn func(t *testing.T, file string)) {
 	var files []string
 	err := filepath.WalkDir(osutil.Abs(dir), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if d.Name()[0] != '.' && filepath.Ext(d.Name()) == ".c" {
 			files = append(files, path)
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
If the target directory provided to filepath.WalkDir is missing or inaccessible, the fs.DirEntry argument passed to the callback is nil. Failing to handle the error argument first causes a panic (nil pointer dereference) when accessing the entry's name.

Explicitly checking and returning the error allows it to bubble up, ensuring a clean and debuggable test failure instead of a cryptic crash.
