### PR TITLE
dashboard: record manager name for AI jobs

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -412,6 +412,7 @@ func handleAIJobCreate(ctx context.Context, r *http.Request, hdr *uiHeader) erro
 			return fmt.Errorf("%w: failed to get manager build config: %w", ErrClientBadRequest, err)
 		}
 		args["KernelConfigID"] = build.KernelConfig
+		args["KernelConfigManager"] = manager
 	} else {
 		return fmt.Errorf("%w: either a custom kernel config or a manager is required", ErrClientBadRequest)
 	}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1143,6 +1143,32 @@ func TestAIManualJobCreate(t *testing.T) {
 	require.Equal(t, "https://repo.test", args["KernelRepo"])
 	require.Equal(t, "123456", args["KernelCommit"])
 
+	// Test creation with KernelConfigManager.
+	body, err = c.POSTForm("/ains/ai", url.Values{
+		"ai-job-create":       []string{"repro-c"},
+		"KernelRepo":          []string{"https://repo.test"},
+		"KernelCommit":        []string{"123456"},
+		"KernelConfigManager": []string{"manager1"},
+		"BugDescription":      []string{"test bug 2"},
+		"TargetArch":          []string{"amd64"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(body), "AI workflow repro-c is created")
+
+	jobManager, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "agent-manager",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: "repro-c", Name: "repro-c"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, "", jobManager.ID)
+	require.Equal(t, "repro-c", jobManager.Workflow)
+	require.Equal(t, "test bug 2", jobManager.Args["BugDescription"])
+	require.Equal(t, "manager1", jobManager.Args["KernelConfigManager"])
+	require.Equal(t, "config1", jobManager.Args["KernelConfig"])
+
 	body, err = c.POSTForm("/ains/ai", url.Values{
 		"ai-job-create": []string{"patching"},
 		"ReproC":        []string{"int main() {}"},


### PR DESCRIPTION
For AI jobs submitted via the dashboard, record the name of the manager from which the config was taken (unless it is None). It should be shown on the trajectory page along with other inputs.

Rationale: Jobs that are created manually can be used as inputs for other jobs, and we don't want to copy the config, but just use the manager name.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
