### PR TITLE
prog: return all validation errors

### DIFF
--- a/prog/encoding_test.go
+++ b/prog/encoding_test.go
@@ -609,3 +609,17 @@ syz_mount_image$ext4(&(0x7f0000000080)='ext4\x00', &(0x7f00000000c0)='./file0\x0
 `,
 		string(p.Serialize(SkipImages)))
 }
+
+func TestValidateMultipleErrors(t *testing.T) {
+	target := initTargetTest(t, "linux", "amd64")
+	data := []byte(`
+openat(0xffffffffffffff9c, &(0x7f0000000000)='../file1\x00', 0x0, 0x0)
+openat(0xffffffffffffff9c, &(0x7f0000000040)='../file2\x00', 0x0, 0x0)
+`)
+	_, err := target.Deserialize(data, Strict)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "call #0 openat")
+	assert.Contains(t, err.Error(), "escaping filename \"../file1\\x00\"")
+	assert.Contains(t, err.Error(), "call #1 openat")
+	assert.Contains(t, err.Error(), "escaping filename \"../file2\\x00\"")
+}

--- a/prog/validation.go
+++ b/prog/validation.go
@@ -4,6 +4,7 @@
 package prog
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -51,22 +52,27 @@ func (p *Prog) validateWithOpts(opts validationOptions) error {
 		args:     make(map[Arg]bool),
 		uses:     make(map[Arg]Arg),
 	}
+	var errs []error
 	for i, c := range p.Calls {
 		if c.Meta == nil {
-			return fmt.Errorf("call does not have meta information")
+			errs = append(errs, fmt.Errorf("call #%d: does not have meta information", i))
+			continue
 		}
 		ctx.currentCall = c
 		if err := ctx.validateCall(c); err != nil {
-			return fmt.Errorf("call #%d %v: %w", i, c.Meta.Name, err)
+			errs = append(errs, fmt.Errorf("call #%d %v: %w", i, c.Meta.Name, err))
 		}
 	}
 	ctx.currentCall = nil
 	for u, orig := range ctx.uses {
 		if !ctx.args[u] {
-			return fmt.Errorf("use of %+v referes to an out-of-tree arg\narg: %#v", orig, u)
+			errs = append(errs, fmt.Errorf("use of %+v referes to an out-of-tree arg\narg: %#v", orig, u))
 		}
 	}
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
 }
 
 func (ctx *validCtx) validateCall(c *Call) error {


### PR DESCRIPTION
Currently Prog.validateWithOpts returns immediately upon encountering the first call validation error. When deserializing or validating programs with multiple invalid calls (such as escaping filenames or mismatched resource types), only the first error is reported, hiding subsequent failures.

Returning all errors at once is particularly useful for automated agents (e.g., in pkg/aflow), enabling them to inspect and fix all validation errors in a single iteration rather than encountering them one by one.

Accumulate validation errors across all calls in the program and return them joined via errors.Join.