### PR TITLE
dashboard/app: allow selecting target manager for repro workflows

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -1596,6 +1596,7 @@ func apiAITrajectoryLog(ctx context.Context, req *dashapi.AITrajectoryReq) (any,
 type uiWorkflow struct {
 	Name             string
 	CustomBaseCommit bool
+	SelectManager    bool
 }
 
 // aiBugWorkflows returns active workflows that are applicable for the bug.
@@ -1612,6 +1613,7 @@ func aiBugWorkflows(ctx context.Context, bug *Bug) ([]*uiWorkflow, error) {
 			result = append(result, &uiWorkflow{
 				Name:             flow.Name,
 				CustomBaseCommit: flow.Type == ai.WorkflowPatching,
+				SelectManager:    flow.Type == ai.WorkflowReproC || flow.Type == ai.WorkflowRepro,
 			})
 		}
 	}
@@ -1675,6 +1677,16 @@ func bugJobCreate(ctx context.Context, workflow string, typ ai.WorkflowType, bug
 		"BaseRepository":  cfg.AI.BaseRepository,
 		"BaseBranch":      cfg.AI.BaseBranch,
 		"BaseCommit":      cfg.AI.BaseCommit,
+	}
+	if manager, ok := extraArgs["KernelConfigManager"].(string); ok && manager != "" {
+		manager, _ = activeManager(ctx, manager, bug.Namespace)
+		mgrBuild, err := lastManagerBuild(ctx, bug.Namespace, manager)
+		if err != nil {
+			return "", fmt.Errorf("failed to get manager build config: %w", err)
+		}
+		args["KernelConfigID"] = mgrBuild.KernelConfig
+		args["KernelConfigManager"] = manager
+		args["TargetArch"] = mgrBuild.Arch
 	}
 	maps.Copy(args, extraArgs)
 	return aidb.CreateJob(ctx, &aidb.Job{

--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -58,6 +58,10 @@ func (p *uiAIJobsPage) IsAdmin() bool {
 	return p.Header.Admin
 }
 
+func (p *uiAIJobsPage) ShowTestOnManager() bool {
+	return false
+}
+
 type ManualWorkflowSpec struct {
 	Name        string
 	Type        ai.WorkflowType
@@ -214,6 +218,10 @@ func (p *uiAIJobPage) GetJobs() []*uiAIJob {
 
 func (p *uiAIJobPage) IsAdmin() bool {
 	return p.Header.Admin
+}
+
+func (p *uiAIJobPage) ShowTestOnManager() bool {
+	return p.Header.AIActions
 }
 
 type uiAIJobDetails struct {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1109,6 +1109,10 @@ func TestAIReproCJobCreateFromBugPage(t *testing.T) {
 
 	build := testBuild(1)
 	c.aiClient.UploadBuild(build)
+	build2 := testBuild(2)
+	build2.Manager = "manager2"
+	build2.Arch = "arm64"
+	c.aiClient.UploadBuild(build2)
 	crash := testCrashWithRepro(build, 1)
 	c.aiClient.ReportCrash(crash)
 	extID := c.aiClient.pollEmailExtID()
@@ -1119,6 +1123,7 @@ func TestAIReproCJobCreateFromBugPage(t *testing.T) {
 	jobCreateURL := fmt.Sprintf("/bug?id=%v", bug.keyHash(c.ctx))
 	values := url.Values{}
 	values.Set("ai-job-create", "repro-c")
+	values.Set("KernelConfigManager", "manager2")
 	_, err := c.AuthPOSTForm(AccessUser, jobCreateURL, values)
 	require.NoError(t, err)
 
@@ -1127,6 +1132,9 @@ func TestAIReproCJobCreateFromBugPage(t *testing.T) {
 	require.Equal(t, "repro-c", resp.Workflow)
 
 	require.Equal(t, "title1\n\nreport1", resp.Args["BugDescription"])
+	require.Equal(t, "manager2", resp.Args["KernelConfigManager"])
+	require.Equal(t, "config2", resp.Args["KernelConfig"])
+	require.Equal(t, "arm64", resp.Args["TargetArch"])
 }
 
 func TestAIJobRestart(t *testing.T) {

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -2025,7 +2025,12 @@ func handleTestReproCRequest(ctx context.Context, args *testReproCReqArgs) (*Job
 	if existing := findDuplicateTestReproCJob(ctx, args.bugKey, manager, args.reproC); existing != nil {
 		return existing, nil
 	}
-	build, err := loadBuild(ctx, args.bug.Namespace, crash.BuildID)
+	var build *Build
+	if manager != "" {
+		build, err = lastManagerBuild(ctx, args.bug.Namespace, manager)
+	} else {
+		build, err = loadBuild(ctx, args.bug.Namespace, crash.BuildID)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to load build: %w", err)
 	}
@@ -2037,7 +2042,7 @@ func handleTestReproCRequest(ctx context.Context, args *testReproCReqArgs) (*Job
 			bug:     args.bug,
 			bugKey:  args.bugKey,
 			user:    args.user,
-			manager: targetMgr,
+			manager: manager,
 			repo:    build.KernelRepo,
 			branch:  build.KernelBranch,
 			reproC:  args.reproC,

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -316,6 +316,10 @@ func (p *uiBugPage) IsAdmin() bool {
 	return p.Header.Admin
 }
 
+func (p *uiBugPage) ShowTestOnManager() bool {
+	return p.Header.AIActions
+}
+
 type uiBugDetails struct {
 	*uiBug
 	// If DupOf is not nil, uiBug is a duplicate of DupOf.

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -306,6 +306,8 @@ type uiBugPage struct {
 	PatchVersions   []*uiPatchVersion
 	AIWorkflows     []*uiWorkflow
 	AIJobs          []*uiAIJob
+	Managers        []string
+	DefaultManager  string
 }
 
 func (p *uiBugPage) GetJobs() []*uiAIJob {
@@ -1245,16 +1247,24 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 			return err
 		}
 	}
+	managers, err := CachedManagerList(ctx, bug.Namespace)
+	if err != nil {
+		return err
+	}
+	slices.Sort(managers)
+
 	data := &uiBugPage{
-		Header:        hdr,
-		Now:           timeNow(ctx),
-		Sections:      sections,
-		LabelGroups:   getLabelGroups(ctx, bug),
-		Crashes:       crashesTable,
-		Bug:           bugDetails,
-		PatchVersions: patchVersions,
-		AIWorkflows:   aiWorkflows,
-		AIJobs:        aiJobs,
+		Header:         hdr,
+		Now:            timeNow(ctx),
+		Sections:       sections,
+		LabelGroups:    getLabelGroups(ctx, bug),
+		Crashes:        crashesTable,
+		Bug:            bugDetails,
+		PatchVersions:  patchVersions,
+		AIWorkflows:    aiWorkflows,
+		AIJobs:         aiJobs,
+		Managers:       managers,
+		DefaultManager: bugDefaultManager(ctx, bug, bugDetails),
 	}
 	if accessLevel == AccessAdmin && !bug.hasUserSubsystems() {
 		data.DebugSubsystems = urlutil.SetParam(data.Bug.Link, "debug_subsystems", "1")
@@ -1275,6 +1285,17 @@ func handleBug(ctx context.Context, w http.ResponseWriter, r *http.Request) erro
 	}
 
 	return serveTemplate(w, "bug.html", data)
+}
+
+func bugDefaultManager(ctx context.Context, bug *Bug, bugDetails *uiBugDetails) string {
+	defaultManager := ""
+	if len(bugDetails.Crashes) > 0 {
+		defaultManager = bugDetails.Crashes[0].Manager
+	} else if len(bug.HappenedOn) > 0 {
+		defaultManager = bug.HappenedOn[0]
+	}
+	manager, _ := activeManager(ctx, defaultManager, bug.Namespace)
+	return manager
 }
 
 func handleBugJobCreate(ctx context.Context, r *http.Request, hdr *uiHeader,
@@ -1330,6 +1351,9 @@ func parseAIJobArgs(r *http.Request, workflow string, aiWorkflows []*uiWorkflow)
 			return nil, fmt.Errorf("custom base commit is empty")
 		}
 		args["BaseCommit"] = r.FormValue("base_commit")
+	}
+	if selected != nil && selected.SelectManager && r.FormValue("KernelConfigManager") != "" {
+		args["KernelConfigManager"] = r.FormValue("KernelConfigManager")
 	}
 	return args, nil
 }

--- a/dashboard/app/templates/bug.html
+++ b/dashboard/app/templates/bug.html
@@ -50,7 +50,9 @@ Page with details about a single bug.
 		<form method="POST">
 			<select name="ai-job-create" onchange="displayAICreateJobArgs(this)">
 				{{range $flow := .AIWorkflows}}
-					<option value="{{$flow.Name}}" {{if $flow.CustomBaseCommit}}data-custom-base-commit="true" {{end}}>{{$flow.Name}}
+					<option value="{{$flow.Name}}"
+						{{if $flow.CustomBaseCommit}}data-custom-base-commit="true" {{end}}
+						{{if $flow.SelectManager}}data-select-manager="true" {{end}}>{{$flow.Name}}
 					</option>
 				{{end}}
 			</select>
@@ -64,6 +66,14 @@ Page with details about a single bug.
 				<input type="text" name="base_commit" id="base_commit_input" style="display: none" size="40"
 					placeholder="Base commit hash"
 					value="{{with index .Crashes.Crashes 0}}{{.KernelCommit}}{{end}}">
+			</span>
+			<span id="ai-set-manager" class="ai-create-job-args" style="display: none">
+				<label for="ai-manager-select">Manager:</label>
+				<select name="KernelConfigManager" id="ai-manager-select">
+					{{range $m := .Managers}}
+						<option value="{{$m}}" {{if eq $m $.DefaultManager}}selected{{end}}>{{$m}}</option>
+					{{end}}
+				</select>
 			</span>
 			<input type="submit" value="✨ Create"/>
 		</form>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -769,7 +769,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					<span>{{$res.Name}}: {{if $res.Value}}✅{{else}}❌{{end}}</span>
 				{{end}}
 			{{end}}
-			{{if $job.CanTestOnManager}}
+			{{if and $.ShowTestOnManager $job.CanTestOnManager}}
 				<form action="/ai_job" method="POST" style="display:inline-block; margin-left: 5px;">
 					<input type="hidden" name="id" value="{{$job.ID}}">
 					<input type="hidden" name="action" value="test_repro_c">

--- a/pkg/html/pages/common.js
+++ b/pkg/html/pages/common.js
@@ -121,10 +121,17 @@ document.addEventListener("DOMContentLoaded", function () {
 
 function displayAICreateJobArgs(select) {
 	if (!select) select = document.querySelector('select[name="ai-job-create"]');
-	var args = document.getElementById('ai-set-base-commit');
-	if (!select || !args) return;
+	if (!select) return;
 
-	args.style.display = select.options[select.selectedIndex].getAttribute('data-custom-base-commit') ? 'inline' : 'none';
+	var opt = select.options[select.selectedIndex];
+	var args = document.getElementById('ai-set-base-commit');
+	if (args) {
+		args.style.display = opt && opt.getAttribute('data-custom-base-commit') ? 'inline' : 'none';
+	}
+	var mgr = document.getElementById('ai-set-manager');
+	if (mgr) {
+		mgr.style.display = opt && opt.getAttribute('data-select-manager') ? 'inline' : 'none';
+	}
 
 	var custom = document.getElementById('base_commit_custom');
 	var input = document.getElementById('base_commit_input');


### PR DESCRIPTION
When triggering reproducer generation workflows (repro and repro-c) from
a bug's page, the job previously defaulted to using the kernel config and
manager from the crash build. This prevented users from targeting specific
manager configurations (such as different architectures or sanitizers)
or testing the resulting reproducer on alternative managers.

Add a manager selection dropdown to the bug page AI workflow form for
repro and repro-c jobs, pre-selecting the active manager from the top
crash in the crash table. Use the selected manager's latest build config
when generating the reproducer, and route subsequent manager testing
jobs to that manager.