### PR TITLE
dashboard/app: cache found-bugs graph in memcache

### DIFF
--- a/dashboard/app/cache.go
+++ b/dashboard/app/cache.go
@@ -77,6 +77,10 @@ func cacheUpdate(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		}
+		graph := createFoundBugs(c, filterStableGraphBugs(c, bugs, ns))
+		if err := setCachedObject(c, foundBugsGraphKey(ns), 6*time.Hour, graph); err != nil {
+			log.Errorf(c, "failed to store found bugs graph for ns=%v: %v", ns, err)
+		}
 	}
 }
 
@@ -112,12 +116,7 @@ func buildAndStoreCached(ctx context.Context, bugs []*Bug, backports []*rawBackp
 		}
 	}
 
-	item := &memcache.Item{
-		Key:        cacheKey(ns, accessLevel),
-		Object:     v,
-		Expiration: 4 * time.Hour, // supposed to be updated by cron every hour
-	}
-	if err := memcache.Gob.Set(ctx, item); err != nil {
+	if err := setCachedObject(ctx, cacheKey(ns, accessLevel), 4*time.Hour, v); err != nil {
 		return nil, err
 	}
 	return v, nil
@@ -211,7 +210,7 @@ func minuteCacheNsUpdate(ctx context.Context, ns string) error {
 }
 
 func CachedManagerList(ctx context.Context, ns string) ([]string, error) {
-	return cachedObjectList(ctx,
+	return cachedObject(ctx,
 		fmt.Sprintf("%s-managers-list", ns),
 		time.Minute,
 		func(ctx context.Context) ([]string, error) {
@@ -222,7 +221,7 @@ func CachedManagerList(ctx context.Context, ns string) ([]string, error) {
 
 func CachedUIManagers(ctx context.Context, accessLevel AccessLevel, ns string,
 	filter *userBugFilter) ([]*uiManager, error) {
-	return cachedObjectList(ctx,
+	return cachedObject(ctx,
 		fmt.Sprintf("%s-%v-%v-ui-managers", ns, accessLevel, filter.Hash()),
 		5*time.Minute,
 		func(ctx context.Context) ([]*uiManager, error) {
@@ -231,29 +230,36 @@ func CachedUIManagers(ctx context.Context, accessLevel AccessLevel, ns string,
 	)
 }
 
-func cachedObjectList[T any](ctx context.Context, key string, period time.Duration,
-	load func(context.Context) ([]T, error)) ([]T, error) {
-	// Check if the object is in cache.
-	var obj []T
-	_, err := memcache.Gob.Get(ctx, key, &obj)
-	if err == nil {
-		return obj, nil
-	} else if err != memcache.ErrCacheMiss {
-		return nil, err
-	}
-
-	// Load the object.
-	obj, err = load(ctx)
-	if err != nil {
-		return nil, err
-	}
+func setCachedObject[T any](ctx context.Context, key string, period time.Duration, obj T) error {
 	item := &memcache.Item{
 		Key:        key,
 		Object:     obj,
 		Expiration: period,
 	}
-	if err := memcache.Gob.Set(ctx, item); err != nil {
-		return nil, err
+	return memcache.Gob.Set(ctx, item)
+}
+
+func cachedObject[T any](ctx context.Context, key string, period time.Duration,
+	load func(context.Context) (T, error)) (T, error) {
+	// Check if the object is in cache.
+	var obj T
+	_, err := memcache.Gob.Get(ctx, key, &obj)
+	if err == nil {
+		return obj, nil
+	} else if err != memcache.ErrCacheMiss {
+		var zero T
+		return zero, err
+	}
+
+	// Load the object.
+	obj, err = load(ctx)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if err := setCachedObject(ctx, key, period, obj); err != nil {
+		var zero T
+		return zero, err
 	}
 	return obj, nil
 }

--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -170,19 +170,37 @@ func handleGraphLifetimes(ctx context.Context, w http.ResponseWriter, r *http.Re
 	return serveTemplate(w, "graph_lifetimes.html", data)
 }
 
+func foundBugsGraphKey(ns string) string {
+	return fmt.Sprintf("%s-found-bugs-graph", ns)
+}
+
+func CachedFoundBugsGraph(ctx context.Context, ns string) (*uiGraph, error) {
+	return cachedObject(ctx,
+		foundBugsGraphKey(ns),
+		6*time.Hour,
+		func(ctx context.Context) (*uiGraph, error) {
+			bugs, err := loadStableGraphBugs(ctx, ns)
+			if err != nil {
+				return nil, err
+			}
+			return createFoundBugs(ctx, bugs), nil
+		},
+	)
+}
+
 func handleFoundBugsGraph(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	hdr, err := commonHeader(ctx, r, w, "")
 	if err != nil {
 		return err
 	}
-	bugs, err := loadStableGraphBugs(ctx, hdr.Namespace)
+	graph, err := CachedFoundBugsGraph(ctx, hdr.Namespace)
 	if err != nil {
 		return err
 	}
 	data := &uiHistogramPage{
 		Title:  hdr.Namespace + " bugs found per month",
 		Header: hdr,
-		Graph:  createFoundBugs(ctx, bugs),
+		Graph:  graph,
 	}
 	return serveTemplate(w, "graph_histogram.html", data)
 }
@@ -230,22 +248,22 @@ func loadGraphBugs(ctx context.Context, ns string) ([]*Bug, error) {
 // loadStableGraphBugs is similar to loadGraphBugs, but it does not remove duplicates and auto-invalidated bugs.
 // This ensures that the set of bugs does not change much over time.
 func loadStableGraphBugs(ctx context.Context, ns string) ([]*Bug, error) {
-	filter := func(query *db.Query) *db.Query {
-		return query.Filter("Namespace=", ns)
-	}
-	bugs, _, err := loadAllBugs(ctx, filter)
+	bugs, _, err := loadNamespaceBugs(ctx, ns)
 	if err != nil {
 		return nil, err
 	}
-	n := 0
+	return filterStableGraphBugs(ctx, bugs, ns), nil
+}
+
+func filterStableGraphBugs(ctx context.Context, bugs []*Bug, ns string) []*Bug {
+	var res []*Bug
 	lastReporting := getNsConfig(ctx, ns).lastActiveReporting()
 	for _, bug := range bugs {
 		if isStableBug(ctx, bug, lastReporting) {
-			bugs[n] = bug
-			n++
+			res = append(res, bug)
 		}
 	}
-	return bugs[:n], nil
+	return res
 }
 
 func isStableBug(ctx context.Context, bug *Bug, lastReporting int) bool {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -497,7 +497,7 @@ type userBugFilter struct {
 }
 
 func cachedBugIDsWithPendingPatch(ctx context.Context, ns string) ([]string, error) {
-	return cachedObjectList(ctx,
+	return cachedObject(ctx,
 		fmt.Sprintf("%s-ai-pending-patches", ns),
 		5*time.Minute,
 		func(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
Generating the bugs-found-per-month graph queries all bugs in the namespace from Datastore on every request. Because historical counts change slowly, this incurs unnecessary latency and Datastore reads.

Generalize `cachedObjectList` to `cachedObject` to support single objects, and cache the found-bugs graph in memcache for 24 hours with hourly cron preheating.