### PR TITLE
syz-cluster/series-tracker: set report level based on direct request

### DIFF
--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -156,12 +156,9 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, s
 	var directRequest bool
 	if cfg.DirectList != "" {
 		canonicalDirect := email.CanonicalEmail(cfg.DirectList)
-		for _, addr := range first.RawCc {
-			if email.CanonicalEmail(addr) == canonicalDirect {
-				directRequest = true
-				break
-			}
-		}
+		directRequest = slices.ContainsFunc(first.RawCc, func(addr string) bool {
+			return email.CanonicalEmail(addr) == canonicalDirect
+		})
 	}
 	reportLevel := api.ReportLevelBugs
 	if directRequest {

--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -153,7 +153,20 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, s
 		return nil
 	}
 	first := series.Patches[0]
-	reportLevel := api.ReportLevelAll
+	var directRequest bool
+	if cfg.DirectList != "" {
+		canonicalDirect := email.CanonicalEmail(cfg.DirectList)
+		for _, addr := range first.RawCc {
+			if email.CanonicalEmail(addr) == canonicalDirect {
+				directRequest = true
+				break
+			}
+		}
+	}
+	reportLevel := api.ReportLevelBugs
+	if directRequest {
+		reportLevel = api.ReportLevelAll
+	}
 	if first.OwnEmail {
 		// If another bot instance reads the same mailing list, we don't want to
 		// spam it back. So we still fuzz the series, but don't report the results.
@@ -201,16 +214,6 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, s
 	} else if !ret.Saved {
 		log.Printf("series %s already exists in the DB", series.MessageID)
 		return nil
-	}
-	var directRequest bool
-	if cfg.DirectList != "" {
-		canonicalDirect := email.CanonicalEmail(cfg.DirectList)
-		for _, addr := range first.RawCc {
-			if email.CanonicalEmail(addr) == canonicalDirect {
-				directRequest = true
-				break
-			}
-		}
 	}
 
 	_, err = sf.client.UploadSession(ctx, &api.NewSession{

--- a/syz-cluster/series-tracker/main_test.go
+++ b/syz-cluster/series-tracker/main_test.go
@@ -6,7 +6,13 @@ package main
 import (
 	"testing"
 
+	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/email/lore"
+	"github.com/google/syzkaller/syz-cluster/pkg/app"
+	"github.com/google/syzkaller/syz-cluster/pkg/controller"
+	"github.com/google/syzkaller/syz-cluster/pkg/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSeriesProcessor(t *testing.T) {
@@ -42,4 +48,91 @@ second body`,
 		"a@a.com", "b@b.com",
 		"bob@example.com", "d@d.com",
 	}, sp.Emails())
+}
+
+func TestHandleSeriesReportLevel(t *testing.T) {
+	tests := []struct {
+		name            string
+		directList      string
+		rawCc           []string
+		ownEmail        bool
+		wantDirect      bool
+		wantReportLevel string
+	}{
+		{
+			name:            "standard series",
+			directList:      "direct@syzkaller.com",
+			rawCc:           []string{"user@test.com"},
+			ownEmail:        false,
+			wantDirect:      false,
+			wantReportLevel: "bugs",
+		},
+		{
+			name:            "direct request series",
+			directList:      "direct@syzkaller.com",
+			rawCc:           []string{"user@test.com", "direct@syzkaller.com"},
+			ownEmail:        false,
+			wantDirect:      true,
+			wantReportLevel: "all",
+		},
+		{
+			name:            "own email series",
+			directList:      "direct@syzkaller.com",
+			rawCc:           []string{"user@test.com"},
+			ownEmail:        true,
+			wantDirect:      false,
+			wantReportLevel: "none",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, ctx := app.TestEnvironment(t)
+			client := controller.TestServer(t, env)
+			sessionRepo := db.NewSessionRepository(env.Spanner)
+
+			sf := &SeriesFetcher{client: client}
+			cfg := &app.AppConfig{
+				DirectList: tt.directList,
+			}
+			msgID := "msg-" + tt.name
+			series := &lore.Series{
+				Subject:   "Subject " + tt.name,
+				MessageID: msgID,
+				Patches: []lore.Patch{
+					{
+						Email: &lore.Email{
+							Email: &email.Email{
+								MessageID: msgID,
+								Author:    "author@test.com",
+								RawCc:     tt.rawCc,
+								OwnEmail:  tt.ownEmail,
+							},
+						},
+					},
+				},
+			}
+			idToReader := map[string]lore.EmailReader{
+				msgID: {
+					Read: func() ([]byte, error) {
+						return []byte("patch content"), nil
+					},
+				},
+			}
+
+			err := sf.handleSeries(ctx, cfg, series, idToReader)
+			require.NoError(t, err)
+
+			dbSeries, err := db.NewSeriesRepository(env.Spanner).GetByExtID(ctx, msgID)
+			require.NoError(t, err)
+			require.NotNil(t, dbSeries)
+
+			sessions, err := sessionRepo.ListForSeries(ctx, dbSeries)
+			require.NoError(t, err)
+			require.Len(t, sessions, 1)
+
+			assert.Equal(t, tt.wantDirect, sessions[0].Direct.Bool)
+			assert.Equal(t, tt.wantReportLevel, sessions[0].ReportLevel.StringVal)
+		})
+	}
 }


### PR DESCRIPTION
Standard patch series polled from mailing lists were previously uploaded with ReportLevel set to ReportLevelAll. This caused the report generator to treat them as requiring a full report upon completion, even when no bugs or findings were discovered, resulting in unwanted moderation notifications.

Determine directRequest before selecting the report level so that standard public series default to ReportLevelBugs (only reporting when findings exist), while on-demand direct requests continue to use ReportLevelAll.