### PR TITLE
pkg/aflow: add an LLM-based patch refining step

### DIFF
--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -4,17 +4,14 @@
 package crash
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"slices"
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/kernel"
+	"github.com/google/syzkaller/pkg/aflow/tool/patchdiff"
 	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/sys/targets"
@@ -147,25 +144,7 @@ func currentDiff(repo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	diff, err := osutil.RunCmd(time.Minute, repo, "git", "diff", "-U0")
-	if err != nil {
-		return "", err
-	}
-	formatDiff, err := findClangFormatDiff()
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command(formatDiff, "-p1", "-i", "-style=file")
-	cmd.Stdin = bytes.NewReader(diff)
-	cmd.Dir = repo
-	if output, err := osutil.Run(10*time.Minute, cmd); err != nil {
-		return "", fmt.Errorf("%w\n%s", err, output)
-	}
-	diff, err = osutil.RunCmd(time.Minute, repo, "git", "diff")
-	if err != nil {
-		return "", err
-	}
-	return string(diff), nil
+	return patchdiff.Diff(repo)
 }
 
 func undoChanges(repo string) error {
@@ -181,22 +160,4 @@ func undoChanges(repo string) error {
 	// We do not use -fdx to keep object files around and make the next tool call faster.
 	_, err = osutil.RunCmd(time.Minute, repo, "git", "clean", "-fd")
 	return err
-}
-
-func findClangFormatDiff() (string, error) {
-	// It may be installed at different paths, and there may or may not be the version number.
-	paths := []string{
-		"/usr/lib/clang-format*/clang-format-diff.py",
-		"/usr/share/clang/clang-format*/clang-format-diff.py",
-	}
-	for _, path := range paths {
-		files, _ := filepath.Glob(path)
-		if len(files) == 0 {
-			continue
-		}
-		// If there are version numbers, we want to find the latest one.
-		slices.Sort(files)
-		return files[len(files)-1], nil
-	}
-	return "", fmt.Errorf("can't find clang-format-diff.py, install clang-format package")
 }

--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -27,6 +27,10 @@ import (
 // and resets source code state to HEAD (removes all local edits).
 var TestPatch = aflow.NewFuncAction("test-patch", testPatch)
 
+// TestPatchInplace is like TestPatch, but it leaves the local edits applied
+// to the source tree instead of resetting it to HEAD.
+var TestPatchInplace = aflow.NewFuncAction("test-patch-inplace", testPatchInplace)
+
 type testArgs struct {
 	AgentName        string
 	TargetOS         string
@@ -49,8 +53,12 @@ type testResult struct {
 }
 
 func testPatch(ctx *aflow.Context, args testArgs) (testResult, error) {
-	res := testResult{}
 	defer undoChanges(args.KernelScratchSrc)
+	return testPatchInplace(ctx, args)
+}
+
+func testPatchInplace(ctx *aflow.Context, args testArgs) (testResult, error) {
+	res := testResult{}
 
 	diff, err := currentDiff(args.KernelScratchSrc)
 	if err != nil {

--- a/pkg/aflow/action/kernel/checkpatch.go
+++ b/pkg/aflow/action/kernel/checkpatch.go
@@ -1,0 +1,38 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package kernel
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow/tool/patchdiff"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+// Checkpatch runs scripts/checkpatch.pl on the current diff in the repo.
+// It returns the output string, a boolean indicating if checkpatch found issues, and an error.
+func Checkpatch(repo string) (string, bool, error) {
+	diff, err := patchdiff.Diff(repo, "HEAD")
+	if err != nil {
+		return "", false, err
+	}
+
+	cmd := osutil.Command("scripts/checkpatch.pl", "--no-tree", "-")
+	cmd.Dir = repo
+	if err := osutil.Sandbox(cmd, true, false); err != nil {
+		return "", false, err
+	}
+	cmd.Stdin = strings.NewReader(diff)
+
+	output, err := osutil.Run(1*time.Minute, cmd)
+	if err != nil {
+		if verr, ok := errors.AsType[*osutil.VerboseError](err); ok {
+			return string(verr.Output), true, nil
+		}
+		return "", false, err
+	}
+	return string(output), false, nil
+}

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -181,22 +181,29 @@ type applyGitPatchArgs struct {
 	PatchHistory     []ai.PatchHistoryEntry
 }
 
+func applyGitDiff(dir, diff string) error {
+	if diff == "" {
+		return nil
+	}
+	cmd := osutil.Command("git", "apply", "-")
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(diff)
+	if err := osutil.Sandbox(cmd, true, false); err != nil {
+		return err
+	}
+	if output, err := osutil.Run(time.Minute, cmd); err != nil {
+		return fmt.Errorf("failed to apply patch: %w\n%s", err, output)
+	}
+	return nil
+}
+
 func applyGitPatchFunc(ctx *aflow.Context, args applyGitPatchArgs) (struct{}, error) {
 	if len(args.PatchHistory) == 0 {
 		return struct{}{}, aflow.FlowError(fmt.Errorf("PatchHistory is empty"))
 	}
 	latest := args.PatchHistory[len(args.PatchHistory)-1]
-	if latest.Diff == "" {
-		return struct{}{}, nil
+	if err := applyGitDiff(args.KernelScratchSrc, latest.Diff); err != nil {
+		return struct{}{}, aflow.FlowError(err)
 	}
-
-	// Apply the diff.
-	cmd := exec.Command("git", "apply")
-	cmd.Dir = args.KernelScratchSrc
-	cmd.Stdin = strings.NewReader(latest.Diff)
-	if _, err := osutil.Run(time.Minute, cmd); err != nil {
-		return struct{}{}, aflow.FlowError(fmt.Errorf("failed to apply previous patch: %w", err))
-	}
-
 	return struct{}{}, nil
 }

--- a/pkg/aflow/flow/patching/formatting.go
+++ b/pkg/aflow/flow/patching/formatting.go
@@ -1,0 +1,128 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import (
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/action/crash"
+	"github.com/google/syzkaller/pkg/aflow/action/kernel"
+	"github.com/google/syzkaller/pkg/aflow/flow/common"
+	"github.com/google/syzkaller/pkg/aflow/tool/checkpatch"
+	"github.com/google/syzkaller/pkg/aflow/tool/clangformat"
+	"github.com/google/syzkaller/pkg/aflow/tool/codeeditor"
+	"github.com/google/syzkaller/pkg/aflow/tool/patchdiff"
+)
+
+func patchRefinementLoop(initStyleItems bool) aflow.Action {
+	actions := []aflow.Action{applyPatch}
+	if initStyleItems {
+		actions = append(actions, aflow.NewFuncAction("init-style-items", func(ctx *aflow.Context, args struct{}) (struct {
+			StyleItems []string
+		}, error) {
+			return struct{ StyleItems []string }{}, nil
+		}))
+	}
+	actions = append(actions,
+		&aflow.DoWhile{
+			While:         "NeedRefinement",
+			MaxIterations: 5,
+			MapOutputs: map[string]string{
+				"PatchDiff":        "PatchDiff",
+				"TestError":        "TestError",
+				"CheckpatchOutput": "CheckpatchOutput",
+				"NeedRefinement":   "NeedRefinement",
+			},
+			Do: aflow.Pipeline(
+				&aflow.LLMAgent{
+					Name:        "patch-formatter",
+					Model:       aflow.GoodBalancedModel,
+					Reply:       "FormatterExplanation",
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: formatterInstruction,
+					Prompt:      formatterPrompt,
+					Tools: aflow.Tools(common.CodeAccessTools, codeeditor.Tool,
+						patchdiff.Tool, checkpatch.Tool, clangformat.Tool),
+				},
+				crash.TestPatchInplace, // -> PatchDiff or TestError
+				runCheckpatch,
+			),
+		},
+	)
+	return aflow.Pipeline(actions...)
+}
+
+var applyPatch = aflow.NewFuncAction("apply-patch", func(ctx *aflow.Context, args struct {
+	KernelScratchSrc string
+	PatchDiff        string
+}) (struct{}, error) {
+	return struct{}{}, applyGitDiff(args.KernelScratchSrc, args.PatchDiff)
+})
+
+var runCheckpatch = aflow.NewFuncAction("run-checkpatch", func(ctx *aflow.Context, args struct {
+	KernelScratchSrc string
+	TestError        string
+}) (struct {
+	CheckpatchOutput string
+	NeedRefinement   bool
+}, error) {
+	output, hasErrors, err := kernel.Checkpatch(args.KernelScratchSrc)
+	if err != nil {
+		return struct {
+			CheckpatchOutput string
+			NeedRefinement   bool
+		}{}, err
+	}
+
+	return struct {
+		CheckpatchOutput string
+		NeedRefinement   bool
+	}{
+		CheckpatchOutput: output,
+		NeedRefinement:   hasErrors || args.TestError != "",
+	}, nil
+})
+
+const formatterInstruction = `
+You are an expert Linux kernel developer tasked with formatting a kernel patch.
+Your objective is purely formatting: you must ensure the patch complies with the kernel's coding style,
+conforms to the surrounding code rules, and passes checkpatch.pl, while preserving the code logic exactly as it is.
+You should stop once the requested formatting changes are done and checkpatch.pl is happy.
+Do not question the requested changes unless they are obviously wrong.
+If the code already conforms to the requested changes, surrounding code rules,
+and checkpatch.pl is happy, you should just finish your task.
+
+WARNING: The {{.toolClangFormat}} tool may break the formatting of the surrounding code (like manual alignment).
+Use it with caution. We want to make the change fit into the existing formatting as much as possible.
+`
+
+const formatterPrompt = `
+The current patch diff is:
+
+{{.PatchDiff}}
+
+{{if .StyleItems}}
+The reviewers requested the following style changes:
+{{range .StyleItems}}
+- {{.}}
+{{end}}
+{{end}}
+
+{{if .CheckpatchOutput}}
+The checkpatch.pl output is:
+{{.CheckpatchOutput}}
+{{end}}
+
+{{if .TestError}}
+Your previous formatting changes broke the build/test:
+{{.TestError}}
+Please fix the errors.
+{{end}}
+
+{{if .FormatterExplanation}}
+Your previous reasoning was:
+{{.FormatterExplanation}}
+{{end}}
+
+Use the provided tools to format the patch.
+`

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -54,7 +54,8 @@ type PatchIterationInputs struct {
 }
 
 type verdictAgentOutputs struct {
-	CodeItems         []string `jsonschema:"Clean list of changes explicitly requested for the code itself."`
+	CodeItems         []string `jsonschema:"Clean list of changes explicitly requested for the code logic itself."`
+	StyleItems        []string `jsonschema:"Clean list of changes requested for code style and formatting."`
 	DescriptionItems  []string `jsonschema:"Clean list of changes requested to the commit description/changelog."`
 	FixesItems        []string `jsonschema:"Clean list of comments suggesting Fixes tag is incorrect or needs update."`
 	UpdateFixesReason string   `jsonschema:"Explanation of why Fixes tag needs update, and any hints by reviewers."`
@@ -62,7 +63,8 @@ type verdictAgentOutputs struct {
 }
 
 func validateVerdictOutputs(ctx *aflow.Context, state struct{}, args verdictAgentOutputs) (verdictAgentOutputs, error) {
-	hasItems := len(args.CodeItems) > 0 || len(args.DescriptionItems) > 0 || len(args.FixesItems) > 0
+	hasItems := len(args.CodeItems) > 0 || len(args.StyleItems) > 0 ||
+		len(args.DescriptionItems) > 0 || len(args.FixesItems) > 0
 	hasResend := args.ResendReason != ""
 	if hasItems && hasResend {
 		return args, aflow.BadCallError("cannot provide both Items arrays and a ResendReason; " +
@@ -128,8 +130,9 @@ func init() {
 							Condition: "CodeItems",
 							Do: patchGenerationLoop(
 								applyGitPatch, patchIterationInstruction, patchIterationPrompt, viewPatchHistoryTool),
-							Else: aflow.Pipeline(applyGitPatch, forwardPatchDiff),
+							Else: forwardPatchDiff,
 						},
+						patchRefinementLoop(false),
 						&aflow.If{
 							Condition: "FixesItems",
 							Do: aflow.Pipeline(
@@ -223,6 +226,7 @@ var viewPatchHistoryTool = aflow.NewFuncTool("view-patch-history", func(ctx *afl
 
 var extractTriageResults = aflow.NewFuncAction("extract-triage-results", func(ctx *aflow.Context, args struct {
 	CodeItems        []string
+	StyleItems       []string
 	DescriptionItems []string
 	FixesItems       []string
 	ResendReason     string
@@ -232,7 +236,7 @@ var extractTriageResults = aflow.NewFuncAction("extract-triage-results", func(ct
 	return struct {
 		NeedNewVersion bool
 	}{
-		NeedNewVersion: len(args.CodeItems) > 0 || len(args.DescriptionItems) > 0 ||
+		NeedNewVersion: len(args.CodeItems) > 0 || len(args.StyleItems) > 0 || len(args.DescriptionItems) > 0 ||
 			len(args.FixesItems) > 0 || args.ResendReason != "",
 	}, nil
 })
@@ -434,10 +438,11 @@ Your task is to determine if a new version of the patch needs to be generated ba
 You must also distill the messy email feedback into clean lists of requirements for downstream agents.
 CRITICAL: You must extract actionable items ONLY from the new comments provided in the current iteration.
 Do not extract items from previous historical comments.
-Separate the actionable items into three strictly divided categories:
-1. CodeActionItems: Changes requested to the C/header source code.
-2. DescriptionActionItems: Changes requested to the commit description or changelog.
-3. FixesActionItems: Feedback regarding the Fixes tag.
+Separate the actionable items into four strictly divided categories:
+1. CodeActionItems: Changes requested to the C/header source code logic.
+2. StyleActionItems: Changes requested for code style and formatting.
+3. DescriptionActionItems: Changes requested to the commit description or changelog.
+4. FixesActionItems: Feedback regarding the Fixes tag.
 Watch out for citations (lines starting with >) which often contain previous messages or context, not new requirements.
 Note: You shouldn't fully debug the issue right now. Just do a cautious check if the V+1 patch is necessary.
 

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -91,6 +91,7 @@ func init() {
 				},
 				kernel.CheckoutScratch,
 				patchGenerationLoop(nil, patchInstruction, patchPrompt),
+				patchRefinementLoop(true),
 				&aflow.LLMAgent{
 					Name:        "fixes-finder",
 					Model:       aflow.BestExpensiveModel,

--- a/pkg/aflow/loop.go
+++ b/pkg/aflow/loop.go
@@ -60,7 +60,15 @@ func (dw *DoWhile) loop(ctx *Context) error {
 		if err := ctx.finishSpan(span, err); err != nil {
 			return err
 		}
-		if ctx.state[dw.While].(string) == "" {
+		val := ctx.state[dw.While]
+		cond := false
+		switch v := val.(type) {
+		case string:
+			cond = v != ""
+		case bool:
+			cond = v
+		}
+		if !cond {
 			for from, to := range dw.MapOutputs {
 				if val, ok := ctx.state[from]; ok {
 					ctx.state[to] = val
@@ -121,7 +129,14 @@ func (dw *DoWhile) verify(ctx *verifyContext) {
 		ctx.inputs, ctx.outputs = true, false
 		dw.Do.verify(ctx)
 		ctx.requireNotEmpty("DoWhile", "While", dw.While)
-		ctx.requireInput("DoWhile", dw.While, reflect.TypeFor[string]())
+		state := ctx.state[dw.While]
+		if state == nil {
+			ctx.errorf("DoWhile", "no input %v", dw.While)
+		} else if state.typ.Kind() != reflect.String && state.typ.Kind() != reflect.Bool {
+			ctx.errorf("DoWhile", "input %v has wrong type: want string or bool, has %v", dw.While, state.typ)
+		} else {
+			state.used = true
+		}
 	}
 }
 

--- a/pkg/aflow/loop.go
+++ b/pkg/aflow/loop.go
@@ -21,6 +21,9 @@ type DoWhile struct {
 	// Max interations for the loop.
 	// Must be specified to avoid unintended effectively infinite loops.
 	MaxIterations int
+	// MapOutputs renames or overrides variables produced inside the loop
+	// before exposing them to the parent context upon loop completion.
+	MapOutputs map[string]string
 
 	loopVars map[string]reflect.Type
 }
@@ -58,6 +61,11 @@ func (dw *DoWhile) loop(ctx *Context) error {
 			return err
 		}
 		if ctx.state[dw.While].(string) == "" {
+			for from, to := range dw.MapOutputs {
+				if val, ok := ctx.state[from]; ok {
+					ctx.state[to] = val
+				}
+			}
 			return nil
 		}
 	}
@@ -86,11 +94,26 @@ func (dw *DoWhile) verify(ctx *verifyContext) {
 	if outputs {
 		ctx.inputs, ctx.outputs = false, true
 		origState := maps.Clone(ctx.state)
+		for from := range dw.MapOutputs {
+			delete(ctx.state, from)
+		}
 		dw.Do.verify(ctx)
 		dw.loopVars = make(map[string]reflect.Type)
 		for name, desc := range ctx.state {
 			if origState[name] == nil {
 				dw.loopVars[name] = desc.typ
+			}
+		}
+		maps.Copy(ctx.state, origState)
+		for from, to := range dw.MapOutputs {
+			desc := ctx.state[from]
+			if desc == nil {
+				ctx.errorf("DoWhile", "MapOutputs source %v is not produced in loop", from)
+				continue
+			}
+			ctx.state[to] = &varState{
+				action: "DoWhile",
+				typ:    desc.typ,
 			}
 		}
 	}

--- a/pkg/aflow/loop_test.go
+++ b/pkg/aflow/loop_test.go
@@ -103,6 +103,19 @@ func TestDoWhileErrors(t *testing.T) {
 			}),
 			While: "Output1",
 		}})
+
+	type invalidOutput struct {
+		Output1 int
+	}
+	testRegistrationError[struct{}, struct{}](t,
+		"flow test: action DoWhile: input Output1 has wrong type: want string or bool, has int",
+		&Flow{Root: &DoWhile{
+			Do: NewFuncAction("body", func(ctx *Context, args struct{}) (invalidOutput, error) {
+				return invalidOutput{}, nil
+			}),
+			While:         "Output1",
+			MaxIterations: 10,
+		}})
 }
 
 func TestDoWhileMaxIters(t *testing.T) {
@@ -350,6 +363,27 @@ func TestDoWhileMapOutputs(t *testing.T) {
 				}
 				return struct{}{}, nil
 			}),
+		),
+		nil,
+		nil,
+	)
+}
+
+func TestDoWhileBool(t *testing.T) {
+	type loopActionResults struct {
+		KeepGoing bool
+	}
+	iter := 0
+	testFlow[struct{}, struct{}](t, nil, map[string]any{},
+		Pipeline(
+			&DoWhile{
+				While:         "KeepGoing",
+				MaxIterations: 5,
+				Do: NewFuncAction("step", func(ctx *Context, args struct{}) (loopActionResults, error) {
+					iter++
+					return loopActionResults{KeepGoing: iter < 3}, nil
+				}),
+			},
 		),
 		nil,
 		nil,

--- a/pkg/aflow/loop_test.go
+++ b/pkg/aflow/loop_test.go
@@ -319,3 +319,39 @@ func TestLoopVarDefinedOutside(t *testing.T) {
 		)},
 	)
 }
+
+func TestDoWhileMapOutputs(t *testing.T) {
+	type outerInitResults struct {
+		PatchDiff string
+	}
+	type loopActionResults struct {
+		Continue  string
+		PatchDiff string
+	}
+	type consumerArgs struct {
+		RefinedDiff string
+	}
+	testFlow[struct{}, struct{}](t, nil, map[string]any{},
+		Pipeline(
+			NewFuncAction("init-action", func(ctx *Context, args struct{}) (outerInitResults, error) {
+				return outerInitResults{PatchDiff: "initial"}, nil
+			}),
+			&DoWhile{
+				MaxIterations: 1,
+				While:         "Continue",
+				MapOutputs:    map[string]string{"PatchDiff": "RefinedDiff"},
+				Do: NewFuncAction("loop-action", func(ctx *Context, args struct{ PatchDiff string }) (loopActionResults, error) {
+					return loopActionResults{Continue: "", PatchDiff: args.PatchDiff + "+refined"}, nil
+				}),
+			},
+			NewFuncAction("consumer", func(ctx *Context, args consumerArgs) (struct{}, error) {
+				if args.RefinedDiff != "initial+refined" {
+					return struct{}{}, fmt.Errorf("expected 'initial+refined', got %q", args.RefinedDiff)
+				}
+				return struct{}{}, nil
+			}),
+		),
+		nil,
+		nil,
+	)
+}

--- a/pkg/aflow/testdata/TestDoWhileBool.trajectory.json
+++ b/pkg/aflow/testdata/TestDoWhileBool.trajectory.json
@@ -1,0 +1,132 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Results": {
+			"KeepGoing": true
+		}
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:08Z",
+		"Finished": "0001-01-01T00:00:09Z",
+		"Results": {
+			"KeepGoing": true
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:10Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:12Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:12Z",
+		"Finished": "0001-01-01T00:00:13Z",
+		"Results": {
+			"KeepGoing": false
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:14Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:15Z"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:16Z",
+		"Results": {}
+	}
+]

--- a/pkg/aflow/testdata/TestDoWhileMapOutputs.trajectory.json
+++ b/pkg/aflow/testdata/TestDoWhileMapOutputs.trajectory.json
@@ -1,0 +1,101 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "init-action",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "init-action",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:03Z",
+		"Results": {
+			"PatchDiff": "initial"
+		}
+	},
+	{
+		"Seq": 2,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "loop-action",
+		"Started": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "loop-action",
+		"Started": "0001-01-01T00:00:06Z",
+		"Finished": "0001-01-01T00:00:07Z",
+		"Results": {
+			"Continue": "",
+			"PatchDiff": "initial+refined"
+		}
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:04Z",
+		"Finished": "0001-01-01T00:00:09Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "consumer",
+		"Started": "0001-01-01T00:00:10Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "consumer",
+		"Started": "0001-01-01T00:00:10Z",
+		"Finished": "0001-01-01T00:00:11Z",
+		"Results": {}
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"Results": {}
+	}
+]

--- a/pkg/aflow/tool/checkpatch/checkpatch.go
+++ b/pkg/aflow/tool/checkpatch/checkpatch.go
@@ -1,0 +1,38 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package checkpatch provides a tool to run the Linux kernel's checkpatch.pl script.
+package checkpatch
+
+import (
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/action/kernel"
+)
+
+var Tool = aflow.NewFuncTool("checkpatch", checkpatch, `
+The tool runs the Linux kernel's scripts/checkpatch.pl script on the current patch.
+It reports style and formatting issues in the patch.
+`)
+
+type state struct {
+	KernelScratchSrc string
+}
+
+type args struct{}
+
+type result struct {
+	Output string `jsonschema:"Output of the checkpatch.pl script."`
+}
+
+func checkpatch(ctx *aflow.Context, state state, args args) (result, error) {
+	if state.KernelScratchSrc == "" {
+		return result{}, aflow.BadCallError("KernelScratchSrc is not set")
+	}
+
+	output, _, err := kernel.Checkpatch(state.KernelScratchSrc)
+	if err != nil {
+		return result{}, err
+	}
+
+	return result{Output: output}, nil
+}

--- a/pkg/aflow/tool/clangformat/clangformat.go
+++ b/pkg/aflow/tool/clangformat/clangformat.go
@@ -1,0 +1,69 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package clangformat provides a tool to run clang-format on kernel source files.
+package clangformat
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+var Tool = aflow.NewFuncTool("clang-format", clangFormat, `
+The tool runs clang-format on a specific file to fix formatting issues.
+WARNING: clang-format may break existing formatting (like manual alignment) and should be used with caution.
+`)
+
+type state struct {
+	KernelScratchSrc string
+}
+
+type args struct {
+	File string `jsonschema:"The file to format (relative to the repository root)."`
+}
+
+type result struct {
+	Output string `jsonschema:"Output of the clang-format command."`
+}
+
+func clangFormat(ctx *aflow.Context, state state, args args) (result, error) {
+	if state.KernelScratchSrc == "" {
+		return result{}, aflow.BadCallError("KernelScratchSrc is not set")
+	}
+	if args.File == "" {
+		return result{}, aflow.BadCallError("File is required")
+	}
+
+	// Write the style file to a temporary file outside the repository.
+	tmpFile, err := os.CreateTemp("", "syz-clang-format-*.clang-format")
+	if err != nil {
+		return result{}, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	style := fmt.Sprintf("BasedOnStyle: InheritParentConfig=%s\nColumnLimit: 100\n", state.KernelScratchSrc)
+	if _, err := tmpFile.WriteString(style); err != nil {
+		tmpFile.Close()
+		return result{}, err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return result{}, err
+	}
+
+	cmd := osutil.Command("clang-format", "-style=file:"+tmpFile.Name(), "-i", args.File)
+	cmd.Dir = state.KernelScratchSrc
+	if err := osutil.Sandbox(cmd, true, false); err != nil {
+		return result{}, err
+	}
+
+	output, err := osutil.Run(10*time.Minute, cmd)
+	if err != nil {
+		return result{}, err
+	}
+
+	return result{Output: string(output)}, nil
+}

--- a/pkg/aflow/tool/patchdiff/patchdiff.go
+++ b/pkg/aflow/tool/patchdiff/patchdiff.go
@@ -33,21 +33,33 @@ type result struct {
 	Output string `jsonschema:"Output of the git diff command."`
 }
 
+// Diff runs a sandboxed git diff command in the specified repository.
+func Diff(repo string, args ...string) (string, error) {
+	gitDiffArgs := append([]string{"diff"}, args...)
+	cmd := osutil.Command("git", gitDiffArgs...)
+	cmd.Dir = repo
+	if err := osutil.Sandbox(cmd, true, false); err != nil {
+		return "", err
+	}
+	output, err := osutil.Run(1*time.Minute, cmd)
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
 func patchDiff(ctx *aflow.Context, state state, args args) (result, error) {
 	if state.KernelScratchSrc == "" {
 		return result{}, aflow.BadCallError("KernelScratchSrc is not set")
 	}
 
 	// Compare working tree to HEAD with expanded context.
-	gitArgs := []string{"diff", "HEAD", "--function-context", "-U10"}
+	gitArgs := []string{"HEAD", "--function-context", "-U10"}
 	if args.File != "" {
 		gitArgs = append(gitArgs, "--", args.File)
 	}
 
-	cmd := osutil.Command("git", gitArgs...)
-	cmd.Dir = state.KernelScratchSrc
-
-	output, err := osutil.Run(1*time.Minute, cmd)
+	output, err := Diff(state.KernelScratchSrc, gitArgs...)
 	if err != nil {
 		if verr, ok := errors.AsType[*osutil.VerboseError](err); ok {
 			if bytes.Contains(verr.Output, []byte("outside repository")) {
@@ -60,5 +72,5 @@ func patchDiff(ctx *aflow.Context, state state, args args) (result, error) {
 		return result{}, err
 	}
 
-	return result{Output: string(output)}, nil
+	return result{Output: output}, nil
 }


### PR DESCRIPTION
Closes https://github.com/google/syzkaller/issues/7623

Switch from pure `clang-format`-based formatting to LLM-based one. This will let us better adjust the patch style to the surrounding code and will let the agent react to user comments regarding code style.

See individual commits.