### PR TITLE
syz-cluster/dashboard: better highlight results on per-series page

### DIFF
--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/html/urlutil"
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/blob"
 	"github.com/google/syzkaller/syz-cluster/pkg/db"
@@ -192,6 +193,68 @@ type uiSeriesData struct {
 	Sessions     []uiSessionData
 	Versions     []*db.Series
 	TotalPatches int
+}
+
+func (s uiSessionData) ActiveFindings() []*db.Finding {
+	var res []*db.Finding
+	for _, t := range s.Tests {
+		for _, f := range t.Findings {
+			if f.InvalidatedAt.IsNull() {
+				res = append(res, f)
+			}
+		}
+	}
+	return res
+}
+
+func (s uiSessionData) StatusBadgeClass() string {
+	if len(s.ActiveFindings()) > 0 {
+		return "bg-danger"
+	}
+	switch s.Status() {
+	case db.SessionStatusInProgress:
+		return "bg-info text-dark"
+	case db.SessionStatusFinished:
+		for _, t := range s.Tests {
+			if t.Result == api.TestFailed || t.Result == api.TestError {
+				return "bg-warning text-dark"
+			}
+		}
+		return "bg-success"
+	default:
+		return "bg-secondary"
+	}
+}
+
+func (s uiSessionData) StatusText() string {
+	if count := len(s.ActiveFindings()); count > 0 {
+		return fmt.Sprintf("%d Findings", count)
+	}
+	if s.Status() == db.SessionStatusFinished {
+		for _, t := range s.Tests {
+			if t.Result == api.TestFailed || t.Result == api.TestError {
+				return "Steps Failed"
+			}
+		}
+		return "Passed"
+	}
+	return string(s.Status())
+}
+
+func (s uiSeriesData) MainSession() *uiSessionData {
+	for i := range s.Sessions {
+		if s.Sessions[i].JobID.IsNull() {
+			return &s.Sessions[i]
+		}
+	}
+	return nil
+}
+
+func (s uiSeriesData) MainFindings() []*db.Finding {
+	if sess := s.MainSession(); sess != nil {
+		return sess.ActiveFindings()
+	}
+	return nil
 }
 
 func (h *dashboardHandler) fetchSessionData(ctx context.Context, session *db.Session) (uiSessionData, error) {

--- a/syz-cluster/dashboard/templates/series.html
+++ b/syz-cluster/dashboard/templates/series.html
@@ -92,18 +92,62 @@
                 {{end}}
            </tbody>
         </table>
+
+        <!-- Series Summary Block -->
+        {{$mainSession := .MainSession}}
+        {{$mainFindings := .MainFindings}}
+        {{if or $mainSession $mainFindings}}
+        <div class="card my-3">
+            <div class="card-header bg-light d-flex justify-content-between align-items-center py-2">
+                <h6 class="mb-0 fw-bold">Series Summary</h6>
+                {{if $mainFindings}}
+                    <span class="badge bg-danger fs-6">{{len $mainFindings}} Findings</span>
+                {{else if $mainSession}}
+                    <span class="badge {{$mainSession.StatusBadgeClass}} fs-6">{{$mainSession.StatusText}}</span>
+                {{end}}
+            </div>
+            <div class="card-body py-2">
+                {{if $mainFindings}}
+                    <div class="alert alert-danger mb-0 p-2">
+                        {{template "findings_list" $mainFindings}}
+                    </div>
+                {{else if $mainSession}}
+                    {{if eq $mainSession.StatusText "Passed"}}
+                        <div class="alert alert-success mb-0 py-2">
+                            ✓ All tests passed. No findings.
+                        </div>
+                    {{else if eq $mainSession.StatusText "Steps Failed"}}
+                        <div class="alert alert-warning mb-0 py-2">
+                            Some test steps failed.
+                        </div>
+                    {{else if eq $mainSession.Status "skipped"}}
+                        <div class="alert alert-secondary mb-0 py-2">
+                            Session skipped: {{if not $mainSession.SkipReason.IsNull}}{{$mainSession.SkipReason.StringVal}}{{else}}N/A{{end}}
+                        </div>
+                    {{else}}
+                        <div class="alert alert-info mb-0 py-2">
+                            Status: {{$mainSession.StatusText}}
+                        </div>
+                    {{end}}
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+
+        <h5 class="mt-4 mb-2">Sessions</h5>
         {{range .Sessions}}
         <div class="card mb-2">
             <div class="card-header d-flex justify-content-between align-items-center py-1">
                 <div>
-                    <h6 class="mb-0">
+                    <h6 class="mb-0 d-inline-block me-2">
                         Session {{.CreatedAt.Format "2006-01-02"}}
-                        {{if .Job}}
-                            <span class="badge bg-info text-dark">Job</span>
-                        {{end}}
                     </h6>
+                    <span class="badge {{.StatusBadgeClass}} me-1">{{.StatusText}}</span>
                     {{if .Job}}
-                        <small class="text-muted">Job requested at: <a href="{{.JobLink}}" target="_blank">{{.JobLink}}</a></small>
+                        <span class="badge bg-info text-dark">Job</span>
+                    {{end}}
+                    {{if .Job}}
+                        <small class="text-muted ms-2">Job requested at: <a href="{{.JobLink}}" target="_blank">{{.JobLink}}</a></small>
                     {{end}}
                 </div>
                 <button class="btn btn-sm btn-outline-secondary btn-collapse" data-bs-toggle="collapse" data-bs-target="#session-{{.ID}}" aria-expanded="{{if .Uncollapsed}}true{{else}}false{{end}}" aria-controls="session-{{.ID}}">
@@ -159,26 +203,37 @@
                     <td>{{if .BaseBuild}}{{template "build_info" .BaseBuild}}{{end}}</td>
                     <td>{{if .PatchedBuild}}{{template "build_info" .PatchedBuild}}[patched]{{end}}</td>
                     <th>
-                        {{.Result}}
+                        {{if eq .Result "passed"}}
+                            <span class="badge bg-success">passed</span>
+                        {{else if eq .Result "failed"}}
+                            <span class="badge bg-danger">failed</span>
+                        {{else if eq .Result "error"}}
+                            <span class="badge bg-warning text-dark">error</span>
+                        {{else if eq .Result "running"}}
+                            <span class="badge bg-primary">running</span>
+                        {{else if eq .Result "skipped"}}
+                            <span class="badge bg-secondary">skipped</span>
+                        {{else}}
+                            <span class="badge bg-secondary">{{.Result}}</span>
+                        {{end}}
                         {{if .LogURI}}
-                            <a href="/sessions/{{.SessionID}}/test_logs?name={{.TestName}}" class="modal-link-raw">[Log]</a>
+                            <a href="/sessions/{{.SessionID}}/test_logs?name={{.TestName}}" class="modal-link-raw ms-1">[Log]</a>
                         {{end}}
                         {{if .ArtifactsArchiveURI}}
-                            <a href="/sessions/{{.SessionID}}/test_artifacts?name={{.TestName}}">[Artifacts]</a>
+                            <a href="/sessions/{{.SessionID}}/test_artifacts?name={{.TestName}}" class="ms-1">[Artifacts]</a>
                         {{end}}
                     </th>
                 </tr>
                 {{range .Steps}}
                 <tr>
-                    <td class="pl-4"><small class="text-muted">&#8627;</small> <span class="text-muted">{{.Title}}</span></td>
+                    <td class="ps-4"><small class="text-muted">&#8627;</small> <span class="text-muted">{{.Title}}</span></td>
                     <td>
                         {{if .Base}}
-                        <span class="{{if eq .Base.Result "passed"}}text-success{{else if eq .Base.Result "failed"
-                            }}text-danger{{else}}text-warning{{end}}">
+                        <span class="badge {{if eq .Base.Result "passed"}}bg-success{{else if eq .Base.Result "failed"}}bg-danger{{else}}bg-warning text-dark{{end}}">
                             {{.Base.Result}}
                         </span>
                         {{if .Base.LogURI}}
