### PR TITLE
syz-ci: fix sandbox permission error when cloning job repo

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -685,6 +685,12 @@ func (jp *JobProcessor) initJobRepo(mgr *Manager, repoDir string) error {
 		return fmt.Errorf("failed to remove job repo dir: %w", err)
 	}
 	if osutil.IsExist(mgr.kernelBuildDir) {
+		if err := osutil.MkdirAll(repoDir); err != nil {
+			return fmt.Errorf("failed to create job repo dir: %w", err)
+		}
+		if err := osutil.SandboxChown(repoDir); err != nil {
+			return fmt.Errorf("failed to chown job repo dir: %w", err)
+		}
 		jp.Logf(0, "cloning job repo from %v using reference", mgr.kernelBuildDir)
 		cmd := exec.Command("git", "clone", "--reference", mgr.kernelBuildDir, mgr.kernelBuildDir, repoDir)
 		if err := osutil.Sandbox(cmd, true, false); err != nil {


### PR DESCRIPTION
I'm hoping this will fix #7760 

When initJobRepo clones the kernel repo using --reference, it runs git clone sandboxed under the unprivileged syzkaller user. Because the parent directory was created by root (0755), git clone fails to create the target work tree directory with "Permission denied", forcing syz-ci to always fall back to fetching from scratch.

Create the target directory and chown it to the sandbox user beforehand so that the sandboxed git clone process can write to it.