### PR TITLE
pkg/lore-relay: handle default Google Workspace DKIM signatures

### DIFF
--- a/pkg/lore-relay/relay.go
+++ b/pkg/lore-relay/relay.go
@@ -94,11 +94,25 @@ func (r *Relay) checkDKIM(raw []byte, author string) error {
 		return errors.New("no DKIM signatures found")
 	}
 	for _, v := range verifications {
-		if v.Err == nil && strings.ToLower(v.Domain) == authorDomain {
+		if v.Err == nil && matchDKIMDomain(v.Domain, authorDomain) {
 			return nil
 		}
 	}
 	return errors.New("all DKIM signatures failed or mismatched domain")
+}
+
+func matchDKIMDomain(dkimDomain, authorDomain string) bool {
+	dkimDomain = strings.ToLower(dkimDomain)
+	authorDomain = strings.ToLower(authorDomain)
+	if dkimDomain == authorDomain {
+		return true
+	}
+	// Google Workspace default DKIM signature.
+	// We trust Google Workspace's internal sender verification.
+	if strings.HasSuffix(dkimDomain, ".gappssmtp.com") {
+		return true
+	}
+	return false
 }
 
 // Run starts the relay loop.

--- a/pkg/lore-relay/relay_test.go
+++ b/pkg/lore-relay/relay_test.go
@@ -17,6 +17,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMatchDKIMDomain(t *testing.T) {
+	tests := []struct {
+		dkimDomain   string
+		authorDomain string
+		match        bool
+	}{
+		{"example.com", "example.com", true},
+		{"EXAMPLE.COM", "example.com", true},
+		{"example.com", "EXAMPLE.COM", true},
+		{"example-com.20251104.gappssmtp.com", "example.com", true},
+		{"other.com", "example.com", false},
+		{"example-com.20251104.gappssmtp.com", "other.com", true},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("%s_%s", test.dkimDomain, test.authorDomain)
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.match, matchDKIMDomain(test.dkimDomain, test.authorDomain))
+		})
+	}
+}
+
 type mockSender struct {
 	sent []*sender.Email
 	id   int


### PR DESCRIPTION
Google Workspace uses a default gappssmtp.com DKIM signature when a
custom key isn't set, formatting the domain as
<domain-with-hyphens>.<date>.gappssmtp.com.

Update the DKIM verification logic to allow these signatures by trusting
Google Workspace's internal sender verification, which prevents users
from sending emails with unverified From addresses. This prevents valid
emails from being rejected.