### PR TITLE
dashboard/app: migrate header navigation to Bootstrap

### DIFF
--- a/dashboard/app/static/bootstrap.bundle.min.js
+++ b/dashboard/app/static/bootstrap.bundle.min.js
@@ -1,0 +1,1 @@
+../../../syz-cluster/dashboard/static/bootstrap.bundle.min.js

--- a/dashboard/app/static/bootstrap.min.css
+++ b/dashboard/app/static/bootstrap.min.css
@@ -1,0 +1,1 @@
+../../../syz-cluster/dashboard/static/bootstrap.min.css

--- a/dashboard/app/static/dashboard.css
+++ b/dashboard/app/static/dashboard.css
@@ -1,0 +1,196 @@
+/*
+ * Dashboard-Specific Styling & Bootstrap Integration stylesheet.
+ * 
+ * DESIGN ARCHITECTURE:
+ * This stylesheet imports Bootstrap 5 to support responsive navigation bars (such as
+ * collapsible mobile menus and interactive dropdowns) while ensuring the legacy page content
+ * (tables, logs, text blocks) remains styled exactly as it originally was.
+ */
+
+/* 
+ * CSS CASCADE LAYERS DECLARATION
+ * 
+ * Declares the layers hierarchy. CSS Cascade Layers allow us to control style specificity.
+ * Precedence Order (Lowest to Highest):
+ *   - 'bootstrap' layer: Holds all standard Bootstrap rules.
+ *   - 'reset' layer: Reverts global tag overrides set by Bootstrap Reboot.
+ *   - Unlayered styles (everything else in this file and style.css): Always overrides layered rules.
+ */
+@layer bootstrap, reset;
+
+/* 
+ * BOOTSTRAP LIBRARY IMPORT
+ * 
+ * Imports Bootstrap 5 compiled CSS locally and confines its rules 
+ * to the 'bootstrap' layer. This prevents Bootstrap's Reboot defaults (which reset
+ * global tags like body, table, h1, a) from overriding our custom styles in style.css.
+ */
+@import url("/static/bootstrap.min.css") layer(bootstrap);
+
+/*
+ * BOOTSTRAP REBOOT RESET LAYER
+ * 
+ * Bootstrap Reboot automatically overrides default browser styles for elements like 
+ * tables, headers, and inputs. Since we only want Bootstrap for the header navigation bar,
+ * this block reverts those tag changes back to their default browser values, preventing
+ * rendering differences across the rest of the dashboard pages.
+ */
+@layer reset {
+	/* Revert Bootstrap Reboot changes for global tags back to browser defaults.
+	   We use :not() to protect the new Bootstrap-based header and its sub-navigation bar. */
+	:is(h1, h2, h3, h4, h5, h6, p, ol, ul, table, caption, th, td, input, button, select, textarea, pre, code):not(#topbar *, .sub-nav *) {
+		all: revert;
+	}
+
+	/* Specifically revert layout properties for common tags that Bootstrap modifies,
+	   ensuring legacy rows (like filesystem navigation) don't become too high. */
+	:is(div, pre, span):not(#topbar *, .sub-nav *) {
+		box-sizing: content-box;
+		line-height: normal;
+	}
+
+	/* Revert global anchor link resets so default browser/legacy link styling applies */
+	:is(a, a:visited):not(#topbar *, .sub-nav *) {
+		color: revert;
+		text-decoration: revert;
+	}
+}
+/*
+ * TOPBAR CONTAINER DISPLAY
+ * 
+ * Configures the topbar container to stretch with overflowing page layouts.
+ */
+#topbar {
+	display: table;
+	width: 100%;
+	margin-bottom: 20px;
+}
+/*
+ * SUB-NAVIGATION PILLS BAR
+ * 
+ * Styles the secondary navigation tabs bar ("Open", "Fixed", "Graphs", "Coverage", etc.) 
+ * to look exactly like the original non-Bootstrap tabs while using Bootstrap's nav pills elements.
+ */
+.sub-nav {
+	padding-top: 15px;
+	padding-bottom: 6px;
+	display: table;
+	width: 100%;
+}
+
+/* Resets list margins/paddings on navigation container list */
+.sub-nav .nav-pills {
+	margin: 0;
+	padding-left: 0;
+	padding-right: 0;
+	width: 100%;
+	flex-wrap: nowrap; /* Enforce single line layout even on narrow mobile screens */
+}
+
+/* Sets default margin spacing around tab items and prevents shrinking on small screens */
+.sub-nav .nav-item {
+	margin: 4px;
+	flex-shrink: 0;
+	display: flex; /* Make the li a flex container to stretch the nested link */
+}
+
+/* Align first navigation tab with the topbar logo */
+.sub-nav .nav-item:first-child {
+	margin-left: 0;
+}
+
+/* Align last navigation tab (Send us feedback) with topbar right links */
+.sub-nav .nav-item:last-child {
+	margin-right: 0;
+}
+
+/* Styles default, unselected tab link buttons */
+.sub-nav .nav-link {
+	padding: 4px;
+	border: 1px solid black;
+	border-radius: 0; /* Keeps original rectangular borders */
+	color: #375EAB;
+	font-weight: normal;
+	display: flex; /* Change from inline-flex to flex to stretch inside the li */
+	align-items: center;
+	background-color: transparent;
+}
+
+/* Hover style for default tab links */
+.sub-nav .nav-link:hover {
+	background-color: #ddd;
+}
+
+/* Styles the currently active tab (selected tab) */
+.sub-nav .nav-link.active {
+	font-weight: bold;
+	border: 3px solid black; /* Thicker border indicates selection */
+	padding: 2px; /* Adjusted padding to compensate for thicker border */
+	background-color: transparent;
+	color: #375EAB;
+}
+
+/*
+ * TOPBAR BRAND LOGO & SYSTEM SELECT DROPDOWN
+ * 
+ * Re-applies legacy styling rules for topbar elements to preserve exact fonts 
+ * and font sizes.
+ */
+/* Brand logo ("syzbot") link styling */
+#topbar .navbar-brand, #topbar .navbar-brand:visited {
+	font-family: inherit;
+	font-weight: bold;
+	color: #375EAB;
+	font-size: 32px;
+	padding: 0;
+	margin: 0;
+}
+
+/* Target system selector dropdown list */
+#topbar select.namespace {
+	font-family: Arial, sans-serif;
+	font-size: 18px;
+	font-weight: bold;
+	color: #375EAB;
+	margin-left: 20px;
+}
+
+/*
+ * TOPBAR EXTERNAL LINKS
+ * 
+ * Align external links (mailing list, source, docs, sign-in) located in the 
+ * top-right corner.
+ */
+.topbar-links {
+	font-size: 16px;
+	color: #375EAB;
+	align-self: flex-start;
+	padding-top: 5px;
+}
+
+.topbar-links a {
+	color: #375EAB;
+	text-decoration: none;
+}
+
+/*
+ * GLOBAL BODY LAYOUT ADJUSTMENTS
+ * 
+ * Restores browser defaults for typography and margin that Bootstrap Reboot overrides.
+ * Also configures min-width to ensure the body stretches to fit wide tables, which
+ * prevents the topbar header from being cut off on narrow viewports.
+ */
+body {
+	font-family: revert;
+	font-size: revert;
+	line-height: normal; /* Restore standard vertical spacing layout */
+	margin: revert;
+	color: black;
+	min-width: fit-content; /* Ensure body stretches to fit wide tables, preventing header cutoffs */
+}
+
+/* Override legacy `#topbar a` rule to ensure active dropdown links render with white text */
+#topbar .dropdown-item.active,
+#topbar .dropdown-item:active {
+	color: #fff;
+}

