### PR TITLE
pkg/aflow/tool/syzlang: add get-execution-trace tool

### DIFF
--- a/pkg/aflow/tool/syzlang/coverage.go
+++ b/pkg/aflow/tool/syzlang/coverage.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/crash"
+	"github.com/google/syzkaller/pkg/symbolizer"
 )
 
 var (
@@ -29,7 +31,18 @@ Covered lines are prefixed with '* '.
 If the total output exceeds the maximum line limit, it will be truncated. Use 'Functions' to narrow down your request.
 `)
 
-	Coverage = []aflow.Tool{CoverageFiles, FileCoverage}
+	ExecutionTrace = aflow.NewFuncTool("get-execution-trace", getExecutionTrace, `
+Tool returns the execution trace (chain of function calls) triggered by a specific program execution.
+Because the raw trace is extremely large, it is compressed by keeping only unique functions
+in their order of appearance, and filtering out kernel infrastructure noise.
+You MUST provide 'SyscallIndex' (1-based index of the call statement in the syzlang program,
+e.g. 1 for the 1st call). Use -1 to get the trace for extra (background) coverage.
+You can use 'GrepPattern' to filter trace lines matching a regular expression or substring pattern.
+If the trace is too large, it will be truncated. You can use 'Offset' and 'Limit' to paginate
+through trace output lines.
+`)
+
+	Coverage = []aflow.Tool{CoverageFiles, FileCoverage, ExecutionTrace}
 )
 
 type CoverageFilesArgs struct {
@@ -41,6 +54,11 @@ type CoverageFilesResult struct {
 }
 
 func getCoverageFiles(ctx *aflow.Context, state reproduceState, args CoverageFilesArgs) (CoverageFilesResult, error) {
+	if args.ExecutionCachedID == "" {
+		return CoverageFilesResult{}, aflow.BadCallError(
+			"No ExecutionCachedID provided. You must execute a seed before " +
+				"requesting coverage and provide the ExecutionCachedID.")
+	}
 	coverage, err := crash.LoadCoverage(ctx, args.ExecutionCachedID)
 	if err != nil {
 		return CoverageFilesResult{}, aflow.BadCallError("failed to read coverage: %v", err)
@@ -217,4 +235,356 @@ func getFileCoverage(ctx *aflow.Context, state reproduceState, args FileCoverage
 	}
 
 	return res, nil
+}
+
+type ExecutionTraceArgs struct {
+	ExecutionCachedID string `jsonschema:"Cached ID returned by the reproduce-crash or execute-seed tool."`
+	SyscallIndex      int    `jsonschema:"REQUIRED: 1-based syscall index to inspect. Use -1 for extra coverage."`
+	FilterSubsystem   string `json:",omitempty" jsonschema:"Optional: Filter output by file path prefix."`
+	GrepPattern       string `json:",omitempty" jsonschema:"Optional: Filter trace by function or file regex/substring."`
+	IncludeNoise      bool   `json:",omitempty" jsonschema:"Optional: Include noisy functions (e.g., locks, allocators)."`
+	Offset            int    `json:",omitempty" jsonschema:"Optional: 1-based starting line number for trace lines."`
+	Limit             int    `json:",omitempty" jsonschema:"Optional: Maximum number of trace lines to return."`
+}
+
+type SyscallTrace struct {
+	CallIndex int      `jsonschema:"The 1-based index of the syscall in the syzkaller program. -1 for extra coverage."`
+	Trace     []string `jsonschema:"The chain of function calls for this syscall."`
+}
+
+type ExecutionTraceResult struct {
+	Traces []SyscallTrace `jsonschema:"The execution traces for the requested syscall(s)."`
+}
+
+func getExecutionTrace(
+	ctx *aflow.Context, state reproduceState, args ExecutionTraceArgs) (ExecutionTraceResult, error) {
+	var grepRe *regexp.Regexp
+	if args.GrepPattern != "" {
+		var err error
+		if grepRe, err = regexp.Compile("(?i)" + args.GrepPattern); err != nil {
+			return ExecutionTraceResult{}, aflow.BadCallError("invalid GrepPattern regex: %v", err)
+		}
+	}
+
+	coverage, err := crash.LoadCoverage(ctx, args.ExecutionCachedID)
+	if err != nil {
+		return ExecutionTraceResult{}, aflow.BadCallError("failed to read coverage: %v", err)
+	}
+	if len(coverage) == 0 {
+		return ExecutionTraceResult{}, aflow.BadCallError("no coverage data available")
+	}
+
+	var res ExecutionTraceResult
+
+	idx := -1
+	if args.SyscallIndex == -1 {
+		idx = len(coverage) - 1
+	} else {
+		idx = args.SyscallIndex - 1
+		if idx < 0 || idx >= len(coverage)-1 {
+			maxSyscall := max(0, len(coverage)-1)
+			return ExecutionTraceResult{},
+				aflow.BadCallError(
+					"SyscallIndex %d is out of bounds (1-%d). Use -1 for extra coverage.",
+					args.SyscallIndex, maxSyscall,
+				)
+		}
+	}
+	res.Traces = append(res.Traces, processSyscallTrace(args.SyscallIndex, coverage[idx], grepRe, args))
+	return res, nil
+}
+
+const executionTraceMaxLines = 1000
+
+var noisePrefixes = []string{
+	// Tracing and logging.
+	"trace_",
+	"printk_", "vprintk_", "console_",
+
+	// RCU.
+	"rcu_", "__rcu_", "srcu_",
+
+	// Sanitizers.
+	"kasan_", "kcsan_", "kmsan_", "__asan_", "__msan_", "__tsan_", "__csan_",
+
+	// Architecture helpers.
+	"arch_spin_", "arch_raw_spin_", "arch_read_lock", "arch_write_lock",
+	"arch_mutex_", "arch_local_irq_", "arch_atomic", "arch_cmpxchg",
+	"arch_cpu_", "arch_static_branch",
+
+	// Locking and synchronization.
+	"mutex_", "down_read", "up_read", "down_write", "up_write",
+	"spin_lock", "spin_unlock", "__mutex_", "__spin_", "rwsem_",
+	"read_lock", "read_unlock", "write_lock", "write_unlock", "raw_spin_lock",
+	"raw_spin_unlock", "lock_acquire", "lock_release", "preempt_", "local_irq_",
+	"irq_", "__mmap_lock_",
+
+	// Memory allocation.
+	"kmalloc", "kzalloc", "kfree", "vmalloc", "vfree", "kvmalloc", "kvzalloc",
+	"kvfree", "kmem_cache_alloc",
+	"kmem_cache_free", "__kmalloc",
+
+	// User memory copying & faults.
+	"copy_from_user", "_copy_from_user", "__copy_from_user", "copy_to_user",
+	"_copy_to_user", "__copy_to_user",
+	"__arch_copy_", "fault_in_", "do_user_addr_fault",
+
+	// Scheduling.
+	"cond_resched", "might_sleep", "__might_sleep", "should_resched",
+}
+
+func isNoiseFunction(name string) bool {
+	for _, p := range noisePrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+type traceLine struct {
+	PC               uint64
+	Func             string
+	File             string
+	Line             int
+	MatchesSubsystem bool
+	IsNoise          bool
+}
+
+func (line traceLine) shouldPrint(args ExecutionTraceArgs) bool {
+	if args.FilterSubsystem == "" {
+		return !line.IsNoise || args.IncludeNoise
+	}
+	return line.MatchesSubsystem
+}
+
+func formatTraceLine(line traceLine, suffix string) string {
+	var loc string
+	if line.File != "" {
+		if line.Line > 0 {
+			loc = fmt.Sprintf(" (%s:%d)", line.File, line.Line)
+		} else {
+			loc = fmt.Sprintf(" (%s)", line.File)
+		}
+	}
+	var pcStr string
+	if line.PC != 0 {
+		pcStr = fmt.Sprintf(" [0x%x]", line.PC)
+	}
+	return fmt.Sprintf("%s%s%s%s", line.Func, loc, pcStr, suffix)
+}
+
+func processSyscallTrace(
+	idx int, callcov []symbolizer.Frame, grepRe *regexp.Regexp, args ExecutionTraceArgs) SyscallTrace {
+	trace := SyscallTrace{CallIndex: idx}
+	var lines []traceLine
+	var lastFunc string
+
+	for _, frame := range callcov {
+		if frame.Func == "" || frame.Func == lastFunc {
+			continue
+		}
+		lastFunc = frame.Func
+
+		matchesSub := args.FilterSubsystem != "" && strings.HasPrefix(frame.File, args.FilterSubsystem)
+		isNoise := isNoiseFunction(frame.Func)
+
+		lines = append(lines, traceLine{
+			PC:               frame.PC,
+			Func:             frame.Func,
+			File:             frame.File,
+			Line:             frame.Line,
+			MatchesSubsystem: matchesSub,
+			IsNoise:          isNoise,
+		})
+	}
+
+	var out []string
+	hasFilter := grepRe != nil || args.FilterSubsystem != ""
+
+	if hasFilter {
+		out = filterTraceWithContext(lines, grepRe, args)
+	} else {
+		out = formatDefaultTrace(lines, args)
+	}
+
+	if len(out) == 0 {
+		if args.SyscallIndex == -1 {
+			out = []string{"[no extra background coverage (SyscallIndex: -1) was recorded during this execution run]"}
+		} else {
+			out = []string{fmt.Sprintf("[no execution trace recorded for syscall index %d]", args.SyscallIndex)}
+		}
+	}
+
+	if args.Offset > 0 || args.Limit > 0 {
+		out = paginateTrace(out, args.Offset, args.Limit, executionTraceMaxLines)
+	} else if len(out) > executionTraceMaxLines {
+		out = truncateTrace(out, executionTraceMaxLines)
+	}
+	trace.Trace = out
+	return trace
+}
+
+func paginateTrace(out []string, offset, limit, maxLines int) []string {
+	if limit <= 0 {
+		limit = maxLines
+	}
+	limit = min(limit, 2000)
+
+	start := 0
+	if offset > 0 {
+		if offset > len(out) {
+			return []string{fmt.Sprintf("[Offset %d is out of bounds; trace has %d lines total (valid line numbers: 1 to %d)]",
+				offset, len(out), len(out))}
+		}
+		start = offset - 1
+	}
+
+	end := min(len(out), start+limit)
+
+	newOut := make([]string, 0, end-start+2)
+	if start > 0 {
+		msg := fmt.Sprintf("... [lines 1 to %d omitted (%d lines). Showing lines %d to %d of %d total lines] ...",
+			start, start, start+1, end, len(out))
+		newOut = append(newOut, msg)
+	}
+
+	newOut = append(newOut, out[start:end]...)
+
+	if end < len(out) {
+		msg := fmt.Sprintf("... [%d lines remaining (lines %d to %d). "+
+			"Use get-execution-trace with Offset=%d and Limit=%d to view next part] ...",
+			len(out)-end, end+1, len(out), end+1, limit)
+		newOut = append(newOut, msg)
+	}
+	return newOut
+}
+
+func findDirectMatches(lines []traceLine, grepRe *regexp.Regexp, args ExecutionTraceArgs) ([]bool, int) {
+	isDirectMatch := make([]bool, len(lines))
+	matchCount := 0
+
+	for i, line := range lines {
+		matchesGrep := grepRe == nil || grepRe.MatchString(line.Func) || grepRe.MatchString(line.File)
+
+		if line.shouldPrint(args) && matchesGrep {
+			isDirectMatch[i] = true
+			matchCount++
+		}
+	}
+	return isDirectMatch, matchCount
+}
+
+func filterTraceWithContext(lines []traceLine, grepRe *regexp.Regexp, args ExecutionTraceArgs) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	isDirectMatch, matchCount := findDirectMatches(lines, grepRe, args)
+
+	var out []string
+
+	// If no matches found in this trace, return head (10) and tail (10) context frames.
+	if matchCount == 0 {
+		headCount, tailCount := 10, 10
+		if len(lines) <= headCount+tailCount {
+			for _, line := range lines {
+				out = append(out, formatTraceLine(line, " (context)"))
+			}
+			return out
+		}
+		for i := range headCount {
+			out = append(out, formatTraceLine(lines[i], " (context)"))
+		}
+		omitted := len(lines) - (headCount + tailCount)
+		out = append(out, fmt.Sprintf("... [no filter match; %d lines omitted] ...", omitted))
+		for i := len(lines) - tailCount; i < len(lines); i++ {
+			out = append(out, formatTraceLine(lines[i], " (context)"))
+		}
+		return out
+	}
+
+	// Direct matches found: include Syscall Entry Frame (Frame 0), 3 Parents, 3 Children, and Matches.
+	keep := make([]bool, len(lines))
+	keep[0] = true // Syscall Entry Frame.
+
+	for i := range lines {
+		if isDirectMatch[i] {
+			keep[i] = true
+			for p := max(0, i-3); p < i; p++ {
+				keep[p] = true // Up to 3 Parent Callers.
+			}
+			for c := i + 1; c <= min(len(lines)-1, i+3); c++ {
+				keep[c] = true // Up to 3 Child Callees.
+			}
+		}
+	}
+
+	var lastSeenFunc string
+
+	for i, line := range lines {
+		if !keep[i] {
+			continue
+		}
+		// Skip low-level noise functions in context frames unless they are direct matches
+		// or they belong to the explicitly requested subsystem filter.
+		isNoise := line.IsNoise && !args.IncludeNoise
+		if isNoise && !line.MatchesSubsystem && !isDirectMatch[i] {
+			continue
+		}
+		// Deduplicate consecutive hits of the same function to compress the trace.
+		// Note: lastSeenFunc is intentionally not reset across skipped noise frames.
+		// If a function calls a noise function and returns to itself, the duplicate
+		// post-return frame is skipped.
+		// However, always print direct matches to ensure matching frames are highlighted.
+		if line.Func == lastSeenFunc && !isDirectMatch[i] {
+			continue
+		}
+		lastSeenFunc = line.Func
+
+		if isDirectMatch[i] {
+			suffix := ""
+			if grepRe != nil {
+				suffix = "  <-- MATCH"
+			}
+			out = append(out, formatTraceLine(line, suffix))
+		} else {
+			out = append(out, formatTraceLine(line, " (context)"))
+		}
+	}
+
+	return out
+}
+
+func formatDefaultTrace(lines []traceLine, args ExecutionTraceArgs) []string {
+	var out []string
+	var lastSeenFunc string
+
+	for _, line := range lines {
+		if !line.shouldPrint(args) {
+			continue
+		}
+		if line.Func == lastSeenFunc {
+			continue
+		}
+		lastSeenFunc = line.Func
+
+		out = append(out, formatTraceLine(line, ""))
+	}
+	return out
+}
+
+func truncateTrace(out []string, maxLines int) []string {
+	half := maxLines / 2
+	newOut := make([]string, 0, maxLines+1)
+	newOut = append(newOut, out[:half]...)
+
+	omitted := len(out) - maxLines
+	truncMsg := fmt.Sprintf("... [trace truncated. Total trace length: %d lines. %d lines omitted (lines %d to %d). "+
+		"Use the 'get-execution-trace' tool with Offset=%d and Limit=%d to view the hidden middle section.] ...",
+		len(out), omitted, half+1, len(out)-half, half+1, maxLines)
+	newOut = append(newOut, truncMsg)
+
+	newOut = append(newOut, out[len(out)-half:]...)
+	return newOut
 }

--- a/pkg/aflow/tool/syzlang/coverage_test.go
+++ b/pkg/aflow/tool/syzlang/coverage_test.go
@@ -4,6 +4,7 @@
 package syzlang
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,4 +170,302 @@ void foo(void) {
 
 	require.Len(t, res.Snippets, 2)
 	require.Contains(t, res.Snippets[1], "nonexistent_function: [No coverage found or function does not exist]")
+}
+
+func TestExecutionTrace(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	dummyCov := [][]symbolizer.Frame{
+		{
+			{Func: "sys_read", File: "fs/read_write.c"},
+			{Func: "sys_read", File: "fs/read_write.c"},
+			{Func: "rcu_read_lock", File: "kernel/rcu.c"}, // Noise.
+			{Func: "vfs_read", File: "fs/read_write.c"},
+			{Func: "trace_read", File: "fs/trace.c"}, // Noise.
+			{Func: "vfs_read", File: "fs/read_write.c"},
+			{Func: "fuse_read", File: "fs/fuse/file.c"}, // Deep call.
+			{Func: "sys_read", File: "fs/read_write.c"}, // Return back to sys_read.
+			{Func: "vfs_read", File: "fs/read_write.c"}, // Another call to vfs_read.
+			{Func: ""},
+			{Func: "sys_read", File: "fs/read_write.c"},
+		},
+		{
+			{Func: "sys_write", File: "fs/read_write.c"},
+			{Func: "vfs_write", File: "fs/read_write.c"},
+		},
+	}
+
+	var deepCov []symbolizer.Frame
+	for i := 0; i <= 55; i++ {
+		deepCov = append(deepCov, symbolizer.Frame{Func: fmt.Sprintf("func_%d", i+1), File: "kernel/noise.c"})
+	}
+	dummyCov = append(dummyCov, deepCov)
+
+	_, reproExecCachedID, err := aflow.CacheObject(ctx, "repro", "dummy-desc-3", func() (map[string]any, error) {
+		return map[string]any{"Coverage": dummyCov}, nil
+	})
+	require.NoError(t, err)
+
+	// Test 1: Basic pseudo-call tree (no limits, no filters).
+	idx := 1
+	res, err := getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+	require.Equal(t, 1, res.Traces[0].CallIndex)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c)", "vfs_read (fs/read_write.c)",
+		"fuse_read (fs/fuse/file.c)", "sys_read (fs/read_write.c)",
+		"vfs_read (fs/read_write.c)", "sys_read (fs/read_write.c)",
+	}, res.Traces[0].Trace)
+
+	// Test 2: Filtering by subsystem.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		FilterSubsystem:   "fs/fuse/",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c) (context)", "vfs_read (fs/read_write.c) (context)",
+		"fuse_read (fs/fuse/file.c)", "sys_read (fs/read_write.c) (context)",
+		"vfs_read (fs/read_write.c) (context)", "sys_read (fs/read_write.c) (context)",
+	}, res.Traces[0].Trace)
+
+	// Test 3: FilterSubsystem bypasses noise filter for its own path.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		FilterSubsystem:   "kernel/rcu",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c) (context)", "rcu_read_lock (kernel/rcu.c)",
+		"vfs_read (fs/read_write.c) (context)",
+	}, res.Traces[0].Trace)
+
+	// Test 4: IncludeNoise true includes all noise everywhere.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		IncludeNoise:      true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c)", "rcu_read_lock (kernel/rcu.c)",
+		"vfs_read (fs/read_write.c)", "trace_read (fs/trace.c)",
+		"vfs_read (fs/read_write.c)", "fuse_read (fs/fuse/file.c)",
+		"sys_read (fs/read_write.c)", "vfs_read (fs/read_write.c)",
+		"sys_read (fs/read_write.c)",
+	}, res.Traces[0].Trace)
+
+	// Test 5: FilterSubsystem with zero matches returns head (10) and tail (10) context.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      -1,
+		FilterSubsystem:   "fs/fuse/", // filter doesn't match anything in deepCov
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"func_1 (kernel/noise.c) (context)",
+		"func_2 (kernel/noise.c) (context)",
+		"func_3 (kernel/noise.c) (context)",
+		"func_4 (kernel/noise.c) (context)",
+		"func_5 (kernel/noise.c) (context)",
+		"func_6 (kernel/noise.c) (context)",
+		"func_7 (kernel/noise.c) (context)",
+		"func_8 (kernel/noise.c) (context)",
+		"func_9 (kernel/noise.c) (context)",
+		"func_10 (kernel/noise.c) (context)",
+		"... [no filter match; 36 lines omitted] ...",
+		"func_47 (kernel/noise.c) (context)",
+		"func_48 (kernel/noise.c) (context)",
+		"func_49 (kernel/noise.c) (context)",
+		"func_50 (kernel/noise.c) (context)",
+		"func_51 (kernel/noise.c) (context)",
+		"func_52 (kernel/noise.c) (context)",
+		"func_53 (kernel/noise.c) (context)",
+		"func_54 (kernel/noise.c) (context)",
+		"func_55 (kernel/noise.c) (context)",
+		"func_56 (kernel/noise.c) (context)",
+	}, res.Traces[0].Trace)
+
+	// Test 6: Out of bounds index.
+	idxOut := 5
+	_, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idxOut,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SyscallIndex 5 is out of bounds")
+
+	// Test 7: Extra coverage index passed explicitly (should fail).
+	// dummyCov has length 3 (index 2 is extra coverage, valid syscall indices are 1-2).
+	_, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      3,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SyscallIndex 3 is out of bounds (1-2). Use -1 for extra coverage.")
+
+	// Test 8: GrepPattern substring match on function name.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		GrepPattern:       "fuse_",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c) (context)", "vfs_read (fs/read_write.c) (context)",
+		"fuse_read (fs/fuse/file.c)  <-- MATCH", "sys_read (fs/read_write.c) (context)",
+		"vfs_read (fs/read_write.c) (context)", "sys_read (fs/read_write.c) (context)",
+	}, res.Traces[0].Trace)
+
+	// Test 9: GrepPattern regex match.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		GrepPattern:       "vfs_.*",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c) (context)",
+		"vfs_read (fs/read_write.c)  <-- MATCH",
+		"vfs_read (fs/read_write.c)  <-- MATCH", "fuse_read (fs/fuse/file.c) (context)",
+		"sys_read (fs/read_write.c) (context)", "vfs_read (fs/read_write.c)  <-- MATCH",
+		"sys_read (fs/read_write.c) (context)",
+	}, res.Traces[0].Trace)
+
+	// Test 10: GrepPattern match on file path.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		GrepPattern:       "fs/read_write.c",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"sys_read (fs/read_write.c)  <-- MATCH",
+		"vfs_read (fs/read_write.c)  <-- MATCH",
+		"vfs_read (fs/read_write.c)  <-- MATCH", "fuse_read (fs/fuse/file.c) (context)",
+		"sys_read (fs/read_write.c)  <-- MATCH", "vfs_read (fs/read_write.c)  <-- MATCH",
+		"sys_read (fs/read_write.c)  <-- MATCH",
+	}, res.Traces[0].Trace)
+
+	// Test 11: Invalid GrepPattern regex error.
+	_, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      idx,
+		GrepPattern:       "[invalid(",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid GrepPattern regex")
+
+	// Test 12: Offset and Limit pagination.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      1,
+		Offset:            3,
+		Limit:             2,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+	require.Equal(t, []string{
+		"... [lines 1 to 2 omitted (2 lines). Showing lines 3 to 4 of 6 total lines] ...",
+		"fuse_read (fs/fuse/file.c)",
+		"sys_read (fs/read_write.c)",
+		"... [2 lines remaining (lines 5 to 6). Use get-execution-trace with Offset=5 and Limit=2 to view next part] ...",
+	}, res.Traces[0].Trace)
+
+	// Test 13: Global truncation (trace > 1000 lines) without pagination parameters.
+	var longCov []symbolizer.Frame
+	for i := range 1100 {
+		longCov = append(longCov, symbolizer.Frame{Func: fmt.Sprintf("func_%d", i+1), File: "fs/fuse/file.c"})
+	}
+	_, reproExecCachedIDLong, err := aflow.CacheObject(ctx, "repro", "dummy-desc-long", func() (map[string]any, error) {
+		return map[string]any{"Coverage": [][]symbolizer.Frame{longCov, nil}}, nil
+	})
+	require.NoError(t, err)
+
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedIDLong,
+		SyscallIndex:      1,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+	require.Len(t, res.Traces[0].Trace, 1001) // 500 head + 1 message + 500 tail.
+	require.Equal(t, "func_1 (fs/fuse/file.c)", res.Traces[0].Trace[0])
+	require.Contains(t, res.Traces[0].Trace[500], "... [trace truncated. Total trace length: 1100 lines.")
+	require.Equal(t, "func_1100 (fs/fuse/file.c)", res.Traces[0].Trace[1000])
+
+	// Test 14: Background coverage (index -1) without filters.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      -1,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+	require.Equal(t, -1, res.Traces[0].CallIndex)
+	require.Len(t, res.Traces[0].Trace, 56)
+	require.Equal(t, "func_1 (kernel/noise.c)", res.Traces[0].Trace[0])
+	require.Equal(t, "func_56 (kernel/noise.c)", res.Traces[0].Trace[55])
+
+	// Test 15: Out of bounds offset pagination.
+	res, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      1,
+		Offset:            1200,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+	require.Equal(t, []string{
+		"[Offset 1200 is out of bounds; trace has 6 lines total (valid line numbers: 1 to 6)]",
+	}, res.Traces[0].Trace)
+}
+
+func TestExecutionTraceNoCoverage(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+	_, reproExecCachedID, err := aflow.CacheObject(ctx, "repro", "dummy-desc-empty", func() (map[string]any, error) {
+		return map[string]any{"Coverage": [][]symbolizer.Frame{}}, nil
+	})
+	require.NoError(t, err)
+	_, err = getExecutionTrace(ctx, reproduceState{}, ExecutionTraceArgs{
+		ExecutionCachedID: reproExecCachedID,
+		SyscallIndex:      -1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no coverage data available")
+}
+
+func TestIsNoiseFunction(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"arch_prctl", false},
+		{"sys_arch_prctl", false},
+		{"do_arch_prctl", false},
+		{"arch_ptrace", false},
+		{"arch_do_signal_or_restart", false},
+		{"arch_setup_additional_pages", false},
+		{"arch_spin_lock", true},
+		{"arch_spin_unlock", true},
+		{"arch_raw_spin_lock", true},
+		{"arch_local_irq_save", true},
+		{"arch_atomic_read", true},
+		{"arch_cmpxchg", true},
+		{"arch_cpu_idle", true},
+		{"arch_mutex_lock", true},
+		{"arch_static_branch", true},
+		{"rcu_read_lock", true},
+		{"printk", false},
+		{"printk_deferred", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isNoiseFunction(tt.name))
+		})
+	}
 }

--- a/pkg/cover/backend/pc.go
+++ b/pkg/cover/backend/pc.go
@@ -14,14 +14,7 @@ func PreviousInstructionPC(target *targets.Target, vm string, pc uint64) uint64 
 		// gVisor coverage returns real PCs that don't need adjustment.
 		return pc
 	}
-	offset := instructionLen(target.Arch)
-	pc -= offset
-	// THUMB instructions are 2 or 4 bytes with low bit set.
-	// ARM instructions are always 4 bytes.
-	if target.Arch == targets.ARM {
-		return pc & ^uint64(1)
-	}
-	return pc
+	return pc - instructionLen(target.Arch)
 }
 
 func PreviousInstructionPCs(target *targets.Target, vm string, cov []uint64) []uint64 {
@@ -36,14 +29,7 @@ func NextInstructionPC(target *targets.Target, vm string, pc uint64) uint64 {
 	if vm == targets.GVisor {
 		return pc
 	}
-	offset := instructionLen(target.Arch)
-	pc += offset
-	// THUMB instructions are 2 or 4 bytes with low bit set.
-	// ARM instructions are always 4 bytes.
-	if target.Arch == targets.ARM {
-		return pc & ^uint64(1)
-	}
-	return pc
+	return pc + instructionLen(target.Arch)
 }
 
 func instructionLen(arch string) uint64 {
@@ -55,7 +41,7 @@ func instructionLen(arch string) uint64 {
 	case targets.ARM64:
 		return 4
 	case targets.ARM:
-		return 3
+		return 4
 	case targets.PPC64LE:
 		return 4
 	case targets.MIPS64LE:

--- a/pkg/cover/backend/pc_test.go
+++ b/pkg/cover/backend/pc_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreviousNextInstructionPC(t *testing.T) {
+	for os, arches := range targets.List {
+		if os == targets.TestOS {
+			continue
+		}
+		for _, target := range arches {
+			target := targets.Get(target.OS, target.Arch)
+			t.Run(target.OS+"-"+target.Arch, func(t *testing.T) {
+				const startPC = uint64(0x80000104)
+
+				prev := PreviousInstructionPC(target, "", startPC)
+				next := NextInstructionPC(target, "", prev)
+				require.Equal(t, startPC, next)
+
+				// Test gVisor VM mode which should leave PCs unchanged.
+				require.Equal(t, startPC, PreviousInstructionPC(target, targets.GVisor, startPC))
+				require.Equal(t, startPC, NextInstructionPC(target, targets.GVisor, startPC))
+			})
+		}
+	}
+}
+
+func TestARMInstructionPC(t *testing.T) {
+	target := targets.Get(targets.Linux, targets.ARM)
+	require.NotNil(t, target)
+
+	const pc = uint64(0x80000104)
+	prev := PreviousInstructionPC(target, "", pc)
+	require.Equal(t, uint64(0x80000100), prev)
+	next := NextInstructionPC(target, "", prev)
+	require.Equal(t, pc, next)
+
+	// Check an unaligned PC.
+	const oddPC = uint64(0x80000105)
+	require.Equal(t, uint64(0x80000101), PreviousInstructionPC(target, "", oddPC))
+	require.Equal(t, oddPC, NextInstructionPC(target, "", PreviousInstructionPC(target, "", oddPC)))
+}

--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/syzkaller/pkg/cover/backend"
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -408,6 +409,18 @@ func (inst *ExecProgInstance) retrieveCoverageFiles(vmCoverFilePrefix string, nc
 		cover, err := parseCoverageData(catOutput)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse cover data from %s: %w", file, err)
+		}
+		// syz-execprog (running inside the VM) shifts the PCs using
+		// PreviousInstructionPC before writing them to the coverage files. However,
+		// the host-side symbolizer expects raw PCs and performs its own VM-aware PC
+		// adjustment. To prevent double-adjustment of PCs on the host, we apply
+		// NextInstructionPC to reconstruct the original raw PCs retrieved from the
+		// VM.
+		target := inst.mgrCfg.SysTarget
+		for i, pc := range cover {
+			// syz-execprog hardcodes "" inside the VM; we must match it here to undo
+			// the shift.
+			cover[i] = backend.NextInstructionPC(target, "", pc)
 		}
 		coverage = append(coverage, cover)
 	}

--- a/pkg/instance/execprog_test.go
+++ b/pkg/instance/execprog_test.go
@@ -120,8 +120,10 @@ func TestRetrieveCoverageFiles_Success(t *testing.T) {
 	coverage, err := execProgInst.retrieveCoverageFiles(prefix, 2)
 	require.NoError(t, err)
 	require.Len(t, coverage, 3)
-	require.Equal(t, []uint64{0x123, 0x456}, coverage[0])
-	require.Equal(t, []uint64{0x789}, coverage[1])
+	// Expected PCs reflect NextInstructionPC adjustment (+5 on AMD64) applied by retrieveCoverageFiles
+	// to reconstruct original raw PCs from syz-execprog shifted output (0x123 -> 0x128, 0x456 -> 0x45b, 0x789 -> 0x78e).
+	require.Equal(t, []uint64{0x128, 0x45b}, coverage[0])
+	require.Equal(t, []uint64{0x78e}, coverage[1])
 	require.Nil(t, coverage[2])
 }
 


### PR DESCRIPTION
Add `get-execution-trace` which returns the function call trace of the
last syzkaller program execution given the line of the syscall. This
helps the LLM understand what impact its program has.

---
**Fix syz-execprog PC addr**

The syz-execprog tool inside the VM shifts coverage PCs to match call
instruction sites. However, the host-side reproduction symbolizer
expects raw PCs (which is consistent with the syz-manager behaviour) and
applies its own PC adjustment, causing double adjustment on QEMU/GCE VM
platforms.

Revert the VM-side adjustment immediately after reading the coverage
files so that all returned coverage data consists of raw PCs, ensuring
host-side symbolization is performed exactly once with correct parameters.