### PR TITLE
executor: treat ENOMEM in pselect as transient error

### DIFF
--- a/executor/conn.h
+++ b/executor/conn.h
@@ -213,8 +213,16 @@ public:
 			if (pselect(max_fd_ + 1, &rdset_, nullptr, nullptr, &timeout, nullptr) >= 0)
 				break;
 
-			if (errno != EINTR && errno != EAGAIN)
-				fail("pselect failed");
+			if (errno == EINTR)
+				continue;
+			// In a fuzzing context (e.g. under memory pressure or kernel fault injection
+			// like failslab), pselect can fail with ENOMEM. Treat it as a transient
+			// condition alongside EAGAIN and retry after a short delay.
+			if (errno == EAGAIN || errno == ENOMEM) {
+				sleep_ms(1);
+				continue;
+			}
+			fail("pselect failed");
 		}
 	}
 


### PR DESCRIPTION
When a test program enables kernel fault injection (e.g. failslab), pselect calls in Select::Wait can fail with ENOMEM. Treat ENOMEM as a transient condition alongside EINTR and EAGAIN, retrying after a short delay instead of aborting the executor with a SYZFAIL error.

Closes https://syzkaller.appspot.com/bug?extid=21754e32646fab1f6fbc