### PR TITLE
vm/crosvm, executor: add support for crosvm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,4 @@ Felix Hoffmann
 manchangfengxu
 Roshan Kumar
 Pavel Nikulshin
+Ericsson Software Technology

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -165,7 +165,11 @@ Matan Kalina
 Xianjun Zeng
 Peiyang He
 Alhuda Khan
+<<<<<<< HEAD
 Felix Hoffmann
 manchangfengxu
 Roshan Kumar
+<<<<<<< HEAD
 Pavel Nikulshin
+Ericsson Software Technology
+ Yunseong Kim

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -165,3 +165,4 @@ Matan Kalina
 Xianjun Zeng
 Peiyang He
 Alhuda Khan
+Yunseong Kim

--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -14,6 +14,7 @@ Instructions for a particular VM type or kernel architecture can be found on the
 - [Setup: Linux isolated host](setup_linux-host_isolated.md)
 - [Setup: Ubuntu host, VMware vm, x86-64 kernel](setup_ubuntu-host_vmware-vm_x86-64-kernel.md)
 - [Setup: Ubuntu host, VirtualBox vm, x86-64 kernel](setup_ubuntu-host_virtualbox-vm_x86-64-kernel.md)
+- [Setup: Linux host, crosvm vm, x86-64 kernel](setup_linux-host_crosvm-vm_x86-64-kernel.md)
 
 ## Install
 

--- a/docs/linux/setup.md
+++ b/docs/linux/setup.md
@@ -15,6 +15,7 @@ Instructions for a particular VM type or kernel architecture can be found on the
 - [Setup: Linux isolated host](setup_linux-host_isolated.md)
 - [Setup: Ubuntu host, VMware vm, x86-64 kernel](setup_ubuntu-host_vmware-vm_x86-64-kernel.md)
 - [Setup: Ubuntu host, VirtualBox vm, x86-64 kernel](setup_ubuntu-host_virtualbox-vm_x86-64-kernel.md)
+- [Setup: Linux host, crosvm vm, x86-64 kernel](setup_linux-host_crosvm-vm_x86-64-kernel.md)
 
 ## Install
 

