### PR TITLE
dashboard/app: workaround gcloud Python 3.9 issue in batch export

### DIFF
--- a/dashboard/app/batch_db_export.go
+++ b/dashboard/app/batch_db_export.go
@@ -35,7 +35,9 @@ func exportDBScript(srcNamespace, archivePath string) string {
 		"git clone -q --depth 1 --branch master --single-branch https://github.com/google/syzkaller\n" +
 		"cd syzkaller\n" +
 		"echo \"Getting auth token...\"\n" +
-		"token=$(gcloud auth print-access-token)\n" +
+		"token=$(curl -sSf -H \"Metadata-Flavor: Google\" " +
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | " +
+		"sed -n 's/.*\"access_token\":\"\\([^\"]*\\)\".*/\\1/p')\n" +
 		"if [ -z \"$token\" ]; then echo \"WARNING: gcloud auth token is empty\"; fi\n" +
 		"echo \"Running syz-db-export inside syz-env...\"\n" +
 		"CI=1 ./tools/syz-env \"" + // CI=1 to suppress "The input device is not a TTY".


### PR DESCRIPTION
The official Cloud Batch Debian 11 image pre-installs a gcloud version that no longer supports Python 3.9 (which is the default on Debian 11). This causes the batch job script to fail immediately when running `gcloud auth print-access-token`.

Workaround this by retrieving the access token directly from the GCE metadata server using curl and sed. This removes the dependency on gcloud on the host VM and avoids the Python version mismatch.
