### PR TITLE
pkg/aflow/flow/repro: validate generated syzkaller programs

### DIFF
--- a/pkg/aflow/action/actionsyzlang/format.go
+++ b/pkg/aflow/action/actionsyzlang/format.go
@@ -28,7 +28,7 @@ func formatActionFunc(ctx *aflow.Context, args FormatArgs) (FormatResult, error)
 	if err != nil {
 		return FormatResult{}, err
 	}
-	p, err := pt.Deserialize([]byte(args.CandidateReproSyz), prog.Strict)
+	p, err := pt.Deserialize([]byte(args.CandidateReproSyz), prog.NonStrict)
 	if err != nil {
 		return FormatResult{}, fmt.Errorf("failed to deserialize syzkaller program: %w", err)
 	}

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -54,12 +54,9 @@ func init() {
 				kernel.Build,
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
-					Name:  "crash-repro-finder",
-					Model: aflow.BestExpensiveModel,
-					Outputs: aflow.LLMOutputs[struct {
-						ReproOpts         string `jsonschema:"The repro configuration options."`
-						CandidateReproSyz string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
-					}](),
+					Name:    "crash-repro-finder",
+					Model:   aflow.BestExpensiveModel,
+					Outputs: aflow.ValidatedLLMOutputs[ReproFinderResult, ReproFinderState](validateReproFinderOutputs),
 					Tools: aflow.Tools(
 						common.CodeAccessTools,
 						syzlang.ReadDescription,
@@ -85,6 +82,32 @@ func init() {
 			),
 		},
 	)
+}
+
+type ReproFinderResult struct {
+	ReproOpts         string `jsonschema:"The repro configuration options."`
+	CandidateReproSyz string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
+}
+
+type ReproFinderState struct {
+	TargetOS   string
+	TargetArch string
+}
+
+func validateReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
+	res ReproFinderResult) (ReproFinderResult, error) {
+	pt, err := prog.GetTarget(state.TargetOS, state.TargetArch)
+	if err != nil {
+		return res, err
+	}
+	p, err := pt.Deserialize([]byte(res.CandidateReproSyz), prog.NonStrict)
+	if err != nil {
+		return res, aflow.BadCallError("failed to deserialize syzkaller program: %v", err)
+	}
+	if len(p.Calls) == 0 {
+		return res, aflow.BadCallError("the generated syzkaller program is empty (contains 0 system calls)")
+	}
+	return res, nil
 }
 
 const reproInstruction = `

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/syzkaller/docs"
 	"github.com/google/syzkaller/pkg/aflow"
-	"github.com/google/syzkaller/pkg/aflow/action/actionsyzlang"
 	"github.com/google/syzkaller/pkg/aflow/action/crash"
 	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/aflow/ai"
@@ -67,7 +66,6 @@ func init() {
 					Instruction: reproInstruction,
 					Prompt:      reproPrompt,
 				},
-				actionsyzlang.Format,
 				crash.Reproduce,
 				aflow.NewFuncAction("compare", func(ctx *aflow.Context,
 					args struct {
@@ -85,8 +83,8 @@ func init() {
 }
 
 type ReproFinderResult struct {
-	ReproOpts         string `jsonschema:"The repro configuration options."`
-	CandidateReproSyz string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
+	ReproOpts string `jsonschema:"The repro configuration options."`
+	ReproSyz  string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
 }
 
 type ReproFinderState struct {
@@ -100,13 +98,14 @@ func validateReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
 	if err != nil {
 		return res, err
 	}
-	p, err := pt.Deserialize([]byte(res.CandidateReproSyz), prog.NonStrict)
+	p, err := pt.Deserialize([]byte(res.ReproSyz), prog.NonStrict)
 	if err != nil {
 		return res, aflow.BadCallError("failed to deserialize syzkaller program: %v", err)
 	}
 	if len(p.Calls) == 0 {
 		return res, aflow.BadCallError("the generated syzkaller program is empty (contains 0 system calls)")
 	}
+	res.ReproSyz = string(p.Serialize())
 	return res, nil
 }
 


### PR DESCRIPTION
Previously, if the crash-repro-finder agent generated an invalid syzkaller
program, the workflow would fail downstream during the formatting step.
By using ValidatedLLMOutputs and attempting to deserialize the program,
we can catch severe syntax errors early and return a BadCallError. This
allows the LLM to see the error message and retry the generation.