### PR TITLE
pkg/corpus: reset slice header instead of zeroing backing array in clear()

### DIFF
--- a/pkg/corpus/prio.go
+++ b/pkg/corpus/prio.go
@@ -79,8 +79,7 @@ func (corpus *Corpus) Programs() []*prog.Prog {
 }
 
 func (pl *ProgramsList) clear() {
-	clear(pl.progs)
-	pl.progs = pl.progs[:0]
-	pl.accPrios = pl.accPrios[:0]
+	pl.progs = nil
+	pl.accPrios = nil
 	pl.sumPrios = 0
 }


### PR DESCRIPTION
When Corpus.Minimize() runs, ProgramsList.clear() used to execute clear() on the progs slice. Because Corpus.Programs() shares the backing array with pl.progs, clear() zeroed out elements to nil while worker threads were actively iterating over their snapshot. This led to nil pointer dereference panics.

Instead of zeroing the backing array, reset pl.progs and pl.accPrios to nil. Worker threads can continue reading safely from the old immutable array, while new additions allocate a fresh backing array without hot-path overhead.

Closes https://github.com/google/syzkaller/issues/7720