### PR TITLE
syz-cluster/pkg/workflow: handle empty base build in retest parameter

### DIFF
--- a/syz-cluster/pkg/workflow/template.yaml
+++ b/syz-cluster/pkg/workflow/template.yaml
@@ -163,7 +163,7 @@ spec:
                 - name: patched-build-id
                   value: "{{=jsonpath(steps['patched-build'].outputs.parameters.result, '$.build_id')}}"
                 - name: base-build-id
-                  value: "{{=steps['base-build'].outputs.parameters.result ? jsonpath(steps['base-build'].outputs.parameters.result, '$.build_id') : ''}}"
+                  value: "{{=jsonpath(inputs.parameters.element, '$.base.commit_hash') != '' ? jsonpath(steps['base-build'].outputs.parameters.result, '$.build_id') : ''}}"
                 - name: track
                   value: "{{=jsonpath(inputs.parameters.element, '$.track')}}"
               artifacts:


### PR DESCRIPTION
When a target omits a base commit hash, the base-build step is skipped. Evaluating steps['base-build'].outputs on a skipped step fails in Argo, causing retest-action to crash on launch and preventing bug stats from being calculated.

Check $.base.commit_hash first so base-build-id safely evaluates to an empty string when base-build is skipped.