### PR TITLE
pkg/aflow: support snapshot mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,7 +86,7 @@ linters:
     goconst:
       min-len: 3
       min-occurrences: 3
-      ignore-string-values: ['\.html|^true$']
+      ignore-string-values: ['\.html|^true$|^qemu$']
     gocritic:
       disable-all: true
       enabled-checks:

--- a/pkg/aflow/action/crash/config.go
+++ b/pkg/aflow/action/crash/config.go
@@ -42,6 +42,8 @@ type TargetConfig struct {
 	NeedStrace bool
 	// Isolation sandbox type (e.g., "none", "namespace", "setuid", "android").
 	Sandbox string
+	// Whether to run VM in snapshot mode (only supported with qemu VM type).
+	Snapshot bool
 }
 
 // Validate checks if the target configuration is valid.
@@ -111,6 +113,10 @@ func BuildConfig(args TargetConfig, workdir string) (*mgrconfig.Config, error) {
 	if args.Sandbox != "" {
 		cfg.Sandbox = args.Sandbox
 	}
+	if args.Snapshot && args.Type != "qemu" {
+		return nil, fmt.Errorf("snapshot mode is only supported with qemu VM type")
+	}
+	cfg.Snapshot = args.Snapshot
 	cfg.Experimental.DescriptionsMode = mgrconfig.AnyDescriptionsMode
 	if args.NeedStrace && args.StraceBin != "" {
 		cfg.StraceBin = args.StraceBin

--- a/pkg/aflow/action/crash/configure_runner.go
+++ b/pkg/aflow/action/crash/configure_runner.go
@@ -22,6 +22,7 @@ type ConfigureRunnerArgs struct {
 	VM         json.RawMessage
 	KernelSrc  string
 	KernelObj  string
+	Snapshot   bool
 }
 
 func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct{}, error) {
@@ -38,6 +39,7 @@ func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct
 		VM:         args.VM,
 		KernelSrc:  args.KernelSrc,
 		KernelObj:  args.KernelObj,
+		Snapshot:   args.Snapshot,
 	}
 
 	if err := targetCfg.Validate(); err != nil {

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -96,6 +96,7 @@ func init() {
 			Consts: map[string]any{
 				"NeedStrace": false,
 				"Sandbox":    "none",
+				"Snapshot":   false,
 			},
 			Root: aflow.Pipeline(
 				// Setup base kernel for code tools.

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -57,6 +57,7 @@ func init() {
 			Consts: map[string]any{
 				"NeedStrace": false,
 				"Sandbox":    "none",
+				"Snapshot":   false,
 				// For convenience of the patch-iteration workflow.
 				"ReviewedBy": []string{},
 				"AckedBy":    []string{},

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -49,6 +49,7 @@ func init() {
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"ReproC":                       "", // is needed by crash.Reproduce
 				"NeedStrace":                   false,
+				"Snapshot":                     false,
 			},
 			Root: aflow.Pipeline(
 				kernel.Checkout,

--- a/pkg/execbackend/snapshot.go
+++ b/pkg/execbackend/snapshot.go
@@ -105,13 +105,19 @@ func (serv *snapshotServer) RunRequests(ctx context.Context, inst *vm.Instance,
 		defer serv.cfg.Stats.StatNumFuzzing.Add(-1)
 	}
 
-	for first := true; ctx.Err() == nil; first = false {
-		if serv.cfg.Stats.StatExecs != nil {
-			serv.cfg.Stats.StatExecs.Add(1)
-		}
+	// Poll for execution requests. When no request is available (req == nil),
+	// sleep and retry instead of returning, because returning from RunRequests
+	// signals to the VM dispatcher that the instance lifecycle has ended and
+	// would cause the VM to be restarted.
+	first := true
+	for ctx.Err() == nil {
 		req := serv.dist.Next(inst.Index())
 		if req == nil {
-			return nil, nil
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if serv.cfg.Stats.StatExecs != nil {
+			serv.cfg.Stats.StatExecs.Add(1)
 		}
 		if first {
 			envFlags = req.ExecOpts.EnvFlags
@@ -119,6 +125,7 @@ func (serv *snapshotServer) RunRequests(ctx context.Context, inst *vm.Instance,
 				req.Done(&queue.Result{Status: queue.Crashed})
 				return nil, err
 			}
+			first = false
 		}
 		if envFlags != req.ExecOpts.EnvFlags {
 			panic(fmt.Sprintf("request env flags has changed: 0x%x -> 0x%x",


### PR DESCRIPTION
**pkg/aflow: support snapshot mode**

Adding snapshot mode to provide more isolation between program runs with a persistent vm.

**pkg/execbackend: prevent VM restart on empty snapshot request queue**

Previously, RunRequests returns directly when no request is immediately
available, signaling to the VM dispatcher that the instance lifecycle
has ended, causing the VM to be constantly restarted when request queue
is empty. RunRequests now polls continuously when the request queue is
temporarily empty in snapshot mode. This behavior aligns with the one
om non-snapshot mode.