### PR TITLE
pkg/coveragedb: rely only on sessions table for garbage deletion

### DIFF
--- a/dashboard/app/cron.yaml
+++ b/dashboard/app/cron.yaml
@@ -28,7 +28,7 @@ cron:
 # We're adding data w/o transactions.
 # It is important to run clean operation when there are no batch_coverage in progress.
 - url: /cron/batch_coverage_clean
-  schedule: every saturday 12:00
+  schedule: every day 12:00
 # Export reproducers every week.
 - url: /cron/batch_db_export
   schedule: every saturday 00:00

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -303,65 +303,15 @@ type sessionRow struct {
 	Session string
 }
 
-type activeSessionRow struct {
-	Session string
-	Created time.Time
-}
-
-type orphanFinder struct {
-	// client is the Spanner client used to execute queries.
-	client *spanner.Client
-	// validSessions is the set of completed session IDs present in merge_history.
-	validSessions map[string]bool
-	// processedSessions tracks session IDs already processed to avoid duplicates and redundant lookups.
-	processedSessions map[string]bool
-	// activeSessions maps registered session IDs in the sessions table to their creation time.
-	activeSessions map[string]time.Time
-	// cutoff is the threshold time; sessions created before this time are considered expired.
-	cutoff time.Time
-	// sessionCh is the channel used to send expired session IDs to deletion workers.
-	sessionCh chan<- string
-}
-
-func (f *orphanFinder) stream(ctx context.Context, sql string) error {
-	iter := f.client.Single().Query(ctx, spanner.Statement{SQL: sql})
-	defer iter.Stop()
-	for {
-		r, err := pkgspanner.ReadRow[sessionRow](iter)
-		if err != nil {
-			return err
-		}
-		if r == nil {
-			break
-		}
-		if f.validSessions[r.Session] || f.processedSessions[r.Session] {
-			continue
-		}
-		f.processedSessions[r.Session] = true
-		created, ok := f.activeSessions[r.Session]
-		if !ok || created.Before(f.cutoff) {
-			select {
-			case f.sessionCh <- r.Session:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-	}
-	return nil
-}
-
-// DeleteGarbage cleans up orphaned database entries that are no longer associated with active merge sessions.
+// DeleteGarbage cleans up database entries for sessions that are:
+//  1. Present in "sessions" table but created more than 1 week ago (failed/abandoned sessions).
+//  2. Not present in "merge_history" (i.e. they are not completed sessions).
 //
-// It identifies sessions in "files" and "functions" tables that are:
-//  1. Not present in "merge_history" (i.e. they are not completed sessions).
-//  2. Either missing from "sessions" table (legacy active sessions, which are deleted immediately)
-//     or present in "sessions" table but created more than 1 week ago (failed/abandoned sessions).
+// Active incomplete sessions (created within the last week) and completed sessions
+// (present in "merge_history") are preserved.
 //
-// Active incomplete sessions (present in "sessions" table and created within the last week)
-// are preserved to allow ongoing uploads to complete.
-//
-// To avoid slow anti-joins in Spanner, this function fetches all valid and active sessions first,
-// then streams distinct sessions from files and functions, performing the filtering in Go.
+// It does NOT clean up orphaned records in "files" or "functions" tables that do not
+// have a corresponding record in the "sessions" table.
 //
 // To avoid exceeding Spanner mutation limits, entries are deleted in batches of 10,000.
 //
@@ -371,33 +321,24 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		return 0, 0, fmt.Errorf("nil spannerclient")
 	}
 
-	// 1. Get all valid sessions from merge_history
-	validSessions := make(map[string]bool)
-	iterHistory := client.Single().Query(ctx, spanner.Statement{
-		SQL: `SELECT DISTINCT session FROM merge_history`})
-	defer iterHistory.Stop()
-	historyRows, err := pkgspanner.ReadRows[sessionRow](iterHistory)
-	if err != nil {
-		return 0, 0, err
-	}
-	for _, r := range historyRows {
-		validSessions[r.Session] = true
-	}
+	cutoff := time.Now().Add(-oneWeekAgo)
 
-	// 2. Get all active sessions from sessions
-	activeSessions := make(map[string]time.Time)
+	// 1. Get only the expired sessions that need to be deleted.
 	iterSessions := client.Single().Query(ctx, spanner.Statement{
-		SQL: `SELECT session, created FROM sessions`})
+		SQL: `SELECT session FROM sessions s
+              WHERE s.created < $1
+                AND NOT EXISTS (
+                  SELECT 1 FROM merge_history m WHERE m.session = s.session
+                )`,
+		Params: map[string]any{"p1": cutoff},
+	})
 	defer iterSessions.Stop()
-	sessionRows, err := pkgspanner.ReadRows[activeSessionRow](iterSessions)
+	sessionRows, err := pkgspanner.ReadRows[sessionRow](iterSessions)
 	if err != nil {
 		return 0, 0, err
 	}