--- a/dashboard/app/templates/error.html
+++ b/dashboard/app/templates/error.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-	{{template "head_bootstrap" .Header}}
+	{{template "head" .Header}}
 	<title>syzbot</title>
 </head>
 <body>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -10,33 +10,13 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 {{/* Common page head part, invoked with *uiHeader */}}
 {{define "head"}}
-	<link rel="stylesheet" href="/static/style.css"/>
-	<script src="/static/common.js"></script>
-	{{if .AnalyticsTrackingID}}
-		<script async src="https://www.googletagmanager.com/gtag/js?id={{.AnalyticsTrackingID}}"></script>
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag() { dataLayer.push(arguments); }
-			gtag('js', new Date());
-			gtag('config', '{{.AnalyticsTrackingID}}');
-		</script>
-	{{end}}
-{{end}}
-
-{{/* Common page head part with Bootstrap, invoked with *uiHeader */}}
-{{define "head_bootstrap"}}
 	{{/* Required meta tags for responsive design on mobile devices */}}
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	{{/* Bootstrap 5.3.3 CSS compiled styles from Google Hosted Libraries */}}
-	<link href="https://ajax.googleapis.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css"
-		rel="stylesheet"
-		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-		crossorigin="anonymous">
-	{{/* Bootstrap 5.3.3 JS Bundle from Google Hosted Libraries, deferred to load asynchronously */}}
-	<script src="https://ajax.googleapis.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js"
-		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-		crossorigin="anonymous"
-		defer></script>
+	{{/* Bootstrap 5.3.3 JS Bundle loaded locally */}}
+	<script src="/static/bootstrap.bundle.min.js" defer></script>
+	<link rel="stylesheet" href="/static/style.css"/>
+	<link rel="stylesheet" href="/static/dashboard.css"/>
+	<script src="/static/common.js"></script>
 	{{/* Google Analytics tracking code, injected only if AnalyticsTrackingID is configured in production */}}
 	{{if .AnalyticsTrackingID}}
 		<script async src="https://www.googletagmanager.com/gtag/js?id={{.AnalyticsTrackingID}}"></script>
