### PR TITLE
docs/adding_new_os_support.md: fix leftover sed annotation

### DIFF
--- a/docs/adding_new_os_support.md
+++ b/docs/adding_new_os_support.md
@@ -20,7 +20,7 @@ The intended function will be called according to the target kernel as defined b
 - The OS name is added to `pkg/build/build.go` along with the supported architecture
 - Creating a file that builds the image for the targeted kernel under `pkg/build/`. This file contains functions for configuring the build of the bootable image, for building it, and for generate SSH keys which will be used by Syzkaller in order to access the VM. There is a file per each of the supported OSes by Syzkaller where the name pattern is `GOOS.go`.
 
-- Adding the given target to the `s/makefile/Makefile/`.
+- Adding the given target to the `Makefile`.
 
 ## Report files `pkg/report/`
 


### PR DESCRIPTION
The `Makefile` bullet contains the sed expression `s/makefile/Makefile/` instead of the result of applying it, so the sentence currently reads:

> - Adding the given target to the `s/makefile/Makefile/`.

It should read:

> - Adding the given target to the `Makefile`.

Docs-only change, no code affected.