### PR TITLE
pkg/aflow/tool/clangformat: fix style config for clang-format

### DIFF
--- a/pkg/aflow/tool/clangformat/clangformat.go
+++ b/pkg/aflow/tool/clangformat/clangformat.go
@@ -5,8 +5,6 @@
 package clangformat
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -38,23 +36,7 @@ func clangFormat(ctx *aflow.Context, state state, args args) (result, error) {
 		return result{}, aflow.BadCallError("File is required")
 	}
 
-	// Write the style file to a temporary file outside the repository.
-	tmpFile, err := os.CreateTemp("", "syz-clang-format-*.clang-format")
-	if err != nil {
-		return result{}, err
-	}
-	defer os.Remove(tmpFile.Name())
-
-	style := fmt.Sprintf("BasedOnStyle: InheritParentConfig=%s\nColumnLimit: 100\n", state.KernelScratchSrc)
-	if _, err := tmpFile.WriteString(style); err != nil {
-		tmpFile.Close()
-		return result{}, err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return result{}, err
-	}
-
-	cmd := osutil.Command("clang-format", "-style=file:"+tmpFile.Name(), "-i", args.File)
+	cmd := osutil.Command("clang-format", "-style={BasedOnStyle: InheritParentConfig, ColumnLimit: 100}", "-i", args.File)
 	cmd.Dir = state.KernelScratchSrc
 
 	output, err := osutil.Run(10*time.Minute, cmd)

--- a/pkg/aflow/tool/clangformat/clangformat_test.go
+++ b/pkg/aflow/tool/clangformat/clangformat_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package clangformat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClangFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "arch/arm64/kernel"), 0755))
+
+	// Create a .clang-format in repo root.
+	require.NoError(t, osutil.WriteFile(filepath.Join(repoDir, ".clang-format"), []byte(`BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+ColumnLimit: 80
+BreakBeforeBraces: Linux
+`)))
+
+	// Verify that a 96-character line is not wrapped, confirming the ColumnLimit: 100 override.
+	testFile := filepath.Join(repoDir, "arch/arm64/kernel/test.c")
+	code := `
+int long_function_name(int first_argument_name, int second_argument_name, int third_argument_name) {
+    int x = 1;
+    int y = 2;
+    return x + y;
+}
+`[1:]
+	require.NoError(t, osutil.WriteFile(testFile, []byte(code)))
+
+	aflow.TestTool(t, Tool,
+		state{KernelScratchSrc: repoDir},
+		args{File: "arch/arm64/kernel/test.c"},
+		func(res result) {
+			content, err := os.ReadFile(testFile)
+			require.NoError(t, err)
+			expected := `
+int long_function_name(int first_argument_name, int second_argument_name, int third_argument_name)
+{
+	int x = 1;
+	int y = 2;
+	return x + y;
+}
+`[1:]
+			require.Equal(t, expected, string(content))
+		},
+		"", aflow.TestWorkdir(tmpDir))
+}


### PR DESCRIPTION
Standard clang-format fails when parsing non-standard `InheritParentConfig=<path>` syntax generated in temporary style files.

Pass inline `-style={BasedOnStyle: InheritParentConfig, ColumnLimit: 100}` to inherit repository configuration without temporary files.