### PR TITLE
pkg/aflow/backend/gemini: fix uninitialized proto part oneof field

### DIFF
--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/google/syzkaller/pkg/log"
 	"google.golang.org/genai"
 )
 
@@ -366,7 +367,20 @@ func toGenaiContent(msg *backend.Message) *genai.Content {
 				},
 			})
 		} else {
-			c.Parts = append(c.Parts, &genai.Part{Text: p.Text, Thought: p.Thought, ThoughtSignature: p.ThoughtSignature})
+			if p.Text == "" && !p.Thought && len(p.ThoughtSignature) == 0 {
+				log.Logf(2, "aflow/gemini: skipping empty text part without thought metadata")
+				continue
+			}
+			text := p.Text
+			if text == "" {
+				log.Logf(2, "aflow/gemini: replacing empty text part with fallback to initialize proto oneof field")
+				text = "<no text generated>"
+			}
+			c.Parts = append(c.Parts, &genai.Part{
+				Text:             text,
+				Thought:          p.Thought,
+				ThoughtSignature: p.ThoughtSignature,
+			})
 		}
 	}
 	return c

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/genai"
 )
 
@@ -144,4 +145,24 @@ func TestParseLLMErrorBackoff(t *testing.T) {
 	if !errors.As(err, &rErr) || rErr.Delay != time.Second || !rErr.IsExponential {
 		t.Errorf("expected RetryError with 1s exponential delay, got %v", err)
 	}
+}
+
+func TestToGenaiContentEmptyTextParts(t *testing.T) {
+	msg := &backend.Message{
+		Role: backend.RoleModel,
+		Parts: []backend.Part{
+			{Text: ""},                // Completely empty part -> skipped.
+			{Text: "", Thought: true}, // Thought part with empty text -> replaced with fallback.
+			{Text: "hello"},           // Normal text part -> kept as "hello".
+			{FunctionCall: &backend.FunctionCall{Name: "test_tool"}}, // Tool call -> kept.
+		},
+	}
+	got := toGenaiContent(msg)
+	require.Equal(t, "model", got.Role)
+	require.Len(t, got.Parts, 3)
+	require.Equal(t, "<no text generated>", got.Parts[0].Text)
+	require.True(t, got.Parts[0].Thought)
+	require.Equal(t, "hello", got.Parts[1].Text)
+	require.NotNil(t, got.Parts[2].FunctionCall)
+	require.Equal(t, "test_tool", got.Parts[2].FunctionCall.Name)
 }


### PR DESCRIPTION
When Gemini model responses contain parts with empty text content (such as thinking signature or thought-only parts), converting history back to Gemini API request payloads produces genai.Part objects with zero-value text fields. Because Protobuf requires at least one field inside the part oneof data union to be initialized, subsequent API calls were failing with HTTP 400 INVALID_ARGUMENT errors.

Sanitizing these parts prevents API request validation failures during multi-turn agent history serialization.

Error msg:
```
Error 400, Message: * GenerateContentRequest.contents[127].parts[1].data: required oneof field 'data' must have one initialized field
, Status: INVALID_ARGUMENT, Details: [map[@type:type.googleapis.com/google.rpc.DebugInfo detail:[ORIGINAL ERROR] generic::invalid_argument: * GenerateContentRequest.contents[127].parts[1].data: required oneof field 'data' must have one initialized field
 [google.rpc.error_details_ext] { message: "* GenerateContentRequest.contents[127].parts[1].data: required oneof field \'data\' must have one initialized field\n" details { type_url: "type.googleapis.com/language_labs.genai.debug.GeminiApiDebugInfo" value: "<redacted>\nr* GenerateContentRequest.contents[127].parts[1].data: required oneof field \'data\' must have one initialized field\n\0224net/proto2/contrib/validator/validator_util.cc:117:0" } }]]
```