### PR TITLE
pkg/build: fix LLVM=1 detection when ccache is used

### DIFF
--- a/pkg/build/linux.go
+++ b/pkg/build/linux.go
@@ -200,14 +200,19 @@ func LinuxMakeArgs(target *targets.Target, compiler, linker, ccache, buildDir st
 			linker = target.KernelLinker
 		}
 	}
+	// The standard way to build Linux with clang is to pass LLVM=1 instead of CC= and LD=.
+	// We should also determine it before we rewrite the compiler variable.
+	isLLVM := compiler == targets.DefaultLLVMCompiler && (linker == "" || linker == targets.DefaultLLVMLinker)
 	if compiler != "" {
 		if ccache != "" {
 			compiler = ccache + " " + compiler
 		}
 	}
-	// The standard way to build Linux with clang is to pass LLVM=1 instead of CC= and LD=.
-	if compiler == targets.DefaultLLVMCompiler && (linker == "" || linker == targets.DefaultLLVMLinker) {
+	if isLLVM {
 		args = append(args, "LLVM=1")
+		if ccache != "" {
+			args = append(args, "CC="+compiler)
+		}
 	} else {
 		if compiler != "" {
 			args = append(args, "CC="+compiler)


### PR DESCRIPTION
If ccache is used, the compiler string becomes "ccache clang", causing the strict LLVM=1 check to fail. Without LLVM=1, the kernel build falls back to GNU binutils, which fails to process LLVM object files on arm64.

Account for the ccache prefix when checking for the default LLVM compiler. Explicitly pass CC alongside LLVM=1 so ccache is still utilized.

***

This fixed build errors like https://syzkaller.appspot.com/ai_job?id=7ad301e7-9ef4-44cf-bc13-cea16385eb5e
