### PR TITLE
dashboard, pkg: add client_info API and namespace schema field

### DIFF
--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -84,6 +84,7 @@ var apiHandlers = map[string]APIHandler{
 	"add_build_assets":      nsHandler(apiAddBuildAssets),
 	"log_to_repro":          nsHandler(apiLogToReproduce),
 	"repro_task_done":       nsHandler(apiReproTaskDone),
+	"client_info":           nsHandler(apiClientInfo),
 }
 
 type JSONHandler func(ctx context.Context, r *http.Request) (any, error)
@@ -2021,4 +2022,11 @@ func apiSaveCoverage(ctx context.Context, payload io.Reader) (any, error) {
 			descr.Namespace, descr.DateTo.String(), descr.TotalRows)
 	}
 	return &rowsCreated, err
+}
+
+// apiClientInfo returns the namespace name associated with the authenticated client.
+// This allows clients (like syz-ci) to dynamically discover their namespace
+// and use it to tag uploaded coverage data.
+func apiClientInfo(ctx context.Context, ns string, req *dashapi.ClientInfoReq) (any, error) {
+	return &dashapi.ClientInfoResp{Namespace: ns}, nil
 }

--- a/dashboard/app/api_test.go
+++ b/dashboard/app/api_test.go
@@ -379,3 +379,12 @@ func TestCreateUploadURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Regexp(t, "blobstorage/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.upload", url)
 }
+
+func TestClientInfo(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	resp, err := c.client.ClientInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, "test1", resp.Namespace)
+}

--- a/dashboard/dashapi/dashapi.go
+++ b/dashboard/dashapi/dashapi.go
@@ -807,6 +807,19 @@ func (dash *Dashboard) UploadManagerStats(req *ManagerStatsReq) error {
 	return dash.Query("manager_stats", req, nil)
 }
 
+type ClientInfoReq struct {
+}
+
+type ClientInfoResp struct {
+	Namespace string
+}
+
+func (dash *Dashboard) ClientInfo() (*ClientInfoResp, error) {
+	resp := new(ClientInfoResp)
+	err := dash.Query("client_info", nil, resp)
+	return resp, err
+}
+
 // NewAsset describes a build asset (e.g., kernel or disk image) uploaded to cloud storage.
 //
 // Asset lifetime:

--- a/pkg/cover/manager_to_ci.go
+++ b/pkg/cover/manager_to_ci.go
@@ -11,8 +11,11 @@ import (
 
 // CIDetails fields will be added to every CSV line.
 type CIDetails struct {
-	Version        int    `json:"version"`
-	Timestamp      string `json:"timestamp"`
+	Version   int    `json:"version"`
+	Timestamp string `json:"timestamp"`
+	// Namespace is optional (omitempty) during rollout to support old syz-ci
+	// instances and tests. It should be made required once rollout is complete.
+	Namespace      string `json:"namespace,omitempty"`
 	FuzzingMinutes int    `json:"fuzzing_minutes"`
 	Arch           string `json:"arch"`
 	BuildID        string `json:"build_id"`

--- a/pkg/coveragedb/bq-schema.json
+++ b/pkg/coveragedb/bq-schema.json
@@ -12,6 +12,12 @@
     "description": "the record version to simplify future changes"
   },
   {
+    "name": "namespace",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "transient state: optional during rollout, will be required later"
+  },
+  {
     "name": "fuzzing_minutes",
     "type": "INTEGER",
     "mode": "REQUIRED",


### PR DESCRIPTION
Prepare the dashboard and coverage pipeline for transitioning to a single BigQuery table by adding the namespace field to the schema and exposing the client_info API.

- Add client_info API to dashboard to allow syz-ci to query its namespace.
- Update BQ schema to include namespace column.
- Add Namespace field to CIDetails struct in pkg/cover.
