### PR TITLE
pkg/aflow: introduce token limits for workflow runs

### DIFF
--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -24,11 +24,12 @@ import (
 
 // ExecuteOptions groups the execution environment and infrastructure limits for a workflow run.
 type ExecuteOptions struct {
-	Provider backend.Provider
-	Workdir  string
-	Cache    *Cache
-	OnEvent  onEvent
-	Debug    bool
+	Provider   backend.Provider
+	Workdir    string
+	Cache      *Cache
+	OnEvent    onEvent
+	Debug      bool
+	TokenLimit int
 }
 
 // Execute executes the given AI workflow with provided inputs and returns workflow outputs.
@@ -56,6 +57,7 @@ func (flow *Flow) Execute(ctx context.Context, inputs map[string]any, opts Execu
 		state:       inputs,
 		onEvent:     opts.OnEvent,
 		runnerDebug: opts.Debug,
+		tokenLimit:  opts.TokenLimit,
 	}
 
 	defer c.Close()
@@ -183,21 +185,23 @@ var (
 )
 
 type Context struct {
-	Context       context.Context
-	Workdir       string
-	provider      backend.Provider
-	cache         *Cache
-	cachedDirs    []string
-	tempDirs      []string
-	state         map[string]any
-	onEvent       onEvent
-	spanSeq       int
-	spanNesting   int
-	runnerMu      sync.Mutex
-	runnerManager *RunnerManager
-	runnerEg      *errgroup.Group
-	runnerCancel  context.CancelFunc
-	runnerDebug   bool
+	Context        context.Context
+	Workdir        string
+	provider       backend.Provider
+	cache          *Cache
+	cachedDirs     []string
+	tempDirs       []string
+	state          map[string]any
+	onEvent        onEvent
+	spanSeq        int
+	spanNesting    int
+	runnerMu       sync.Mutex
+	runnerManager  *RunnerManager
+	runnerEg       *errgroup.Group
+	runnerCancel   context.CancelFunc
+	runnerDebug    bool
+	tokenLimit     int
+	consumedTokens int64
 	stubContext
 }
 
@@ -224,6 +228,17 @@ func (ctx *Context) runWithState(state map[string]any, fn func(*Context) error) 
 		ctx.state = oldState
 	}()
 	return fn(ctx)
