### PR TITLE
pkg/aflow: structured LLM tools

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -200,6 +200,24 @@ type stubContext struct {
 		*backend.GenerateResponse, error)
 }
 
+// runWithState executes the given function with the context's state temporarily
+// swapped out. This is useful for running sub-agents in an isolated state
+// scope, preventing their internal variables and tool outputs from leaking into
+// the parent state.
+//
+// WARNING: This method is NOT thread-safe. It mutates the receiver's state
+// in-place. It is safe to use only because aflow workflow execution is entirely
+// sequential and does not execute actions in parallel or spawn background
+// goroutines that access ctx.state.
+func (ctx *Context) runWithState(state map[string]any, fn func(*Context) error) error {
+	oldState := ctx.state
+	ctx.state = state
+	defer func() {
+		ctx.state = oldState
+	}()
+	return fn(ctx)
+}
+
 func (ctx *Context) Cache(typ, desc string, populate func(string) error) (string, error) {
 	dir, err := ctx.cache.Create(typ, desc, populate)
 	if err != nil {

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -50,6 +50,9 @@ type LLMAgent struct {
 	Prompt string
 	// Set of tools for the agent to use.
 	Tools []Tool
+	// Whether this agent is being run as a sub-agent by another agent.
+	// Used to control truncation behavior (sub-agents can be forced to answer now).
+	SubAgent bool
 
 	// Token limit for historical messages. If > 0, when the total input tokens exceed this limit,
 	// the agent will pause, call a cheaper model to summarize the entire history, and then drop
@@ -305,7 +308,7 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 }
 
 func (a *agentSession) tryAnswerNow(cfg *backend.GenerateConfig, overflow bool) bool {
-	if a.Reply != llmToolReply || len(a.req) < 3 || a.answerNow {
+	if !a.SubAgent || len(a.req) < 3 || a.answerNow {
 		return false
 	}
 	a.answerNow = true
@@ -381,19 +384,7 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 			return "", nil, err
 		}
 
-		if span.InputTokens > 0 {
-			var assignedTokens int
-			for _, msg := range a.req {
-				assignedTokens += msg.tokenCount
-			}
-			newTokens := span.InputTokens - assignedTokens
-			if newTokens > 0 {
-				a.req[len(a.req)-1].tokenCount += newTokens
-			}
-			if anchorTokens == 0 {
-				anchorTokens = span.InputTokens
-			}
-		}
+		a.updateInputTokens(span.InputTokens, &anchorTokens)
 
 		// If the LLM did not provide any reply and does not want to call any
 		// tools, we got an empty response. Populate the `Part`s with `Text`
@@ -435,6 +426,23 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 	}
 	return "", nil, fmt.Errorf("agent reached max iterations limit (%v)",
 		maxLLMIterations)
+}
+
+func (a *agentSession) updateInputTokens(inputTokens int, anchorTokens *int) {
+	if inputTokens <= 0 {
+		return
+	}
+	var assignedTokens int
+	for _, msg := range a.req {
+		assignedTokens += msg.tokenCount
+	}
+	newTokens := inputTokens - assignedTokens
+	if newTokens > 0 {
+		a.req[len(a.req)-1].tokenCount += newTokens
+	}
+	if *anchorTokens == 0 {
+		*anchorTokens = inputTokens
+	}
 }
 
 func (a *agentSession) checkFinalReply(ctx *Context, reply string) (string, string, error) {

--- a/pkg/aflow/llm_tool.go
+++ b/pkg/aflow/llm_tool.go
@@ -4,17 +4,18 @@
 package aflow
 
 import (
-	"errors"
 	"fmt"
+	"maps"
+	"reflect"
 
 	"github.com/google/syzkaller/pkg/aflow/backend"
 )
 
-// LLMTool acts like a tool for the parent LLM, but is itself implemented as an LLM agent.
+// StructuredLLMTool acts like a tool for the parent LLM, but is itself implemented as an LLM agent.
 // It can have own tools, different from the parent LLM agent.
 // It can do complex multi-step research, and provide a concise answer to the parent LLM
 // without polluting its context window.
-type LLMTool struct {
+type StructuredLLMTool[State, Args, Results any] struct {
 	// Most fields match that of LLMAgent.
 	// The prompt is not specified here, and is provided by the parent LLM.
 	Name     string
@@ -25,60 +26,135 @@ type LLMTool struct {
 	Instruction string
 	Tools       []Tool
 
+	// Prompt template for the subagent, formatted using both State and Args.
+	Prompt string
+
+	// Optional structured outputs configuration for the subagent.
+	// Use LLMOutputs or ValidatedLLMOutputs/ValidatedLLMToolOutputs functions to create it.
+	Outputs *llmOutputs
+
 	agent *LLMAgent
 }
 
-type llmToolArgs struct {
+type DefaultLLMArgs struct {
 	Question string `jsonschema:"Question you have."`
 }
 
-type llmToolResults struct {
+// StringLLMToolResult is the standardized result for unstructured text answers.
+type StringLLMToolResult struct {
 	Answer string `jsonschema:"Answer to your question."`
 }
 
-func (t *LLMTool) declaration() *backend.FunctionDeclaration {
+// LLMTool is a generic type alias that maps to StructuredLLMTool natively.
+type LLMTool[State, Args any] = StructuredLLMTool[State, Args, StringLLMToolResult]
+
+func (t *StructuredLLMTool[State, Args, Results]) declaration() *backend.FunctionDeclaration {
 	return &backend.FunctionDeclaration{
 		Name:                 t.Name,
 		Description:          t.Description,
-		ParametersJSONSchema: mustSchemaFor[llmToolArgs](),
-		ResponseJSONSchema:   mustSchemaFor[llmToolResults](),
+		ParametersJSONSchema: mustSchemaFor[Args](),
+		ResponseJSONSchema:   mustSchemaFor[Results](),
 	}
 }
 
-func (t *LLMTool) execute(ctx *Context, args map[string]any) (map[string]any, error) {
-	a, err := convertFromMap[llmToolArgs](args, false, true)
+func (t *StructuredLLMTool[State, Args, Results]) execute(ctx *Context, args map[string]any) (map[string]any, error) {
+	s, err := convertFromMap[State](ctx.state, false, true)
 	if err != nil {
 		return nil, err
 	}
-	// We temporarily use ctx.state to provide the prompt to the agent,
-	// and extract the reply.
-	ctx.state[llmToolPrompt] = a.Question
-	defer delete(ctx.state, llmToolPrompt)
-	if err := t.agent.execute(ctx); err != nil {
+	a, err := convertFromMap[Args](args, false, true)
+	if err != nil {
 		return nil, err
 	}
-	reply, ok := ctx.state[llmToolReply]
-	if !ok {
-		return nil, errors.New("state does not contain LLMTool reply")
+
+	combined := make(map[string]any)
+	maps.Copy(combined, convertToMap(s))
+	maps.Copy(combined, convertToMap(a))
+	for _, tool := range t.Tools {
+		name := tool.declaration().Name
+		combined[toolTemplateName(name)] = name
 	}
-	delete(ctx.state, llmToolReply)
-	return map[string]any{"Answer": reply}, nil
+
+	prompt := formatTemplate(t.Prompt, combined)
+
+	// Create a scoped sub-state for the sub-agent.
+	// It inherits all parent state variables, but any mutations made by
+	// the sub-agent will remain isolated in this map.
+	subState := make(map[string]any, len(ctx.state)+2)
+	maps.Copy(subState, ctx.state)
+	subState[llmToolPrompt] = prompt
+	subState[llmToolArgs] = a
+
+	// Execute the sub-agent using the scoped state.
+	err = ctx.runWithState(subState, func(ctx *Context) error {
+		return t.agent.execute(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the generated results cleanly using type conversion.
+	res, err := convertFromMap[Results](subState, false, true)
+	if err != nil {
+		return nil, err
+	}
+	return convertToMap(res), nil
 }
 
 const (
 	llmToolPrompt = "AFLOW_LLMTOOL_PROMPT"
 	llmToolReply  = "AFLOW_LLMTOOL_REPLY"
+	llmToolArgs   = "AFLOW_LLMTOOL_ARGS"
 )
 
-func (t *LLMTool) verify(ctx *verifyContext) {
+func (t *StructuredLLMTool[State, Args, Results]) verify(ctx *verifyContext) {
+	ctx.requireNotEmpty(t.Name, "Name", t.Name)
+	ctx.requireNotEmpty(t.Name, "Description", t.Description)
+	requireSchema[Args](ctx, t.Name, "Args")
+	requireSchema[Results](ctx, t.Name, "Results")
+	requireInputs[State](ctx, t.Name)
+
+	vars := make(map[string]reflect.Type)
+	maps.Insert(vars, foreachFieldOf[State]())
+	maps.Insert(vars, foreachFieldOf[Args]())
+	for _, tool := range t.Tools {
+		vars[toolTemplateName(tool.declaration().Name)] = reflect.TypeFor[string]()
+	}
+	if _, err := verifyTemplate(t.Prompt, vars); err != nil {
+		ctx.errorf(t.Name, "invalid prompt template: %v", err)
+	}
 	t.agent = &LLMAgent{
 		Name:        t.Name,
 		Model:       t.Model,
-		Reply:       llmToolReply,
 		TaskType:    t.TaskType,
 		Instruction: t.Instruction,
 		Prompt:      fmt.Sprintf("{{.%v}}", llmToolPrompt),
 		Tools:       t.Tools,
+		SubAgent:    true,
 	}
+
+	if t.Outputs != nil {
+		t.agent.Outputs = t.Outputs
+	} else {
+		t.agent.Outputs = LLMOutputs[Results]()
+	}
+
+	// We verify the sub-agent with outputs disabled so that its internal tools
+	// (like set-results) do not register their outputs (e.g. Results fields) into
+	// the parent flow's state. Otherwise, the parent flow would falsely report
+	// them as unused outputs.
+	oldOutputs := ctx.outputs
+	ctx.outputs = false
 	t.agent.verify(ctx)
+	ctx.outputs = oldOutputs
+}
+
+// ValidatedLLMToolOutputs creates an *llmOutputs for StructuredLLMTool whose validation callback requires tool Args.
+func ValidatedLLMToolOutputs[Results, State, Args any](
+	validate func(*Context, State, Args, Results) (Results, error),
+) *llmOutputs {
+	return ValidatedLLMOutputs[Results, State](func(ctx *Context, state State, res Results) (Results, error) {
+		a, _ := ctx.state[llmToolArgs].(Args)
+		return validate(ctx, state, a, res)
+	})
 }

--- a/pkg/aflow/llm_tool_test.go
+++ b/pkg/aflow/llm_tool_test.go
@@ -26,12 +26,13 @@ func TestLLMTool(t *testing.T) {
 		&LLMAgent{
 			Reply: "Reply",
 			Tools: []Tool{
-				&LLMTool{
+				&LLMTool[inputs, DefaultLLMArgs]{
 					Name:        "researcher",
 					Model:       "sub-agent-model",
 					TaskType:    FormalReasoningTask,
 					Description: "researcher description",
 					Instruction: "researcher instruction",
+					Prompt:      `{{.Question}}`,
 					Tools: []Tool{
 						NewFuncTool("researcher-tool", func(ctx *Context, state inputs, args toolArgs) (struct{}, error) {
 							// State passed all the way from the workflow inputs.
@@ -66,7 +67,15 @@ func TestLLMTool(t *testing.T) {
 				},
 			},
 			// Sub-agent returns result.
-			backend.Part{Text: "Nothing."},
+			backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id_out1",
+					Name: "set-results",
+					Args: map[string]any{
+						"Answer": "Nothing.",
+					},
+				},
+			},
 			// Repeat the same one more time.
 			backend.Part{
 				FunctionCall: &backend.FunctionCall{
@@ -97,7 +106,15 @@ func TestLLMTool(t *testing.T) {
 				},
 			},
 			&backend.InputTokenOverflowError{Err: fmt.Errorf("the input token count exceeds the maximum")},
-			backend.Part{Text: "Still nothing."},
+			backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id_out2",
+					Name: "set-results",
+					Args: map[string]any{
+						"Answer": "Still nothing.",
+					},
+				},
+			},
 			// Main returns result.
 			backend.Part{Text: "YES"},
 		},
@@ -136,22 +153,23 @@ func TestLLMToolMaxIters(t *testing.T) {
 			},
 		})
 	}
-	replies = append(replies,
-		// Sub-agent returns result.
-		backend.Part{Text: "Nothing."},
-		// Main returns result.
-		backend.Part{Text: "YES"},
-	)
-	testFlow[struct{}, outputs](t, nil, map[string]any{"Reply": "YES"},
+	// The agent hits maxLLMIterations and attempts to answer now.
+	// We provide an invalid reply so that it fails to produce structured output,
+	// terminating the loop and returning the max iterations limit error.
+	replies = append(replies, &backend.Part{Text: "I give up!"})
+	testFlow[struct{}, outputs](t, nil,
+		"tool researcher failed: error: agent reached max iterations limit (250)\n"+
+			"args: map[Question:What do you think?]",
 		&LLMAgent{
 			Reply: "Reply",
 			Tools: []Tool{
-				&LLMTool{
+				&LLMTool[struct{}, DefaultLLMArgs]{
 					Name:        "researcher",
 					Model:       "sub-agent-model",
 					TaskType:    FormalReasoningTask,
 					Description: "researcher description",
 					Instruction: "researcher instruction",
+					Prompt:      `{{.Question}}`,
 					Tools: []Tool{
 						NewFuncTool("researcher-tool", func(ctx *Context, state struct{}, args toolArgs) (struct{}, error) {
 							return struct{}{}, nil
@@ -161,6 +179,76 @@ func TestLLMToolMaxIters(t *testing.T) {
 			},
 		},
 		replies,
+		nil,
+	)
+}
+
+func TestLLMToolValidation(t *testing.T) {
+	type outputs struct {
+		Reply string
+	}
+
+	type testResult struct {
+		Answer string `jsonschema:"Answer"`
+	}
+
+	testFlow[struct{}, outputs](t, nil, map[string]any{"Reply": "YES"},
+		&LLMAgent{
+			Reply: "Reply",
+			Tools: []Tool{
+				&StructuredLLMTool[struct{}, DefaultLLMArgs, testResult]{
+					Name:        "researcher",
+					Model:       "sub-agent-model",
+					TaskType:    FormalReasoningTask,
+					Description: "researcher description",
+					Instruction: "researcher instruction",
+					Prompt:      `{{.Question}}`,
+					Outputs: ValidatedLLMToolOutputs[testResult, struct{}, DefaultLLMArgs](
+						func(ctx *Context, state struct{}, args DefaultLLMArgs, res testResult) (testResult, error) {
+							assert.Equal(t, "What do you think?", args.Question)
+							if res.Answer == "Bad reply" {
+								return res, BadCallError("this reply is bad")
+							}
+							return res, nil
+						},
+					),
+				},
+			},
+		},
+		[]any{
+			// Main agent calls the tool sub-agent.
+			&backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id0",
+					Name: "researcher",
+					Args: map[string]any{
+						"Question": "What do you think?",
+					},
+				},
+			},
+			// Sub-agent returns bad result.
+			&backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id1",
+					Name: "set-results",
+					Args: map[string]any{
+						"Answer": "Bad reply",
+					},
+				},
+			},
+			// Sub-agent returns good result.
+			&backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id2",
+					Name: "set-results",
+					Args: map[string]any{
+						"Answer": "Good reply",
+					},
+				},
+			},
+			// Main returns result.
+			backend.Part{Text: "YES"},
+		},
 		nil,
 	)
 }

--- a/pkg/aflow/runner_test.go
+++ b/pkg/aflow/runner_test.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,7 +67,13 @@ func testFlow[Inputs, Outputs any](t *testing.T, inputs map[string]any, result a
 				storeCfg = &cfgCopy
 			}
 			requests = append(requests, llmRequest{model, storeCfg, slices.Clone(req)})
-			require.NotEmpty(t, llmReplies, "unexpected LLM call")
+			if len(llmReplies) == 0 {
+				var b strings.Builder
+				for _, r := range req {
+					b.WriteString(fmt.Sprintf("%v\n", r.Parts))
+				}
+				t.Fatalf("unexpected LLM call! Request:\n%s", b.String())
+			}
 			reply := llmReplies[0]
 			if cb, ok := reply.(func(string, *backend.GenerateConfig, []*backend.Message) (
 				*backend.GenerateResponse, error)); ok {

--- a/pkg/aflow/testdata/TestLLMTool.llm.json
+++ b/pkg/aflow/testdata/TestLLMTool.llm.json
@@ -67,7 +67,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
 					}
 				],
 				"role": "user"
@@ -94,6 +94,40 @@
 							},
 							"responseJsonSchema": {
 								"type": "object",
+								"additionalProperties": false
+							}
+						}
+					]
+				},
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer to your question."
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer to your question."
+									}
+								},
+								"required": [
+									"Answer"
+								],
 								"additionalProperties": false
 							}
 						}
@@ -248,7 +282,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
 					}
 				],
 				"role": "user"
@@ -275,6 +309,40 @@
 							},
 							"responseJsonSchema": {
 								"type": "object",
+								"additionalProperties": false
+							}
+						}
+					]
+				},
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer to your question."
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer to your question."
+									}
+								},
+								"required": [
+									"Answer"
+								],
 								"additionalProperties": false
 							}
 						}
