### PR TITLE
tools/gvisor-smoke-test.sh: Unmount `null-netns` before workdir cleanup

### DIFF
--- a/tools/gvisor-smoke-test.sh
+++ b/tools/gvisor-smoke-test.sh
@@ -7,6 +7,7 @@ set -xeuo pipefail
 workdir="$(mktemp -d /tmp/syzkaller-gvisor-test.XXXXXX)"
 
 cleanup() {
+  while sudo -E umount "$workdir/workdir/gvisor_root/null-netns" 2>/dev/null; do true; done
   sudo -E rm -rf "$workdir"
 }
 


### PR DESCRIPTION
Needed after https://github.com/google/gvisor/pull/13950, which pins a shared netns at this path and makes it unremovable until unmounted.