### PR TITLE
pkg/instance: pass target VM arch to syz-execprog

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -261,7 +261,8 @@ func (inst *ExecProgInstance) RunSyzProgFile(progFile string, opts RunOptions) (
 		return nil, &TestError{Title: fmt.Sprintf("failed to copy prog to VM: %v", err)}
 	}
 	command := ExecprogCmd(inst.execprogBin, inst.executorBin, inst.mgrCfg.TargetOS, inst.mgrCfg.TargetArch,
-		inst.mgrCfg.Type, opts.Opts, !inst.OldFlagsCompatMode, inst.mgrCfg.Timeouts.Slowdown, coverFile, vmProgFile)
+		inst.mgrCfg.TargetVMArch, inst.mgrCfg.Type, opts.Opts, !inst.OldFlagsCompatMode,
+		inst.mgrCfg.Timeouts.Slowdown, coverFile, vmProgFile)
 	res, err := inst.runCommand(command, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -489,7 +489,7 @@ func (inst *inst) csourceOptions() (csource.Options, error) {
 
 // ExecprogCmd returns the command to run execprog.
 // nolint:revive
-func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Options,
+func ExecprogCmd(execprog, executor, OS, arch, vmArch, vmType string, opts csource.Options,
 	optionalFlags bool, slowdown int, coverFile, progFile string) string {
 	repeatCount := 1
 	if opts.Repeat {
@@ -512,11 +512,15 @@ func ExecprogCmd(execprog, executor, OS, arch, vmType string, opts csource.Optio
 			opts.FaultCall, opts.FaultNth)
 	}
 	if optionalFlags {
-		optionalArg += " " + tool.OptionalFlags([]tool.Flag{
+		optFlags := []tool.Flag{
 			{Name: "slowdown", Value: fmt.Sprint(slowdown)},
 			{Name: "sandbox_arg", Value: fmt.Sprint(opts.SandboxArg)},
 			{Name: "type", Value: fmt.Sprint(vmType)},
-		})
+		}
+		if vmArch != "" && vmArch != arch {
+			optFlags = append(optFlags, tool.Flag{Name: "vmarch", Value: vmArch})
+		}
+		optionalArg += " " + tool.OptionalFlags(optFlags)
 	}
 	coverArg := ""
 	if coverFile != "" {

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -39,7 +39,7 @@ func TestExecprogCmd(t *testing.T) {
 	flagSandbox := flags.String("sandbox", "none", "sandbox for fuzzing (none/setuid/namespace/android)")
 	flagSlowdown := flags.Int("slowdown", 1, "")
 	flagSandboxArg := flags.Int("sandbox_arg", 0, "argument for sandbox runner to adjust it via config")
-	cmdLine := ExecprogCmd(os.Args[0], "/myexecutor", targets.FreeBSD, targets.I386, "vmtype",
+	cmdLine := ExecprogCmd(os.Args[0], "/myexecutor", targets.FreeBSD, targets.I386, targets.AMD64, "vmtype",
 		csource.Options{
 			Sandbox:    "namespace",
 			SandboxArg: 3,

--- a/tools/syz-execprog/execprog.go
+++ b/tools/syz-execprog/execprog.go
@@ -38,6 +38,7 @@ import (
 var (
 	flagOS         = flag.String("os", runtime.GOOS, "target os")
 	flagArch       = flag.String("arch", runtime.GOARCH, "target arch")
+	flagVMArch     = flag.String("vmarch", "", "target VM arch (if different from -arch)")
 	flagType       = flag.String("type", "", "target VM type")
 	flagCoverFile  = flag.String("coverfile", "", "write coverage to the file")
 	flagRepeat     = flag.Int("repeat", 1, "repeat execution that many times (0 for infinite loop)")
@@ -164,6 +165,11 @@ func main() {
 		},
 	}
 
+	vmArch := *flagVMArch
+	if vmArch == "" {
+		vmArch = target.Arch
+	}
+
 	cfg := &rpcserver.LocalConfig{
 		Config: rpcserver.Config{
 			Config: vminfo.Config{
@@ -176,6 +182,7 @@ func main() {
 				Sandbox:    sandbox,
 				SandboxArg: int64(*flagSandboxArg),
 			},
+			VMArch:   vmArch,
 			Procs:    *flagProcs,
 			Slowdown: *flagSlowdown,
 		},


### PR DESCRIPTION
When testing 32-on-64 compat targets (like linux/amd64/386), syz-executor needs to know the underlying kernel is 64-bit so that it initializes KCOV via KCOV_INIT_TRACE64 instead of KCOV_INIT_TRACE32.

Standalone syz-execprog lacked a -vmarch flag and defaulted to TargetArch (386), causing rpcserver.RunLocal to report a 32-bit kernel and failing coverage initialization with ENOTTY.

Add the -vmarch flag to syz-execprog and pass it from ExecprogCmd via OptionalFlags when vmArch differs from arch.