### PR TITLE
syz-cluster: use --shared clones

### DIFF
--- a/syz-cluster/workflow/build/workflow-template.yaml
+++ b/syz-cluster/workflow/build/workflow-template.yaml
@@ -37,7 +37,7 @@ spec:
           - sh
           - -c
           - |
-            git clone --reference /kernel-repo -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo ./workdir
+            git clone --shared -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo ./workdir
         env:
         - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
           value: "1"

--- a/syz-cluster/workflow/triage/workflow-template.yaml
+++ b/syz-cluster/workflow/triage/workflow-template.yaml
@@ -23,7 +23,7 @@ spec:
             - sh
             - -c
             - |
-              git clone --reference /kernel-repo -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo /workdir
+              git clone --shared -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo /workdir
               git -C /workdir commit-graph write --reachable
           env:
             - name: GIT_DISCOVERY_ACROSS_FILESYSTEM


### PR DESCRIPTION
Since the shared repository is on a different filesystem, the --reference option we used before did not actually let us reuse the same origin repository. It only gets slower with time as we add more trees and the repository size grows.

Switch to --shared clones, which are a bit less robust in case of a gc on the shared repository, but maintain very high performance.

Closes https://github.com/google/syzkaller/issues/7672