### PR TITLE
dashboard/app: distinguish between patch and reproducer test results

### DIFF
--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -548,7 +548,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					{{else if and $job.CrashTitle (eq $job.Type 0)}}
 						{{optlink $job.CrashReportLink "report"}}
 					{{else if formatTime $job.Finished}}
-						OK
+						{{if and (eq $job.Type 0) (not $job.PatchLink)}}no crash{{else}}OK{{end}}
 						{{if ne $job.Type 0}}
 							({{if $job.Commit}}1{{else}}{{len $job.Commits}}{{end}})
 						{{end}}


### PR DESCRIPTION
Currently, when a testing job (JobTestPatch) finishes without an error or crash report, the dashboard renders "OK" in the Result column regardless of whether a code patch was tested or only a C reproducer was executed.

For patch testing requests, "OK" indicates that the proposed patch successfully prevented the crash. However, for reproducer testing requests (e.g. testing candidate reproducers without a patch applied), rendering "OK" is ambiguous and confusing, as it actually means that the reproducer failed to trigger a crash.

Render "no crash" instead of "OK" for finished testing jobs where no patch was provided (i.e. PatchLink is empty).

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
