### PR TITLE
pkg/rpcserver: avoid panic when closing uninitialized server

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -247,7 +247,10 @@ func (serv *server) Close() error {
 	serv.baseSource.Store(queue.Callback(func() *queue.Request {
 		return nil
 	}))
-	return serv.serv.Close()
+	if serv.serv != nil {
+		return serv.serv.Close()
+	}
+	return nil
 }
 
 func (serv *server) Setup() error {


### PR DESCRIPTION
Callers may execute server cleanup in deferred calls when an initialization error occurs before Setup() is called. Check that the underlying network listener exists before attempting to close it to allow safe and idempotent teardown.