### PR TITLE
syz-cluster/dashboard: hide prevented bugs statistics by default

### DIFF
--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -380,14 +380,15 @@ func (h *dashboardHandler) sessionInfo(w http.ResponseWriter, r *http.Request) e
 
 func (h *dashboardHandler) statsPage(w http.ResponseWriter, r *http.Request) error {
 	type StatsPageData struct {
-		Processed     []*db.CountPerWeek
-		Findings      []*db.CountPerWeek
-		Reports       []*db.CountPerWeek
-		Delay         []*db.DelayPerWeek
-		Distribution  []*db.StatusPerWeek
-		PreventedBugs []*db.PreventedBugsStats
-		MonthlyStats  MonthlyStats
-		JobsServed    []*db.JobsPerMonth
+		Processed         []*db.CountPerWeek
+		Findings          []*db.CountPerWeek
+		Reports           []*db.CountPerWeek
+		Delay             []*db.DelayPerWeek
+		Distribution      []*db.StatusPerWeek
+		PreventedBugs     []*db.PreventedBugsStats
+		ShowPreventedBugs bool
+		MonthlyStats      MonthlyStats
+		JobsServed        []*db.JobsPerMonth
 	}
 	var data StatsPageData
 	var err error
@@ -411,9 +412,12 @@ func (h *dashboardHandler) statsPage(w http.ResponseWriter, r *http.Request) err
 	if err != nil {
 		return fmt.Errorf("failed to query distribution data: %w", err)
 	}
-	data.PreventedBugs, err = h.statsRepo.PreventedBugsPerMonth(r.Context())
-	if err != nil {
-		return fmt.Errorf("failed to query prevented bugs data: %w", err)
+	data.ShowPreventedBugs = r.FormValue("unstable_stats") != ""
+	if data.ShowPreventedBugs {
+		data.PreventedBugs, err = h.statsRepo.PreventedBugsPerMonth(r.Context())
+		if err != nil {
+			return fmt.Errorf("failed to query prevented bugs data: %w", err)
+		}
 	}
 
 	reportsPerMonth, err := h.statsRepo.ReportsPerMonth(r.Context())

--- a/syz-cluster/dashboard/handler_test.go
+++ b/syz-cluster/dashboard/handler_test.go
@@ -29,6 +29,7 @@ func TestURLs(t *testing.T) {
 	urls := []string{
 		baseURL,
 		baseURL + "/stats",
+		baseURL + "/stats?unstable_stats=true",
 		urlGen.Series(ids.SeriesID),
 		baseURL + "/session/" + ids.SessionID,
 	}

--- a/syz-cluster/dashboard/templates/graphs.html
+++ b/syz-cluster/dashboard/templates/graphs.html
@@ -110,8 +110,12 @@
       </div>
       <hr class="my-4">
 
+      {{if .ShowPreventedBugs}}
       <div class="chart-wrapper mb-4" id="prevented-bugs">
         <h2 class="h4"><a href="#prevented-bugs" class="text-decoration-none text-reset">Prevented Bugs Statistics (monthly)</a></h2>
+        <div class="alert alert-warning" role="alert">
+          Warning: Prevented bugs statistics are broken for data collected between March and July 2026.
+        </div>
         <p class="text-muted small">
           How many bugs were found in the early series versions, but not in the final one. Data is aggregated by the month the patch series was published.
         </p>
@@ -138,6 +142,7 @@
         <p>No data available yet.</p>
         {{end}}
       </div>
+      {{end}}
     </main>
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
Prevented bugs statistics collected between March and July 2026 are broken and incomplete. Displaying this section by default on the statistics page presents misleading data to dashboard users.

Hide the prevented bugs statistics section by default on the /stats page and avoid querying database statistics unnecessarily.

Allow displaying the section only when the `unstable_stats` URL parameter is explicitly passed (e.g., /stats?unstable_stats=true), displaying a warning alert box to inform users of the data inaccuracies for the affected period.
