### PR TITLE
dashboard/app: clarify bot reply behavior in AI patch footer

### DIFF
--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -350,6 +350,7 @@ func apiAIPollReport(ctx context.Context, req *dashapi.PollExternalReportReq) (a
 		if result.Patch == nil {
 			result.CanUpstream = false
 		}
+		result.AddressComments = stageCfg.AddressComments
 
 		return &dashapi.PollExternalReportResp{
 			Result: result,

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -120,6 +120,7 @@ func TestAIExternalReporting(t *testing.T) {
 	// Poll for pending reports and confirm published.
 	pollResp := c.pollAndConfirmReport(t, "lore", "moderation-msg-id")
 	require.True(t, pollResp.Result.CanUpstream)
+	require.True(t, pollResp.Result.AddressComments)
 	require.Equal(t, "123456789012", pollResp.Result.Patch.Fixes.Hash)
 	require.Equal(t, "original bug", pollResp.Result.Patch.Fixes.Title)
 
@@ -167,6 +168,7 @@ func TestAIExternalReporting(t *testing.T) {
 	// "Report" to the public lists.
 	pollResp = c.pollAndConfirmReport(t, "lore", "msg-id-123")
 	require.False(t, pollResp.Result.CanUpstream)
+	require.False(t, pollResp.Result.AddressComments)
 	require.Equal(t, &dashapi.NewReportResult{
 		Subject:    "Test Subject",
 		Body:       "Test Body",
@@ -715,9 +717,10 @@ func TestAIPatchIterationSuccess(t *testing.T) {
 
 	gotResult := pollRepResp.Result
 	wantResult := &dashapi.ReportPollResult{
-		ID:          gotResult.ID,
-		CanUpstream: true,
-		To:          []string{"moderation@test.com"},
+		ID:              gotResult.ID,
+		CanUpstream:     true,
+		AddressComments: true,
+		To:              []string{"moderation@test.com"},
 		Patch: &dashapi.NewReportResult{
 			Subject:    "New Subject",
 			Body:       "New Body",
@@ -1288,9 +1291,10 @@ func TestAIPatchIterationReplySuccess(t *testing.T) {
 
 	gotResult := pollRepResp.Result
 	wantResult := &dashapi.ReportPollResult{
-		ID:          gotResult.ID,
-		CanUpstream: false,
-		To:          []string{"moderation@test.com"},
+		ID:              gotResult.ID,
+		CanUpstream:     false,
+		AddressComments: true,
+		To:              []string{"moderation@test.com"},
 		Replies: []*dashapi.ReplyResult{
 			{Body: "I will fix it.", ReplyExtID: "<comment-id-1>", ReplyAuthor: "reviewer@email.com"},
 		},

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -108,11 +108,12 @@ type ReportPollResult struct {
 	ID          string // JobReporting ID
 	CanUpstream bool
 	// Emails with name ("First Last" <email@address.com>).
-	To            []string
-	Cc            []string
-	Patch         *NewReportResult `json:",omitempty"`
-	Replies       []*ReplyResult   `json:",omitempty"`
-	ThreadSubject string           `json:",omitempty"` // Used as the email subject when replying without a new patch.
+	To              []string
+	Cc              []string
+	Patch           *NewReportResult `json:",omitempty"`
+	Replies         []*ReplyResult   `json:",omitempty"`
+	ThreadSubject   string           `json:",omitempty"` // Used as the email subject when replying without a new patch.
+	AddressComments bool             `json:",omitempty"`
 }
 
 type NewReportResult struct {

--- a/pkg/lore-relay/templates.go
+++ b/pkg/lore-relay/templates.go
@@ -21,10 +21,11 @@ var templatesFS embed.FS
 
 // TemplateData holds data for rendering email templates.
 type TemplateData struct {
-	Patch       *dashapi.NewReportResult
-	Replies     []*dashapi.ReplyResult
-	DocsLink    string
-	CanUpstream bool
+	Patch           *dashapi.NewReportResult
+	Replies         []*dashapi.ReplyResult
+	DocsLink        string
+	CanUpstream     bool
+	AddressComments bool
 }
 
 func renderTemplate(name, tmplStr string, data TemplateData) (string, error) {
@@ -44,8 +45,9 @@ func renderTemplate(name, tmplStr string, data TemplateData) (string, error) {
 // RenderBody renders the email body based on the poll result.
 func RenderBody(cfg *Config, res *dashapi.ReportPollResult) (string, error) {
 	data := TemplateData{
-		DocsLink:    cfg.DocsLink,
-		CanUpstream: res.CanUpstream,
+		DocsLink:        cfg.DocsLink,
+		CanUpstream:     res.CanUpstream,
+		AddressComments: res.AddressComments,
 	}
 	if res.Patch != nil {
 		var recipients []ai.Recipient

--- a/pkg/lore-relay/templates/new_patch.txt
+++ b/pkg/lore-relay/templates/new_patch.txt
@@ -18,6 +18,8 @@ and send it to the upstream kernel mailing lists.
 Reply with '#syz reject' to reject it ('#syz unreject' to undo).
 
 {{ end }}See {{.DocsLink}} for information about AI-generated patches.
-You can comment on the patch as usual, syzbot will try to address
+{{ if .AddressComments }}You can comment on the patch as usual, syzbot will try to address
 the comments and send a new version of the patch if necessary.
-syzbot engineers can be reached at syzkaller@googlegroups.com.
+{{ else }}The person who has signed off on the patch is responsible for
+addressing comments.
+{{ end }}syzbot engineers can be reached at syzkaller@googlegroups.com.

--- a/pkg/lore-relay/testdata/patch_moderation.in.json
+++ b/pkg/lore-relay/testdata/patch_moderation.in.json
@@ -1,5 +1,6 @@
 {
   "CanUpstream": true,
+  "AddressComments": true,
   "Patch": {
     "Subject": "Fix a bug in subsystem",
     "Body": "This patch fixes a bug by doing X and Y.",

--- a/pkg/lore-relay/testdata/patch_v2.out.txt
+++ b/pkg/lore-relay/testdata/patch_v2.out.txt
@@ -27,6 +27,6 @@ diff --git a/file2 b/file2
 base-commit: 123456abcdef
 -- 
 See http://docs.link for information about AI-generated patches.
-You can comment on the patch as usual, syzbot will try to address
-the comments and send a new version of the patch if necessary.
+The person who has signed off on the patch is responsible for
+addressing comments.
 syzbot engineers can be reached at syzkaller@googlegroups.com.


### PR DESCRIPTION
When an AI patch is reported externally, the email footer previously claimed that syzbot would always address comments and send new patch versions. This was misleading for public reporting stages where comment addressing is disabled and syzbot does not actively reply to incoming discussion.

Expose the stage's comment addressing configuration via the report poll API so external reporting relays can render the comment footer conditionally. When comment addressing is disabled for a stage, instruct readers that the person who signed off on the patch is responsible for handling comments instead.