### PR TITLE
vm/vmimpl: show kasan on openbsd

### DIFF
--- a/vm/vmimpl/openbsd.go
+++ b/vm/vmimpl/openbsd.go
@@ -18,6 +18,7 @@ func DiagnoseOpenBSD(w io.Writer) ([]byte, bool) {
 		"set $lines = 0",    // disable pagination
 		"set $maxwidth = 0", // disable line continuation
 		"show panic",
+		"show kasan",
 		"trace",
 		"show registers",
 		"show proc",


### PR DESCRIPTION
It's only conditionally available, but when it works, it's magic.