### PR TITLE
dashboard/app: support subsystem-dependent embargo times

### DIFF
--- a/dashboard/app/config.go
+++ b/dashboard/app/config.go
@@ -372,6 +372,8 @@ type Reporting struct {
 	DailyLimit int
 	// Upstream reports into next reporting after this period.
 	Embargo time.Duration
+	// SubsystemEmbargo overrides/customizes the embargo duration for specific subsystems.
+	SubsystemEmbargo map[string]time.Duration
 	// Type of reporting and its configuration.
 	// The app has one built-in type, EmailConfig, which reports bugs by email.
 	// The user can implement other types to attach to external reporting systems (e.g. Bugzilla).
@@ -482,6 +484,25 @@ func (cfg *Config) ReportingByName(name string) *Reporting {
 		}
 	}
 	return nil
+}
+
+func (reporting *Reporting) EmbargoForBug(bug *Bug) time.Duration {
+	if len(reporting.SubsystemEmbargo) == 0 {
+		return reporting.Embargo
+	}
+	subsystems := bug.LabelValues(SubsystemLabel)
+	if len(subsystems) == 0 {
+		return reporting.Embargo
+	}
+	var maxEmbargo time.Duration
+	for _, sub := range subsystems {
+		embargo, ok := reporting.SubsystemEmbargo[sub.Value]
+		if !ok {
+			embargo = reporting.Embargo
+		}
+		maxEmbargo = max(maxEmbargo, embargo)
+	}
+	return maxEmbargo
 }
 
 // configDontUse holds the configuration object that is installed either by tests
@@ -875,8 +896,19 @@ func checkNamespaceReporting(ns string, cfg *Config) {
 			reporting.DisplayTitle = reporting.Name
 		}
 		reporting.moderation = ri < len(cfg.Reporting)-1
