### PR TITLE
pkg/instance: skip coverage collection on kernel crash

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -265,7 +265,7 @@ func (inst *ExecProgInstance) RunSyzProgFile(progFile string, opts RunOptions) (
 	if err != nil {
 		return nil, err
 	}
-	if coverFile != "" {
+	if coverFile != "" && res.Report == nil {
 		coverage, err := inst.retrieveCoverageFiles(coverFile, ncalls)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When coverage collection is enabled, fetching coverage files via SSH fails with an EOF error if the test program crashed the VM. This turns a successful crash reproduction into a false infrastructure failure.

Skip coverage file retrieval if a crash was already detected during execution, as coverage cannot be fetched from a crashed VM.