@@ -51,113 +31,118 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 
 {{/* Common page header, invoked with *uiHeader */}}
 {{define "header"}}
-	<header id="topbar">
-		<table class="position_table">
-			<tr>
-				<td>
-					<h1><a href="/{{$.Namespace}}">syzbot</a></h1>
-				</td>
-				<td class="namespace_td">
-					<select class="namespace" onchange="window.location.href = '/' + this.value + '{{.Subpage}}';">
-						{{if .Admin}}
-							<option value="admin" {{if eq $.Namespace "admin"}}selected="1"{{end}}>Admin</option>
-						{{end}}
-						{{- range $ns := .Namespaces}}
-							<option value="{{$ns.Name}}" {{if eq $.Namespace $ns.Name}}selected="1"{{end}}>
-								{{- $ns.Caption -}}
-							</option>
-						{{- end -}}
-					</select>
-				</td>
-				<td class="search">
+	<nav id="topbar" class="navbar navbar-light">
+		<div class="container-fluid d-flex align-items-center justify-content-between p-0">
+			<div class="d-flex align-items-center">
+				<a class="navbar-brand" href="/{{$.Namespace}}">syzbot</a>
+				<select class="namespace" onchange="window.location.href = '/' + this.value + '{{.Subpage}}';">
 					{{if .Admin}}
-						<a href="/admin">admin</a> |
+						<option value="admin" {{if eq $.Namespace "admin"}}selected="1"{{end}}>Admin</option>
 					{{end}}
-					{{if .LoginLink}}
-						<a href="{{.LoginLink}}">sign-in</a> |
-					{{end}}
-					<a href="https://groups.google.com/forum/#!forum/syzkaller" target="_blank">mailing list</a> |
-					<a href="https://github.com/google/syzkaller" target="_blank">source</a> |
-					<a href="https://github.com/google/syzkaller/blob/master/docs/syzbot.md" target="_blank">docs</a>
-					{{if eq $.Namespace "upstream"}}
-						| <a href='/upstream/syz-dungeon' title="Syzkaller Dungeon">🏰</a>
-					{{end}}
-				</td>
-			</tr>
-		</table>
-		{{if not (eq .URLPath "/admin")}}
-		<div class="navigation">
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}'><span style="color:DeepPink;">🐞 Open [{{$.BugCounts.Open}}]</span></a>
+					{{- range $ns := .Namespaces}}
+						<option value="{{$ns.Name}}" {{if eq $.Namespace $ns.Name}}selected="1"{{end}}>
+							{{- $ns.Caption -}}
+						</option>
+					{{- end -}}
+				</select>
 			</div>
 
