### PR TITLE
dashboard/app: add logging to db-export batch job script

### DIFF
--- a/dashboard/app/batch_db_export.go
+++ b/dashboard/app/batch_db_export.go
@@ -30,7 +30,7 @@ func handleBatchDBExport(w http.ResponseWriter, r *http.Request) {
 
 func exportDBScript(srcNamespace, archivePath string) string {
 	return "\n" +
-		"set -e\n" +
+		"set -ue\n" +
 		"echo \"Cloning syzkaller...\"\n" +
 		"git clone -q --depth 1 --branch master --single-branch https://github.com/google/syzkaller\n" +
 		"cd syzkaller\n" +

--- a/dashboard/app/batch_db_export.go
+++ b/dashboard/app/batch_db_export.go
@@ -30,12 +30,20 @@ func handleBatchDBExport(w http.ResponseWriter, r *http.Request) {
 
 func exportDBScript(srcNamespace, archivePath string) string {
 	return "\n" +
+		"set -e\n" +
+		"echo \"Cloning syzkaller...\"\n" +
 		"git clone -q --depth 1 --branch master --single-branch https://github.com/google/syzkaller\n" +
 		"cd syzkaller\n" +
+		"echo \"Getting auth token...\"\n" +
 		"token=$(gcloud auth print-access-token)\n" +
+		"if [ -z \"$token\" ]; then echo \"WARNING: gcloud auth token is empty\"; fi\n" +
+		"echo \"Running syz-db-export inside syz-env...\"\n" +
 		"CI=1 ./tools/syz-env \"" + // CI=1 to suppress "The input device is not a TTY".
+		"echo 'Starting export process inside container...' && " +
 		"go run ./tools/syz-db-export/... -namespace " + srcNamespace + " -output export -token $token -j 10 && " +
+		"echo 'Export finished. Creating tarball...' && " +
 		"tar -czf export.tar.gz ./export/ && " +
+		"echo 'Tarball created. Copying to GCS...' && " +
 		"gcloud storage cp export.tar.gz " + archivePath +
 		"\""
 }

--- a/dashboard/app/batch_db_export.go
+++ b/dashboard/app/batch_db_export.go
@@ -40,7 +40,7 @@ func exportDBScript(srcNamespace, archivePath string) string {
 		"echo \"Running syz-db-export inside syz-env...\"\n" +
 		"CI=1 ./tools/syz-env \"" + // CI=1 to suppress "The input device is not a TTY".
 		"echo 'Starting export process inside container...' && " +
-		"go run ./tools/syz-db-export/... -namespace " + srcNamespace + " -output export -token $token -j 10 && " +
+		"go run ./tools/syz-db-export/... -namespace " + srcNamespace + " -output export -token '$token' -j 10 && " +
 		"echo 'Export finished. Creating tarball...' && " +
 		"tar -czf export.tar.gz ./export/ && " +
 		"echo 'Tarball created. Copying to GCS...' && " +


### PR DESCRIPTION
Add echo statements and set -e to the generated bash script for the db-export Batch job. This will help identify which step fails (cloning, getting token, running syz-db-export, archiving, or uploading to GCS) by looking at the logs.
