### PR TITLE
pkg/aflow: enable namespace isolation for sandboxed tools

### DIFF
--- a/pkg/aflow/action/kernel/checkpatch.go
+++ b/pkg/aflow/action/kernel/checkpatch.go
@@ -22,7 +22,7 @@ func Checkpatch(repo string) (string, bool, error) {
 
 	cmd := osutil.Command("scripts/checkpatch.pl", "--no-tree", "-")
 	cmd.Dir = repo
-	if err := osutil.Sandbox(cmd, true, false); err != nil {
+	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return "", false, err
 	}
 	cmd.Stdin = strings.NewReader(diff)

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -188,7 +188,7 @@ func applyGitDiff(dir, diff string) error {
 	cmd := osutil.Command("git", "apply", "-")
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(diff)
-	if err := osutil.Sandbox(cmd, true, false); err != nil {
+	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return err
 	}
 	if output, err := osutil.Run(time.Minute, cmd); err != nil {

--- a/pkg/aflow/tool/clangformat/clangformat.go
+++ b/pkg/aflow/tool/clangformat/clangformat.go
@@ -53,10 +53,13 @@ func clangFormat(ctx *aflow.Context, state state, args args) (result, error) {
 	if err := tmpFile.Close(); err != nil {
 		return result{}, err
 	}
+	if err := osutil.SandboxChown(tmpFile.Name()); err != nil {
+		return result{}, err
+	}
 
 	cmd := osutil.Command("clang-format", "-style=file:"+tmpFile.Name(), "-i", args.File)
 	cmd.Dir = state.KernelScratchSrc
-	if err := osutil.Sandbox(cmd, true, false); err != nil {
+	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return result{}, err
 	}
 

--- a/pkg/aflow/tool/patchdiff/patchdiff.go
+++ b/pkg/aflow/tool/patchdiff/patchdiff.go
@@ -38,7 +38,7 @@ func Diff(repo string, args ...string) (string, error) {
 	gitDiffArgs := append([]string{"diff"}, args...)
 	cmd := osutil.Command("git", gitDiffArgs...)
 	cmd.Dir = repo
-	if err := osutil.Sandbox(cmd, true, false); err != nil {
+	if err := osutil.Sandbox(cmd, true, true); err != nil {
 		return "", err
 	}
 	output, err := osutil.Run(1*time.Minute, cmd)


### PR DESCRIPTION
Sandboxed tools in pkg/aflow passed net=false to osutil.Sandbox. Dropping user privileges without mount namespace isolation causes execve to fail with permission denied in production syz-agent environments.

Pass net=true to osutil.Sandbox across these tools to enable namespace isolation and resolve execution errors.
