### PR TITLE
vm/qemu: use relative path for ivs.sock

### DIFF
--- a/vm/qemu/snapshot_linux.go
+++ b/vm/qemu/snapshot_linux.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"syscall"
@@ -100,7 +101,15 @@ func (inst *instance) snapshotEnable() ([]string, error) {
 	}
 	inst.eventFD = eventFD
 
+	// UNIX domain socket paths are limited to ~108 characters.
+	// Prefer a relative path if it is shorter than the absolute path to avoid exceeding the limit.
 	sockPath := filepath.Join(inst.workdir, "ivs.sock")
+	if wd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(wd, sockPath); err == nil && len(rel) < len(sockPath) {
+			sockPath = rel
+		}
+	}
+
 	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockPath, Net: "unix"})
 	if err != nil {
 		return nil, fmt.Errorf("qemu: unix listen on %v failed: %w", sockPath, err)


### PR DESCRIPTION
Under Linux, UNIX domain socket paths are limited to 108 characters. When syzkaller is run from a deeply nested directory, the absolute path for the ivshmem socket (ivs.sock) can exceed this limit, causing the bind syscall to fail with EINVAL.

Resolve this by converting the socket path to a relative path from the process's working directory before binding and launching QEMU. This reduces the path length significantly while maintaining VM instance isolation.
