### PR TITLE
pkg/fuzzer/queue: don't treat never-active VMs as active

### DIFF
--- a/pkg/fuzzer/queue/distributor.go
+++ b/pkg/fuzzer/queue/distributor.go
@@ -113,8 +113,17 @@ func (dist *Distributor) hasOtherActive(set []ExecutorID) bool {
 		if contains(set, vm) {
 			continue
 		}
+		last := active[vm].Load()
+		// A zero value means the VM has never served a request, so it is not
+		// active. Without this check the unused slots (the active slice is
+		// over-allocated in noteActive) count as recently active until seq
+		// exceeds the recency window, which starves Avoid requests on setups
+		// with a single VM (their only executor is the one being avoided).
+		if last == 0 {
+			continue
+		}
 		// 1000 is semi-random notion of recency.
-		if active[vm].Load()+1000 < seq {
+		if last+1000 < seq {
 			continue
 		}
 		return true

--- a/pkg/fuzzer/queue/distributor_test.go
+++ b/pkg/fuzzer/queue/distributor_test.go
@@ -46,3 +46,20 @@ func TestDistributor(t *testing.T) {
 	q.Submit(req)
 	assert.Equal(t, req, dist.Next(1))
 }
+
+// TestDistributorSingleVM checks that on a single-VM setup a request that avoids
+// the only VM is still dispatched to it immediately, rather than delayed forever.
+// Regression test: unused (over-allocated) slots in the active slice used to count
+// as recently active while seq was below the recency window, so hasOtherActive
+// wrongly reported another active VM and starved the Avoid (triage) request.
+func TestDistributorSingleVM(t *testing.T) {
+	q := Plain()
+	dist := Distribute(q)
+
+	// VM 0 is the only VM that ever serves requests.
+	req := &Request{Avoid: []ExecutorID{{VM: 0}}}
+	q.Submit(req)
+	// With only VM 0 active, avoidance is impossible, so it must get the request
+	// right away without waiting out the recency window.
+	assert.Equal(t, req, dist.Next(0))
+}


### PR DESCRIPTION
noteActive over-allocates the active slice (vm+10 slots) and leaves the unused entries at 0. hasOtherActive read a 0 entry as recently active (0+1000 < seq is false while seq <= 1000), so on a single-VM run every triage request -- which avoids the VM that produced its signal, i.e. the only executor -- was delayed and, because seq never reaches the recency window, never dispatched. Triage deadlocked and the corpus never grew.

Skip entries with a zero timestamp before the recency check; noteActive uses seq.Add(1) so an active VM is always >= 1. TestDistributorSingleVM covers it (returns nil without the fix).
