### PR TITLE
pkg/aflow: promote targeted codesearch tools and add timeout delay guidance

### DIFF
--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -457,7 +457,10 @@ Your goal is to analyze a Linux kernel bug description and propose a strategy to
 with a minimal, standalone C program.
 This is for the strictly defensive purpose of verifying a bugfix in an isolated environment.
 Do NOT propose an exploit. Focus on minimal technical reproduction of the bug state.
-Keep your analysis and strategy proposal concise. Do not write long explanations.`
+Keep your analysis and strategy proposal concise. Do not write long explanations.
+When looking up C function or struct definitions, prefer 'codesearch-definition-source'
+and 'codesearch-struct-layout' first. Fall back to 'read-file' or 'grepper' if symbol lookup fails
+or when inspecting macros, headers, or non-C files.`
 
 const initialResearcherPrompt = `Bug Description: {{.BugDescription}}`
 
@@ -468,6 +471,8 @@ Analyze the technical diagnosis provided in the oracle feedback and translate it
 into concrete, step-by-step instructions for the repro-generator on how to modify
 the code structure, alignments, offsets, or parameters of the candidate program.
 Do NOT repeat searches for the same symbols or files. Use the information you have already gathered.
+When looking up function/struct definitions, prefer 'codesearch-definition-source' and 'codesearch-struct-layout' first.
+Fall back to 'read-file' or 'grepper' for macros, headers, or if symbol lookup fails.
 If you are stuck, try a different approach or proceed to generate a candidate reproducer.`
 
 const refinerPrompt = `Bug Description: {{.BugDescription}}
@@ -501,6 +506,10 @@ you MUST include detailed logging and error checking in the generated C program:
    'execve()'). All environment checks, capability probings, and reproduction
    steps must be performed directly using standard Linux system calls (such
    as 'open', 'socket', 'ioctl', 'stat', etc.).
+8. When reproducing asynchronous kernel timeouts or warnings, always
+   include a sufficient delay (using sleep or similar) after deleting
+   or unregistering the device to allow the kernel's asynchronous
+   timeout to trigger before program exit.
 
 {{if not .CapabilitiesVerified}}
 === PHASE 1: CAPABILITY PROBING (GENERATION) ===

--- a/pkg/aflow/tool/codeexpert/codeexpert.go
+++ b/pkg/aflow/tool/codeexpert/codeexpert.go
@@ -83,6 +83,15 @@ verifying their existence first using content search or directory listing tools.
 If a file, symbol, or directory is not found via content search ('grepper') or
 directory listing ('codesearch-dir-index'), treat it as completely absent.
 Do not attempt to guess alternative names, extensions, or directories.
+
+Tool Selection Guidelines:
+1. For C functions, structs, and variables: Prefer 'codesearch-definition-source'
+   or 'codesearch-struct-layout' FIRST to retrieve clean, exact definitions
+   without line-number guessing.
+2. If symbol lookup fails (e.g., preprocessor macros, macro-generated code, or
+   disabled #ifdef branches), fall back to 'read-file' or 'grepper'.
+3. For file headers, #include directives, preprocessor macro definitions, and
+   non-C files (Kconfig, Makefiles, docs): Use 'read-file' or 'grepper' directly.
 `
 
 const instructionGitRestrictions = `Do NOT use 'git-log' to search for the presence or existence of files in the


### PR DESCRIPTION
…idance

- Promote 'codesearch-definition-source' and 'codesearch-struct-layout' in codeexpert and reproc system prompts to reduce 'read-file' and broad 'grepper' context inflation.
- Add instruction #8 in reproc generator prompt mandating an explicit delay (e.g., 'sleep(15);') when reproducing asynchronous kernel timeouts or unregister warnings.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