-	for _, r := range sessionRows {
-		activeSessions[r.Session] = r.Created
-	}
 
-	// 3. Stream distinct sessions from files and functions and feed to workers.
+	// 2. Process expired sessions.
 	var deletedRows atomic.Int64
 	var deletedSessions atomic.Int64
 	eg, gCtx := errgroup.WithContext(ctx)
@@ -418,24 +359,14 @@ func DeleteGarbage(ctx context.Context, client *spanner.Client) (int64, int64, e
 		})
 	}
 
-	finder := &orphanFinder{
-		client:            client,
-		validSessions:     validSessions,
-		processedSessions: make(map[string]bool),
-		activeSessions:    activeSessions,
-		cutoff:            time.Now().Add(-oneWeekAgo),
-		sessionCh:         sessionCh,
-	}
-
 	eg.Go(func() error {
 		defer close(sessionCh)
-
-		if err := finder.stream(gCtx, `SELECT DISTINCT session FROM files`); err != nil {
-			return err
-		}
-
-		if err := finder.stream(gCtx, `SELECT DISTINCT session FROM functions`); err != nil {
-			return err
+		for _, r := range sessionRows {
+			select {
+			case sessionCh <- r.Session:
+			case <-gCtx.Done():
+				return gCtx.Err()
+			}
 		}
 		return nil
 	})

--- a/pkg/coveragedb/coveragedb_test.go
+++ b/pkg/coveragedb/coveragedb_test.go
@@ -421,14 +421,12 @@ func TestDeleteGarbage(t *testing.T) {
 	require.NoError(t, err)
 
 	// We expect:
-	// - sessionFailed, sessionOldGarbage, sessionFuncsOnly are deleted: 3 sessions.
+	// - Only sessionFailed is deleted: 1 session.
 	// - deleted rows:
 	//   - sessionFailed: 1 files + 1 functions = 2 rows
-	//   - sessionOldGarbage: 1 files + 1 functions = 2 rows
-	//   - sessionFuncsOnly: 1 functions = 1 row
-	//   Total: 5 rows.
-	assert.Equal(t, int64(3), deletedSessions)
-	assert.Equal(t, int64(5), deletedRows)
+	//   Total: 2 rows.
+	assert.Equal(t, int64(1), deletedSessions)
+	assert.Equal(t, int64(2), deletedRows)
 
 	// Verify DB state.
 	assertRowExists(t, client, "sessions", spanner.Key{sessionCompleted})
@@ -443,12 +441,13 @@ func TestDeleteGarbage(t *testing.T) {
 	assertRowNotExists(t, client, "files", spanner.Key{sessionFailed, "*", "file-failed"})
 	assertRowNotExists(t, client, "functions", spanner.Key{sessionFailed, "file-failed", "func-failed"})
 
-	assertRowNotExists(t, client, "sessions", spanner.Key{sessionOldGarbage})
-	assertRowNotExists(t, client, "files", spanner.Key{sessionOldGarbage, "*", "file-old-garbage"})
-	assertRowNotExists(t, client, "functions", spanner.Key{sessionOldGarbage, "file-old-garbage", "func-old-garbage"})
+	// sessionOldGarbage and sessionFuncsOnly have no sessions record, so they should NOT be deleted.
+	// We only delete sessions present in the "sessions" table to avoid race conditions where a
+	// concurrent writer is actively creating a new session and filling its files/functions.
+	assertRowExists(t, client, "files", spanner.Key{sessionOldGarbage, "*", "file-old-garbage"})
+	assertRowExists(t, client, "functions", spanner.Key{sessionOldGarbage, "file-old-garbage", "func-old-garbage"})
 
-	assertRowNotExists(t, client, "sessions", spanner.Key{sessionFuncsOnly})
-	assertRowNotExists(t, client, "functions", spanner.Key{sessionFuncsOnly, "file-funcs-only", "func-funcs-only"})
+	assertRowExists(t, client, "functions", spanner.Key{sessionFuncsOnly, "file-funcs-only", "func-funcs-only"})
 }
 
 func assertRowExists(t *testing.T, client *spanner.Client, table string, key spanner.Key) {


### PR DESCRIPTION
Modify DeleteGarbage to use the "sessions" table as the sole source of truth for identifying expired sessions.

Previously, the cleanup job streamed distinct sessions from the "files" and "functions" tables to identify "orphaned" sessions that were missing from the "sessions" table. This caused performance issues and a critical race condition: new sessions actively uploading data could be misclassified as orphans and deleted concurrently.

With this change, we only clean up sessions that have a record in the "sessions" table and meet the expiration criteria (older than 1 week and not in "merge_history"). Legacy orphaned records without "sessions" entries are ignored. This simplifies the logic, speeds up the analysis phase, and prevents the race condition.
