### PR TITLE
pkg/aflow/backend/gemini: retry model catalog queries

### DIFF
--- a/pkg/aflow/backend/backend.go
+++ b/pkg/aflow/backend/backend.go
@@ -135,6 +135,22 @@ func (e *RetryError) Unwrap() error {
 	return e.Err
 }
 
+const maxLLMBackoff = 3 * time.Minute
+
+func BackoffDuration(try int, baseDelay time.Duration) time.Duration {
+	if baseDelay == 0 {
+		return 0
+	}
+	backoff := baseDelay
+	for range try {
+		backoff *= 2
+		if backoff >= maxLLMBackoff {
+			return maxLLMBackoff
+		}
+	}
+	return backoff
+}
+
 // OutputTokenOverflowError indicates that the model reached its output token limit.
 type OutputTokenOverflowError struct {
 	Err error

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -102,11 +102,47 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 	// successfully returns detailed metadata for all models (such as their InputTokenLimit,
 	// OutputTokenLimit, and SupportedActions) without requiring any special IAM configurations.
 	// Therefore, we query the catalog dynamically here.
+	const maxInitRetries = 5
+
+	var models map[string]*modelInfo
+	for i := range maxInitRetries {
+		models, err = p.queryModelsOnce(ctx, client)
+		if err == nil {
+			break
+		}
+		parsedErr := parseLLMError(err, "")
+		var retryErr *backend.RetryError
+		if !errors.As(parsedErr, &retryErr) {
+			break
+		}
+		if i == maxInitRetries-1 {
+			break
+		}
+		delay := retryErr.Delay
+		if retryErr.IsExponential {
+			delay = backend.BackoffDuration(i, retryErr.Delay)
+		}
+		select {
+		case <-ctx.Done():
+			p.err = ctx.Err()
+			return p.err
+		case <-time.After(delay):
+		}
+	}
+	if err != nil {
+		p.err = err
+		return err
+	}
+	p.models = models
+	p.modelPathPrefix = "models/"
+	return nil
+}
+
+func (p *Provider) queryModelsOnce(ctx context.Context, client *genai.Client) (map[string]*modelInfo, error) {
 	models := make(map[string]*modelInfo)
-	for m, err := range client.Models.All(ctx) {
-		if err != nil {
-			p.err = err
-			return err
+	for m, e := range client.Models.All(ctx) {
+		if e != nil {
+			return nil, e
 		}
 		if !slices.Contains(m.SupportedActions, "generateContent") ||
 			strings.Contains(m.Name, "-image") ||
@@ -120,9 +156,7 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 			OutputTokenLimit: int(m.OutputTokenLimit),
 		}
 	}
-	p.models = models
-	p.modelPathPrefix = "models/"
-	return nil
+	return models, nil
 }
 
 func (p *Provider) Client(ctx context.Context) (backend.Client, error) {

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -763,20 +763,6 @@ const (
 	maxLLMBackoff    = 3 * time.Minute
 )
 
-func llmBackoffDuration(try int, baseDelay time.Duration) time.Duration {
-	if baseDelay == 0 {
-		return 0
-	}
-	backoff := baseDelay
-	for range try {
-		backoff *= 2
-		if backoff >= maxLLMBackoff {
-			return maxLLMBackoff
-		}
-	}
-	return backoff
-}
-
 func (a *LLMAgent) generateContent(ctx *Context, cfg *backend.GenerateConfig,
 	req []*backend.Message, candidate int, model backend.ModelCategory,
 	span *trajectory.Span) (*backend.GenerateResponse, error) {
@@ -799,7 +785,7 @@ func (a *LLMAgent) generateContent(ctx *Context, cfg *backend.GenerateConfig,
 				}
 				delay := retryErr.Delay
 				if retryErr.IsExponential {
-					delay = llmBackoffDuration(try, retryErr.Delay)
+					delay = backend.BackoffDuration(try, retryErr.Delay)
 				}
 				ctx.sleep(delay)
 				continue


### PR DESCRIPTION
The Gemini API catalog endpoint (Models.All) can occasionally return transient 503 errors. Since this query happens during provider initialization (before the main aflow retry logic for generateContent calls), a failure here causes the entire job to fail immediately.

Add a retry loop with exponential backoff around the catalog query to handle these transient errors gracefully. Use the existing parseLLMError function to ensure we only retry on retryable errors. Extract the exponential backoff duration calculation to the backend package so it can be shared between the agent and the provider.
