### PR TITLE
pkg/instance: disable repeat for coverage collection

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -475,6 +475,12 @@ func (inst *inst) csourceOptions() (csource.Options, error) {
 	// Combine repro options and default options in a way that increases chances to reproduce the crash.
 	// We always enable threaded/collide as it should be [almost] strictly better.
 	opts.Repeat, opts.Threaded = true, true
+	if inst.collectCoverage {
+		opts.Repeat = false
+		opts.Procs = 1
+		opts.NetReset = false
+		opts.RepeatTimes = 0
+	}
 	return opts, nil
 }
 


### PR DESCRIPTION
Coverage retrieval from the syz-executor is not supported when execution repeat is enabled. Disable the repeat option in reproducer options if coverage collection is explicitly requested to allow coverage extraction in agentic workflows.