### PR TITLE
dashboard/app: allow disabling AI comment replies per stage

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1296,7 +1296,18 @@ func finishIterationJob(ctx context.Context, job *aidb.Job) error {
 	hasPatch := res.PatchDiff != ""
 	hasReplies := len(res.Replies) > 0
 
-	err = aidb.IterationJobDone(ctx, job.ID, args.TargetCommentIDs, job.ParentReportingID.StringVal, hasPatch, hasReplies)
+	err = aidb.IterationJobDone(ctx, job.ID, args.TargetCommentIDs, job.ParentReportingID.StringVal,
+		hasPatch, hasReplies, func(ns, stage string) bool {
+			nsCfg := getNsConfig(ctx, ns)
+			if nsCfg == nil || nsCfg.AI == nil {
+				return false
+			}
+			idx := nsCfg.AI.StageIndexByName(stage)
+			if idx == -1 {
+				return false
+			}
+			return nsCfg.AI.Stages[idx].ReplyToComments
+		})
 	if err != nil {
 		log.Errorf(ctx, "failed to finalize iteration job %v: %v", job.ID, err)
 	}
@@ -1622,6 +1633,7 @@ func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, 
 				return false, fmt.Errorf("failed to load pending comment groups for %v/%v: %w", ns, stage.Name, err)
 			}
 			for _, g := range grp {
+				g.ReplyToComments = stage.ReplyToComments
 				if timeNow(ctx).Sub(g.LatestComment) < stage.IterationDebounce {
 					continue
 				}
@@ -1637,7 +1649,7 @@ func autoCreatePatchIterationJobs(ctx context.Context, client APIClient) (bool, 
 	})
 	const maxGroupsPerPoll = 5
 	for _, g := range groups[:min(len(groups), maxGroupsPerPoll)] {
-		job, err := aidb.CreatePatchIterationJob(ctx, g.ReportingID)
+		job, err := aidb.CreatePatchIterationJob(ctx, g.ReportingID, g.ReplyToComments)
 		if err != nil {
 			log.Errorf(ctx, "failed to create patch iteration job for %v: %v", g.ReportingID, err)
 		} else if job != nil {

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -314,7 +314,7 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 				return nil, err
 			}
 		case ai.WorkflowPatchIteration:
-			err = populateIterationReportResult(ctx, job, version, r.Stage, result, authors)
+			err = populateIterationReportResult(ctx, job, version, r.Stage, stageCfg.ReplyToComments, result, authors)
 			if err != nil {
 				return nil, err
 			}
@@ -418,7 +418,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 }
 
 func populateIterationReportResult(ctx context.Context, job *aidb.Job, version int,
-	currentStage string, result *dashapi.ReportPollResult, authors []string) error {
+	currentStage string, replyToComments bool, result *dashapi.ReportPollResult, authors []string) error {
 	res, err := castJobResults[ai.PatchIterationOutputs](job)
 	if err != nil {
 		return fmt.Errorf("failed to cast job results: %w", err)
@@ -442,7 +442,7 @@ func populateIterationReportResult(ctx context.Context, job *aidb.Job, version i
 			return err
 		}
 		result.Patch.Changelog = collectChangelog(ctx, job.ID, currentStage)
-	} else if len(res.Replies) > 0 {
+	} else if replyToComments && len(res.Replies) > 0 {
 		var comments []*aidb.JobComment
 		if job.ParentReportingID.Valid {
 			comments, _ = aidb.LoadJobCommentsByReporting(ctx, job.ParentReportingID.StringVal)

--- a/dashboard/app/ai_report_lore_test.go
+++ b/dashboard/app/ai_report_lore_test.go
@@ -375,6 +375,7 @@ func TestAILoreIntegrationComment(t *testing.T) {
 				ServingIntegration: "lore",
 				MailingList:        "moderation@test.com",
 				AddressComments:    true,
+				ReplyToComments:    true,
 				IterationDebounce:  10 * time.Minute,
 			},
 		},

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1441,7 +1441,13 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 
 	c.SetAIConfig("ains", &AIConfig{
 		Stages: []AIPatchStageConfig{
-			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{
+				Name:               "moderation",
+				ServingIntegration: "lore",
+				MailingList:        "moderation@test.com",
+				AddressComments:    true,
+				ReplyToComments:    true,
+			},
 			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
 		},
 	})
@@ -1494,6 +1500,7 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 	resp, err := c.agentClient.AIJobPoll(pollReq)
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.ID)
+	require.Equal(t, true, resp.Args["ReplyToComments"])
 
 	// Simulate a second comment arriving WHILE the job is running (or polled).
 	// This represents the race condition.
@@ -1563,6 +1570,90 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp2.ID)
 	require.NotEqual(t, resp.ID, resp2.ID) // Must be a new job.
