### PR TITLE
pkg/aflow: remove sandboxing from scratch repo tools

### DIFF
--- a/pkg/aflow/action/kernel/checkpatch.go
+++ b/pkg/aflow/action/kernel/checkpatch.go
@@ -22,9 +22,6 @@ func Checkpatch(repo string) (string, bool, error) {
 
 	cmd := osutil.Command("scripts/checkpatch.pl", "--no-tree", "-")
 	cmd.Dir = repo
-	if err := osutil.Sandbox(cmd, true, true); err != nil {
-		return "", false, err
-	}
 	cmd.Stdin = strings.NewReader(diff)
 
 	output, err := osutil.Run(1*time.Minute, cmd)

--- a/pkg/aflow/flow/patching/actions.go
+++ b/pkg/aflow/flow/patching/actions.go
@@ -188,9 +188,6 @@ func applyGitDiff(dir, diff string) error {
 	cmd := osutil.Command("git", "apply", "-")
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(diff)
-	if err := osutil.Sandbox(cmd, true, true); err != nil {
-		return err
-	}
 	if output, err := osutil.Run(time.Minute, cmd); err != nil {
 		return fmt.Errorf("failed to apply patch: %w\n%s", err, output)
 	}

--- a/pkg/aflow/tool/clangformat/clangformat.go
+++ b/pkg/aflow/tool/clangformat/clangformat.go
@@ -53,15 +53,9 @@ func clangFormat(ctx *aflow.Context, state state, args args) (result, error) {
 	if err := tmpFile.Close(); err != nil {
 		return result{}, err
 	}
-	if err := osutil.SandboxChown(tmpFile.Name()); err != nil {
-		return result{}, err
-	}
 
 	cmd := osutil.Command("clang-format", "-style=file:"+tmpFile.Name(), "-i", args.File)
 	cmd.Dir = state.KernelScratchSrc
-	if err := osutil.Sandbox(cmd, true, true); err != nil {
-		return result{}, err
-	}
 
 	output, err := osutil.Run(10*time.Minute, cmd)
 	if err != nil {

--- a/pkg/aflow/tool/patchdiff/patchdiff.go
+++ b/pkg/aflow/tool/patchdiff/patchdiff.go
@@ -38,9 +38,6 @@ func Diff(repo string, args ...string) (string, error) {
 	gitDiffArgs := append([]string{"diff"}, args...)
 	cmd := osutil.Command("git", gitDiffArgs...)
 	cmd.Dir = repo
-	if err := osutil.Sandbox(cmd, true, true); err != nil {
-		return "", err
-	}
 	output, err := osutil.Run(1*time.Minute, cmd)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The scratch repository is created and operated on by root (e.g. by codeeditor and kernel.Build). Recent changes sandboxed patchdiff, checkpatch, and clangformat, dropping their privileges to the syzkaller user. This caused "permission denied" errors because the syzkaller user cannot access the root-owned scratch directory.

Remove sandboxing from these tools so they run as root, matching the directory ownership and resolving the execution errors.