### PR TITLE
pkg/aflow: pass agent name in repro-c workflow

### DIFF
--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -11,6 +11,7 @@ import (
 )
 
 type RunCReproArgs struct {
+	AgentName       string
 	TargetArch      string
 	Syzkaller       string
 	Image           string
@@ -52,6 +53,7 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 
 	reproduceArgs := ReproduceArgs{
 		TargetConfig: TargetConfig{
+			AgentName:    args.AgentName,
 			TargetArch:   args.TargetArch,
 			Syzkaller:    args.Syzkaller,
 			Image:        args.Image,

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -24,6 +24,7 @@ import (
 )
 
 type ReproCInputs struct {
+	AgentName      string
 	TargetOS       string
 	TargetArch     string
 	BugDescription string


### PR DESCRIPTION
GCE VM pool creation requires an instance name (env.Name). ReproCInputs and RunCReproArgs omitted AgentName, causing cfg.Name to remain empty and failing GCE VM pool initialization with "config param name is empty".

Pass AgentName through ReproCInputs and RunCReproArgs to TargetConfig.

***

Should fix cases like this:
https://syzkaller.appspot.com/ai_job?id=e51f7bd1-b9e1-4908-ab0a-73fcaff106d7