+}
+
+func (ctx *Context) ConsumeTokens(tokens int) error {
+	if ctx.tokenLimit == 0 {
+		return nil
+	}
+	ctx.consumedTokens += int64(tokens)
+	if ctx.consumedTokens > int64(ctx.tokenLimit) {
+		return FlowError(fmt.Errorf("workflow reached token limit (%v)", ctx.tokenLimit))
+	}
+	return nil
 }
 
 func (ctx *Context) Cache(typ, desc string, populate func(string) error) (string, error) {

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -22,12 +22,20 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// ExecuteOptions groups the execution environment and infrastructure limits for a workflow run.
+type ExecuteOptions struct {
+	Provider backend.Provider
+	Workdir  string
+	Cache    *Cache
+	OnEvent  onEvent
+	Debug    bool
+}
+
 // Execute executes the given AI workflow with provided inputs and returns workflow outputs.
 // The workdir argument should point to a dir owned by aflow to store private data,
 // it can be shared across parallel executions in the same process, and preferably
 // preserved across process restarts for caching purposes.
-func (flow *Flow) Execute(ctx context.Context, provider backend.Provider, workdir string, debug bool,
-	inputs map[string]any, cache *Cache, onEvent onEvent) (map[string]any, error) {
+func (flow *Flow) Execute(ctx context.Context, inputs map[string]any, opts ExecuteOptions) (map[string]any, error) {
 	convertedInputs, err := flow.checkInputs(inputs)
 	if err != nil {
 		return nil, fmt.Errorf("flow inputs are missing: %w", err)
@@ -35,19 +43,19 @@ func (flow *Flow) Execute(ctx context.Context, provider backend.Provider, workdi
 	inputs = convertedInputs
 	inputs = maps.Clone(inputs)
 	maps.Insert(inputs, maps.All(flow.Consts))
-	llmClient, err := provider.Client(ctx)
+	llmClient, err := opts.Provider.Client(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM client: %w", err)
 	}
 
 	c := &Context{
 		Context:     ctx,
-		Workdir:     osutil.Abs(workdir),
-		provider:    provider,
-		cache:       cache,
+		Workdir:     osutil.Abs(opts.Workdir),
+		provider:    opts.Provider,
+		cache:       opts.Cache,
 		state:       inputs,
-		onEvent:     onEvent,
-		runnerDebug: debug,
+		onEvent:     opts.OnEvent,
+		runnerDebug: opts.Debug,
 	}
 
 	defer c.Close()

--- a/pkg/aflow/flow/patching/iteration_test.go
+++ b/pkg/aflow/flow/patching/iteration_test.go
@@ -54,7 +54,10 @@ func TestPatchIterationInputsBackwardCompatibility(t *testing.T) {
 	}
 
 	onEvent := func(span *trajectory.Span) error { return nil }
-	_, err := flow.Execute(context.Background(), &dummyProvider{}, "", false, inputs, nil, onEvent)
+	_, err := flow.Execute(context.Background(), inputs, aflow.ExecuteOptions{
+		Provider: &dummyProvider{},
+		OnEvent:  onEvent,
+	})
 	if err != nil {
 		require.False(t, strings.Contains(err.Error(), "flow inputs are missing"),
 			"expected checkInputs to succeed without ReplyToComments, got: %v", err)

--- a/pkg/aflow/flow_test.go
+++ b/pkg/aflow/flow_test.go
@@ -280,7 +280,12 @@ func TestNoInputs(t *testing.T) {
 	cache, err := newTestCache(t, filepath.Join(workdir, "cache"), 0, stub.timeNow)
 	require.NoError(t, err)
 	onEvent := func(span *trajectory.Span) error { return nil }
-	_, err = flows["test"].Execute(ctx, &dummyProvider{}, workdir, false, inputs, cache, onEvent)
+	_, err = flows["test"].Execute(ctx, inputs, ExecuteOptions{
+		Provider: &dummyProvider{},
+		Workdir:  workdir,
+		Cache:    cache,
+		OnEvent:  onEvent,
+	})
 	require.Equal(t, err.Error(), "flow inputs are missing:"+
 		" aflow.flowInputs: field \"InBar\" is not present when converting map")
 }

--- a/pkg/aflow/flow_test.go
+++ b/pkg/aflow/flow_test.go
@@ -472,3 +472,26 @@ func TestFlowRegistrationErrors(t *testing.T) {
 			Root: Pipeline(),
 		})
 }
+
+func TestConsumeTokens(t *testing.T) {
+	t.Run("disabled when zero limit", func(t *testing.T) {
+		ctx := &Context{tokenLimit: 0}
+		require.NoError(t, ctx.ConsumeTokens(100))
+		require.NoError(t, ctx.ConsumeTokens(1000000))
+	})
+
+	t.Run("within limit", func(t *testing.T) {
+		ctx := &Context{tokenLimit: 100}
+		require.NoError(t, ctx.ConsumeTokens(50))
+		require.NoError(t, ctx.ConsumeTokens(50))
+	})
+
+	t.Run("exceed limit", func(t *testing.T) {
+		ctx := &Context{tokenLimit: 100}
+		require.NoError(t, ctx.ConsumeTokens(50))
+		err := ctx.ConsumeTokens(51)
+		require.Error(t, err)
+		require.True(t, IsFlowError(err))
+		require.Contains(t, err.Error(), "workflow reached token limit (100)")
+	})
+}

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -398,6 +398,9 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 			return "", nil, respErr
 		}
 		reply, calls, respErr := a.parseResponse(resp, span)
+		if respErr == nil {
+			respErr = ctx.ConsumeTokens(span.InputTokens + span.OutputTokens)
+		}
 		if err := ctx.finishSpan(span, respErr); err != nil {
 			return "", nil, err
 		}
@@ -576,6 +579,9 @@ func (a *agentSession) compressContext(
 	// but we don't want to clutter the trajectory UI with those thoughts.
 	span.Thoughts = ""
 
+	if respErr == nil {
+		respErr = ctx.ConsumeTokens(span.InputTokens + span.OutputTokens)
+	}
 	if respErr != nil {
 		return nil, 0, ctx.finishSpan(span, respErr)
 	}

--- a/pkg/aflow/runner_test.go
+++ b/pkg/aflow/runner_test.go
@@ -116,7 +116,12 @@ func testFlow[Inputs, Outputs any](t *testing.T, inputs map[string]any, result a
 	if inputs == nil {
 		inputs = map[string]any{}
 	}
-	got, err := flows["test"].Execute(ctx, &dummyProvider{}, workdir, false, inputs, cache, onEvent)
+	got, err := flows["test"].Execute(ctx, inputs, ExecuteOptions{
+		Provider: &dummyProvider{},
+		Workdir:  workdir,
+		Cache:    cache,
+		OnEvent:  onEvent,
+	})
 	switch result := result.(type) {
 	case map[string]any:
 		require.NoError(t, err)

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -354,7 +354,12 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ou
 		return nil, fmt.Errorf("failed to initialize LLM provider: %w", err)
 	}
 	defer provider.Close()
-	return flow.Execute(ctx, provider, s.workdir, false, inputs, s.cache, onEvent)
+	return flow.Execute(ctx, inputs, aflow.ExecuteOptions{
+		Provider: provider,
+		Workdir:  s.workdir,
+		Cache:    s.cache,
+		OnEvent:  onEvent,
+	})
 }
 
 func (s *Server) modelOverQuota(flow *aflow.Flow) bool {

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -47,7 +47,10 @@ func main() {
 	}
 }
 
-const workdir = "workdir"
+const (
+	workdir           = "workdir"
+	defaultTokenLimit = 100 * 1000 * 1000 // 100M tokens
+)
 
 func run(configFile string, exitOnUpgrade, autoUpdate bool, syzkallerDir, name string) error {
 	cfg, err := loadConfig(configFile)
@@ -355,10 +358,11 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ou
 	}
 	defer provider.Close()
 	return flow.Execute(ctx, inputs, aflow.ExecuteOptions{
-		Provider: provider,
-		Workdir:  s.workdir,
-		Cache:    s.cache,
-		OnEvent:  onEvent,
+		Provider:   provider,
+		Workdir:    s.workdir,
+		Cache:      s.cache,
+		OnEvent:    onEvent,
+		TokenLimit: defaultTokenLimit,
 	})
 }
 

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -105,7 +105,12 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 	}
 	defer provider.Close()
 
-	outputs, err := workflowDesc.Execute(aiCtx, provider, "/tmp/aflow-cache", false, initialState, cache, onEvent)
+	outputs, err := workflowDesc.Execute(aiCtx, initialState, aflow.ExecuteOptions{
+		Provider: provider,
+		Workdir:  "/tmp/aflow-cache",
+		Cache:    cache,
+		OnEvent:  onEvent,
+	})
 
 	var htmlReport []byte
 	buf := new(bytes.Buffer)

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -34,7 +34,10 @@ type AITriageResult struct {
 	Trajectory    []byte
 }
 
-const aiEvaluationTimeout = time.Hour
+const (
+	aiEvaluationTimeout = time.Hour
+	defaultTokenLimit   = 5 * 1000 * 1000 // 5M tokens
+)
 
 func CommitPatchForAflow(ops *GitTreeOps) error {
 	if _, err := ops.Run("add", "-A"); err != nil {
@@ -106,10 +109,11 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 	defer provider.Close()
 
 	outputs, err := workflowDesc.Execute(aiCtx, initialState, aflow.ExecuteOptions{
-		Provider: provider,
-		Workdir:  "/tmp/aflow-cache",
-		Cache:    cache,
-		OnEvent:  onEvent,
+		Provider:   provider,
+		Workdir:    "/tmp/aflow-cache",
+		Cache:      cache,
+		OnEvent:    onEvent,
+		TokenLimit: defaultTokenLimit,
 	})
 
 	var htmlReport []byte

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -154,7 +154,13 @@ func run(ctx context.Context, args RunArgs) error {
 	}
 	defer provider.Close()
 
-	output, err := flow.Execute(ctx, provider, args.Workdir, args.Debug, inputs, cache, onEventFunc)
+	output, err := flow.Execute(ctx, inputs, aflow.ExecuteOptions{
+		Provider: provider,
+		Workdir:  args.Workdir,
+		Cache:    cache,
+		OnEvent:  onEventFunc,
+		Debug:    args.Debug,
+	})
 	if err != nil {
 		return err
 	}

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -40,9 +40,10 @@ func main() {
 			" and save into -input file")
 		flagAuth = flag.Bool("auth", false, "use gcloud auth token for downloading bugs (set it up with"+
 			" gcloud auth application-default login)")
-		flagHTML   = flag.String("html", "", "write execution trajectory into this local HTML file in real-time")
-		flagOutput = flag.String("output", "", "save final workflow output to this JSON file")
-		flagDebug  = flag.Bool("debug", false, "enable runner debug logging")
+		flagHTML       = flag.String("html", "", "write execution trajectory into this local HTML file in real-time")
+		flagOutput     = flag.String("output", "", "save final workflow output to this JSON file")
+		flagDebug      = flag.Bool("debug", false, "enable runner debug logging")
+		flagTokenLimit = flag.Int("token-limit", 0, "maximum tokens allowed for the workflow run (0 = no limit)")
 	)
 	defer tool.Init()()
 	if *flagDownloadBug != "" {
@@ -82,6 +83,7 @@ func main() {
 		OutputFile: *flagOutput,
 		CacheSize:  cacheSize,
 		Debug:      *flagDebug,
+		TokenLimit: *flagTokenLimit,
 	}); err != nil {
 		tool.Failf("%v", osutil.VerboseMessage(err))
 	}
@@ -97,6 +99,7 @@ type RunArgs struct {
 	OutputFile string
 	CacheSize  uint64
 	Debug      bool
+	TokenLimit int
 }
 
 func run(ctx context.Context, args RunArgs) error {
@@ -155,11 +158,12 @@ func run(ctx context.Context, args RunArgs) error {
 	defer provider.Close()
 
 	output, err := flow.Execute(ctx, inputs, aflow.ExecuteOptions{
-		Provider: provider,
-		Workdir:  args.Workdir,
-		Cache:    cache,
-		OnEvent:  onEventFunc,
-		Debug:    args.Debug,
+		Provider:   provider,
+		Workdir:    args.Workdir,
+		Cache:      cache,
+		OnEvent:    onEventFunc,
+		Debug:      args.Debug,
+		TokenLimit: args.TokenLimit,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, workflows only supported iteration limits, which was insufficient to control costs since a single workflow could consume an excessive number of LLM tokens across several large generations without hitting the iteration cap. Also, the iteration gap only applies for one LLM agent run and does not take loop structure into account.

Introduce a configurable cumulative token limit that tracks the sum from input and output tokens per workflow run. Workflows that exceed the limit are safely aborted, preventing runaway budget consumption, while the exhaustion errors are cleanly preserved in the trajectory trace.

