### PR TITLE
Makefile: change xargs -P0 to -P100

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ format_cpp:
 |pkg/flatrpc/flatrpc.h\
 |pkg/covermerger/testdata/integration/\
 |executor/android/.*_policy.h" \
-	| xargs -I {} -P 0 clang-format --style=file -i {}
+	| xargs -I {} -P 100 clang-format --style=file -i {}
 
 format_sys: bin/syz-fmt
 	bin/syz-fmt all


### PR DESCRIPTION
OpenBSD bails on -P0 whereas GNU xargs treats it as "as many as OS limits would allow". Right now the source tree is at < 100 files, so the change is a no-op in practice.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
