### PR TITLE
mod: bump github.com/speakeasy-api/git-diff-parser from 0.0.3 to 0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sergi/go-diff v1.4.0
-	github.com/speakeasy-api/git-diff-parser v0.0.3
+	github.com/speakeasy-api/git-diff-parser v0.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-diff v0.7.0 h1:9uLlrd5T46OXs5qpp8L/MTltk0zikUGi0sNNyCpA8G0=
 github.com/sourcegraph/go-diff v0.7.0/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
-github.com/speakeasy-api/git-diff-parser v0.0.3 h1:LL12d+HMtSyj6O/hQqIn/lgDPYI6ci/DEhk0la/xA+0=
-github.com/speakeasy-api/git-diff-parser v0.0.3/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
+github.com/speakeasy-api/git-diff-parser v0.2.0 h1:fvPsWhTqTt+8j9Kx4eXF6kRRqDUC60gy0VII4PnjIHA=
+github.com/speakeasy-api/git-diff-parser v0.2.0/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=

--- a/tools/syz-fix-analyzer/fix-analyzer.go
+++ b/tools/syz-fix-analyzer/fix-analyzer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/google/syzkaller/dashboard/api"
@@ -157,16 +158,25 @@ func isFixable(bug api.BugSummary, repo vcs.Repo) (BugType, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	diff, errs := git_diff_parser.Parse(string(com.Patch))
-	if len(errs) != 0 {
-		return "", false, fmt.Errorf("parsing patch: %v", errs)
+	var files []*git_diff_parser.FileDiff
+	fn := func(file *git_diff_parser.FileDiff, change *git_diff_parser.ContentChange) (bool, string) {
+		if !slices.ContainsFunc(files, func(f *git_diff_parser.FileDiff) bool {
+			return f.FromFile == file.FromFile && f.ToFile == file.ToFile
+		}) {
+			files = append(files, file)
+		}
+		return false, ""
 	}
-	if len(diff.FileDiff) != 1 {
+	_, _, err = git_diff_parser.SignificantChange(string(com.Patch), fn)
+	if err != nil {
+		return "", false, fmt.Errorf("parsing patch: %w", err)
+	}
+	if len(files) != 1 {
 		return typ, false, nil
 	}
-	file := diff.FileDiff[0]
+	file := files[0]
 	if file.IsBinary || file.FromFile != file.ToFile ||
-		!strings.HasSuffix(file.FromFile, ".c") && !strings.HasSuffix(file.FromFile, ".h") {
+		(!strings.HasSuffix(file.FromFile, ".c") && !strings.HasSuffix(file.FromFile, ".h")) {
 		return typ, false, nil
 	}
 	if len(file.Hunks) != 1 {


### PR DESCRIPTION
Bumps github.com/speakeasy-api/git-diff-parser from 0.0.3 to 0.2.0.

The new version introduces breaking API changes (making Parse and key structs private).
Adapted tools/syz-fix-analyzer/fix-analyzer.go to use the public SignificantChange API to resolve compilation errors.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
