### PR TITLE
pkg/html: reduce stat column width

### DIFF
--- a/pkg/html/pages/style.css
+++ b/pkg/html/pages/style.css
@@ -184,7 +184,7 @@ table td, table th {
 }
 
 .list_table .stat {
-	width: 55pt;
+	width: 45pt;
 	font-family: monospace;
 	text-align: right;
 }


### PR DESCRIPTION
Reduce the default width of .stat columns from 55pt to 45pt.
This affects the main dashboard, the local manager UI, syz-reporter, and syz-testbed.