### PR TITLE
syz-cluster/pkg/app: handle nil EmailReporting in OwnEmails

### DIFF
--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -80,7 +80,10 @@ type EmailConfig struct {
 	SubjectPrefix string `yaml:"subjectPrefix"`
 }
 
-func (c EmailConfig) OwnEmails() []string {
+func (c *EmailConfig) OwnEmails() []string {
+	if c == nil {
+		return nil
+	}
 	var own []string
 	if c.Dashapi != nil && c.Dashapi.From != "" {
 		own = append(own, c.Dashapi.From)
@@ -160,7 +163,7 @@ func (c AppConfig) Validate() error {
 	return nil
 }
 
-func (c EmailConfig) Validate() error {
+func (c *EmailConfig) Validate() error {
 	for _, err := range []error{
 		ensureNonEmpty("name", c.Name),
 		ensureEmail("supportEmail", c.SupportEmail),

--- a/syz-cluster/pkg/app/config_test.go
+++ b/syz-cluster/pkg/app/config_test.go
@@ -47,6 +47,9 @@ func TestConfigs(t *testing.T) {
 }
 
 func TestOwnEmails(t *testing.T) {
+	var nilCfg *EmailConfig
+	require.Nil(t, nilCfg.OwnEmails())
+
 	cfg := &EmailConfig{
 		Dashapi: &DashapiConfig{
 			From: "bot@dashapi.com",


### PR DESCRIPTION
In environments where email reporting is disabled (e.g. GKE staging), emailReporting is omitted from the config, leaving cfg.EmailReporting nil.

Calling OwnEmails on a nil pointer panicked because of its value receiver. Change OwnEmails to a pointer receiver and safely return nil when called on a nil pointer.