### PR TITLE
pkg/aflow: add Try action flow construct

### DIFF
--- a/pkg/aflow/func_tool.go
+++ b/pkg/aflow/func_tool.go
@@ -4,6 +4,7 @@
 package aflow
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -35,6 +36,12 @@ func NewFuncTool[State, Args, Results any](name string, fn func(*Context, State,
 // instead of failing the whole workflow.
 func BadCallError(message string, args ...any) error {
 	return &badCallError{fmt.Errorf(message, args...)}
+}
+
+// IsBadCallError checks if err was created by BadCallError.
+func IsBadCallError(err error) bool {
+	var callErr *badCallError
+	return errors.As(err, &callErr)
 }
 
 type badCallError struct {

--- a/pkg/aflow/testdata/TestTry/BadCallErrorCaught.trajectory.json
+++ b/pkg/aflow/testdata/TestTry/BadCallErrorCaught.trajectory.json
@@ -1,0 +1,71 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-bad-call",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-bad-call",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"Error": "judge stopped execution",
+		"Results": {}
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "catch-action",
+		"Started": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "catch-action",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"CatchVal": "caught"
+		}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"Results": {
+			"CatchVal": "caught",
+			"Error": "judge stopped execution"
+		}
+	}
+]

--- a/pkg/aflow/testdata/TestTry/FatalFlowErrorNotCaught.trajectory.json
+++ b/pkg/aflow/testdata/TestTry/FatalFlowErrorNotCaught.trajectory.json
@@ -1,0 +1,51 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-fatal-error",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-fatal-error",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"Error": "fatal kernel build error",
+		"Results": {}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Error": "fatal kernel build error"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Error": "fatal kernel build error"
+	}
+]

--- a/pkg/aflow/testdata/TestTry/GenericErrorNotCaught.trajectory.json
+++ b/pkg/aflow/testdata/TestTry/GenericErrorNotCaught.trajectory.json
@@ -1,0 +1,51 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-generic-error",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-generic-error",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"Error": "infrastructure failure",
+		"Results": {}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Error": "infrastructure failure"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Error": "infrastructure failure"
+	}
+]

--- a/pkg/aflow/testdata/TestTry/SuccessNoCatch.trajectory.json
+++ b/pkg/aflow/testdata/TestTry/SuccessNoCatch.trajectory.json
@@ -1,0 +1,54 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-success",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "action",
+		"Name": "do-success",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"Results": {
+			"DoVal": "success"
+		}
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "try",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"DoVal": "success",
+			"Error": ""
+		}
+	}
+]

--- a/pkg/aflow/try.go
+++ b/pkg/aflow/try.go
@@ -1,0 +1,65 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"reflect"
+
+	"github.com/google/syzkaller/pkg/aflow/trajectory"
+)
+
+// Try represents a "try { Do } catch { Catch }" action.
+// It only catches BadCallError (e.g. judge stopping execution or recoverable LLM errors)
+// from Do and executes Catch. Fatal errors (e.g. FlowError, token limit overflows,
+// or infrastructure failures) are not caught and will propagate up.
+type Try struct {
+	Do       Action
+	Catch    Action
+	ErrorVar string
+}
+
+func (t *Try) execute(ctx *Context) error {
+	span := &trajectory.Span{
+		Type: trajectory.SpanAction,
+		Name: "try",
+	}
+	if err := ctx.startSpan(span); err != nil {
+		return err
+	}
+
+	err := t.Do.execute(ctx)
+	if err != nil {
+		// Fatal errors (e.g. flow errors, token limit overflows, or infrastructure failures)
+		// are not caught and should propagate up to fail/stop the workflow.
+		if !IsBadCallError(err) {
+			return ctx.finishSpan(span, err)
+		}
+		if t.ErrorVar != "" {
+			ctx.state[t.ErrorVar] = err.Error()
+		}
+		var catchErr error
+		if t.Catch != nil {
+			catchErr = t.Catch.execute(ctx)
+		}
+		return ctx.finishSpan(span, catchErr)
+	}
+
+	if t.ErrorVar != "" {
+		ctx.state[t.ErrorVar] = ""
+	}
+	return ctx.finishSpan(span, nil)
+}
+
+func (t *Try) verify(ctx *verifyContext) {
+	t.Do.verify(ctx)
+	if t.Catch != nil {
+		t.Catch.verify(ctx)
+	}
+	if t.ErrorVar != "" {
+		ctx.state[t.ErrorVar] = &varState{
+			action: "try output",
+			typ:    reflect.TypeFor[string](),
+		}
+	}
+}