+			<div class="topbar-links">
+				{{if .Admin}}
+					<a href="/admin">admin</a> |
+				{{end}}
+				{{if .LoginLink}}
+					<a href="{{.LoginLink}}">sign-in</a> |
+				{{end}}
+				<a href="https://groups.google.com/forum/#!forum/syzkaller" target="_blank">mailing list</a> |
+				<a href="https://github.com/google/syzkaller" target="_blank">source</a> |
+				<a href="https://github.com/google/syzkaller/blob/master/docs/syzbot.md" target="_blank">docs</a>
+				{{if eq $.Namespace "upstream"}}
+					| <a href="/upstream/syz-dungeon" title="Syzkaller Dungeon">🏰</a>
+				{{end}}
+		</div>
+
+
+	{{if not (eq .URLPath "/admin")}}
+	<div class="sub-nav">
+		<ul class="nav nav-pills">
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}">
+					<span style="color:DeepPink;">🐞 Open [{{$.BugCounts.Open}}]</span>
+				</a>
+			</li>
 			{{if .ShowSubsystems}}
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/subsystems" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/subsystems'><span style="color:DeepPink;">≡</span> Subsystems</a>
-			</div>
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/subsystems" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/subsystems">
+					<span style="color:DeepPink;">≡</span> Subsystems
+				</a>
+			</li>
 			{{end}}
-
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/fixed" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/fixed'><span style="color:ForestGreen;">🐞 Fixed [{{$.BugCounts.Fixed}}]</span></a>
-			</div>
-
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/invalid" $.Namespace)}}_selected{{end}}" href='/{{$.Namespace}}/invalid'>
-				<a href='/{{$.Namespace}}/invalid'><span style="color:RoyalBlue;">🐞 Invalid [{{$.BugCounts.Invalid}}]</span></a>
-			</div>
-
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/fixed" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/fixed">
+					<span style="color:ForestGreen;">🐞 Fixed [{{$.BugCounts.Fixed}}]</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/invalid" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/invalid">
+					<span style="color:RoyalBlue;">🐞 Invalid [{{$.BugCounts.Invalid}}]</span>
+				</a>
+			</li>
 			{{if gt .MissingBackports 0}}
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/backports" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/backports'><span style="color:ForestGreen;">⬇</span> Missing Backports [{{$.MissingBackports}}]</a>
-			</div>
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/backports" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/backports">
+					<span style="color:ForestGreen;">⬇</span> Missing Backports [{{$.MissingBackports}}]
+				</a>
+			</li>
 			{{end}}
