### PR TITLE
syz-ci: support running unit tests on verified images

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -189,6 +189,9 @@ func (env *env) CleanKernel(buildCfg *BuildKernelConfig) error {
 }
 
 func SetConfigImage(cfg *mgrconfig.Config, imageDir string, reliable bool) error {
+	if cfg.Type == "none" {
+		return nil
+	}
 	cfg.KernelObj = filepath.Join(imageDir, "obj")
 	cfg.Image = filepath.Join(imageDir, "image")
 	if keyFile := filepath.Join(imageDir, "key"); osutil.IsExist(keyFile) {
@@ -544,17 +547,51 @@ func RunnerCmd(prog, fwdAddr, os, arch string, poolIdx, vmIdx int, threaded, new
 // The crash report, if the testing failed.
 // An error if there was a problem not related to testing the kernel.
 func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
+	return runManagerMode(cfg, "smoke-test")
+}
+
+// RunTests executes syz-manager in the run-tests mode to execute unit tests matching
+// the specified tests pattern, and returns two values:
+// The crash report, if the testing failed.
+// An error if there was a problem not related to testing the kernel.
+func RunTests(cfg *mgrconfig.Config, tests string) (*report.Report, error) {
+	var extraArgs []string
+	if tests != "" {
+		extraArgs = append(extraArgs, "-tests="+tests)
+	}
+	return runManagerMode(cfg, "run-tests", extraArgs...)
+}
+
+func runManagerModeArgs(cfg *mgrconfig.Config, mode string, extraArgs ...string) (string, []string, error) {
+	if cfg == nil {
+		return "", nil, errors.New("config is nil")
+	}
+	configFile := filepath.Join(cfg.Workdir, "manager.cfg")
+	bin := filepath.Join(cfg.Syzkaller, "bin", "syz-manager")
+	args := append([]string{"-config", configFile, "-mode=" + mode, "-vv=2"}, extraArgs...)
+	return bin, args, nil
+}
+
+func runManagerMode(cfg *mgrconfig.Config, mode string, extraArgs ...string) (*report.Report, error) {
+	if cfg == nil {
+		return nil, errors.New("config is nil")
+	}
 	if !vm.AllowsOvercommit(cfg.Type) {
 		return nil, nil // No support for creating machines out of thin air.
+	}
+	bin, args, err := runManagerModeArgs(cfg, mode, extraArgs...)
+	if err != nil {
+		return nil, err
 	}
 	osutil.MkdirAll(cfg.Workdir)
 	configFile := filepath.Join(cfg.Workdir, "manager.cfg")
 	if err := config.SaveFile(configFile, cfg); err != nil {
 		return nil, err
 	}
+	reportFile := filepath.Join(cfg.Workdir, "report.json")
+	os.Remove(reportFile)
 	timeout := 30 * time.Minute * cfg.Timeouts.Scale
-	bin := filepath.Join(cfg.Syzkaller, "bin", "syz-manager")
-	output, retErr := osutil.RunCmd(timeout, "", bin, "-config", configFile, "-mode=smoke-test", "-vv=2")
+	output, retErr := osutil.RunCmd(timeout, "", bin, args...)
 	if retErr == nil {
 		return nil, nil
 	}
@@ -578,7 +615,7 @@ func RunSmokeTest(cfg *mgrconfig.Config) (*report.Report, error) {
 	}
 	rep := new(report.Report)
 	if err := json.Unmarshal(reportData, rep); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal smoke test report: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal test report: %w", err)
 	}
 	return rep, nil
 }

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -7,10 +7,12 @@ import (
 	"flag"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
 )
@@ -141,5 +143,56 @@ func TestRunnerCmd(t *testing.T) {
 
 	if got, want := *flagEnv, false; got != want {
 		t.Errorf("bad new-env: %t, want: %t", got, want)
+	}
+}
+
+func TestRunManagerModeArgs(t *testing.T) {
+	// 1. Test nil config returns error.
+	_, _, err := runManagerModeArgs(nil, "run-tests")
+	if err == nil || !strings.Contains(err.Error(), "config is nil") {
+		t.Fatalf("expected 'config is nil' error, got: %v", err)
+	}
+
+	// 2. Setup environment using hardcoded paths (no disk writes).
+	cfg := &mgrconfig.Config{
+		Type:      "qemu",
+		Workdir:   "/my/fake/workdir",
+		Syzkaller: "/my/fake/syzkaller",
+	}
+
+	// 3. Test smoke-test mode.
+	bin, args, err := runManagerModeArgs(cfg, "smoke-test")
+	if err != nil {
+		t.Fatalf("runManagerModeArgs failed: %v", err)
+	}
+	expectedBin := "/my/fake/syzkaller/bin/syz-manager"
+	if bin != expectedBin {
+		t.Errorf("bad bin: got %q, want %q", bin, expectedBin)
+	}
+	expectedArgs := []string{
+		"-config", "/my/fake/workdir/manager.cfg",
+		"-mode=smoke-test",
+		"-vv=2",
+	}
+	if !slices.Equal(args, expectedArgs) {
+		t.Errorf("bad args: got %q, want %q", args, expectedArgs)
+	}
+
+	// 4. Test run-tests mode with extra args.
+	bin, args, err = runManagerModeArgs(cfg, "run-tests", "-tests=my-tests-pattern")
+	if err != nil {
+		t.Fatalf("runManagerModeArgs failed: %v", err)
+	}
+	if bin != expectedBin {
+		t.Errorf("bad bin: got %q, want %q", bin, expectedBin)
+	}
+	expectedArgs = []string{
+		"-config", "/my/fake/workdir/manager.cfg",
+		"-mode=run-tests",
+		"-vv=2",
+		"-tests=my-tests-pattern",
+	}
+	if !slices.Equal(args, expectedArgs) {
+		t.Errorf("bad args: got %q, want %q", args, expectedArgs)
 	}
 }

--- a/pkg/runtest/run.go
+++ b/pkg/runtest/run.go
@@ -87,7 +87,9 @@ func (rt *Context) log(msg string, args ...any) {
 }
 
 func (rt *Context) Run(ctx context.Context) error {
-	rt.generatePrograms()
+	if err := rt.generatePrograms(); err != nil {
+		return err
+	}
 	var ok, fail, broken, skip int
 	for _, req := range rt.requests {
 		result := ""
@@ -634,4 +636,26 @@ func parseBinOutput(req *runRequest) ([]*flatrpc.ProgInfo, error) {
 		info.Calls[call].Error = int32(errno)
 	}
 	return infos, nil
+}
+
+func (rt *Context) Failures() []string {
+	var failures []string
+	for _, req := range rt.requests {
+		if req.failing != "" {
+			failures = append(failures, fmt.Sprintf("%v: %v", req.name, req.failing))
+		} else if req.err != nil {
+			failures = append(failures, fmt.Sprintf("%v: %v", req.name, req.err))
+		}
+	}
+	return failures
+}
+
+func (rt *Context) FailingTests() []string {
+	var names []string
+	for _, req := range rt.requests {
+		if req.failing != "" || req.err != nil {
+			names = append(names, req.name)
+		}
+	}
+	return names
 }

--- a/pkg/runtest/run_test.go
+++ b/pkg/runtest/run_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -593,4 +594,37 @@ func TestParsing(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestContextFailures(t *testing.T) {
+	ctx := &Context{
+		requests: []*runRequest{
+			{
+				name: "test1",
+			},
+			{
+				name:    "test2",
+				failing: "parsing error",
+			},
+			{
+				name: "test3",
+				err:  errors.New("execution error"),
+			},
+			{
+				name: "test4",
+			},
+		},
+	}
+	failures := ctx.Failures()
+	expected := []string{
+		"test2: parsing error",
+		"test3: execution error",
+	}
+	assert.Equal(t, expected, failures)
+
+	expectedTests := []string{
+		"test2",
+		"test3",
+	}
+	assert.Equal(t, expectedTests, ctx.FailingTests())
 }

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -497,22 +497,44 @@ func (mgr *Manager) testImage(imageDir string, info *BuildInfo) error {
 	if err != nil {
 		return fmt.Errorf("failed to create manager config: %w", err)
 	}
-	rep, err := instance.RunSmokeTest(mgrcfg)
-	if err != nil {
-		mgr.Errorf("%s", err)
-		return err
-	} else if rep == nil {
-		return nil
+	var rep *report.Report
+	if mgr.mgrcfg.Tests != "" {
+		log.Logf(0, "%v: running tests %q...", mgr.name, mgr.mgrcfg.Tests)
+		rep, err = instance.RunTests(mgrcfg, mgr.mgrcfg.Tests)
+		if err != nil {
+			mgr.Errorf("%s", err)
+			return err
+		}
+		if rep != nil {
+			// Override the title to a constant string to ensure all unit test failures
+			// are grouped under a single bug on the dashboard. The list of specific
+			// failing tests is still visible in the crash log output.
+			rep.Title = "SYZFATAL: unit test error"
+			rep.AltTitles = nil
+			if err := mgr.reportBuildError(rep, info, imageDir); err != nil {
+				mgr.Errorf("failed to report image error: %v", err)
+			}
+			return fmt.Errorf("%s", rep.Title)
+		}
+	} else {
+		rep, err = instance.RunSmokeTest(mgrcfg)
+		if err != nil {
+			mgr.Errorf("%s", err)
+			return err
+		}
+		if rep != nil {
+			rep.Title = fmt.Sprintf("%v test error: %v", mgr.mgrcfg.RepoAlias, rep.Title)
+			// There are usually no duplicates for boot errors, so we reset AltTitles.
+			// But if we pass them, we would need to add the same prefix as for Title
+			// in order to avoid duping boot bugs with non-boot bugs.
+			rep.AltTitles = nil
+			if err := mgr.reportBuildError(rep, info, imageDir); err != nil {
+				mgr.Errorf("failed to report image error: %v", err)
+			}
+			return fmt.Errorf("%s", rep.Title)
+		}
 	}
-	rep.Title = fmt.Sprintf("%v test error: %v", mgr.mgrcfg.RepoAlias, rep.Title)
-	// There are usually no duplicates for boot errors, so we reset AltTitles.
-	// But if we pass them, we would need to add the same prefix as for Title
-	// in order to avoid duping boot bugs with non-boot bugs.
-	rep.AltTitles = nil
-	if err := mgr.reportBuildError(rep, info, imageDir); err != nil {
-		mgr.Errorf("failed to report image error: %v", err)
-	}
-	return fmt.Errorf("%s", rep.Title)
+	return nil
 }
 
 func (mgr *Manager) reportBuildError(rep *report.Report, info *BuildInfo, imageDir string) error {

--- a/syz-ci/syz-ci.go
+++ b/syz-ci/syz-ci.go
@@ -227,7 +227,9 @@ type ManagerConfig struct {
 	// fuzzing won't be started on this instance.
 	// By default it's 30 days.
 	MaxKernelLagDays int `json:"max_kernel_lag_days"`
-	managercfg       *mgrconfig.Config
+	// Tests to run in run-tests mode after smoke test (optional).
+	Tests      string `json:"tests"`
+	managercfg *mgrconfig.Config
 
 	// Auto-assigned ports used by test instances.
 	testRPCPort int

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -160,6 +160,7 @@ var (
 		Name: "run-tests",
 		Description: `run unit tests
 	Run sys/os/test/* tests in various modes and print results.`,
+		FailOnCrashes: true,
 	}
 	ModeIfaceProbe = &Mode{
 		Name: "iface-probe",
@@ -1222,27 +1223,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 		mgr.serv.SetSource(queue.DefaultOpts(ctx, opts))
 		return nil
 	case ModeRunTests:
-		ctx := &runtest.Context{
-			Dir:      filepath.Join(mgr.cfg.Syzkaller, "sys", mgr.cfg.Target.OS, "test"),
-			Target:   mgr.cfg.Target,
-			Features: features,
-			EnabledCalls: map[string]map[*prog.Syscall]bool{
-				mgr.cfg.Sandbox: enabledSyscalls,
-			},
-			LogFunc: func(text string) { fmt.Println(text) },
-			Verbose: true,
-			Debug:   *flagDebug,
-			Tests:   *flagTests,
-		}
-		ctx.Init()
-		go func() {
-			err := ctx.Run(context.Background())
-			if err != nil {
-				log.Fatal(err)
-			}
-			mgr.exit("tests")
-		}()
-		mgr.serv.SetSource(ctx)
+		mgr.runTestsMode(features, enabledSyscalls)
 		return nil
 	case ModeIfaceProbe:
 		exec := queue.Plain()
@@ -1261,6 +1242,52 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 		return nil
 	}
 	panic(fmt.Sprintf("unexpected mode %q", mgr.mode.Name))
+}
+
+func (mgr *Manager) runTestsMode(features flatrpc.Feature, enabledSyscalls map[*prog.Syscall]bool) {
+	ctx := &runtest.Context{
+		Dir:      filepath.Join(mgr.cfg.Syzkaller, "sys", mgr.cfg.Target.OS, "test"),
+		Target:   mgr.cfg.Target,
+		Features: features,
+		EnabledCalls: map[string]map[*prog.Syscall]bool{
+			mgr.cfg.Sandbox: enabledSyscalls,
+		},
+		LogFunc: func(text string) { fmt.Println(text) },
+		Verbose: true,
+		Debug:   *flagDebug,
+		Tests:   *flagTests,
+	}
+	ctx.Init()
+	go func() {
+		err := ctx.Run(context.Background())
+		if err != nil {
+			failures := ctx.Failures()
+			failingTests := ctx.FailingTests()
+			var title string
+			if len(failingTests) == 1 {
+				title = failingTests[0]
+			} else if len(failingTests) > 1 {
+				title = fmt.Sprintf("%v and %v others", failingTests[0], len(failingTests)-1)
+			} else {
+				title = "unit tests failed"
+			}
+			output := []byte(strings.Join(failures, "\n"))
+			if len(failures) == 0 {
+				output = []byte(err.Error())
+			}
+			rep := &report.Report{
+				Title:  title,
+				Output: output,
+			}
+			reportPath := filepath.Join(mgr.cfg.Workdir, "report.json")
+			if writeErr := osutil.WriteJSON(reportPath, rep); writeErr != nil {
+				log.Errorf("failed to write report.json: %v", writeErr)
+			}
+			log.Fatal(err)
+		}
+		mgr.exit("tests")
+	}()
+	mgr.serv.SetSource(ctx)
 }
 
 type corpusRunner struct {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -103,6 +103,9 @@ func vmType(fullName string) string {
 // override resource limits specified in config (e.g. can OOM). But it works and
 // makes lots of things much simpler.
 func AllowsOvercommit(typ string) bool {
+	if typ == "none" {
+		return true
+	}
 	return vmimpl.Types[vmType(typ)].Overcommit
 }
 


### PR DESCRIPTION
Add Tests parameter to ManagerConfig. If specified, syz-ci runs syz-manager in -mode=run-tests after the smoke test passes. This enables executing specific subsets of unit tests on the newly built kernel image before moving to fuzzing.

Refactored instance.RunSmokeTest to use a generic helper runManagerMode and added instance.RunTests.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
