### PR TITLE
pkg/aflow: add iteration limit to llm tools

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -347,12 +347,22 @@ func (a *agentSession) tryAnswerNow(cfg *backend.GenerateConfig, overflow bool) 
 	return true
 }
 
+// maxIterationsError returns a recoverable BadCallError for subagents, or a
+// hard error for main agents.
+func (a *agentSession) maxIterationsError() error {
+	if a.SubAgent {
+		return BadCallError("agent reached max iterations limit (%v)", a.maxIterations)
+	}
+	return fmt.Errorf("agent reached max iterations limit (%v)", a.maxIterations)
+}
+
 func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map[string]Tool,
 	instruction, prompt string, candidate int) (string, map[string]any, error) {
 	a.req = []llmMessage{{content: &backend.Message{
 		Role:  backend.RoleUser,
 		Parts: []backend.Part{{Text: prompt}},
 	}}}
+
 	var anchorTokens int
 	for iter := 0; iter < a.maxIterations || a.tryAnswerNow(cfg, false); iter++ {
 		var currentInputTokens int
@@ -447,8 +457,7 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 			}
 		}
 	}
-	return "", nil, fmt.Errorf("agent reached max iterations limit (%v)",
-		a.maxIterations)
+	return "", nil, a.maxIterationsError()
 }
 
 func (a *agentSession) updateInputTokens(inputTokens int, anchorTokens *int) {

--- a/pkg/aflow/llm_tool.go
+++ b/pkg/aflow/llm_tool.go
@@ -33,6 +33,10 @@ type StructuredLLMTool[State, Args, Results any] struct {
 	// Use LLMOutputs or ValidatedLLMOutputs/ValidatedLLMToolOutputs functions to create it.
 	Outputs *llmOutputs
 
+	// Maximum number of iterations for the tool execution.
+	// If 0, default to defaultMaxLLMIterations (250).
+	MaxIterations int
+
 	agent *LLMAgent
 }
 
@@ -124,13 +128,14 @@ func (t *StructuredLLMTool[State, Args, Results]) verify(ctx *verifyContext) {
 		ctx.errorf(t.Name, "invalid prompt template: %v", err)
 	}
 	t.agent = &LLMAgent{
-		Name:        t.Name,
-		Model:       t.Model,
-		TaskType:    t.TaskType,
-		Instruction: t.Instruction,
-		Prompt:      fmt.Sprintf("{{.%v}}", llmToolPrompt),
-		Tools:       t.Tools,
-		SubAgent:    true,
+		Name:          t.Name,
+		Model:         t.Model,
+		TaskType:      t.TaskType,
+		Instruction:   t.Instruction,
+		Prompt:        fmt.Sprintf("{{.%v}}", llmToolPrompt),
+		Tools:         t.Tools,
+		SubAgent:      true,
+		MaxIterations: t.MaxIterations,
 	}
 
 	if t.Outputs != nil {

--- a/pkg/aflow/llm_tool_test.go
+++ b/pkg/aflow/llm_tool_test.go
@@ -153,13 +153,15 @@ func TestLLMToolMaxIters(t *testing.T) {
 			},
 		})
 	}
-	// The agent hits maxLLMIterations and attempts to answer now.
+	// The sub-agent hits maxLLMIterations and attempts to answer now.
 	// We provide an invalid reply so that it fails to produce structured output,
-	// terminating the loop and returning the max iterations limit error.
+	// causing the sub-agent loop to end and return BadCallError.
 	replies = append(replies, &backend.Part{Text: "I give up!"})
+	// The main agent receives the BadCallError as a tool error response and continues,
+	// providing its final reply without terminating the flow.
+	replies = append(replies, &backend.Part{Text: "Sub-agent reached limit, but flow continues!"})
 	testFlow[struct{}, outputs](t, nil,
-		"tool researcher failed: error: agent reached max iterations limit (250)\n"+
-			"args: map[Question:What do you think?]",
+		map[string]any{"Reply": "Sub-agent reached limit, but flow continues!"},
 		&LLMAgent{
 			Reply: "Reply",
 			Tools: []Tool{

--- a/pkg/aflow/testdata/TestLLMToolMaxIters.llm.json
+++ b/pkg/aflow/testdata/TestLLMToolMaxIters.llm.json
@@ -787793,5 +787793,95 @@
 				"role": "user"
 			}
 		]
+	},
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher description",
+							"name": "researcher",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Question": {
+										"type": "string",
+										"description": "Question you have."
+									}
+								},
+								"required": [
+									"Question"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer to your question."
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id0",
+							"args": {
+								"Question": "What do you think?"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id0",
+							"response": {
+								"error": "agent reached max iterations limit (250)"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
 	}
 ]

--- a/pkg/aflow/testdata/TestLLMToolMaxIters.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMToolMaxIters.trajectory.json
@@ -9845,16 +9845,33 @@
 		}
 	},
 	{
+		"Seq": 506,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:16:51Z"
+	},
+	{
+		"Seq": 506,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:16:51Z",
+		"Finished": "0001-01-01T00:16:52Z"
+	},
+	{
 		"Seq": 1,
 		"Nesting": 1,
 		"Type": "agent",
 		"Name": "smarty",
 		"Model": "model",
 		"Started": "0001-01-01T00:00:02Z",
-		"Finished": "0001-01-01T00:16:51Z",
-		"Error": "tool researcher failed: error: agent reached max iterations limit (250)\nargs: map[Question:What do you think?]",
+		"Finished": "0001-01-01T00:16:53Z",
 		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
-		"Prompt": "Prompt"
+		"Prompt": "Prompt",
+		"Reply": "Sub-agent reached limit, but flow continues!"
 	},
 	{
 		"Seq": 0,
@@ -9862,7 +9879,9 @@
 		"Type": "flow",
 		"Name": "test",
 		"Started": "0001-01-01T00:00:01Z",
-		"Finished": "0001-01-01T00:16:52Z",
-		"Error": "tool researcher failed: error: agent reached max iterations limit (250)\nargs: map[Question:What do you think?]"
+		"Finished": "0001-01-01T00:16:54Z",
+		"Results": {
+			"Reply": "Sub-agent reached limit, but flow continues!"
+		}
 	}
 ]


### PR DESCRIPTION
Add configurable maximum iteration limits to structured LLM tools to prevent unbounded execution loops and ensure timely termination of subagent turns.

