### PR TITLE
dashboard/app: render Test on Manager button in AI Jobs table

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -520,7 +520,7 @@ func handleAIJobPagePost(ctx context.Context, job *aidb.Job, r *http.Request, hd
 		if job.Workflow != string(ai.WorkflowReproC) {
 			return "", fmt.Errorf("%w: only C reproducer jobs can be tested", ErrClientBadRequest)
 		}
-		return "", handleAITestReproCJob(ctx, job, r)
+		return handleAITestReproCJob(ctx, job, r)
 
 	default:
 		return "", fmt.Errorf("%w: unknown action %q", ErrClientBadRequest, action)
@@ -717,7 +717,11 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 		return err
 	}
 	if newJobID != "" {
-		http.Redirect(w, r, "/ai_job?id="+newJobID, http.StatusFound)
+		redirectURL := newJobID
+		if !strings.HasPrefix(redirectURL, "/") {
+			redirectURL = "/ai_job?id=" + newJobID
+		}
+		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return nil
 	}
 
@@ -2180,29 +2184,29 @@ func extractExecutedModels(trajectory []*aidb.TrajectorySpan) []string {
 }
 
 // handleAITestReproCJob launches a C reproducer test job for a given AI job.
-func handleAITestReproCJob(ctx context.Context, aiJob *aidb.Job, r *http.Request) error {
+func handleAITestReproCJob(ctx context.Context, aiJob *aidb.Job, r *http.Request) (string, error) {
 	user := currentUser(ctx)
 	if user == nil {
-		return ErrAccess
+		return "", ErrAccess
 	}
 	resultsMap, ok := aiJob.Results.Value.(map[string]any)
 	if !ok {
-		return fmt.Errorf("%w: invalid AI job results format", ErrClientBadRequest)
+		return "", fmt.Errorf("%w: invalid AI job results format", ErrClientBadRequest)
 	}
 	reproCStr, _ := resultsMap[textReproC].(string)
 	if reproCStr == "" {
-		return fmt.Errorf("%w: C reproducer is empty", ErrClientBadRequest)
+		return "", fmt.Errorf("%w: C reproducer is empty", ErrClientBadRequest)
 	}
 	if !aiJob.BugID.Valid || aiJob.BugID.StringVal == "" {
-		return fmt.Errorf("%w: AI job has no associated Bug ID", ErrClientBadRequest)
+		return "", fmt.Errorf("%w: AI job has no associated Bug ID", ErrClientBadRequest)
 	}
 	bugKey := db.NewKey(ctx, "Bug", aiJob.BugID.StringVal, 0, nil)
 	bug := new(Bug)
 	if err := db.Get(ctx, bugKey, bug); err != nil {
-		return fmt.Errorf("failed to get bug %v: %w", aiJob.BugID.StringVal, err)
+		return "", fmt.Errorf("failed to get bug %v: %w", aiJob.BugID.StringVal, err)
 	}
 	if err := checkAccessLevel(ctx, r, bug.sanitizeAccess(ctx, accessLevel(ctx, r))); err != nil {
-		return err
+		return "", err
 	}
 	manager, _ := resultsMap["KernelConfigManager"].(string)
 	if manager == "" {
@@ -2214,7 +2218,7 @@ func handleAITestReproCJob(ctx context.Context, aiJob *aidb.Job, r *http.Request
 		manager = bug.HappenedOn[0]
 	}
 	if manager == "" {
-		return fmt.Errorf("%w: could not determine target manager for bug", ErrClientBadRequest)
+		return "", fmt.Errorf("%w: could not determine target manager for bug", ErrClientBadRequest)
 	}
 	_, err := handleTestReproCRequest(ctx, &testReproCReqArgs{
 		bug:     bug,
@@ -2223,5 +2227,13 @@ func handleAITestReproCJob(ctx context.Context, aiJob *aidb.Job, r *http.Request
 		manager: manager,
 		reproC:  []byte(reproCStr),
 	})
-	return err
+	if err != nil {
+		return "", err
+	}
+	if redirect := r.FormValue("redirect"); redirect != "" {
+		if strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") {
+			return redirect, nil
+		}
+	}
+	return fmt.Sprintf("/bug?id=%v", bug.keyHash(ctx)), nil
 }

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1438,7 +1438,10 @@ func TestAITestReproC(t *testing.T) {
 	testValues.Set("id", aiJobResp.ID)
 	testValues.Set("action", "test_repro_c")
 	_, err = c.AuthPOSTForm(AccessUser, "/ai_job", testValues)
-	require.NoError(t, err)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusFound, httpErr.Code)
+	require.Equal(t, fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx)), httpErr.Headers.Get("Location"))
 
 	pollResp, err := c.globalClient.JobPoll(&dashapi.JobPollReq{
 		Managers: map[string]dashapi.ManagerJobs{

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -766,6 +766,13 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					<span>{{$res.Name}}: {{if $res.Value}}✅{{else}}❌{{end}}</span>
 				{{end}}
 			{{end}}
+			{{if $job.CanTestOnManager}}
+				<form action="/ai_job" method="POST" style="display:inline-block; margin-left: 5px;">
+					<input type="hidden" name="id" value="{{$job.ID}}">
+					<input type="hidden" name="action" value="test_repro_c">
+					<input type="submit" value="Test on Manager" class="btn">
+				</form>
+			{{end}}
 		</td>
 		<td class="ai_correct" title="{{$job.CorrectTitle}}">{{$job.Correct}}</td>
 		<td class="title">{{link $job.DescriptionLink $job.Description}}</td>


### PR DESCRIPTION
Add a "Test on Manager" action button to the AI Jobs table rendered on
the bug detail page, restoring quick triggering of C reproducer test
jobs directly from bug reports.
    
Update handleAITestReproCJob to issue an HTTP 302 redirect back to the
bug page upon job creation.
