### PR TITLE
syz-ci: query manager namespace from dashboard

### DIFF
--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -86,6 +86,7 @@ type Manager struct {
 	cfg            *Config
 	repo           vcs.Repo
 	mgrcfg         *ManagerConfig
+	namespace      string
 	managercfg     *mgrconfig.Config
 	cmd            *ManagerCmd
 	dash           ManagerDashapi
@@ -101,6 +102,7 @@ type ManagerDashapi interface {
 	ReportBuildError(req *dashapi.BuildErrorReq) error
 	UploadBuild(build *dashapi.Build) error
 	BuilderPoll(manager string) (*dashapi.BuilderPollResp, error)
+	ClientInfo() (*dashapi.ClientInfoResp, error)
 	LogError(name, msg string, args ...any)
 	CommitPoll() (*dashapi.CommitPollResp, error)
 	UploadCommits(commits []dashapi.Commit) error
@@ -954,7 +956,27 @@ func (mgr *Manager) uploadCoverJSONLToGCS(ctx context.Context, gcsClient gcs.Cli
 	return eg.Wait()
 }
 
+func (mgr *Manager) getNamespace() (string, error) {
+	if mgr.namespace != "" {
+		return mgr.namespace, nil
+	}
+	if mgr.dash == nil {
+		return "", nil
+	}
+	log.Logf(0, "%s: requesting namespace from dashboard...", mgr.name)
+	info, err := mgr.dash.ClientInfo()
+	if err != nil {
+		return "", fmt.Errorf("failed to get namespace from dashboard: %w", err)
+	}
+	mgr.namespace = info.Namespace
+	return mgr.namespace, nil
+}
+
 func (mgr *Manager) uploadCoverStat(ctx context.Context, fuzzingMinutes int) error {
+	ns, err := mgr.getNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get namespace: %w", err)
+	}
 	// Coverage report generation consumes and caches lots of memory.
 	// In the syz-ci context report generation won't be used after this point,
 	// so tell manager to flush report generator.
@@ -975,6 +997,7 @@ func (mgr *Manager) uploadCoverStat(ctx context.Context, fuzzingMinutes int) err
 			if err := cover.WriteCIJSONLine(w, covInfo, cover.CIDetails{
 				Version:        1,
 				Timestamp:      curTime.Format(time.RFC3339Nano),
+				Namespace:      ns,
 				FuzzingMinutes: fuzzingMinutes,
 				Arch:           mgr.lastBuild.Arch,
 				BuildID:        mgr.lastBuild.ID,

--- a/syz-ci/manager_test.go
+++ b/syz-ci/manager_test.go
@@ -34,6 +34,11 @@ func (dm *dashapiMock) BuilderPoll(manager string) (*dashapi.BuilderPollResp, er
 	return args.Get(0).(*dashapi.BuilderPollResp), args.Error(1)
 }
 
+func (dm *dashapiMock) ClientInfo() (*dashapi.ClientInfoResp, error) {
+	args := dm.Called()
+	return args.Get(0).(*dashapi.ClientInfoResp), args.Error(1)
+}
+
 // We don't care about the methods below for now.
 func (dm *dashapiMock) ReportBuildError(req *dashapi.BuildErrorReq) error { return nil }
 func (dm *dashapiMock) UploadBuild(build *dashapi.Build) error            { return nil }
@@ -251,4 +256,19 @@ func (m *mockWriteCloser) Write(p []byte) (n int, err error) {
 func (m *mockWriteCloser) Close() error {
 	m.closedTimes++
 	return nil
+}
+
+func TestGetNamespace(t *testing.T) {
+	mockDash := new(dashapiMock)
+	mgr := Manager{
+		name: "test-manager",
+		dash: mockDash,
+	}
+
+	mockDash.On("ClientInfo").Return(&dashapi.ClientInfoResp{Namespace: "dash-namespace"}, nil).Once()
+	ns, err := mgr.getNamespace()
+	assert.NoError(t, err)
+	assert.Equal(t, "dash-namespace", ns)
+
+	mockDash.AssertExpectations(t)
 }


### PR DESCRIPTION
Update syz-ci to retrieve the namespace for coverage uploads dynamically:
- Add namespace field to Manager struct and getNamespace() helper.
- In getNamespace(), query the new dashboard ClientInfo API to resolve the
  namespace.
- In uploadCoverStat, use the resolved namespace when writing raw coverage JSONL.
- Mock ClientInfo in tests and add TestGetNamespace.