### PR TITLE
syz-cluster: support extraOwnEmails configuration

### DIFF
--- a/syz-cluster/email-reporter/main.go
+++ b/syz-cluster/email-reporter/main.go
@@ -106,17 +106,10 @@ func runConsumerLoop(ctx context.Context, msgCh <-chan *lore.PolledEmail, handle
 }
 
 func MakeLorePoller(repoDir string, emailCfg *app.EmailConfig, msgCh chan *lore.PolledEmail) (*lore.Poller, error) {
-	var ownEmails []string
-	if emailCfg.Dashapi != nil {
-		ownEmails = append(ownEmails, emailCfg.Dashapi.From)
-	}
-	if emailCfg.SMTP != nil {
-		ownEmails = append(ownEmails, emailCfg.SMTP.From)
-	}
 	return lore.NewPoller(lore.PollerConfig{
 		RepoDir:        repoDir,
 		URL:            emailCfg.LoreArchiveURL,
-		OwnEmails:      ownEmails,
+		OwnEmails:      emailCfg.OwnEmails(),
 		LookbackPeriod: 48 * time.Hour,
 		Tracer:         &debugtracer.GenericTracer{TraceWriter: os.Stdout, WithTime: true},
 	})

--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -22,6 +22,9 @@ emailReporting:
   sender: dashapi
   supportEmail: syzkaller@googlegroups.com
   creditEmail: syzbot@syzkaller.appspotmail.com
+  # Additional bot addresses not in Dashapi or SMTP From fields.
+  extraOwnEmails:
+    - syzbot@kernel.org
   archiveList: syzbot@lists.linux.dev
   moderationList: syzkaller-upstream-moderation@googlegroups.com
   reportCc:

--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"gopkg.in/yaml.v3"
 )
@@ -59,6 +60,8 @@ type EmailConfig struct {
 	SupportEmail string `yaml:"supportEmail"`
 	// The address will be suggested for the Tested-by tag.
 	CreditEmail string `yaml:"creditEmail"`
+	// Extra own email addresses to recognize.
+	ExtraOwnEmails []string `yaml:"extraOwnEmails"`
 	// The means to send the emails ("smtp", "dashapi").
 	Sender string `yaml:"sender"`
 	// Will be used if Sender is "smtp".
@@ -75,6 +78,18 @@ type EmailConfig struct {
 	LoreArchiveURL string `yaml:"loreArchiveURL"`
 	// The prefix which will be added to all reports' titles.
 	SubjectPrefix string `yaml:"subjectPrefix"`
+}
+
+func (c EmailConfig) OwnEmails() []string {
+	var own []string
+	if c.Dashapi != nil && c.Dashapi.From != "" {
+		own = append(own, c.Dashapi.From)
+	}
+	if c.SMTP != nil && c.SMTP.From != "" {
+		own = append(own, c.SMTP.From)
+	}
+	own = append(own, c.ExtraOwnEmails...)
+	return email.MergeEmailLists(own)
 }
 
 type SMTPConfig struct {

--- a/syz-cluster/pkg/app/config_test.go
+++ b/syz-cluster/pkg/app/config_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigs(t *testing.T) {
@@ -42,4 +44,23 @@ func TestConfigs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("filepath.Walk failed: %v", err)
 	}
+}
+
+func TestOwnEmails(t *testing.T) {
+	cfg := &EmailConfig{
+		Dashapi: &DashapiConfig{
+			From: "bot@dashapi.com",
+		},
+		SMTP: &SMTPConfig{
+			From: "bot@smtp.com",
+		},
+		ExtraOwnEmails: []string{
+			"bot@kernel.org",
+			"bot@dashapi.com",
+		},
+	}
+
+	got := cfg.OwnEmails()
+	want := []string{"bot@dashapi.com", "bot@kernel.org", "bot@smtp.com"}
+	require.Equal(t, want, got)
 }

--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -115,13 +115,14 @@ func (sf *SeriesFetcher) Update(ctx context.Context, from time.Time) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch the config: %w", err)
 	}
+	ownEmails := cfg.EmailReporting.OwnEmails()
 	for _, item := range list {
 		// TODO: this could be done in several threads.
 		rawBody, err := item.Read()
 		if err != nil {
 			return fmt.Errorf("failed to read email %s: %w", item.Hash, err)
 		}
-		email, err := lore.Parse(rawBody, nil, nil)
+		email, err := lore.Parse(rawBody, ownEmails, nil)
 		if err != nil {
 			log.Printf("failed to parse email: %v", err)
 			continue


### PR DESCRIPTION
Syz-cluster previously only recognized emails defined in Dashapi or SMTP From fields as own emails. Additional bot addresses (such as syzbot@kernel.org) were not recognized, causing series tracker and email poller to fail to identify bot authored messages.

Add an extraOwnEmails configuration option to EmailConfig and pass the merged list of own emails to lore parser and lore poller. Add syzbot@kernel.org to the prod GKE configuration.