### PR TITLE
syz-cluster/workflow: set fsGroupChangePolicy to OnRootMismatch

### DIFF
--- a/syz-cluster/workflow/build/workflow-template.yaml
+++ b/syz-cluster/workflow/build/workflow-template.yaml
@@ -15,6 +15,7 @@ spec:
       securityContext:
         runAsUser: 10000
         fsGroup: 10000
+        fsGroupChangePolicy: "OnRootMismatch"
       inputs:
         parameters:
           - name: findings

--- a/syz-cluster/workflow/triage/workflow-template.yaml
+++ b/syz-cluster/workflow/triage/workflow-template.yaml
@@ -15,6 +15,7 @@ spec:
       securityContext:
         runAsUser: 10000
         fsGroup: 10000
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
         - name: setup-repo
           image: ${IMAGE_PREFIX}triage-action:${IMAGE_TAG}


### PR DESCRIPTION
Mounting large persistent volumes such as the kernel source repository in build and triage action pods currently causes severe startup delays. By default, Kubernetes recursively traverses every file and directory in the volume to update permissions to match fsGroup, taking upwards of 7-10+ minutes per pod startup.

Set fsGroupChangePolicy to OnRootMismatch in the pod securityContext for build and triage workflow templates. This instructs kubelet to check only the root directory of the volume, skipping recursive permission checks when ownership already matches.