### PR TITLE
tools/docker/syzbot: disable background git auto-gc and auto-maintenance

### DIFF
--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -116,6 +116,9 @@ RUN apt-get install -y -q ca-certificates \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update && apt-get install -y google-cloud-cli
 RUN git config --system credential.'https://*.*.sourcemanager.dev'.helper gcloud.sh
+# Prevent git from detaching background maintenance processes which can leave stranded lock
+# files (e.g., HEAD.lock) if the container is SIGKILLed.
+RUN git config --system gc.autoDetach false
 
 # Copy the custom strace build.
 COPY --from=strace-builder /opt/bin/strace /opt/bin/strace


### PR DESCRIPTION
Git spawns detached background processes for auto-GC (gc.autoDetach) and auto-maintenance (maintenance.auto in Git >= 2.31) during fetch/commit.

In containers, these detached processes accumulate as defunct processes when parent processes exit without reaping them. Furthermore, if a container is SIGKILLed during rollout or update, the background process leaves lock files (e.g., .git/HEAD.lock) on persistent disk, breaking future jobs.

Disable gc.autoDetach and maintenance.auto system-wide in the base image so all Git operations run synchronously in the foreground.

***

Hopefully closes https://github.com/google/syzkaller/issues/7718