### PR TITLE
pkg/aflow: support reading input field from file

### DIFF
--- a/tools/syz-aflow/README.md
+++ b/tools/syz-aflow/README.md
@@ -40,9 +40,12 @@ If the workflow needs to perform actions that interact with VMs (like reproducin
     "qemu_args": "-machine q35 -enable-kvm -smp 2,sockets=2,cores=1"
   },
   "ReproSyz": "syz_open$dir(0x0, 0x1) ...",
-  "KernelConfig": "CONFIG_XYZ=y\nCONFIG_ABC=n"
+  "KernelConfig": "@/path/to/linux.config"
 }
 ```
+
+Any string field in the input JSON starting with `@` (e.g. `"@/path/to/file"` or `"@./relative/path"`) will be automatically expanded with the contents of that file. Relative paths are resolved relative to the directory of the `-input` JSON file. Literal leading `@` characters can be escaped with `@@` (e.g. `"@@literal"`).
+
 
 ### Flags
 

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/backend"
@@ -113,6 +114,9 @@ func run(ctx context.Context, args RunArgs) error {
 	}
 	var inputs map[string]any
 	if err := json.Unmarshal(inputData, &inputs); err != nil {
+		return err
+	}
+	if err := expandFileInputs(inputs, filepath.Dir(args.InputFile)); err != nil {
 		return err
 	}
 	cache, err := aflow.NewCache(filepath.Join(args.Workdir, "cache"), args.CacheSize)
@@ -298,4 +302,56 @@ func parseSize(s string) (uint64, error) {
 		return 0, fmt.Errorf("unknown size suffix %q", suffix)
 	}
 	return size, nil
+}
+
+// expandFileInputs recursively traverses workflow inputs and replaces any
+// string value prefixed with "@" with the contents of the referenced file on
+// disk. Relative file paths are resolved against baseDir (the directory
+// containing the -input JSON file). Literal leading "@" characters can be
+// escaped using "@@".
+func expandFileInputs(inputs map[string]any, baseDir string) error {
+	for key, val := range inputs {
+		expanded, err := expandValue(val, baseDir)
+		if err != nil {
+			return fmt.Errorf("failed to read input file for %q: %w", key, err)
+		}
+		inputs[key] = expanded
+	}
+	return nil
+}
+
+func expandValue(val any, baseDir string) (any, error) {
+	switch v := val.(type) {
+	case string:
+		if strings.HasPrefix(v, "@@") {
+			return v[1:], nil
+		}
+		if !strings.HasPrefix(v, "@") {
+			return v, nil
+		}
+		path := v[1:]
+		if !filepath.IsAbs(path) && baseDir != "" {
+			path = filepath.Join(baseDir, path)
+		}
+		data, err := os.ReadFile(osutil.Abs(path))
+		if err != nil {
+			return nil, fmt.Errorf("(%s): %w", v, err)
+		}
+		return string(data), nil
+	case map[string]any:
+		// Recursively traverse nested JSON objects (e.g. "VM" config object).
+		return v, expandFileInputs(v, baseDir)
+	case []any:
+		// Traverse JSON arrays of strings, nested lists, or nested objects.
+		for i, elem := range v {
+			expanded, err := expandValue(elem, baseDir)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]%w", i, err)
+			}
+			v[i] = expanded
+		}
+		return v, nil
+	default:
+		return val, nil
+	}
 }

--- a/tools/syz-aflow/aflow_test.go
+++ b/tools/syz-aflow/aflow_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandFileInputs(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.config")
+	configContent := "CONFIG_TEST=y\nCONFIG_FOO=n\n"
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	crashFile := filepath.Join(tempDir, "crash.log")
+	crashContent := "BUG: unable to handle kernel paging request"
+	err = os.WriteFile(crashFile, []byte(crashContent), 0644)
+	require.NoError(t, err)
+
+	subDir := filepath.Join(tempDir, "sub")
+	err = os.MkdirAll(subDir, 0755)
+	require.NoError(t, err)
+	reproFile := filepath.Join(subDir, "repro.c")
+	reproContent := "int main() { return 0; }"
+	err = os.WriteFile(reproFile, []byte(reproContent), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		inputs    map[string]any
+		baseDir   string
+		want      map[string]any
+		expectErr bool
+	}{
+		{
+			name: "no-at-prefix",
+			inputs: map[string]any{
+				"BugTitle":     "KASAN: use-after-free",
+				"KernelConfig": "CONFIG_TEST=y\n",
+				"Count":        42,
+				"Enabled":      true,
+			},
+			baseDir: tempDir,
+			want: map[string]any{
+				"BugTitle":     "KASAN: use-after-free",
+				"KernelConfig": "CONFIG_TEST=y\n",
+				"Count":        42,
+				"Enabled":      true,
+			},
+		},
+		{
+			name: "absolute-path",
+			inputs: map[string]any{
+				"KernelConfig": "@" + configFile,
+			},
+			baseDir: "",
+			want: map[string]any{
+				"KernelConfig": configContent,
+			},
+		},
+		{
+			name: "relative-path",
+			inputs: map[string]any{
+				"CrashReport": "@crash.log",
+				"ReproC":      "@sub/repro.c",
+			},
+			baseDir: tempDir,
+			want: map[string]any{
+				"CrashReport": crashContent,
+				"ReproC":      reproContent,
+			},
+		},
+		{
+			name: "escaped-at-prefix",
+			inputs: map[string]any{
+				"Mention": "@@developer",
+			},
+			baseDir: tempDir,
+			want: map[string]any{
+				"Mention": "@developer",
+			},
+		},
+		{
+			name: "nested-map-and-slice",
+			inputs: map[string]any{
+				"VM": map[string]any{
+					"Config": "@test.config",
+				},
+				"ExtraFiles": []any{
+					"@crash.log",
+					"regular_string",
+					"@@literal_at",
+				},
+				"NestedMatrix": []any{
+					[]any{
+						"@crash.log",
+						"@@escape",
+					},
+				},
+			},
+			baseDir: tempDir,
+			want: map[string]any{
+				"VM": map[string]any{
+					"Config": configContent,
+				},
+				"ExtraFiles": []any{
+					crashContent,
+					"regular_string",
+					"@literal_at",
+				},
+				"NestedMatrix": []any{
+					[]any{
+						crashContent,
+						"@escape",
+					},
+				},
+			},
+		},
+		{
+			name: "missing-file-error",
+			inputs: map[string]any{
+				"KernelConfig": "@non_existent_file.config",
+			},
+			baseDir:   tempDir,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := expandFileInputs(tc.inputs, tc.baseDir)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, tc.inputs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Linux build config can be large and keeping it inside a workflow configuration file is not elegant. Allow reading the kernel build config from a file specified in the same named field.
