### PR TITLE
pkg/clangtool: fix C++ static constructor interception race

### DIFF
--- a/pkg/aflow/tool/codesearcher/codesearcher.go
+++ b/pkg/aflow/tool/codesearcher/codesearcher.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/syzkaller/pkg/clangtool"
 	"github.com/google/syzkaller/pkg/codesearch"
 	"github.com/google/syzkaller/pkg/hash"
-	"github.com/google/syzkaller/tools/clang/codesearch"
+	clangtoolimpl "github.com/google/syzkaller/tools/clang/codesearch"
 )
 
 var (

--- a/pkg/clangtool/clangtool.go
+++ b/pkg/clangtool/clangtool.go
@@ -155,6 +155,9 @@ func (v *Verifier) LineRange(file string, start, end int) {
 }
 
 func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, file string) (OutputPtr, error) {
+	if !plugins[cfg.Tool] {
+		return nil, fmt.Errorf("clang tool %q is not compiled in", cfg.Tool)
+	}
 	relFile := strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(filepath.Clean(file),
 		cfg.KernelSrc), cfg.KernelObj), "/")
 	// Suppress warning since we may build the tool on a different clang
@@ -170,7 +173,7 @@ func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, file stri
 	cmd := exec.Command(bin, "-p", cfg.KernelObj,
 		"--extra-arg=-w", "--extra-arg=-fparse-all-comments", file)
 	cmd.Dir = cfg.KernelObj
-	// This tells the C++ clang tool to execute in a constructor.
+	// This tells the tool (via Register()) to execute as a clang plugin.
 	cmd.Env = append([]string{fmt.Sprintf("%v=%v", runToolEnv, cfg.Tool)}, os.Environ()...)
 	data, err := cmd.Output()
 	if err != nil {
@@ -197,11 +200,21 @@ func runTool[Output any, OutputPtr OutputDataPtr[Output]](cfg *Config, file stri
 
 const runToolEnv = "SYZ_RUN_CLANGTOOL"
 
+var plugins = make(map[string]bool)
+
 func init() {
-	// The C++ clang tool was supposed to intercept execution in a constructor,
-	// execute and exit. If we got here with the env var set, something is wrong.
-	if name := os.Getenv(runToolEnv); name != "" {
-		panic(fmt.Sprintf("clang tool %q is not compiled in", name))
+	// Register is used in CGO plugins that may be ignored by deadcode.
+	runtime.KeepAlive(Register)
+}
+
+// Register registers a clang tool plugin.
+// If the current process was executed to run this specific tool, Register
+// will execute it immediately and exit the process.
+func Register(name string, f func()) {
+	plugins[name] = true
+	if os.Getenv(runToolEnv) == name {
+		f()
+		os.Exit(0)
 	}
 }
 

--- a/pkg/clangtool/cmain.go
+++ b/pkg/clangtool/cmain.go
@@ -1,0 +1,35 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux && cgo
+
+package clangtool
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"os"
+	"unsafe"
+)
+
+// RunCMain executes a C main function, managing argc/argv conversion and cleanup.
+// It will call os.Exit with the result of mainFunc.
+func RunCMain(mainFunc func(argc int, argv unsafe.Pointer) int) {
+	args := os.Args
+	argc := C.int(len(args))
+	argv := make([]*C.char, len(args))
+	for i, arg := range args {
+		argv[i] = C.CString(arg)
+	}
+	var argvPtr **C.char
+	if len(argv) > 0 {
+		argvPtr = (**C.char)(unsafe.Pointer(&argv[0]))
+	}
+	res := mainFunc(int(argc), unsafe.Pointer(argvPtr))
+	for _, ptr := range argv {
+		C.free(unsafe.Pointer(ptr))
+	}
+	os.Exit(res)
+}

--- a/tools/clang/codesearch/codesearch.cpp
+++ b/tools/clang/codesearch/codesearch.cpp
@@ -402,8 +402,6 @@ static int Main(int argc, const char** argv) {
   return 0;
 }
 
-__attribute__((constructor)) static void ctor(int argc, const char** argv) {
-  const char* run = getenv("SYZ_RUN_CLANGTOOL");
-  if (run && !strcmp(run, "codesearch"))
-    exit(Main(argc, argv));
+extern "C" {
+int syz_codesearch_main(int argc, char** argv) { return Main(argc, (const char**)argv); }
 }

--- a/tools/clang/codesearch/plugin.go
+++ b/tools/clang/codesearch/plugin.go
@@ -1,0 +1,25 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux && cgo
+
+package clangtoolimpl
+
+/*
+extern int syz_codesearch_main(int argc, char** argv);
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/google/syzkaller/pkg/clangtool"
+)
+
+func init() {
+	clangtool.Register(Tool, func() {
+		clangtool.RunCMain(func(argc int, argv unsafe.Pointer) int {
+			return int(C.syz_codesearch_main(C.int(argc), (**C.char)(argv)))
+		})
+	})
+}

--- a/tools/clang/declextract/declextract.cpp
+++ b/tools/clang/declextract/declextract.cpp
@@ -1017,8 +1017,6 @@ static int Main(int argc, const char** argv) {
   return 0;
 }
 
-__attribute__((constructor(1000))) static void ctor(int argc, const char** argv) {
-  const char* run = getenv("SYZ_RUN_CLANGTOOL");
-  if (run && !strcmp(run, "declextract"))
-    exit(Main(argc, argv));
+extern "C" {
+int syz_declextract_main(int argc, char** argv) { return Main(argc, (const char**)argv); }
 }

--- a/tools/clang/declextract/plugin.go
+++ b/tools/clang/declextract/plugin.go
@@ -1,0 +1,25 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux && cgo
+
+package clangtoolimpl
+
+/*
+extern int syz_declextract_main(int argc, char** argv);
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/google/syzkaller/pkg/clangtool"
+)
+
+func init() {
+	clangtool.Register(Tool, func() {
+		clangtool.RunCMain(func(argc int, argv unsafe.Pointer) int {
+			return int(C.syz_declextract_main(C.int(argc), (**C.char)(argv)))
+		})
+	})
+}

--- a/tools/syz-declextract/declextract.go
+++ b/tools/syz-declextract/declextract.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/google/syzkaller/pkg/subsystem/lists"
 	"github.com/google/syzkaller/pkg/tool"
 	"github.com/google/syzkaller/sys/targets"
-	"github.com/google/syzkaller/tools/clang/declextract"
+	clangtoolimpl "github.com/google/syzkaller/tools/clang/declextract"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/tools/syz-declextract/declextract_test.go
+++ b/tools/syz-declextract/declextract_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/syzkaller/pkg/declextract"
 	"github.com/google/syzkaller/pkg/ifaceprobe"
 	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/tools/clang/declextract"
+	clangtoolimpl "github.com/google/syzkaller/tools/clang/declextract"
 )
 
 func TestClangTool(t *testing.T) {


### PR DESCRIPTION
Intercepting tool execution via C++ static constructors causes the clang tools (e.g., codesearch) to run before the Go runtime is fully initialized. This early execution leads to unpredictable initialization races when interacting with complex libraries like LLVM.

Fix this by moving execution into an auto-intercepting Go registry. Tools now register themselves via `clangtool.Register` in a CGO `init()` function, which immediately executes the tool via `extern "C"` if requested. This guarantees the Go runtime has booted safely.

If a requested tool is not compiled in, the process falls back and panics cleanly during `tool.Init()`.
