### PR TITLE
pkg/db: ensure corpus db hash determinism

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -139,7 +139,11 @@ func (db *DB) compact() error {
 	}
 	buf := new(bytes.Buffer)
 	serializeHeader(buf, db.Version)
-	for key, rec := range records {
+	// Sort the keys to make the resulting file bytes deterministic. Otherwise,
+	// the file hash would change on every compaction, breaking e.g. the cache in
+	// aflow.
+	for _, key := range slices.Sorted(maps.Keys(records)) {
+		rec := records[key]
 		serializeRecord(buf, key, rec.Val, rec.Seq)
 	}
 	f, err := os.Create(db.filename + ".tmp")
@@ -346,13 +350,13 @@ func ReadCorpus(filename string, target *prog.Target) (progs []*prog.Prog, err e
 	if filename == "" {
 		return
 	}
-	db, err := Open(filename, false)
+	_, records, _, err := deserializeFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database file: %w", err)
 	}
-	recordKeys := slices.Sorted(maps.Keys(db.Records))
+	recordKeys := slices.Sorted(maps.Keys(records))
 	for _, key := range recordKeys {
-		p, err := target.Deserialize(db.Records[key].Val, prog.NonStrict)
+		p, err := target.Deserialize(records[key].Val, prog.NonStrict)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deserialize corpus program: %w", err)
 		}
@@ -373,10 +377,11 @@ func Merge(into string, other []string, target *prog.Target) ([]DeserializeFailu
 	}
 	var failed []DeserializeFailure
 	for _, add := range other {
-		addDB, err := Open(add, false)
+		_, addRecords, _, err := deserializeFile(add)
 		if err == nil {
 			// It's a DB file.
-			for key, rec := range addDB.Records {
+			for _, key := range slices.Sorted(maps.Keys(addRecords)) {
+				rec := addRecords[key]
 				dstDB.Save(key, rec.Val, rec.Seq)
 			}
 			continue

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -12,7 +12,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/hash"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/prog"
+	_ "github.com/google/syzkaller/sys"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -320,5 +324,60 @@ func TestOversizeKeyLen(t *testing.T) {
 	// No records should have been recovered — the first record was malformed.
 	if len(db.Records) != 0 {
 		t.Fatalf("expected 0 records, got %d", len(db.Records))
+	}
+}
+
+func TestDeterministic(t *testing.T) {
+	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFn := tempFile(t)
+	defer os.Remove(srcFn)
+	db, err := Open(srcFn, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := target.DefaultChoiceTable()
+	rs := rand.NewSource(0)
+	for i := range 50 {
+		p := target.Generate(rand.New(rs), 5, ct)
+		data := p.Serialize()
+		db.Save(hash.String(data), data, uint64(i))
+	}
+	if err := db.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	mergeAndRead := func() ([]byte, [][]byte) {
+		dstFn := tempFile(t)
+		defer os.Remove(dstFn)
+		if _, err := Merge(dstFn, []string{srcFn}, target); err != nil {
+			t.Fatal(err)
+		}
+		rawBytes, err := os.ReadFile(dstFn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		progs, err := ReadCorpus(dstFn, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var serializedProgs [][]byte
+		for _, p := range progs {
+			serializedProgs = append(serializedProgs, p.Serialize())
+		}
+		return rawBytes, serializedProgs
+	}
+
+	firstBytes, firstProgs := mergeAndRead()
+	for range 10 {
+		gotBytes, gotProgs := mergeAndRead()
+		if !bytes.Equal(firstBytes, gotBytes) {
+			t.Fatal("Merge output file bytes are non-deterministic")
+		}
+		if !reflect.DeepEqual(firstProgs, gotProgs) {
+			t.Fatal("ReadCorpus output program order is non-deterministic")
+		}
 	}
 }


### PR DESCRIPTION
Previously, when a corpus database is read with ReadCorpus, its hash might change due to undeterminism of the Golang's map traversal. Force sorted traversal to make the hash of a corpus db the same with same programs.
