### PR TITLE
syz-cluster: support path regexps in fuzz triage targets

### DIFF
--- a/syz-cluster/overlays/gke/prod/global-config.yaml
+++ b/syz-cluster/overlays/gke/prod/global-config.yaml
@@ -121,6 +121,8 @@ trees:
 fuzz_targets:
   - email_lists:
       - kvm@vger.kernel.org
+    path_regexps:
+      - "kvm|virt"
     focus: kvm
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-kasan-gce-root-corpus.db
     campaigns:
@@ -128,6 +130,8 @@ fuzz_targets:
         kernel_config: upstream-apparmor-kasan.config
   - email_lists:
       - io-uring@vger.kernel.org
+    path_regexps:
+      - "io_uring"
     focus: io_uring
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-kasan-gce-root-corpus.db
     campaigns:
@@ -135,6 +139,8 @@ fuzz_targets:
         kernel_config: upstream-apparmor-kasan.config
   - email_lists:
       - bpf@vger.kernel.org
+    path_regexps:
+      - "bpf"
     focus: bpf
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-bpf-kasan-gce-corpus.db
     campaigns:
@@ -144,6 +150,8 @@ fuzz_targets:
       - netdev@vger.kernel.org
       - netfilter-devel@vger.kernel.org
       - linux-wireless@vger.kernel.org
+    path_regexps:
+      - "^net/|^drivers/net/|include/net/"
     focus: net
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-net-kasan-gce-corpus.db
     campaigns:
@@ -154,6 +162,8 @@ fuzz_targets:
       - linux-block@vger.kernel.org
       - linux-unionfs@vger.kernel.org
       - linux-ext4@vger.kernel.org
+    path_regexps:
+      - "^fs/|^block/|drivers/block"
     focus: fs
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci2-upstream-fs-corpus.db
     campaigns:

--- a/syz-cluster/overlays/gke/staging/global-config.yaml
+++ b/syz-cluster/overlays/gke/staging/global-config.yaml
@@ -22,6 +22,24 @@ trees:
     URL: https://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next
     branch: master
 fuzz_targets:
+  - email_lists:
+      - netdev@vger.kernel.org
+    path_regexps:
+      - "^net/|^drivers/net/|include/net/"
+    focus: net
+    corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-net-kasan-gce-corpus.db
+    campaigns:
+      - track: KASAN
+        kernel_config: upstream-apparmor-kasan.config
+  - email_lists:
+      - linux-ext4@vger.kernel.org
+    path_regexps:
+      - "^fs/|^block/|drivers/block"
+    focus: fs
+    corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci2-upstream-fs-corpus.db
+    campaigns:
+      - track: KASAN
+        kernel_config: upstream-apparmor-kasan.config
   - corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-kasan-gce-root-corpus.db
     campaigns:
       - track: KASAN

--- a/syz-cluster/overlays/local/minikube/global-config.yaml
+++ b/syz-cluster/overlays/local/minikube/global-config.yaml
@@ -26,6 +26,8 @@ fuzz_targets:
       - netdev@vger.kernel.org
       - netfilter-devel@vger.kernel.org
       - linux-wireless@vger.kernel.org
+    path_regexps:
+      - "^net/|^drivers/net/|include/net/"
     focus: net
     corpus_url: https://storage.googleapis.com/syzkaller/corpus/ci-upstream-net-kasan-gce-corpus.db
     campaigns:

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -5,7 +5,12 @@
 // used for communication between components and workflow steps.
 package api
 
