### PR TITLE
Fix coverage reporting on FreeBSD

### DIFF
--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -774,6 +774,39 @@ private:
 		setup_kcsan_filter(conn_reply.race_frames);
 #endif
 
+		// Execute commands requested by the manager.
+		for (const auto& cmd : conn_reply.commands) {
+			auto result = std::make_unique<rpc::CommandResultRawT>();
+			result->cmd = cmd;
+			const char* cmd_str = nullptr;
+			switch (cmd) {
+			case rpc::Command::ECHO_TEST:
+				cmd_str = "echo test";
+				break;
+			case rpc::Command::KLDSTAT:
+				cmd_str = "kldstat";
+				break;
+			default:
+				break;
+			}
+			if (cmd_str == nullptr) {
+				result->error = "unknown command";
+			} else {
+				FILE* fp = popen(cmd_str, "r");
+				if (fp == nullptr) {
+					result->error = strerror(errno);
+				} else {
+					char buf[4096];
+					size_t n;
+					while ((n = fread(buf, 1, sizeof(buf), fp)) > 0)
+						result->output.insert(result->output.end(), buf, buf + n);
+					if (pclose(fp) != 0)
+						result->error = "command failed";
+				}
+			}
+			info_req.command_results.push_back(std::move(result));
+		}
+
 		conn_.Send(info_req);
 
 		rpc::InfoReplyRawT info_reply;

--- a/pkg/flatrpc/conn_test.go
+++ b/pkg/flatrpc/conn_test.go
@@ -35,6 +35,7 @@ func TestConn(t *testing.T) {
 		RaceFrames: []string{"bar", "baz"},
 		Features:   FeatureCoverage | FeatureLeak,
 		Files:      []string{"file1"},
+		Commands:   []Command{CommandECHO_TEST},
 	}
 	executorMsg := &ExecutorMessage{
 		Msg: &ExecutorMessages{
@@ -130,6 +131,7 @@ func BenchmarkConn(b *testing.B) {
 		RaceFrames: []string{"bar", "baz"},
 		Features:   FeatureCoverage | FeatureLeak,
 		Files:      []string{"file1"},
+		Commands:   []Command{CommandECHO_TEST},
 	}
 
 	serv, err := Listen("127.0.0.1:0")

--- a/pkg/flatrpc/flatrpc.fbs
+++ b/pkg/flatrpc/flatrpc.fbs
@@ -37,6 +37,13 @@ enum Feature : uint64 (bit_flags) {
 	MemoryDump,
 }
 
+// Commands that can be executed on the VM to gather information.
+// The executor maps these to actual command strings.
+enum Command : uint32 {
+	ECHO_TEST,
+	KLDSTAT,
+}
+
 table ConnectHelloRaw {
 	cookie			:uint64;
 }
@@ -64,16 +71,25 @@ table ConnectReplyRaw {
 	features		:Feature;
 	// Fuzzer reads these files inside of the VM and returns contents in InfoRequest.files.
 	files			:[string];
+	// Commands to execute on the VM. Results are returned in InfoRequest.command_results.
+	commands		:[Command];
 }
 
 table InfoRequestRaw {
 	error			:string;
 	features		:[FeatureInfoRaw];
 	files			:[FileInfoRaw];
+	command_results		:[CommandResultRaw];
 }
 
 table InfoReplyRaw {
 	cover_filter		:[uint64];
+}
+
+table CommandResultRaw {
+	cmd			:Command;
+	output			:[uint8];
+	error			:string;
 }
 
 table FileInfoRaw {

--- a/pkg/flatrpc/flatrpc.go
+++ b/pkg/flatrpc/flatrpc.go
@@ -124,6 +124,30 @@ func (v Feature) String() string {
 	return "Feature(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
+type Command uint32
+
+const (
+	CommandECHO_TEST Command = 0
+	CommandKLDSTAT   Command = 1
+)
+
+var EnumNamesCommand = map[Command]string{
+	CommandECHO_TEST: "ECHO_TEST",
+	CommandKLDSTAT:   "KLDSTAT",
+}
+
+var EnumValuesCommand = map[string]Command{
+	"ECHO_TEST": CommandECHO_TEST,
+	"KLDSTAT":   CommandKLDSTAT,
+}
+
+func (v Command) String() string {
+	if s, ok := EnumNamesCommand[v]; ok {
+		return s
+	}
+	return "Command(" + strconv.FormatInt(int64(v), 10) + ")"
+}
+
 type HostMessagesRaw byte
 
 const (
@@ -739,18 +763,19 @@ func ConnectRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 }
 
 type ConnectReplyRawT struct {
-	Debug            bool     `json:"debug"`
-	Cover            bool     `json:"cover"`
-	CoverEdges       bool     `json:"cover_edges"`
-	Kernel64Bit      bool     `json:"kernel_64_bit"`
-	Procs            int32    `json:"procs"`
-	Slowdown         int32    `json:"slowdown"`
-	SyscallTimeoutMs int32    `json:"syscall_timeout_ms"`
-	ProgramTimeoutMs int32    `json:"program_timeout_ms"`
-	LeakFrames       []string `json:"leak_frames"`
-	RaceFrames       []string `json:"race_frames"`
-	Features         Feature  `json:"features"`
-	Files            []string `json:"files"`
+	Debug            bool      `json:"debug"`
+	Cover            bool      `json:"cover"`
+	CoverEdges       bool      `json:"cover_edges"`
+	Kernel64Bit      bool      `json:"kernel_64_bit"`
+	Procs            int32     `json:"procs"`
+	Slowdown         int32     `json:"slowdown"`
+	SyscallTimeoutMs int32     `json:"syscall_timeout_ms"`
+	ProgramTimeoutMs int32     `json:"program_timeout_ms"`
+	LeakFrames       []string  `json:"leak_frames"`
+	RaceFrames       []string  `json:"race_frames"`
+	Features         Feature   `json:"features"`
+	Files            []string  `json:"files"`
+	Commands         []Command `json:"commands"`
 }
 
 func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
@@ -796,6 +821,15 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 		}
 		filesOffset = builder.EndVector(filesLength)
 	}
+	commandsOffset := flatbuffers.UOffsetT(0)
+	if t.Commands != nil {
+		commandsLength := len(t.Commands)
+		ConnectReplyRawStartCommandsVector(builder, commandsLength)
+		for j := commandsLength - 1; j >= 0; j-- {
+			builder.PrependUint32(uint32(t.Commands[j]))
+		}
+		commandsOffset = builder.EndVector(commandsLength)
+	}
 	ConnectReplyRawStart(builder)
 	ConnectReplyRawAddDebug(builder, t.Debug)
 	ConnectReplyRawAddCover(builder, t.Cover)
@@ -809,6 +843,7 @@ func (t *ConnectReplyRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffse
 	ConnectReplyRawAddRaceFrames(builder, raceFramesOffset)
 	ConnectReplyRawAddFeatures(builder, t.Features)
 	ConnectReplyRawAddFiles(builder, filesOffset)
+	ConnectReplyRawAddCommands(builder, commandsOffset)
 	return ConnectReplyRawEnd(builder)
 }
 
@@ -836,6 +871,11 @@ func (rcv *ConnectReplyRaw) UnPackTo(t *ConnectReplyRawT) {
 	t.Files = make([]string, filesLength)
 	for j := 0; j < filesLength; j++ {
 		t.Files[j] = string(rcv.Files(j))
+	}
+	commandsLength := rcv.CommandsLength()
+	t.Commands = make([]Command, commandsLength)
+	for j := 0; j < commandsLength; j++ {
+		t.Commands[j] = rcv.Commands(j)
 	}
 }
 
@@ -1042,8 +1082,34 @@ func (rcv *ConnectReplyRaw) FilesLength() int {
 	return 0
 }
 
+func (rcv *ConnectReplyRaw) Commands(j int) Command {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return Command(rcv._tab.GetUint32(a + flatbuffers.UOffsetT(j*4)))
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) CommandsLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *ConnectReplyRaw) MutateCommands(j int, n Command) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.MutateUint32(a+flatbuffers.UOffsetT(j*4), uint32(n))
+	}
+	return false
+}
+
 func ConnectReplyRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(12)
