### PR TITLE
pkg/aflow: add view-failed-attempts tool to patch generation flows

### DIFF
--- a/pkg/aflow/flow/patching/attempts.go
+++ b/pkg/aflow/flow/patching/attempts.go
@@ -1,0 +1,94 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/aflow"
+)
+
+type FailedAttempt struct {
+	Strategy string
+	Diff     string
+	Error    string
+}
+
+type recordFailedAttemptArgs struct {
+	TestError        string
+	PatchExplanation string
+	PatchDiff        string
+	FailedAttempts   []FailedAttempt
+}
+
+type recordFailedAttemptResult struct {
+	FailedAttempts []FailedAttempt
+}
+
+var recordFailedAttempt = aflow.NewFuncAction("recordFailedAttempt", recordFailedAttemptImpl)
+
+func recordFailedAttemptImpl(ctx *aflow.Context, args recordFailedAttemptArgs) (recordFailedAttemptResult, error) {
+	if args.TestError == "" {
+		return recordFailedAttemptResult{FailedAttempts: args.FailedAttempts}, nil
+	}
+
+	attempts := slices.Clone(args.FailedAttempts)
+	attempts = append(attempts, FailedAttempt{
+		Strategy: strings.TrimSpace(args.PatchExplanation),
+		Diff:     strings.TrimSpace(args.PatchDiff),
+		Error:    strings.TrimSpace(args.TestError),
+	})
+
+	return recordFailedAttemptResult{FailedAttempts: attempts}, nil
+}
+
+type viewFailedAttemptsArgs struct {
+	AttemptIndex int `json:",omitempty" jsonschema:"1-based index of the failed attempt to view. 0 for summary."`
+}
+
+type viewFailedAttemptsResult struct {
+	Result string `jsonschema:"The requested failed attempt information."`
+}
+
+var viewFailedAttemptsTool = aflow.NewFuncTool("view-failed-attempts", viewFailedAttemptsToolImpl,
+	"View previous failed attempts to fix the bug, including their strategies, diffs, and resulting errors.")
+
+func viewFailedAttemptsToolImpl(ctx *aflow.Context, state struct {
+	FailedAttempts []FailedAttempt
+}, args viewFailedAttemptsArgs) (viewFailedAttemptsResult, error) {
+	if len(state.FailedAttempts) == 0 {
+		return viewFailedAttemptsResult{"No failed attempts yet."}, nil
+	}
+
+	var summary strings.Builder
+	summary.WriteString(fmt.Sprintf("There are %d previous failed attempts:\n", len(state.FailedAttempts)))
+	for i, attempt := range state.FailedAttempts {
+		// Truncate strategy and error for the summary.
+		strategy := attempt.Strategy
+		if len(strategy) > 100 {
+			strategy = strategy[:100] + "..."
+		}
+		errStr := attempt.Error
+		if len(errStr) > 100 {
+			errStr = errStr[:100] + "..."
+		}
+		summary.WriteString(fmt.Sprintf("Attempt %d:\n  Strategy: %s\n  Error: %s\n", i+1, strategy, errStr))
+	}
+	summary.WriteString("Call this tool with a specific AttemptIndex to see its full strategy, diff, and error.")
+
+	if args.AttemptIndex == 0 {
+		return viewFailedAttemptsResult{summary.String()}, nil
+	}
+
+	if args.AttemptIndex < 1 || args.AttemptIndex > len(state.FailedAttempts) {
+		return viewFailedAttemptsResult{fmt.Sprintf("Note: the specified attempt index (%d) is not found.\n\n%s",
+			args.AttemptIndex, summary.String())}, nil
+	}
+
+	attempt := state.FailedAttempts[args.AttemptIndex-1]
+	return viewFailedAttemptsResult{fmt.Sprintf("Attempt %d\n\nStrategy:\n%s\n\nDiff:\n%s\n\nError:\n%s\n",
+		args.AttemptIndex, attempt.Strategy, attempt.Diff, attempt.Error)}, nil
+}

