### PR TITLE
pkg/aflow/syzspec: consolidate SyzFS and simplify tool validation

### DIFF
--- a/pkg/aflow/syzspec/syzfs.go
+++ b/pkg/aflow/syzspec/syzfs.go
@@ -13,23 +13,22 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"github.com/google/syzkaller/pkg/aflow"
 )
 
 const autoTxt = "auto.txt"
 
-// IsAutoTxt reports whether name is an auto-generated description file ("auto.txt" or "auto.txt.const").
+// IsAutoTxt reports whether name or its base filename is an auto-generated description file
+// ("auto.txt" or "auto.txt.const").
 func IsAutoTxt(name string) bool {
-	return name == autoTxt || name == autoTxt+".const"
+	base := filepath.Base(filepath.ToSlash(name))
+	return base == autoTxt || base == autoTxt+".const"
 }
 
 // SyzFS provides a filesystem view of syzkaller files for a specific OS target
 // from local repository directories.
 type SyzFS struct {
-	fs.FS
-	osTarget      string
-	syzkallerPath string
+	syzkallerDir string
+	osTarget     string
 }
 
 // OSTarget returns the OS target for which syzkaller files are scoped in this SyzFS instance.
@@ -39,13 +38,7 @@ func (s *SyzFS) OSTarget() string {
 
 // SyzkallerPath returns the root syzkaller directory for this SyzFS instance.
 func (s *SyzFS) SyzkallerPath() string {
-	return s.syzkallerPath
-}
-
-// ReadDir reads the named directory from the SyzFS filesystem, returning all
-// its directory entries.
-func (s *SyzFS) ReadDir(dir string) ([]fs.DirEntry, error) {
-	return fs.ReadDir(s.FS, dir)
+	return s.syzkallerDir
 }
 
 // NewSyzFS creates a SyzFS instance for the given syzkaller directory and OS target.
@@ -57,21 +50,12 @@ func NewSyzFS(syzkallerDir, osTarget string) *SyzFS {
 	}
 
 	return &SyzFS{
-		FS: sysDirFS{
-			syzkallerDir: syzkallerDir,
-			osTarget:     normalizedOS,
-		},
-		osTarget:      normalizedOS,
-		syzkallerPath: syzkallerDir,
+		syzkallerDir: syzkallerDir,
+		osTarget:     normalizedOS,
 	}
 }
 
