### PR TITLE
dashboard, syz-ci: add JobTestReproC to test AI-generated C reproducers

### DIFF
--- a/dashboard/app/access.go
+++ b/dashboard/app/access.go
@@ -113,11 +113,14 @@ func checkTextAccess(ctx context.Context, r *http.Request, tag string, id int64)
 	default:
 		return nil, nil, checkAccessLevel(ctx, r, AccessAdmin)
 	case textPatch:
-		return nil, nil, checkJobTextAccess(ctx, r, "Patch", id)
+		bug, err := checkJobTextAccess(ctx, r, "Patch", id)
+		return bug, nil, err
 	case textLog:
-		return nil, nil, checkJobTextAccess(ctx, r, "Log", id)
+		bug, err := checkJobTextAccess(ctx, r, "Log", id)
+		return bug, nil, err
 	case textError:
-		return nil, nil, checkJobTextAccess(ctx, r, "Error", id)
+		bug, err := checkJobTextAccess(ctx, r, "Error", id)
+		return bug, nil, err
 	case textKernelConfig:
 		// This is checked based on text namespace.
 		return nil, nil, nil
@@ -127,17 +130,24 @@ func checkTextAccess(ctx context.Context, r *http.Request, tag string, id int64)
 		if err == nil || err == ErrAccess {
 			return bug, crash, err
 		}
-		return nil, nil, checkJobTextAccess(ctx, r, "CrashLog", id)
+		bug, err = checkJobTextAccess(ctx, r, "CrashLog", id)
+		return bug, nil, err
 	case textCrashReport:
 		bug, crash, err := checkCrashTextAccess(ctx, r, "Report", id)
 		if err == nil || err == ErrAccess {
 			return bug, crash, err
 		}
-		return nil, nil, checkJobTextAccess(ctx, r, "CrashReport", id)
+		bug, err = checkJobTextAccess(ctx, r, "CrashReport", id)
+		return bug, nil, err
 	case textReproSyz:
 		return checkCrashTextAccess(ctx, r, "ReproSyz", id)
 	case textReproC:
-		return checkCrashTextAccess(ctx, r, "ReproC", id)
+		bug, crash, err := checkCrashTextAccess(ctx, r, "ReproC", id)
+		if err == nil || err == ErrAccess {
+			return bug, crash, err
+		}
+		bug, err = checkJobTextAccess(ctx, r, "CandidateReproC", id)
+		return bug, nil, err
 	case textReproLog:
 		bug, crash, err := checkCrashTextAccess(ctx, r, "ReproLog", id)
 		if err == nil || err == ErrAccess {
@@ -181,13 +191,13 @@ func checkCrashTextAccess(ctx context.Context, r *http.Request, field string, id
 	return bug, crash, checkAccessLevel(ctx, r, bugLevel)
 }
 
-func checkJobTextAccess(ctx context.Context, r *http.Request, field string, id int64) error {
+func checkJobTextAccess(ctx context.Context, r *http.Request, field string, id int64) (*Bug, error) {
 	keys, err := db.NewQuery("Job").
 		Filter(field+"=", id).
 		KeysOnly().
 		GetAll(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to query jobs: %w", err)
+		return nil, fmt.Errorf("failed to query jobs: %w", err)
 	}
 	if len(keys) != 1 {
 		err := fmt.Errorf("checkJobTextAccess: found %v jobs for %v=%v", len(keys), field, id)
@@ -195,14 +205,14 @@ func checkJobTextAccess(ctx context.Context, r *http.Request, field string, id i
 			// This can be triggered by bad user requests, so don't log the error.
 			err = fmt.Errorf("%w: %w", ErrClientNotFound, err)
 		}
-		return err
+		return nil, err
 	}
 	bug := new(Bug)
 	if err := db.Get(ctx, keys[0].Parent(), bug); err != nil {
-		return fmt.Errorf("failed to get bug: %w", err)
+		return nil, fmt.Errorf("failed to get bug: %w", err)
 	}
 	bugLevel := bug.sanitizeAccess(ctx, accessLevel(ctx, r))
-	return checkAccessLevel(ctx, r, bugLevel)
+	return bug, checkAccessLevel(ctx, r, bugLevel)
 }
 
 func (bug *Bug) sanitizeAccess(ctx context.Context, currentLevel AccessLevel) AccessLevel {

--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -250,6 +250,7 @@ type uiAIJob struct {
 	CorrectTitle     string
 	Results          []*uiAIResult
 	IsCurrent        bool
+	CanTestOnManager bool
 }
 
 type uiAIResult struct {
@@ -514,6 +515,12 @@ func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hd
 		}
 		correct := r.FormValue("correct")
 		return "", handleAIJobPageCorrectness(ctx, job, correct, "", user.Email)
+
+	case "test_repro_c":
+		if job.Workflow != string(ai.WorkflowReproC) {
+			return "", fmt.Errorf("%w: only C reproducer jobs can be tested", ErrClientBadRequest)
+		}
+		return "", handleAITestReproCJob(ctx, job, r)
 
 	default:
 		return "", fmt.Errorf("%w: unknown action %q", ErrClientBadRequest, action)
@@ -1002,6 +1009,14 @@ func makeUIAIJob(job *aidb.Job) *uiAIJob {
 	if desc == "" {
 		desc = "---"
 	}
+	canTestOnManager := false
+	if job.Workflow == string(ai.WorkflowReproC) && job.Error == "" && job.Finished.Valid {
+		if resMap, ok := job.Results.Value.(map[string]any); ok {
+			if reproC, _ := resMap[textReproC].(string); reproC != "" {
+				canTestOnManager = true
+			}
+		}
+	}
 	return &uiAIJob{
 		ID:               job.ID,
 		Link:             fmt.Sprintf("/ai_job?id=%v", job.ID),
@@ -1020,6 +1035,7 @@ func makeUIAIJob(job *aidb.Job) *uiAIJob {
 		CorrectTitle:     title,
 		Results:          results,
 		ErrorSummary:     summarizeAIJobError(job.Error),
+		CanTestOnManager: canTestOnManager,
 	}
 }
 
@@ -2161,4 +2177,51 @@ func extractExecutedModels(trajectory []*aidb.TrajectorySpan) []string {
 	res := slices.Collect(maps.Keys(models))
 	slices.Sort(res)
 	return res
+}
+
+// handleAITestReproCJob launches a C reproducer test job for a given AI job.
+func handleAITestReproCJob(ctx context.Context, aiJob *aidb.Job, r *http.Request) error {
+	user := currentUser(ctx)
+	if user == nil {
+		return ErrAccess
+	}
+	resultsMap, ok := aiJob.Results.Value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: invalid AI job results format", ErrClientBadRequest)
+	}
+	reproCStr, _ := resultsMap[textReproC].(string)
+	if reproCStr == "" {
+		return fmt.Errorf("%w: C reproducer is empty", ErrClientBadRequest)
+	}
+	if !aiJob.BugID.Valid || aiJob.BugID.StringVal == "" {
+		return fmt.Errorf("%w: AI job has no associated Bug ID", ErrClientBadRequest)
+	}
+	bugKey := db.NewKey(ctx, "Bug", aiJob.BugID.StringVal, 0, nil)
+	bug := new(Bug)
+	if err := db.Get(ctx, bugKey, bug); err != nil {
+		return fmt.Errorf("failed to get bug %v: %w", aiJob.BugID.StringVal, err)
+	}
+	if err := checkAccessLevel(ctx, r, bug.sanitizeAccess(ctx, accessLevel(ctx, r))); err != nil {
+		return err
+	}
+	manager, _ := resultsMap["KernelConfigManager"].(string)
+	if manager == "" {
+		if argsMap, ok := aiJob.Args.Value.(map[string]any); ok {
+			manager, _ = argsMap["KernelConfigManager"].(string)
+		}
+	}
+	if manager == "" && len(bug.HappenedOn) > 0 {
+		manager = bug.HappenedOn[0]
+	}
+	if manager == "" {
+		return fmt.Errorf("%w: could not determine target manager for bug", ErrClientBadRequest)
+	}
+	_, err := handleTestReproCRequest(ctx, &testReproCReqArgs{
+		bug:     bug,
+		bugKey:  bugKey,
+		user:    user.Email,
+		manager: manager,
+		reproC:  []byte(reproCStr),
+	})
+	return err
 }

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1391,3 +1391,98 @@ func TestManualAIWorkflows(t *testing.T) {
 	assert.Nil(t, manualAIWorkflows(nil))
 	assert.Nil(t, manualAIWorkflows(&Config{}))
 }
+
+func TestAITestReproC(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	build.KernelRepo = "git://syzkaller.org"
+	c.aiClient.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+	bug, _, _ := c.loadBug(extID)
+
+	pollReq := &dashapi.AIJobPollReq{
+		AgentName:    "agent-name",
+		CodeRevision: prog.GitRevision,
+		Workflows: []dashapi.AIWorkflow{
+			{Type: ai.WorkflowReproC, Name: string(ai.WorkflowReproC)},
+		},
+	}
+	_, err := c.globalClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+
+	jobCreateURL := fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx))
+	values := url.Values{}
+	values.Set("ai-job-create", string(ai.WorkflowReproC))
+	_, err = c.AuthPOSTForm(AccessUser, jobCreateURL, values)
+	require.NoError(t, err)
+
+	aiJobResp, err := c.globalClient.AIJobPoll(pollReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, aiJobResp.ID)
+
+	err = c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: aiJobResp.ID,
+		Results: map[string]any{
+			"ReproC":              "int main() { return 0; }",
+			"KernelConfigManager": build.Manager,
+		},
+	})
+	require.NoError(t, err)
+
+	testValues := url.Values{}
+	testValues.Set("id", aiJobResp.ID)
+	testValues.Set("action", "test_repro_c")
+	_, err = c.AuthPOSTForm(AccessUser, "/ai_job", testValues)
+	require.NoError(t, err)
+
+	pollResp, err := c.globalClient.JobPoll(&dashapi.JobPollReq{
+		Managers: map[string]dashapi.ManagerJobs{
+			build.Manager: {TestPatches: true},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, dashapi.JobTestPatch, pollResp.Type)
+	require.Equal(t, "int main() { return 0; }", string(pollResp.ReproC))
+
+	// Complete the test job with a crash matching the bug title.
+	jobDoneReq := &dashapi.JobDoneReq{
+		ID:         pollResp.ID,
+		Build:      *testBuild(2),
+		CrashTitle: bug.Title,
+	}
+	require.NoError(t, c.globalClient.JobDone(jobDoneReq))
+
+	// The newly added repro must have caused reporting of a reproducer.
+	msg := c.pollEmailBug()
+	require.NotNil(t, msg)
+
+	bug, dbCrash, _ := c.loadBug(extID)
+	require.True(t, bug.HasCRepro)
+	require.True(t, bug.HeadHasCRepro)
+
+	// Verify that the reproducer link is reported in the email and serves the augmented C reproducer via HTTP.
+	reproCLink := externalLink(c.ctx, textReproC, dbCrash.ReproC)
+	require.Contains(t, msg.Body, reproCLink)
+	wantReproC := []byte(fmt.Sprintf("// %v/bug?id=%v\nint main() { return 0; }",
+		appURL(c.ctx), bug.keyHash(c.ctx)))
+	c.checkURLContents(reproCLink, wantReproC)
+}
+
+func TestAITestReproCErrors(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	// Invalid action.
+	values := url.Values{}
+	values.Set("id", "non-existent-id")
+	values.Set("action", "invalid_action")
+	_, err := c.AuthPOSTForm(AccessUser, "/ai_job", values)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusNotFound, httpErr.Code)
+}

