### PR TITLE
pkg/aflow: support Suggested-by tags in patch iteration workflow

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -399,21 +399,22 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	}
 
 	return &dashapi.NewReportResult{
-		Subject:    subject,
-		Body:       body,
-		GitDiff:    res.PatchDiff,
-		BaseCommit: res.KernelCommit,
-		BaseTree:   res.KernelRepo,
-		Version:    version,
-		To:         to,
-		Cc:         cc,
-		Tools:      models,
-		Authors:    authors,
-		Fixes:      res.Fixes,
-		ReviewedBy: res.ReviewedBy,
-		AckedBy:    res.AckedBy,
-		TestedBy:   res.TestedBy,
-		ReportedBy: res.ReportedBy,
+		Subject:     subject,
+		Body:        body,
+		GitDiff:     res.PatchDiff,
+		BaseCommit:  res.KernelCommit,
+		BaseTree:    res.KernelRepo,
+		Version:     version,
+		To:          to,
+		Cc:          cc,
+		Tools:       models,
+		Authors:     authors,
+		Fixes:       res.Fixes,
+		ReviewedBy:  res.ReviewedBy,
+		AckedBy:     res.AckedBy,
+		TestedBy:    res.TestedBy,
+		ReportedBy:  res.ReportedBy,
+		SuggestedBy: res.SuggestedBy,
 	}, nil
 }
 
