### PR TITLE
dashboard/app: hide AI job errors for non-admins

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -50,6 +50,14 @@ type uiAIJobsPage struct {
 	PrevCursorID    string
 }
 
+func (p *uiAIJobsPage) GetJobs() []*uiAIJob {
+	return p.Jobs
+}
+
+func (p *uiAIJobsPage) IsAdmin() bool {
+	return p.Header.Admin
+}
+
 type ManualWorkflowSpec struct {
 	Name        string
 	Type        ai.WorkflowType
@@ -71,6 +79,7 @@ type ManualWorkflowField struct {
 const (
 	maxAIJobDoneErrorLen     = 1 << 20
 	maxAIJobListErrorSummary = 200
+	aiErrorPlaceholder       = "log-in to see details"
 )
 
 func manualAIWorkflows(cfg *Config) []ManualWorkflowSpec {
@@ -197,6 +206,14 @@ type uiAIJobPage struct {
 	CanSetCorrectness  bool
 	Reportings         []*uiJobReporting
 	CanRestart         bool
+}
+
+func (p *uiAIJobPage) GetJobs() []*uiAIJob {
+	return p.Jobs
+}
+
+func (p *uiAIJobPage) IsAdmin() bool {
+	return p.Header.Admin
 }
 
 type uiAIJobDetails struct {
@@ -343,6 +360,9 @@ func handleAIJobsPage(ctx context.Context, w http.ResponseWriter, r *http.Reques
 	var uiJobs []*uiAIJob
 	for _, job := range jobs {
 		uiJobs = append(uiJobs, makeUIAIJob(job))
+	}
+	if !hdr.Admin {
+		sanitizeUIJobs(uiJobs...)
 	}
 	workflows, err := aidb.LoadActiveWorkflows(ctx)
 	if err != nil {
@@ -755,16 +775,31 @@ func handleAIJobPage(ctx context.Context, w http.ResponseWriter, r *http.Request
 
 	uiJob := makeUIAIJob(job)
 	uiTrajectory := makeUIAITrajectory(trajectory)
-	trajectoryHTML, err := aflowhtml.RenderTrajectory(uiTrajectory)
-	if err != nil {
-		return err
-	}
 	uiReportings, err := loadJobReportingsWithComments(ctx, job.ID)
 	if err != nil {
 		return err
 	}
 
 	uiJobs, err := buildUIJobChain(ctx, r, job, uiJob)
+	if err != nil {
+		return err
+	}
+
+	if !hdr.Admin {
+		sanitizeUIJobs(uiJobs...)
+		for _, h := range uiHistory {
+			if h.Error != "" {
+				h.Error = aiErrorPlaceholder
+			}
+		}
+		for _, span := range uiTrajectory {
+			if span.Error != "" {
+				span.Error = aiErrorPlaceholder
+			}
+		}
+	}
+
+	trajectoryHTML, err := aflowhtml.RenderTrajectory(uiTrajectory)
 	if err != nil {
 		return err
 	}
@@ -962,6 +997,15 @@ func filterJobsAccess(ctx context.Context, r *http.Request, jobs []*aidb.Job) ([
 		return accessLevel < bugAccess[job.BugID.StringVal]
 	})
 	return jobs, nil
+}
+
+func sanitizeUIJobs(jobs ...*uiAIJob) {
+	for _, job := range jobs {
+		if job != nil && job.Error != "" {
+			job.Error = aiErrorPlaceholder
+			job.ErrorSummary = ""
+		}
+	}
 }
 
 func makeUIAIJob(job *aidb.Job) *uiAIJob {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1327,3 +1327,110 @@ func TestAITestReproCErrors(t *testing.T) {
 	require.ErrorAs(t, err, &httpErr)
 	require.Equal(t, http.StatusNotFound, httpErr.Code)
 }
+
+func TestAIJobsErrorVisibility(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	// Poll to make workflow active.
+	c.pollAIWorkflow(t, ai.WorkflowPatching)
+
+	// Create a job.
+	jobID := c.createAIJob(extID, string(ai.WorkflowPatching), "")
+
+	// Fail the job with an error.
+	errText := "Some sensitive error message: password=123"
+	require.NoError(t, c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID:    jobID,
+		Error: errText,
+	}))
+
+	// Log a command error to create a history entry with an error.
+	historyErrText := "Some sensitive history error: password=456"
+	require.NoError(t, aidb.LogCommandError(c.ctx, aidb.LogCommandErrorArgs{
+		JobID:         jobID,
+		CommandSource: "email",
+		CommandExtID:  "msg-id",
+		User:          "reviewer@google.com",
+		Action:        "upstream",
+		Error:         historyErrText,
+	}))
+
+	// Upload a trajectory span with an error.
+	trajectoryErrText := "Some sensitive trajectory error: password=789"
+	require.NoError(t, c.agentClient.AITrajectoryLog(&dashapi.AITrajectoryReq{
+		AgentName: "test-agent",
+		JobID:     jobID,
+		Span: &trajectory.Span{
+			Seq:      0,
+			Type:     trajectory.SpanFlow,
+			Name:     string(ai.WorkflowPatching),
+			Started:  c.mockedTime,
+			Finished: c.mockedTime.Add(time.Minute),
+			Error:    trajectoryErrText,
+		},
+	}))
+
+	// 1. Check via GET /ai_job as Admin (should see all errors and Error column).
+	respAdmin, err := c.AuthGET(AccessAdmin, fmt.Sprintf("/ai_job?id=%v", jobID))
+	require.NoError(t, err)
+	require.Contains(t, string(respAdmin), errText)
+	require.Contains(t, string(respAdmin), historyErrText)
+	require.Contains(t, string(respAdmin), trajectoryErrText)
+	require.Contains(t, string(respAdmin), ">Error</a></th>")
+
+	// 2. Check via GET /ai_job as User (should NOT see errors, but see placeholder, and NO Error column).
+	respUser, err := c.AuthGET(AccessUser, fmt.Sprintf("/ai_job?id=%v", jobID))
+	require.NoError(t, err)
+	require.NotContains(t, string(respUser), errText)
+	require.NotContains(t, string(respUser), historyErrText)
+	require.NotContains(t, string(respUser), trajectoryErrText)
+	require.Contains(t, string(respUser), aiErrorPlaceholder)
+	require.NotContains(t, string(respUser), ">Error</a></th>")
+
+	// 3. Check JSON output as Admin.
+	respAdminJSON, err := c.AuthGET(AccessAdmin, fmt.Sprintf("/ai_job?id=%v&json=1", jobID))
+	require.NoError(t, err)
+	require.Contains(t, string(respAdminJSON), errText)
+
+	// 4. Check JSON output as User (should NOT see error, but see placeholder).
+	respUserJSON, err := c.AuthGET(AccessUser, fmt.Sprintf("/ai_job?id=%v&json=1", jobID))
+	require.NoError(t, err)
+	require.NotContains(t, string(respUserJSON), errText)
+	require.Contains(t, string(respUserJSON), aiErrorPlaceholder)
+
+	// 5. Check via GET /ains/ai (summary page) as Admin (should see error and Error column).
+	respSummaryAdmin, err := c.AuthGET(AccessAdmin, "/ains/ai")
+	require.NoError(t, err)
+	require.Contains(t, string(respSummaryAdmin), errText)
+	require.Contains(t, string(respSummaryAdmin), ">Error</a></th>")
+
+	// 6. Check via GET /ains/ai (summary page) as User (should NOT see error or
+	// placeholder, and NO Error column).
+	respSummaryUser, err := c.AuthGET(AccessUser, "/ains/ai")
+	require.NoError(t, err)
+	require.NotContains(t, string(respSummaryUser), errText)
+	require.NotContains(t, string(respSummaryUser), aiErrorPlaceholder)
+	require.NotContains(t, string(respSummaryUser), ">Error</a></th>")
+	// 7. Check bug page as Admin (should see error and Error column).
+	bug, _, _ := c.loadBug(extID)
+	bugURL := fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx))
+	respBugAdmin, err := c.AuthGET(AccessAdmin, bugURL)
+	require.NoError(t, err)
+	require.Contains(t, string(respBugAdmin), errText)
+	require.Contains(t, string(respBugAdmin), ">Error</a></th>")
+
+	// 8. Check bug page as User (should NOT see error or placeholder, and NO Error column).
+	respBugUser, err := c.AuthGET(AccessUser, bugURL)
+	require.NoError(t, err)
+	require.NotContains(t, string(respBugUser), errText)
+	require.NotContains(t, string(respBugUser), aiErrorPlaceholder)
+	require.NotContains(t, string(respBugUser), ">Error</a></th>")
+}

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -307,6 +307,14 @@ type uiBugPage struct {
 	AIJobs          []*uiAIJob
 }
 
+func (p *uiBugPage) GetJobs() []*uiAIJob {
+	return p.AIJobs
+}
+
+func (p *uiBugPage) IsAdmin() bool {
+	return p.Header.Admin
+}
+
 type uiBugDetails struct {
 	*uiBug
 	// If DupOf is not nil, uiBug is a duplicate of DupOf.
@@ -1222,6 +1230,9 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 		jobs = compactAIJobs(jobs)
 		for _, job := range jobs {
 			aiJobs = append(aiJobs, makeUIAIJob(job))
+		}
+		if !hdr.Admin {
+			sanitizeUIJobs(aiJobs...)
 		}
 
 		patchVersions, err = getPatchVersions(ctx, bug, jobs, hdr.AIActions)

--- a/dashboard/app/templates/ai_job.html
+++ b/dashboard/app/templates/ai_job.html
@@ -14,7 +14,7 @@ Detailed info on a single AI job execution.
 </head>
 <body>
 	{{template "header" .Header}}
-	{{template "ai_job_list" .Jobs}}
+	{{template "ai_job_list" .}}
 
 	<b>Agent:</b> {{if .Job.AgentName}}{{.Job.AgentName}}{{else}}---{{end}}<br>
 	<b>External Bug ID:</b> {{if .Job.ExternalBugID}}{{.Job.ExternalBugID}}{{else}}---{{end}}<br><br>

--- a/dashboard/app/templates/ai_jobs.html
+++ b/dashboard/app/templates/ai_jobs.html
@@ -82,7 +82,7 @@ List of AI jobs page.
 			<input type="checkbox" id="show_aborted" name="show_aborted" onchange="this.form.submit()" {{if .ShowAborted}}checked{{end}}> YES
 	</form>
 	{{template "ai_pagination" .}}
-	{{template "ai_job_list" .Jobs}}
+	{{template "ai_job_list" .}}
 	{{template "ai_pagination" .}}
 </body>
 </html>

--- a/dashboard/app/templates/bug.html
+++ b/dashboard/app/templates/bug.html
@@ -88,7 +88,7 @@ Page with details about a single bug.
 				<span>✨ AI Jobs ({{len .AIJobs}})</span>
 			</div>
 			<div class="content">
-				{{template "ai_job_list" .AIJobs}}
+				{{template "ai_job_list" .}}
 			</div>
 		</div>
 	{{end}}

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -753,10 +753,12 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<th><a onclick="return sortTable(this, 'Started', textSort)" href="#">Started</a></th>
 		<th><a onclick="return sortTable(this, 'Finished', textSort)" href="#">Finished</a></th>
 		<th><a onclick="return sortTable(this, 'Revision', textSort)" href="#">Revision</a></th>
+		{{if .IsAdmin}}
 		<th><a onclick="return sortTable(this, 'Error', textSort)" href="#">Error</a></th>
+		{{end}}
 	</tr></thead>
 	<tbody>
-	{{range $job := .}}
+	{{range $job := .GetJobs}}
 	<tr {{if $job.IsCurrent}}class="ai_current_job"{{end}}>
 		<td class="stat">{{link $job.Link (formatShortHash $job.ID)}}</td>
 		<td>{{$job.Workflow}}</td>
@@ -773,12 +775,14 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 		<td>{{formatTime $job.Started}}</td>
 		<td>{{formatTime $job.Finished}}</td>
 		<td class="stat">{{link $job.CodeRevisionLink (formatShortHash $job.CodeRevision)}}</td>
+		{{if $.IsAdmin}}
 		<td class="ai_job_error_cell">
 			<pre class="ai_job_error">{{$job.ErrorSummary}}</pre>
 			{{if lt (len $job.ErrorSummary) (len $job.Error)}}
 				<div class="ai_job_error_note">truncated to first 200 bytes; open job for full error</div>
 			{{end}}
 		</td>
+		{{end}}
 	</tr>
 	{{end}}
 	</tbody>


### PR DESCRIPTION
Only expose error messages and error summaries on AI job pages, trajectory logs, and job review history to users with admin privileges. This prevents leaking potentially sensitive details to non-admin users.

Add a test case to verify error visibility restrictions.