-                        <a href="/test_steps/{{.Base.ID}}/log" class="modal-link-raw">[Log]</a>
+                        <a href="/test_steps/{{.Base.ID}}/log" class="modal-link-raw ms-1">[Log]</a>
                         {{end}}
                         {{else}}
                         <span class="text-muted">-</span>
@@ -186,12 +241,11 @@
                     </td>
                     <td>
                         {{if .Patched}}
-                        <span class="{{if eq .Patched.Result "passed"}}text-success{{else if eq .Patched.Result "failed"
-                            }}text-danger{{else}}text-warning{{end}}">
+                        <span class="badge {{if eq .Patched.Result "passed"}}bg-success{{else if eq .Patched.Result "failed"}}bg-danger{{else}}bg-warning text-dark{{end}}">
                             {{.Patched.Result}}
                         </span>
                         {{if .Patched.LogURI}}
-                        <a href="/test_steps/{{.Patched.ID}}/log" class="modal-link-raw">[Log]</a>
+                        <a href="/test_steps/{{.Patched.ID}}/log" class="modal-link-raw ms-1">[Log]</a>
                         {{end}}
                         {{else}}
                         <span class="text-muted">-</span>
@@ -202,28 +256,8 @@
                 {{end}}
                 {{if .Findings}}
                 <tr>
