### PR TITLE
tools/clang/declextract: fix build with newer Clang versions

### DIFF
--- a/tools/clang/declextract/declextract.cpp
+++ b/tools/clang/declextract/declextract.cpp
@@ -22,7 +22,11 @@
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceManager.h"
+#if __has_include("clang/Basic/TypeTraits.h")
 #include "clang/Basic/TypeTraits.h"
+#else
+#include "clang/Basic/BuiltinTraits.h"
+#endif
 #include "clang/Basic/Version.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Tooling/CommonOptionsParser.h"


### PR DESCRIPTION
In newer versions of clang (see https://github.com/llvm/llvm-project/commit/6bb30c03650c9ebc816d089ea78b36a246116f07), `clang/Basic/TypeTraits.h` was folded into `clang/Basic/BuiltinTraits.h`.

Use `__has_include` to include `clang/Basic/TypeTraits.h` when present, and fall back to `clang/Basic/BuiltinTraits.h` to maintain compatibility across different Clang header versions.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