+}
+
+func TestAIPatchIterationReplyDisabled(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{
+				Name:               "moderation",
+				ServingIntegration: "lore",
+				MailingList:        "moderation@test.com",
+				AddressComments:    true,
+				ReplyToComments:    false,
+			},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com"},
+		},
+	})
+
+	// 1. Setup bug and job.
+	_, jobID := c.setupAIPatchJob(t)
+
+	// Poll to mark the job as started.
+	_, err := c.agentClient.AIJobPoll(&dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows:    []dashapi.AIWorkflow{{Type: ai.WorkflowPatching, Name: "patching"}},
+	})
+	require.NoError(t, err)
+
+	c.finishAIPatchJob(t, jobID, nil)
+
+	reportings, err := aidb.LoadJobReportings(c.ctx, jobID)
+	require.NoError(t, err)
+	require.Len(t, reportings, 1)
+	reporting := reportings[0]
+
+	err = c.globalClient.AIConfirmReport(&dashapi.ConfirmPublishedReq{
+		ReportID:       reporting.ID,
+		PublishedExtID: "<message-id-1>",
+	})
+	require.NoError(t, err)
+
+	// 2. Simulate comment arrival.
+	_, err = c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		Source:       dashapi.AIJobSourceLore,
+		RootExtID:    "<message-id-1>",
+		MessageExtID: "<comment-id-1>",
+		Author:       "reviewer@email.com",
+		Comment:      &dashapi.CommentCommand{Subject: "Re: [PATCH RFC] Test Subject", Body: "This is a comment"},
+	})
+	require.NoError(t, err)
+
+	// 3. Advance time to pass debounce (30 mins).
+	c.advanceTime(31 * time.Minute)
+
+	// 4. Poll should return the job.
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "test-agent",
+		CodeRevision: "test-rev",
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowPatchIteration, Name: "patch-iteration"},
+		},
+	}
+	resp, err := c.agentClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.ID)
+	require.Equal(t, false, resp.Args["ReplyToComments"])
+
+	// 5. Complete the job with REPLIES only.
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: resp.ID,
+		Results: map[string]any{
+			"Replies": []map[string]any{
+				{"ReplyTo": "<comment-id-1>", "Text": "I will fix it."},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 6. Verify AIPollReport returns nil result because ReplyToComments is false.
+	pollRepResp, err := c.globalClient.AIPollReport(&dashapi.PollExternalReportReq{Source: dashapi.AIJobSourceLore})
+	require.NoError(t, err)
+	require.Nil(t, pollRepResp.Result)
 }
 
 func TestAIManualPushToReporting(t *testing.T) {

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -958,8 +958,9 @@ func LoadJobCommentsByReporting(ctx context.Context, reportingID string) ([]*Job
 }
 
 type PendingCommentGroup struct {
-	ReportingID   string
-	LatestComment time.Time
+	ReportingID     string
+	LatestComment   time.Time
+	ReplyToComments bool
 }
 
 func LoadPendingCommentGroups(ctx context.Context, namespace, stage string) ([]*PendingCommentGroup, error) {
@@ -982,7 +983,7 @@ func LoadJobReporting(ctx context.Context, id string) (*JobReporting, error) {
 	})
 }
 
-func CreatePatchIterationJob(ctx context.Context, reportingID string) (*Job, error) {
+func CreatePatchIterationJob(ctx context.Context, reportingID string, replyToComments bool) (*Job, error) {
 	client, err := dbClient(ctx)
 	if err != nil {
 		return nil, err
@@ -1062,6 +1063,7 @@ func CreatePatchIterationJob(ctx context.Context, reportingID string) (*Job, err
 
 		extractBaseCommitArgs(parentJob, argsMap)
 		argsMap["TargetCommentIDs"] = commentIDs
+		argsMap["ReplyToComments"] = replyToComments
 
 		job = &Job{
 			ID:                uuid.NewString(),
@@ -1219,8 +1221,11 @@ func markCommentsProcessedTx(txn *spanner.ReadWriteTransaction, ids []string) er
 	return txn.BufferWrite(mutations)
 }
 
+// IterationJobDone finalizes an iteration job and creates a new reporting row if needed.
+// TODO: We pass isReplyAllowed callback to avoid a circular package dependency between aidb and package main.
 func IterationJobDone(ctx context.Context, jobID string, commentIDs []string,
-	parentReportingID string, hasPatch, hasReplies bool) error {
+	parentReportingID string, hasPatch, hasReplies bool,
+	isReplyAllowed func(ns, stage string) bool) error {
 	client, err := dbClient(ctx)
 	if err != nil {
 		return err
@@ -1277,8 +1282,13 @@ func IterationJobDone(ctx context.Context, jobID string, commentIDs []string,
 			return err
 		}
 
-		// If the job didn't generate a patch or replies, we don't need to report it externally.
-		if !hasPatch && !hasReplies {
+		// If the job didn't generate a patch or replies (or replying is disabled for this stage),
+		// we don't need to report it externally.
+		replyAllowed := true
+		if isReplyAllowed != nil {
+			replyAllowed = isReplyAllowed(parentJob.Namespace, parentRep.Stage)
+		}
+		if !hasPatch && (!hasReplies || !replyAllowed) {
 			return nil
 		}
 

--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -169,6 +169,7 @@ type AIPatchStageConfig struct {
 	NoParallelReports  bool
 	MergePatchCc       bool          // If true, CC people mentioned in the patch report (authors, reviewers).
 	AddressComments    bool          // If true, automatically trigger a patch iteration on new comments.
+	ReplyToComments    bool          // If true, allow AI to generate and post conversational text replies to comments.
 	IterationDebounce  time.Duration // Wait time before creating a new iteration. Defaults to 30m.
 }
 

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1288,7 +1288,7 @@ func handleManualIterationJob(ctx context.Context, r *http.Request,
 	if r.Method != http.MethodPost {
 		return ErrAccess
 	}
-	job, err := aidb.CreatePatchIterationJob(ctx, reportingID)
+	job, err := aidb.CreatePatchIterationJob(ctx, reportingID, true)
 	if err != nil {
 		return fmt.Errorf("failed to create patch iteration job for %v: %w", reportingID, err)
 	} else if job == nil {

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -38,6 +38,9 @@ type PatchIterationInputs struct {
 	// Discussion history grouped by patch version.
 	PatchHistory []ai.PatchHistoryEntry
 
+	// Whether textual comment replies are enabled for this stage.
+	ReplyToComments bool `json:",omitzero"`
+
 	// Base fixes tag from previous version.
 	BaseFixes ai.FixesTag `json:",omitzero"`
 
@@ -161,27 +164,31 @@ func init() {
 					),
 				},
 
-				// Evaluate each new thread comment individually to decide if it needs a direct reply.
-				&aflow.ForEach{
-					List: "NewComments",
-					Item: "CurrentComment",
-					Do: aflow.Pipeline(
-						&aflow.LLMAgent{
-							Name:  "comment-reply-agent",
-							Model: aflow.BestExpensiveModel,
-							// nolint: lll
-							Outputs: aflow.LLMOutputs[struct {
-								Action    string `jsonschema:"Either 'reply' or 'ignore'"`
-								Reason    string `jsonschema:"Explanation of why you chose to reply or ignore"`
-								Quote     string `jsonschema:"A brief, relevant verbatim excerpt (1-3 lines) cut directly from the original comment being replied to."`
-								ReplyText string `jsonschema:"The final text of your reply."`
-							}](),
-							TaskType:    aflow.FormalReasoningTask,
-							Instruction: commentProcessInstruction,
-							Prompt:      commentProcessPrompt,
-						},
-						appendCommentReply,
-					),
+				// Evaluate each new thread comment individually to decide if it needs a direct reply,
+				// provided that replying to comments is enabled for this stage.
+				&aflow.If{
+					Condition: "ReplyToComments",
+					Do: &aflow.ForEach{
+						List: "NewComments",
+						Item: "CurrentComment",
+						Do: aflow.Pipeline(
+							&aflow.LLMAgent{
+								Name:  "comment-reply-agent",
+								Model: aflow.BestExpensiveModel,
+								// nolint: lll
+								Outputs: aflow.LLMOutputs[struct {
+									Action    string `jsonschema:"Either 'reply' or 'ignore'"`
+									Reason    string `jsonschema:"Explanation of why you chose to reply or ignore"`
+									Quote     string `jsonschema:"A brief, relevant verbatim excerpt (1-3 lines) cut directly from the original comment being replied to."`
+									ReplyText string `jsonschema:"The final text of your reply."`
+								}](),
+								TaskType:    aflow.FormalReasoningTask,
+								Instruction: commentProcessInstruction,
+								Prompt:      commentProcessPrompt,
+							},
+							appendCommentReply,
+						),
+					},
 				},
 			),
 		})
@@ -475,6 +482,11 @@ with standard JSON escapes (like \n for newlines and \" for quotes), but are oth
 `
 
 const verdictPrompt = `
+{{if not .ReplyToComments}}
+Note: Sending textual comment replies is disabled for this stage. The bot cannot reply to comments
+or ask clarifying questions; it can only generate and send a new patch version if actionable
+changes are requested.
+{{end}}
 Bug title: {{jsonMarshal .BugTitle}}
 Crash report:
 {{jsonMarshal .CrashReport}}

--- a/pkg/aflow/flow/patching/iteration_test.go
+++ b/pkg/aflow/flow/patching/iteration_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/google/syzkaller/pkg/aflow/trajectory"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyProvider struct{}
+
+func (p *dummyProvider) Client(ctx context.Context) (backend.Client, error) { return nil, nil }
+
+func (p *dummyProvider) Models(ctx context.Context) ([]string, error) { return nil, nil }
+
+func (p *dummyProvider) ResolveModels(category backend.ModelCategory) []string {
+	return []string{"model1"}
+}
+
+func (p *dummyProvider) Close() error { return nil }
+
+func TestPatchIterationInputsBackwardCompatibility(t *testing.T) {
+	flow := aflow.Flows[string(ai.WorkflowPatchIteration)]
+	require.NotNil(t, flow)
+
+	// Simulate existing job inputs where ReplyToComments is omitted.
+	inputs := map[string]any{
+		"AgentName":      "test-agent",
+		"TargetOS":       "linux",
+		"TargetArch":     "amd64",
+		"Syzkaller":      "syzkaller",
+		"Image":          "image",
+		"Type":           "type",
+		"VM":             []byte("{}"),
+		"KernelConfig":   "config",
+		"BugTitle":       "title",
+		"CrashReport":    "report",
+		"ReproOpts":      "opts",
+		"ReproSyz":       "syz",
+		"ReproC":         "c",
+		"PatchHistory":   []ai.PatchHistoryEntry{},
+		"BaseRepository": "repo",
+		"BaseBranch":     "branch",
+		"BaseCommit":     "commit",
+		"StraceBin":      "strace",
+	}
+
+	onEvent := func(span *trajectory.Span) error { return nil }
+	_, err := flow.Execute(context.Background(), &dummyProvider{}, "", false, inputs, nil, onEvent)
+	if err != nil {
+		require.False(t, strings.Contains(err.Error(), "flow inputs are missing"),
+			"expected checkInputs to succeed without ReplyToComments, got: %v", err)
+	}
+}


### PR DESCRIPTION
Automatic comment replying is still an experimental feature. We want to avoid sending unmoderated text replies to public mailing lists, and for now it is cleaner to only allow conversational replies during the moderation stage. This also simplifies the overall implementation of #7671.

Add a ReplyToComments configuration option to AIPatchStageConfig. When disabled for a stage, pass the flag to the patch iteration workflow to skip generating text replies and suppress creating external report entries if no new patch version was produced.

Cc https://github.com/google/syzkaller/issues/7671