+	builder.StartObject(13)
 }
 func ConnectReplyRawAddDebug(builder *flatbuffers.Builder, debug bool) {
 	builder.PrependBoolSlot(0, debug, false)
@@ -1090,14 +1156,21 @@ func ConnectReplyRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOf
 func ConnectReplyRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
+func ConnectReplyRawAddCommands(builder *flatbuffers.Builder, commands flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(commands), 0)
+}
+func ConnectReplyRawStartCommandsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
 func ConnectReplyRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
 type InfoRequestRawT struct {
-	Error    string             `json:"error"`
-	Features []*FeatureInfoRawT `json:"features"`
-	Files    []*FileInfoRawT    `json:"files"`
+	Error          string               `json:"error"`
+	Features       []*FeatureInfoRawT   `json:"features"`
+	Files          []*FileInfoRawT      `json:"files"`
+	CommandResults []*CommandResultRawT `json:"command_results"`
 }
 
 func (t *InfoRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
@@ -1134,10 +1207,24 @@ func (t *InfoRequestRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffset
 		}
 		filesOffset = builder.EndVector(filesLength)
 	}
+	commandResultsOffset := flatbuffers.UOffsetT(0)
+	if t.CommandResults != nil {
+		commandResultsLength := len(t.CommandResults)
+		commandResultsOffsets := make([]flatbuffers.UOffsetT, commandResultsLength)
+		for j := 0; j < commandResultsLength; j++ {
+			commandResultsOffsets[j] = t.CommandResults[j].Pack(builder)
+		}
+		InfoRequestRawStartCommandResultsVector(builder, commandResultsLength)
+		for j := commandResultsLength - 1; j >= 0; j-- {
+			builder.PrependUOffsetT(commandResultsOffsets[j])
+		}
+		commandResultsOffset = builder.EndVector(commandResultsLength)
+	}
 	InfoRequestRawStart(builder)
 	InfoRequestRawAddError(builder, errorOffset)
 	InfoRequestRawAddFeatures(builder, featuresOffset)
 	InfoRequestRawAddFiles(builder, filesOffset)
+	InfoRequestRawAddCommandResults(builder, commandResultsOffset)
 	return InfoRequestRawEnd(builder)
 }
 
@@ -1156,6 +1243,13 @@ func (rcv *InfoRequestRaw) UnPackTo(t *InfoRequestRawT) {
 		x := FileInfoRaw{}
 		rcv.Files(&x, j)
 		t.Files[j] = x.UnPack()
+	}
+	commandResultsLength := rcv.CommandResultsLength()
+	t.CommandResults = make([]*CommandResultRawT, commandResultsLength)
+	for j := 0; j < commandResultsLength; j++ {
+		x := CommandResultRaw{}
+		rcv.CommandResults(&x, j)
+		t.CommandResults[j] = x.UnPack()
 	}
 }
 
@@ -1251,8 +1345,28 @@ func (rcv *InfoRequestRaw) FilesLength() int {
 	return 0
 }
 