@@ -402,7 +470,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
 					}
 				],
 				"role": "user"

--- a/pkg/aflow/testdata/TestLLMTool.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMTool.trajectory.json
@@ -50,7 +50,7 @@
 		"Name": "researcher",
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:06Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
 		"Prompt": "What do you think?"
 	},
 	{
@@ -110,16 +110,42 @@
 		"Finished": "0001-01-01T00:00:12Z"
 	},
 	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:13Z",
+		"Args": {
+			"Answer": "Nothing."
+		}
+	},
+	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
+		"Args": {
+			"Answer": "Nothing."
+		},
+		"Results": {
+			"Answer": "Nothing."
+		}
+	},
+	{
 		"Seq": 4,
 		"Nesting": 3,
 		"Type": "agent",
 		"Name": "researcher",
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:06Z",
-		"Finished": "0001-01-01T00:00:13Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
-		"Prompt": "What do you think?",
-		"Reply": "Nothing."
+		"Finished": "0001-01-01T00:00:15Z",
+		"Results": {
+			"Answer": "Nothing."
+		},
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What do you think?"
 	},
 	{
 		"Seq": 3,
@@ -127,7 +153,7 @@
 		"Type": "tool",
 		"Name": "researcher",
 		"Started": "0001-01-01T00:00:05Z",
-		"Finished": "0001-01-01T00:00:14Z",
+		"Finished": "0001-01-01T00:00:16Z",
 		"Args": {
 			"Question": "What do you think?"
 		},
@@ -136,137 +162,119 @@
 		}
 	},
 	{
-		"Seq": 8,
+		"Seq": 9,
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:15Z"
-	},
-	{
-		"Seq": 8,
-		"Nesting": 2,
-		"Type": "llm",
-		"Name": "smarty",
-		"Model": "model",
-		"Started": "0001-01-01T00:00:15Z",
-		"Finished": "0001-01-01T00:00:16Z"
+		"Started": "0001-01-01T00:00:17Z"
 	},
 	{
 		"Seq": 9,
 		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:17Z",
+		"Finished": "0001-01-01T00:00:18Z"
+	},
+	{
+		"Seq": 10,
+		"Nesting": 2,
 		"Type": "tool",
 		"Name": "researcher",
-		"Started": "0001-01-01T00:00:17Z",
+		"Started": "0001-01-01T00:00:19Z",
 		"Args": {
 			"Question": "But really?"
 		}
 	},
 	{
-		"Seq": 10,
+		"Seq": 11,
 		"Nesting": 3,
 		"Type": "agent",
 		"Name": "researcher",
 		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:18Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Started": "0001-01-01T00:00:20Z",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
 		"Prompt": "But really?"
 	},
 	{
-		"Seq": 11,
+		"Seq": 12,
 		"Nesting": 4,
 		"Type": "llm",
 		"Name": "researcher",
 		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:19Z"
-	},
-	{
-		"Seq": 11,
-		"Nesting": 4,
-		"Type": "llm",
-		"Name": "researcher",
-		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:19Z",
-		"Finished": "0001-01-01T00:00:20Z"
+		"Started": "0001-01-01T00:00:21Z"
 	},
 	{
 		"Seq": 12,
 		"Nesting": 4,
-		"Type": "tool",
-		"Name": "researcher-tool",
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:21Z",
-		"Args": {
-			"Something": "subtool input 2"
-		}
-	},
-	{
-		"Seq": 12,
-		"Nesting": 4,
-		"Type": "tool",
-		"Name": "researcher-tool",
-		"Started": "0001-01-01T00:00:21Z",
-		"Finished": "0001-01-01T00:00:22Z",
-		"Args": {
-			"Something": "subtool input 2"
-		},
-		"Results": {}
+		"Finished": "0001-01-01T00:00:22Z"
 	},
 	{
 		"Seq": 13,
 		"Nesting": 4,
-		"Type": "llm",
-		"Name": "researcher",
-		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:23Z"
-	},
-	{
-		"Seq": 13,
-		"Nesting": 4,
-		"Type": "llm",
-		"Name": "researcher",
-		"Model": "sub-agent-model",
+		"Type": "tool",
+		"Name": "researcher-tool",
 		"Started": "0001-01-01T00:00:23Z",
-		"Finished": "0001-01-01T00:00:24Z"
+		"Args": {
+			"Something": "subtool input 2"
+		}
+	},
+	{
+		"Seq": 13,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "researcher-tool",
+		"Started": "0001-01-01T00:00:23Z",
+		"Finished": "0001-01-01T00:00:24Z",
+		"Args": {
+			"Something": "subtool input 2"
+		},
+		"Results": {}
 	},
 	{
 		"Seq": 14,
 		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:25Z"
+	},
+	{
+		"Seq": 14,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:25Z",
+		"Finished": "0001-01-01T00:00:26Z"
+	},
+	{
+		"Seq": 15,
+		"Nesting": 4,
 		"Type": "tool",
 		"Name": "researcher-tool",
-		"Started": "0001-01-01T00:00:25Z",
+		"Started": "0001-01-01T00:00:27Z",
 		"Args": {
 			"Something": "subtool input 3"
 		}
 	},
 	{
-		"Seq": 14,
+		"Seq": 15,
 		"Nesting": 4,
 		"Type": "tool",
 		"Name": "researcher-tool",
-		"Started": "0001-01-01T00:00:25Z",
-		"Finished": "0001-01-01T00:00:26Z",
-		"Args": {
-			"Something": "subtool input 3"
-		},
-		"Results": {}
-	},
-	{
-		"Seq": 15,
-		"Nesting": 4,
-		"Type": "llm",
-		"Name": "researcher",
-		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:27Z"
-	},
-	{
-		"Seq": 15,
-		"Nesting": 4,
-		"Type": "llm",
-		"Name": "researcher",
-		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:27Z",
 		"Finished": "0001-01-01T00:00:28Z",
-		"Error": "the input token count exceeds the maximum"
+		"Args": {
+			"Something": "subtool input 3"
+		},
+		"Results": {}
 	},
 	{
 		"Seq": 16,
@@ -283,27 +291,71 @@
 		"Name": "researcher",
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:29Z",
-		"Finished": "0001-01-01T00:00:30Z"
+		"Finished": "0001-01-01T00:00:30Z",
+		"Error": "the input token count exceeds the maximum"
 	},
 	{
-		"Seq": 10,
+		"Seq": 17,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:31Z"
+	},
+	{
+		"Seq": 17,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:31Z",
+		"Finished": "0001-01-01T00:00:32Z"
+	},
+	{
+		"Seq": 18,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:33Z",
+		"Args": {
+			"Answer": "Still nothing."
+		}
+	},
+	{
+		"Seq": 18,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:33Z",
+		"Finished": "0001-01-01T00:00:34Z",
+		"Args": {
+			"Answer": "Still nothing."
+		},
+		"Results": {
+			"Answer": "Still nothing."
+		}
+	},
+	{
+		"Seq": 11,
 		"Nesting": 3,
 		"Type": "agent",
 		"Name": "researcher",
 		"Model": "sub-agent-model",
-		"Started": "0001-01-01T00:00:18Z",
-		"Finished": "0001-01-01T00:00:31Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
-		"Prompt": "But really?",
-		"Reply": "Still nothing."
+		"Started": "0001-01-01T00:00:20Z",
+		"Finished": "0001-01-01T00:00:35Z",
+		"Results": {
+			"Answer": "Still nothing."
+		},
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "But really?"
 	},
 	{
-		"Seq": 9,
+		"Seq": 10,
 		"Nesting": 2,
 		"Type": "tool",
 		"Name": "researcher",
-		"Started": "0001-01-01T00:00:17Z",
-		"Finished": "0001-01-01T00:00:32Z",
+		"Started": "0001-01-01T00:00:19Z",
+		"Finished": "0001-01-01T00:00:36Z",
 		"Args": {
 			"Question": "But really?"
 		},
@@ -312,21 +364,21 @@
 		}
 	},
 	{
-		"Seq": 17,
+		"Seq": 19,
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:33Z"
+		"Started": "0001-01-01T00:00:37Z"
 	},
 	{
-		"Seq": 17,
+		"Seq": 19,
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty",
 		"Model": "model",
-		"Started": "0001-01-01T00:00:33Z",
-		"Finished": "0001-01-01T00:00:34Z"
+		"Started": "0001-01-01T00:00:37Z",
+		"Finished": "0001-01-01T00:00:38Z"
 	},
 	{
 		"Seq": 1,
@@ -335,7 +387,7 @@
 		"Name": "smarty",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Finished": "0001-01-01T00:00:35Z",
+		"Finished": "0001-01-01T00:00:39Z",
 		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
 		"Prompt": "Prompt",
 		"Reply": "YES"
@@ -346,7 +398,7 @@
 		"Type": "flow",
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
-		"Finished": "0001-01-01T00:00:36Z",
+		"Finished": "0001-01-01T00:00:40Z",
 		"Results": {
 			"Reply": "YES"
 		}

--- a/pkg/aflow/testdata/TestLLMToolMaxIters.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMToolMaxIters.trajectory.json
@@ -50,7 +50,7 @@
 		"Name": "researcher",
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:06Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
 		"Prompt": "What do you think?"
 	},
 	{
@@ -9828,9 +9828,9 @@
 		"Model": "sub-agent-model",
 		"Started": "0001-01-01T00:00:06Z",
 		"Finished": "0001-01-01T00:16:49Z",
-		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n",
-		"Prompt": "What do you think?",
-		"Reply": "Nothing."
+		"Error": "agent reached max iterations limit (250)",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What do you think?"
 	},
 	{
 		"Seq": 3,
@@ -9839,29 +9839,10 @@
 		"Name": "researcher",
 		"Started": "0001-01-01T00:00:05Z",
 		"Finished": "0001-01-01T00:16:50Z",
+		"Error": "agent reached max iterations limit (250)",
 		"Args": {
 			"Question": "What do you think?"
-		},
-		"Results": {
-			"Answer": "Nothing."
 		}
-	},
-	{
-		"Seq": 506,
-		"Nesting": 2,
-		"Type": "llm",
-		"Name": "smarty",
-		"Model": "model",
-		"Started": "0001-01-01T00:16:51Z"
-	},
-	{
-		"Seq": 506,
-		"Nesting": 2,
-		"Type": "llm",
-		"Name": "smarty",
-		"Model": "model",
-		"Started": "0001-01-01T00:16:51Z",
-		"Finished": "0001-01-01T00:16:52Z"
 	},
 	{
 		"Seq": 1,
@@ -9870,10 +9851,10 @@
 		"Name": "smarty",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Finished": "0001-01-01T00:16:53Z",
+		"Finished": "0001-01-01T00:16:51Z",
+		"Error": "tool researcher failed: error: agent reached max iterations limit (250)\nargs: map[Question:What do you think?]",
 		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
-		"Prompt": "Prompt",
-		"Reply": "YES"
+		"Prompt": "Prompt"
 	},
 	{
 		"Seq": 0,
@@ -9881,9 +9862,7 @@
 		"Type": "flow",
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
-		"Finished": "0001-01-01T00:16:54Z",
-		"Results": {
-			"Reply": "YES"
-		}
+		"Finished": "0001-01-01T00:16:52Z",
+		"Error": "tool researcher failed: error: agent reached max iterations limit (250)\nargs: map[Question:What do you think?]"
 	}
 ]

