### PR TITLE
syz-ci: disable strace on jobs

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -354,8 +354,7 @@ func (jp *JobProcessor) process(job *Job) *dashapi.JobDoneReq {
 	req, mgr := job.req, job.mgr
 
 	dir := filepath.Join(jp.baseDir, mgr.managercfg.TargetOS)
-	mgrcfg := new(mgrconfig.Config)
-	*mgrcfg = *mgr.managercfg
+	mgrcfg := mgr.jobConfig()
 	mgrcfg.Workdir = filepath.Join(dir, "workdir")
 	repoDir := filepath.Join(dir, "kernel")
 	mgrcfg.KernelSrc = filepath.Join(repoDir, mgr.mgrcfg.KernelSrcSuffix)

--- a/syz-ci/manager.go
+++ b/syz-ci/manager.go
@@ -578,8 +578,7 @@ func (mgr *Manager) reportBuildError(rep *report.Report, info *BuildInfo, imageD
 }
 
 func (mgr *Manager) createTestConfig(imageDir string, info *BuildInfo) (*mgrconfig.Config, error) {
-	mgrcfg := new(mgrconfig.Config)
-	*mgrcfg = *mgr.managercfg
+	mgrcfg := mgr.jobConfig()
 	mgrcfg.Name += "-test"
 	mgrcfg.Tag = info.KernelCommit
 	mgrcfg.HTTP = "" // Don't start the HTTP server.
@@ -597,6 +596,15 @@ func (mgr *Manager) createTestConfig(imageDir string, info *BuildInfo) (*mgrconf
 		return nil, fmt.Errorf("bad manager config: %w", err)
 	}
 	return mgrcfg, nil
+}
+
+// disable strace on all syz-ci jobs.
+func (mgr *Manager) jobConfig() *mgrconfig.Config {
+	mgrcfg := new(mgrconfig.Config)
+	*mgrcfg = *mgr.managercfg
+	mgrcfg.StraceBin = ""
+	mgrcfg.StraceBinOnTarget = false
+	return mgrcfg
 }
 
 func (mgr *Manager) writeConfig(buildTag string) (string, error) {


### PR DESCRIPTION
Patch testing (#syz test) builds syzkaller at the bug's original historical commit (req.SyzkallerCommit). Older syzkaller commits lack the strace output handling fixes, causing jobs to fail with SYZFAIL when strace is enabled.

Disable StraceBin specifically for syz-ci jobs so patch testing on older commits works reliably without needing to remove strace_bin from syz-manager configs.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
