### PR TITLE
dashboard/app: avoid saving AI moderation lists to ExtraCcList

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -102,6 +102,19 @@ func formatUpstreamedBy(name, email string) string {
 	return email
 }
 
+func filterStageEmails(nsCfg *Config, emails []string) []string {
+	if nsCfg.AI == nil {
+		return emails
+	}
+	var stageEmails []string
+	for _, stage := range nsCfg.AI.Stages {
+		if stage.MailingList != "" {
+			stageEmails = append(stageEmails, stage.MailingList)
+		}
+	}
+	return email.SubtractEmailLists(emails, stageEmails)
+}
+
 func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	currentReporting *aidb.JobReporting, req *dashapi.SendExternalCommandReq) error {
 	if err := checkActionAuthorized(ctx, job, req); err != nil {
@@ -140,6 +153,7 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 	}
 	extraCcList = email.MergeEmailLists(extraCcList, req.Cc)
 	extraCcList = email.SubtractEmailLists(extraCcList, ownEmails(ctx))
+	extraCcList = filterStageEmails(nsCfg, extraCcList)
 
 	return aidb.UpstreamReportCommand(ctx, aidb.UpstreamReportArgs{
 		Job: job,
@@ -555,6 +569,9 @@ func handleCommentCommand(ctx context.Context,
 	}
 
 	extraCc := email.SubtractEmailLists(req.Cc, ownEmails(ctx))
+	nsCfg := getNsConfig(ctx, job.Namespace)
+	extraCc = filterStageEmails(nsCfg, extraCc)
+
 	err = aidb.SaveJobComment(ctx, &aidb.JobComment{
 		ReportingID:  reporting.ID,
 		ExtID:        req.MessageExtID,

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -113,11 +113,22 @@ func TestAIExternalReporting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "moderation-msg-id",
+		MessageExtID: "<comment-1>",
+		Author:       "someguy@test.com",
+		Cc:           []string{"moderation@test.com", "other@example.com"},
+		Comment:      &dashapi.CommentCommand{Body: "Looks good to me!"},
+	})
+	require.NoError(t, err)
+
 	// Upstream the result.
 	resp, err := c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
 		RootExtID: "moderation-msg-id",
 		Upstream:  &dashapi.UpstreamCommand{},
 		Author:    "test-user",
+		Cc:        []string{"moderation@test.com", "yetanother@example.com"},
 		Source:    "lore",
 	})
 	require.NoError(t, err)
@@ -173,7 +184,9 @@ func TestAIExternalReporting(t *testing.T) {
 		ReportedBy: []string{"syzbot+" + extID + "@" + appengine.AppID(c.ctx) + ".appspotmail.com"},
 	}, pollResp.Result.Patch)
 	require.Equal(t, []string{"public@test.com", "test-user"}, pollResp.Result.To)
-	require.Equal(t, []string{`"Reviewer" <reviewer@test.com>`}, pollResp.Result.Cc)
+	require.Equal(t, []string{
+		`"Reviewer" <reviewer@test.com>`, "other@example.com", "yetanother@example.com",
+	}, pollResp.Result.Cc)
 
 	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
 		ReportID:       pollResp.Result.ID,


### PR DESCRIPTION
Prevent the dashboard from mistakenly adding moderation email addresses to the ExtraCcList during handleCommentCommand and processUpstreamSubcommand. This stops the CC leak at its source rather than filtering it later when patches are sent to public mailing lists.