+func (rcv *InfoRequestRaw) CommandResults(obj *CommandResultRaw, j int) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
+		obj.Init(rcv._tab.Bytes, x)
+		return true
+	}
+	return false
+}
+
+func (rcv *InfoRequestRaw) CommandResultsLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
 func InfoRequestRawStart(builder *flatbuffers.Builder) {
-	builder.StartObject(3)
+	builder.StartObject(4)
 }
 func InfoRequestRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(error), 0)
@@ -1267,6 +1381,12 @@ func InfoRequestRawAddFiles(builder *flatbuffers.Builder, files flatbuffers.UOff
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(files), 0)
 }
 func InfoRequestRawStartFilesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
+func InfoRequestRawAddCommandResults(builder *flatbuffers.Builder, commandResults flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(commandResults), 0)
+}
+func InfoRequestRawStartCommandResultsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func InfoRequestRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
@@ -1383,6 +1503,154 @@ func InfoReplyRawStartCoverFilterVector(builder *flatbuffers.Builder, numElems i
 	return builder.StartVector(8, numElems, 8)
 }
 func InfoReplyRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	return builder.EndObject()
+}
+
+type CommandResultRawT struct {
+	Cmd    Command `json:"cmd"`
+	Output []byte  `json:"output"`
+	Error  string  `json:"error"`
+}
+
+func (t *CommandResultRawT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil {
+		return 0
+	}
+	outputOffset := flatbuffers.UOffsetT(0)
+	if t.Output != nil {
+		outputOffset = builder.CreateByteString(t.Output)
+	}
+	errorOffset := flatbuffers.UOffsetT(0)
+	if t.Error != "" {
+		errorOffset = builder.CreateString(t.Error)
+	}
+	CommandResultRawStart(builder)
+	CommandResultRawAddCmd(builder, t.Cmd)
+	CommandResultRawAddOutput(builder, outputOffset)
+	CommandResultRawAddError(builder, errorOffset)
+	return CommandResultRawEnd(builder)
+}
+
+func (rcv *CommandResultRaw) UnPackTo(t *CommandResultRawT) {
+	t.Cmd = rcv.Cmd()
+	t.Output = rcv.OutputBytes()
+	t.Error = string(rcv.Error())
+}
+
+func (rcv *CommandResultRaw) UnPack() *CommandResultRawT {
+	if rcv == nil {
+		return nil
+	}
+	t := &CommandResultRawT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
+type CommandResultRaw struct {
+	_tab flatbuffers.Table
+}
+
+func GetRootAsCommandResultRaw(buf []byte, offset flatbuffers.UOffsetT) *CommandResultRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset:])
+	x := &CommandResultRaw{}
+	x.Init(buf, n+offset)
+	return x
+}
+
+func FinishCommandResultRawBuffer(builder *flatbuffers.Builder, offset flatbuffers.UOffsetT) {
+	builder.Finish(offset)
+}
+
+func GetSizePrefixedRootAsCommandResultRaw(buf []byte, offset flatbuffers.UOffsetT) *CommandResultRaw {
+	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
+	x := &CommandResultRaw{}
+	x.Init(buf, n+offset+flatbuffers.SizeUint32)
+	return x
+}
+
+func FinishSizePrefixedCommandResultRawBuffer(builder *flatbuffers.Builder, offset flatbuffers.UOffsetT) {
+	builder.FinishSizePrefixed(offset)
+}
+
+func (rcv *CommandResultRaw) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *CommandResultRaw) Table() flatbuffers.Table {
+	return rcv._tab
+}
+
+func (rcv *CommandResultRaw) Cmd() Command {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return Command(rcv._tab.GetUint32(o + rcv._tab.Pos))
+	}
+	return 0
+}
+
+func (rcv *CommandResultRaw) MutateCmd(n Command) bool {
+	return rcv._tab.MutateUint32Slot(4, uint32(n))
+}
+
+func (rcv *CommandResultRaw) Output(j int) byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
+	}
+	return 0
+}
+
+func (rcv *CommandResultRaw) OutputLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *CommandResultRaw) OutputBytes() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *CommandResultRaw) MutateOutput(j int, n byte) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), n)
+	}
+	return false
+}
+
+func (rcv *CommandResultRaw) Error() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func CommandResultRawStart(builder *flatbuffers.Builder) {
+	builder.StartObject(3)
+}
+func CommandResultRawAddCmd(builder *flatbuffers.Builder, cmd Command) {
+	builder.PrependUint32Slot(0, uint32(cmd), 0)
+}
+func CommandResultRawAddOutput(builder *flatbuffers.Builder, output flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(output), 0)
+}
+func CommandResultRawStartOutputVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(1, numElems, 1)
+}
+func CommandResultRawAddError(builder *flatbuffers.Builder, error flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(error), 0)
+}
+func CommandResultRawEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 

--- a/pkg/flatrpc/flatrpc.h
+++ b/pkg/flatrpc/flatrpc.h
@@ -35,6 +35,10 @@ struct InfoReplyRaw;
 struct InfoReplyRawBuilder;
 struct InfoReplyRawT;
 
+struct CommandResultRaw;
+struct CommandResultRawBuilder;
+struct CommandResultRawT;
+
 struct FileInfoRaw;
 struct FileInfoRawBuilder;
 struct FileInfoRawT;
@@ -221,6 +225,36 @@ inline const char *EnumNameFeature(Feature e) {
     case Feature::MemoryDump: return "MemoryDump";
     default: return "";
   }
