### PR TITLE
pkg/aflow: prefer gemini-3.5-flash over 3-flash-preview

### DIFF
--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -143,7 +143,7 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 	case backend.BestExpensiveModel:
 		return []string{"gemini-3.1-pro-preview"}
 	case backend.GoodBalancedModel:
-		return []string{"gemini-3-flash-preview", "gemini-3.5-flash"}
+		return []string{"gemini-3.5-flash", "gemini-3-flash-preview"}
 	default:
 		return nil
 	}

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -24,7 +24,7 @@ func TestProviderResolveModels(t *testing.T) {
 		{
 			name:     "resolves good balanced model pool",
 			category: backend.GoodBalancedModel,
-			want:     []string{"gemini-3-flash-preview", "gemini-3.5-flash"},
+			want:     []string{"gemini-3.5-flash", "gemini-3-flash-preview"},
 		},
 		{
 			name:     "resolves best expensive model pool",


### PR DESCRIPTION
Update the GoodBalancedModel category to use gemini-3.5-flash as the primary model, falling back to gemini-3-flash-preview if needed.