### PR TITLE
pkg/aflow/action/crash: consolidate and unify VM target configuration

### DIFF
--- a/pkg/aflow/action/crash/config.go
+++ b/pkg/aflow/action/crash/config.go
@@ -1,0 +1,127 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+// TargetConfig defines the configuration for building a target environment for
+// running programs in a VM.
+type TargetConfig struct {
+	// Name identifying the agent instance.
+	AgentName string
+	// Target architecture of the kernel under test (e.g., "amd64", "arm64").
+	TargetArch string
+	// Directory path containing syzkaller host/target binaries.
+	Syzkaller string
+	// Path to the disk image file used by the VM.
+	Image string
+	// Virtual machine type (e.g., "qemu" or "gce").
+	Type string
+	// JSON-encoded VM-type-specific configurations.
+	VM json.RawMessage
+	// Directory path containing the kernel source tree.
+	KernelSrc string
+	// Directory path containing kernel build artifacts (such as vmlinux).
+	KernelObj string
+	// Git commit hash/revision of the kernel.
+	KernelCommit string
+	// Kernel build configuration (.config file content).
+	KernelConfig string
+	// Path to the host strace binary.
+	StraceBin string
+	// Whether to capture strace output during test execution.
+	NeedStrace bool
+	// Isolation sandbox type (e.g., "none", "namespace", "setuid", "android").
+	Sandbox string
+}
+
+// Validate checks if the target configuration is valid.
+func (args TargetConfig) Validate() error {
+	if targets.Get(targets.Linux, args.TargetArch) == nil {
+		return fmt.Errorf("unsupported target: %v/%v", targets.Linux, args.TargetArch)
+	}
+	switch args.Type {
+	case "qemu", "gce":
+	default:
+		return fmt.Errorf("unsupported VM type %q", args.Type)
+	}
+	switch args.Sandbox {
+	case "", "none", "setuid", "namespace", "android":
+	default:
+		return fmt.Errorf("unsupported sandbox type %q", args.Sandbox)
+	}
+	return nil
+}
+
+func BuildConfig(args TargetConfig, workdir string) (*mgrconfig.Config, error) {
+	var vmConfig map[string]any
+	if len(args.VM) > 0 {
+		if err := json.Unmarshal(args.VM, &vmConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse VM config: %w", err)
+		}
+	}
+	if vmConfig == nil {
+		vmConfig = make(map[string]any)
+	}
+
+	targetArch := args.TargetArch
+	image := args.Image
+
+	kernelPath := filepath.Join(args.KernelObj, filepath.FromSlash(build.LinuxKernelImage(targetArch)))
+	switch args.Type {
+	case "qemu":
+		vmConfig["kernel"] = kernelPath
+	case "gce":
+		params := build.Params{
+			TargetOS:     targets.Linux,
+			TargetArch:   targetArch,
+			UserspaceDir: image,
+			OutputDir:    workdir,
+		}
+		if err := build.EmbedLinuxKernel(params, kernelPath); err != nil {
+			return nil, fmt.Errorf("failed to embed kernel into image: %w", err)
+		}
+		image = filepath.Join(workdir, "image")
+	}
+
+	vmCfg, err := json.Marshal(vmConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize VM config: %w", err)
+	}
+
+	cfg := mgrconfig.DefaultValues()
+	cfg.Name = args.AgentName
+	cfg.RawTarget = targets.Linux + "/" + targetArch
+	cfg.Workdir = workdir
+	cfg.Syzkaller = args.Syzkaller
+	cfg.KernelObj = args.KernelObj
+	cfg.KernelSrc = args.KernelSrc
+	cfg.Image = image
+	cfg.Type = args.Type
+	cfg.VM = vmCfg
+	if args.Sandbox != "" {
+		cfg.Sandbox = args.Sandbox
+	}
+	cfg.Experimental.DescriptionsMode = mgrconfig.AnyDescriptionsMode
+	if args.NeedStrace && args.StraceBin != "" {
+		cfg.StraceBin = args.StraceBin
+		cfg.StraceBinOnTarget = false
+	}
+
+	if err := mgrconfig.SetTargets(cfg); err != nil {
+		return nil, err
+	}
+	if err := mgrconfig.Complete(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/pkg/aflow/action/crash/config_test.go
+++ b/pkg/aflow/action/crash/config_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  TargetConfig
+		wantErr bool
+	}{
+		{
+			name: "valid qemu config",
+			config: TargetConfig{
+				TargetArch: "amd64",
+				Type:       "qemu",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid gce config",
+			config: TargetConfig{
+				TargetArch: "amd64",
+				Type:       "gce",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported target arch",
+			config: TargetConfig{
+				TargetArch: "invalid",
+				Type:       "qemu",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported VM type",
+			config: TargetConfig{
+				TargetArch: "amd64",
+				Type:       "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid custom sandbox",
+			config: TargetConfig{
+				TargetArch: "amd64",
+				Type:       "qemu",
+				Sandbox:    "namespace",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported sandbox type",
+			config: TargetConfig{
+				TargetArch: "amd64",
+				Type:       "qemu",
+				Sandbox:    "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func setupDummySyzkaller(t *testing.T) string {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin", "linux_amd64")
+	err := os.MkdirAll(binDir, 0755)
+	require.NoError(t, err)
+
+	for _, file := range []string{"syz-execprog", "syz-executor"} {
+		err = os.WriteFile(filepath.Join(binDir, file), []byte("dummy"), 0644)
+		require.NoError(t, err)
+	}
+	return dir
+}
+
+func TestBuildConfig(t *testing.T) {
+	syzDir := setupDummySyzkaller(t)
+
+	createDummyImage := func(t *testing.T) string {
+		tmp := t.TempDir()
+		img := filepath.Join(tmp, "dummy_image")
+		err := os.WriteFile(img, []byte("dummy image data"), 0644)
+		require.NoError(t, err)
+		return img
+	}
+
+	t.Run("qemu defaults", func(t *testing.T) {
+		img := createDummyImage(t)
+		cfg := TargetConfig{
+			TargetArch: "amd64",
+			Type:       "qemu",
+			Syzkaller:  syzDir,
+			Image:      img,
+			KernelObj:  "dummy_kernel_obj",
+		}
+		res, err := BuildConfig(cfg, t.TempDir())
+		require.NoError(t, err)
+		require.Equal(t, "qemu", res.Type)
+		require.Equal(t, "none", res.Sandbox)
+		require.Equal(t, img, res.Image)
+		require.Equal(t, "any", res.Experimental.DescriptionsMode)
+
+		var vmCfg map[string]any
+		err = json.Unmarshal(res.VM, &vmCfg)
+		require.NoError(t, err)
+		expectedKernel := filepath.Join("dummy_kernel_obj", filepath.FromSlash("arch/x86/boot/bzImage"))
+		require.Equal(t, expectedKernel, vmCfg["kernel"])
+	})
+
+	t.Run("qemu custom options", func(t *testing.T) {
+		img := createDummyImage(t)
+		vmRaw := json.RawMessage(`{"count":2,"cpu":"4"}`)
+		straceBin := filepath.Join(t.TempDir(), "strace")
+		err := os.WriteFile(straceBin, []byte("dummy strace"), 0755)
+		require.NoError(t, err)
+
+		cfg := TargetConfig{
+			TargetArch: "amd64",
+			Type:       "qemu",
+			Syzkaller:  syzDir,
+			Image:      img,
+			KernelObj:  "dummy_kernel_obj",
+			VM:         vmRaw,
+			Sandbox:    "namespace",
+			NeedStrace: true,
+			StraceBin:  straceBin,
+		}
+		res, err := BuildConfig(cfg, t.TempDir())
+		require.NoError(t, err)
+		require.Equal(t, "namespace", res.Sandbox)
+		require.Equal(t, straceBin, res.StraceBin)
+		require.False(t, res.StraceBinOnTarget)
+
+		var vmCfg map[string]any
+		err = json.Unmarshal(res.VM, &vmCfg)
+		require.NoError(t, err)
+		require.Equal(t, float64(2), vmCfg["count"])
+		require.Equal(t, "4", vmCfg["cpu"])
+		expectedKernel := filepath.Join("dummy_kernel_obj", filepath.FromSlash("arch/x86/boot/bzImage"))
+		require.Equal(t, expectedKernel, vmCfg["kernel"])
+	})
+
+	t.Run("gce image embed error", func(t *testing.T) {
+		img := createDummyImage(t)
+		cfg := TargetConfig{
+			TargetArch: "amd64",
+			Type:       "gce",
+			Syzkaller:  syzDir,
+			Image:      img,
+			KernelObj:  "dummy_kernel_obj",
+		}
+		_, err := BuildConfig(cfg, t.TempDir())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to embed kernel")
+	})
+}

--- a/pkg/aflow/action/crash/configure_runner.go
+++ b/pkg/aflow/action/crash/configure_runner.go
@@ -30,7 +30,7 @@ func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct
 		return struct{}{}, fmt.Errorf("failed to create workdir for configure-runner: %w", err)
 	}
 
-	reproArgs := ReproduceArgs{
+	targetCfg := TargetConfig{
 		TargetArch: args.TargetArch,
 		Syzkaller:  args.Syzkaller,
 		Image:      args.Image,
@@ -40,11 +40,11 @@ func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct
 		KernelObj:  args.KernelObj,
 	}
 
-	if err := reproArgs.Validate(); err != nil {
+	if err := targetCfg.Validate(); err != nil {
 		return struct{}{}, aflow.FlowError(err)
 	}
 
-	cfg, err := buildConfig(reproArgs, workdir)
+	cfg, err := BuildConfig(targetCfg, workdir)
 	if err != nil {
 		return struct{}{}, fmt.Errorf("failed to build config for runner: %w", err)
 	}

--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -6,7 +6,6 @@ package crash
 
 import (
 	"cmp"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -15,7 +14,6 @@ import (
 	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
-	"github.com/google/syzkaller/pkg/build"
 	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/hash"
@@ -34,21 +32,10 @@ var ErrDidNotCrash = errors.New("reproducer did not crash")
 var Reproduce = aflow.NewFuncAction("crash-reproducer", ReproduceFunc)
 
 type ReproduceArgs struct {
-	AgentName    string
-	TargetArch   string
-	Syzkaller    string
-	Image        string
-	Type         string
-	VM           json.RawMessage
-	ReproOpts    string
-	ReproSyz     string
-	ReproC       string
-	KernelSrc    string
-	KernelObj    string
-	KernelCommit string
-	KernelConfig string
-	StraceBin    string
-	NeedStrace   bool
+	TargetConfig
+	ReproOpts string
+	ReproSyz  string
+	ReproC    string
 }
 
 type reproduceResult struct {
@@ -56,16 +43,6 @@ type reproduceResult struct {
 	ReproducedCrashReport    string
 	OtherCrashReports        []string
 	ReproducedFaultInjection string
-}
-
-func (args *ReproduceArgs) Validate() error {
-	if targets.Get(targets.Linux, args.TargetArch) == nil {
-		return fmt.Errorf("unsupported target: %v/%v", targets.Linux, args.TargetArch)
-	}
-	if args.Type != "qemu" && args.Type != "gce" {
-		return fmt.Errorf("unsupported VM type %q", args.Type)
-	}
-	return nil
 }
 
 type RunTestResult struct {
@@ -95,7 +72,7 @@ func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestR
 		return res, errors.New("run test: coverage collection requires a syzkaller program")
 	}
 
-	cfg, err := buildConfig(args, workdir)
+	cfg, err := BuildConfig(args.TargetConfig, workdir)
 	if err != nil {
 		return res, err
 	}
@@ -242,62 +219,6 @@ func LoadCoverage(ctx *aflow.Context, cachedID string) ([][]symbolizer.Frame, er
 		return nil, err
 	}
 	return cached.Coverage, nil
-}
-
-func buildConfig(args ReproduceArgs, workdir string) (*mgrconfig.Config, error) {
-	var vmConfig map[string]any
-	if err := json.Unmarshal(args.VM, &vmConfig); err != nil {
-		return nil, fmt.Errorf("failed to parse VM config: %w", err)
-	}
-
-	targetArch := args.TargetArch
-	image := args.Image
-
-	switch args.Type {
-	case "qemu":
-		vmConfig["kernel"] = filepath.Join(args.KernelObj, filepath.FromSlash(build.LinuxKernelImage(targetArch)))
-	case "gce":
-		params := build.Params{
-			TargetOS:     targets.Linux,
-			TargetArch:   targetArch,
-			UserspaceDir: image,
-			OutputDir:    workdir,
-		}
-		kernelPath := filepath.Join(args.KernelObj, filepath.FromSlash(build.LinuxKernelImage(targetArch)))
-		if err := build.EmbedLinuxKernel(params, kernelPath); err != nil {
-			return nil, fmt.Errorf("failed to embed kernel into image: %w", err)
-		}
-		image = filepath.Join(workdir, "image")
-	}
-
-	vmCfg, err := json.Marshal(vmConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize VM config: %w", err)
-	}
-
-	cfg := mgrconfig.DefaultValues()
-	cfg.Name = args.AgentName
-	cfg.RawTarget = targets.Linux + "/" + targetArch
-	cfg.Workdir = workdir
-	cfg.Syzkaller = args.Syzkaller
-	cfg.KernelObj = args.KernelObj
-	cfg.KernelSrc = args.KernelSrc
-	cfg.Image = image
-	cfg.Type = args.Type
-	cfg.VM = vmCfg
-	cfg.Experimental.DescriptionsMode = mgrconfig.AnyDescriptionsMode
-	if args.NeedStrace && args.StraceBin != "" {
-		cfg.StraceBin = args.StraceBin
-		cfg.StraceBinOnTarget = false
-	}
-
-	if err := mgrconfig.SetTargets(cfg); err != nil {
-		return nil, err
-	}
-	if err := mgrconfig.Complete(cfg); err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,

--- a/pkg/aflow/action/crash/reproduce_test.go
+++ b/pkg/aflow/action/crash/reproduce_test.go
@@ -87,7 +87,9 @@ func TestAggregateTestResults(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			args := ReproduceArgs{
-				TargetArch: "amd64",
+				TargetConfig: TargetConfig{
+					TargetArch: "amd64",
+				},
 			}
 			res, err := aggregateTestResults(tc.results, crashReporter, args)
 			require.NoError(t, err)
@@ -139,8 +141,10 @@ func TestSymbolize(t *testing.T) {
 	}
 
 	args := ReproduceArgs{
-		TargetArch: "amd64",
-		Type:       "qemu",
+		TargetConfig: TargetConfig{
+			TargetArch: "amd64",
+			Type:       "qemu",
+		},
 	}
 	// amd64 instruction length is 5.
 	// So 0x1005 should be shifted to 0x1000.

--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -51,17 +51,19 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	}
 
 	reproduceArgs := ReproduceArgs{
-		TargetArch:   args.TargetArch,
-		Syzkaller:    args.Syzkaller,
-		Image:        args.Image,
-		Type:         args.Type,
-		VM:           args.VM,
-		KernelSrc:    args.KernelSrc,
-		KernelObj:    args.KernelObj,
-		KernelCommit: args.KernelCommit,
-		KernelConfig: args.KernelConfig,
-		ReproC:       args.FormattedReproC,
-		StraceBin:    args.StraceBin,
+		TargetConfig: TargetConfig{
+			TargetArch:   args.TargetArch,
+			Syzkaller:    args.Syzkaller,
+			Image:        args.Image,
+			Type:         args.Type,
+			VM:           args.VM,
+			KernelSrc:    args.KernelSrc,
+			KernelObj:    args.KernelObj,
+			KernelCommit: args.KernelCommit,
+			KernelConfig: args.KernelConfig,
+			StraceBin:    args.StraceBin,
+		},
+		ReproC: args.FormattedReproC,
 	}
 
 	// Run 1: without strace.

--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -107,19 +107,21 @@ func testPatchRepro(ctx *aflow.Context, args testArgs) (string, error) {
 		return "", err
 	}
 	reproduceArgs := ReproduceArgs{
-		AgentName:    args.AgentName,
-		TargetArch:   args.TargetArch,
-		Syzkaller:    args.Syzkaller,
-		Image:        args.Image,
-		Type:         args.Type,
-		VM:           args.VM,
-		ReproOpts:    args.ReproOpts,
-		ReproSyz:     args.ReproSyz,
-		ReproC:       args.ReproC,
-		KernelSrc:    args.KernelScratchSrc,
-		KernelObj:    args.KernelScratchSrc,
-		KernelCommit: args.KernelCommit,
-		KernelConfig: args.KernelConfig,
+		TargetConfig: TargetConfig{
+			AgentName:    args.AgentName,
+			TargetArch:   args.TargetArch,
+			Syzkaller:    args.Syzkaller,
+			Image:        args.Image,
+			Type:         args.Type,
+			VM:           args.VM,
+			KernelSrc:    args.KernelScratchSrc,
+			KernelObj:    args.KernelScratchSrc,
+			KernelCommit: args.KernelCommit,
+			KernelConfig: args.KernelConfig,
+		},
+		ReproOpts: args.ReproOpts,
+		ReproSyz:  args.ReproSyz,
+		ReproC:    args.ReproC,
 	}
 	testRes, err := RunTest(reproduceArgs, workdir, false)
 	if err != nil {

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -93,6 +93,7 @@ func init() {
 		&aflow.Flow{
 			Consts: map[string]any{
 				"NeedStrace": false,
+				"Sandbox":    "none",
 			},
 			Root: aflow.Pipeline(
 				// Setup base kernel for code tools.

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -56,6 +56,7 @@ func init() {
 		&aflow.Flow{
 			Consts: map[string]any{
 				"NeedStrace": false,
+				"Sandbox":    "none",
 				// For convenience of the patch-iteration workflow.
 				"ReviewedBy": []string{},
 				"AckedBy":    []string{},

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -47,6 +47,7 @@ func init() {
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"ReproC":                       "", // is needed by crash.Reproduce
 				"NeedStrace":                   false,
+				"Sandbox":                      "none",
 			},
 			Root: aflow.Pipeline(
 				kernel.Checkout,

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -90,7 +90,7 @@ func convertFromMapReflect(v reflect.Value, m map[string]any, strict, tool bool)
 	m = maps.Clone(m)
 	t := v.Type()
 	for _, fieldType := range reflect.VisibleFields(t) {
-		if !fieldType.IsExported() {
+		if !fieldType.IsExported() || fieldType.Anonymous {
 			continue
 		}
 		name := fieldType.Name
@@ -254,6 +254,9 @@ func foreachField(data any) iter.Seq2[string, reflect.Value] {
 	return func(yield func(string, reflect.Value) bool) {
 		v := reflect.ValueOf(data).Elem()
 		for _, field := range reflect.VisibleFields(v.Type()) {
+			if field.Anonymous {
+				continue
+			}
 			if !yield(field.Name, v.FieldByIndex(field.Index)) {
 				break
 			}

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -240,6 +240,20 @@ func TestConvertFromMap(t *testing.T) {
 	}{
 		T: t1,
 	}, "", "")
+
+	type Embedded struct {
+		B string
+	}
+	testConvertFromMap(t, true, map[string]any{
+		"A": 1.0,
+		"B": "foo",
+	}, struct {
+		Embedded
+		A int
+	}{
+		Embedded: Embedded{B: "foo"},
+		A:        1,
+	}, "", "")
 }
 
 func testConvertFromMap[T any](t *testing.T, strict bool, input map[string]any, output T, toolErr, nonToolErr string) {

--- a/pkg/aflow/tool/syzlang/reproduce.go
+++ b/pkg/aflow/tool/syzlang/reproduce.go
@@ -63,16 +63,18 @@ func reproduce(ctx *aflow.Context, state reproduceState, args ReproduceArgs) (Re
 	}
 
 	reproArgs := crash.ReproduceArgs{
-		TargetArch:   state.TargetArch,
-		Syzkaller:    state.Syzkaller,
-		Image:        state.Image,
-		Type:         state.Type,
-		VM:           state.VM,
-		ReproSyz:     args.ReproSyz,
-		KernelSrc:    state.KernelSrc,
-		KernelObj:    state.KernelObj,
-		KernelCommit: state.KernelCommit,
-		KernelConfig: state.KernelConfig,
+		TargetConfig: crash.TargetConfig{
+			TargetArch:   state.TargetArch,
+			Syzkaller:    state.Syzkaller,
+			Image:        state.Image,
+			Type:         state.Type,
+			VM:           state.VM,
+			KernelSrc:    state.KernelSrc,
+			KernelObj:    state.KernelObj,
+			KernelCommit: state.KernelCommit,
+			KernelConfig: state.KernelConfig,
+		},
+		ReproSyz: args.ReproSyz,
 	}
 
 	testRes, cachedID, err := crash.ReproduceFuncWithCoverage(ctx, reproArgs, true)


### PR DESCRIPTION
Consolidate target VM configuration fields into a single shared struct
to reduce code duplication across actions (such as test and reproduce)
and to simplify the action arguments schema. This also enables
standardizing settings like procs and sandbox across workflows.