### PR TITLE
syz-cluster: remove KMSAN tracks

### DIFF
--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -149,8 +149,6 @@ fuzz_targets:
     campaigns:
       - track: KASAN
         kernel_config: upstream-apparmor-kasan.config
-      - track: KMSAN
-        kernel_config: upstream-kmsan.config
   - email_lists:
       - linux-fsdevel@vger.kernel.org
       - linux-block@vger.kernel.org

--- a/syz-cluster/overlays/gke/staging/global-config.yaml
+++ b/syz-cluster/overlays/gke/staging/global-config.yaml
@@ -26,5 +26,3 @@ fuzz_targets:
     campaigns:
       - track: KASAN
         kernel_config: upstream-apparmor-kasan.config
-      - track: KMSAN
-        kernel_config: upstream-kmsan.config

--- a/syz-cluster/overlays/local/minikube/global-config.yaml
+++ b/syz-cluster/overlays/local/minikube/global-config.yaml
@@ -31,8 +31,6 @@ fuzz_targets:
     campaigns:
       - track: KASAN
         kernel_config: upstream-apparmor-kasan.config
-      - track: KMSAN
-        kernel_config: upstream-kmsan.config
   - corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-kasan-gce-root-corpus.db
     campaigns:
       - track: KASAN


### PR DESCRIPTION
The sanitizer is currently broken in the mainline linux. Disable KMSAN tracks in syz-cluster until it's working again.