-                  <td colspan="4">
-                    <table class="table mb-0">
-                      <tbody>
-                      {{range .Findings}}
-                      <tr>
-                        <td>
-                          {{if not .InvalidatedAt.IsNull}}<b>[invalidated]</b>{{end}}
-                          {{if .ReportURI}}
-                            <a href="/findings/{{.ID}}/report" class="modal-link-raw">{{.Title}}</a>
-                          {{else}}
-                            {{.Title}}
-                          {{end}}
-                        </td>
-                        <td>
-                          {{if .LogURI}}<a href="/findings/{{.ID}}/log" class="modal-link-raw">[Log]</a>{{end}}
-                          {{if .SyzReproURI}}<a href="/findings/{{.ID}}/syz_repro" class="modal-link-raw">[Syz Repro]</a>{{end}}
-                          {{if .CReproURI}}<a href="/findings/{{.ID}}/c_repro" class="modal-link-raw">[C Repro]</a>{{end}}
-                        </td>
-                      </tr>
-                      {{end}}
-                      </tbody>
-                    </table>
+                  <td colspan="4" class="px-3 py-1">
+                    {{template "findings_list" .Findings}}
                   </td>
                 </tr>
                 {{end}}
@@ -236,3 +270,4 @@
         {{end}}
     </div>
 {{end}}
+

--- a/syz-cluster/dashboard/templates/templates.html
+++ b/syz-cluster/dashboard/templates/templates.html
@@ -7,3 +7,30 @@
 <a href="/builds/{{.ID}}/log" class="modal-link-raw">[Log]</a>
 {{end}}
 {{end}}
+
+{{define "findings_list"}}
+<div class="findings-list">
+  {{range .}}
+  <div class="d-flex justify-content-between align-items-center py-1 border-bottom border-secondary-subtle">
+    <div class="me-2">
+      {{if not .InvalidatedAt.IsNull}}
+        <span class="badge bg-secondary me-1">[invalidated]</span>
+      {{else}}
+        <span class="badge bg-danger me-1">finding</span>
+      {{end}}
+      {{if .ReportURI}}
+        <a href="/findings/{{.ID}}/report" class="modal-link-raw fw-bold text-dark">{{.Title}}</a>
+      {{else}}
+        <span class="fw-bold">{{.Title}}</span>
+      {{end}}
+    </div>
+    <div class="text-nowrap ms-2">
+      {{if .LogURI}}<a href="/findings/{{.ID}}/log" class="btn btn-sm btn-outline-secondary modal-link-raw py-0 px-1">Log</a>{{end}}
+      {{if .SyzReproURI}}<a href="/findings/{{.ID}}/syz_repro" class="btn btn-sm btn-outline-danger modal-link-raw py-0 px-1 ms-1">Syz Repro</a>{{end}}
+      {{if .CReproURI}}<a href="/findings/{{.ID}}/c_repro" class="btn btn-sm btn-outline-danger modal-link-raw py-0 px-1 ms-1">C Repro</a>{{end}}
+    </div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+


### PR DESCRIPTION
It was difficult to quickly tell if a patch series passed testing or found bugs without manually inspecting individual session cards.

Add a Series Summary block at the top of the per-series page for the latest automated run. Highlight active findings and reproducers, or show a success banner when all tests pass.

Add color-coded badges for session headers and test verdicts, and use a shared template to display findings cleanly across views.

***

You could preview it by running `DOCKERARGS="-p 8082:8082" ./tools/syz-env go test -v ./syz-cluster/dashboard/ -run TestLocalUI -local-ui -local-ui-addr=:8082 -timeout=0`.