### PR TITLE
syz-cluster/overlays: add more subsystem trees

### DIFF
--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -90,6 +90,22 @@ trees:
     branch: next
     email_lists:
       - linux-media@vger.kernel.org
+  - name: axboe
+    URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/axboe/linux.git
+    branch: for-next
+    email_lists:
+      - linux-block@vger.kernel.org
+      - io-uring@vger.kernel.org
+  - name: wireless-next
+    URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/wireless/wireless-next.git
+    branch: main
+    email_lists:
+      - linux-wireless@vger.kernel.org
+  - name: vfs
+    URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/vfs/vfs.git
+    branch: vfs.all
+    email_lists:
+      - linux-fsdevel@vger.kernel.org
   - name: torvalds
     URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
     branch: master


### PR DESCRIPTION
Many incoming patch series fail triage with "failed to find a base commit" and remain non-applied because their maintainer trees are absent from the syz-cluster configuration.

Add the axboe (block & io_uring), wireless-next, and vfs maintainer trees to global-config.yaml to improve the situation with non-applied series. This allows the triage pipeline to fetch active subsystem integration branches and successfully match base commits for patches submitted to those mailing lists.