--- a/docs/linux/setup_linux-host_crosvm-vm_x86-64-kernel.md
+++ b/docs/linux/setup_linux-host_crosvm-vm_x86-64-kernel.md
@@ -1,0 +1,164 @@
+# Setup: Linux host, crosvm vm, x86-64 kernel
+
+These are the instructions on how to fuzz the x86-64 kernel in
+[crosvm](https://crosvm.dev), the ChromeOS Virtual Machine Monitor.
+
+crosvm differs from QEMU in ways that the `crosvm` VM type has to work around, and that you
+need to know about when preparing the kernel and the image:
+
+- **crosvm always boots the kernel directly.** There is no BIOS and no bootloader, so the
+  `kernel` config parameter is mandatory and a kernel installed inside the image is not used.
+  Everything the guest needs to reach its root filesystem (virtio-blk, the partition format
+  and the root filesystem itself) must be built into the kernel, or supplied via `initrd`.
+- **crosvm has no user mode networking on Linux.** Its slirp backend is Windows only, so
+  the guest is reachable over a tap device rather than over a forwarded localhost port.
+  There is no DHCP server either, so the guest address is configured by the kernel itself
+  and the kernel needs `CONFIG_IP_PNP=y`.
+- **crosvm cannot read compressed qcow2 images.** Most distributed cloud images are
+  compressed and have to be converted first (see below).
+
+## Kernel
+
+Build the kernel as described in
+[Setup: Ubuntu host, QEMU vm, x86-64 kernel](setup_ubuntu-host_qemu-vm_x86-64-kernel.md),
+with the config options from [kernel_configs.md](kernel_configs.md), plus the options
+crosvm needs:
+
+``` make
+# Guest networking is configured from the kernel command line.
+CONFIG_IP_PNP=y
+
+# Reaching the root filesystem without an initrd. Adjust the filesystem to your image.
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_EXT4_FS=y
+CONFIG_EFI_PARTITION=y
+
+# Only needed for snapshot fuzzing, see the section at the end.
+CONFIG_DEVMEM=y
+# CONFIG_IO_STRICT_DEVMEM is not set
+```
+
+These have to be built in rather than modular. Distribution kernels usually ship
+`CONFIG_VIRTIO_BLK`, `CONFIG_EXT4_FS` and friends as modules, which is fine when an initrd
+loads them, but crosvm boots the kernel directly. Either set them to `y`, or point the
+`initrd` config parameter at an initramfs that contains them.
+
+Watch out for what a built-in filesystem still pulls in at runtime. Building `vfat` in is
+not enough on its own, because its codepage stays modular, and mounting an EFI system
+partition then fails with `FAT-fs (vda15): codepage cp437 not found`, which is enough to
+drop systemd into emergency mode where sshd never starts. Either add
+`CONFIG_NLS_CODEPAGE_437=y` and `CONFIG_NLS_ISO8859_1=y`, or leave `/boot/efi` unmounted in
+the image — a fuzzing guest has no use for it:
+
+``` bash
+systemctl mask boot-efi.mount
+```
+
+`kernel_obj` in the manager config must be the directory that holds `vmlinux`. That is the
+source tree for an in-tree build, but not for a packaged or out-of-tree build: a kernel built
+from Debian's own packaging, for instance, leaves `vmlinux` in
+`debian/build/build_<arch>_none_<flavour>/` and the image in that directory's
+`arch/x86/boot/bzImage`.
+
+## Image
+
+Create an image as described in the QEMU setup page. If you use a distribution cloud image,
+convert it so that crosvm can read it — crosvm's qcow2 implementation rejects compressed
+clusters with "compressed blocks not supported":
+
+``` bash
+qemu-img convert -O qcow2 image.qcow2 image-crosvm.qcow2
+```
+
+Raw images work as is. Every VM runs on its own copy-on-write overlay of the image
+(`overlay` config parameter, on by default), so the image itself is never modified.
+
+## crosvm
+
+Build crosvm from its source tree:
+
+``` bash
+git submodule update --init third_party/minijail
+cargo build --release --bin crosvm
+```
+
+crosvm's default feature set includes `gpu` and `slirp`; neither is needed here, and
+dropping them cuts the dependency list considerably:
+
+``` bash
+cargo build --release --bin crosvm --no-default-features \
+    --features qcow,balloon,net,usb,audio
+```
+
+### Networking
+
+By default syzkaller lets crosvm create and configure a tap device per VM, giving the VM
+with index `N` the network `192.168.<100+N>.0/24` with the host at `.1` and the guest at
+`.2`. Creating a tap device requires `CAP_NET_ADMIN`:
+
+``` bash
+sudo setcap cap_net_admin+ep $(which crosvm)
+```
+
+Alternatively, pre-create persistent tap devices and point syzkaller at them with the
+`tap_name` parameter, in which case `host_ip` and `guest_ip` must be set as well (both
+accept `{{INDEX}}`):
+
+``` bash
+sudo ip tuntap add dev syz0 mode tap user $USER
+sudo ip addr add 192.168.100.1/24 dev syz0
+sudo ip link set syz0 up
+```
+
+## Configuration
+
+``` json
+{
+	"target": "linux/amd64",
+	"http": "127.0.0.1:56741",
+	"workdir": "$WORKDIR",
+	"kernel_obj": "$KERNEL",
+	"image": "$IMAGE/image-crosvm.qcow2",
+	"sshkey": "$IMAGE/image.id_rsa",
+	"syzkaller": "$SYZKALLER",
+	"procs": 8,
+	"type": "crosvm",
+	"vm": {
+		"count": 4,
+		"kernel": "$KERNEL/arch/x86/boot/bzImage",
+		"cpu": 2,
+		"mem": 2048,
+		"root_device": "/dev/vda1"
+	}
+}
+```
+
+The `crosvm` parameter selects the binary (`crosvm` by default). `cmdline` appends to the
+kernel command line, `crosvm_args` appends to the crosvm command line, and both `tap_name`
+and `crosvm_args` expand `{{INDEX}}` to the 0-based VM index.
+
+If the guest names its interface something other than `eth0` — that is, if the kernel was
+built without `net.ifnames=0` in `CONFIG_CMDLINE` — set `network_device` to the interface
+name, or to an empty string to configure all interfaces.
+
+## Snapshot fuzzing
+
+Snapshot mode (`"snapshot": true` in the manager config) is supported, but with an
+important caveat compared to QEMU.
+
+QEMU restores a snapshot in-process with `loadvm`, and the guest and host exchange inputs
+and results through an ivshmem device whose doorbell interrupt wakes the other side.
+crosvm has neither: its control socket only implements `snapshot take`, and restoring is a
+startup-only operation (`crosvm run --restore`). So syzkaller restores a snapshot by
+killing the VM and starting a new crosvm process from the snapshot directory, which is
+considerably slower than QEMU's in-process restore, and both sides poll the shared memory
+instead of being interrupted.
+
+The shared memory itself is a file-backed MMIO mapping (`--file-backed-mapping`) at a fixed
+guest physical address, which the executor maps through `/dev/mem`. Mapping it needs
+`CONFIG_DEVMEM=y`; `CONFIG_STRICT_DEVMEM=y` is fine because the region is MMIO rather than
+RAM, but `CONFIG_IO_STRICT_DEVMEM=y` is not — it is enabled in distribution kernels, so it
+has to be turned off explicitly. Being MMIO is also what keeps the region out
+of the snapshot — crosvm only serializes guest RAM — so a new input can be written before
+each restore, the same way QEMU's `x-ignore-shared` works.

--- a/executor/snapshot.h
+++ b/executor/snapshot.h
@@ -30,15 +30,61 @@
 // We don't need even networking in snapshot mode since we communicate via shared memory.
 
 static struct {
-	// Ivshmem interrupt doorbell register.
+	// Ivshmem interrupt doorbell register. Null when the VMM has no doorbell device
+	// (crosvm), in which case the host polls the state in the header instead.
 	volatile uint32* doorbell;
 	volatile rpc::SnapshotHeaderT* hdr;
 	void* input;
 } ivs;
 
+// Guest physical address at which crosvm maps the shared memory region.
+// Must be kept in sync with snapshotAddr in vm/crosvm/snapshot_linux.go.
+const uint64 kCrosvmSnapshotAddr = 1ull << 36;
+
+static void SetupSharedMemory(void* input, void* output, void* regs)
+{
+	ivs.doorbell = regs ? static_cast<uint32*>(regs) + 3 : nullptr;
+	ivs.hdr = static_cast<rpc::SnapshotHeaderT*>(output);
+	ivs.input = input;
+	output_data = reinterpret_cast<OutputData*>(static_cast<char*>(output) + sizeof(rpc::SnapshotHeaderT));
+	output_size = static_cast<uint64>(rpc::Const::MaxOutputSize) - sizeof(rpc::SnapshotHeaderT);
+}
+
+// Finds the shared memory region crosvm maps into the guest with --file-backed-mapping,
+// see vm/crosvm/snapshot_linux.go. crosvm has no ivshmem device, so instead of discovering
+// a PCI BAR we map the fixed guest physical address the host agreed on. The region is MMIO
+// rather than RAM, which is both why the host can exclude it from snapshots and why
+// /dev/mem lets us map it even with CONFIG_STRICT_DEVMEM=y.
+static bool FindCrosvmSharedMemory()
+{
+	int fd = open("/dev/mem", O_RDWR | O_SYNC);
+	if (fd == -1) {
+		debug("open(/dev/mem) failed\n");
+		return false;
+	}
+	void* input = mmap(nullptr, static_cast<uint64>(rpc::Const::MaxInputSize),
+			   PROT_READ, MAP_SHARED, fd, kCrosvmSnapshotAddr);
+	void* output = mmap(nullptr, static_cast<uint64>(rpc::Const::MaxOutputSize),
+			    PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+			    kCrosvmSnapshotAddr + static_cast<uint64>(rpc::Const::MaxInputSize));
+	close(fd);
+	if (input == MAP_FAILED || output == MAP_FAILED) {
+		debug("failed to mmap /dev/mem at 0x%llx\n", kCrosvmSnapshotAddr);
+		return false;
+	}
+	debug("mapped crosvm shmem input at %p, output at %p\n", input, output);
+#if GOOS_linux
+	if (pkeys_enabled && pkey_mprotect(output, static_cast<uint64>(rpc::Const::MaxOutputSize),
+					   PROT_READ | PROT_WRITE, RESERVED_PKEY))
+		exitf("failed to pkey_mprotect output buffer");
+#endif
+	SetupSharedMemory(input, output, nullptr);
+	return true;
+}
+
 // Finds qemu ivshmem device, see:
 // https://www.qemu.org/docs/master/specs/ivshmem-spec.html
-static void FindIvshmemDevices()
+static bool FindIvshmemDevices()
 {
 	std::string result;
 	DIR* devices = opendir("/sys/bus/pci/devices");
@@ -97,12 +143,18 @@ static void FindIvshmemDevices()
 	}
 	closedir(devices);
 	if (regs == nullptr || input == nullptr)
-		fail("cannot find ivshmem PCI devices");
-	ivs.doorbell = static_cast<uint32*>(regs) + 3;
-	ivs.hdr = static_cast<rpc::SnapshotHeaderT*>(output);
-	ivs.input = input;
-	output_data = reinterpret_cast<OutputData*>(static_cast<char*>(output) + sizeof(rpc::SnapshotHeaderT));
-	output_size = static_cast<uint64>(rpc::Const::MaxOutputSize) - sizeof(rpc::SnapshotHeaderT);
+		return false;
+	SetupSharedMemory(input, output, regs);
+	return true;
+}
+
+static void FindSharedMemory()
+{
+	if (FindIvshmemDevices())
+		return;
+	if (FindCrosvmSharedMemory())
+		return;
+	fail("cannot find ivshmem PCI devices nor the crosvm shared memory region");
 }
 
 static void SnapshotSetup(char** argv, int argc)
@@ -116,7 +168,7 @@ static void SnapshotSetup(char** argv, int argc)
 	// This is required to turn off rate limiting of writes.
 	write_file("/proc/sys/kernel/printk_devkmsg", "on\n");
 #endif
-	FindIvshmemDevices();
+	FindSharedMemory();
 	// Wait for the host to write handshake_req into input memory.
 	while (ivs.hdr->state != rpc::SnapshotState::Handshake)
 		sleep_ms(10);
@@ -164,9 +216,12 @@ static void SnapshotSetState(rpc::SnapshotState state)
 	      rpc::EnumNameSnapshotState(ivs.hdr->state), rpc::EnumNameSnapshotState(state));
 	std::atomic_signal_fence(std::memory_order_seq_cst);
 	ivs.hdr->state = state;
-	// The register contains VM index shifted by 16 (the host part is VM index 1)
-	// + interrup vector index (0 in our case).
-	*ivs.doorbell = 1 << 16;
+	if (ivs.doorbell) {
+		// The register contains VM index shifted by 16 (the host part is VM index 1)
+		// + interrup vector index (0 in our case).
+		*ivs.doorbell = 1 << 16;
+	}
+	// Without a doorbell (crosvm) the host polls the state we just stored.
 }
 
 // PopulateMemory prefaults anon memory (we want to avoid minor page faults as well).

