### PR TITLE
dashboard/app: add bug resolution rate graph

### DIFF
--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -28,6 +28,11 @@ type uiBugLifetimesPage struct {
 	Lifetimes []uiBugLifetime
 }
 
+type uiResolutionPage struct {
+	Header *uiHeader
+	Graph  *uiGraph
+}
+
 type uiHistogramPage struct {
 	Title  string
 	Header *uiHeader
@@ -203,6 +208,125 @@ func handleFoundBugsGraph(ctx context.Context, w http.ResponseWriter, r *http.Re
 		Graph:  graph,
 	}
 	return serveTemplate(w, "graph_histogram.html", data)
+}
+
+func handleResolutionGraph(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	hdr, err := commonHeader(ctx, r, w, "")
+	if err != nil {
+		return err
+	}
+	bugs, err := loadGraphBugs(ctx, hdr.Namespace)
+	if err != nil {
+		return err
+	}
+	lastReporting := getNsConfig(ctx, hdr.Namespace).lastActiveReporting()
+	data := &uiResolutionPage{
+		Header: hdr,
+		Graph:  createResolutionGraph(timeNow(ctx), bugs, lastReporting),
+	}
+	return serveTemplate(w, "graph_resolution.html", data)
+}
+
+const resolutionRateMonths = 6
+
+// createResolutionGraph computes the percentage of bugs addressed within X months (X=1..resolutionRateMonths).
+// To prevent population shift in the denominator across horizons (which would cause the cumulative
+// resolution curve to decrease), we evaluate a fixed mature cohort of bugs reported between 2 years
+// and resolutionRateMonths ago (T_reported in [now - 2 years, now - resolutionRateMonths]).
+// This guarantees every bug in the cohort has at least resolutionRateMonths of observation history, producing a
+// constant denominator and a strictly non-decreasing resolution curve across all months.
+func createResolutionGraph(now time.Time, bugs []*Bug, lastReporting int) *uiGraph {
+	twoYearsAgo := now.AddDate(-2, 0, 0)
+	cohortCutoff := now.AddDate(0, -resolutionRateMonths, 0)
+	var columns []uiGraphColumn
+
+	for month := 1; month <= resolutionRateMonths; month++ {
+		total := 0
+		fixed := 0
+
+		for _, bug := range bugs {
+			// Duplicate bugs are resolved via their canonical bug (which is counted separately).
+			if bug.Status == BugStatusDup {
+				continue
+			}
+			repDate := bugReportedDate(bug, lastReporting)
+			// Restrict dataset to bugs in the fixed mature cohort (reported between 2 years ago and resolutionRateMonths ago).
+			if repDate.Before(twoYearsAgo) || repDate.After(cohortCutoff) {
+				continue
+			}
+			// Auto-obsoleted bugs (where syzbot stopped hitting the bug after 90 days without a fix)
+			// remain in the denominator for all mature horizons as unfixed bugs. They are not skipped or dropped,
+			// which prevents an artificial 90-day resolution rate spike.
+			// Manually obsoleted bugs are treated as resolved at their closure date via bugFixDate.
+			total++
+			fixDate := bugFixDate(bug)
+			if !fixDate.IsZero() && !fixDate.After(repDate.AddDate(0, month, 0)) {
+				fixed++
+			}
+		}
+
+		var pct float32
+		if total > 0 {
+			pct = float32(fixed) / float32(total) * 100
+		}
+
+		columns = append(columns, uiGraphColumn{
+			Hint:       fmt.Sprintf("%dm", month),
+			Annotation: pct,
+			Vals:       []uiGraphValue{{Val: pct, Hint: fmt.Sprintf("%d/%d bugs (%.1f%%)", fixed, total, pct)}},
+		})
+	}
+
+	return &uiGraph{
+		Headers: []uiGraphHeader{{Name: "% Addressed Within X Months", Color: "#26ba1c"}},
+		Columns: columns,
+	}
+}
+
+// bugReportedDate determines the timestamp when a bug became publicly reported.
+// Bugs that reached the final reporting stage (e.g., LKML) use that stage's exact report timestamp.
+// Bugs fixed or closed before reaching the final stage use their initial report timestamp or first seen time.
+func bugReportedDate(bug *Bug, lastReporting int) time.Time {
+	if len(bug.Reporting) > lastReporting && !bug.Reporting[lastReporting].Reported.IsZero() {
+		return bug.Reporting[lastReporting].Reported
+	}
+	for _, r := range bug.Reporting {
+		if !r.Reported.IsZero() {
+			return r.Reported
+		}
+	}
+	return bug.FirstTime
+}
+
+// bugFixDate determines the true resolution timestamp for a bug.
+// Developers often fix bugs in git commits before syzbot detects and closes the bug in Datastore.
+// We prefer the earliest commit date from CommitInfo to measure real-world time-to-fix accurately,
+// falling back to Bug.Closed or Bug.FixTime if commit metadata is unavailable.
+func bugFixDate(bug *Bug) time.Time {
+	var earliestCommit time.Time
+	for _, com := range bug.CommitInfo {
+		if !com.Date.IsZero() && (earliestCommit.IsZero() || com.Date.Before(earliestCommit)) {
+			earliestCommit = com.Date
+		}
+	}
+	if !earliestCommit.IsZero() {
+		return earliestCommit
+	}
+	if bug.Status == BugStatusFixed && !bug.Closed.IsZero() {
+		return bug.Closed
+	}
+	if !bug.FixTime.IsZero() {
+		return bug.FixTime
+	}
+	// If a maintainer manually invalidates/obsoletes a bug, consider manual obsoletion
+	// as resolution (resolved/addressed), using the bug closure timestamp as the resolution date.
+	if bug.Status == BugStatusInvalid {
+		rep := lastReportedReporting(bug)
+		if rep != nil && !rep.Auto && !bug.Closed.IsZero() {
+			return bug.Closed
+		}
+	}
+	return time.Time{}
 }
 
 func loadGraphBugs(ctx context.Context, ns string) ([]*Bug, error) {

--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -28,6 +28,19 @@ type uiBugLifetimesPage struct {
 	Lifetimes []uiBugLifetime
 }
 
+type uiResolutionPage struct {
+	Header *uiHeader
+	Rates  []uiResolutionRate
+	Graph  *uiGraph
+}
+
+type uiResolutionRate struct {
+	Months       int
+	TotalBugs    int
+	FixedCount   int
+	FixedPercent float32
+}
+
 type uiHistogramPage struct {
 	Title  string
 	Header *uiHeader
@@ -203,6 +216,136 @@ func handleFoundBugsGraph(ctx context.Context, w http.ResponseWriter, r *http.Re
 		Graph:  graph,
 	}
 	return serveTemplate(w, "graph_histogram.html", data)
+}
+
+func handleResolutionGraph(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	hdr, err := commonHeader(ctx, r, w, "")
+	if err != nil {
+		return err
+	}
+	bugs, err := loadGraphBugs(ctx, hdr.Namespace)
+	if err != nil {
+		return err
+	}
+	lastReporting := getNsConfig(ctx, hdr.Namespace).lastActiveReporting()
+	rates, graph := createResolutionRates(timeNow(ctx), bugs, lastReporting)
+	data := &uiResolutionPage{
+		Header: hdr,
+		Rates:  rates,
+		Graph:  graph,
+	}
+	return serveTemplate(w, "graph_resolution.html", data)
+}
+
+const resolutionRateMonths = 6
+
+// createResolutionRates computes the percentage of bugs addressed within X months (X=1..resolutionRateMonths).
+// To prevent population shift in the denominator across horizons (which would cause the cumulative
+// resolution curve to decrease), we evaluate a fixed mature cohort of bugs reported between 2 years
+// and resolutionRateMonths ago (T_reported in [now - 2 years, now - resolutionRateMonths]).
+// This guarantees every bug in the cohort has at least resolutionRateMonths of observation history, producing a
+// constant denominator and a strictly non-decreasing resolution curve across all months.
+func createResolutionRates(now time.Time, bugs []*Bug, lastReporting int) ([]uiResolutionRate, *uiGraph) {
+	twoYearsAgo := now.AddDate(-2, 0, 0)
+	cohortCutoff := now.AddDate(0, -resolutionRateMonths, 0)
+	var rates []uiResolutionRate
+	var columns []uiGraphColumn
+
+	for month := 1; month <= resolutionRateMonths; month++ {
+		total := 0
+		fixed := 0
+
+		for _, bug := range bugs {
+			// Duplicate bugs are resolved via their canonical bug (which is counted separately).
+			if bug.Status == BugStatusDup {
+				continue
+			}
+			repDate := bugReportedDate(bug, lastReporting)
+			// Restrict dataset to bugs in the fixed mature cohort (reported between 2 years ago and resolutionRateMonths ago).
+			if repDate.Before(twoYearsAgo) || repDate.After(cohortCutoff) {
+				continue
+			}
+			// Auto-obsoleted bugs (where syzbot stopped hitting the bug after 90 days without a fix)
+			// remain in the denominator for all mature horizons as unfixed bugs. They are not skipped or dropped,
+			// which prevents an artificial 90-day resolution rate spike.
+			// Manually obsoleted bugs are treated as resolved at their closure date via bugFixDate.
+			total++
+			fixDate := bugFixDate(bug)
+			if !fixDate.IsZero() && !fixDate.After(repDate.AddDate(0, month, 0)) {
+				fixed++
+			}
+		}
+
+		var pct float32
+		if total > 0 {
+			pct = float32(fixed) / float32(total) * 100
+		}
+
+		rates = append(rates, uiResolutionRate{
+			Months:       month,
+			TotalBugs:    total,
+			FixedCount:   fixed,
+			FixedPercent: pct,
+		})
+
+		columns = append(columns, uiGraphColumn{
+			Hint:       fmt.Sprintf("%dm", month),
+			Annotation: pct,
+			Vals:       []uiGraphValue{{Val: pct, Hint: fmt.Sprintf("%d/%d bugs (%.1f%%)", fixed, total, pct)}},
+		})
+	}
+
+	graph := &uiGraph{
+		Headers: []uiGraphHeader{{Name: "% Addressed Within X Months", Color: "#26ba1c"}},
+		Columns: columns,
+	}
+	return rates, graph
+}
+
+// bugReportedDate determines the timestamp when a bug became publicly reported.
+// Bugs that reached the final reporting stage (e.g., LKML) use that stage's exact report timestamp.
+// Bugs fixed or closed before reaching the final stage use their initial report timestamp or first seen time.
+func bugReportedDate(bug *Bug, lastReporting int) time.Time {
+	if len(bug.Reporting) > lastReporting && !bug.Reporting[lastReporting].Reported.IsZero() {
+		return bug.Reporting[lastReporting].Reported
+	}
+	for _, r := range bug.Reporting {
+		if !r.Reported.IsZero() {
+			return r.Reported
+		}
+	}
+	return bug.FirstTime
+}
+
+// bugFixDate determines the true resolution timestamp for a bug.
+// Developers often fix bugs in git commits before syzbot detects and closes the bug in Datastore.
+// We prefer the earliest commit date from CommitInfo to measure real-world time-to-fix accurately,
+// falling back to Bug.Closed or Bug.FixTime if commit metadata is unavailable.
+func bugFixDate(bug *Bug) time.Time {
+	var earliestCommit time.Time
+	for _, com := range bug.CommitInfo {
+		if !com.Date.IsZero() && (earliestCommit.IsZero() || com.Date.Before(earliestCommit)) {
+			earliestCommit = com.Date
+		}
+	}
+	if !earliestCommit.IsZero() {
+		return earliestCommit
+	}
+	if bug.Status == BugStatusFixed && !bug.Closed.IsZero() {
+		return bug.Closed
+	}
+	if !bug.FixTime.IsZero() {
+		return bug.FixTime
+	}
+	// If a maintainer manually invalidates/obsoletes a bug, consider manual obsoletion
+	// as resolution (resolved/addressed), using the bug closure timestamp as the resolution date.
+	if bug.Status == BugStatusInvalid {
+		rep := lastReportedReporting(bug)
+		if rep != nil && !rep.Auto && !bug.Closed.IsZero() {
+			return bug.Closed
+		}
+	}
+	return time.Time{}
 }
 
 func loadGraphBugs(ctx context.Context, ns string) ([]*Bug, error) {

--- a/dashboard/app/graphs_test.go
+++ b/dashboard/app/graphs_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManagersGraphs(t *testing.T) {
@@ -144,4 +146,115 @@ func TestManagersGraph_FuzzingMetric_BadRequest_OnMalformedInput(t *testing.T) {
 	c := managersGraphFixture(t)
 	_, err := c.AuthGET(AccessAdmin, "/test2/graph/fuzzing?Metrics=MaxCorpus'%2F*%22ZYLQ%22*%2F+AND+'0'%3D'0&Months=27")
 	c.expectBadReqest(err)
+}
+
+func TestResolutionRates(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	type testBug struct {
+		reportedMonthsAgo int
+		closedMonthsAgo   int
+		fixedMonthsAgo    int
+		status            int
+		auto              bool
+	}
+	makeBug := func(tb testBug) *Bug {
+		b := &Bug{
+			FirstTime: now.AddDate(0, -tb.reportedMonthsAgo, 0),
+			Reporting: []BugReporting{
+				{Name: "stage0", Reported: now.AddDate(0, -tb.reportedMonthsAgo, 0)},
+				{Name: "stage1", Reported: now.AddDate(0, -tb.reportedMonthsAgo, 0), Auto: tb.auto},
+			},
+			Status: tb.status,
+		}
+		if tb.closedMonthsAgo > 0 {
+			b.Closed = now.AddDate(0, -tb.closedMonthsAgo, 0)
+		}
+		if tb.fixedMonthsAgo > 0 {
+			b.CommitInfo = append(b.CommitInfo, Commit{Date: now.AddDate(0, -tb.fixedMonthsAgo, 0)})
+		}
+		return b
+	}
+
+	testBugs := []testBug{
+		// Included in cohort (reported 6-24 months ago):
+		{
+			// Fixed 1m after report.
+			reportedMonthsAgo: 6,
+			fixedMonthsAgo:    5,
+			status:            BugStatusFixed,
+		},
+		{
+			// Fixed 3m after report.
+			reportedMonthsAgo: 7,
+			closedMonthsAgo:   4,
+			status:            BugStatusFixed,
+		},
+		{
+			// Auto-obsoleted 3m after report.
+			reportedMonthsAgo: 8,
+			closedMonthsAgo:   5,
+			status:            BugStatusInvalid,
+			auto:              true,
+		},
+		{
+			// Manually closed 2m after report.
+			reportedMonthsAgo: 9,
+			closedMonthsAgo:   7,
+			status:            BugStatusInvalid,
+		},
+		// Excluded from cohort:
+		{
+			// Too recent (< 6m).
+			reportedMonthsAgo: 0,
+			status:            BugStatusOpen,
+		},
+		{
+			// Too old (> 24m).
+			reportedMonthsAgo: 36,
+			closedMonthsAgo:   36,
+			status:            BugStatusFixed,
+		},
+		{
+			// Duplicate.
+			reportedMonthsAgo: 6,
+			closedMonthsAgo:   1,
+			status:            BugStatusDup,
+		},
+	}
+
+	var bugs []*Bug
+	for _, tb := range testBugs {
+		bugs = append(bugs, makeBug(tb))
+	}
+
+	rates, graph := createResolutionRates(now, bugs, 1)
+	require.Len(t, rates, 6)
+	require.Len(t, graph.Columns, 6)
+
+	expected := []struct {
+		fixed   int
+		ratePct float32
+	}{
+		{fixed: 1, ratePct: 25.0}, // Month 1: bug1 fixed (1m).
+		{fixed: 2, ratePct: 50.0}, // Month 2: bug1, bugManualInvalid (2m).
+		{fixed: 3, ratePct: 75.0}, // Month 3: bug1, bug2 (3m), bugManualInvalid.
+		{fixed: 3, ratePct: 75.0}, // Month 4.
+		{fixed: 3, ratePct: 75.0}, // Month 5.
+		{fixed: 3, ratePct: 75.0}, // Month 6.
+	}
+
+	for i, tt := range expected {
+		assert.Equal(t, 4, rates[i].TotalBugs)
+		assert.Equal(t, tt.fixed, rates[i].FixedCount)
+		assert.Equal(t, tt.ratePct, rates[i].FixedPercent)
+	}
+}
+
+func TestResolutionGraphEndpoint(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	reply, err := c.AuthGET(AccessAdmin, "/test2/graph/resolution")
+	require.NoError(t, err)
+	assert.Contains(t, string(reply), "bug resolution rates")
 }

--- a/dashboard/app/graphs_test.go
+++ b/dashboard/app/graphs_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManagersGraphs(t *testing.T) {
@@ -144,4 +146,115 @@ func TestManagersGraph_FuzzingMetric_BadRequest_OnMalformedInput(t *testing.T) {
 	c := managersGraphFixture(t)
 	_, err := c.AuthGET(AccessAdmin, "/test2/graph/fuzzing?Metrics=MaxCorpus'%2F*%22ZYLQ%22*%2F+AND+'0'%3D'0&Months=27")
 	c.expectBadReqest(err)
+}
+
+func TestResolutionGraph(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	type testBug struct {
+		reportedMonthsAgo int
+		closedMonthsAgo   int
+		fixedMonthsAgo    int
+		status            int
+		auto              bool
+	}
+	makeBug := func(tb testBug) *Bug {
+		b := &Bug{
+			FirstTime: now.AddDate(0, -tb.reportedMonthsAgo, 0),
+			Reporting: []BugReporting{
+				{Name: "stage0", Reported: now.AddDate(0, -tb.reportedMonthsAgo, 0)},
+				{Name: "stage1", Reported: now.AddDate(0, -tb.reportedMonthsAgo, 0), Auto: tb.auto},
+			},
+			Status: tb.status,
+		}
+		if tb.closedMonthsAgo > 0 {
+			b.Closed = now.AddDate(0, -tb.closedMonthsAgo, 0)
+		}
+		if tb.fixedMonthsAgo > 0 {
+			b.CommitInfo = append(b.CommitInfo, Commit{Date: now.AddDate(0, -tb.fixedMonthsAgo, 0)})
+		}
+		return b
+	}
+
+	testBugs := []testBug{
+		// Included in cohort (reported 6-24 months ago):
+		{
+			// Fixed 1m after report.
+			reportedMonthsAgo: 6,
+			fixedMonthsAgo:    5,
+			status:            BugStatusFixed,
+		},
+		{
+			// Fixed 3m after report.
+			reportedMonthsAgo: 7,
+			closedMonthsAgo:   4,
+			status:            BugStatusFixed,
+		},
+		{
+			// Auto-obsoleted 3m after report.
+			reportedMonthsAgo: 8,
+			closedMonthsAgo:   5,
+			status:            BugStatusInvalid,
+			auto:              true,
+		},
+		{
+			// Manually closed 2m after report.
+			reportedMonthsAgo: 9,
+			closedMonthsAgo:   7,
+			status:            BugStatusInvalid,
+		},
+		// Excluded from cohort:
+		{
+			// Too recent (< 6m).
+			reportedMonthsAgo: 0,
+			status:            BugStatusOpen,
+		},
+		{
+			// Too old (> 24m).
+			reportedMonthsAgo: 36,
+			closedMonthsAgo:   36,
+			status:            BugStatusFixed,
+		},
+		{
+			// Duplicate.
+			reportedMonthsAgo: 6,
+			closedMonthsAgo:   1,
+			status:            BugStatusDup,
+		},
+	}
+
+	var bugs []*Bug
+	for _, tb := range testBugs {
+		bugs = append(bugs, makeBug(tb))
+	}
+
+	graph := createResolutionGraph(now, bugs, 1)
+	require.Len(t, graph.Columns, 6)
+
+	expected := []struct {
+		val  float32
+		hint string
+	}{
+		{val: 25.0, hint: "1/4 bugs (25.0%)"}, // Month 1: bug1 fixed (1m).
+		{val: 50.0, hint: "2/4 bugs (50.0%)"}, // Month 2: bug1, bugManualInvalid (2m).
+		{val: 75.0, hint: "3/4 bugs (75.0%)"}, // Month 3: bug1, bug2 (3m), bugManualInvalid.
+		{val: 75.0, hint: "3/4 bugs (75.0%)"}, // Month 4.
+		{val: 75.0, hint: "3/4 bugs (75.0%)"}, // Month 5.
+		{val: 75.0, hint: "3/4 bugs (75.0%)"}, // Month 6.
+	}
+
+	for i, tt := range expected {
+		require.Equal(t, tt.val, graph.Columns[i].Annotation)
+		require.Len(t, graph.Columns[i].Vals, 1)
+		require.Equal(t, tt.val, graph.Columns[i].Vals[0].Val)
+		require.Equal(t, tt.hint, graph.Columns[i].Vals[0].Hint)
+	}
+}
+
+func TestResolutionGraphEndpoint(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	reply, err := c.AuthGET(AccessAdmin, "/test2/graph/resolution")
+	require.NoError(t, err)
+	assert.Contains(t, string(reply), "bug resolution rates")
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -67,6 +67,7 @@ func initHTTPHandlers() {
 	http.Handle("/{ns}/invalid", handlerWrapper(handleInvalid))
 	http.Handle("/{ns}/graph/bugs", handlerWrapper(handleKernelHealthGraph))
 	http.Handle("/{ns}/graph/lifetimes", handlerWrapper(handleGraphLifetimes))
+	http.Handle("/{ns}/graph/resolution", handlerWrapper(handleResolutionGraph))
 	http.Handle("/{ns}/graph/fuzzing", handlerWrapper(handleGraphFuzzing))
 	http.Handle("/{ns}/graph/crashes", handlerWrapper(handleGraphCrashes))
 	http.Handle("/{ns}/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))

--- a/dashboard/app/router_test.go
+++ b/dashboard/app/router_test.go
@@ -21,6 +21,7 @@ func TestRouterExactMatch(t *testing.T) {
 	}{
 		{"/", http.StatusFound},
 		{"/upstream", http.StatusOK},
+		{"/upstream/graph/resolution", http.StatusOK},
 		{"/upstream/bug-summaries", http.StatusInternalServerError},
 		{"/upstream/graph/coverage/invalid", http.StatusNotFound},
 		{"/upstream/invalid_route", http.StatusNotFound},

--- a/dashboard/app/templates/graph_resolution.html
+++ b/dashboard/app/templates/graph_resolution.html
@@ -1,0 +1,89 @@
+{{/*
+Copyright 2026 syzkaller project authors. All rights reserved.
+Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+Bug resolution rates graph and statistics.
+*/}}
+
+<!doctype html>
+<html>
+<head>
+	<title>{{.Header.Namespace}} bug resolution rates</title>
+	{{template "head" .Header}}
+
+	<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+	<script type="text/javascript">
+		google.load("visualization", "1", {packages:["corechart"]});
+		google.setOnLoadCallback(drawCharts);
+		function drawCharts() {
+			var data = new google.visualization.DataTable();
+			data.addColumn({type: 'string', label: 'Horizon'});
+			{{range $.Graph.Headers}}
+				data.addColumn({type: 'number', label: "{{.Name}}"});
+			{{end}}
+			data.addColumn({type: 'number', role: 'annotation'});
+			data.addRows([
+				{{range $.Graph.Columns}}
+					["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],
+				{{end}}
+			]);
+			new google.visualization.ColumnChart(document.getElementById('graph_div')).
+				draw(data, {
+					width: "100%",
+					height: 400,
+					chartArea: {width: '90%', height: '80%'},
+					legend: {position: 'none'},
+					focusTarget: "category",
+					vAxis: {
+						title: '% Addressed',
+						minValue: 0,
+						maxValue: 100,
+						gridlines: {multiple: 10},
+					},
+					hAxis: {
+						title: 'Time Window (Months After Reporting)',
+						maxAlternation: 1,
+					},
+					series: {
+						0: {color: "#26ba1c"}
+					},
+					annotations: { textStyle: { color: 'black', bold: true }}
+				});
+		}
+	</script>
+</head>
+<body>
+	{{template "header" .Header}}
+	<div id="graph_div"></div>
+
+	{{if len $.Rates}}
+		<table class="list_table" style="margin: 20px auto; width: 90%; max-width: 800px;">
+			<caption>
+				Bug resolution rate within X months for bugs reported between 2 years ago and 6 months ago.
+				{{if ge (len $.Rates) 3}}
+					{{$rate3 := index $.Rates 2}}
+					(3-Month Resolution Rate: <b>{{printf "%.1f" $rate3.FixedPercent}}%</b> — {{$rate3.FixedCount}} out of {{$rate3.TotalBugs}} mature bugs addressed).
+				{{end}}
+			</caption>
+			<thead>
+				<tr>
+					<th>Horizon</th>
+					<th>Addressed Bugs</th>
+					<th>Total Mature Bugs</th>
+					<th>% Addressed</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{range $.Rates}}
+					<tr>
+						<td>Within {{.Months}} Month{{if gt .Months 1}}s{{end}}</td>
+						<td>{{.FixedCount}}</td>
+						<td>{{.TotalBugs}}</td>
+						<td><b>{{printf "%.1f" .FixedPercent}}%</b></td>
+					</tr>
+				{{end}}
+			</tbody>
+		</table>
+	{{end}}
+</body>
+</html>

--- a/dashboard/app/templates/graph_resolution.html
+++ b/dashboard/app/templates/graph_resolution.html
@@ -1,0 +1,60 @@
+{{/*
+Copyright 2026 syzkaller project authors. All rights reserved.
+Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+Bug resolution rates graph.
+*/}}
+
+<!doctype html>
+<html>
+<head>
+	<title>{{.Header.Namespace}} bug resolution rates</title>
+	{{template "head" .Header}}
+
+	<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+	<script type="text/javascript">
+		google.load("visualization", "1", {packages:["corechart"]});
+		google.setOnLoadCallback(drawCharts);
+		function drawCharts() {
+			var data = new google.visualization.DataTable();
+			data.addColumn({type: 'string', label: 'Horizon'});
+			{{range $.Graph.Headers}}
+				data.addColumn({type: 'number', label: "{{.Name}}"});
+			{{end}}
+			data.addColumn({type: 'number', role: 'annotation'});
+			data.addRows([
+				{{range $.Graph.Columns}}
+					["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],
+				{{end}}
+			]);
+			new google.visualization.ColumnChart(document.getElementById('graph_div')).
+				draw(data, {
+					width: "100%",
+					height: 400,
+					chartArea: {width: '90%', height: '80%'},
+					legend: {position: 'none'},
+					focusTarget: "category",
+					vAxis: {
+						title: '% Addressed',
+						minValue: 0,
+						maxValue: 100,
+						gridlines: {multiple: 10},
+					},
+					hAxis: {
+						title: 'Time Window (Months After Reporting)',
+						maxAlternation: 1,
+					},
+					series: {
+						0: {color: "#26ba1c"}
+					},
+					annotations: { textStyle: { color: 'black', bold: true }}
+				});
+		}
+	</script>
+</head>
+<body>
+	{{template "header" .Header}}
+	<div id="graph_div"></div>
+</body>
+</html>
+

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -102,13 +102,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			</li>
 			
 			<li class="nav-item dropdown">
-				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)) (eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
+				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)) (eq .URLPath (printf "/%v/graph/resolution" $.Namespace)) (eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
 					<span style="color:DarkOrange;">📈</span>Graphs
 				</a>
 				<ul class="dropdown-menu">
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/bugs" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/bugs">Kernel Health</a></li>
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/found-bugs">Bugs/Month</a></li>
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/lifetimes">Bug Lifetimes</a></li>
+					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/resolution" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/resolution">Bug Resolution Rate</a></li>
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/fuzzing">Fuzzing</a></li>
 				</ul>
 			</li>


### PR DESCRIPTION
Add a resolution rate page displaying the percentage of bugs addressed within 1 to 6 months for bugs reported in the last 2 years.

Enforce a maturity cutoff (excluding bugs reported less than X months ago) to prevent open recent bugs from deflating resolution rates. Calculate fix dates using Git commit timestamps when available rather than Datastore closure dates.