### PR TITLE
pkg/aflow/syzspec: sanitize filesystem errors in syzfs

### DIFF
--- a/pkg/aflow/syzspec/syzfs.go
+++ b/pkg/aflow/syzspec/syzfs.go
@@ -6,6 +6,7 @@
 package syzspec
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path"
@@ -79,27 +80,29 @@ func (s sysDirFS) resolvePath(name string) string {
 }
 
 func (s sysDirFS) Open(name string) (fs.File, error) {
-	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
-	}
-	fullPath := s.resolvePath(name)
-	return os.Open(fullPath)
+	return withResolvedPath(s, name, "open", func(p string) (fs.File, error) {
+		return os.Open(p)
+	})
 }
 
 func (s sysDirFS) ReadFile(name string) ([]byte, error) {
-	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrInvalid}
-	}
-	fullPath := s.resolvePath(name)
-	return os.ReadFile(fullPath)
+	return withResolvedPath[[]byte](s, name, "readfile", os.ReadFile)
 }
 
 func (s sysDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return withResolvedPath[[]fs.DirEntry](s, name, "readdir", os.ReadDir)
+}
+
+func withResolvedPath[T any](s sysDirFS, name, op string, fn func(string) (T, error)) (T, error) {
 	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+		var zero T
+		return zero, &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
 	}
-	fullPath := s.resolvePath(name)
-	return os.ReadDir(fullPath)
+	res, err := fn(s.resolvePath(name))
+	if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+		pathErr.Path = name
+	}
+	return res, err
 }
 
 // CleanPath normalizes the given file path by removing redundant elements,
@@ -120,12 +123,14 @@ func (s *SyzFS) CleanPath(file string) string {
 	if isLocalSyzFile(cleaned) {
 		return cleaned
 	}
-	if suffix, ok := strings.CutPrefix(cleaned, "sys/"+s.osTarget+"/"); ok {
-		cleaned = suffix
-	} else if suffix, ok := strings.CutPrefix(cleaned, s.osTarget+"/"); ok {
-		cleaned = suffix
-	} else if suffix, ok := strings.CutPrefix(cleaned, "sys/"); ok {
-		cleaned = suffix
+	for _, prefix := range []string{"sys/" + s.osTarget, s.osTarget, "sys"} {
+		if suffix, ok := strings.CutPrefix(cleaned, prefix+"/"); ok {
+			cleaned = suffix
+			break
+		} else if cleaned == prefix {
+			cleaned = ""
+			break
+		}
 	}
 	return cleaned
 }

--- a/pkg/aflow/tool/syzlang/spec_test.go
+++ b/pkg/aflow/tool/syzlang/spec_test.go
@@ -216,3 +216,29 @@ func TestValidateFilePath(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanPath_TrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	syzFS := syzspec.NewSyzFS(syzkallerRepoRoot(t), "linux")
+
+	require.Equal(t, "", syzFS.CleanPath("sys/linux/"))
+	require.Equal(t, "", syzFS.CleanPath("sys/linux"))
+	require.Equal(t, "vusb.txt", syzFS.CleanPath("sys/linux/vusb.txt"))
+	require.Equal(t, "test/vusb_hid", syzFS.CleanPath("sys/linux/test/vusb_hid"))
+}
+
+func TestSanitizeError_NoHostPathLeak(t *testing.T) {
+	t.Parallel()
+
+	state := specToolsState{
+		SyzFS: syzspec.NewSyzFS(syzkallerRepoRoot(t), "linux"),
+	}
+
+	_, err := syzGrepper(nil, state, syzGrepperArgs{
+		PathPrefix: "test/non_existent_dir",
+		Expression: "SECONDARY_EXEC_SHADOW_VMCS",
+	})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), syzkallerRepoRoot(t))
+}


### PR DESCRIPTION
Wrap filesystem operations in a runOS helper to rewrite *os.PathError path fields and prevent leaking host directory structures.