-import "time"
+import (
+	"slices"
+	"time"
+
+	"github.com/google/syzkaller/pkg/vcs"
+)
 
 // TriageResult is the output passed to other workflow steps.
 type TriageResult struct {
@@ -82,10 +87,11 @@ type KernelFuzzConfig struct {
 
 // FuzzTriageTarget is a single record in the list of supported fuzz configs.
 type FuzzTriageTarget struct {
-	EmailLists []string            `json:"email_lists" yaml:"email_lists"`
-	Focus      string              `json:"focus" yaml:"focus"`
-	CorpusURL  string              `json:"corpus_url" yaml:"corpus_url"`
-	Campaigns  []*KernelFuzzConfig `json:"campaigns" yaml:"campaigns"`
+	EmailLists  []string            `json:"email_lists" yaml:"email_lists"`
+	PathRegexps []string            `json:"path_regexps" yaml:"path_regexps"`
+	Focus       string              `json:"focus" yaml:"focus"`
+	CorpusURL   string              `json:"corpus_url" yaml:"corpus_url"`
+	Campaigns   []*KernelFuzzConfig `json:"campaigns" yaml:"campaigns"`
 }
 
 type BuildRequest struct {
@@ -192,6 +198,20 @@ func (s *Series) PatchBodies() [][]byte {
 		ret = append(ret, patch.Body)
 	}
 	return ret
+}
+
+func (s *Series) ModifiedFiles() []string {
+	if s == nil {
+		return nil
+	}
+	var files []string
+	for _, patch := range s.PatchBodies() {
+		for _, diff := range vcs.ParseGitDiff(patch) {
+			files = append(files, diff.Name)
+		}
+	}
+	slices.Sort(files)
+	return slices.Compact(files)
 }
 
 type SeriesPatch struct {

--- a/syz-cluster/pkg/api/api_test.go
+++ b/syz-cluster/pkg/api/api_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeriesPatchBodies(t *testing.T) {
+	emptySeries := &Series{}
+	require.Nil(t, emptySeries.PatchBodies())
+
+	series := &Series{
+		Patches: []SeriesPatch{
+			{Body: []byte("patch1")},
+			{Body: []byte("patch2")},
+		},
+	}
+	require.Equal(t, [][]byte{[]byte("patch1"), []byte("patch2")}, series.PatchBodies())
+}
+
+func TestSeriesModifiedFiles(t *testing.T) {
+	var nilSeries *Series
+	require.Nil(t, nilSeries.ModifiedFiles())
+
+	emptySeries := &Series{}
+	require.Empty(t, emptySeries.ModifiedFiles())
+
+	series := &Series{
+		Patches: []SeriesPatch{
+			{Body: []byte("diff --git a/b.c b/b.c\ndiff --git a/a.c b/a.c\n")},
+			{Body: []byte("diff --git a/b.c b/b.c\ndiff --git a/c.c b/c.c\n")},
+		},
+	}
+	require.Equal(t, []string{"a.c", "b.c", "c.c"}, series.ModifiedFiles())
+}

--- a/syz-cluster/pkg/app/config.go
+++ b/syz-cluster/pkg/app/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/mail"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -161,6 +162,11 @@ func (c AppConfig) Validate() error {
 		}
 	}
 	for _, target := range c.FuzzTargets {
+		for _, r := range target.PathRegexps {
+			if _, err := regexp.Compile(r); err != nil {
+				return fmt.Errorf("invalid path regexp %q: %w", r, err)
+			}
+		}
 		for _, campaign := range target.Campaigns {
 			if campaign.Track != string(api.TrackKASAN) && campaign.Track != string(api.TrackKMSAN) {
 				return fmt.Errorf("unsupported fuzzing track %q, must be %q or %q",

--- a/syz-cluster/pkg/app/config_test.go
+++ b/syz-cluster/pkg/app/config_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,4 +67,16 @@ func TestOwnEmails(t *testing.T) {
 	got := cfg.OwnEmails()
 	want := []string{"bot@dashapi.com", "bot@kernel.org", "bot@smtp.com"}
 	require.Equal(t, want, got)
+}
+
+func TestFuzzTargetsValidation(t *testing.T) {
+	cfg := AppConfig{
+		URL: "http://example.com",
+		FuzzTargets: []*api.FuzzTriageTarget{
+			{
+				PathRegexps: []string{"[invalid("},
+			},
+		},
+	}
+	require.ErrorContains(t, cfg.Validate(), "invalid path regexp")
 }

--- a/syz-cluster/pkg/triage/fuzz_target.go
+++ b/syz-cluster/pkg/triage/fuzz_target.go
@@ -4,7 +4,7 @@
 package triage
 
 import (
-	"maps"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -16,15 +16,16 @@ func SelectFuzzConfigs(series *api.Series, fuzzConfigs []*api.FuzzTriageTarget) 
 	for _, cc := range series.Cc {
 		seriesCc[strings.ToLower(cc)] = true
 	}
+	modifiedFiles := series.ModifiedFiles()
 	var ret, defaultRet []*api.KernelFuzzConfig
 	for _, config := range fuzzConfigs {
-		intersects := false
-		for _, cc := range config.EmailLists {
-			intersects = intersects || seriesCc[cc]
-		}
-		if intersects {
+		matched := slices.ContainsFunc(config.EmailLists, func(cc string) bool {
+			return seriesCc[cc]
+		})
+		matched = matched || matchesPaths(config.PathRegexps, modifiedFiles)
+		if matched {
 			ret = append(ret, expandCampaigns(config)...)
-		} else if len(config.EmailLists) == 0 {
+		} else if len(config.EmailLists) == 0 && len(config.PathRegexps) == 0 {
 			defaultRet = append(defaultRet, expandCampaigns(config)...)
 		}
 	}
@@ -33,6 +34,22 @@ func SelectFuzzConfigs(series *api.Series, fuzzConfigs []*api.FuzzTriageTarget) 
 		return ret
 	}
 	return defaultRet
+}
+
+func matchesPaths(regexps, modifiedFiles []string) bool {
+	if len(regexps) == 0 || len(modifiedFiles) == 0 {
+		return false
+	}
+	for _, r := range regexps {
+		re, err := regexp.Compile(r)
+		if err != nil {
+			continue
+		}
+		if slices.ContainsFunc(modifiedFiles, re.MatchString) {
+			return true
+		}
+	}
+	return false
 }
 
 func expandCampaigns(config *api.FuzzTriageTarget) []*api.KernelFuzzConfig {
@@ -108,10 +125,7 @@ func mergeFuzzConfigs(configs []*api.KernelFuzzConfig) *api.FuzzConfig {
 }
 
 func unique(list []string) []string {
-	seen := make(map[string]struct{}, len(list))
-	for _, s := range list {
-		seen[s] = struct{}{}
-	}
-	unique := slices.Sorted(maps.Keys(seen))
-	return unique
+	list = slices.Clone(list)
+	slices.Sort(list)
+	return slices.Compact(list)
 }

--- a/syz-cluster/pkg/triage/fuzz_target_test.go
+++ b/syz-cluster/pkg/triage/fuzz_target_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSelectFuzzConfigs(t *testing.T) {
-	bpf, bpfKmsan, net, mainline := &api.KernelFuzzConfig{},
+	bpf, bpfKmsan, net, fs, mainline := &api.KernelFuzzConfig{},
+		&api.KernelFuzzConfig{},
 		&api.KernelFuzzConfig{},
 		&api.KernelFuzzConfig{},
 		&api.KernelFuzzConfig{}
@@ -25,6 +26,11 @@ func TestSelectFuzzConfigs(t *testing.T) {
 			Campaigns:  []*api.KernelFuzzConfig{net},
 		},
 		{
+			EmailLists:  []string{"fs@list"},
+			PathRegexps: []string{"^fs/|include/linux/fs"},
+			Campaigns:   []*api.KernelFuzzConfig{fs},
+		},
+		{
 			EmailLists: nil,
 			Campaigns:  []*api.KernelFuzzConfig{mainline},
 		},
@@ -35,19 +41,44 @@ func TestSelectFuzzConfigs(t *testing.T) {
 		series   *api.Series
 	}{
 		{
-			testName: "select-one",
+			testName: "select-by-email",
 			result:   []*api.KernelFuzzConfig{net},
 			series:   &api.Series{Cc: []string{"net@list"}},
 		},
 		{
-			testName: "select-both",
+			testName: "select-both-by-email",
 			result:   []*api.KernelFuzzConfig{bpf, bpfKmsan, net},
 			series:   &api.Series{Cc: []string{"bpf@list", "net@list"}},
 		},
 		{
-			testName: "fallback",
+			testName: "select-by-path-only",
+			result:   []*api.KernelFuzzConfig{fs},
+			series: &api.Series{
+				Cc: []string{"unknown@list"},
+				Patches: []api.SeriesPatch{
+					{Body: []byte("diff --git a/fs/ext4/super.c b/fs/ext4/super.c\n--- a/fs/ext4/super.c\n+++ b/fs/ext4/super.c\n")},
+				},
+			},
+		},
+		{
+			testName: "select-by-email-and-path",
+			result:   []*api.KernelFuzzConfig{net, fs},
+			series: &api.Series{
+				Cc: []string{"net@list"},
+				Patches: []api.SeriesPatch{
+					{Body: []byte("diff --git a/fs/ext4/super.c b/fs/ext4/super.c\n--- a/fs/ext4/super.c\n+++ b/fs/ext4/super.c\n")},
+				},
+			},
+		},
+		{
+			testName: "fallback-when-neither-matches",
 			result:   []*api.KernelFuzzConfig{mainline},
-			series:   &api.Series{Cc: []string{"unknown@list"}},
+			series: &api.Series{
+				Cc: []string{"unknown@list"},
+				Patches: []api.SeriesPatch{
+					{Body: []byte("diff --git a/mm/vma.c b/mm/vma.c\n--- a/mm/vma.c\n+++ b/mm/vma.c\n")},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Selecting fuzzing targets solely based on Cc'd mailing lists can miss relevant campaigns when authors do not include subsystem mailing lists in their patch submission.

Add path_regexps to fuzz triage target configurations so targets can match by modified file paths in addition to email lists. Extract and deduplicate modified file paths from patch diffs in Series.ModifiedFiles, and update target selection to trigger if either the email list matches or any modified file matches the target's path regexps.