-		if !reporting.moderation && reporting.Embargo != 0 {
+		if !reporting.moderation && (reporting.Embargo != 0 || len(reporting.SubsystemEmbargo) > 0) {
 			panic(fmt.Sprintf("embargo in the last reporting %v", reporting.Name))
+		}
+		if reporting.Embargo < 0 {
+			panic(fmt.Sprintf("negative embargo %v in %v", reporting.Embargo, reporting.Name))
+		}
+		for sub, embargo := range reporting.SubsystemEmbargo {
+			if embargo <= 0 {
+				panic(fmt.Sprintf("non-positive embargo %v for subsystem %q in reporting %q", embargo, sub, reporting.Name))
+			}
+			if cfg.Subsystems.Service != nil && cfg.Subsystems.Service.ByName(sub) == nil {
+				panic(fmt.Sprintf("unknown subsystem %q in reporting %q embargo", sub, reporting.Name))
+			}
 		}
 		checkConfigAccessLevel(&reporting.AccessLevel, parentAccessLevel,
 			fmt.Sprintf("reporting %q/%q", ns, reporting.Name))

--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -410,7 +410,7 @@ func isStableBug(ctx context.Context, bug *Bug, lastReporting int) bool {
 			continue
 		}
 		reporting := getNsConfig(ctx, bug.Namespace).ReportingByName(bug.Reporting[i].Name)
-		if !bug.Reporting[i].Reported.IsZero() && reporting.Embargo != 0 {
+		if !bug.Reporting[i].Reported.IsZero() && reporting.EmbargoForBug(bug) != 0 {
 			continue
 		}
 		if reporting.Filter(bug) == FilterSkip {

--- a/dashboard/app/notifications_test.go
+++ b/dashboard/app/notifications_test.go
@@ -6,13 +6,16 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/subsystem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmailNotifUpstreamEmbargo(t *testing.T) {
@@ -41,6 +44,128 @@ func TestEmailNotifUpstreamEmbargo(t *testing.T) {
 	c.expectEQ(upstreamReport.Subject, "[syzbot] "+crash.Title)
 	c.expectNE(upstreamReport.Sender, report.Sender)
 	c.expectEQ(upstreamReport.To, []string{"bugs@syzkaller.com", "default@maintainers.com"})
+}
+
+func TestEmailNotifUpstreamSubsystemEmbargo(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	c.transformContext = func(ctx context.Context) context.Context {
+		newConfig := replaceNamespaceConfig(ctx, "test2", func(cfg *Config) *Config {
+			ret := *cfg
+			ret.Subsystems.Service = subsystem.MustMakeService(testSubsystems, 0)
+			ret.Reporting = slices.Clone(ret.Reporting)
+			ret.Reporting[0].SubsystemEmbargo = map[string]time.Duration{
+				"subsystemA": 21 * 24 * time.Hour,
+			}
+			return &ret
+		})
+		return contextWithConfig(ctx, newConfig)
+	}
+
+	build := testBuild(1)
+	c.client2.UploadBuild(build)
+
+	crash := testCrash(build, 1)
+	c.client2.ReportCrash(crash)
+	report := c.pollEmailBug()
+	c.incomingEmail(report.Sender, "#syz set subsystems: subsystemA\n")
+
+	// Upstreaming for subsystemA happens after 21 days (higher than the default 14 days).
+	// After 15 days, the default 14-day embargo has passed, but subsystemA is still embargoed.
+	c.advanceTime(15 * 24 * time.Hour)
+	c.expectNoEmail()
+
+	// After 22 days total, it should be upstreamed.
+	c.advanceTime(7 * 24 * time.Hour)
+	notif := c.pollEmailBug()
+	upstream := c.pollEmailBug()
+	c.expectEQ(notif.Subject, crash.Title)
+	c.expectEQ(upstream.Subject, "[syzbot] [subsystemA] "+crash.Title)
+}
+
+func TestReportingEmbargoForBug(t *testing.T) {
+	rep := &Reporting{
+		Embargo: 14 * 24 * time.Hour,
+		SubsystemEmbargo: map[string]time.Duration{
+			"subA": 7 * 24 * time.Hour,
+			"subB": 21 * 24 * time.Hour,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		reporting *Reporting
+		bug       *Bug
+		want      time.Duration
+	}{
+		{
+			name:      "no SubsystemEmbargo configured -> default embargo",
+			reporting: &Reporting{Embargo: 10 * 24 * time.Hour},
+			bug: &Bug{
+				Labels: []BugLabel{{Label: SubsystemLabel, Value: "subA"}},
+			},
+			want: 10 * 24 * time.Hour,
+		},
+		{
+			name:      "no subsystems -> default embargo",
+			reporting: rep,
+			bug:       &Bug{},
+			want:      14 * 24 * time.Hour,
+		},
+		{
+			name:      "single matching subsystem (lower)",
+			reporting: rep,
+			bug: &Bug{
+				Labels: []BugLabel{{Label: SubsystemLabel, Value: "subA"}},
+			},
+			want: 7 * 24 * time.Hour,
+		},
+		{
+			name:      "single matching subsystem (higher)",
+			reporting: rep,
+			bug: &Bug{
+				Labels: []BugLabel{{Label: SubsystemLabel, Value: "subB"}},
+			},
+			want: 21 * 24 * time.Hour,
+		},
+		{
+			name:      "single unconfigured subsystem -> default embargo",
+			reporting: rep,
+			bug: &Bug{
+				Labels: []BugLabel{{Label: SubsystemLabel, Value: "subOther"}},
+			},
+			want: 14 * 24 * time.Hour,
+		},
+		{
+			name:      "multiple matching subsystems -> longest embargo",
+			reporting: rep,
+			bug: &Bug{
+				Labels: []BugLabel{
+					{Label: SubsystemLabel, Value: "subA"},
+					{Label: SubsystemLabel, Value: "subB"},
+				},
+			},
+			want: 21 * 24 * time.Hour,
+		},
+		{
+			name:      "matching and unconfigured subsystems -> max with default",
+			reporting: rep,
+			bug: &Bug{
+				Labels: []BugLabel{
+					{Label: SubsystemLabel, Value: "subA"},
+					{Label: SubsystemLabel, Value: "subOther"},
+				},
+			},
+			want: 14 * 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.reporting.EmbargoForBug(tt.bug))
+		})
+	}
 }
 
 func TestEmailNotifUpstreamSkip(t *testing.T) {

--- a/dashboard/app/reporting.go
+++ b/dashboard/app/reporting.go
@@ -213,12 +213,13 @@ var notificationGenerators = []func(context.Context, *Bug, *Reporting,
 	// Embargo upstreaming.
 	func(ctx context.Context, bug *Bug, reporting *Reporting,
 		bugReporting *BugReporting) (*dashapi.BugNotification, error) {
+		embargo := reporting.EmbargoForBug(bug)
 		if reporting.moderation &&
-			reporting.Embargo != 0 &&
+			embargo != 0 &&
 			len(bug.Commits) == 0 &&
 			bugReporting.OnHold.IsZero() &&
-			timeSince(ctx, bugReporting.Reported) > reporting.Embargo {
-			log.Infof(ctx, "%v: upstreaming (embargo): %v", bug.Namespace, bug.Title)
+			timeSince(ctx, bugReporting.Reported) > embargo {
+			log.Infof(ctx, "%v: upstreaming (embargo %v): %v", bug.Namespace, embargo, bug.Title)
 			return createNotification(ctx, dashapi.BugNotifUpstream, true, "", bug, reporting, bugReporting)
 		}
 		return nil, nil


### PR DESCRIPTION
Allow customizing embargo durations per subsystem instead of enforcing a single global embargo period across all bugs in a reporting stage.

Add per-subsystem embargo overrides to the stage configuration. When evaluating embargo for a bug with multiple subsystems, use the maximum duration among them, falling back to the stage default for unconfigured subsystems.