### PR TITLE
syz-cluster/pkg/service: limit clean ReportLevelAll reports to patch author

### DIFF
--- a/syz-cluster/pkg/reporter/api_test.go
+++ b/syz-cluster/pkg/reporter/api_test.go
@@ -389,3 +389,26 @@ func TestPatchTestReportingFailedStep(t *testing.T) {
 	assert.Equal(t, "Testing failed due to an infrastructure error.", failedReport.Error)
 	assert.Len(t, failedReport.Tests, 2)
 }
+
+func TestReportLevelAllNoFindings(t *testing.T) {
+	env, ctx := app.TestEnvironment(t)
+	client := controller.TestServer(t, env)
+
+	testSeries := controller.DummySeries()
+	testSeries.AuthorEmail = "author@user.com"
+	ids := controller.UploadTestSeries(t, ctx, client, testSeries, controller.WithReportLevel(api.ReportLevelAll))
+	controller.StartSession(t, env, ids.SessionID)
+	controller.MarkSessionFinished(t, env, ids.SessionID)
+
+	generator := NewGenerator(env)
+	err := generator.Process(ctx, 1)
+	require.NoError(t, err)
+
+	reportClient := TestServer(t, env)
+	nextResp, err := reportClient.GetNextReport(ctx, api.LKMLReporter)
+	require.NoError(t, err)
+	require.NotNil(t, nextResp.Report)
+
+	assert.Empty(t, nextResp.Report.Findings)
+	assert.Equal(t, []string{"author@user.com"}, nextResp.Report.Cc)
+}

--- a/syz-cluster/pkg/service/report.go
+++ b/syz-cluster/pkg/service/report.go
@@ -125,7 +125,18 @@ func (rs *ReportService) Next(ctx context.Context, reporter string) (*api.NextRe
 	} else {
 		reportObj.Type = api.ReportTypeBug
 		reportObj.InReplyTo = series.ExtID
-		reportObj.Cc = series.Cc
+		// For ReportLevelAll with no findings, limit recipients to just the patch author
+		// to avoid spamming subsystem mailing lists with clean test reports.
+		// If AuthorEmail is empty, keep Cc empty so the report is only sent to the archive list.
+		if session.ReportLevel.StringVal == string(api.ReportLevelAll) && len(findings) == 0 {
+			if series.AuthorEmail != "" {
+				reportObj.Cc = []string{series.AuthorEmail}
+			} else {
+				reportObj.Cc = nil
+			}
+		} else {
+			reportObj.Cc = series.Cc
+		}
 	}
 
 	return &api.NextReportResp{


### PR DESCRIPTION
When ReportLevelAll is enabled, sessions without findings currently emit clean test reports to all CC'd public mailing lists and developers, creating unnecessary email noise for maintainers.

When generating a bug report under ReportLevelAll with zero findings, restrict the report's Cc list to only the patch author's email address. The email reporter will still automatically route the outgoing email to the author while keeping our archive mailing list in CC.