### PR TITLE
syz-cluster/pkg/triage: drop focus filter when merging with unfocused targets

### DIFF
--- a/syz-cluster/pkg/triage/fuzz_target.go
+++ b/syz-cluster/pkg/triage/fuzz_target.go
@@ -88,9 +88,7 @@ func MergeKernelFuzzConfigs(configs []*api.KernelFuzzConfig) []*MergedFuzzConfig
 func mergeFuzzConfigs(configs []*api.KernelFuzzConfig) *api.FuzzConfig {
 	var ret api.FuzzConfig
 	for _, config := range configs {
-		if config.Focus != "" {
-			ret.Focus = append(ret.Focus, config.Focus)
-		}
+		ret.Focus = append(ret.Focus, config.Focus)
 		if config.CorpusURL != "" {
 			ret.CorpusURLs = append(ret.CorpusURLs, config.CorpusURL)
 		}
@@ -98,7 +96,13 @@ func mergeFuzzConfigs(configs []*api.KernelFuzzConfig) *api.FuzzConfig {
 		// Must be the same.
 		ret.BugTitleRe = config.BugTitleRe
 	}
-	ret.Focus = unique(ret.Focus)
+	if slices.Contains(ret.Focus, "") {
+		// If there's at least one unfocused target,
+		// we fuzz everything this way.
+		ret.Focus = nil
+	} else {
+		ret.Focus = unique(ret.Focus)
+	}
 	ret.CorpusURLs = unique(ret.CorpusURLs)
 	return &ret
 }

--- a/syz-cluster/pkg/triage/fuzz_target_test.go
+++ b/syz-cluster/pkg/triage/fuzz_target_test.go
@@ -114,22 +114,44 @@ func TestMergeKernelFuzzConfigs(t *testing.T) {
 }
 
 func TestMergeFuzzConfigs(t *testing.T) {
-	assert.Equal(t, &api.FuzzConfig{
-		Focus:          []string{"bpf", "net"},
-		CorpusURLs:     []string{"url1", "url2"},
-		SkipCoverCheck: true,
-		BugTitleRe:     "regexp",
-	}, mergeFuzzConfigs([]*api.KernelFuzzConfig{
-		{
-			Focus:      "net",
-			CorpusURL:  "url2",
-			BugTitleRe: "regexp",
-		},
-		{
-			Focus:          "bpf",
-			CorpusURL:      "url1",
-			BugTitleRe:     "regexp",
+	t.Run("all-focused", func(t *testing.T) {
+		assert.Equal(t, &api.FuzzConfig{
+			Focus:          []string{"bpf", "net"},
+			CorpusURLs:     []string{"url1", "url2"},
 			SkipCoverCheck: true,
-		},
-	}))
+			BugTitleRe:     "regexp",
+		}, mergeFuzzConfigs([]*api.KernelFuzzConfig{
+			{
+				Focus:      "net",
+				CorpusURL:  "url2",
+				BugTitleRe: "regexp",
+			},
+			{
+				Focus:          "bpf",
+				CorpusURL:      "url1",
+				BugTitleRe:     "regexp",
+				SkipCoverCheck: true,
+			},
+		}))
+	})
+	t.Run("with-unfocused", func(t *testing.T) {
+		assert.Equal(t, &api.FuzzConfig{
+			Focus:          nil,
+			CorpusURLs:     []string{"url1", "url2"},
+			SkipCoverCheck: true,
+			BugTitleRe:     "regexp",
+		}, mergeFuzzConfigs([]*api.KernelFuzzConfig{
+			{
+				Focus:      "fs",
+				CorpusURL:  "url2",
+				BugTitleRe: "regexp",
+			},
+			{
+				Focus:          "",
+				CorpusURL:      "url1",
+				BugTitleRe:     "regexp",
+				SkipCoverCheck: true,
+			},
+		}))
+	})
 }


### PR DESCRIPTION
When a patch series matches multiple targets with the same track, one target might have a narrow subsystem focus (e.g. fs) while another is unfocused (all syscalls enabled, e.g. mm). Previously, mergeFuzzConfigs collected all non-empty focus areas, causing a single focused target to restrict syscalls for the entire session.

Clear the merged focus filter if any of the merged campaigns is unfocused, preserving full syscall access while still combining corpus URLs and flags.