@@ -437,6 +438,7 @@ func populateIterationReportResult(ctx context.Context, job *aidb.Job, version i
 			AckedBy:          res.AckedBy,
 			TestedBy:         res.TestedBy,
 			ReportedBy:       res.ReportedBy,
+			SuggestedBy:      res.SuggestedBy,
 		}, version, authors)
 		if err != nil {
 			return err

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -1532,5 +1532,8 @@ func extractBaseCommitArgs(job *Job, argsMap map[string]any) {
 		if tags, ok := m["ReportedBy"].([]any); ok && tags != nil {
 			argsMap["BaseReportedBy"] = tags
 		}
+		if tags, ok := m["SuggestedBy"].([]any); ok && tags != nil {
+			argsMap["BaseSuggestedBy"] = tags
+		}
 	}
 }

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -116,21 +116,22 @@ type ReportPollResult struct {
 }
 
 type NewReportResult struct {
-	Subject    string
-	Body       string
-	Version    int
-	GitDiff    string
-	Changelog  []ChangelogEntry
-	To         []string
-	Cc         []string
-	Tools      []string
-	Authors    []string
-	BaseCommit string
-	BaseTree   string
-	Fixes      ai.FixesTag
-	Links      []string
-	Closes     []string
-	ReportedBy []string
+	Subject     string
+	Body        string
+	Version     int
+	GitDiff     string
+	Changelog   []ChangelogEntry
+	To          []string
+	Cc          []string
+	Tools       []string
+	Authors     []string
+	BaseCommit  string
+	BaseTree    string
+	Fixes       ai.FixesTag
+	Links       []string
+	Closes      []string
+	ReportedBy  []string
+	SuggestedBy []string
 
 	ReviewedBy []string
 	AckedBy    []string

--- a/docs/syzbot_ai_patches.md
+++ b/docs/syzbot_ai_patches.md
@@ -88,7 +88,7 @@ Once rejected, the system clears the conflict, and you can successfully
 ### What happens to my tags (Reviewed-by, Acked-by)?
 
 During the review process, reviewers often provide standard tags like
-`Reviewed-by:`, `Acked-by:`, `Tested-by:`, or `Reported-by:`.
+`Reviewed-by:`, `Acked-by:`, `Tested-by:`, `Reported-by:`, or `Suggested-by:`.
 
 `syzbot` automatically parses and accumulates these tags from review comments.
 When a newer iteration of the patch is generated, these tags are reliably

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -34,10 +34,11 @@ type PatchIterationOutputs struct {
 	Recipients       []Recipient
 	Fixes            FixesTag
 
-	ReviewedBy []string
-	AckedBy    []string
-	TestedBy   []string
-	ReportedBy []string
+	ReviewedBy  []string
+	AckedBy     []string
+	TestedBy    []string
+	ReportedBy  []string
+	SuggestedBy []string
 
 	NewChangeLog string
 	Replies      []CommentReply
@@ -81,10 +82,11 @@ type PatchingOutputs struct {
 	Recipients       []Recipient
 	Fixes            FixesTag
 
-	ReviewedBy []string
-	AckedBy    []string
-	TestedBy   []string
-	ReportedBy []string
+	ReviewedBy  []string
+	AckedBy     []string
+	TestedBy    []string
+	ReportedBy  []string
+	SuggestedBy []string
 }
 
 type FixesTag struct {

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -44,10 +44,11 @@ type PatchIterationInputs struct {
 	// Base fixes tag from previous version.
 	BaseFixes ai.FixesTag `json:",omitzero"`
 
-	BaseReviewedBy []string `json:",omitempty"`
-	BaseAckedBy    []string `json:",omitempty"`
-	BaseTestedBy   []string `json:",omitempty"`
-	BaseReportedBy []string `json:",omitempty"`
+	BaseReviewedBy  []string `json:",omitempty"`
+	BaseAckedBy     []string `json:",omitempty"`
+	BaseTestedBy    []string `json:",omitempty"`
+	BaseReportedBy  []string `json:",omitempty"`
+	BaseSuggestedBy []string `json:",omitempty"`
 
 	// See patching workflow.
 	BaseRepository string
@@ -613,7 +614,7 @@ e.g. "as I already told you", "as explained in the commit message", etc.
 
 
 If a reviewer asks to add or remove a tag (like Reviewed-by, Acked-by, etc) that is NOT in the supported
-list: "Reviewed-by", "Acked-by", "Tested-by", "Reported-by", you MUST reply and explain that the
+list: "Reviewed-by", "Acked-by", "Tested-by", "Reported-by", "Suggested-by", you MUST reply and explain that the
 automated system currently only supports processing this specific list of tags, so you cannot apply
 their tag automatically.
 

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -59,10 +59,11 @@ func init() {
 				"Sandbox":    "none",
 				"Snapshot":   false,
 				// For convenience of the patch-iteration workflow.
-				"ReviewedBy": []string{},
-				"AckedBy":    []string{},
-				"TestedBy":   []string{},
-				"ReportedBy": []string{},
+				"ReviewedBy":  []string{},
+				"AckedBy":     []string{},
+				"TestedBy":    []string{},
+				"ReportedBy":  []string{},
+				"SuggestedBy": []string{},
 			},
 			Root: aflow.Pipeline(
 				baseCommitPicker,

--- a/pkg/aflow/flow/patching/tags.go
+++ b/pkg/aflow/flow/patching/tags.go
@@ -18,13 +18,14 @@ type tagExtractorArgs struct {
 	RemoveTags []ai.EmailTag `jsonschema:"List of tags reviewers asked to remove/drop."`
 }
 
-var acceptedTags = []string{"Reviewed-by", "Acked-by", "Tested-by", "Reported-by"}
+var acceptedTags = []string{"Reviewed-by", "Acked-by", "Tested-by", "Reported-by", "Suggested-by"}
 
 type tagExtractorState struct {
-	BaseReviewedBy []string
-	BaseAckedBy    []string
-	BaseTestedBy   []string
-	BaseReportedBy []string
+	BaseReviewedBy  []string
+	BaseAckedBy     []string
+	BaseTestedBy    []string
+	BaseReportedBy  []string
+	BaseSuggestedBy []string
 }
 
 func normalizeTagValue(val string) string {
@@ -41,10 +42,11 @@ func normalizeTagValue(val string) string {
 func validateTagExtractorOutputs(ctx *aflow.Context, state tagExtractorState,
 	args tagExtractorArgs) (tagExtractorArgs, error) {
 	tagsMap := map[string][]string{
-		"Reviewed-by": state.BaseReviewedBy,
-		"Acked-by":    state.BaseAckedBy,
-		"Tested-by":   state.BaseTestedBy,
-		"Reported-by": state.BaseReportedBy,
+		"Reviewed-by":  state.BaseReviewedBy,
+		"Acked-by":     state.BaseAckedBy,
+		"Tested-by":    state.BaseTestedBy,
+		"Reported-by":  state.BaseReportedBy,
+		"Suggested-by": state.BaseSuggestedBy,
 	}
 
 	var validAddTags []ai.EmailTag
@@ -81,27 +83,30 @@ func validateTagExtractorOutputs(ctx *aflow.Context, state tagExtractorState,
 }
 
 type tagsMergerArgs struct {
-	AddTags        []ai.EmailTag
-	RemoveTags     []ai.EmailTag
-	BaseReviewedBy []string
-	BaseAckedBy    []string
-	BaseTestedBy   []string
-	BaseReportedBy []string
+	AddTags         []ai.EmailTag
+	RemoveTags      []ai.EmailTag
+	BaseReviewedBy  []string
+	BaseAckedBy     []string
+	BaseTestedBy    []string
+	BaseReportedBy  []string
+	BaseSuggestedBy []string
 }
 
 type tagsMergerResult struct {
-	ReviewedBy []string
-	AckedBy    []string
-	TestedBy   []string
-	ReportedBy []string
+	ReviewedBy  []string
+	AckedBy     []string
+	TestedBy    []string
+	ReportedBy  []string
+	SuggestedBy []string
 }
 
 func mergeTags(ctx *aflow.Context, args tagsMergerArgs) (tagsMergerResult, error) {
 	tagsMap := map[string][]string{
-		"Reviewed-by": slices.Clone(args.BaseReviewedBy),
-		"Acked-by":    slices.Clone(args.BaseAckedBy),
-		"Tested-by":   slices.Clone(args.BaseTestedBy),
-		"Reported-by": slices.Clone(args.BaseReportedBy),
+		"Reviewed-by":  slices.Clone(args.BaseReviewedBy),
+		"Acked-by":     slices.Clone(args.BaseAckedBy),
+		"Tested-by":    slices.Clone(args.BaseTestedBy),
+		"Reported-by":  slices.Clone(args.BaseReportedBy),
+		"Suggested-by": slices.Clone(args.BaseSuggestedBy),
 	}
 
 	for _, tag := range args.RemoveTags {
@@ -118,10 +123,11 @@ func mergeTags(ctx *aflow.Context, args tagsMergerArgs) (tagsMergerResult, error
 	}
 
 	return tagsMergerResult{
-		ReviewedBy: tagsMap["Reviewed-by"],
-		AckedBy:    tagsMap["Acked-by"],
-		TestedBy:   tagsMap["Tested-by"],
-		ReportedBy: tagsMap["Reported-by"],
+		ReviewedBy:  tagsMap["Reviewed-by"],
+		AckedBy:     tagsMap["Acked-by"],
+		TestedBy:    tagsMap["Tested-by"],
+		ReportedBy:  tagsMap["Reported-by"],
+		SuggestedBy: tagsMap["Suggested-by"],
 	}, nil
 }
 
@@ -139,7 +145,7 @@ var tagExtractor = &aflow.LLMAgent{
 const tagExtractorInstruction = `
 You are an expert Linux kernel maintainer. Your task is to extract review tags from comments on a proposed patch.
 Reviewers may provide tags to add to the commit.
-The exact list of supported tags is: "Reviewed-by", "Acked-by", "Tested-by", "Reported-by".
+The exact list of supported tags is: "Reviewed-by", "Acked-by", "Tested-by", "Reported-by", "Suggested-by".
 Extract these exact tags into AddTags. The values must be valid names and emails (e.g., "Name <email@example.com>").
 If reviewers explicitly retract a tag or ask to drop it, put it into RemoveTags.
 

--- a/pkg/aflow/flow/patching/tags_test.go
+++ b/pkg/aflow/flow/patching/tags_test.go
@@ -25,6 +25,7 @@ func TestMergeTags(t *testing.T) {
 			// Duplicate tag with different name to check email-based deduplication.
 			{Tag: "Tested-by", Value: "test@test.com"},
 			{Tag: "Reviewed-by", Value: "old@rev.com"},
+			{Tag: "Suggested-by", Value: "Suggester <suggester@syzbot.org>"},
 		},
 		RemoveTags: []ai.EmailTag{
 			{Tag: "Reviewed-by", Value: "Drop Me <drop@me.com>"},
@@ -37,6 +38,7 @@ func TestMergeTags(t *testing.T) {
 	require.Equal(t, []string{"Old Reviewer <old@rev.com>", "New Reviewer <new@rev.com>"}, result.ReviewedBy)
 	require.Equal(t, []string{"New Acker <ack@ack.com>"}, result.AckedBy)
 	require.Equal(t, []string{"Existing Tester <test@test.com>"}, result.TestedBy)
+	require.Equal(t, []string{"Suggester <suggester@syzbot.org>"}, result.SuggestedBy)
 	require.Empty(t, result.ReportedBy)
 }
 
@@ -60,6 +62,7 @@ func TestValidateTagExtractorOutputs(t *testing.T) {
 					{Tag: "Reviewed-by", Value: "Valid Name <valid@email.com>"},
 					{Tag: "Tested-by", Value: "Valid Tester <test@email.com>"},
 					{Tag: "Reported-by", Value: "syzbot+12345@testapp.appspotmail.com"},
+					{Tag: "Suggested-by", Value: "Suggester <suggester@syzbot.org>"},
 				},
 				RemoveTags: []ai.EmailTag{
 					{Tag: "Acked-by", Value: "Drop <drop@email.com>"},
@@ -70,6 +73,7 @@ func TestValidateTagExtractorOutputs(t *testing.T) {
 					{Tag: "Reviewed-by", Value: "Valid Name <valid@email.com>"},
 					{Tag: "Tested-by", Value: "Valid Tester <test@email.com>"},
 					{Tag: "Reported-by", Value: "syzbot+12345@testapp.appspotmail.com"},
+					{Tag: "Suggested-by", Value: "Suggester <suggester@syzbot.org>"},
 				},
 				RemoveTags: []ai.EmailTag{
 					{Tag: "Acked-by", Value: "Drop <drop@email.com>"},
@@ -94,10 +98,10 @@ func TestValidateTagExtractorOutputs(t *testing.T) {
 			name: "Unsupported tag type",
 			args: tagExtractorArgs{
 				AddTags: []ai.EmailTag{
-					{Tag: "Suggested-by", Value: "Valid <valid@email.com>"},
+					{Tag: "Foo-by", Value: "Valid <valid@email.com>"},
 				},
 			},
-			wantErr: "tag \"Suggested-by\" is not one of the accepted tags",
+			wantErr: "tag \"Foo-by\" is not one of the accepted tags",
 		},
 		{
 			name: "Invalid email",

--- a/pkg/email/patch.go
+++ b/pkg/email/patch.go
@@ -57,14 +57,15 @@ func ParsePatch(message []byte) (diff string) {
 }
 
 type PatchTemplateData struct {
-	BaseCommit string
-	Fixes      ai.FixesTag
-	Tools      []string
-	Authors    []string
-	Recipients []ai.Recipient
-	Links      []string
-	Closes     []string
-	ReportedBy []string
+	BaseCommit  string
+	Fixes       ai.FixesTag
+	Tools       []string
+	Authors     []string
+	Recipients  []ai.Recipient
+	Links       []string
+	Closes      []string
+	ReportedBy  []string
+	SuggestedBy []string
 
 	ReviewedBy []string
 	AckedBy    []string
@@ -100,6 +101,7 @@ func FormatPatchDescription(description string, data PatchTemplateData) string {
 		"links":       data.Links,
 		"closes":      data.Closes,
 		"reportedBy":  data.ReportedBy,
+		"suggestedBy": data.SuggestedBy,
 		"reviewedBy":  data.ReviewedBy,
 		"ackedBy":     data.AckedBy,
 		"testedBy":    data.TestedBy,
@@ -129,6 +131,8 @@ Acked-by: {{$addr}}{{end}}
 Tested-by: {{$addr}}{{end}}
 {{- range $addr := .reportedBy}}
 Reported-by: {{$addr}}{{end}}
+{{- range $addr := .suggestedBy}}
+Suggested-by: {{$addr}}{{end}}
 {{- range $link := .closes}}
 Closes: {{$link}}{{end}}
 {{- range $link := .links}}

--- a/pkg/email/patch_test.go
+++ b/pkg/email/patch_test.go
@@ -533,6 +533,7 @@ func TestFormatPatch(t *testing.T) {
 		recipients  []ai.Recipient
 		links       []string
 		reportedBy  []string
+		suggestedBy []string
 		reviewedBy  []string
 		ackedBy     []string
 		testedBy    []string
@@ -561,10 +562,11 @@ Something was broken. This fixes it.
 				"https://syzkaller.appspot.com/bug?id=123",
 				"https://syzkaller.appspot.com/syzbot/ai?job_id=456",
 			},
-			reportedBy: []string{"syzbot+12345@testapp.appspotmail.com"},
-			reviewedBy: []string{"Alice <alice@test.com>", "Bob <bob@test.com>"},
-			ackedBy:    []string{"Charlie <charley@test.com>"},
-			testedBy:   []string{"Dave <dave@test.com>"},
+			reportedBy:  []string{"syzbot+12345@testapp.appspotmail.com"},
+			suggestedBy: []string{"Suggester <suggester@syzbot.org>"},
+			reviewedBy:  []string{"Alice <alice@test.com>", "Bob <bob@test.com>"},
+			ackedBy:     []string{"Charlie <charley@test.com>"},
+			testedBy:    []string{"Dave <dave@test.com>"},
 			want: `mm: fix something
 
 Something was broken. This fixes it.
@@ -576,6 +578,7 @@ Reviewed-by: Bob <bob@test.com>
 Acked-by: Charlie <charley@test.com>
 Tested-by: Dave <dave@test.com>
 Reported-by: syzbot+12345@testapp.appspotmail.com
+Suggested-by: Suggester <suggester@syzbot.org>
 Link: https://syzkaller.appspot.com/bug?id=123
 Link: https://syzkaller.appspot.com/syzbot/ai?job_id=456
 Signed-off-by: syzbot@kernel.org
@@ -648,16 +651,17 @@ base-commit: f5e343a447510a663fbf6215584a9bf8e03bfd5c
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			got := FormatPatch(test.description, test.diff, PatchTemplateData{
-				BaseCommit: test.baseCommit,
-				Fixes:      test.fixes,
-				Tools:      test.tools,
-				Authors:    test.authors,
-				Recipients: test.recipients,
-				Links:      test.links,
-				ReportedBy: test.reportedBy,
-				ReviewedBy: test.reviewedBy,
-				AckedBy:    test.ackedBy,
-				TestedBy:   test.testedBy,
+				BaseCommit:  test.baseCommit,
+				Fixes:       test.fixes,
+				Tools:       test.tools,
+				Authors:     test.authors,
+				Recipients:  test.recipients,
+				Links:       test.links,
+				ReportedBy:  test.reportedBy,
+				SuggestedBy: test.suggestedBy,
+				ReviewedBy:  test.reviewedBy,
+				AckedBy:     test.ackedBy,
+				TestedBy:    test.testedBy,
 			})
 			assert.Equal(t, test.want, got)
 		})

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -68,16 +68,17 @@ func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 		// TODO: Figure out what Authors we want to use here.
 		res.Patch.Body = strings.TrimSpace(email.FormatPatchDescription(
 			res.Patch.Body, email.PatchTemplateData{
-				Fixes:      res.Patch.Fixes,
-				Tools:      res.Patch.Tools,
-				Authors:    res.Patch.Authors,
-				Recipients: recipients,
-				Links:      res.Patch.Links,
-				Closes:     res.Patch.Closes,
-				ReportedBy: res.Patch.ReportedBy,
-				ReviewedBy: res.Patch.ReviewedBy,
-				AckedBy:    res.Patch.AckedBy,
-				TestedBy:   res.Patch.TestedBy,
+				Fixes:       res.Patch.Fixes,
+				Tools:       res.Patch.Tools,
+				Authors:     res.Patch.Authors,
+				Recipients:  recipients,
+				Links:       res.Patch.Links,
+				Closes:      res.Patch.Closes,
+				ReportedBy:  res.Patch.ReportedBy,
+				SuggestedBy: res.Patch.SuggestedBy,
+				ReviewedBy:  res.Patch.ReviewedBy,
+				AckedBy:     res.Patch.AckedBy,
+				TestedBy:    res.Patch.TestedBy,
 			}))
 		data.Patch = res.Patch
 		tmpl, err := templatesFS.ReadFile("templates/new_patch.txt")


### PR DESCRIPTION
Credit reviewers who provide idea suggestions during automated patch review.

Support extracting and preserving Suggested-by tags across patch iterations and include them when rendering patch commit descriptions.