-
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/graph/crashes" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/graph/crashes'><span style="color:ForestGreen;">≡</span> Crashes</a>
-			</div>
-
-			<div class="dropdown navigation_tab">
-				<button class="dropbtn"><span style="color:DarkOrange;">📈</span>Graphs</button>
-				<div class="dropdown-content">
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/bugs" $.Namespace)}}_selected{{end}}"
-						href='/{{$.Namespace}}/graph/bugs'>Kernel&nbsp;Health</a>
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)}}_selected{{end}}"
-						href='/{{$.Namespace}}/graph/found-bugs'>Bugs/Month</a>
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)}}_selected{{end}}"
-						href='/{{$.Namespace}}/graph/lifetimes'>Bug&nbsp;Lifetimes</a>
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace)}}_selected{{end}}"
-						href='/{{$.Namespace}}/graph/fuzzing'>Fuzzing</a>
-				</div>
-			</div>
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/graph/crashes" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/crashes">
+					<span style="color:ForestGreen;">≡</span> Crashes
+				</a>
+			</li>
+			
+			<li class="nav-item dropdown">
+				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)) (eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
+					<span style="color:DarkOrange;">📈</span>Graphs
+				</a>
+				<ul class="dropdown-menu">
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/bugs" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/bugs">Kernel Health</a></li>
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/found-bugs">Bugs/Month</a></li>
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/lifetimes">Bug Lifetimes</a></li>
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/fuzzing">Fuzzing</a></li>
+				</ul>
+			</li>
 
 			{{if .ShowCoverageMenu}}
-			<div class="dropdown navigation_tab">
-				<button class="dropbtn"><span style="color:DarkOrange;">📈</span>Coverage</button>
-				<div class="dropdown-content">
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/graph/coverage" $.Namespace)}}_selected{{end}}"
-						href="/{{$.Namespace}}/graph/coverage?period=quarter">Total</a>
-					<a class="navigation_tab{{if eq .URLPath (printf "/%v/coverage" $.Namespace)}}_selected{{end}}"
-						href="/{{$.Namespace}}/coverage?period=month">Repo&nbsp;Heatmap</a>
+			<li class="nav-item dropdown">
+				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/coverage" $.Namespace)) (eq .URLPath (printf "/%v/coverage" $.Namespace)) (eq .URLPath (printf "/%v/coverage/subsystems" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
+					<span style="color:DarkOrange;">📈</span>Coverage
+				</a>
+				<ul class="dropdown-menu">
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/coverage" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/coverage?period=quarter">Total</a></li>
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/coverage" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/coverage?period=month">Repo Heatmap</a></li>
 					{{if .ShowSubsystems}}
-						<a class="navigation_tab{{if eq .URLPath (printf "/%v/coverage/subsystems" $.Namespace)}}_selected{{end}}"
-							href="/{{$.Namespace}}/coverage/subsystems?period=month">Subsystems&nbsp;Heatmap</a>
+						<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/coverage/subsystems" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/coverage/subsystems?period=month">Subsystems Heatmap</a></li>
 					{{end}}
-				</div>
-			</div>
+				</ul>
+			</li>
 			{{end}}
+
 			{{if .AI}}
-			<div class="navigation_tab{{if eq .URLPath (printf "/%v/ai" $.Namespace)}}_selected{{end}}">
-				<a href='/{{$.Namespace}}/ai'>✨ AI</a>
-			</div>
+			<li class="nav-item">
+				<a class="nav-link {{if eq .URLPath (printf "/%v/ai" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/ai">✨ AI</a>
+			</li>
 			{{end}}
+
 			{{if .ContactEmail}}
-			<div class="navigation_tab">
-				<a href='mailto:{{.ContactEmail}}'><span style="color:ForestGreen;">💬</span> Send us feedback</a>
-			</div>
+			<li class="nav-item ms-auto">
+				<a class="nav-link" href="mailto:{{.ContactEmail}}"><span style="color:ForestGreen;">💬</span> Send us feedback</a>
+			</li>
 			{{end}}
-		</div>
-		{{end}}
-	</header>
-	<br>
+		</ul>
+	</div>
+	{{end}}
+</nav>
 	{{if .Message}}
 		<div class="flash-message">{{.Message}}</div>
 	{{end}}

--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -535,53 +535,7 @@ aside {
 	margin-bottom: 5pt;
 }
 
-/* Dropdown Button */
-.dropbtn {
-	background-color: transparent;
-	color: #375EAB;
-	text-decoration: none;
-	border: none;
-	font-family: inherit;
-	font-size: inherit;
-	padding: 0;
-	margin: 0;
-}
 
-/* The container <div> - needed to position the dropdown content */
-.dropdown {
-	position: relative;
-	display: inline-block;
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
-/* Dropdown Content (Hidden by Default) */
-.dropdown-content {
-	display: none;
-	flex-direction: column;
-	position: absolute;
-	background-color: #f1f1f1;
-	z-index: 1;
-	top: 100%;
-	left: 0;
-	margin-top: 1px;
-}
-
-/* Links inside the dropdown */
-.dropdown-content div a {
-	color: black;
-	text-decoration: none;
-	display: block;
-}
-
-/* Change color of dropdown links on hover */
-.dropdown-content a:hover {background-color: #ddd;}
-
-/* Show the dropdown menu on hover */
-.dropdown:hover .dropdown-content {display: flex;}
-
-/* Change the background color of the dropdown button when the dropdown content is shown */
-.dropdown:hover .dropbtn {background-color: #ddd;}
 
 .rank .tooltiptext {
 	visibility: hidden;


### PR DESCRIPTION
Migrate the custom header and sub-navigation bar to standard Bootstrap
components (.navbar, .nav-pills, .dropdown). This simplifies the codebase
and introduces several layout improvements:

- Use Bootstrap's flex alignment (ms-auto) to push the "Send us feedback"
  button to the far right.
- Integrate Bootstrap's .dropdown-toggle to show standard caret symbols
  on expandable menus.
- Standardize layout rules with flex stretching to ensure all navigation
  buttons render at the exact same height regardless of content or state.
- Align topbar metadata links vertically with the brand logo.