### PR TITLE
syz-cluster/pkg/db: skip non-existing series stats in bulk update

### DIFF
--- a/syz-cluster/pkg/db/series_stats_repo.go
+++ b/syz-cluster/pkg/db/series_stats_repo.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -75,7 +74,7 @@ func (repo *SeriesStatsRepository) BulkUpdate(ctx context.Context, ids []string,
 		for _, id := range ids {
 			stat, ok := existingMap[id]
 			if !ok {
-				return fmt.Errorf("stats for series %q not found", id)
+				continue
 			}
 			cb(stat)
 			stat.UpdatedAt = time.Now()

--- a/syz-cluster/pkg/db/series_stats_repo_test.go
+++ b/syz-cluster/pkg/db/series_stats_repo_test.go
@@ -6,7 +6,7 @@ package db
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSeriesStatsOutdated(t *testing.T) {
@@ -18,7 +18,7 @@ func TestSeriesStatsOutdated(t *testing.T) {
 
 	series2 := &Series{ExtID: "series-ext-id-2"}
 	err := seriesRepo.Insert(ctx, series2, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	session2 := dtd.dummySession(series2)
 	dtd.setLatestSession(series2, session2)
@@ -30,8 +30,35 @@ func TestSeriesStatsOutdated(t *testing.T) {
 	dtd.finishSession(session1)
 
 	list, err := repo.ListOutdated(ctx, ListOutdatedFilter{Limit: 10, CurrentVersion: "v2"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Session2 is not yet finished.
-	assert.Len(t, list, 1)
-	assert.Equal(t, series1.ID, list[0].ID)
+	require.Len(t, list, 1)
+	require.Equal(t, series1.ID, list[0].ID)
+}
+
+func TestSeriesStatsBulkUpdateMissing(t *testing.T) {
+	client, ctx := NewTransientDB(t)
+	repo := NewSeriesStatsRepository(client)
+	seriesRepo := NewSeriesRepository(client)
+	series1 := &Series{ExtID: "ext-missing-1"}
+	series2 := &Series{ExtID: "ext-missing-2"}
+	require.NoError(t, seriesRepo.Insert(ctx, series1, nil))
+	require.NoError(t, seriesRepo.Insert(ctx, series2, nil))
+
+	require.NoError(t, repo.Upsert(ctx, &SeriesStats{ID: series1.ID, PreventedBugs: 1}))
+
+	ids := []string{series1.ID, series2.ID}
+	err := repo.BulkUpdate(ctx, ids, func(s *SeriesStats) {
+		s.PreventedBugs = 5
+	})
+	require.NoError(t, err)
+
+	stat1, err := repo.GetByID(ctx, series1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stat1)
+	require.Equal(t, int64(5), stat1.PreventedBugs)
+
+	stat2, err := repo.GetByID(ctx, series2.ID)
+	require.NoError(t, err)
+	require.Nil(t, stat2)
 }


### PR DESCRIPTION
When a new series version is processed, BulkUpdate is called to clear stats on older versions of the series family. Older versions may not have rows in the SeriesStats table if stats were never calculated for them before.

Previously, BulkUpdate returned an error when encountering a missing entry, causing transaction rollbacks. Skip non-existing SeriesStats records instead.