### PR TITLE
report/openbsd: title KASAN faults whose panic line is interleaved

### DIFF
--- a/pkg/report/openbsd.go
+++ b/pkg/report/openbsd.go
@@ -49,7 +49,15 @@ var openbsdOopses = append([]*oops{
 				//     panic directly with NO __asan_ frame: kasan_mem{cpy,move,set,cmp}
 				// Plus the byte helpers (memcpy/strlcpy/copyin/...) that are callees,
 				// never the bug themselves.
-				title: compile(`Caught invalid memory access(?Us:.*)\n(?:[^\n]* at ` +
+				// On MP the initial console panic line can be interleaved
+				// character-by-character with another CPU's printf, leaving the
+				// only clean "Caught invalid memory access" inside the "show
+				// panic" output. The optional prefix lets this format start its
+				// match at the same position as the generic "show panic" format
+				// below, so it wins the position tie by list order instead of
+				// losing by one line.
+				title: compile(`(?:\nddb\{\d+\}> show panic(?Us:.*)[*]cpu\d+: )?` +
+					`Caught invalid memory access(?Us:.*)\n(?:[^\n]* at ` +
 					`(?:__asan_(?:load|store)(?:[0-9]+|N)+_noabort|` +
 					`kasan_mem(?:cpy|move|set|cmp)|` +
 					`memcpy|memmove|memset|memcmp|` +

--- a/pkg/report/testdata/openbsd/report/43
+++ b/pkg/report/testdata/openbsd/report/43
@@ -1,0 +1,358 @@
+TITLE: KASAN: invalid memory access in sysctl_sysvipc
+TYPE: KASAN-UNKNOWN
+
+panic:WA CRNauIgNhG:t  iSnPLv aNlOiTd  LmOeWmEoRrEyD  aONcc eSsYsS CaAt LfLf f2f 8-0203074010847c7c5b d0EX sITi z0e  a3
+6  Stopped at      savectx+0x9e:   movl    $0,%gs:0x688
+    TID    PID    UID     PRFLAGS     PFLAGS  CPU  COMMAND
+ 508557  50888      0        0x10  0x4000000    1  syz-executor
+*110200  91710      0         0x2          0    0  syz-executor
+savectx() at savectx+0x9e
+end of kernel
+end trace frame: 0x79167e32fab0, count: 14
+https://www.openbsd.org/ddb.html describes the minimum info required in bug
+reports.  Insufficient info makes it difficult to find and fix bugs.
+ddb{0}> 
+ddb{0}> set $lines = 0
+ddb{0}> set $maxwidth = 0
+ddb{0}> show panic
+*cpu1: Caught invalid memory access at ffff8000018ccbd0 size 36 op 1
+ddb{0}> show kasan
+KASAN: invalid write of 36 bytes at 0xffff8000018ccbd0 from pc 0xffffffff83a4a827
+KASAN: first bad byte at 0xffff8000018ccbd0 (+0); shadow 0xfb: malloc redzone (out-of-bounds)
+KASAN: 0xffff8000018ccbd0 is 0 bytes inside the 16-byte malloc slot [0xffff8000018ccbd0..0xffff8000018ccbe0)
+KASAN: allocated at:
+#0  malloc+0xda0 sys/kern/kern_malloc.c:446
+#1  sysctl_sysvipc+0x377 sys/kern/kern_sysctl.c:-1
+#2  kern_sysctl_dirs+0x30f sys/kern/kern_sysctl.c:429
+#3  kern_sysctl+0x1ce sys/kern/kern_sysctl.c:529
+#4  sys_sysctl+0x54f sys/kern/kern_sysctl.c:309
+#5  syscall+0x1089 mi_syscall sys/sys/syscall_mi.h:176 [inline]
+#5  syscall+0x1089 sys/arch/amd64/amd64/trap.c:783
+#6  Xsyscall+0x128
+KASAN: pc: sysctl_sysvipc+0x397
+KASAN: call trace:
+#0  kasan_memcpy+0x1ca kasan_shadow_check sys/kern/subr_kasan.c:-1 [inline]
+#0  kasan_memcpy+0x1ca sys/kern/subr_kasan.c:1025
+#1  sysctl_sysvipc+0x397 sys/kern/kern_sysctl.c:2712
+#2  kern_sysctl_dirs+0x30f sys/kern/kern_sysctl.c:429
+#3  kern_sysctl+0x1ce sys/kern/kern_sysctl.c:529
+#4  sys_sysctl+0x54f sys/kern/kern_sysctl.c:309
+#5  syscall+0x1089 mi_syscall sys/sys/syscall_mi.h:176 [inline]
+#5  syscall+0x1089 sys/arch/amd64/amd64/trap.c:783
+#6  Xsyscall+0x128
+KASAN: shadow of 0xffff8000018cca80..0xffff8000018ccd00 (1 cell = 8 bytes):
+ 0xffff8000018cca80: fc 08 fc 08 fc 08 fc 08 fc 08 fc 08 fc 08 fc 08
+ 0xffff8000018ccb00: fc 08 fc 08 fc 08 fc 08 fc 08 fc 08 fc 08 04 fb
+>0xffff8000018ccb80: fc 08 04 fb 08 fb 08 fb fc 08[fb]08 fc 08 08 08
+ 0xffff8000018ccc00: 08 08 08 08 08 08 08 08 08 08 08 08 08 08 08 08
+ 0xffff8000018ccc80: 08 08 08 08 08 08 08 08 08 08 08 08 08 08 08 08
+KASAN: legend: 00 valid; 01..07 partial; fb malloc redzone; fc malloc freed; fd pool freed; fe kmem; fa global; f1..f4/f8 stack/scope
+ddb{0}> trace
+savectx() at savectx+0x9e
+end of kernel
+end trace frame: 0x79167e32fab0, count: -1
+ddb{0}> show registers
+rdi               0xffffffff85df27c0    panicstr
+rsi               0xffffffff8529f640    __sancov_gen_cov_switch_values.22
+rbp               0xffff800029a5c8f0
+rbx                                0
+rdx                                0
+rcx               0xffffffff8521aff0    cpu_info_full_primary+0x1ff0
+rax                             0x3a
+r8                0xffff800029a5c7c0
+r9                0xffff800029a5c240
+r10                                0
+r11               0xffffffff8416f5d0    x86_bus_space_io_read_1
+r12                                0
+r13                                0
+r14               0xffff80002996a548
+r15                                0
+rip               0xffffffff810f534e    savectx+0x9e
+cs                               0x8
+rflags                          0x46
+rsp               0xffff800029a5c870
+ss                              0x10
+savectx+0x9e:   movl    $0,%gs:0x688
+ddb{0}> show proc
+PROC (syz-executor) tid=110200 pid=91710 tcnt=1 stat=onproc
+    flags process=2<EXEC> proc=0
+    runpri=17, usrpri=77, slppri=17, nice=20
+    wchan=0x0, wmesg=, ps_single=0x0 scnt=0 ecnt=0
+    forw=0xffffffffffffffff, list=0xffff80002996a2b0,0xffff80002996b250
+    process=0xffff8000298a5ce8 user=0xffff800029a51000, vmspace=0xffff8000017cd5c0
+    estcpu=36, cpticks=28, pctcpu=0.22, user=0, sys=26, intr=2
+ddb{0}> ps
+   PID     TID   PPID    UID  S       FLAGS  WAIT          COMMAND
+ 97905  233159  91710      0  2           0                syz-executor
+  4952  400711  93515      0  2           0                syz-executor
+  4952  229864  93515      0  3   0x4000000  biowait       syz-executor
+  6045  168338  29358      0  2           0                syz-executor
+  6045  437944  29358      0  3   0x4000080  fsleep        syz-executor
+ 52644  385677  68500      0  2           0                syz-executor
+ 50888   32167   4036      0  3        0x90  nanoslp       syz-executor
+ 50888  508557   4036      0  7   0x4000010                syz-executor
+ 50888  155118   4036      0  3   0x4000090  fsleep        syz-executor
+   167  419580  75362      0  2           0                syz-executor
+   167   61222  75362      0  3   0x4000080  fsleep        syz-executor
+ 56418  201295  89352      0  3      0x3000  suspend       syz-executor
+ 56418  422357  89352      0  2   0x4081000                syz-executor
+ 92308  441189  59811      0  3        0x80  nanoslp       syz-executor
+ 92308  239024  59811      0  3   0x4000080  kqread        syz-executor
+ 92308   81830  59811      0  3   0x4000080  fsleep        syz-executor
+ 59811  191209  32833      0  3        0x82  nanoslp       syz-executor
+ 68500  106330  32833      0  3        0x82  nanoslp       syz-executor
+  4036  245386  32833      0  3        0x82  nanoslp       syz-executor
+*91710  110200  32833      0  7         0x2                syz-executor
+ 75362  276497  32833      0  2       0xc82                syz-executor
+ 93515  339993  32833      0  3        0x82  nanoslp       syz-executor
+ 29358  341819  32833      0  2       0xc82                syz-executor
+ 89352  232768  32833      0  2       0xc82                syz-executor
+ 32833  385204  28909      0  3        0x82  kqread        syz-executor
+ 28909   33546  56071      0  3    0x10008a  sigsusp       ksh
+ 56071  395443  25959      0  3        0x98  kqread        sshd-session
+ 25959  357357  45876      0  3        0x92  kqread        sshd-session
+ 58483  256270      1      0  3    0x100083  ttyin         getty
+ 45876   73151      1      0  3        0x88  kqread        sshd
+ 62807  204429  15021     74  2   0x1100092                pflogd
+ 15021    7662      1      0  3        0x80  sbwait        pflogd
+ 40290  363396  16730     73  2   0x1100090                syslogd
+ 16730  198743      1      0  3    0x100082  sbwait        syslogd
+ 34276  342722      1      0  3    0x100080  kqread        resolvd
+ 93745   38318   2349     77  3    0x100092  kqread        dhcpleased
+ 97966  175938   2349     77  3    0x100092  kqread        dhcpleased
+  2349  129585      1      0  3        0x80  kqread        dhcpleased
+ 76804  162575      0      0  2  0x40014200                smr
+ 96487  205594      0      0  2     0x14200                zerothread
+ 60182    6890      0      0  3     0x14200  aiodoned      aiodoned
+ 15713  391631      0      0  3     0x14200  syncer        update
+ 44052  445070      0      0  3     0x14200  cleaner       cleaner
+ 14966   10452      0      0  3     0x14200  reaper        reaper
+  9782  340902      0      0  3     0x14200  pgdaemon      pagedaemon
+ 99950  351341      0      0  3     0x14200  bored         viomb
+ 59632  110826      0      0  3  0x40014200  acpi0         acpi0
+ 94504  426621      0      0  3  0x40014200                idle1
+ 36261   84943      0      0  3     0x14200  bored         softnet1
+ 93734  393988      0      0  3     0x14200  bored         softnet0
+ 28617  273986      0      0  3     0x14200  bored         systqmp
+ 45397  235086      0      0  3     0x14200  bored         systq
+ 47053   50685      0      0  3     0x14200  tmoslp        softclockmp
+ 71768  396234      0      0  3  0x40014200  tmoslp        softclock
+ 66914  345442      0      0  3  0x40014200                idle0
+     1  452570      0      0  3        0x82  wait          init
+     0       0     -1      0  3     0x10200  scheduler     swapper
+ddb{0}> show all locks
+Process 4952 (syz-executor) thread 0xffff80003a30fa18 (229864)
+exclusive rrwlock inode r = 0 (0xffff800001d34b60)
+#0  witness_lock+0x632 stacktrace_save sys/sys/stacktrace.h:37 [inline]
+#0  witness_lock+0x632 sys/kern/subr_witness.c:1160
+#1  rw_do_enter_write+0x53e sys/kern/kern_rwlock.c:320
+#2  rrw_enter+0xf0 sys/kern/kern_rwlock.c:621
+#3  VOP_LOCK+0x17e sys/kern/vfs_vops.c:527
+#4  vn_lock+0xca sys/kern/vfs_vnops.c:576
+#5  sys_truncate+0x11c sys/kern/vfs_syscalls.c:2835
+#6  syscall+0x1089 mi_syscall sys/sys/syscall_mi.h:176 [inline]
+#6  syscall+0x1089 sys/arch/amd64/amd64/trap.c:783
+#7  Xsyscall+0x128
+Process 91710 (syz-executor) thread 0xffff80002996a548 (110200)
+exclusive kernel_lock &kernel_lock r = 0 (0xffffffff8542a300)
+#0  witness_lock+0x632 stacktrace_save sys/sys/stacktrace.h:37 [inline]
+#0  witness_lock+0x632 sys/kern/subr_witness.c:1160
+#1  syscall+0x1048 mi_syscall sys/sys/syscall_mi.h:175 [inline]
+#1  syscall+0x1048 sys/arch/amd64/amd64/trap.c:783
+#2  Xsyscall+0x128
+ddb{0}> show malloc
+           Type InUse  MemUse  HighUse   Limit  Requests Type Lim
+         devbuf 11064  12326K   12334K 166960K     12190        0
+            pcb    17     24K      24K 166960K        29        0
+         rtable   239     12K      13K 166960K       353        0
+             pf    34     22K      22K 166960K        47        0
+         ifaddr    43     12K      12K 166960K        46        0
+        ifgroup    55      2K       2K 166960K        59        0
+         sysctl     1      1K      13K 166960K         5        0
+       counters    70     42K      43K 166960K        72        0
+       ioctlops     0      0K       4K 166960K      1492        0
+            iov     0      0K       8K 166960K         2        0
+          mount     1      1K       1K 166960K         1        0
+            log     0      0K       0K 166960K         4        0
+         vnodes  1295     83K      84K 166960K      1399        0
+      UFS quota     1     36K      36K 166960K         1        0
+      UFS mount     5     44K      44K 166960K         5        0
+            shm     2      2K       6K 166960K         4        0
+         VM map     2      1K       1K 166960K         2        0
+            sem     5      0K       0K 166960K         5        0
+        dirhash    12      2K       2K 166960K        12        0
+           ACPI  1734    201K     292K 166960K     11964        0
+      file desc    18     65K      93K 166960K       203        0
+          sigio     0      0K       0K 166960K         1        0
+           proc    72    128K     177K 166960K       565        0
+        subproc    72      9K       9K 166960K        72        0
+    NFS srvsock     1      0K       0K 166960K         1        0
+     NFS daemon     1     20K      20K 166960K         1        0
+    ip_moptions     0      0K       0K 166960K         4        0
+       in_multi    99      7K       7K 166960K        99        0
+    ether_multi     1      0K       0K 166960K         1        0
+            mrt     0      0K       0K 166960K         7        0
+    ISOFS mount     1     36K      36K 166960K         1        0
+  MSDOSFS mount     1     20K      20K 166960K         1        0
+           ttys    49    344K     344K 166960K        49        0
+           exec     0      0K       2K 166960K       385        0
+   fusefs mount     1     36K      36K 166960K         1        0
+            tdb     3      1K       1K 166960K         3        0
+        VM swap     8     62K      64K 166960K        10        0
+       UVM amap   221    232K     254K 166960K      3695        0
+       UVM aobj     8      4K       4K 166960K         8        0
+     pinsyscall  1067   1746K    1746K 166960K      1362        0
+        memdesc     1      4K       4K 166960K         1        0
+    crypto data     1      1K       1K 166960K         1        0
+            NDP    12      0K       2K 166960K        29        0
+           temp    39   9162K    9176K 166960K      4807        0
+         kqueue    14     41K      64K 166960K        49        0
+      SYN cache     2     16K      16K 166960K         2        0
+ddb{0}> show all pools
+Name      Size Requests Fail Releases Pgreq Pgrel Npage Hiwat Minpg Maxpg Idle
+plcache    128       28    0        0     1     0     1     1     0     8    0
+rtpcb      120       36    0       33     1     0     1     1     0     8    0
+rtentry    176      112    0        1     6     0     6     6     0     8    0
+unpcb      144      135    0      114     3     0     3     3     0     8    2
+syncache   336        4    0        4     2     1     1     1     0     8    1
+tcpcb      736       12    0        8     1     0     1     1     0     8    0
+arp        136       18    0        0     1     0     1     1     0     8    0
+inpcb      328       98    0       90     2     0     2     2     0     8    1
+nd6        152       25    0        0     1     0     1     1     0     8    0
+kcovpl      48        8    0        0     1     0     1     1     0     8    0
+pfosfp      40     1428    0     1005     5     0     5     5     0     8    0
+pfosfpen   112     1428    0      714    21     0    21    21     0     8    0
+pfstitem    24       24    0        0     1     0     1     1     0     8    0
+pfstkey    128       24    0        0     1     0     1     1     0     8    0
+pfstate    448       24    0        0     3     0     3     3     0     8    0
+pfrule     1360      21    0       16     2     1     1     2     0     8    0
+art_heap8  4096       1    0        0     1     0     1     1     0     8    0
+art_heap4  256      455    0        0    29     0    29    29     0     8    0
+art_table   40      456    0        0     5     0     5     5     0     8    0
+art_node    32      112    0       11     1     0     1     1     0     8    0
+sysvmsgpl   40        1    0        1     1     0     1     1     0     8    1
+semupl     112        1    0        1     1     0     1     1     0     8    1
+semapl      72        3    0        0     1     0     1     1     0     8    0
+shmpl      112        5    0        0     1     0     1     1     0     8    0
+dirhash    1024      17    0        0     3     0     3     3     0     8    0
+dino2pl    256     1671    0      201    93     0    93    93     0     8    0
+ffsino     296     1671    0      201   114     0   114   114     0     8    0
+nchpl      144     1949    0      252    64     0    64    64     0     8    0
+vnodes     216     1781    0        0    99     0    99    99     0     8    0
+namei      1024    6286    0     6286     1     0     1     1     0     8    1
+percpumem   16       52    0        1     1     0     1     1     0     8    0
+kstatmem   264       29    0        2     2     0     2     2     0     8    0
+scxspl     216     7472    0     7470     5     3     2     3     1     8    1
+plimitpl   152       33    0       16     1     0     1     1     0     8    0
+sigapl     424      521    0      473     7     0     7     7     0     8    1
+knotepl    120      109    0        0     4     0     4     4     0     8    0
+kqueuepl   224       53    0       42     1     0     1     1     0     8    0
+pipepl     344      169    0      141     6     0     6     6     0     8    3
+fdescpl    528      505    0      473     3     0     3     3     0     8    0
+filepl     160     2150    0     1930    13     0    13    13     0     8    3
+lockfpl    104       21    0       19     1     0     1     1     0     8    0
+lockfspl    48       10    0        8     1     0     1     1     0     8    0
+sessionpl  144       29    0       20     1     0     1     1     0     8    0
+pgrppl      48       37    0       20     1     0     1     1     0     8    0
+ucredpl    104      200    0      185     1     0     1     1     0     8    0
+zombiepl   144      474    0      473     1     0     1     1     0     8    0
+processpl  1232     521    0      473     5     0     5     5     0     8    0
+procpl     664      648    0      592     6     0     6     6     0     8    0
+sockpl     752      274    0      242     7     0     7     7     0     8    3
+mcl64k     65536      1    0        0     1     0     1     1     0     8    0
+mcl8k      8192       4    0        0     1     0     1     1     0     8    0
+mcl4k      4096     118    0        0    15     0    15    15     0     8    0
+mcl2k      2048      19    0        0     3     0     3     3     0     8    0
+mextrefs    64       18    0        0     1     0     1     1     0     8    0
+mtagpl      96        1    0        0     1     0     1     1     0     8    0
+mbufpl     256      141    0        0     9     0     9     9     0     8    0
+bufpl      272     2420    0      106   155     0   155   155     0     8    0
+anonpl      32     3877    0        0    32     0    32    32     0   222    0
+amapchunkpl 152   10431    0     9997    22     1    21    21     0   158    2
+amappl16   200     2050    0     2025     5     3     2     5     0     8    0
+amappl15   192        5    0        4     1     0     1     1     0     8    0
+amappl14   184      429    0      428     1     0     1     1     0     8    0
+amappl13   176      123    0      111     1     0     1     1     0     8    0
+amappl12   168      753    0      724     2     0     2     2     0     8    0
+amappl11   160       31    0       31     2     1     1     1     0     8    1
+amappl10   152       67    0       53     1     0     1     1     0     8    0
+amappl9    144      374    0      374     1     1     0     1     0     8    0
+amappl8    136      101    0       98     1     0     1     1     0     8    0
+amappl7    128      152    0      139     1     0     1     1     0     8    0
+amappl6    120      160    0      159     1     0     1     1     0     8    0
+amappl5    112      105    0       95     1     0     1     1     0     8    0
+amappl4    104      299    0      278     1     0     1     1     0     8    0
+amappl3     96     1879    0     1777     4     0     4     4     0     8    1
+amappl2     88      535    0      475     2     0     2     2     0     8    0
+amappl1     80    10636    0    10029    16     0    16    16     0     8    3
+amappl      88     2958    0     2809     4     0     4     4     0    92    0
+uvmvnodes   80      100    0        0     3     0     3     3     0     8    0
+dma4096    4096       1    0        1     1     1     0     1     0     8    0
+dma1024    1024       1    0        0     1     0     1     1     0     8    0
+dma256     256        6    0        6     1     1     0     1     0     8    0
+dma128     128      253    0      253     1     1     0     1     0     8    0
+dma64       64        6    0        6     1     1     0     1     0     8    0
+dma32       32        7    0        7     1     1     0     1     0     8    0
+dma16       16       18    0       17     1     0     1     1     0     8    0
+aobjpl      72        7    0        0     1     0     1     1     0     8    0
+uaddrrnd    24      505    0      473     1     0     1     1     0     8    0
+uaddrbest   32        2    0        0     1     0     1     1     0     8    0
+uaddr       24      505    0      473     1     0     1     1     0     8    0
+vmmpekpl   168     6296    0     6258     2     0     2     2     0     8    0
+vmmpepl    168    41605    0    39672    90     2    88    88     0   357    1
+vmsppl     488      504    0      473     5     0     5     5     0     8    1
+rwobjpl     80    15456    0    14441    25     0    25    25     0     8    1
+pdppl      4096    1019    0      946   105    32    73    87     0     8    0
+pvpl        32     9982    0        0    81     0    81    81     0   265    0
+pmappl     256      504    0      473     3     0     3     3     0     8    0
+extentpl    40       46    0       28     1     0     1     1     0     8    0
+phpool     120      430    0       36    13     0    13    13     0     8    0
+ddb{0}> machine ddbcpu 0
+Invalid cpu 0
+ddb{0}> trace
+savectx() at savectx+0x9e
+end of kernel
+end trace frame: 0x79167e32fab0, count: -1
+ddb{0}> machine ddbcpu 1
+Stopped at      x86_ipi_db+0x19:        leave
+x86_ipi_db(ffff800028fe3ff0) at x86_ipi_db+0x19 sys/arch/amd64/amd64/db_interface.c:412
+x86_ipi_handler() at x86_ipi_handler+0x112 sys/arch/amd64/amd64/ipi.c:106
+Xresume_lapic_ipi() at Xresume_lapic_ipi+0x27
+x86_bus_space_io_read_4(b008,0) at x86_bus_space_io_read_4+0x29 sys/arch/amd64/amd64/bus_space.c:682
+acpitimer_delay(1) at acpitimer_delay+0x8a acpitimer_read sys/dev/acpi/acpitimer.c:141 [inline]
+acpitimer_delay(1) at acpitimer_delay+0x8a sys/dev/acpi/acpitimer.c:120
+comcnputc(800,20) at comcnputc+0x342 sys/dev/ic/com.c:1274
+cnputc(20) at cnputc+0xaf sys/dev/cons.c:218
+db_putchar(6f) at db_putchar+0x182 db_force_whitespace sys/ddb/db_output.c:-1 [inline]
+db_putchar(6f) at db_putchar+0x182 sys/ddb/db_output.c:153
+kprintf() at kprintf+0x2aad sys/kern/subr_prf.c:1065
+db_printf(ffffffff84c4fd20) at db_printf+0x102 sys/kern/subr_prf.c:-1
+panic(ffffffff84632b4f) at panic+0x17d sys/kern/subr_prf.c:217
+kasan_memcpy(ffff8000018ccbd0,ffff80003bb40160,24) at kasan_memcpy+0x1ec
+sysctl_sysvipc(ffff80003bb40828,1,200000000180,ffff80003bb40800) at sysctl_sysvipc+0x397 sys/kern/kern_sysctl.c:2712
+kern_sysctl_dirs(33,ffff80003bb40828,1,200000000180,ffff80003bb40800,0,1,1ffff0000776807c) at kern_sysctl_dirs+0x30f sys/kern/kern_sysctl.c:429
+end trace frame: 0xffff80003bb40770, count: 0
+ddb{1}> trace
+x86_ipi_db(ffff800028fe3ff0) at x86_ipi_db+0x19 sys/arch/amd64/amd64/db_interface.c:412
+x86_ipi_handler() at x86_ipi_handler+0x112 sys/arch/amd64/amd64/ipi.c:106
+Xresume_lapic_ipi() at Xresume_lapic_ipi+0x27
+x86_bus_space_io_read_4(b008,0) at x86_bus_space_io_read_4+0x29 sys/arch/amd64/amd64/bus_space.c:682
+acpitimer_delay(1) at acpitimer_delay+0x8a acpitimer_read sys/dev/acpi/acpitimer.c:141 [inline]
+acpitimer_delay(1) at acpitimer_delay+0x8a sys/dev/acpi/acpitimer.c:120
+comcnputc(800,20) at comcnputc+0x342 sys/dev/ic/com.c:1274
+cnputc(20) at cnputc+0xaf sys/dev/cons.c:218
+db_putchar(6f) at db_putchar+0x182 db_force_whitespace sys/ddb/db_output.c:-1 [inline]
+db_putchar(6f) at db_putchar+0x182 sys/ddb/db_output.c:153
+kprintf() at kprintf+0x2aad sys/kern/subr_prf.c:1065
+db_printf(ffffffff84c4fd20) at db_printf+0x102 sys/kern/subr_prf.c:-1
+panic(ffffffff84632b4f) at panic+0x17d sys/kern/subr_prf.c:217
+kasan_memcpy(ffff8000018ccbd0,ffff80003bb40160,24) at kasan_memcpy+0x1ec
+sysctl_sysvipc(ffff80003bb40828,1,200000000180,ffff80003bb40800) at sysctl_sysvipc+0x397 sys/kern/kern_sysctl.c:2712
+kern_sysctl_dirs(33,ffff80003bb40828,1,200000000180,ffff80003bb40800,0,1,1ffff0000776807c) at kern_sysctl_dirs+0x30f sys/kern/kern_sysctl.c:429
+kern_sysctl(ffff80003bb40824,2,200000000180,ffff80003bb40800,0,fffa,ffff80003bb40a80) at kern_sysctl+0x1ce sys/kern/kern_sysctl.c:529
+sys_sysctl(ffff800045ff7248,ffff80003bb40a80,ffff80003bb409e0) at sys_sysctl+0x54f sys/kern/kern_sysctl.c:309
+syscall(ffff80003bb40a80) at syscall+0x1089 mi_syscall sys/sys/syscall_mi.h:176 [inline]
+syscall(ffff80003bb40a80) at syscall+0x1089 sys/arch/amd64/amd64/trap.c:783
+Xsyscall() at Xsyscall+0x128
+end of kernel
+end trace frame: 0x9fa7e77d590, count: -18


### PR DESCRIPTION
On MP the initial console panic line can be interleaved character-by-character with another CPU's printf (e.g. "panic: Caught invalid memory access" merged with "WARNING: SPL NOT LOWERED ON SYSCALL EXIT"), so the only clean "Caught invalid memory access" string appears inside the "ddb> show panic" output -- one line AFTER the generic show-panic format's match start. extractDescription prefers the earliest match, so the generic format won and the report fell back to the generic bucket title even though the report contains a full KASAN backtrace (after "machine ddbcpu N", ddb having attached on the non-crashing CPU).

Give the KASAN title format an optional "ddb> show panic" prefix so its match can start at the same position as the generic format and win the tie by list order. Reports with an intact panic line still match at the top of the output, and reports with no usable KASAN trace still fail this format entirely and fall through to the generic title.

Testdata 43 is the real report: interleaved panic line, ddb on the wrong CPU, crash backtrace only after "machine ddbcpu 1"; it now titles "KASAN: invalid memory access in sysctl_sysvipc" instead of the generic "panic: Caught invalid memory access at ADDR size NUM op NUM".
