### PR TITLE
pkg/aflow: limit parallel tool calls per model turn

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -102,6 +102,8 @@ const (
 	maxHistorySize            = 20 // Large enough to catch alternating loops.
 	// We abort execution after this many iterations to prevent infinite loops.
 	defaultMaxLLMIterations = 250
+	// Maximum number of parallel tool calls allowed per model turn.
+	maxParallelToolCalls = 10
 )
 
 type TaskType int
@@ -694,6 +696,17 @@ func (a *LLMAgent) config(ctx *Context) (*backend.GenerateConfig, string, string
 }
 
 func (a *agentSession) callTools(ctx *Context, tools map[string]Tool, calls []*backend.FunctionCall) error {
+	if len(calls) > maxParallelToolCalls {
+		a.req = append(a.req, llmMessage{content: &backend.Message{
+			Role: backend.RoleUser,
+			Parts: []backend.Part{{
+				Text: fmt.Sprintf("too many parallel tool calls (%d), maximum allowed is %d; "+
+					"please reduce the number of tool calls per turn",
+					len(calls), maxParallelToolCalls),
+			}},
+		}})
+		return nil
+	}
 	responses := &backend.Message{
 		Role: backend.RoleUser,
 	}

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -537,3 +537,60 @@ func TestLLMAgentMaxIterations(t *testing.T) {
 		nil,
 	)
 }
+
+func TestMaxParallelToolCalls(t *testing.T) {
+	type outputs struct {
+		Reply string
+	}
+	type toolArgs struct {
+		Arg int `jsonschema:"something"`
+	}
+	var parts []backend.Part
+	for i := range maxParallelToolCalls + 1 {
+		parts = append(parts, backend.Part{
+			FunctionCall: &backend.FunctionCall{
+				ID:   fmt.Sprintf("id%d", i),
+				Name: "some-tool",
+				Args: map[string]any{
+					"Arg": i,
+				},
+			},
+		})
+	}
+	toolExecutionCount := 0
+	replies := []any{
+		&backend.GenerateResponse{
+			Parts: parts,
+		},
+		func(model string, cfg *backend.GenerateConfig, req []*backend.Message) (*backend.GenerateResponse, error) {
+			require.GreaterOrEqual(t, len(req), 2)
+			lastMsg := req[len(req)-1]
+			require.Equal(t, backend.RoleUser, lastMsg.Role)
+			require.Len(t, lastMsg.Parts, 1)
+			expectedErr := fmt.Sprintf(
+				"too many parallel tool calls (%d), maximum allowed is %d; "+
+					"please reduce the number of tool calls per turn",
+				maxParallelToolCalls+1, maxParallelToolCalls,
+			)
+			require.Equal(t, expectedErr, lastMsg.Parts[0].Text)
+			return &backend.GenerateResponse{
+				Parts: []backend.Part{{Text: "Done"}},
+			}, nil
+		},
+	}
+	testFlow[struct{}, outputs](t, nil,
+		map[string]any{"Reply": "Done"},
+		&LLMAgent{
+			Reply: "Reply",
+			Tools: []Tool{
+				NewFuncTool("some-tool", func(ctx *Context, state struct{}, args toolArgs) (struct{}, error) {
+					toolExecutionCount++
+					return struct{}{}, nil
+				}, "some-tool description"),
+			},
+		},
+		replies,
+		nil,
+	)
+	require.Equal(t, 0, toolExecutionCount, "tools should not be executed when maxParallelToolCalls is exceeded")
+}

--- a/pkg/aflow/testdata/TestMaxParallelToolCalls.llm.json
+++ b/pkg/aflow/testdata/TestMaxParallelToolCalls.llm.json
@@ -1,0 +1,180 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "some-tool description",
+							"name": "some-tool",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Arg": {
+										"type": "integer",
+										"description": "something"
+									}
+								},
+								"required": [
+									"Arg"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id0",
+							"args": {
+								"Arg": 0
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id1",
+							"args": {
+								"Arg": 1
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id2",
+							"args": {
+								"Arg": 2
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id3",
+							"args": {
+								"Arg": 3
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id4",
+							"args": {
+								"Arg": 4
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id5",
+							"args": {
+								"Arg": 5
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id6",
+							"args": {
+								"Arg": 6
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id7",
+							"args": {
+								"Arg": 7
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id8",
+							"args": {
+								"Arg": 8
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id9",
+							"args": {
+								"Arg": 9
+							},
+							"name": "some-tool"
+						}
+					},
+					{
+						"functionCall": {
+							"id": "id10",
+							"args": {
+								"Arg": 10
+							},
+							"name": "some-tool"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"text": "too many parallel tool calls (11), maximum allowed is 10; please reduce the number of tool calls per turn"
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestMaxParallelToolCalls.trajectory.json
+++ b/pkg/aflow/testdata/TestMaxParallelToolCalls.trajectory.json
@@ -1,0 +1,76 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:07Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt",
+		"Reply": "Done"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"Results": {
+			"Reply": "Done"
+		}
+	}
+]


### PR DESCRIPTION
Runaway LLM agents can issue large numbers of tool calls in parallel within a single response turn, burning tons of tokens at once. Enforcing a constant limit per turn prevents agents from overwhelming system resources when misbehaving.
