### PR TITLE
dashboard/app: support flexible coverage export with filtering

### DIFF
--- a/dashboard/app/coverage.go
+++ b/dashboard/app/coverage.go
@@ -60,12 +60,15 @@ type funcStyleBodyJS func(
 ) (template.CSS, template.HTML, template.HTML, error)
 
 type coverageHeatmapParams struct {
-	manager    string
-	subsystem  string
-	onlyUnique bool
-	periodType string
-	nPeriods   int
-	dateTo     civil.Date
+	manager       string
+	subsystem     string
+	onlyUnique    bool
+	periodType    string
+	nPeriods      int
+	dateTo        civil.Date
+	filepath      string
+	withCovered   bool
+	withUncovered bool
 	cover.Format
 }
 
@@ -86,12 +89,15 @@ func makeHeatmapParams(ctx context.Context, r *http.Request) (*coverageHeatmapPa
 	}
 
 	return &coverageHeatmapParams{
-		manager:    getParam[string](r, ManagerName.ParamName()),
-		subsystem:  getParam[string](r, SubsystemName.ParamName()),
-		onlyUnique: onlyUnique,
-		periodType: periodType,
-		nPeriods:   nPeriods,
-		dateTo:     getParam[civil.Date](r, DateTo.ParamName(), civil.DateOf(timeNow(ctx))),
+		manager:       getParam[string](r, ManagerName.ParamName()),
+		subsystem:     getParam[string](r, SubsystemName.ParamName()),
+		onlyUnique:    onlyUnique,
+		periodType:    periodType,
+		nPeriods:      nPeriods,
+		dateTo:        getParam[civil.Date](r, DateTo.ParamName(), civil.DateOf(timeNow(ctx))),
+		filepath:      getParam[string](r, FilePath.ParamName()),
+		withCovered:   getParam[bool](r, WithCovered.ParamName(), true),
+		withUncovered: getParam[bool](r, WithUncovered.ParamName(), true),
 		Format: cover.Format{
 			DropCoveredLines0:         onlyUnique,
 			OrderByCoveredLinesDrop:   getParam[bool](r, OrderByCoverDrop.ParamName()),
@@ -180,6 +186,8 @@ const (
 	PeriodType        = covPageParam("period")
 	SubsystemName     = covPageParam("subsystem")
 	UniqueOnly        = covPageParam("unique-only")
+	WithCovered       = covPageParam("with-covered")
+	WithUncovered     = covPageParam("with-uncovered")
 	// keep-sorted end
 )
 
@@ -236,6 +244,7 @@ func handleHeatmap(ctx context.Context, w http.ResponseWriter, hdr *uiHeader, p 
 			Subsystem: p.subsystem,
 			Manager:   p.manager,
 			Periods:   periods,
+			FilePath:  p.filepath,
 		},
 		p.onlyUnique, subsystems, managers, p.Format,
 	); err != nil {

--- a/dashboard/app/public_json_api.go
+++ b/dashboard/app/public_json_api.go
@@ -208,6 +208,8 @@ func GetJSONDescrFor(page any) ([]byte, error) {
 }
 
 func writeExtAPICoverageFor(ctx context.Context, w io.Writer, ns, repo string, p *coverageHeatmapParams) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	// By default, return the previous month coverage. It guarantees the good numbers.
 	//
 	// The alternative is to return the current month.
@@ -224,9 +226,15 @@ func writeExtAPICoverageFor(ctx context.Context, w io.Writer, ns, repo string, p
 	}
 	subsystem := ""
 	manager := ""
+	filepath := ""
+	withCovered := true
+	withUncovered := true
 	if p != nil {
 		subsystem = p.subsystem
 		manager = p.manager
+		filepath = p.filepath
+		withCovered = p.withCovered
+		withUncovered = p.withUncovered
 	}
 	covCh, errCh := coveragedb.FilesCoverageStream(ctx, covDBClient,
 		&coveragedb.SelectScope{
@@ -234,8 +242,9 @@ func writeExtAPICoverageFor(ctx context.Context, w io.Writer, ns, repo string, p
 			Subsystem: subsystem,
 			Manager:   manager,
 			Periods:   tps,
+			FilePath:  filepath,
 		})
-	if err := writeFileCoverage(ctx, w, repo, ff, covCh); err != nil {
+	if err := writeFileCoverage(ctx, w, repo, ff, covCh, withCovered, withUncovered); err != nil {
 		return fmt.Errorf("populateFileCoverage: %w", err)
 	}
 	if err := <-errCh; err != nil {
@@ -245,7 +254,7 @@ func writeExtAPICoverageFor(ctx context.Context, w io.Writer, ns, repo string, p
 }
 
 func writeFileCoverage(ctx context.Context, w io.Writer, repo string, ff *coveragedb.FunctionFinder,
-	covCh <-chan *coveragedb.FileCoverageWithLineInfo) error {
+	covCh <-chan *coveragedb.FileCoverageWithLineInfo, withCovered, withUncovered bool) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "\t")
 	for {
@@ -254,7 +263,7 @@ func writeFileCoverage(ctx context.Context, w io.Writer, repo string, ff *covera
 			if fileCov == nil {
 				return nil
 			}
-			funcsCov, err := genFuncsCov(fileCov, ff)
+			funcsCov, err := genFuncsCov(fileCov, ff, withCovered, withUncovered)
 			if err != nil {
 				return fmt.Errorf("genFuncsCov: %w", err)
 			}
@@ -273,9 +282,15 @@ func writeFileCoverage(ctx context.Context, w io.Writer, repo string, ff *covera
 }
 
 func genFuncsCov(fc *coveragedb.FileCoverageWithLineInfo, ff *coveragedb.FunctionFinder,
-) ([]*cover.FuncCoverage, error) {
+	withCovered, withUncovered bool) ([]*cover.FuncCoverage, error) {
 	nameToLines := map[string][]*cover.Block{}
 	for i, hitCount := range fc.HitCounts {
+		if hitCount > 0 && !withCovered {
+			continue
+		}
+		if hitCount == 0 && !withUncovered {
+			continue
+		}
 		lineNum := int(fc.LinesInstrumented[i])
 		funcName, err := ff.FileLineToFuncName(fc.Filepath, lineNum)
 		if err != nil {

--- a/dashboard/app/public_json_api_test.go
+++ b/dashboard/app/public_json_api_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/coveragedb"
 	"github.com/google/syzkaller/pkg/coveragedb/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -316,8 +315,8 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := writeExtAPICoverageFor(ctx, &buf, "test-ns", "test-repo", nil)
-	assert.NoError(t, err)
-	assert.Equal(t, `{
+	require.NoError(t, err)
+	require.Equal(t, `{
 	"repo": "test-repo",
 	"commit": "test-commit",
 	"file_path": "/file",
@@ -350,6 +349,194 @@ func TestWriteExtAPICoverageFor(t *testing.T) {
 					"from_line": 4,
 					"from_column": 0,
 					"to_line": 4,
+					"to_column": -1
+				}
+			]
+		}
+	]
+}
+`, buf.String())
+}
+
+func TestWriteExtAPICoverageFor_Flags(t *testing.T) {
+	ctx := setCoverageDBClient(context.Background(), fileFuncLinesDBFixture(t,
+		[]*coveragedb.FuncLines{
+			{
+				FilePath: "/file",
+				FuncName: "func_name",
+				Lines:    []int64{1, 2, 3, 4},
+			},
+		},
+		[]*coveragedb.FileCoverageWithLineInfo{
+			{
+				FileCoverageWithDetails: coveragedb.FileCoverageWithDetails{
+					Filepath: "/file",
+					Commit:   "test-commit",
+				},
+				LinesInstrumented: []int64{1, 2, 3, 4},
+				HitCounts:         []int64{10, 20, 30, 0},
+			},
+		},
+	))
+
+	tests := []struct {
+		name          string
+		withCovered   bool
+		withUncovered bool
+		wantJSON      string
+	}{
+		{
+			name:          "both",
+			withCovered:   true,
+			withUncovered: true,
+			wantJSON: `{
+	"repo": "test-repo",
+	"commit": "test-commit",
+	"file_path": "/file",
+	"functions": [
+		{
+			"func_name": "func_name",
+			"blocks": [
+				{
+					"hit_count": 10,
+					"from_line": 1,
+					"from_column": 0,
+					"to_line": 1,
+					"to_column": -1
+				},
+				{
+					"hit_count": 20,
+					"from_line": 2,
+					"from_column": 0,
+					"to_line": 2,
+					"to_column": -1
+				},
+				{
+					"hit_count": 30,
+					"from_line": 3,
+					"from_column": 0,
+					"to_line": 3,
+					"to_column": -1
+				},
+				{
+					"from_line": 4,
+					"from_column": 0,
+					"to_line": 4,
+					"to_column": -1
+				}
+			]
+		}
+	]
+}
+`,
+		},
+		{
+			name:          "only uncovered",
+			withCovered:   false,
+			withUncovered: true,
+			wantJSON: `{
+	"repo": "test-repo",
+	"commit": "test-commit",
+	"file_path": "/file",
+	"functions": [
+		{
+			"func_name": "func_name",
+			"blocks": [
+				{
+					"from_line": 4,
+					"from_column": 0,
+					"to_line": 4,
+					"to_column": -1
+				}
+			]
+		}
+	]
+}
+`,
+		},
+		{
+			name:          "none",
+			withCovered:   false,
+			withUncovered: false,
+			wantJSON: `{
+	"repo": "test-repo",
+	"commit": "test-commit",
+	"file_path": "/file",
+	"functions": null
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			params := &coverageHeatmapParams{
+				withCovered:   tc.withCovered,
+				withUncovered: tc.withUncovered,
+			}
+			err := writeExtAPICoverageFor(ctx, &buf, "test-ns", "test-repo", params)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantJSON, buf.String())
+		})
+	}
+}
+
+func TestWriteExtAPICoverageFor_FilePath(t *testing.T) {
+	ctx := setCoverageDBClient(context.Background(), fileFuncLinesDBFixture(t,
+		[]*coveragedb.FuncLines{
+			{
+				FilePath: "/dir/file1",
+				FuncName: "func1",
+				Lines:    []int64{1},
+			},
+			{
+				FilePath: "/other/file2",
+				FuncName: "func2",
+				Lines:    []int64{1},
+			},
+		},
+		[]*coveragedb.FileCoverageWithLineInfo{
+			{
+				FileCoverageWithDetails: coveragedb.FileCoverageWithDetails{
+					Filepath: "/dir/file1",
+					Commit:   "test-commit",
+				},
+				LinesInstrumented: []int64{1},
+				HitCounts:         []int64{10},
+			},
+			{
+				FileCoverageWithDetails: coveragedb.FileCoverageWithDetails{
+					Filepath: "/other/file2",
+					Commit:   "test-commit",
+				},
+				LinesInstrumented: []int64{1},
+				HitCounts:         []int64{20},
+			},
+		},
+	))
+
+	// Query for "/dir" prefix.
+	var buf bytes.Buffer
+	params := &coverageHeatmapParams{
+		filepath:    "/dir",
+		withCovered: true,
+	}
+	err := writeExtAPICoverageFor(ctx, &buf, "test-ns", "test-repo", params)
+	require.NoError(t, err)
+	require.Equal(t, `{
+	"repo": "test-repo",
+	"commit": "test-commit",
+	"file_path": "/dir/file1",
+	"functions": [
+		{
+			"func_name": "func1",
+			"blocks": [
+				{
+					"hit_count": 10,
+					"from_line": 1,
+					"from_column": 0,
+					"to_line": 1,
 					"to_column": -1
 				}
 			]

--- a/pkg/coveragedb/coveragedb.go
+++ b/pkg/coveragedb/coveragedb.go
@@ -556,6 +556,7 @@ type SelectScope struct {
 	Subsystem string
 	Manager   string
 	Periods   []TimePeriod
+	FilePath  string
 }
 
 // FilesCoverageStream streams information about all the line coverage.
@@ -651,6 +652,10 @@ where
 	if scope.Subsystem != "" {
 		stmt.SQL += " and $5=ANY(subsystems)"
 		stmt.Params["p5"] = scope.Subsystem
+	}
+	if scope.FilePath != "" {
+		stmt.SQL += " and starts_with(files.filepath, $6)"
+		stmt.Params["p6"] = scope.FilePath
 	}
 	stmt.SQL += "\norder by files.filepath"
 	return stmt


### PR DESCRIPTION
Add `with-covered` and `with-uncovered` query parameters to the public JSON coverage API to allow filtering of covered and uncovered line coordinates. Add `filepath` query parameter to allow path prefix filtering, which is passed down to Spanner query to speed up retrieval.

