### PR TITLE
vm: allow ssh-rsa public key authentication

### DIFF
--- a/vm/vmimpl/util.go
+++ b/vm/vmimpl/util.go
@@ -90,6 +90,7 @@ func sshArgs(debug bool, sshKey, portArg string, port, forwardPort int, systemSS
 	}
 	args = append(args,
 		"-o", "BatchMode=yes",
+		"-o", "PubkeyAcceptedAlgorithms=+ssh-rsa",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "ConnectTimeout=10",
 	)


### PR DESCRIPTION
Allow the SSH client to use the legacy ssh-rsa public-key signature algorithm when connecting to guest VMs.

This restores compatibility with older guest images that only accept RSA/SHA-1 authentication, allowing them to remain usable as syzkaller fuzzing targets with modern OpenSSH clients.