### PR TITLE
all: migrate golang.org/x/exp/maps to standard maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/sergi/go-diff v1.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
-	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/perf v0.0.0-20260512194132-3cf34090a3db
 	golang.org/x/sync v0.21.0
@@ -324,6 +323,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/pkg/cover/heatmap.go
+++ b/pkg/cover/heatmap.go
@@ -10,13 +10,12 @@ import (
 	"fmt"
 	"html/template"
 	"slices"
-	"sort"
 	"strings"
 
 	"cloud.google.com/go/spanner"
 	"github.com/google/syzkaller/pkg/coveragedb"
 	_ "github.com/google/syzkaller/pkg/subsystem/lists"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 type templateHeatmapRow struct {
@@ -111,11 +110,14 @@ func (thm *templateHeatmapRow) prepareDataFor(pageColumns []pageColumnTarget, na
 	for _, item := range thm.builder {
 		thm.Items = append(thm.Items, item)
 	}
-	sort.Slice(thm.Items, func(i, j int) bool {
-		if thm.Items[i].IsDir != thm.Items[j].IsDir {
-			return thm.Items[i].IsDir
+	slices.SortFunc(thm.Items, func(a, b *templateHeatmapRow) int {
+		if a.IsDir != b.IsDir {
+			if a.IsDir {
+				return -1
+			}
+			return 1
 		}
-		return thm.Items[i].Name < thm.Items[j].Name
+		return strings.Compare(a.Name, b.Name)
 	})
 	for _, pageColumn := range pageColumns {
 		var dateCoverage int64
@@ -183,9 +185,8 @@ func FilesCoverageToTemplateData(fCov []*coveragedb.FileCoverageWithDetails, nam
 			fc.TimePeriod)
 		columns[pageColumnTarget{TimePeriod: fc.TimePeriod, Commit: fc.Commit}] = struct{}{}
 	}
-	targetDateAndCommits := maps.Keys(columns)
-	sort.Slice(targetDateAndCommits, func(i, j int) bool {
-		return targetDateAndCommits[i].TimePeriod.DateTo.Before(targetDateAndCommits[j].TimePeriod.DateTo)
+	targetDateAndCommits := slices.SortedFunc(maps.Keys(columns), func(a, b pageColumnTarget) int {
+		return a.TimePeriod.DateTo.Compare(b.TimePeriod.DateTo)
 	})
 	for _, tdc := range targetDateAndCommits {
 		tp := tdc.TimePeriod

--- a/pkg/cover/report.go
+++ b/pkg/cover/report.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/vminfo"
 	"github.com/google/syzkaller/sys/targets"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 type ReportGenerator struct {
@@ -202,7 +202,7 @@ func uniquePCs(progs ...Prog) []uint64 {
 			PCs[pc] = true
 		}
 	}
-	return maps.Keys(PCs)
+	return slices.Collect(maps.Keys(PCs))
 }
 
 func (rg *ReportGenerator) symbolizePCs(PCs []uint64) error {

--- a/pkg/covermerger/covermerger.go
+++ b/pkg/covermerger/covermerger.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/google/syzkaller/pkg/coveragedb"
 	"github.com/google/syzkaller/pkg/log"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
+	"maps"
 )
 
 const (
@@ -118,8 +118,7 @@ func mergedCoverageRecords(fmr *FileMergeResult) ([]*coveragedb.MergedCoverageRe
 	if !fmr.FileExists {
 		return nil, nil
 	}
-	lines := maps.Keys(fmr.HitCounts)
-	slices.Sort(lines)
+	lines := slices.Sorted(maps.Keys(fmr.HitCounts))
 	mgrStat := make(map[string]*coveragedb.Coverage)
 	mgrStat[allManagers] = &coveragedb.Coverage{}
 
@@ -158,7 +157,7 @@ func mergedCoverageRecords(fmr *FileMergeResult) ([]*coveragedb.MergedCoverageRe
 			FileData: managerCoverage,
 		})
 	}
-	return res, maps.Values(funcLines)
+	return res, slices.Collect(maps.Values(funcLines))
 }
 
 // bestFuncName selects the most frequent function from the list of candidates.
@@ -188,7 +187,7 @@ func batchFileData(c *Config, targetFilePath string, records []*FileRecord) (*Me
 		repoCommitsMap[record.RepoCommit] = true
 	}
 	repoCommitsMap[c.Base] = true
-	repoCommits := maps.Keys(repoCommitsMap)
+	repoCommits := slices.Collect(maps.Keys(repoCommitsMap))
 	fvs, err := c.FileVersProvider.GetFileVersions(targetFilePath, repoCommits...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to getFileVersions: %w", err)

--- a/pkg/email/lore/parse.go
+++ b/pkg/email/lore/parse.go
@@ -13,7 +13,7 @@ import (
 	"slices"
 	"strconv"
 
-	"golang.org/x/exp/maps"
+	"maps"
 	"strings"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
@@ -226,13 +226,7 @@ func (c *parseCtx) process() {
 				unique[id] = struct{}{}
 			}
 		}
-		ids := maps.Keys(unique)
-		if len(ids) == 0 {
-			ids = nil
-		} else {
-			slices.Sort(ids)
-		}
-		thread.BugIDs = ids
+		thread.BugIDs = slices.Sorted(maps.Keys(unique))
 	}
 }
 

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -17,8 +18,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-
-	"golang.org/x/exp/maps"
 )
 
 type Email struct {
@@ -568,8 +567,11 @@ func MergeEmailLists(lists ...[]string) []string {
 			merged[addr.Address] = true
 		}
 	}
-	result := maps.Keys(merged)
-	slices.Sort(result)
+	if len(merged) == 0 {
+		// Return non-nil empty slice because callers/tests expect it (e.g. JSON serialization).
+		return []string{}
+	}
+	result := slices.Sorted(maps.Keys(merged))
 	if len(result) > maxEmails {
 		result = result[:maxEmails]
 	}

--- a/pkg/kconfig/minimize.go
+++ b/pkg/kconfig/minimize.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/bisect/minimize"
 	"github.com/google/syzkaller/pkg/debugtracer"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // Minimize finds an equivalent with respect to the provided predicate, but smaller config.
@@ -109,8 +109,7 @@ func (kconf *KConfig) addDependencies(base, full *ConfigFile, configs []string) 
 			}
 		}
 	}
-	sorted := maps.Keys(closure)
-	slices.Sort(sorted)
+	sorted := slices.Sorted(maps.Keys(closure))
 	return sorted
 }
 

--- a/pkg/subsystem/linux/subsystems.go
+++ b/pkg/subsystem/linux/subsystems.go
@@ -12,7 +12,7 @@ import (
 	"slices"
 
 	"github.com/google/syzkaller/pkg/subsystem"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 func ListFromRepo(repo string) ([]*subsystem.Subsystem, *subsystem.DebugInfo, error) {
@@ -233,8 +233,7 @@ func unique(list []string) []string {
 	for _, s := range list {
 		m[s] = struct{}{}
 	}
-	ret := maps.Keys(m)
-	slices.Sort(ret)
+	ret := slices.Sorted(maps.Keys(m))
 	return ret
 }
 

--- a/tools/syz-db/syz-db.go
+++ b/tools/syz-db/syz-db.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/sys"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 func main() {
@@ -227,8 +227,7 @@ func print(file string) {
 	if err != nil {
 		tool.Failf("failed to open database: %v", err)
 	}
-	keys := maps.Keys(db.Records)
-	slices.Sort(keys)
+	keys := slices.Sorted(maps.Keys(db.Records))
 	for _, key := range keys {
 		rec := db.Records[key]
 		fmt.Printf("%v\n%v\n", key, string(rec.Val))

--- a/tools/syz-testbed/table.go
+++ b/tools/syz-testbed/table.go
@@ -6,12 +6,12 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"slices"
 
 	"github.com/google/syzkaller/pkg/stat/sample"
-	"golang.org/x/exp/maps"
 )
 
 type Cell = any
@@ -123,10 +123,9 @@ func (t *Table) AddRow(row string, cells ...Cell) {
 	}
 }
 
+// SortedRows is used by the HTML template to iterate over rows in a sorted order.
 func (t *Table) SortedRows() []string {
-	rows := maps.Keys(t.Cells)
-	slices.Sort(rows)
-	return rows
+	return slices.Sorted(maps.Keys(t.Cells))
 }
 
 func (t *Table) ToStrings() [][]string {
@@ -134,7 +133,7 @@ func (t *Table) ToStrings() [][]string {
 	headers := append([]string{t.TopLeftHeader}, t.ColumnHeaders...)
 	table = append(table, headers)
 	if t.Cells != nil {
-		rowHeaders := t.SortedRows()
+		rowHeaders := slices.Sorted(maps.Keys(t.Cells))
 		for _, row := range rowHeaders {
 			tableRow := []string{row}
 			for _, column := range t.ColumnHeaders {


### PR DESCRIPTION
Migrated all usages of golang.org/x/exp/maps to the standard library maps package (and slices package where iterators are collected). Removed golang.org/x/exp from direct dependencies in go.mod.
