### PR TITLE
pkg/aflow: simplify ReproOpts generation in repro workflow

### DIFF
--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -15,7 +15,10 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/flow/common"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 	"github.com/google/syzkaller/pkg/aflow/tool/syzlang"
+	"github.com/google/syzkaller/pkg/csource"
+	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
 )
 
 type ReproInputs struct {
@@ -46,7 +49,6 @@ func init() {
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"ReproC":                       "", // is needed by crash.Reproduce
 				"NeedStrace":                   false,
-				"Sandbox":                      "none",
 			},
 			Root: aflow.Pipeline(
 				kernel.Checkout,
@@ -55,7 +57,7 @@ func init() {
 				&aflow.LLMAgent{
 					Name:    "crash-repro-finder",
 					Model:   aflow.BestExpensiveModel,
-					Outputs: aflow.ValidatedLLMOutputs[ReproFinderResult, ReproFinderState](validateReproFinderOutputs),
+					Outputs: aflow.ValidatedLLMOutputs[ReproFinderResult, ReproFinderState](formatReproFinderOutputs),
 					Tools: aflow.Tools(
 						common.CodeAccessTools,
 						syzlang.ReadDescription,
@@ -66,6 +68,7 @@ func init() {
 					Instruction: reproInstruction,
 					Prompt:      reproPrompt,
 				},
+				generateReproOpts,
 				crash.Reproduce,
 				aflow.NewFuncAction("compare", func(ctx *aflow.Context,
 					args struct {
@@ -83,8 +86,8 @@ func init() {
 }
 
 type ReproFinderResult struct {
-	ReproOpts string `jsonschema:"The repro configuration options."`
-	ReproSyz  string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
+	Sandbox  string `jsonschema:"Sandbox to use for execution (none/setuid/namespace/android)."`
+	ReproSyz string `jsonschema:"Valid syzkaller reproducer program without triple backticks."`
 }
 
 type ReproFinderState struct {
@@ -92,8 +95,13 @@ type ReproFinderState struct {
 	TargetArch string
 }
 
-func validateReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
+func formatReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
 	res ReproFinderResult) (ReproFinderResult, error) {
+	switch res.Sandbox {
+	case "", "none", "setuid", "namespace", "android":
+	default:
+		return res, aflow.BadCallError("unsupported sandbox type %q", res.Sandbox)
+	}
 	pt, err := prog.GetTarget(state.TargetOS, state.TargetArch)
 	if err != nil {
 		return res, err
@@ -109,8 +117,34 @@ func validateReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
 	return res, nil
 }
 
+var generateReproOpts = aflow.NewFuncAction("generate-repro-opts", func(_ *aflow.Context, args struct {
+	TargetArch string
+	Sandbox    string
+}) (struct{ ReproOpts string }, error) {
+	cfg := mgrconfig.DefaultValues()
+	cfg.RawTarget = targets.Linux + "/" + args.TargetArch
+	if args.Sandbox != "" {
+		cfg.Sandbox = args.Sandbox
+	}
+	if err := mgrconfig.SetTargets(cfg); err != nil {
+		return struct{ ReproOpts string }{}, err
+	}
+	cfg.Timeouts = cfg.SysTarget.Timeouts(1)
+	opts := csource.DefaultOpts(cfg)
+	return struct{ ReproOpts string }{string(opts.Serialize())}, nil
+})
+
 const reproInstruction = `
-You are an expert in the Linux kernel fuzzing. Your goal is to write a syzkaller program to trigger a specific bug.
+You are an expert in Linux kernel fuzzing. Your goal is to write a syzkaller program to trigger a specific bug.
+
+Execution sandboxes ('Sandbox' output field):
+- "none": Runs test processes as root without Linux namespace isolation (PID, Net, IPC, User).
+- "setuid": Runs test processes under unprivileged user accounts (drops root privileges and capabilities).
+- "namespace": Runs test processes inside isolated Linux namespaces
+  (CLONE_NEWNS, CLONE_NEWUTS, CLONE_NEWIPC, CLONE_NEWPID, CLONE_NEWNET,
+  CLONE_NEWUSER) with isolated network devices (loopback, tun, etc.).
+  Use this for network, IPC, or namespace bugs.
+- "android": Simulates Android application privilege and SELinux restrictions (drops privileges to Android UIDs/GIDs).
 
 Document about syzkaller program syntax:
 ===

--- a/pkg/aflow/tool/syzlang/reproduce.go
+++ b/pkg/aflow/tool/syzlang/reproduce.go
@@ -21,6 +21,7 @@ You MUST use this tool to verify your generated syz repro program.
 
 type ReproduceArgs struct {
 	ReproSyz string `jsonschema:"Syz program to verify and execute."`
+	Sandbox  string `jsonschema:"Sandbox to use for execution (none/setuid/namespace/android)."`
 }
 
 type ReproduceResult struct {
@@ -73,8 +74,13 @@ func reproduce(ctx *aflow.Context, state reproduceState, args ReproduceArgs) (Re
 			KernelObj:    state.KernelObj,
 			KernelCommit: state.KernelCommit,
 			KernelConfig: state.KernelConfig,
+			Sandbox:      args.Sandbox,
 		},
 		ReproSyz: args.ReproSyz,
+	}
+
+	if err := reproArgs.Validate(); err != nil {
+		return ReproduceResult{}, aflow.BadCallError("invalid configuration: %v", err)
 	}
 
 	testRes, cachedID, err := crash.ReproduceFuncWithCoverage(ctx, reproArgs, true)


### PR DESCRIPTION
The crash-repro-finder agent previously generated a full JSON string for ReproOpts. This was error-prone because most options do not affect syz-execprog and could not be tested via the syzlang.Reproduce tool.

Let the agent only select the sandbox level. Auto-generate the full ReproOpts string using default manager options, and update syzlang.Reproduce to accept the sandbox argument for testing.