--- a/pkg/aflow/try_test.go
+++ b/pkg/aflow/try_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestTry(t *testing.T) {
+	type actionArgs struct{}
+
+	t.Run("BadCallErrorCaught", func(t *testing.T) {
+		type inputs struct{}
+		type flowOutputs struct {
+			CatchVal string
+			Error    string
+		}
+		type catchOutputs struct {
+			CatchVal string
+		}
+		doAction := NewFuncAction("do-bad-call", func(ctx *Context, args actionArgs) (struct{}, error) {
+			return struct{}{}, BadCallError("judge stopped execution")
+		})
+		catchAction := NewFuncAction("catch-action", func(ctx *Context, args actionArgs) (catchOutputs, error) {
+			return catchOutputs{CatchVal: "caught"}, nil
+		})
+
+		testFlow[inputs, flowOutputs](t, map[string]any{}, map[string]any{
+			"CatchVal": "caught",
+			"Error":    "judge stopped execution",
+		}, &Try{
+			Do:       doAction,
+			Catch:    catchAction,
+			ErrorVar: "Error",
+		}, nil, nil)
+	})
+
+	t.Run("FatalFlowErrorNotCaught", func(t *testing.T) {
+		type inputs struct{}
+		type flowOutputs struct {
+			CatchVal string
+			Error    string
+		}
+		type catchOutputs struct {
+			CatchVal string
+		}
+		doAction := NewFuncAction("do-fatal-error", func(ctx *Context, args actionArgs) (struct{}, error) {
+			return struct{}{}, FlowError(fmt.Errorf("fatal kernel build error"))
+		})
+		catchAction := NewFuncAction("catch-action", func(ctx *Context, args actionArgs) (catchOutputs, error) {
+			return catchOutputs{CatchVal: "should not be reached"}, nil
+		})
+
+		testFlow[inputs, flowOutputs](t, map[string]any{}, "fatal kernel build error", &Try{
+			Do:       doAction,
+			Catch:    catchAction,
+			ErrorVar: "Error",
+		}, nil, nil)
+	})
+
+	t.Run("GenericErrorNotCaught", func(t *testing.T) {
+		type inputs struct{}
+		type flowOutputs struct {
+			CatchVal string
+			Error    string
+		}
+		type catchOutputs struct {
+			CatchVal string
+		}
+		doAction := NewFuncAction("do-generic-error", func(ctx *Context, args actionArgs) (struct{}, error) {
+			return struct{}{}, errors.New("infrastructure failure")
+		})
+		catchAction := NewFuncAction("catch-action", func(ctx *Context, args actionArgs) (catchOutputs, error) {
+			return catchOutputs{CatchVal: "should not be reached"}, nil
+		})
+
+		testFlow[inputs, flowOutputs](t, map[string]any{}, "infrastructure failure", &Try{
+			Do:       doAction,
+			Catch:    catchAction,
+			ErrorVar: "Error",
+		}, nil, nil)
+	})
+
+	t.Run("SuccessNoCatch", func(t *testing.T) {
+		type inputs struct{}
+		type flowOutputs struct {
+			DoVal string
+			Error string
+		}
+		type doOutputs struct {
+			DoVal string
+		}
+		doAction := NewFuncAction("do-success", func(ctx *Context, args actionArgs) (doOutputs, error) {
+			return doOutputs{DoVal: "success"}, nil
+		})
+		catchAction := NewFuncAction("catch-action", func(ctx *Context, args actionArgs) (struct{}, error) {
+			return struct{}{}, nil
+		})
+
+		testFlow[inputs, flowOutputs](t, map[string]any{}, map[string]any{
+			"DoVal": "success",
+			"Error": "",
+		}, &Try{
+			Do:       doAction,
+			Catch:    catchAction,
+			ErrorVar: "Error",
+		}, nil, nil)
+	})
+}


### PR DESCRIPTION
Introduce the Try action block to the aflow package. This enables error catching and handling logic during action pipeline executions, allowing control flow to branch upon failure.
