### PR TITLE
syz-cluster/series-tracker: limit bug-free direct request replies

### DIFF
--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -147,6 +147,8 @@ func (sf *SeriesFetcher) Update(ctx context.Context, from time.Time) error {
 	return nil
 }
 
+const maxDirectReportAllCc = 4
+
 func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, series *lore.Series,
 	idToReader map[string]lore.EmailReader) error {
 	if series.Corrupted != "" {
@@ -162,7 +164,7 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, s
 		})
 	}
 	reportLevel := api.ReportLevelBugs
-	if directRequest {
+	if directRequest && len(first.Cc) < maxDirectReportAllCc {
 		reportLevel = api.ReportLevelAll
 	}
 	if first.OwnEmail {

--- a/syz-cluster/series-tracker/main_test.go
+++ b/syz-cluster/series-tracker/main_test.go
@@ -76,6 +76,14 @@ func TestHandleSeriesReportLevel(t *testing.T) {
 			wantReportLevel: "all",
 		},
 		{
+			name:            "direct request series with many cc",
+			directList:      "direct@syzkaller.com",
+			rawCc:           []string{"user1@test.com", "user2@test.com", "user3@test.com", "direct@syzkaller.com"},
+			ownEmail:        false,
+			wantDirect:      true,
+			wantReportLevel: "bugs",
+		},
+		{
 			name:            "own email series",
 			directList:      "direct@syzkaller.com",
 			rawCc:           []string{"user@test.com"},
@@ -105,6 +113,7 @@ func TestHandleSeriesReportLevel(t *testing.T) {
 							Email: &email.Email{
 								MessageID: msgID,
 								Author:    "author@test.com",
+								Cc:        tt.rawCc,
 								RawCc:     tt.rawCc,
 								OwnEmail:  tt.ownEmail,
 							},


### PR DESCRIPTION
When a patch series is directly sent or CC'd to syz-cluster, the bot currently sends a reply email after fuzzing even if no bugs were found. If sent to a large public mailing list, sending a "no bugs found" reply to everyone causes unnecessary noise.

Only set the report level to all when the total number of recipients (Cc and To addresses) is below a cut-off of 4. If there are 4 or more recipients, default to reporting only when bugs are found.
