### PR TITLE
pkg/aflow: configurable MaxIterations for LLMAgent

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -58,6 +58,10 @@ type LLMAgent struct {
 	// the agent will pause, call a cheaper model to summarize the entire history, and then drop
 	// all intermediate messages, leaving only the anchor prompt and the new summary.
 	compressTokens int
+
+	// Maximum number of iterations for the agent execution.
+	// If 0, default to defaultMaxLLMIterations (250).
+	MaxIterations int
 }
 
 type agentSession struct {
@@ -71,6 +75,8 @@ type agentSession struct {
 	// answerNow is set to true when the input overflows and the agent must
 	// immediately respond.
 	answerNow bool
+	// Resolved max iterations.
+	maxIterations int
 }
 
 type llmMessage struct {
@@ -95,7 +101,7 @@ const (
 	hardLoopDetectionLimit    = 6
 	maxHistorySize            = 20 // Large enough to catch alternating loops.
 	// We abort execution after this many iterations to prevent infinite loops.
-	maxLLMIterations = 250
+	defaultMaxLLMIterations = 250
 )
 
 type TaskType int
@@ -303,7 +309,14 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 	if err := ctx.startSpan(span); err != nil {
 		return "", nil, err
 	}
-	s := &agentSession{LLMAgent: a}
+	maxIterations := a.MaxIterations
+	if maxIterations <= 0 {
+		maxIterations = defaultMaxLLMIterations
+	}
+	s := &agentSession{
+		LLMAgent:      a,
+		maxIterations: maxIterations,
+	}
 	reply, outputs, err := s.chat(ctx, cfg, tools, instruction, span.Prompt, candidate)
 	if err == nil {
 		span.Reply = reply
@@ -339,7 +352,7 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 		Parts: []backend.Part{{Text: prompt}},
 	}}}
 	var anchorTokens int
-	for iter := 0; iter < maxLLMIterations || a.tryAnswerNow(cfg, false); iter++ {
+	for iter := 0; iter < a.maxIterations || a.tryAnswerNow(cfg, false); iter++ {
 		var currentInputTokens int
 		for _, msg := range a.req {
 			currentInputTokens += msg.tokenCount
@@ -430,7 +443,7 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 		}
 	}
 	return "", nil, fmt.Errorf("agent reached max iterations limit (%v)",
-		maxLLMIterations)
+		a.maxIterations)
 }
 
 func (a *agentSession) updateInputTokens(inputTokens int, anchorTokens *int) {

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -502,3 +502,38 @@ func TestModelFallbackTrajectory(t *testing.T) {
 		nil,
 	)
 }
+
+func TestLLMAgentMaxIterations(t *testing.T) {
+	type outputs struct {
+		Reply string
+	}
+	type toolArgs struct {
+		Arg int `jsonschema:"something"`
+	}
+	replies := []any{}
+	for i := range 3 {
+		replies = append(replies, &backend.Part{
+			FunctionCall: &backend.FunctionCall{
+				ID:   "id1",
+				Name: "some-tool",
+				Args: map[string]any{
+					"Arg": i,
+				},
+			},
+		})
+	}
+	testFlow[struct{}, outputs](t, nil,
+		"agent reached max iterations limit (3)",
+		&LLMAgent{
+			Reply:         "Reply",
+			MaxIterations: 3,
+			Tools: []Tool{
+				NewFuncTool("some-tool", func(ctx *Context, state struct{}, args toolArgs) (struct{}, error) {
+					return struct{}{}, nil
+				}, "some-tool description"),
+			},
+		},
+		replies,
+		nil,
+	)
+}

--- a/pkg/aflow/llm_tool_test.go
+++ b/pkg/aflow/llm_tool_test.go
@@ -142,7 +142,7 @@ func TestLLMToolMaxIters(t *testing.T) {
 		},
 	}
 	// Sub-agent calls own tool maxLLMIterations times.
-	for i := range maxLLMIterations {
+	for i := range defaultMaxLLMIterations {
 		replies = append(replies, &backend.Part{
 			FunctionCall: &backend.FunctionCall{
 				ID:   "id1",

--- a/pkg/aflow/testdata/TestLLMAgentMaxIterations.llm.json
+++ b/pkg/aflow/testdata/TestLLMAgentMaxIterations.llm.json
@@ -1,0 +1,156 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "some-tool description",
+							"name": "some-tool",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Arg": {
+										"type": "integer",
+										"description": "something"
+									}
+								},
+								"required": [
+									"Arg"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"args": {
+								"Arg": 0
+							},
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"args": {
+								"Arg": 0
+							},
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"args": {
+								"Arg": 1
+							},
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestLLMAgentMaxIterations.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMAgentMaxIterations.trajectory.json
@@ -1,0 +1,157 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:05Z",
+		"Args": {
+			"Arg": 0
+		}
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Args": {
+			"Arg": 0
+		},
+		"Results": {}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:09Z",
+		"Args": {
+			"Arg": 1
+		}
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Args": {
+			"Arg": 1
+		},
+		"Results": {}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:12Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:13Z",
+		"Args": {
+			"Arg": 2
+		}
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "some-tool",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
+		"Args": {
+			"Arg": 2
+		},
+		"Results": {}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:15Z",
+		"Error": "agent reached max iterations limit (3)",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:16Z",
+		"Error": "agent reached max iterations limit (3)"
+	}
+]


### PR DESCRIPTION
Support configurable MaxIterations limits on LLMAgents to prevent runaway execution loops and provide a default limit of 250 iterations for backward compatibility.