-type sysDirFS struct {
-	syzkallerDir string
-	osTarget     string
-}
-
-func (s sysDirFS) resolvePath(name string) string {
+func (s *SyzFS) resolvePath(name string) string {
 	name = filepath.ToSlash(filepath.Clean(name))
 	if isLocalSyzFile(name) {
 		return filepath.Join(s.syzkallerDir, name)
@@ -79,30 +63,44 @@ func (s sysDirFS) resolvePath(name string) string {
 	return filepath.Join(s.syzkallerDir, "sys", s.osTarget, name)
 }
 
-func (s sysDirFS) Open(name string) (fs.File, error) {
+func withResolvedPath[T any](s *SyzFS, name, op string, fn func(string) (T, error)) (T, error) {
+	if !fs.ValidPath(name) {
+		var zero T
+		return zero, &fs.PathError{Op: op, Path: name, Err: errors.New("invalid file path")}
+	}
+	resolved := s.resolvePath(name)
+	if IsAutoTxt(resolved) {
+		var zero T
+		return zero, &fs.PathError{
+			Op:   op,
+			Path: name,
+			Err:  errors.New("access to auto.txt or auto.txt.const is disallowed"),
+		}
+	}
+	res, err := fn(resolved)
+	if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+		pathErr.Path = name
+	}
+	return res, err
+}
+
+// Open opens the named file from the SyzFS filesystem.
+func (s *SyzFS) Open(name string) (fs.File, error) {
 	return withResolvedPath(s, name, "open", func(p string) (fs.File, error) {
 		return os.Open(p)
 	})
 }
 
-func (s sysDirFS) ReadFile(name string) ([]byte, error) {
-	return withResolvedPath[[]byte](s, name, "readfile", os.ReadFile)
+// ReadFile reads and returns the contents of the file at the specified path from the SyzFS filesystem.
+// It validates and cleans the path before reading.
+func (s *SyzFS) ReadFile(file string) ([]byte, error) {
+	return withResolvedPath[[]byte](s, s.CleanPath(file), "readfile", os.ReadFile)
 }
 
-func (s sysDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+// ReadDir reads the named directory from the SyzFS filesystem, returning all
+// its directory entries.
+func (s *SyzFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return withResolvedPath[[]fs.DirEntry](s, name, "readdir", os.ReadDir)
-}
-
-func withResolvedPath[T any](s sysDirFS, name, op string, fn func(string) (T, error)) (T, error) {
-	if !fs.ValidPath(name) {
-		var zero T
-		return zero, &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
-	}
-	res, err := fn(s.resolvePath(name))
-	if pathErr, ok := errors.AsType[*os.PathError](err); ok {
-		pathErr.Path = name
-	}
-	return res, err
 }
 
 // CleanPath normalizes the given file path by removing redundant elements,
@@ -113,8 +111,8 @@ func (s *SyzFS) CleanPath(file string) string {
 		return ""
 	}
 	cleaned := filepath.Clean(file)
-	if filepath.IsAbs(cleaned) && s.syzkallerPath != "" {
-		rel, err := filepath.Rel(s.syzkallerPath, cleaned)
+	if filepath.IsAbs(cleaned) && s.syzkallerDir != "" {
+		rel, err := filepath.Rel(s.syzkallerDir, cleaned)
 		if err == nil && !strings.HasPrefix(rel, "..") {
 			cleaned = rel
 		}
@@ -133,26 +131,6 @@ func (s *SyzFS) CleanPath(file string) string {
 		}
 	}
 	return cleaned
-}
-
-// ReadFile reads and returns the contents of the file at the specified path from the SyzFS filesystem.
-// It validates and cleans the path before reading.
-func (s *SyzFS) ReadFile(file string) ([]byte, error) {
-	cleanedFile := s.CleanPath(file)
-
-	if strings.HasPrefix(cleanedFile, "..") || filepath.IsAbs(cleanedFile) {
-		return nil, aflow.BadCallError("invalid file path %q", file)
-	}
-
-	// Disallow auto.txt or auto.txt.const.
-	if IsAutoTxt(cleanedFile) {
-		return nil, aflow.BadCallError("access to auto.txt or auto.txt.const is disallowed")
-	}
-
-	if cleanedFile == "" {
-		return nil, nil
-	}
-	return fs.ReadFile(s.FS, cleanedFile)
 }
 
 // DescriptionFiles returns the list of syzlang description files (e.g. sys.txt)
@@ -190,7 +168,13 @@ func (s *SyzFS) TestSeeds() []string {
 	return files
 }
 
+var localSyzDirs = []string{"executor", "docs"}
+
 func isLocalSyzFile(file string) bool {
-	return file == "executor" || strings.HasPrefix(file, "executor/") ||
-		file == "docs" || strings.HasPrefix(file, "docs/")
+	for _, dir := range localSyzDirs {
+		if file == dir || strings.HasPrefix(file, dir+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/aflow/syzspec/syzlang_test.go
+++ b/pkg/aflow/syzspec/syzlang_test.go
@@ -4,11 +4,14 @@
 package syzspec
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/google/syzkaller/sys"
 )
 
 func TestCombineSyzPrograms(t *testing.T) {
@@ -57,18 +60,24 @@ func TestCombineSyzPrograms(t *testing.T) {
 func TestBaseSeedCallCount(t *testing.T) {
 	t.Parallel()
 
-	count, err := BaseSeedCallCount(nil, "amd64")
-	require.NoError(t, err)
-	require.Equal(t, 0, count)
+	tests := []struct {
+		name     string
+		progData []byte
+		want     int
+	}{
+		{name: "nil data", progData: nil, want: 0},
+		{name: "empty data", progData: []byte(""), want: 0},
+		{name: "single call", progData: []byte("getpid()\n"), want: 1},
+	}
 
-	count, err = BaseSeedCallCount([]byte(""), "amd64")
-	require.NoError(t, err)
-	require.Equal(t, 0, count)
-
-	progData := []byte("getpid()\n")
-	count, err = BaseSeedCallCount(progData, "amd64")
-	require.NoError(t, err)
-	require.Equal(t, 1, count)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			count, err := BaseSeedCallCount(tt.progData, "amd64")
+			require.NoError(t, err)
+			require.Equal(t, tt.want, count)
+		})
+	}
 }
 
 func TestSyzFS(t *testing.T) {
@@ -143,8 +152,192 @@ func TestBaseTestSeedLoad(t *testing.T) {
 
 func TestIsAutoTxt(t *testing.T) {
 	t.Parallel()
-	require.True(t, IsAutoTxt("auto.txt"))
-	require.True(t, IsAutoTxt("auto.txt.const"))
-	require.False(t, IsAutoTxt("sys.txt"))
-	require.False(t, IsAutoTxt("auto.txt.foo"))
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "auto.txt", want: true},
+		{path: "auto.txt.const", want: true},
+		{path: "test/auto.txt", want: true},
+		{path: "test/auto.txt.const", want: true},
+		{path: "sys/linux/auto.txt", want: true},
+		{path: "/abs/path/sys/linux/auto.txt", want: true},
+		{path: "sys.txt", want: false},
+		{path: "auto.txt.foo", want: false},
+		{path: "test/auto.txt.foo", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, IsAutoTxt(tt.path))
+		})
+	}
+}
+
+func TestCleanPath(t *testing.T) {
+	t.Parallel()
+
+	syzDir := "/tmp/mock_syzkaller"
+	syzFS := NewSyzFS(syzDir, "linux")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty path", input: "", expected: ""},
+		{name: "bare description file", input: "sys.txt", expected: "sys.txt"},
+		{name: "bare const file", input: "sys.txt.const", expected: "sys.txt.const"},
+		{name: "virtual seed path", input: "test/syz_mount_0", expected: "test/syz_mount_0"},
+		{name: "local executor file", input: "executor/common.h", expected: "executor/common.h"},
+		{name: "local docs file", input: "docs/linux/kernel.md", expected: "docs/linux/kernel.md"},
+		{name: "sys/linux prefix", input: "sys/linux/sys.txt", expected: "sys.txt"},
+		{name: "sys/linux test prefix", input: "sys/linux/test/seed1.txt", expected: "test/seed1.txt"},
+		{name: "os target prefix", input: "linux/sys.txt", expected: "sys.txt"},
+		{name: "sys prefix only", input: "sys/sys.txt", expected: "sys.txt"},
+		{
+			name:     "absolute path under repo root for description",
+			input:    filepath.Join(syzDir, "sys", "linux", "sys.txt"),
+			expected: "sys.txt",
+		},
+		{
+			name:     "absolute path under repo root for test seed",
+			input:    filepath.Join(syzDir, "sys", "linux", "test", "seed1.txt"),
+			expected: "test/seed1.txt",
+		},
+		{
+			name:     "absolute path under repo root for docs",
+			input:    filepath.Join(syzDir, "docs", "guide.md"),
+			expected: "docs/guide.md",
+		},
+		{
+			name:     "absolute path under repo root for executor",
+			input:    filepath.Join(syzDir, "executor", "common.h"),
+			expected: "executor/common.h",
+		},
+		{name: "relative traversal path", input: "../sys.txt", expected: "../sys.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := syzFS.CleanPath(tt.input)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSyzFS_VirtualFileSystem(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sysLinux := filepath.Join(tmpDir, "sys", "linux")
+	sysLinuxTest := filepath.Join(sysLinux, "test")
+	executorDir := filepath.Join(tmpDir, "executor")
+	docsDir := filepath.Join(tmpDir, "docs")
+
+	require.NoError(t, os.MkdirAll(sysLinuxTest, 0755))
+	require.NoError(t, os.MkdirAll(executorDir, 0755))
+	require.NoError(t, os.MkdirAll(docsDir, 0755))
+
+	// Setup mock files across virtual locations.
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinux, "sys.txt"), []byte("sys content"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinux, "sys.txt.const"), []byte("SYS_CONST = 1"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinuxTest, "seed1.txt"), []byte("seed data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(executorDir, "common.h"), []byte("common header"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(docsDir, "guide.md"), []byte("guide doc"), 0644))
+
+	syzFS := NewSyzFS(tmpDir, "linux")
+	require.Equal(t, "linux", syzFS.OSTarget())
+	require.Equal(t, tmpDir, syzFS.SyzkallerPath())
+
+	// 1. Root description files.
+	data, err := syzFS.ReadFile("sys.txt")
+	require.NoError(t, err)
+	require.Equal(t, "sys content", string(data))
+
+	dataConst, err := syzFS.ReadFile("sys.txt.const")
+	require.NoError(t, err)
+	require.Equal(t, "SYS_CONST = 1", string(dataConst))
+
+	// 2. Test seeds.
+	dataSeed, err := syzFS.ReadFile("test/seed1.txt")
+	require.NoError(t, err)
+	require.Equal(t, "seed data", string(dataSeed))
+
+	// 3. Executor headers.
+	dataExec, err := syzFS.ReadFile("executor/common.h")
+	require.NoError(t, err)
+	require.Equal(t, "common header", string(dataExec))
+
+	// 4. Docs.
+	dataDoc, err := syzFS.ReadFile("docs/guide.md")
+	require.NoError(t, err)
+	require.Equal(t, "guide doc", string(dataDoc))
+
+	// 5. Directory listings.
+	entries, err := syzFS.ReadDir(".")
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	require.Contains(t, names, "sys.txt")
+	require.Contains(t, names, "sys.txt.const")
+	require.Contains(t, names, "test")
+
+	testEntries, err := syzFS.ReadDir("test")
+	require.NoError(t, err)
+	require.Len(t, testEntries, 1)
+	require.Equal(t, "seed1.txt", testEntries[0].Name())
+
+	// 6. fs.Stat and fs.WalkDir compatibility.
+	testStat, err := fs.Stat(syzFS, "test")
+	require.NoError(t, err)
+	require.True(t, testStat.IsDir())
+
+	// 7. Non-existent files.
+	_, errMissing := syzFS.ReadFile("nonexistent.txt")
+	require.Error(t, errMissing)
+}
+
+func TestSyzFS_SecurityAndRestrictions(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sysLinux := filepath.Join(tmpDir, "sys", "linux")
+	sysLinuxTest := filepath.Join(sysLinux, "test")
+	docsDir := filepath.Join(tmpDir, "docs")
+	require.NoError(t, os.MkdirAll(sysLinuxTest, 0755))
+	require.NoError(t, os.MkdirAll(docsDir, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinux, "auto.txt"), []byte("auto"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinux, "auto.txt.const"), []byte("auto const"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sysLinuxTest, "auto.txt"), []byte("auto in test"), 0644))
+
+	syzFS := NewSyzFS(tmpDir, "linux")
+
+	disallowedPaths := []struct {
+		name string
+		path string
+	}{
+		{name: "disallow auto.txt", path: "auto.txt"},
+		{name: "disallow auto.txt.const", path: "auto.txt.const"},
+		{name: "disallow auto.txt in subdirectories", path: "test/auto.txt"},
+		{name: "disallow parent traversal", path: "../sys.txt"},
+		{name: "disallow docs traversal", path: "docs/../passwd.md"},
+		{name: "disallow executor traversal", path: "executor/../../etc/passwd"},
+		{name: "disallow test traversal", path: "test/../../sys.txt"},
+		{name: "disallow absolute path", path: "/etc/passwd"},
+	}
+
+	for _, tt := range disallowedPaths {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := syzFS.ReadFile(tt.path)
+			require.Error(t, err)
+		})
+	}
 }

--- a/pkg/aflow/tool/syzlang/spec.go
+++ b/pkg/aflow/tool/syzlang/spec.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -122,32 +121,6 @@ func syzGrepper(ctx *aflow.Context, state specToolsState, args syzGrepperArgs) (
 	return syzGrepperResults{Output: res}, err
 }
 
-func validateFilePath(file string) error {
-	if file != "" {
-		cleaned := file
-		if suffix, ok := strings.CutPrefix(cleaned, "test/"); ok {
-			cleaned = suffix
-		} else if suffix, ok := strings.CutPrefix(cleaned, "executor/"); ok {
-			cleaned = suffix
-		} else if suffix, ok := strings.CutPrefix(cleaned, "docs/"); ok {
-			cleaned = suffix
-		}
-		if strings.Contains(cleaned, "..") || filepath.IsAbs(cleaned) {
-			return aflow.BadCallError("invalid file path %q", file)
-		}
-		if !strings.HasPrefix(file, "executor/") &&
-			!strings.HasPrefix(file, "docs/") &&
-			!strings.HasPrefix(file, "test/") &&
-			(strings.Contains(cleaned, "/") || strings.Contains(cleaned, "\\")) {
-			return aflow.BadCallError("invalid file path %q", file)
-		}
-		if syzspec.IsAutoTxt(cleaned) {
-			return aflow.BadCallError("access to auto.txt or auto.txt.const is disallowed")
-		}
-	}
-	return nil
-}
-
 func newScanner(f io.Reader) *bufio.Scanner {
 	scanner := bufio.NewScanner(f)
 	buf := make([]byte, 0, defaultScanBufferSize)
@@ -169,10 +142,8 @@ func resolveTargetFiles(syzFS *syzspec.SyzFS, file string) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if !d.IsDir() {
-				if err := validateFilePath(p); err == nil {
-					targetFiles = append(targetFiles, p)
-				}
+			if !d.IsDir() && !syzspec.IsAutoTxt(d.Name()) {
+				targetFiles = append(targetFiles, p)
 			}
 			return nil
 		})
@@ -185,10 +156,6 @@ func resolveTargetFiles(syzFS *syzspec.SyzFS, file string) ([]string, error) {
 }
 
 func grepSyzSpec(syzFS *syzspec.SyzFS, expression, file string) (string, error) {
-	if err := validateFilePath(file); err != nil {
-		return "", err
-	}
-
 	re, err := regexp.Compile(expression)
 	if err != nil {
 		return "", aflow.BadCallError("bad expression: %v", err)
@@ -346,9 +313,6 @@ func paginateSyzSpec(syzFS *syzspec.SyzFS, file string, firstLine,
 	lineCount int) (string, error) {
 	if file == "" {
 		return "", aflow.BadCallError("File must be provided")
-	}
-	if err := validateFilePath(file); err != nil {
-		return "", err
 	}
 
 	f, err := syzFS.Open(file)

--- a/pkg/aflow/tool/syzlang/spec_test.go
+++ b/pkg/aflow/tool/syzlang/spec_test.go
@@ -179,44 +179,6 @@ func TestSyzGrepper(t *testing.T) {
 	require.Equal(t, "No matches found.", resDotGrep.Output)
 }
 
-func TestValidateFilePath(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
-	}{
-		{name: "empty path", path: "", wantErr: false},
-		{name: "valid description file", path: "sys.txt", wantErr: false},
-		{name: "valid const file", path: "sys.txt.const", wantErr: false},
-		{name: "valid test file", path: "test/syz_mount_image_btrfs_0", wantErr: false},
-		{name: "valid executor file", path: "executor/common.h", wantErr: false},
-		{name: "valid docs file", path: "docs/linux/kernel.md", wantErr: false},
-		{name: "path traversal in root", path: "../sys.txt", wantErr: true},
-		{name: "path traversal inside test/", path: "test/../sys.txt", wantErr: true},
-		{name: "path traversal inside executor/", path: "executor/../../configs/something.conf", wantErr: true},
-		{name: "absolute path", path: "/etc/passwd", wantErr: true},
-		{name: "disallowed directory path without prefix", path: "sys/linux/sys.txt", wantErr: true},
-		{name: "backslash in unprefixed path", path: "sys\\sys.txt", wantErr: true},
-		{name: "auto.txt disallowed", path: "auto.txt", wantErr: true},
-		{name: "auto.txt.const disallowed", path: "auto.txt.const", wantErr: true},
-		{name: "auto.txt disallowed with test prefix", path: "test/auto.txt", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			err := validateFilePath(tt.path)
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestCleanPath_TrailingSlash(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
SyzFS previously wrapped an internal sysDirFS struct with duplicated configuration fields and split error handling across the filesystem and tool layers. Path validation in pkg/aflow/tool/syzlang/spec.go duplicated filesystem-level access checks, while SyzFS.ReadFile leaked LLM agent framework error types (aflow.BadCallError) into a foundational filesystem abstraction.

Unify sysDirFS directly into SyzFS, implement standard io/fs interfaces, resolve all virtual paths through a single canonical mapping, and decouple pkg/aflow/syzspec from package aflow.
