### PR TITLE
syz-cluster: unify kernel workspace preparation across workflow steps

### DIFF
--- a/syz-cluster/pkg/workspace/workspace.go
+++ b/syz-cluster/pkg/workspace/workspace.go
@@ -1,0 +1,55 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package workspace manages repository checkouts and patch application for workflow actions.
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/google/syzkaller/pkg/debugtracer"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/google/syzkaller/syz-cluster/pkg/triage"
+)
+
+type Workspace struct {
+	*triage.GitTreeOps
+	dir    string
+	tracer debugtracer.DebugTracer
+}
+
+// New initializes a Workspace for the specified repository directory.
+func New(dir string, tracer debugtracer.DebugTracer) (*Workspace, error) {
+	ops, err := triage.NewGitTreeOps(dir, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize repository: %w", err)
+	}
+	return &Workspace{
+		GitTreeOps: ops,
+		dir:        dir,
+		tracer:     tracer,
+	}, nil
+}
+
+// Checkout checks out the given commit (or branch within treeName) and applies the provided patch series.
+func (ws *Workspace) Checkout(treeName, commit string, patches [][]byte) (*vcs.Commit, error) {
+	if ws.tracer != nil {
+		ws.tracer.Logf("checking out %q in %q", commit, treeName)
+	}
+	vcsCommit, err := ws.GitTreeOps.Commit(treeName, commit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit info: %w", err)
+	}
+	if len(patches) > 0 && ws.tracer != nil {
+		ws.tracer.Logf("applying %d patches", len(patches))
+	}
+	if err := ws.ApplySeries(vcsCommit.Hash, patches); err != nil {
+		return nil, fmt.Errorf("failed to apply series: %w", err)
+	}
+	return vcsCommit, nil
+}
+
+// CommitPatches stages and commits applied patches into git history for AI evaluation tools.
+func (ws *Workspace) CommitPatches() error {
+	return triage.CommitPatchForAflow(ws.GitTreeOps)
+}