--- a/pkg/aflow/testdata/TestLLMToolValidation.llm.json
+++ b/pkg/aflow/testdata/TestLLMToolValidation.llm.json
@@ -1,0 +1,257 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher description",
+							"name": "researcher",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Question": {
+										"type": "string",
+										"description": "Question you have."
+									}
+								},
+								"required": [
+									"Question"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "researcher instruction\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "What do you think?"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "What do you think?"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"args": {
+								"Answer": "Bad reply"
+							},
+							"name": "set-results"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"response": {
+								"error": "this reply is bad"
+							},
+							"name": "set-results"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher description",
+							"name": "researcher",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Question": {
+										"type": "string",
+										"description": "Question you have."
+									}
+								},
+								"required": [
+									"Question"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id0",
+							"args": {
+								"Question": "What do you think?"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id0",
+							"response": {
+								"Answer": "Good reply"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestLLMToolValidation.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMToolValidation.trajectory.json
@@ -1,0 +1,207 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "researcher",
+		"Started": "0001-01-01T00:00:05Z",
+		"Args": {
+			"Question": "What do you think?"
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "agent",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:06Z",
+		"Instruction": "researcher instruction\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What do you think?"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:09Z",
+		"Args": {
+			"Answer": "Bad reply"
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Error": "this reply is bad",
+		"Args": {
+			"Answer": "Bad reply"
+		},
+		"Results": {
+			"Answer": "Bad reply"
+		}
+	},
+	{
+		"Seq": 7,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:12Z"
+	},
+	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:13Z",
+		"Args": {
+			"Answer": "Good reply"
+		}
+	},
+	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
+		"Args": {
+			"Answer": "Good reply"
+		},
+		"Results": {
+			"Answer": "Good reply"
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "agent",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:06Z",
+		"Finished": "0001-01-01T00:00:15Z",
+		"Results": {
+			"Answer": "Good reply"
+		},
+		"Instruction": "researcher instruction\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What do you think?"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "researcher",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:16Z",
+		"Args": {
+			"Question": "What do you think?"
+		},
+		"Results": {
+			"Answer": "Good reply"
+		}
+	},
+	{
+		"Seq": 9,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:17Z"
+	},
+	{
+		"Seq": 9,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:17Z",
+		"Finished": "0001-01-01T00:00:18Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:19Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt",
+		"Reply": "YES"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:20Z",
+		"Results": {
+			"Reply": "YES"
+		}
+	}
+]

--- a/pkg/aflow/tool/codeexpert/codeexpert.go
+++ b/pkg/aflow/tool/codeexpert/codeexpert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
 )
 
-func New(enableGit bool) *aflow.LLMTool {
+func New(enableGit bool) *aflow.LLMTool[struct{}, aflow.DefaultLLMArgs] {
 	var tools []aflow.Tool
 	inst := instructionHeader
 	if enableGit {
@@ -25,12 +25,13 @@ func New(enableGit bool) *aflow.LLMTool {
 		inst += instructionGitRestrictions
 	}
 
-	return &aflow.LLMTool{
+	return &aflow.LLMTool[struct{}, aflow.DefaultLLMArgs]{
 		Name:        "codeexpert",
 		Model:       aflow.GoodBalancedModel,
 		TaskType:    aflow.FormalReasoningTask,
 		Description: description,
 		Instruction: inst,
+		Prompt:      `{{.Question}}`,
 		Tools:       tools,
 	}
 }


### PR DESCRIPTION
**pkg/aflow: structured LLM tools**
Enable parent agents to pass typed parameters and state to subagents and
cleanly extract validated, structured outputs without manual parsing.
This prevents subagent execution state and intermediate variables from
leaking into the parent agent's global state, and enforces static type
safety across state, arguments, and results during validation.

To preserve backwards compatibility for existing text-based tools,
define a generic type alias LLMTool that automatically maps to
StructuredLLMTool with a standardized StringLLMToolResult, avoiding code
churn for legacy unstructured tools.