### PR TITLE
Fix `#syz test` failures.

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -273,6 +273,7 @@ static bool flag_nic_vf;
 static bool flag_vhci_injection;
 static bool flag_wifi;
 static bool flag_delay_kcov_mmap;
+static bool flag_return_error;
 
 static bool flag_collect_cover;
 static bool flag_collect_signal;
@@ -427,6 +428,7 @@ struct handshake_req {
 	uint64 syscall_timeout_ms;
 	uint64 program_timeout_ms;
 	uint64 slowdown_scale;
+	bool return_error;
 };
 
 struct execute_req {
@@ -436,6 +438,7 @@ struct execute_req {
 	uint64 exec_flags;
 	uint64 all_call_signal;
 	bool all_extra_signal;
+	bool return_error;
 };
 
 struct execute_reply {
@@ -848,6 +851,7 @@ void parse_handshake(const handshake_req& req)
 	flag_wifi = (bool)(req.flags & rpc::ExecEnv::EnableWifi);
 	flag_delay_kcov_mmap = (bool)(req.flags & rpc::ExecEnv::DelayKcovMmap);
 	flag_nic_vf = (bool)(req.flags & rpc::ExecEnv::EnableNicVF);
+	flag_return_error = req.return_error;
 }
 
 void receive_execute()
@@ -872,6 +876,7 @@ void parse_execute(const execute_req& req)
 	flag_threaded = req.exec_flags & (uint64)rpc::ExecFlag::Threaded;
 	all_call_signal = req.all_call_signal;
 	all_extra_signal = req.all_extra_signal;
+	flag_return_error = req.return_error;
 
 	debug("[%llums] exec opts: reqid=%llu type=%llu procid=%llu threaded=%d cover=%d comps=%d dedup=%d signal=%d "
 	      " sandbox=%d/%d/%d/%d timeouts=%llu/%llu/%llu kernel_64_bit=%d\n",
@@ -1878,7 +1883,7 @@ rpc::ComparisonRaw convert(const kcov_comparison_t& cmp)
 void failmsg(const char* err, const char* msg, ...)
 {
 	int e = errno;
-	fprintf(stderr, "SYZFAIL: %s\n", err);
+	fprintf(stderr, "%s: %s\n", flag_return_error ? "NOTFAIL" : "SYZFAIL", err);
 	if (msg) {
 		va_list args;
 		va_start(args, msg);

--- a/executor/executor_runner.h
+++ b/executor/executor_runner.h
@@ -386,6 +386,7 @@ private:
 		    .syscall_timeout_ms = opts_.syscall_timeout_ms,
 		    .program_timeout_ms = ProgramTimeoutMs(),
 		    .slowdown_scale = opts_.slowdown,
+		    .return_error = IsSet(msg_->flags, rpc::RequestFlag::ReturnError),
 		};
 		if (write(req_pipe_, &req, sizeof(req)) != sizeof(req)) {
 			debug("request pipe write failed (errno=%d)\n", errno);
@@ -434,6 +435,7 @@ private:
 		    .exec_flags = static_cast<uint64>(msg_->exec_opts->exec_flags()),
 		    .all_call_signal = all_call_signal,
 		    .all_extra_signal = all_extra_signal,
+		    .return_error = IsSet(msg_->flags, rpc::RequestFlag::ReturnError),
 		};
 		exec_start_ = current_time_ms();
 		ChangeState(State::Executing);


### PR DESCRIPTION
'#syz test' commands and syz-crush were failing with 'FATAL: kernel too old' when using the older strace binary. Updating strace to a newer version resolved the 'kernel too old' error, but uncovered a false-positive SYZFAIL report during feature probing (e.g. 'SYZFAIL: setfilecon: setxattr failed').

Feature probing runs requests with the ReturnError flag set so that expected probe failures are returned to the caller for analysis rather than causing false-positive crash reports.

However, when a feature probe setup (such as setfilecon in sandbox_android) failed, failmsg() in executor.cc printed SYZFAIL: to stderr. When running under strace (such as in syz-crush -strace or some #syz test), strace intercepted the write(2, "SYZFAIL: ...") system call and logged it to the VM console stream, where report.Reporter matched SYZFAIL: and wrongly reported a crash.

Fix this by passing the return_error flag in handshake_req and execute_req down to the child executor process, and outputting the NOTFAIL: prefix instead of SYZFAIL: in failmsg() whenever return_error is true.

Fixes #7621.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