--- a/pkg/aflow/flow/patching/attempts_test.go
+++ b/pkg/aflow/flow/patching/attempts_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordFailedAttempt(t *testing.T) {
+	ctx := &aflow.Context{}
+
+	// Test no error.
+	res, err := recordFailedAttemptImpl(ctx, recordFailedAttemptArgs{
+		TestError:      "",
+		FailedAttempts: []FailedAttempt{{Strategy: "old"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res.FailedAttempts))
+
+	// Test with error.
+	res, err = recordFailedAttemptImpl(ctx, recordFailedAttemptArgs{
+		TestError:        "build failed",
+		PatchExplanation: "try this",
+		PatchDiff:        "+ foo()",
+		FailedAttempts:   []FailedAttempt{{Strategy: "old"}},
+	})
+	require.NoError(t, err)
+	attempts := res.FailedAttempts
+	require.Equal(t, 2, len(attempts))
+	require.Equal(t, "try this", attempts[1].Strategy)
+	require.Equal(t, "+ foo()", attempts[1].Diff)
+	require.Equal(t, "build failed", attempts[1].Error)
+}
+
+func TestViewFailedAttemptsTool(t *testing.T) {
+	ctx := &aflow.Context{}
+	state := struct {
+		FailedAttempts []FailedAttempt
+	}{
+		FailedAttempts: []FailedAttempt{
+			{
+				Strategy: "strategy 1",
+				Diff:     "diff 1",
+				Error:    "error 1",
+			},
+			{
+				Strategy: "strategy 2",
+				Diff:     "diff 2",
+				Error:    "error 2",
+			},
+		},
+	}
+
+	// Test summary (AttemptIndex = 0)
+	res, err := viewFailedAttemptsToolImpl(ctx, state, viewFailedAttemptsArgs{AttemptIndex: 0})
+	require.NoError(t, err)
+	result := res.Result
+	require.Contains(t, result, "There are 2 previous failed attempts")
+	require.Contains(t, result, "Attempt 1:")
+	require.Contains(t, result, "strategy 1")
+	require.Contains(t, result, "Attempt 2:")
+	require.Contains(t, result, "strategy 2")
+
+	// Test specific attempt (AttemptIndex = 1)
+	res, err = viewFailedAttemptsToolImpl(ctx, state, viewFailedAttemptsArgs{AttemptIndex: 1})
+	require.NoError(t, err)
+	result = res.Result
+	require.Contains(t, result, "Attempt 1")
+	require.Contains(t, result, "strategy 1")
+	require.Contains(t, result, "diff 1")
+	require.Contains(t, result, "error 1")
+
+	// Test out of bounds attempt (AttemptIndex = 3)
+	res, err = viewFailedAttemptsToolImpl(ctx, state, viewFailedAttemptsArgs{AttemptIndex: 3})
+	require.NoError(t, err)
+	result = res.Result
+	require.Contains(t, result, "Note: the specified attempt index (3) is not found.")
+	require.Contains(t, result, "There are 2 previous failed attempts")
+}

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -391,6 +391,9 @@ A previous version of a patch (v{{.PreviousPatchVersion}}) was generated to fix 
 
 {{.PreviousPatchDiff}}
 
+There are previous versions of this patch and reviewer comments.
+Use the {{.toolViewPatchHistory}} tool to view them.
+
 The triage agent has extracted the following required changes from the reviewers' emails:
 
 {{range $item := .CodeItems}}
@@ -426,7 +429,7 @@ from scratch using the {{.toolCodeeditor}} tool.
 If the strategy looks reasonable to you, proceed with patch generation.
 {{end}}
 {{end}}
-` + commonFaultInjectionPrompt
+` + commonFaultInjectionPrompt + commonFailedAttemptsPrompt
 
 const verdictInstruction = `
 You are an expert Linux kernel developer. You are reviewing comments on a proposed patch for a kernel bug.

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -174,6 +174,14 @@ The explanation of the root cause of the bug is:
 `
 
 // This part is shared between patching and patch-iteration.
+const commonFailedAttemptsPrompt = `
+{{if gt (len .FailedAttempts) 1}}
+There are older failed attempts to fix this bug.
+Use the {{.toolViewFailedAttempts}} tool to view their strategies, diffs, and resulting errors.
+Learn from them and DO NOT repeat the same mistakes.
+{{end}}
+`
+
 const commonFaultInjectionPrompt = `
 
 {{if .ReproducedFaultInjection}}
@@ -268,7 +276,7 @@ in its entirety from scratch using the {{.toolCodeeditor}} tool).
 If the strategy looks reasonable to you, proceed with patch generation.
 {{end}}
 {{end}}
-`
+` + commonFailedAttemptsPrompt
 
 const descriptionInstruction = `
 You are an experienced Linux kernel developer tasked with writing a commit description for
@@ -364,9 +372,11 @@ func patchGenerationLoop(beforeEach aflow.Action, instruction, prompt string, ex
 				TaskType:    aflow.FormalReasoningTask,
 				Instruction: instruction,
 				Prompt:      prompt,
-				Tools:       aflow.Tools(common.CodeAccessTools, codeeditor.Tool, patchdiff.Tool, extraTools),
+				Tools: aflow.Tools(common.CodeAccessTools, codeeditor.Tool, patchdiff.Tool,
+					viewFailedAttemptsTool, extraTools),
 			},
 			crash.TestPatch, // -> PatchDiff or TestError
+			recordFailedAttempt,
 		)...),
 	}
 }


### PR DESCRIPTION
The patch-generator LLM agent previously only saw the error and diff from its immediately preceding attempt. This caused it to sometimes forget older failed approaches and get stuck in a loop, repeating the same mistakes.

Add a recordFailedAttempt action to accumulate the history of failed strategies, diffs, and test errors. Expose this history to the agent via a new view-failed-attempts tool, allowing it to query its past failures and learn from them without cluttering the main prompt with the full history.