### PR TITLE
pkg/aflow: improve duplicate tool call warning message

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -237,6 +237,11 @@ Provide a best-effort answer to the original question with all of the informatio
 you have so far without calling any more tools!
 `
 
+const llmDuplicateCallWarning = `You are repeating the same tool call with the exact same arguments.
+You already have the result of this exact tool call in your conversation history.
+Do NOT request it again. You MUST synthesize the information you already have,
+try a completely different tool, or proceed to the next step.`
+
 type llmOutputs struct {
 	tool           Tool
 	provideOutputs func(*verifyContext, string, bool)
@@ -715,8 +720,7 @@ func (a *agentSession) callTools(ctx *Context, tools map[string]Tool, calls []*b
 		})
 		if isDuplicateErr(toolErr) {
 			responses.Parts = append(responses.Parts, backend.Part{
-				Text: fmt.Sprintf("SYSTEM WARNING: You are repeating tool call %q. "+
-					"Please try a different approach, search term, or proceed without it.", call.Name),
+				Text: fmt.Sprintf("SYSTEM WARNING: %s", toolErr.Error()),
 			})
 		}
 		if toolErr == nil && a.Outputs != nil && tool == a.Outputs.tool {
@@ -955,15 +959,14 @@ func (a *agentSession) recordAndCheckDuplicate(call *backend.FunctionCall) error
 	}
 
 	if repeats == hardLoopDetectionLimit-1 {
-		return newDuplicateCallError("CRITICAL WARNING: This is your %d-th attempt to call %q with args %+v. "+
+		return newDuplicateCallError("CRITICAL: This is your %d-th attempt to call %q with args %+v. "+
 			"You are stuck in a loop. You MUST change your search query, try a different tool, or proceed "+
 			"to the next step with your current knowledge. The next duplicate attempt will force-terminate your execution.",
 			repeats, call.Name, call.Args)
 	}
 
 	if repeats > limit {
-		return newDuplicateCallError("You are repeating the same tool call with the exact same arguments. " +
-			"Please synthesize the information you already have instead of repeating queries.")
+		return newDuplicateCallError(llmDuplicateCallWarning)
 	}
 
 	return nil


### PR DESCRIPTION
Make the warning message for duplicate tool calls more explicit and forceful. The previous message asked the agent to "try a different approach", which sometimes led the agent to alternate between two different tools, getting stuck in an infinite loop while ignoring the warning.

The new message explicitly forbids the agent from requesting the same information again and instructs it to synthesize the information it already has in its conversation history.

Also, extract the warning message to a constant to avoid duplication and ensure that the SYSTEM WARNING text correctly mirrors the specific duplicate error generated (including the critical 5th-attempt warning).
