### PR TITLE
pkg/aflow/action/crash: add tests for patch formatting

### DIFF
--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"time"
@@ -141,21 +140,29 @@ func currentDiff(repo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	formatDiff, err := findClangFormatDiff()
+	err = applyClangFormatDiff(repo, diff)
 	if err != nil {
 		return "", err
-	}
-	cmd := exec.Command(formatDiff, "-p1", "-i", "-style=file")
-	cmd.Stdin = bytes.NewReader(diff)
-	cmd.Dir = repo
-	if output, err := osutil.Run(10*time.Minute, cmd); err != nil {
-		return "", fmt.Errorf("%w\n%s", err, output)
 	}
 	diff, err = osutil.RunCmd(time.Minute, repo, "git", "diff")
 	if err != nil {
 		return "", err
 	}
 	return string(diff), nil
+}
+
+func applyClangFormatDiff(repo string, diff []byte) error {
+	formatDiff, err := findClangFormatDiff()
+	if err != nil {
+		return err
+	}
+	cmd := osutil.Command(formatDiff, "-p1", "-i", "-style=file")
+	cmd.Stdin = bytes.NewReader(diff)
+	cmd.Dir = repo
+	if output, err := osutil.Run(10*time.Minute, cmd); err != nil {
+		return fmt.Errorf("%w\n%s", err, output)
+	}
+	return nil
 }
 
 func undoChanges(repo string) error {

--- a/pkg/aflow/action/crash/test_test.go
+++ b/pkg/aflow/action/crash/test_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClangFormat(t *testing.T) {
+	files, err := filepath.Glob("testdata/clang_format/*")
+	require.NoError(t, err)
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+
+			parts := strings.Split(string(content), "======\n")
+			require.Len(t, parts, 3, "invalid test file format: expected 3 parts")
+
+			base := parts[0]
+			diffBefore := strings.TrimSpace(parts[1])
+			diffAfterExpected := strings.TrimSpace(parts[2])
+
+			repo := vcs.MakeTestRepo(t, t.TempDir())
+			filePath := filepath.Join(repo.Dir, "fuse.c")
+
+			// Write base and commit.
+			err = os.WriteFile(filePath, []byte(base), 0644)
+			require.NoError(t, err)
+			repo.Git("add", "fuse.c")
+			repo.Git("commit", "-m", "base")
+
+			if diffBefore != "" {
+				cmd := osutil.Command("git", "apply", "--unidiff-zero")
+				cmd.Dir = repo.Dir
+				cmd.Stdin = strings.NewReader(diffBefore + "\n")
+				_, err = osutil.Run(time.Minute, cmd)
+				require.NoError(t, err, "git apply failed")
+			}
+
+			diff, err := currentDiff(repo.Dir)
+			require.NoError(t, err)
+
+			// Normalize diff output (git diff adds a trailing newline, test files might not have it)
+			diffStr := strings.TrimSpace(diff)
+
+			require.Equal(t, diffAfterExpected, diffStr, "formatting mismatch")
+		})
+	}
+}

--- a/pkg/aflow/action/crash/testdata/clang_format/1
+++ b/pkg/aflow/action/crash/testdata/clang_format/1
@@ -1,0 +1,23 @@
+struct file_operations fops = {
+	.owner		= THIS_MODULE,
+	.open		= dev_open,
+	.poll		= dev_poll,
+};
+======
+diff --git a/fuse.c b/fuse.c
+index 973890f..1412d28 100644
+--- a/fuse.c
++++ b/fuse.c
+@@ -4,0 +5 @@ struct file_operations fops = {
++	.flush = dev_flush,
+======
+diff --git a/fuse.c b/fuse.c
+index 973890f..248de24 100644
+--- a/fuse.c
++++ b/fuse.c
+@@ -2,4 +2,5 @@ struct file_operations fops = {
+ 	.owner		= THIS_MODULE,
+ 	.open		= dev_open,
+ 	.poll		= dev_poll,
++	.flush		= dev_flush,
+ };

--- a/pkg/aflow/action/crash/testdata/clang_format/2
+++ b/pkg/aflow/action/crash/testdata/clang_format/2
@@ -1,0 +1,26 @@
+void f()
+{
+	if (cond) {
+		if (!vif_is_mld(&sta->sdata) &&
+		    !rcu_access_pointer(sta->sdata->vif))
+			return -EINVAL;
+	}
+}
+======
+diff --git a/fuse.c b/fuse.c
+index 39aff42..13be81f 100644
+--- a/fuse.c
++++ b/fuse.c
+@@ -4,2 +4 @@ void f()
+-		if (!vif_is_mld(&sta->sdata) &&
+-		    !rcu_access_pointer(sta->sdata->vif))
++		if (!vif_is_mld(&sta->sdata) && !rcu_access_pointer(sta->sdata->vif))
+======
+diff --git a/fuse.c b/fuse.c
+index 39aff42..13be81f 100644
+--- a/fuse.c
++++ b/fuse.c
+@@ -4,2 +4 @@ void f()
+-		if (!vif_is_mld(&sta->sdata) &&
+-		    !rcu_access_pointer(sta->sdata->vif))
++		if (!vif_is_mld(&sta->sdata) && !rcu_access_pointer(sta->sdata->vif))


### PR DESCRIPTION
Extract the clang-format-diff.py invocation logic from currentDiff into a dedicated applyClangFormatDiff helper function.

Introduce a table-driven test using the testdata directory to verify formatting behavior against expected git diffs. This helps reproduce and track a bug where clang-format-diff.py unnecessarily re-indents existing, already properly aligned members of a C struct when a single new member is added, resulting in unnecessarily large patches being generated by syzbot.