### PR TITLE
pkg/cover/backend: normalize coverage source paths

### DIFF
--- a/pkg/cover/backend/path.go
+++ b/pkg/cover/backend/path.go
@@ -40,8 +40,10 @@ func CleanPath(path string, kernelDirs *mgrconfig.KernelDirs, splitBuildDelimite
 		path = strings.TrimPrefix(abs, kernelDirs.BuildSrc)
 		absPath = filepath.Join(kernelDirs.Src, path)
 	default:
-		// Assume this is relative path.
-		if filepath.IsAbs(path) {
+		if rel, apath, ok := findRelativeInSrc(abs, kernelDirs.Src, osutil.IsExist); ok {
+			path = rel
+			absPath = apath
+		} else if filepath.IsAbs(path) {
 			absPath = path
 		} else {
 			absPath = filepath.Join(kernelDirs.Src, path)
@@ -49,6 +51,23 @@ func CleanPath(path string, kernelDirs *mgrconfig.KernelDirs, splitBuildDelimite
 	}
 	relPath = strings.TrimLeft(filepath.Clean(path), "/\\")
 	return relPath, absPath
+}
+
+// findRelativeInSrc finds the relative path of an absolute file path within
+// srcDir by checking for subpath existence.
+func findRelativeInSrc(absPath, srcDir string, existFn func(string) bool) (string, string, bool) {
+	if srcDir == "" || !filepath.IsAbs(absPath) {
+		return "", "", false
+	}
+	parts := strings.Split(filepath.ToSlash(absPath), "/")
+	for i := 1; i < len(parts); i++ {
+		rel := strings.Join(parts[i:], "/")
+		targetAbs := filepath.Join(srcDir, rel)
+		if existFn(targetAbs) {
+			return rel, targetAbs, true
+		}
+	}
+	return "", "", false
 }
 
 // Source files for Android may be split between two subdirectories: the common AOSP kernel

--- a/pkg/cover/backend/path_test.go
+++ b/pkg/cover/backend/path_test.go
@@ -4,9 +4,12 @@
 package backend
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/stretchr/testify/require"
 )
 
 type CleanPathAndroidTest struct {
@@ -122,4 +125,25 @@ func TestPathCleanerKernelSrcPath(t *testing.T) {
 	if rel != "relative/path" || abs != "/some_src_dir/relative/path" {
 		t.Errorf("expected rel=relative/path, abs=/some_src_dir/relative/path, got %q, %q", rel, abs)
 	}
+}
+
+func TestPathCleanerFindRelativeInSrc(t *testing.T) {
+	// Test that a DWARF path with a non-matching build prefix is normalized by
+	// CleanPath if the file exists under Src. CleanPath checks file existence on
+	// disk (via osutil.IsExist), so we create a temporary directory and dummy
+	// file.
+	srcDir := t.TempDir()
+
+	targetFile := filepath.Join(srcDir, "drivers", "usb", "core", "devio.c")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetFile), 0755))
+	require.NoError(t, os.WriteFile(targetFile, []byte(""), 0644))
+
+	kernelDirs := &mgrconfig.KernelDirs{
+		Src: srcDir,
+		Obj: srcDir,
+	}
+	dwarfPath := "/syzkaller/workdir/cache/src/hash1111/drivers/usb/core/devio.c"
+	rel, abs := CleanPath(dwarfPath, kernelDirs, nil)
+	require.Equal(t, "drivers/usb/core/devio.c", rel)
+	require.Equal(t, targetFile, abs)
 }


### PR DESCRIPTION
Add fallback in CleanPath function to ensure actual clean up of the path under certain conditions.

Sadly, #7469 wasn't able to cover all cases
