### PR TITLE
pkg/coveragedb: use Partitioned DML for garbage deletion

### DIFF
--- a/dashboard/app/batch_coverage.go
+++ b/dashboard/app/batch_coverage.go
@@ -155,7 +155,13 @@ func nsDataAvailable(ctx context.Context, ns string) ([]coveragedb.TimePeriod, [
 
 func handleBatchCoverageClean(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	deletedSessions, deletedRows, err := coveragedb.DeleteGarbage(ctx, coverageDBClient)
+	workers := 10
+	if wStr := r.URL.Query().Get("workers"); wStr != "" {
+		if val, err := strconv.Atoi(wStr); err == nil && val > 0 {
+			workers = val
+		}
+	}
+	deletedSessions, deletedRows, err := coveragedb.DeleteGarbage(ctx, coverageDBClient, workers)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to coveragedb.DeleteGarbage after deleting %d sessions (%d rows): %s",
 			deletedSessions, deletedRows, err.Error())

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -366,7 +366,7 @@ func (f *orphanFinder) stream(ctx context.Context, sql string) error {
 // To avoid exceeding Spanner mutation limits, entries are deleted in batches of 10,000.
 //
 // Returns the number of deleted sessions and the total number of deleted rows.
-func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, error) {
+func DeleteGarbage(ctx context.Context, client *spanner.Client, workers int) (int64, int64, error) {
 	if client == nil {
 		return 0, 0, fmt.Errorf("nil spannerclient")
 	}
@@ -403,7 +403,10 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 	eg, gCtx := errgroup.WithContext(ctx)
 
 	sessionCh := make(chan string)
-	const numWorkers = 10
+	numWorkers := workers
+	if numWorkers <= 0 {
+		numWorkers = 10
+	}
 
 	// Spawn workers to process garbage sessions.
 	for range numWorkers {

--- a/pkg/coveragedb/coveragedb_test.go
+++ b/pkg/coveragedb/coveragedb_test.go
@@ -417,7 +417,7 @@ func TestDeleteGarbage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run DeleteGarbage.
-	deletedSessions, deletedRows, err := DeleteGarbage(ctx, client)
+	deletedSessions, deletedRows, err := DeleteGarbage(ctx, client, 10)
 	require.NoError(t, err)
 
 	// We expect:


### PR DESCRIPTION
Optimize DeleteGarbage by using Partitioned DML instead of fetching keys and deleting them in batches of 10,000. This should significantly speed up deletion of large sessions (e.g. sessions with millions of records).

We inline the session ID in the DELETE statement as a workaround for a Spanner emulator limitation where it fails to parse query parameters in Partitioned DML for the PostgreSQL dialect. This is safe because session IDs are UUIDs generated internally and loaded from the DB. We have submitted a fix for the emulator bug upstream.