--- a/syz-cluster/workflow/build/main.go
+++ b/syz-cluster/workflow/build/main.go
@@ -18,11 +18,10 @@ import (
 	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/kconfig"
 	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/pkg/vcs"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
-	"github.com/google/syzkaller/syz-cluster/pkg/triage"
+	"github.com/google/syzkaller/syz-cluster/pkg/workspace"
 )
 
 var (
@@ -84,7 +83,13 @@ func main() {
 		TraceWriter: output,
 		OutDir:      "",
 	}
-	commit, err := checkoutKernel(tracer, req, patches)
+	ws, err := workspace.New(*flagRepository, tracer)
+	if err != nil {
+		log.Printf("failed to initialize workspace: %v", err)
+		reportResults(ctx, client, nil, nil, []byte(err.Error()))
+		return
+	}
+	commit, err := ws.Checkout(req.TreeName, req.CommitHash, patches)
 	if commit != nil {
 		uploadReq.CommitHash = commit.Hash
 		uploadReq.CommitDate = commit.CommitDate
@@ -200,23 +205,6 @@ func readRequest() *api.BuildRequest {
 		return nil
 	}
 	return &req
-}
-
-func checkoutKernel(tracer debugtracer.DebugTracer, req *api.BuildRequest, patches [][]byte) (*vcs.Commit, error) {
-	tracer.Logf("checking out %q", req.CommitHash)
-	ops, err := triage.NewGitTreeOps(*flagRepository, true)
-	if err != nil {
-		return nil, err
-	}
-	commit, err := ops.Commit(req.TreeName, req.CommitHash)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get commit info: %w", err)
-	}
-	if len(patches) > 0 {
-		tracer.Logf("applying %d patches", len(patches))
-	}
-	err = ops.ApplySeries(commit.Hash, patches)
-	return commit, err
 }
 
 type BuildResult struct {

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/triage"
+	"github.com/google/syzkaller/syz-cluster/pkg/workspace"
 )
 
 var (
@@ -31,13 +32,14 @@ func main() {
 		app.Fatalf("--session and --repo must be set")
 	}
 	client := app.DefaultClient()
-	repo, err := triage.NewGitTreeOps(*flagRepo, true)
-	if err != nil {
-		app.Fatalf("failed to initialize the repository: %v", err)
-	}
 	ctx := context.Background()
 	output := new(bytes.Buffer)
 	tracer := &debugtracer.GenericTracer{WithTime: true, TraceWriter: output}
+
+	ws, err := workspace.New(*flagRepo, tracer)
+	if err != nil {
+		app.Fatalf("failed to initialize workspace: %v", err)
+	}
 
 	cfg, err := app.Config()
 	if err != nil {
@@ -47,7 +49,7 @@ func main() {
 	triager := &seriesTriager{
 		DebugTracer: tracer,
 		client:      client,
-		ops:         repo,
+		ws:          ws,
 		config:      cfg,
 	}
 	verdict, err := triager.GetVerdict(ctx, *flagSession)
@@ -74,7 +76,7 @@ func main() {
 type seriesTriager struct {
 	debugtracer.DebugTracer
 	client    *api.Client
-	ops       *triage.GitTreeOps
+	ws        *workspace.Workspace
 	config    *app.AppConfig
 	aiVerdict *triage.AITriageResult
 }
@@ -148,15 +150,15 @@ func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *ap
 
 	triager.Logf("continuing with %v in %v", result.Commit, result.Tree.Name)
 
-	if err := triager.ops.ApplySeries(result.Commit, series.PatchBodies()); err != nil {
-		return nil, fmt.Errorf("failed to apply series to base commit: %w", err)
+	if _, err := triager.ws.Checkout(result.Tree.Name, result.Commit, series.PatchBodies()); err != nil {
+		return nil, fmt.Errorf("failed to checkout and apply patches: %w", err)
 	}
 
 	if triager.aiVerdict == nil {
 		triager.aiVerdict = &triage.AITriageResult{WorthFuzzing: true}
 		if !triager.config.AI.Empty() {
-			if err := triage.CommitPatchForAflow(triager.ops); err != nil {
-				return nil, fmt.Errorf("failed to commit patch for aflow: %w", err)
+			if err := triager.ws.CommitPatches(); err != nil {
+				return nil, fmt.Errorf("failed to commit patches for aflow: %w", err)
 			}
 			if aiResult, err := triage.EvaluatePatch(ctx, triager.config, series, triager.DebugTracer, "/workdir"); err != nil {
 				triager.Logf("AI evaluation failed: %v", err)
@@ -273,7 +275,7 @@ func (triager *seriesTriager) selectFromBlobs(series *api.Series, trees []*api.T
 		diff = append(diff, patch.Body...)
 		diff = append(diff, '\n')
 	}
-	baseList, err := triager.ops.BaseForDiff(diff, triager.DebugTracer)
+	baseList, err := triager.ws.BaseForDiff(diff, triager.DebugTracer)
 	if err != nil {
 		return nil, err
 	}
@@ -291,13 +293,13 @@ func (triager *seriesTriager) selectFromBlobs(series *api.Series, trees []*api.T
 
 func (triager *seriesTriager) selectFromBaseCommitHint(commit string, trees []*api.Tree) (*SelectResult, error) {
 	triager.Logf("attempting to use the base commit %s provided by author", commit)
-	commitExists, _ := triager.ops.Git.CommitExists(commit)
+	commitExists, _ := triager.ws.Git.CommitExists(commit)
 	if !commitExists {
 		triager.Logf("commit doesn't exist")
 		return nil, nil
 	}
 	const cutOffDays = 60
-	branchList, err := triager.ops.BranchesThatContain(commit, time.Now().Add(-time.Hour*24*cutOffDays))
+	branchList, err := triager.ws.BranchesThatContain(commit, time.Now().Add(-time.Hour*24*cutOffDays))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query branches: %w", err)
 	}
@@ -334,7 +336,7 @@ func (triager *seriesTriager) selectFromList(ctx context.Context, series *api.Se
 			return nil, fmt.Errorf("failed to query the last build for %q: %w", tree.Name, err)
 		}
 		triager.Logf("%q's last build: %q", tree.Name, lastBuild)
-		selector := triage.NewCommitSelector(triager.ops, triager.DebugTracer)
+		selector := triage.NewCommitSelector(triager.ws.GitTreeOps, triager.DebugTracer)
 		result, err := selector.Select(series, tree, lastBuild)
 		if err != nil {
 			// TODO: the workflow step must be retried.


### PR DESCRIPTION
Workflow steps currently duplicate the logic for checking out kernel trees and applying patch series. A clean, shared interface is required so that build, triage, and fuzzing steps can consistently prepare patched source workspaces.

Consolidate workspace initialization into a reusable package and refactor existing workflow actions to use it.

***

This PR makes more code reusable, which will let us duplicate less code in the fuzzer step to implement https://github.com/google/syzkaller/issues/7734. No functional changes intended.