+}
+
+enum class Command : uint32_t {
+  ECHO_TEST = 0,
+  KLDSTAT = 1,
+  MIN = ECHO_TEST,
+  MAX = KLDSTAT
+};
+
+inline const Command (&EnumValuesCommand())[2] {
+  static const Command values[] = {
+    Command::ECHO_TEST,
+    Command::KLDSTAT
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesCommand() {
+  static const char * const names[3] = {
+    "ECHO_TEST",
+    "KLDSTAT",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameCommand(Command e) {
+  if (::flatbuffers::IsOutRange(e, Command::ECHO_TEST, Command::KLDSTAT)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesCommand()[index];
 }
 
 enum class HostMessagesRaw : uint8_t {
@@ -1043,6 +1077,7 @@ struct ConnectReplyRawT : public ::flatbuffers::NativeTable {
   std::vector<std::string> race_frames{};
   rpc::Feature features = static_cast<rpc::Feature>(0);
   std::vector<std::string> files{};
+  std::vector<rpc::Command> commands{};
 };
 
 struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
@@ -1060,7 +1095,8 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_LEAK_FRAMES = 20,
     VT_RACE_FRAMES = 22,
     VT_FEATURES = 24,
-    VT_FILES = 26
+    VT_FILES = 26,
+    VT_COMMANDS = 28
   };
   bool debug() const {
     return GetField<uint8_t>(VT_DEBUG, 0) != 0;
@@ -1098,6 +1134,9 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *files() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *>(VT_FILES);
   }
+  const ::flatbuffers::Vector<rpc::Command> *commands() const {
+    return GetPointer<const ::flatbuffers::Vector<rpc::Command> *>(VT_COMMANDS);
+  }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_DEBUG, 1) &&
@@ -1118,6 +1157,8 @@ struct ConnectReplyRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
            VerifyOffset(verifier, VT_FILES) &&
            verifier.VerifyVector(files()) &&
            verifier.VerifyVectorOfStrings(files()) &&
+           VerifyOffset(verifier, VT_COMMANDS) &&
+           verifier.VerifyVector(commands()) &&
            verifier.EndTable();
   }
   ConnectReplyRawT *UnPack(const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -1165,6 +1206,9 @@ struct ConnectReplyRawBuilder {
   void add_files(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> files) {
     fbb_.AddOffset(ConnectReplyRaw::VT_FILES, files);
   }
+  void add_commands(::flatbuffers::Offset<::flatbuffers::Vector<rpc::Command>> commands) {
+    fbb_.AddOffset(ConnectReplyRaw::VT_COMMANDS, commands);
+  }
   explicit ConnectReplyRawBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -1189,9 +1233,11 @@ inline ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> leak_frames = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> race_frames = 0,
     rpc::Feature features = static_cast<rpc::Feature>(0),
-    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> files = 0) {
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> files = 0,
+    ::flatbuffers::Offset<::flatbuffers::Vector<rpc::Command>> commands = 0) {
   ConnectReplyRawBuilder builder_(_fbb);
   builder_.add_features(features);
+  builder_.add_commands(commands);
   builder_.add_files(files);
   builder_.add_race_frames(race_frames);
   builder_.add_leak_frames(leak_frames);
@@ -1219,10 +1265,12 @@ inline ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
     const std::vector<::flatbuffers::Offset<::flatbuffers::String>> *leak_frames = nullptr,
     const std::vector<::flatbuffers::Offset<::flatbuffers::String>> *race_frames = nullptr,
     rpc::Feature features = static_cast<rpc::Feature>(0),
-    const std::vector<::flatbuffers::Offset<::flatbuffers::String>> *files = nullptr) {
+    const std::vector<::flatbuffers::Offset<::flatbuffers::String>> *files = nullptr,
+    const std::vector<rpc::Command> *commands = nullptr) {
   auto leak_frames__ = leak_frames ? _fbb.CreateVector<::flatbuffers::Offset<::flatbuffers::String>>(*leak_frames) : 0;
   auto race_frames__ = race_frames ? _fbb.CreateVector<::flatbuffers::Offset<::flatbuffers::String>>(*race_frames) : 0;
   auto files__ = files ? _fbb.CreateVector<::flatbuffers::Offset<::flatbuffers::String>>(*files) : 0;
+  auto commands__ = commands ? _fbb.CreateVector<rpc::Command>(*commands) : 0;
   return rpc::CreateConnectReplyRaw(
       _fbb,
       debug,
@@ -1236,7 +1284,8 @@ inline ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRawDirect(
       leak_frames__,
       race_frames__,
       features,
-      files__);
+      files__,
+      commands__);
 }
 
 ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(::flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1246,6 +1295,7 @@ struct InfoRequestRawT : public ::flatbuffers::NativeTable {
   std::string error{};
   std::vector<std::unique_ptr<rpc::FeatureInfoRawT>> features{};
   std::vector<std::unique_ptr<rpc::FileInfoRawT>> files{};
+  std::vector<std::unique_ptr<rpc::CommandResultRawT>> command_results{};
   InfoRequestRawT() = default;
   InfoRequestRawT(const InfoRequestRawT &o);
   InfoRequestRawT(InfoRequestRawT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -1258,7 +1308,8 @@ struct InfoRequestRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4,
     VT_FEATURES = 6,
-    VT_FILES = 8
+    VT_FILES = 8,
+    VT_COMMAND_RESULTS = 10
   };
   const ::flatbuffers::String *error() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ERROR);
@@ -1268,6 +1319,9 @@ struct InfoRequestRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   const ::flatbuffers::Vector<::flatbuffers::Offset<rpc::FileInfoRaw>> *files() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<rpc::FileInfoRaw>> *>(VT_FILES);
+  }
+  const ::flatbuffers::Vector<::flatbuffers::Offset<rpc::CommandResultRaw>> *command_results() const {
+    return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<rpc::CommandResultRaw>> *>(VT_COMMAND_RESULTS);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1279,6 +1333,9 @@ struct InfoRequestRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
            VerifyOffset(verifier, VT_FILES) &&
            verifier.VerifyVector(files()) &&
            verifier.VerifyVectorOfTables(files()) &&
+           VerifyOffset(verifier, VT_COMMAND_RESULTS) &&
+           verifier.VerifyVector(command_results()) &&
+           verifier.VerifyVectorOfTables(command_results()) &&
            verifier.EndTable();
   }
   InfoRequestRawT *UnPack(const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -1299,6 +1356,9 @@ struct InfoRequestRawBuilder {
   void add_files(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::FileInfoRaw>>> files) {
     fbb_.AddOffset(InfoRequestRaw::VT_FILES, files);
   }
+  void add_command_results(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::CommandResultRaw>>> command_results) {
+    fbb_.AddOffset(InfoRequestRaw::VT_COMMAND_RESULTS, command_results);
+  }
   explicit InfoRequestRawBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -1314,8 +1374,10 @@ inline ::flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> error = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::FeatureInfoRaw>>> features = 0,
-    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::FileInfoRaw>>> files = 0) {
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::FileInfoRaw>>> files = 0,
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<rpc::CommandResultRaw>>> command_results = 0) {
   InfoRequestRawBuilder builder_(_fbb);
+  builder_.add_command_results(command_results);
   builder_.add_files(files);
   builder_.add_features(features);
   builder_.add_error(error);
@@ -1326,15 +1388,18 @@ inline ::flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRawDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *error = nullptr,
     const std::vector<::flatbuffers::Offset<rpc::FeatureInfoRaw>> *features = nullptr,
-    const std::vector<::flatbuffers::Offset<rpc::FileInfoRaw>> *files = nullptr) {
+    const std::vector<::flatbuffers::Offset<rpc::FileInfoRaw>> *files = nullptr,
+    const std::vector<::flatbuffers::Offset<rpc::CommandResultRaw>> *command_results = nullptr) {
   auto error__ = error ? _fbb.CreateString(error) : 0;
   auto features__ = features ? _fbb.CreateVector<::flatbuffers::Offset<rpc::FeatureInfoRaw>>(*features) : 0;
   auto files__ = files ? _fbb.CreateVector<::flatbuffers::Offset<rpc::FileInfoRaw>>(*files) : 0;
+  auto command_results__ = command_results ? _fbb.CreateVector<::flatbuffers::Offset<rpc::CommandResultRaw>>(*command_results) : 0;
   return rpc::CreateInfoRequestRaw(
       _fbb,
       error__,
       features__,
-      files__);
+      files__,
+      command_results__);
 }
 
 ::flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(::flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1400,6 +1465,96 @@ inline ::flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRawDirect(
 }
 
 ::flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRaw(::flatbuffers::FlatBufferBuilder &_fbb, const InfoReplyRawT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+struct CommandResultRawT : public ::flatbuffers::NativeTable {
+  typedef CommandResultRaw TableType;
+  rpc::Command cmd = rpc::Command::ECHO_TEST;
+  std::vector<uint8_t> output{};
+  std::string error{};
+};
+
+struct CommandResultRaw FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef CommandResultRawT NativeTableType;
+  typedef CommandResultRawBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_CMD = 4,
+    VT_OUTPUT = 6,
+    VT_ERROR = 8
+  };
+  rpc::Command cmd() const {
+    return static_cast<rpc::Command>(GetField<uint32_t>(VT_CMD, 0));
+  }
+  const ::flatbuffers::Vector<uint8_t> *output() const {
+    return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_OUTPUT);
+  }
+  const ::flatbuffers::String *error() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_ERROR);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint32_t>(verifier, VT_CMD, 4) &&
+           VerifyOffset(verifier, VT_OUTPUT) &&
+           verifier.VerifyVector(output()) &&
+           VerifyOffset(verifier, VT_ERROR) &&
+           verifier.VerifyString(error()) &&
+           verifier.EndTable();
+  }
+  CommandResultRawT *UnPack(const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(CommandResultRawT *_o, const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static ::flatbuffers::Offset<CommandResultRaw> Pack(::flatbuffers::FlatBufferBuilder &_fbb, const CommandResultRawT* _o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct CommandResultRawBuilder {
+  typedef CommandResultRaw Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_cmd(rpc::Command cmd) {
+    fbb_.AddElement<uint32_t>(CommandResultRaw::VT_CMD, static_cast<uint32_t>(cmd), 0);
+  }
+  void add_output(::flatbuffers::Offset<::flatbuffers::Vector<uint8_t>> output) {
+    fbb_.AddOffset(CommandResultRaw::VT_OUTPUT, output);
+  }
+  void add_error(::flatbuffers::Offset<::flatbuffers::String> error) {
+    fbb_.AddOffset(CommandResultRaw::VT_ERROR, error);
+  }
+  explicit CommandResultRawBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<CommandResultRaw> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<CommandResultRaw>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<CommandResultRaw> CreateCommandResultRaw(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    rpc::Command cmd = rpc::Command::ECHO_TEST,
+    ::flatbuffers::Offset<::flatbuffers::Vector<uint8_t>> output = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> error = 0) {
+  CommandResultRawBuilder builder_(_fbb);
+  builder_.add_error(error);
+  builder_.add_output(output);
+  builder_.add_cmd(cmd);
+  return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<CommandResultRaw> CreateCommandResultRawDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    rpc::Command cmd = rpc::Command::ECHO_TEST,
+    const std::vector<uint8_t> *output = nullptr,
+    const char *error = nullptr) {
+  auto output__ = output ? _fbb.CreateVector<uint8_t>(*output) : 0;
+  auto error__ = error ? _fbb.CreateString(error) : 0;
+  return rpc::CreateCommandResultRaw(
+      _fbb,
+      cmd,
+      output__,
+      error__);
+}
+
+::flatbuffers::Offset<CommandResultRaw> CreateCommandResultRaw(::flatbuffers::FlatBufferBuilder &_fbb, const CommandResultRawT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 struct FileInfoRawT : public ::flatbuffers::NativeTable {
   typedef FileInfoRaw TableType;
@@ -3059,6 +3214,7 @@ inline void ConnectReplyRaw::UnPackTo(ConnectReplyRawT *_o, const ::flatbuffers:
   { auto _e = race_frames(); if (_e) { _o->race_frames.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->race_frames[_i] = _e->Get(_i)->str(); } } else { _o->race_frames.resize(0); } }
   { auto _e = features(); _o->features = _e; }
   { auto _e = files(); if (_e) { _o->files.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->files[_i] = _e->Get(_i)->str(); } } else { _o->files.resize(0); } }
+  { auto _e = commands(); if (_e) { _o->commands.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->commands[_i] = static_cast<rpc::Command>(_e->Get(_i)); } } else { _o->commands.resize(0); } }
 }
 
 inline ::flatbuffers::Offset<ConnectReplyRaw> ConnectReplyRaw::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const ConnectReplyRawT* _o, const ::flatbuffers::rehasher_function_t *_rehasher) {
@@ -3081,6 +3237,7 @@ inline ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(::flatbuffer
   auto _race_frames = _o->race_frames.size() ? _fbb.CreateVectorOfStrings(_o->race_frames) : 0;
   auto _features = _o->features;
   auto _files = _o->files.size() ? _fbb.CreateVectorOfStrings(_o->files) : 0;
+  auto _commands = _o->commands.size() ? _fbb.CreateVector(_o->commands) : 0;
   return rpc::CreateConnectReplyRaw(
       _fbb,
       _debug,
@@ -3094,7 +3251,8 @@ inline ::flatbuffers::Offset<ConnectReplyRaw> CreateConnectReplyRaw(::flatbuffer
       _leak_frames,
       _race_frames,
       _features,
-      _files);
+      _files,
+      _commands);
 }
 
 inline InfoRequestRawT::InfoRequestRawT(const InfoRequestRawT &o)
@@ -3103,12 +3261,15 @@ inline InfoRequestRawT::InfoRequestRawT(const InfoRequestRawT &o)
   for (const auto &features_ : o.features) { features.emplace_back((features_) ? new rpc::FeatureInfoRawT(*features_) : nullptr); }
   files.reserve(o.files.size());
   for (const auto &files_ : o.files) { files.emplace_back((files_) ? new rpc::FileInfoRawT(*files_) : nullptr); }
+  command_results.reserve(o.command_results.size());
+  for (const auto &command_results_ : o.command_results) { command_results.emplace_back((command_results_) ? new rpc::CommandResultRawT(*command_results_) : nullptr); }
 }
 
 inline InfoRequestRawT &InfoRequestRawT::operator=(InfoRequestRawT o) FLATBUFFERS_NOEXCEPT {
   std::swap(error, o.error);
   std::swap(features, o.features);
   std::swap(files, o.files);
+  std::swap(command_results, o.command_results);
   return *this;
 }
 
@@ -3124,6 +3285,7 @@ inline void InfoRequestRaw::UnPackTo(InfoRequestRawT *_o, const ::flatbuffers::r
   { auto _e = error(); if (_e) _o->error = _e->str(); }
   { auto _e = features(); if (_e) { _o->features.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->features[_i]) { _e->Get(_i)->UnPackTo(_o->features[_i].get(), _resolver); } else { _o->features[_i] = std::unique_ptr<rpc::FeatureInfoRawT>(_e->Get(_i)->UnPack(_resolver)); }; } } else { _o->features.resize(0); } }
   { auto _e = files(); if (_e) { _o->files.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->files[_i]) { _e->Get(_i)->UnPackTo(_o->files[_i].get(), _resolver); } else { _o->files[_i] = std::unique_ptr<rpc::FileInfoRawT>(_e->Get(_i)->UnPack(_resolver)); }; } } else { _o->files.resize(0); } }
+  { auto _e = command_results(); if (_e) { _o->command_results.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->command_results[_i]) { _e->Get(_i)->UnPackTo(_o->command_results[_i].get(), _resolver); } else { _o->command_results[_i] = std::unique_ptr<rpc::CommandResultRawT>(_e->Get(_i)->UnPack(_resolver)); }; } } else { _o->command_results.resize(0); } }
 }
 
 inline ::flatbuffers::Offset<InfoRequestRaw> InfoRequestRaw::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const InfoRequestRawT* _o, const ::flatbuffers::rehasher_function_t *_rehasher) {
@@ -3137,11 +3299,13 @@ inline ::flatbuffers::Offset<InfoRequestRaw> CreateInfoRequestRaw(::flatbuffers:
   auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
   auto _features = _o->features.size() ? _fbb.CreateVector<::flatbuffers::Offset<rpc::FeatureInfoRaw>> (_o->features.size(), [](size_t i, _VectorArgs *__va) { return CreateFeatureInfoRaw(*__va->__fbb, __va->__o->features[i].get(), __va->__rehasher); }, &_va ) : 0;
   auto _files = _o->files.size() ? _fbb.CreateVector<::flatbuffers::Offset<rpc::FileInfoRaw>> (_o->files.size(), [](size_t i, _VectorArgs *__va) { return CreateFileInfoRaw(*__va->__fbb, __va->__o->files[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _command_results = _o->command_results.size() ? _fbb.CreateVector<::flatbuffers::Offset<rpc::CommandResultRaw>> (_o->command_results.size(), [](size_t i, _VectorArgs *__va) { return CreateCommandResultRaw(*__va->__fbb, __va->__o->command_results[i].get(), __va->__rehasher); }, &_va ) : 0;
   return rpc::CreateInfoRequestRaw(
       _fbb,
       _error,
       _features,
-      _files);
+      _files,
+      _command_results);
 }
 
 inline InfoReplyRawT *InfoReplyRaw::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {
@@ -3168,6 +3332,38 @@ inline ::flatbuffers::Offset<InfoReplyRaw> CreateInfoReplyRaw(::flatbuffers::Fla
   return rpc::CreateInfoReplyRaw(
       _fbb,
       _cover_filter);
+}
+
+inline CommandResultRawT *CommandResultRaw::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::unique_ptr<CommandResultRawT>(new CommandResultRawT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void CommandResultRaw::UnPackTo(CommandResultRawT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = cmd(); _o->cmd = _e; }
+  { auto _e = output(); if (_e) { _o->output.resize(_e->size()); std::copy(_e->begin(), _e->end(), _o->output.begin()); } }
+  { auto _e = error(); if (_e) _o->error = _e->str(); }
+}
+
+inline ::flatbuffers::Offset<CommandResultRaw> CommandResultRaw::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const CommandResultRawT* _o, const ::flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateCommandResultRaw(_fbb, _o, _rehasher);
+}
+
+inline ::flatbuffers::Offset<CommandResultRaw> CreateCommandResultRaw(::flatbuffers::FlatBufferBuilder &_fbb, const CommandResultRawT *_o, const ::flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const CommandResultRawT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _cmd = _o->cmd;
+  auto _output = _o->output.size() ? _fbb.CreateVector(_o->output) : 0;
+  auto _error = _o->error.empty() ? 0 : _fbb.CreateString(_o->error);
+  return rpc::CreateCommandResultRaw(
+      _fbb,
+      _cmd,
+      _output,
+      _error);
 }
 
 inline FileInfoRawT *FileInfoRaw::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -358,6 +358,7 @@ func (serv *server) handleRunnerConn(ctx context.Context, runner *Runner, conn *
 	opts := &handshakeConfig{
 		VMLess:   serv.cfg.VMLess,
 		Files:    serv.checker.RequiredFiles(),
+		Commands: serv.checker.RequiredCommands(),
 		Timeouts: serv.timeouts,
 		Callback: serv.handleMachineInfo,
 	}
@@ -389,7 +390,13 @@ func (serv *server) handleRunnerConn(ctx context.Context, runner *Runner, conn *
 }
 
 func (serv *server) handleMachineInfo(infoReq *flatrpc.InfoRequestRawT) (handshakeResult, error) {
-	modules, machineInfo, err := serv.checker.MachineInfo(infoReq.Files)
+	cmdResults := make(map[flatrpc.Command][]byte)
+	for _, r := range infoReq.CommandResults {
+		if r != nil && r.Error == "" {
+			cmdResults[r.Cmd] = r.Output
+		}
+	}
+	modules, machineInfo, err := serv.checker.MachineInfo(infoReq.Files, cmdResults)
 	if err != nil {
 		log.Logf(0, "parsing of machine info failed: %v", err)
 		if infoReq.Error == "" {

--- a/pkg/rpcserver/runner.go
+++ b/pkg/rpcserver/runner.go
@@ -72,6 +72,8 @@ type handshakeConfig struct {
 	Files      []string
 	Features   flatrpc.Feature
 
+	Commands []flatrpc.Command
+
 	// Callback() is called in the middle of the handshake process.
 	// The return arguments are the coverage filter and the (possible) error.
 	Callback func(*flatrpc.InfoRequestRawT) (handshakeResult, error)
@@ -105,6 +107,7 @@ func (runner *Runner) Handshake(conn *flatrpc.Conn, cfg *handshakeConfig) (hands
 		RaceFrames:       cfg.RaceFrames,
 		Files:            cfg.Files,
 		Features:         cfg.Features,
+		Commands:         cfg.Commands,
 	}
 	if err := flatrpc.Send(conn, connectReply); err != nil {
 		return handshakeResult{}, err

--- a/pkg/vminfo/freebsd.go
+++ b/pkg/vminfo/freebsd.go
@@ -1,0 +1,60 @@
+// Copyright 2024 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package vminfo
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/flatrpc"
+)
+
+var kldstatRe = regexp.MustCompile(`\s*\d+\s+\d+\s+(0x[0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(\S+)`)
+
+type freebsd struct {
+	nopChecker
+}
+
+func (freebsd) RequiredCommands() []flatrpc.Command {
+	return []flatrpc.Command{flatrpc.CommandKLDSTAT}
+}
+
+func (freebsd) parseModules(files filesystem, cmdResults map[flatrpc.Command][]byte) ([]*KernelModule, error) {
+	data := cmdResults[flatrpc.CommandKLDSTAT]
+	if len(data) == 0 {
+		return nil, nil
+	}
+	// Parse kldstat output, e.g.:
+	// Id Refs Address                Size Name
+	//  1    6 0xffffffff80200000  2603a68 kernel
+	//  2    1 0xffffffff82804000    3baa8 zfs.ko
+	var modules []*KernelModule
+	for _, match := range kldstatRe.FindAllSubmatch(data, -1) {
+		addr, err := strconv.ParseUint(string(match[1]), 0, 64)
+		if err != nil {
+			return nil, fmt.Errorf("module address parsing error: %w", err)
+		}
+		size, err := strconv.ParseUint(string(match[2]), 16, 64)
+		if err != nil {
+			return nil, fmt.Errorf("module size parsing error: %w", err)
+		}
+		name := string(match[3])
+		name = strings.TrimSuffix(name, ".ko")
+		// The "kernel" entry is the base kernel.
+		if name == "kernel" {
+			name = ""
+		}
+		modules = append(modules, &KernelModule{
+			Name: name,
+			Addr: addr,
+			Size: size,
+		})
+	}
+	if modules == nil {
+		return nil, fmt.Errorf("failed to parse kldstat output: %q", data)
+	}
+	return modules, nil
+}

--- a/pkg/vminfo/linux.go
+++ b/pkg/vminfo/linux.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/sys/targets"
 )
 
@@ -47,7 +48,11 @@ func (linux) machineInfos() []machineInfoFunc {
 	}
 }
 
-func (linux linux) parseModules(files filesystem) ([]*KernelModule, error) {
+func (linux) RequiredCommands() []flatrpc.Command {
+	return nil
+}
+
+func (linux linux) parseModules(files filesystem, cmdResults map[flatrpc.Command][]byte) ([]*KernelModule, error) {
 	if linux.vmType == targets.GVisor || linux.vmType == targets.Starnix {
 		return nil, nil
 	}

--- a/pkg/vminfo/vminfo.go
+++ b/pkg/vminfo/vminfo.go
@@ -65,6 +65,8 @@ func New(cfg *Config) *Checker {
 		impl = new(netbsd)
 	case targets.OpenBSD:
 		impl = new(openbsd)
+	case targets.FreeBSD:
+		impl = new(freebsd)
 	default:
 		impl = new(nopChecker)
 	}
@@ -77,9 +79,10 @@ func New(cfg *Config) *Checker {
 	}
 }
 
-func (checker *Checker) MachineInfo(fileInfos []*flatrpc.FileInfo) ([]*KernelModule, []byte, error) {
+func (checker *Checker) MachineInfo(fileInfos []*flatrpc.FileInfo, cmdResults map[flatrpc.Command][]byte) (
+	[]*KernelModule, []byte, error) {
 	files := createVirtualFilesystem(fileInfos)
-	modules, err := checker.parseModules(files)
+	modules, err := checker.parseModules(files, cmdResults)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +129,8 @@ type machineInfoFunc func(files filesystem, w io.Writer) (string, error)
 type checker interface {
 	RequiredFiles() []string
 	CheckFiles() []string
-	parseModules(files filesystem) ([]*KernelModule, error)
+	RequiredCommands() []flatrpc.Command
+	parseModules(files filesystem, cmdResults map[flatrpc.Command][]byte) ([]*KernelModule, error)
 	machineInfos() []machineInfoFunc
 	syscallCheck(*checkContext, *prog.Syscall) string
 }
@@ -184,7 +188,11 @@ func (nopChecker) CheckFiles() []string {
 	return nil
 }
 
-func (nopChecker) parseModules(files filesystem) ([]*KernelModule, error) {
+func (nopChecker) RequiredCommands() []flatrpc.Command {
+	return nil
+}
+
+func (nopChecker) parseModules(files filesystem, cmdResults map[flatrpc.Command][]byte) ([]*KernelModule, error) {
 	return nil, nil
 }
 

--- a/pkg/vminfo/vminfo_test.go
+++ b/pkg/vminfo/vminfo_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/sys"
 	"github.com/google/syzkaller/sys/targets"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostMachineInfo(t *testing.T) {
@@ -35,7 +36,7 @@ func TestHostMachineInfo(t *testing.T) {
 			t.Logf("failed to read %q: %s", file.Name, file.Error)
 		}
 	}
-	modules, info, err := checker.MachineInfo(files)
+	modules, info, err := checker.MachineInfo(files, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,6 +44,39 @@ func TestHostMachineInfo(t *testing.T) {
 	for _, module := range modules {
 		t.Logf("module %q: addr 0x%x size %v", module.Name, module.Addr, module.Size)
 	}
+}
+
+func TestFreeBSDParseModules(t *testing.T) {
+	kldstatOutput := []byte(`Id Refs Address                Size Name
+ 1   97 0xffffffff80200000  25166b0 kernel
+ 2    1 0xffffffff82717000   673a88 zfs.ko
+ 3    1 0xffffffff82d8c000   3835e8 vmm.ko
+ 4    1 0xffffffff83a20000     36f8 fdescfs.ko
+ 5    1 0xffffffff83a24000     3160 amdtemp.ko
+`)
+	f := freebsd{}
+	cmdResults := map[flatrpc.Command][]byte{
+		flatrpc.CommandKLDSTAT: kldstatOutput,
+	}
+	modules, err := f.parseModules(nil, cmdResults)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []*KernelModule{
+		{Name: "", Addr: 0xffffffff80200000, Size: 0x25166b0},
+		{Name: "zfs", Addr: 0xffffffff82717000, Size: 0x673a88},
+		{Name: "vmm", Addr: 0xffffffff82d8c000, Size: 0x3835e8},
+		{Name: "fdescfs", Addr: 0xffffffff83a20000, Size: 0x36f8},
+		{Name: "amdtemp", Addr: 0xffffffff83a24000, Size: 0x3160},
+	}
+	require.Equal(t, expected, modules)
+}
+
+func TestFreeBSDParseModulesEmpty(t *testing.T) {
+	f := freebsd{}
+	modules, err := f.parseModules(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, modules)
 }
 
 func TestSyscalls(t *testing.T) {


### PR DESCRIPTION
Useful coverage reports depend on the ability to build a memory map for the kernel and its loaded kernel modules. With Linux this is done by reading a /proc file in the target VM. On FreeBSD there is no file which yields this info, one must either invoke some system calls to get that info, or run `kldstat`.

After experimenting with some different approaches, it seemed cleanest to provide a way to remotely execute commands in the guest during the executor handshake; then on FreeBSD we can just run `kldstat` and use the output to implement parseModules().