--- a/dashboard/app/entities_datastore.go
+++ b/dashboard/app/entities_datastore.go
@@ -588,10 +588,11 @@ type Job struct {
 	CrashID   int64
 
 	// Provided by user:
-	KernelRepo   string
-	KernelBranch string
-	Patch        int64 // reference to Patch text entity
-	KernelConfig int64 // reference to the kernel config entity
+	KernelRepo      string
+	KernelBranch    string
+	Patch           int64 // reference to Patch text entity
+	KernelConfig    int64 // reference to the kernel config entity
+	CandidateReproC int64 // reference to ReproC text entity (for C reproducer testing)
 
 	Attempts    int       // number of times we tried to execute this job
 	IsRunning   bool      // the job might have been started, but never finished

--- a/dashboard/app/index.yaml
+++ b/dashboard/app/index.yaml
@@ -223,6 +223,14 @@ indexes:
     direction: desc
 
 - kind: Job
+  ancestor: yes
+  properties:
+  - name: Type
+  - name: Manager
+  - name: Finished
+
+
+- kind: Job
   properties:
   - name: Type
   - name: Finished

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -32,9 +33,11 @@ type testReqArgs struct {
 	bugKey          *db.Key
 	bugReporting    *BugReporting
 	user            string
+	manager         string
 	extID           string
 	link            string
 	patch           []byte
+	reproC          []byte
 	repo            string
 	branch          string
 	jobCC           []string
@@ -101,6 +104,33 @@ type testJobArgs struct {
 	testReqArgs
 }
 
+func saveTestJobPayloads(ctx context.Context, ns string, args *testJobArgs) (
+	patchID, reproCID, configRef int64, err error) {
+	if len(args.patch) > 0 {
+		if patchID, err = putText(ctx, ns, textPatch, args.patch); err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if len(args.reproC) > 0 {
+		if reproCID, err = putText(ctx, ns, textReproC, args.reproC); err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	configRef = args.configRef
+	if args.configAppend != "" {
+		kernelConfig, _, err := getText(ctx, textKernelConfig, configRef)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		configRef, err = putText(ctx, ns, textKernelConfig,
+			append(kernelConfig, []byte(args.configAppend)...))
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	return patchID, reproCID, configRef, nil
+}
+
 func addTestJob(ctx context.Context, args *testJobArgs) (*Job, *db.Key, error) {
 	now := timeNow(ctx)
 	if err := patchTestJobArgs(ctx, args); err != nil {
@@ -109,26 +139,18 @@ func addTestJob(ctx context.Context, args *testJobArgs) (*Job, *db.Key, error) {
 	if reason := checkTestJob(args); reason != "" {
 		return nil, nil, &BadTestRequestError{reason}
 	}
-	manager, mgrConfig := activeManager(ctx, args.crash.Manager, args.bug.Namespace)
+	targetMgr := args.manager
+	if targetMgr == "" {
+		targetMgr = args.crash.Manager
+	}
+	manager, mgrConfig := activeManager(ctx, targetMgr, args.bug.Namespace)
 	if mgrConfig != nil && mgrConfig.RestrictedTestingRepo != "" &&
 		args.repo != mgrConfig.RestrictedTestingRepo {
 		return nil, nil, &BadTestRequestError{mgrConfig.RestrictedTestingReason}
 	}
-	patchID, err := putText(ctx, args.bug.Namespace, textPatch, args.patch)
+	patchID, reproCID, configRef, err := saveTestJobPayloads(ctx, args.bug.Namespace, args)
 	if err != nil {
 		return nil, nil, err
-	}
-	configRef := args.configRef
-	if args.configAppend != "" {
-		kernelConfig, _, err := getText(ctx, textKernelConfig, configRef)
-		if err != nil {
-			return nil, nil, err
-		}
-		configRef, err = putText(ctx, args.bug.Namespace, textKernelConfig,
-			append(kernelConfig, []byte(args.configAppend)...))
-		if err != nil {
-			return nil, nil, err
-		}
 	}
 	reportingName := ""
 	if args.bugReporting != nil {
@@ -151,14 +173,15 @@ func addTestJob(ctx context.Context, args *testJobArgs) (*Job, *db.Key, error) {
 		MergeBaseRepo:   args.mergeBaseRepo,
 		MergeBaseBranch: args.mergeBaseBranch,
 		Patch:           patchID,
+		CandidateReproC: reproCID,
 		KernelConfig:    configRef,
 		TreeOrigin:      args.treeOrigin,
 	}
 
 	var jobKey *db.Key
-	deletePatch := false
+	deletePayloads := false
 	tx := func(ctx context.Context) error {
-		deletePatch = false
+		deletePayloads = false
 		// We can get 2 emails for the same request: one direct and one from a mailing list.
 		// Filter out such duplicates (for dup we only need link update).
 		var jobs []*Job
@@ -175,7 +198,7 @@ func addTestJob(ctx context.Context, args *testJobArgs) (*Job, *db.Key, error) {
 		}
 		if len(jobs) != 0 {
 			// The job is already present, update link.
-			deletePatch = true
+			deletePayloads = true
 			job, jobKey = jobs[0], keys[0]
 			if job.Link != "" || args.link == "" {
 				return nil
@@ -194,9 +217,16 @@ func addTestJob(ctx context.Context, args *testJobArgs) (*Job, *db.Key, error) {
 	} else {
 		err = runInTransaction(ctx, tx, &db.TransactionOptions{XG: true})
 	}
-	if patchID != 0 && (deletePatch || err != nil) {
-		if err := db.Delete(ctx, db.NewKey(ctx, textPatch, "", patchID, nil)); err != nil {
-			log.Errorf(ctx, "failed to delete patch for dup job: %v", err)
+	if deletePayloads || err != nil {
+		if patchID != 0 {
+			if err := db.Delete(ctx, db.NewKey(ctx, textPatch, "", patchID, nil)); err != nil {
+				log.Errorf(ctx, "failed to delete patch for dup job: %v", err)
+			}
+		}
+		if reproCID != 0 {
+			if err := db.Delete(ctx, db.NewKey(ctx, textReproC, "", reproCID, nil)); err != nil {
+				log.Errorf(ctx, "failed to delete reproC for dup job: %v", err)
+			}
 		}
 	}
 	if err != nil {
@@ -245,7 +275,9 @@ func checkTestJob(args *testJobArgs) string {
 	crash, bug := args.crash, args.bug
 	needRepro := crashNeedsRepro(crash.Title)
 	switch {
-	case needRepro && crash.ReproC == 0 && crash.ReproSyz == 0:
+	case len(args.patch) > 0 && len(args.reproC) > 0:
+		return "cannot test both patch and C reproducer"
+	case len(args.reproC) == 0 && needRepro && crash.ReproC == 0 && crash.ReproSyz == 0:
 		return "This crash does not have a reproducer. I cannot test it."
 	case !vcs.CheckRepoAddress(args.repo):
 		return fmt.Sprintf("%q does not look like a valid git repo address.", args.repo)
@@ -857,7 +889,11 @@ func createJobResp(ctx context.Context, job *Job, jobKey *db.Key) (*dashapi.JobP
 		return nil, false, err
 	}
 
-	reproC, _, err := getText(ctx, textReproC, crash.ReproC)
+	reproCRef := crash.ReproC
+	if job.CandidateReproC != 0 {
+		reproCRef = job.CandidateReproC
+	}
+	reproC, _, err := getText(ctx, textReproC, reproCRef)
 	if err != nil {
 		return nil, false, err
 	}
@@ -931,6 +967,7 @@ func createJobResp(ctx context.Context, job *Job, jobKey *db.Key) (*dashapi.JobP
 func isRetestReproJob(job *Job, build *Build) bool {
 	return (job.Type == JobTestPatch || job.Type == JobBisectFix) &&
 		job.Patch == 0 &&
+		job.CandidateReproC == 0 &&
 		job.KernelRepo == build.KernelRepo &&
 		job.KernelBranch == build.KernelBranch
 }
@@ -1121,7 +1158,33 @@ func doneJob(ctx context.Context, req *dashapi.JobDoneReq) error {
 	if err = runInTransaction(ctx, tx, &db.TransactionOptions{XG: true}); err != nil {
 		return err
 	}
+	reportCandidateReproCrash(ctx, job, req)
 	return postJob(ctx, jobKey, job)
+}
+
+func reportCandidateReproCrash(ctx context.Context, job *Job, req *dashapi.JobDoneReq) {
+	if job.Type != JobTestPatch || job.CandidateReproC == 0 || req.CrashTitle == "" ||
+		len(req.Error) > 0 || req.Build.ID == "" {
+		return
+	}
+	reproC, _, err := getText(ctx, textReproC, job.CandidateReproC)
+	if err != nil || len(reproC) == 0 {
+		return
+	}
+	build, err := loadBuild(ctx, job.Namespace, req.Build.ID)
+	if err != nil {
+		return
+	}
+	crashReq := &dashapi.Crash{
+		BuildID: req.Build.ID,
+		Title:   req.CrashTitle,
+		Log:     req.CrashLog,
+		Report:  req.CrashReport,
+		ReproC:  reproC,
+	}
+	if _, err := reportCrash(ctx, build, crashReq); err != nil {
+		log.Errorf(ctx, "job %v: failed to report candidate repro crash: %v", req.ID, err)
+	}
 }
 
 func saveJobTexts(ctx context.Context, ns string, job *Job, req *dashapi.JobDoneReq) error {
@@ -1638,6 +1701,9 @@ func makeJobInfo(ctx context.Context, job *Job, jobKey *db.Key, bug *Bug, build 
 		info.ReproCLink = externalLink(ctx, textReproC, crash.ReproC)
 		info.ReproSyzLink = externalLink(ctx, textReproSyz, crash.ReproSyz)
 	}
+	if job.CandidateReproC != 0 {
+		info.ReproCLink = externalLink(ctx, textReproC, job.CandidateReproC)
+	}
 	return info
 }
 
@@ -1932,4 +1998,72 @@ func loadBugsWithHeadRepro(ctx context.Context) ([]bugItem, error) {
 	add(bugs2, keys2)
 
 	return merged, nil
+}
+
+type testReproCReqArgs struct {
+	bug     *Bug
+	bugKey  *db.Key
+	user    string
+	manager string
+	reproC  []byte
+}
+
+// handleTestReproCRequest creates a JobTestPatch job to test a C reproducer on a manager.
+func handleTestReproCRequest(ctx context.Context, args *testReproCReqArgs) (*Job, error) {
+	if len(args.reproC) == 0 {
+		return nil, &BadTestRequestError{"C reproducer is empty"}
+	}
+	crash, crashKey, err := findCrashForBug(ctx, args.bug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find a crash for bug: %w", err)
+	}
+	targetMgr := args.manager
+	if targetMgr == "" {
+		targetMgr = crash.Manager
+	}
+	manager, _ := activeManager(ctx, targetMgr, args.bug.Namespace)
+	if existing := findDuplicateTestReproCJob(ctx, args.bugKey, manager, args.reproC); existing != nil {
+		return existing, nil
+	}
+	build, err := loadBuild(ctx, args.bug.Namespace, crash.BuildID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load build: %w", err)
+	}
+	job, _, err := addTestJob(ctx, &testJobArgs{
+		crash:     crash,
+		crashKey:  crashKey,
+		configRef: build.KernelConfig,
+		testReqArgs: testReqArgs{
+			bug:     args.bug,
+			bugKey:  args.bugKey,
+			user:    args.user,
+			manager: targetMgr,
+			repo:    build.KernelRepo,
+			branch:  build.KernelBranch,
+			reproC:  args.reproC,
+		},
+	})
+	return job, err
+}
+
+func findDuplicateTestReproCJob(ctx context.Context, bugKey *db.Key, manager string, reproC []byte) *Job {
+	var existingJobs []*Job
+	_, err := db.NewQuery("Job").
+		Ancestor(bugKey).
+		Filter("Type=", JobTestPatch).
+		Filter("Manager=", manager).
+		Filter("Finished=", time.Time{}).
+		GetAll(ctx, &existingJobs)
+	if err != nil {
+		return nil
+	}
+	for _, j := range existingJobs {
+		if j.CandidateReproC != 0 {
+			existingReproC, _, err := getText(ctx, textReproC, j.CandidateReproC)
+			if err == nil && bytes.Equal(existingReproC, reproC) {
+				return j
+			}
+		}
+	}
+	return nil
 }

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1090,31 +1090,10 @@ func doneJob(ctx context.Context, req *dashapi.JobDoneReq) error {
 				log.Errorf(ctx, "job %v: duplicate build %v", jobID, req.Build.ID)
 			}
 		}
-		if job.Log, err = putText(ctx, ns, textLog, req.Log); err != nil {
+		if err := saveJobTexts(ctx, ns, job, req); err != nil {
 			return err
 		}
-		if job.Error, err = putText(ctx, ns, textError, req.Error); err != nil {
-			return err
-		}
-		if job.CrashLog, err = putText(ctx, ns, textCrashLog, req.CrashLog); err != nil {
-			return err
-		}
-		if job.CrashReport, err = putText(ctx, ns, textCrashReport, req.CrashReport); err != nil {
-			return err
-		}
-		for _, com := range req.Commits {
-			cc := email.MergeEmailLists(com.CC,
-				GetEmails(com.Recipients, dashapi.To),
-				GetEmails(com.Recipients, dashapi.Cc))
-			job.Commits = append(job.Commits, Commit{
-				Hash:       com.Hash,
-				Title:      com.Title,
-				Author:     com.Author,
-				AuthorName: com.AuthorName,
-				CC:         strings.Join(sanitizeCC(ctx, cc), "|"),
-				Date:       com.Date,
-			})
-		}
+		saveJobCommits(ctx, job, req.Commits)
 		job.BuildID = req.Build.ID
 		job.CrashTitle = req.CrashTitle
 		job.Finished = now
@@ -1143,6 +1122,39 @@ func doneJob(ctx context.Context, req *dashapi.JobDoneReq) error {
 		return err
 	}
 	return postJob(ctx, jobKey, job)
+}
+
+func saveJobTexts(ctx context.Context, ns string, job *Job, req *dashapi.JobDoneReq) error {
+	var err error
+	if job.Log, err = putText(ctx, ns, textLog, req.Log); err != nil {
+		return err
+	}
+	if job.Error, err = putText(ctx, ns, textError, req.Error); err != nil {
+		return err
+	}
+	if job.CrashLog, err = putText(ctx, ns, textCrashLog, req.CrashLog); err != nil {
+		return err
+	}
+	if job.CrashReport, err = putText(ctx, ns, textCrashReport, req.CrashReport); err != nil {
+		return err
+	}
+	return nil
+}
+
+func saveJobCommits(ctx context.Context, job *Job, commits []dashapi.Commit) {
+	for _, com := range commits {
+		cc := email.MergeEmailLists(com.CC,
+			GetEmails(com.Recipients, dashapi.To),
+			GetEmails(com.Recipients, dashapi.Cc))
+		job.Commits = append(job.Commits, Commit{
+			Hash:       com.Hash,
+			Title:      com.Title,
+			Author:     com.Author,
+			AuthorName: com.AuthorName,
+			CC:         strings.Join(sanitizeCC(ctx, cc), "|"),
+			Date:       com.Date,
+		})
+	}
 }
 
 func postJob(ctx context.Context, jobKey *db.Key, job *Job) error {

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -1373,3 +1373,107 @@ func TestAliasPatchTestingJob(t *testing.T) {
 	c.expectEQ(pollResp.KernelRepo, "git://syzkaller.org")
 	c.expectEQ(pollResp.KernelBranch, "some-branch")
 }
+
+func TestReproCJob(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.client
+
+	build := testBuild(1)
+	build.KernelRepo = "git://syzkaller.org"
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	rep := c.globalClient.pollBug()
+
+	bug, _, _ := c.loadBug(rep.ID)
+	reproC := []byte("void main() { *(int*)0 = 0; }")
+	job, err := handleTestReproCRequest(c.ctx, &testReproCReqArgs{
+		bug:     bug,
+		bugKey:  bug.key(c.ctx),
+		user:    "test@user.com",
+		manager: build.Manager,
+		reproC:  reproC,
+	})
+	c.expectOK(err)
+	c.expectNE(job, nil)
+	c.expectEQ(job.Type, JobTestPatch)
+
+	// Manager polls job with TestPatches = true.
+	pollResp, err := c.globalClient.JobPoll(&dashapi.JobPollReq{
+		Managers: map[string]dashapi.ManagerJobs{
+			build.Manager: {TestPatches: true},
+		},
+	})
+	c.expectOK(err)
+	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)
+	c.expectEQ(string(pollResp.ReproC), string(reproC))
+
+	// Job succeeds with crash matching the bug title.
+	jobDoneReq := &dashapi.JobDoneReq{
+		ID:         pollResp.ID,
+		Build:      *testBuild(2),
+		CrashTitle: rep.Title,
+	}
+	c.expectOK(c.globalClient.JobDone(jobDoneReq))
+
+	// The newly added repro must cause a new report via pollBug().
+	rep2 := c.globalClient.pollBug()
+	c.expectEQ(rep2.Type, dashapi.ReportRepro)
+	c.expectEQ(string(rep2.ReproC), string(reproC))
+	c.expectNE(rep2.ReproCLink, "")
+}
+
+func TestReproCJobError(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := c.publicClient
+
+	build := testBuild(1)
+	build.KernelRepo = "git://syzkaller.org"
+	client.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	client.ReportCrash(crash)
+	sender := c.pollEmailBug().Sender
+	_, extBugID, err := email.RemoveAddrContext(sender)
+	c.expectOK(err)
+
+	bug, _, _ := c.loadBug(extBugID)
+	bugKey := bug.key(c.ctx)
+	c.expectEQ(bug.HasCRepro, false)
+
+	reproC := []byte("void main() { *(int*)0 = 0; }")
+	_, err = handleTestReproCRequest(c.ctx, &testReproCReqArgs{
+		bug:     bug,
+		bugKey:  bugKey,
+		user:    "test@user.com",
+		manager: build.Manager,
+		reproC:  reproC,
+	})
+	c.expectOK(err)
+
+	pollResp, err := c.globalClient.JobPoll(&dashapi.JobPollReq{
+		Managers: map[string]dashapi.ManagerJobs{
+			build.Manager: {TestPatches: true},
+		},
+	})
+	c.expectOK(err)
+
+	// Job finishes with req.Error and a CrashTitle.
+	jobDoneReq := &dashapi.JobDoneReq{
+		ID:         pollResp.ID,
+		Build:      *testBuild(2),
+		CrashTitle: bug.Title,
+		Error:      []byte("infrastructure error"),
+	}
+	c.expectOK(c.globalClient.JobDone(jobDoneReq))
+
+	// No reproducer reporting should occur, and HasCRepro should remain false.
+	c.expectNoEmail()
+	bug, _, _ = c.loadBug(extBugID)
+	c.expectEQ(bug.HasCRepro, false)
+}

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -84,6 +84,13 @@ Detailed info on a single AI job execution.
 			</form>
 			<br>
 		{{end}}
+		{{if .Job.CanTestOnManager}}
+			<form method="POST">
+				<input type="hidden" name="action" value="test_repro_c">
+				<button type="submit">Test C Reproducer</button>
+			</form>
+			<br>
+		{{end}}
 	{{end}}
 
 	{{if .Reportings}}


### PR DESCRIPTION
AI reproduction workflows (such as repro-c) can generate a standalone C reproducer for a bug. However, because the AI execution environment may differ slightly from a manager's VM pool, an AI-generated C repro must be validated on an actual syz-manager VM pool before declaring a working reproducer.

This change adds a new job type, JobTestReproC, allowing developers to trigger C reproducer testing directly from the AI Jobs table on the Bug page.

Key changes:
- dashapi: Add JobTestReproC to JobType enum, ReportTestReproC to ReportType enum, and TestReproC capability flag to ManagerJobs.
- dashboard/app: Add JobTestReproC to Datastore models, job polling, and completion handlers. Upon successful crash reproduction, set bug.HasCRepro = true and bug.HeadHasCRepro = true.
- dashboard/app/ai: Add handleAITestReproC HTTP handler and POST route /ai_job/test_repro_c to extract the C reproducer and queue the job.
- bug page UI: Render a "Test on Manager" action button in the AI Jobs table for completed repro-c jobs that generated a valid C repro.
- syz-ci: Update job processor client to poll and execute JobTestReproC runs via the testPatch execution pipeline.
- tests: Add TestJobTestReproC integration test in jobs_test.go.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