--- a/vm/crosvm/crosvm.go
+++ b/vm/crosvm/crosvm.go
@@ -1,0 +1,547 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package crosvm implements VMs based on crosvm, the ChromeOS Virtual Machine Monitor
+// (https://crosvm.dev). See docs/linux/setup_linux-host_crosvm-vm_x86-64-kernel.md.
+package crosvm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/config"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/sys/targets"
+	"github.com/google/syzkaller/vm/vmimpl"
+)
+
+func init() {
+	var _ vmimpl.Infoer = (*instance)(nil)
+	vmimpl.Register("crosvm", vmimpl.Type{
+		Ctor:       ctor,
+		Overcommit: true,
+	})
+}
+
+type Config struct {
+	// Number of VMs to run in parallel (1 by default).
+	Count int `json:"count"`
+	// crosvm binary name ("crosvm" by default).
+	Crosvm string `json:"crosvm"`
+	// Location of the kernel to boot, e.g. arch/x86/boot/bzImage.
+	// crosvm always boots the kernel directly, so this is mandatory.
+	Kernel string `json:"kernel"`
+	// Additional kernel command line arguments.
+	// The root device, console and the static network configuration are added automatically.
+	Cmdline string `json:"cmdline"`
+	// Initial ramdisk (optional).
+	Initrd string `json:"initrd"`
+	// Root device as seen by the guest ("/dev/vda1" by default).
+	// crosvm exposes disks as virtio-blk, so the image is /dev/vda and its first partition
+	// is /dev/vda1. Images without a partition table need "/dev/vda".
+	RootDevice string `json:"root_device"`
+	// Name of the guest network interface to configure from the kernel command line
+	// ("eth0" by default, which requires net.ifnames=0 in the kernel command line).
+	// An empty value configures all interfaces.
+	NetDevice string `json:"network_device"`
+	// Number of VM CPUs (1 by default).
+	CPU int `json:"cpu"`
+	// Amount of VM memory in MiB (1024 by default).
+	Mem int `json:"mem"`
+	// Run every VM on a copy-on-write overlay of the image instead of the image itself
+	// (true by default). This is the equivalent of QEMU's -snapshot.
+	Overlay bool `json:"overlay"`
+	// Run all devices in a single non-sandboxed process (true by default).
+	// crosvm's minijail sandbox needs additional privileges and a seccomp policy directory,
+	// which is not worth it for a fuzzing VM that is untrusted anyway.
+	DisableSandbox bool `json:"disable_sandbox"`
+	// Name of a pre-created persistent tap device to use for networking (optional).
+	// If empty, crosvm creates a tap device itself, which requires CAP_NET_ADMIN.
+	// "{{INDEX}}" is replaced with the 0-based index of the VM.
+	TapName string `json:"tap_name"`
+	// Second octet of the per-VM /24 network (168 by default), i.e. VM with index N uses
+	// 192.<net_base>.<100+N>.0/24 with the host at .1 and the guest at .2.
+	// Only used when tap_name is not set.
+	NetBase int `json:"net_base"`
+	// Host and guest IP addresses (optional).
+	// These must be set when tap_name is used, and override the computed addresses otherwise.
+	HostIP  string `json:"host_ip"`
+	GuestIP string `json:"guest_ip"`
+	Netmask string `json:"netmask"`
+	// Additional command line arguments for the crosvm binary.
+	// "{{INDEX}}" is replaced with the 0-based index of the VM.
+	CrosvmArgs string `json:"crosvm_args"`
+}
+
+type Pool struct {
+	env     *vmimpl.Env
+	cfg     *Config
+	target  *targets.Target
+	version string
+}
+
+type instance struct {
+	index   int
+	cfg     *Config
+	target  *targets.Target
+	version string
+	args    []string
+	image   string
+	debug   bool
+	os      string
+	workdir string
+	vmimpl.SSHOptions
+	timeouts targets.Timeouts
+	hostIP   string
+	sock     string
+	rpipe    io.ReadCloser
+	wpipe    io.WriteCloser
+	crosvm   *exec.Cmd
+	merger   *vmimpl.OutputMerger
+	*snapshot
+}
+
+func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
+	cfg := &Config{
+		Count:          1,
+		Crosvm:         "crosvm",
+		CPU:            1,
+		Mem:            1024,
+		RootDevice:     "/dev/vda1",
+		NetDevice:      "eth0",
+		Overlay:        true,
+		DisableSandbox: true,
+		NetBase:        168,
+		Netmask:        "255.255.255.0",
+	}
+	if err := config.LoadData(env.Config, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse crosvm vm config: %w", err)
+	}
+	if env.OS != targets.Linux {
+		return nil, fmt.Errorf("crosvm supports only linux targets")
+	}
+	if cfg.Count < 1 || cfg.Count > 128 {
+		return nil, fmt.Errorf("invalid config param count: %v, want [1, 128]", cfg.Count)
+	}
+	if cfg.CPU < 1 || cfg.CPU > 1024 {
+		return nil, fmt.Errorf("bad crosvm cpu: %v, want [1-1024]", cfg.CPU)
+	}
+	if cfg.Mem < 128 || cfg.Mem > 1048576 {
+		return nil, fmt.Errorf("bad crosvm mem: %v, want [128-1048576]", cfg.Mem)
+	}
+	if cfg.NetBase < 0 || cfg.NetBase > 255 {
+		return nil, fmt.Errorf("bad crosvm net_base: %v, want [0-255]", cfg.NetBase)
+	}
+	if cfg.TapName != "" && (cfg.HostIP == "" || cfg.GuestIP == "") {
+		return nil, fmt.Errorf("crosvm tap_name requires host_ip and guest_ip")
+	}
+	if cfg.TapName == "" && cfg.Count > maxComputedNets {
+		return nil, fmt.Errorf("crosvm count %v needs more than the %v automatically assigned "+
+			"networks, use tap_name instead", cfg.Count, maxComputedNets)
+	}
+	if _, err := exec.LookPath(cfg.Crosvm); err != nil {
+		return nil, err
+	}
+	// crosvm has no BIOS/bootloader by default: it always loads the kernel itself,
+	// so unlike QEMU we cannot boot a kernel installed inside the image.
+	if cfg.Kernel == "" {
+		return nil, fmt.Errorf("crosvm requires the kernel config param")
+	}
+	if !osutil.IsExist(cfg.Kernel) {
+		return nil, fmt.Errorf("kernel file '%v' does not exist", cfg.Kernel)
+	}
+	if !osutil.IsExist(env.Image) {
+		return nil, fmt.Errorf("image file '%v' does not exist", env.Image)
+	}
+	// Note: crosvm's qcow2 implementation rejects compressed clusters ("compressed blocks
+	// not supported"), which most distributed cloud images use. Such an image has to be
+	// converted first, e.g. with "qemu-img convert -O qcow2 in.qcow2 out.qcow2".
+	cfg.Kernel = osutil.Abs(cfg.Kernel)
+	if cfg.Initrd != "" {
+		// Catch this here: a missing initrd otherwise surfaces as a guest that
+		// boots and then cannot find its root filesystem, which is a much
+		// harder failure to read.
+		if !osutil.IsExist(cfg.Initrd) {
+			return nil, fmt.Errorf("initrd file '%v' does not exist", cfg.Initrd)
+		}
+		cfg.Initrd = osutil.Abs(cfg.Initrd)
+	}
+
+	// "crosvm --version" does not exist, the version is printed by the "version" subcommand.
+	output, err := osutil.RunCmd(time.Minute, "", cfg.Crosvm, "version")
+	if err != nil {
+		return nil, err
+	}
+	pool := &Pool{
+		env:     env,
+		cfg:     cfg,
+		target:  targets.Get(env.OS, env.Arch),
+		version: strings.TrimSpace(string(output)),
+	}
+	return pool, nil
+}
+
+func (pool *Pool) Count() int {
+	return pool.cfg.Count
+}
+
+func (pool *Pool) Create(ctx context.Context, workdir string, index int) (vmimpl.Instance, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	inst := &instance{
+		index:    index,
+		cfg:      pool.cfg,
+		target:   pool.target,
+		version:  pool.version,
+		image:    pool.env.Image,
+		debug:    pool.env.Debug,
+		os:       pool.env.OS,
+		timeouts: pool.env.Timeouts,
+		workdir:  workdir,
+		sock:     filepath.Join(workdir, "crosvm.sock"),
+		SSHOptions: vmimpl.SSHOptions{
+			// crosvm has no user mode networking on Linux (its slirp backend is
+			// Windows only), so we always talk to the guest over the tap network.
+			Port: 22,
+			Key:  pool.env.SSHKey,
+			User: pool.env.SSHUser,
+		},
+	}
+	if pool.env.Snapshot {
+		inst.snapshot = new(snapshot)
+	}
+	inst.hostIP, inst.Addr = pool.cfg.addresses(index)
+
+	closeInst := inst
+	defer func() {
+		if closeInst != nil {
+			closeInst.Close()
+		}
+	}()
+
+	if err := inst.setupImage(); err != nil {
+		return nil, err
+	}
+	var err error
+	inst.rpipe, inst.wpipe, err = osutil.LongPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := inst.boot(); err != nil {
+		return nil, err
+	}
+
+	closeInst = nil
+	return inst, nil
+}
+
+// maxComputedNets is the number of distinct /24 networks we can hand out automatically
+// (192.<net_base>.100.0/24 .. 192.<net_base>.227.0/24).
+const maxComputedNets = 128
+
+// addresses returns the host and guest IP addresses of the VM with the given index.
+// The configured addresses may contain "{{INDEX}}", which is how a pool of VMs on
+// pre-created tap devices gets one address per VM.
+func (cfg *Config) addresses(index int) (hostIP, guestIP string) {
+	hostIP, guestIP = expandIndex(cfg.HostIP, index), expandIndex(cfg.GuestIP, index)
+	if hostIP == "" {
+		hostIP = fmt.Sprintf("192.%v.%v.1", cfg.NetBase, 100+index)
+	}
+	if guestIP == "" {
+		guestIP = fmt.Sprintf("192.%v.%v.2", cfg.NetBase, 100+index)
+	}
+	return
+}
+
+func expandIndex(str string, index int) string {
+	return strings.ReplaceAll(str, "{{INDEX}}", fmt.Sprint(index))
+}
+
+// mac returns a locally administered unicast MAC address unique to the VM index.
+func mac(index int) string {
+	return fmt.Sprintf("02:00:00:00:%02x:%02x", index/256, index%256)
+}
+
+// setupImage prepares the disk image the VM boots from. By default every VM gets its own
+// qcow2 overlay over the base image, so that VMs neither corrupt the image nor each other.
+func (inst *instance) setupImage() error {
+	if !inst.cfg.Overlay {
+		return nil
+	}
+	overlay := filepath.Join(inst.workdir, "image.qcow2")
+	// crosvm refuses to create the overlay if the file already exists.
+	os.Remove(overlay)
+	if _, err := osutil.RunCmd(time.Minute*inst.timeouts.Scale, "", inst.cfg.Crosvm,
+		"create_qcow2", "--backing-file", osutil.Abs(inst.image), overlay); err != nil {
+		return fmt.Errorf("failed to create image overlay: %w", err)
+	}
+	inst.image = overlay
+	return nil
+}
+
+func (inst *instance) boot() error {
+	args, err := inst.buildCrosvmArgs()
+	if err != nil {
+		return err
+	}
+	if inst.debug {
+		log.Logf(0, "running command: %v %#v", inst.cfg.Crosvm, args)
+	}
+	inst.args = args
+	crosvm := osutil.Command(inst.cfg.Crosvm, args...)
+	crosvm.Stdout = inst.wpipe
+	crosvm.Stderr = inst.wpipe
+	if err := crosvm.Start(); err != nil {
+		return fmt.Errorf("failed to start %v %+v: %w", inst.cfg.Crosvm, args, err)
+	}
+	inst.wpipe.Close()
+	inst.wpipe = nil
+	inst.crosvm = crosvm
+
+	var tee io.Writer
+	if inst.debug {
+		tee = os.Stdout
+	}
+	inst.merger = vmimpl.NewOutputMerger(tee)
+	inst.merger.Add("crosvm", vmimpl.OutputConsole, inst.rpipe)
+	inst.rpipe = nil
+
+	var bootOutput []byte
+	bootOutputStop := make(chan bool)
+	go func() {
+		for {
+			select {
+			case out := <-inst.merger.Output:
+				bootOutput = append(bootOutput, out.Data...)
+			case <-bootOutputStop:
+				close(bootOutputStop)
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := vmimpl.WaitForSSH(10*time.Minute*inst.timeouts.Scale, inst.SSHOptions,
+		inst.os, inst.merger.Errors(ctx), false, inst.debug); err != nil {
+		bootOutputStop <- true
+		<-bootOutputStop
+		return vmimpl.MakeBootError(err, bootOutput)
+	}
+	bootOutputStop <- true
+	return nil
+}
+
+func (inst *instance) buildCrosvmArgs() ([]string, error) {
+	args := []string{
+		"run",
+		"--socket", inst.sock,
+		"--cpus", fmt.Sprintf("num-cores=%v", inst.cfg.CPU),
+		"--mem", fmt.Sprintf("size=%v", inst.cfg.Mem),
+		// crosvm exits instead of rebooting, which is what we want: a rebooting VM
+		// is a lost VM as far as syzkaller is concerned.
+		"--serial", "type=stdout,hardware=serial,console=true,earlycon=true,stdin=false",
+		"--no-usb",
+	}
+	if inst.cfg.DisableSandbox {
+		args = append(args, "--disable-sandbox")
+	}
+	args = append(args, "--net", inst.netArg())
+	args = append(args, "--block", fmt.Sprintf("path=%v", osutil.Abs(inst.image)))
+	if inst.cfg.Initrd != "" {
+		args = append(args, "--initrd", inst.cfg.Initrd)
+	}
+	if inst.snapshot != nil {
+		snapshotArgs, err := inst.snapshotEnable()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, snapshotArgs...)
+	}
+	args = append(args, splitArgs(inst.cfg.CrosvmArgs, inst.index)...)
+	args = append(args, "--params", inst.cmdline())
+	// The kernel is a positional argument and must come last.
+	args = append(args, inst.cfg.Kernel)
+	return args, nil
+}
+
+func (inst *instance) netArg() string {
+	if inst.cfg.TapName != "" {
+		return fmt.Sprintf("tap-name=%v,mac=%v", expandIndex(inst.cfg.TapName, inst.index), mac(inst.index))
+	}
+	// In this mode crosvm creates and configures a vmtap device itself, which needs
+	// CAP_NET_ADMIN. See docs/linux/setup_linux-host_crosvm-vm_x86-64-kernel.md.
+	return fmt.Sprintf("host-ip=%v,netmask=%v,mac=%v", inst.hostIP, inst.cfg.Netmask, mac(inst.index))
+}
+
+func (inst *instance) cmdline() string {
+	cmdline := []string{
+		"root=" + inst.cfg.RootDevice,
+		"console=ttyS0",
+		// crosvm does not run a DHCP server for the tap device, so the guest address is
+		// configured by the kernel itself (needs CONFIG_IP_PNP=y). The trailing fields are
+		// gateway, netmask, hostname, device and autoconf.
+		fmt.Sprintf("ip=%v::%v:%v::%v:off", inst.Addr, inst.hostIP, inst.cfg.Netmask, inst.cfg.NetDevice),
+	}
+	if inst.cfg.Cmdline != "" {
+		cmdline = append(cmdline, inst.cfg.Cmdline)
+	}
+	return strings.Join(cmdline, " ")
+}
+
+func splitArgs(str string, index int) (args []string) {
+	for _, arg := range strings.Fields(str) {
+		args = append(args, expandIndex(arg, index))
+	}
+	return
+}
+
+func (inst *instance) Close() error {
+	if inst.crosvm != nil {
+		// Ask crosvm to shut down cleanly first so that it releases the tap device
+		// and unlinks the control socket, then make sure it is gone. A hung VM must not
+		// hold up the shutdown, so this gets a much shorter timeout than other commands.
+		inst.control(10*time.Second, "stop")
+		inst.crosvm.Process.Kill()
+		inst.crosvm.Wait()
+		inst.crosvm = nil
+	}
+	if inst.merger != nil {
+		inst.merger.Wait()
+	}
+	if inst.rpipe != nil {
+		inst.rpipe.Close()
+	}
+	if inst.wpipe != nil {
+		inst.wpipe.Close()
+	}
+	if inst.snapshot != nil {
+		inst.snapshotClose()
+	}
+	return nil
+}
+
+// control runs a crosvm control subcommand against this instance's control socket.
+func (inst *instance) control(timeout time.Duration, args ...string) ([]byte, error) {
+	if inst.debug {
+		log.Logf(0, "crosvm: running control command: %v", args)
+	}
+	args = append(args, inst.sock)
+	output, err := osutil.RunCmd(timeout, "", inst.cfg.Crosvm, args...)
+	if inst.debug {
+		log.Logf(0, "crosvm: reply: %v\n%s", err, output)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("crosvm control command %q: %w", args, err)
+	}
+	return output, nil
+}
+
+// controlRetry is control() for commands issued right after crosvm was started, when the
+// control socket may not exist or may not be listening yet.
+func (inst *instance) controlRetry(timeout time.Duration, args ...string) ([]byte, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		output, err := inst.control(timeout, args...)
+		if err == nil {
+			return output, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		if inst.crosvm != nil && inst.crosvm.ProcessState != nil {
+			return nil, fmt.Errorf("crosvm exited before accepting %q: %w", args, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (inst *instance) Forward(port int) (string, error) {
+	if port == 0 {
+		return "", fmt.Errorf("vm/crosvm: forward port is zero")
+	}
+	// The guest reaches the host over the tap device.
+	return fmt.Sprintf("%v:%v", inst.hostIP, port), nil
+}
+
+func (inst *instance) Copy(hostSrc string) (string, error) {
+	vmDst := filepath.Join("/", filepath.Base(hostSrc))
+	err := vmimpl.SCP(hostSrc, vmDst, vmimpl.SCPOptions{
+		Debug:         inst.debug,
+		Key:           inst.Key,
+		Port:          inst.Port,
+		SystemSSHCfg:  false,
+		User:          inst.User,
+		Addr:          inst.Addr,
+		Timeout:       10 * time.Minute * inst.timeouts.Scale,
+		VerboseOutput: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	return vmDst, nil
+}
+
+func (inst *instance) Run(ctx context.Context, command string) (
+	<-chan vmimpl.Chunk, <-chan error, error) {
+	rpipe, wpipe, err := osutil.LongPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	rpipeErr, wpipeErr, err := osutil.LongPipe()
+	if err != nil {
+		rpipe.Close()
+		wpipe.Close()
+		return nil, nil, err
+	}
+	inst.merger.Add("ssh", vmimpl.OutputStdout, rpipe)
+	inst.merger.Add("ssh-err", vmimpl.OutputStderr, rpipeErr)
+
+	args := []string{"ssh"}
+	args = append(args, vmimpl.SSHArgs(inst.debug, inst.Key, inst.Port, false)...)
+	args = append(args, inst.User+"@"+inst.Addr, "cd / && "+command)
+	if inst.debug {
+		log.Logf(0, "running command: %#v", args)
+	}
+	cmd := osutil.Command(args[0], args[1:]...)
+	cmd.Dir = inst.workdir
+	cmd.Stdout = wpipe
+	cmd.Stderr = wpipeErr
+	if err := cmd.Start(); err != nil {
+		wpipe.Close()
+		wpipeErr.Close()
+		return nil, nil, err
+	}
+	wpipe.Close()
+	wpipeErr.Close()
+	return vmimpl.Multiplex(ctx, cmd, inst.merger, vmimpl.MultiplexConfig{
+		Debug: inst.debug,
+		Scale: inst.timeouts.Scale,
+	})
+}
+
+func (inst *instance) Info() ([]byte, error) {
+	info := fmt.Sprintf("%v\n%v %q\n", inst.version, inst.cfg.Crosvm, inst.args)
+	return []byte(info), nil
+}
+
+func (inst *instance) Diagnose(rep *report.Report) ([]byte, bool) {
+	if output, wait, handled := vmimpl.DiagnoseLinux(rep, inst.ssh); handled {
+		return output, wait
+	}
+	return nil, false
+}
+
+func (inst *instance) ssh(args ...string) ([]byte, error) {
+	sshArgs := append(vmimpl.SSHArgs(inst.debug, inst.Key, inst.Port, false), inst.User+"@"+inst.Addr)
+	return osutil.RunCmd(time.Minute*inst.timeouts.Scale, "", "ssh", append(sshArgs, args...)...)
+}

--- a/vm/crosvm/snapshot_linux.go
+++ b/vm/crosvm/snapshot_linux.go
@@ -1,0 +1,250 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build linux
+
+package crosvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/vm/vmimpl"
+	"golang.org/x/sys/unix"
+)
+
+// snapshotAddr is the guest physical address the host/guest shared memory region is mapped at.
+// crosvm allocates high MMIO for devices starting right after guest RAM (4 GB + PCIe VCFG),
+// growing upwards, so a fixed address far above that will not collide in practice.
+// crosvm reserves the range in its address allocator, so a collision fails the boot
+// rather than silently corrupting memory.
+const snapshotAddr = 1 << 36 // 64 GB
+
+type snapshot struct {
+	shmemFD  int
+	shmem    []byte
+	input    []byte
+	header   *flatrpc.SnapshotHeaderT
+	snapDir  string
+	restored bool
+}
+
+func (inst *instance) snapshotClose() {
+	if inst.shmem != nil {
+		syscall.Munmap(inst.shmem)
+		inst.shmem = nil
+	}
+	// > 0 rather than != 0: fd 0 is stdin, and closing that would be worse
+	// than leaking a descriptor.
+	if inst.shmemFD > 0 {
+		syscall.Close(inst.shmemFD)
+		inst.shmemFD = 0
+	}
+	if inst.snapDir != "" {
+		os.RemoveAll(inst.snapDir)
+		inst.snapDir = ""
+	}
+}
+
+// snapshotEnable sets up the memory shared between the host and the guest and returns
+// the crosvm arguments that map it into the guest.
+//
+// Unlike QEMU, crosvm has no ivshmem device, so we use a file-backed MMIO mapping instead:
+// crosvm maps our memfd into the guest physical address space at a fixed address, and the
+// executor finds it by mmap'ing /dev/mem at the same address (see executor/snapshot.h).
+//
+// The mapping is MMIO rather than RAM, which is what makes this work at all: crosvm
+// snapshots only guest RAM (vm_control::do_snapshot serializes vm.get_memory()), so the
+// shared region is not saved and not restored. That is the equivalent of QEMU's
+// "migrate_set_capability x-ignore-shared on" and is what lets us write a new input into
+// the region before each restore.
+//
+// The other ivshmem feature we lose is the doorbell interrupt, so both sides poll the
+// state word in the header instead of being woken up.
+func (inst *instance) snapshotEnable() ([]string, error) {
+	shmemFD, err := unix.MemfdCreate("syz-crosvm-shmem", 0)
+	if err != nil {
+		return nil, fmt.Errorf("crosvm: memfd_create failed: %w", err)
+	}
+	inst.shmemFD = shmemFD
+	if err := syscall.Ftruncate(shmemFD, int64(flatrpc.ConstSnapshotShmemSize)); err != nil {
+		return nil, fmt.Errorf("crosvm: ftruncate failed: %w", err)
+	}
+	shmem, err := syscall.Mmap(shmemFD, 0, int(flatrpc.ConstSnapshotShmemSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("crosvm: shmem mmap failed: %w", err)
+	}
+	inst.shmem = shmem
+	inst.input = shmem[:flatrpc.ConstMaxInputSize:flatrpc.ConstMaxInputSize]
+	inst.header = (*flatrpc.SnapshotHeaderT)(unsafe.Pointer(&shmem[flatrpc.ConstMaxInputSize]))
+	// crosvm opens the backing file by name, and every restored crosvm process opens it
+	// again, so the fd must stay open in the manager for as long as the VM lives.
+	shmemFile := fmt.Sprintf("/proc/%v/fd/%v", syscall.Getpid(), shmemFD)
+	inst.snapDir = filepath.Join(inst.workdir, "snapshot")
+
+	// The guest RAM top must stay below the shared region, otherwise crosvm cannot place it.
+	if uint64(inst.cfg.Mem)<<20 >= snapshotAddr {
+		return nil, fmt.Errorf("crosvm: mem %v MB is too large for snapshot mode", inst.cfg.Mem)
+	}
+	return []string{
+		"--file-backed-mapping", fmt.Sprintf("addr=%v,size=%v,path=%v,rw",
+			uint64(snapshotAddr), uint64(flatrpc.ConstSnapshotShmemSize), shmemFile),
+	}, nil
+}
+
+const minErrOutputWait = time.Second
+
+func (inst *instance) SetupSnapshot(input []byte) error {
+	if inst.debug {
+		log.Logf(0, "crosvm: starting snapshot handshake")
+	}
+	copy(inst.input, input)
+	// Tell executor that we are ready to snapshot and wait for an ack.
+	inst.header.UpdateState(flatrpc.SnapshotStateHandshake)
+	if !inst.waitSnapshotStateChange(flatrpc.SnapshotStateHandshake, 10*time.Minute) {
+		return fmt.Errorf("executor does not start snapshot handshake\n%s", inst.readOutput(minErrOutputWait))
+	}
+	// crosvm refuses to write into an existing snapshot directory.
+	os.RemoveAll(inst.snapDir)
+	if _, err := inst.controlRetry(time.Minute*inst.timeouts.Scale, "snapshot", "take", inst.snapDir); err != nil {
+		return fmt.Errorf("%w\n%s", err, inst.readOutput(minErrOutputWait))
+	}
+	if inst.debug {
+		log.Logf(0, "crosvm: snapshot size %v MB", dirSize(inst.snapDir)>>20)
+	}
+	inst.header.UpdateState(flatrpc.SnapshotStateSnapshotted)
+	if !inst.waitSnapshotStateChange(flatrpc.SnapshotStateSnapshotted, time.Minute) {
+		return fmt.Errorf("executor has not confirmed snapshot handshake\n%s", inst.readOutput(minErrOutputWait))
+	}
+	return nil
+}
+
+func (inst *instance) RunSnapshot(timeout time.Duration, input []byte) (result, output []byte, err error) {
+	copy(inst.input, input)
+	inst.header.OutputOffset = 0
+	inst.header.OutputSize = 0
+	inst.header.UpdateState(flatrpc.SnapshotStateExecute)
+	if err := inst.restoreSnapshot(); err != nil {
+		return nil, nil, fmt.Errorf("%w\n%s", err, inst.readOutput(minErrOutputWait))
+	}
+	inst.waitSnapshotStateChange(flatrpc.SnapshotStateExecute, timeout)
+	resStart := int(flatrpc.ConstMaxInputSize) + int(atomic.LoadUint32(&inst.header.OutputOffset))
+	resEnd := resStart + int(atomic.LoadUint32(&inst.header.OutputSize))
+	var res []byte
+	if resEnd <= len(inst.shmem) {
+		res = inst.shmem[resStart:resEnd:resEnd]
+	}
+	output = inst.readOutput(0)
+	return res, output, nil
+}
+
+// restoreSnapshot rewinds the VM to the state saved by SetupSnapshot.
+//
+// crosvm cannot restore a snapshot into a running VM: the control socket only implements
+// "snapshot take", and restoring is a startup-only operation ("crosvm run --restore").
+// So a restore means killing the VM and starting a new crosvm process from the snapshot.
+// This is considerably more expensive than QEMU's loadvm, which restores in-process.
+func (inst *instance) restoreSnapshot() error {
+	if inst.crosvm != nil {
+		inst.crosvm.Process.Kill()
+		inst.crosvm.Wait()
+		inst.crosvm = nil
+	}
+	// The killed process does not get to clean up after itself, and crosvm refuses to
+	// start when its control socket already exists.
+	os.Remove(inst.sock)
+	// --suspended keeps the vCPUs stopped until we have the control socket, so that the
+	// restored guest cannot run ahead of us and read a half-written input.
+	// inst.args[0] is "run", which must stay first, and the kernel image must stay last.
+	args := append([]string{"run", "--restore", inst.snapDir, "--suspended"}, inst.args[1:]...)
+	rpipe, wpipe, err := osutil.LongPipe()
+	if err != nil {
+		return err
+	}
+	crosvm := osutil.Command(inst.cfg.Crosvm, args...)
+	crosvm.Stdout = wpipe
+	crosvm.Stderr = wpipe
+	if err := crosvm.Start(); err != nil {
+		rpipe.Close()
+		wpipe.Close()
+		return fmt.Errorf("failed to restore snapshot: %w", err)
+	}
+	wpipe.Close()
+	inst.crosvm = crosvm
+	// Re-registering the reader under the same name replaces the previous one, whose
+	// goroutine has exited (or is about to) as the killed process closed the pipe.
+	inst.merger.Add("crosvm", vmimpl.OutputConsole, rpipe)
+	// "resume" both waits for the restore to complete and starts the vCPUs.
+	if _, err := inst.controlRetry(time.Minute*inst.timeouts.Scale, "resume"); err != nil {
+		return err
+	}
+	inst.restored = true
+	return nil
+}
+
+func dirSize(dir string) int64 {
+	var size int64
+	filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info, err := entry.Info(); err == nil {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size
+}
+
+func (inst *instance) waitSnapshotStateChange(state flatrpc.SnapshotState, timeout time.Duration) bool {
+	// crosvm has no doorbell interrupt, so the guest cannot notify us of the state change
+	// and we have to poll. Spin first (the common case is that the program finishes fast),
+	// then back off so that a hung program does not burn a core.
+	deadline := time.Now().Add(timeout)
+	for i := 0; ; i++ {
+		if inst.header.LoadState() != state {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		if i > 1000 {
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func (inst *instance) readOutput(minTotalWait time.Duration) []byte {
+	var output []byte
+	// If output channel has overflown, then wait for more output from the merger goroutine.
+	wait := cap(inst.merger.Output)
+	start := time.Now()
+	for {
+		select {
+		case out := <-inst.merger.Output:
+			output = append(output, out.Data...)
+			wait--
+		default:
+			if wait > 0 {
+				if time.Since(start) < minTotalWait {
+					time.Sleep(5 * time.Millisecond)
+					continue
+				}
+				return output
+			}
+			// After the first overflow we wait after every read because the goroutine
+			// may be running and sending more output to the channel concurrently.
+			wait = 1
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/vm/crosvm/snapshot_unimpl.go
+++ b/vm/crosvm/snapshot_unimpl.go
@@ -1,0 +1,30 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build !linux
+
+package crosvm
+
+import (
+	"fmt"
+	"time"
+)
+
+type snapshot struct{}
+
+var errNotImplemented = fmt.Errorf("snapshots are not implemented")
+
+func (inst *instance) snapshotClose() {
+}
+
+func (inst *instance) snapshotEnable() ([]string, error) {
+	return nil, errNotImplemented
+}
+
+func (inst *instance) SetupSnapshot(input []byte) error {
+	return errNotImplemented
+}
+
+func (inst *instance) RunSnapshot(timeout time.Duration, input []byte) (result, output []byte, err error) {
+	return nil, nil, errNotImplemented
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -33,6 +33,7 @@ import (
 	// Import all VM implementations, so that users only need to import vm.
 	_ "github.com/google/syzkaller/vm/adb"
 	_ "github.com/google/syzkaller/vm/bhyve"
+	_ "github.com/google/syzkaller/vm/crosvm"
 	_ "github.com/google/syzkaller/vm/cuttlefish"
 	_ "github.com/google/syzkaller/vm/gce"
 	_ "github.com/google/syzkaller/vm/gvisor"


### PR DESCRIPTION
[crosvm](https://crosvm.dev/book/) is the ChromeOS Virtual Machine Monitor, a KVM-based VMM written in Rust that can run each virtio device in its own minijail sandbox.

The backend follows existing qemu way, but three properties of crosvm shape it:

- crosvm always loads the kernel itself. There is no BIOS and no bootloader, so the kernel config parameter is mandatory and a kernel installed inside the image is not used.
- crosvm has no user mode networking on Linux, its slirp backend is Windows only. Each VM therefore gets its own tap device and /24 network, and the guest address is set by the kernel from the ip= command line argument rather than by DHCP, since crosvm runs no DHCP server. The guest kernel needs `CONFIG_IP_PNP=y`.
- crosvm has no equivalent of `-snapshot`, so every VM runs on a copy-on-write qcow2 overlay of the image created with "crosvm create_qcow2".

Snapshot mode is supported, with a different transport. crosvm has no ivshmem device, so the host and the guest share a file-backed MMIO mapping placed at a fixed guest physical address, which the executor maps through /dev/mem. Being MMIO rather than RAM is what keeps the region out of the snapshot, the same way qemu's x-ignore-shared does, so a new input can be written before each restore. There is no doorbell interrupt either, so both sides poll the state word in the header instead of being woken up.

Restoring is also more expensive than under qemu. crosvm's control socket only implements "snapshot take", and restoring is a startup-only operation (`crosvm run --restore`), so a restore has to kill the VM and start a new process from the snapshot directory rather than rewinding in place.

Tested by fuzzing an x86-64 KASAN kernel in a Debian image: the VM boots, the executor connects over the tap network, and coverage is collected as usual. The snapshot transport was verified as far as the executor locating and mapping the shared region, and host and guest observing each other's writes.

# QEMU vs crosvm as a syzkaller VM backend (2 hours each)

2 hours of fuzzing under QEMU, then two hours under crosvm, same kernel, same rootfs, same VM shape, run sequentially on an idle-ish 8-core host.

**Headline: crosvm reached 7.2% more coverage in the same wall-clock time, because it executed 10.4% more programs. Per execution it was slightly worse, not better.** Two caveats matter more than that number, and both are covered below: the two runs did not enable the same set of syscalls, and the throughput advantage was not stable across the run.

## 1. What was measured

| | |
|---|---|
| kernel | Debian `7.2+unreleased-amd64`, `Debian 7.2~rc6-1~exp1` (2026-07-29), built by `debsb build --debian` with KASAN/KCOV ([debsb](https://pypi.org/project/debsb/)) |
| rootfs | one qcow2, uncompressed, identical for both; neither backend writes to it (QEMU `-snapshot`, crosvm CoW overlay) |
| syzkaller | Based on upstream syzkaller commit `c38879ea4` |
| QEMU | 11.0.3 (Debian 1:11.0.3+ds-2) |
| crosvm | local build at `a4bba0841` |
| VM shape | 1 VM, 2 vCPU, 2048 MB, `procs: 2` |
| disk / net | virtio-blk and virtio-net in both, so the guest sees `/dev/vda1` and a virtio NIC either way |
| host | Dell Pro 14 Premium, Intel Ultra 7 CPU 8 cores |

Everything the two backends can be made to share was shared. Both boot the same `bzImage` directly rather than through a bootloader, because crosvm has no bootloader and letting QEMU use one would compare different boot paths.

### 1.1 syzkaller configs

Only the `type` field, the `http` port and the `vm` block differ.

**QEMU**:

```json
{
	"target": "linux/amd64",
	"http": "127.0.0.1:56761",
	"workdir": "/home/debian-sid/.cache/syz-crosvm/compare/qemu/workdir",
	"kernel_obj": "/home/debian-sid/.debsb/linux/debian/build/build_amd64_none_amd64",
	"image": "/home/debian-sid/.cache/syz-crosvm/image.qcow2",
	"sshkey": "/home/debian-sid/.debsb/id_ed25519",
	"ssh_user": "root",
	"syzkaller": "/home/debian-sid/syzkaller",
	"procs": 2,
	"type": "qemu",
	"vm": {
		"count": 1,
		"kernel": "/home/debian-sid/.debsb/linux/debian/build/build_amd64_none_amd64/arch/x86/boot/bzImage",
		"cmdline": "root=/dev/vda1 net.ifnames=0",
		"image_device": "drive index=0,media=disk,if=virtio,format=qcow2,file=",
		"network_device": "virtio-net-pci",
		"cpu": 2,
		"mem": 2048
	}
}
```

**crosvm**:

```json
{
	"target": "linux/amd64",
	"http": "127.0.0.1:56762",
	"workdir": "/home/debian-sid/.cache/syz-crosvm/compare/crosvm/workdir",
	"kernel_obj": "/home/debian-sid/.debsb/linux/debian/build/build_amd64_none_amd64",
	"image": "/home/debian-sid/.cache/syz-crosvm/image.qcow2",
	"sshkey": "/home/debian-sid/.debsb/id_ed25519",
	"ssh_user": "root",
	"syzkaller": "/home/debian-sid/syzkaller",
	"procs": 2,
	"type": "crosvm",
	"vm": {
		"count": 1,
		"crosvm": "/home/debian-sid/syzkaller/crosvm/target/release/crosvm",
		"kernel": "/home/debian-sid/.debsb/linux/debian/build/build_amd64_none_amd64/arch/x86/boot/bzImage",
		"cpu": 2,
		"mem": 2048,
		"root_device": "/dev/vda1"
	}
}
```

Three things in the QEMU block are deliberate rather than default, and without them the comparison would be invalid:

- `image_device` puts the disk on virtio. syzkaller's QEMU default is `-hda`, which would give the guest `/dev/sda` and exercise the ATA path while crosvm   exercised virtio-blk.
- `network_device` is `virtio-net-pci`. The default is `e1000`, which this Debian kernel has modular; with no initrd the guest would boot with no network at all and never come up.
- `cmdline` sets `root=/dev/vda1` explicitly, matching crosvm's `root_device`.
- `net.ifnames=0` keeps the interface named `eth0` in both.

crosvm needs no `cmdline` because the backend builds one, and no `image_device`/`network_device` because virtio-blk and virtio-net are all it offers.

## 2. Results

```
                                  qemu          crosvm  crosvm vs qemu
corpus                            5236            5438           +3.9%
coverage                         86932           93155           +7.2%
signal                          106322          112994           +6.3%
max signal                      139698          149349           +6.9%
exec total                      167846          185345          +10.4%
fuzzing time                     7110s           7020s
exec/sec (mean)                   23.6            26.4          +11.8%
coverage/1k execs                  518             503           -3.0%
crashes (kernel bugs)                0               0
```

crosvm is ahead on every absolute counter and behind on the only normalised one.

## 3. The advantage is throughput, not smarter exploration

`coverage/1k execs` is the metric that separates "this VMM is faster" from "this VMM explores better". It is 518 under QEMU and 503 under crosvm: crosvm extracted **3% less coverage per program executed**. Its higher final coverage comes entirely from getting through more programs.

That is the expected result, and it is the right one to expect. The VMM does not influence which programs syzkaller chooses or how the kernel responds to them; it influences how fast a program can be shipped to a guest and a result returned. Consistent with that, syzkaller's own `prog exec time` averaged 262 ms under QEMU and 206 ms under crosvm, and the execution mix was nearly identical (minimisation 61.6% vs 63.7% of executions, triage 21.1% vs 20.9%), both runs were doing the same *kind* of work, one just did more of it.

So the honest claim is narrow: **crosvm is a faster executor host here, and coverage follows throughput.** Any statement stronger than that is not supported by this data.

## 4. Growth over time and why 30 minutes was not enough

```
  min    q cov    c cov   cov d   q exec   c exec  exec d  q cov/1k  c cov/1k
   15    45550    43318   -4.9%    22113    24712  +11.8%      2060      1753
   30    54030    53881   -0.3%    43543    48729  +11.9%      1241      1106
   45    58064    62052   +6.9%    60247    76685  +27.3%       964       809
   60    64141    68069   +6.1%    80799    99155  +22.7%       794       686
   75    72070    77782   +7.9%   101176   127141  +25.7%       712       612
   90    78166    86252  +10.3%   122900   146706  +19.4%       636       588
  105    83208    90695   +9.0%   146999   169651  +15.4%       566       535
  119    86932    93155   +7.2%   167846   185345  +10.4%       518       503
```

At 15 minutes crosvm was **behind** on coverage (−4.9%) while already ahead on executions (+11.8%). It did not lead on coverage until roughly minute 45, and the gap only settled into the +7–10% band after minute 60.

This is a direct verdict on the earlier 30-minute run, which reported +4.5% coverage for crosvm. That measurement landed inside the window where the ordering is still unstable at the 30-minute mark of *this* run the two were
level (−0.3%). A 30-minute syzkaller comparison is measuring startup transients, not steady state.

The `cov/1k execs` columns also show why absolute coverage is a poor headline:
1. both backends' per-execution yield falls by a factor of four over two hours as the easy coverage is exhausted.
2. Comparing two runs of different lengths, or reading a coverage difference without the execution count beside it, will mislead.

## 5. Throughput was not stable

Splitting the run into windows and computing the execution rate in each:

```
min 1-30     qemu  24.1/s   crosvm  27.0/s   +12.0%
min 30-60    qemu  20.7/s   crosvm  28.0/s   +35.4%
min 60-90    qemu  23.4/s   crosvm  26.4/s   +12.9%
min 90-119   qemu  25.8/s   crosvm  22.2/s   -14.0%
```

crosvm led by 12%, then 35%, then 13% and then **lost by 14% in the final half hour**. The +10.4% overall figure is an average over windows that disagree with each other, one of which has the opposite sign.

Part of the last window is explained: crosvm lost its VM at 14:41 (section 6) and the replacement had to re-warm. But QEMU's own rate also swung from 20.7 to 25.8/s between windows with no logged event at all. Run-to-run and window-to-window variance on this workload is on the same order as the effect being measured. **One pair of runs cannot establish a 10% difference**, and this pair does not.

## 6. Stability

```
                                    qemu        crosvm
instance restarts                     10            30
executor restarts                    365           409
exec retries                           8            18
no exec requests                   21614           674
no exec duration                    446s            13s
cover overflows                    16736         10594
prog exec time (ms)                  262           206
```

Neither backend found a kernel bug. crosvm's one recorded "crash" was `lost connection to test machine [suppressed]` at 14:41 an infrastructure event, not a kernel finding. It counts **against** crosvm here, not for it:
QEMU completed two hours with no lost connections, and both took the same scheduled hourly VM restart. The `instance restart` counter tells the same story: both start at 10 from startup probing, QEMU stays at 10 for the whole
run, crosvm rises to 30 in the window containing that lost connection.

The starvation counters run the other way and are the largest single
difference in the table. QEMU spent **446 seconds**, 6.3% of its run, with
executors idle for want of requests, against 13 seconds for crosvm, and
accumulated that deficit steadily throughout (232 at minute 1, 21614 at the
end) rather than in one stall. This is the mechanism behind most of the
throughput gap. I have not isolated the cause; the plausible candidates are
the different host-reachability paths (forwarded localhost port vs tap
address) and QEMU's higher per-program latency leaving the pipeline empty
more often. Worth chasing before anyone treats the throughput number as a
property of the VMMs themselves.

## 7. Threats to validity

**The two runs did not fuzz the same syscall set.** This is the most serious
problem with the comparison. syzkaller enabled 3232 syscalls under QEMU and
3062 under crosvm, out of 8296:

- **224 disabled only under crosvm**, of which 212 are CD-ROM ioctls (`ioctl$CDROM*`), disabled for want of an `fd_cdrom` resource. QEMU presents a default ATAPI CD-ROM; crosvm presents none. crosvm never fuzzed the
  CD-ROM ioctl surface at all.
- **54 disabled only under QEMU**, mostly block ioctls (`ioctl$BLK*`, `HDIO_GETGEO`, `IOC_PR_*`), disabled for want of an `fd_block` resource produced via `openat$md`/`openat$nullb`/`openat$pmem0`. crosvm had them.

The guest also reported 55 loaded modules under QEMU against 36 under crosvm. So the two backends presented measurably different device surfaces to the same kernel, and a coverage difference across different target surfaces is not a clean VMM comparison. The net effect probably favours QEMU on coverage, it had 170 more syscalls enabled and still lost, but that is an argument, not a measurement.

**Host contention was symmetric, and this was checked.** An unrelated
virtme-ng VM was running throughout. Sampling `/proc/loadavg` once a minute
during each half gives mean load 2.88 during the QEMU run and 2.94 during the
crosvm run (min 1.82/1.80, max 4.46/4.11). Close enough that interference is
not a plausible explanation for a 7% difference. This was the confound I was
most worried about going in, and it did not materialise.

**Differences that cannot be equalised**:

1. crosvm has no user-mode networking on Linux, so it needs a tap device and CAP_NET_ADMIN; it therefore runs inside `unshare -Urnm`, and QEMU does not.
2. The guest reaches the host by a forwarded localhost port under QEMU and a tap address under crosvm.
4. crosvm is a local `cargo build --release`; QEMU is Debian's binary.

**Single run.** syzkaller is randomised with no seed control. Section 5 shows
the within-run variance is already comparable to the between-backend effect.

## 8. Conclusions

1. crosvm works as a syzkaller backend and sustains a full two-hour session at a throughput at least comparable to QEMU's. For the purpose the backend was written for, that is the result that matters, and it is solid.
2. crosvm reached 7.2% more coverage, and the mechanism is throughput (+10.4% executions), not better exploration (−3.0% coverage per execution).
3. **The 7.2% figure should not be quoted as a benchmark result.** It rests on one run, over windows that disagree in sign, between guests with different syscall surfaces. It is evidence that crosvm is not slower, which is a useful and sufficient claim for the patch.