### PR TITLE
executor: fix musl build by adding pkey syscall compat shims

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -11,6 +11,40 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifndef __GLIBC__
+// musl (and other non-glibc libcs) don't declare the pkey_* wrappers or the
+// PKEY_DISABLE_WRITE flag, even though the kernel syscalls exist on any
+// modern Linux. Provide minimal equivalents so the executor keeps building there.
+// pkey_set() has no matching syscall (glibc implements it by writing the
+// PKRU register directly), so it's stubbed to report the feature as
+// unavailable; the callers below already treat that as "protection disabled",
+// same as when the kernel itself lacks pkey support.
+#ifndef PKEY_DISABLE_WRITE
+#define PKEY_DISABLE_WRITE 0x2
+#endif
+
+static int pkey_alloc(unsigned int flags, unsigned int access_rights)
+{
+	return syscall(__NR_pkey_alloc, flags, access_rights);
+}
+
+static int pkey_free(int pkey)
+{
+	return syscall(__NR_pkey_free, pkey);
+}
+
+static int pkey_mprotect(void* addr, size_t len, int prot, int pkey)
+{
+	return syscall(__NR_pkey_mprotect, addr, len, prot, pkey);
+}
+
+static int pkey_set(int pkey, unsigned int rights)
+{
+	errno = ENOSYS;
+	return -1;
+}
+#endif
+
 static bool pkeys_enabled;
 
 // The coverage buffer can realistically overflow. In the non-snapshot mode we cannot afford

--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -1,6 +1,7 @@
 // Copyright 2015 syzkaller project authors. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
@@ -25,17 +26,32 @@
 
 static int pkey_alloc(unsigned int flags, unsigned int access_rights)
 {
+#ifdef __NR_pkey_alloc
 	return syscall(__NR_pkey_alloc, flags, access_rights);
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
 }
 
 static int pkey_free(int pkey)
 {
+#ifdef __NR_pkey_free
 	return syscall(__NR_pkey_free, pkey);
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
 }
 
 static int pkey_mprotect(void* addr, size_t len, int prot, int pkey)
 {
+#ifdef __NR_pkey_mprotect
 	return syscall(__NR_pkey_mprotect, addr, len, prot, pkey);
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
 }
 
 static int pkey_set(int pkey, unsigned int rights)


### PR DESCRIPTION
Fixes #7438 (the musl compile-time part).

musl doesn't declare the glibc `pkey_alloc`/`pkey_free`/`pkey_mprotect`
wrappers or the `PKEY_DISABLE_WRITE` flag, even though the underlying
syscalls exist on any modern Linux kernel. This broke musl-based
executor builds since kcov/output pkey protection was added in c3a6603be.

This adds minimal syscall-based equivalents behind a `#ifndef __GLIBC__`
guard, keeping the diff localized to `executor_linux.h` as discussed in
the issue. `pkey_set()` has no matching syscall (glibc implements it by
writing the PKRU register directly), so it's stubbed to report the
feature as unavailable, which the existing callers already treat the
same as a kernel without pkey support (i.e. `pkeys_enabled` stays
false, protection is skipped, nothing fails).

Verified with musl (Alpine) and glibc (Debian) builds for both amd64
and arm64.

Note: on current master there's a second, unrelated musl incompatibility
in `executor/files.h` (`Glob()` uses GNU-only `glob_t` extension fields
like `GLOB_ALTDIRFUNC`, added after this pkey code, in November 2024).
That's a separate, larger change (reimplementing the directory-filtering
glob logic without glibc extensions) and out of scope here.