### PR TITLE
dashboard/app: ignore missing reporting for candidate repro jobs

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1310,10 +1310,10 @@ func pollCompletedJobs(ctx context.Context, typ string) ([]*dashapi.BugReport, e
 	var reports []*dashapi.BugReport
 	for i, job := range jobs {
 		if job.Reporting == "" {
-			if job.User != "" {
+			if job.User != "" && job.CandidateReproC == 0 {
 				log.Criticalf(ctx, "no reporting for job %v", extJobID(keys[i]))
 			}
-			// In some cases (e.g. repro retesting), it's ok not to have a reporting.
+			// In some cases (e.g. repro retesting, candidate repro testing), it's ok not to have a reporting.
 			continue
 		}
 		reporting := getNsConfig(ctx, job.Namespace).ReportingByName(job.Reporting)


### PR DESCRIPTION
Candidate C reproducer test jobs have a User set when triggered from the dashboard, but leave Reporting empty. This causes pollCompletedJobs to emit a critical error log for every completed test job.

Exclude candidate C reproducer test jobs from this reporting check.