### PR TITLE
pkg/aflow: disallow tool calls in answer-now prompt

### DIFF
--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -246,6 +246,9 @@ Or did you want to call some other tools, but did not actually do that?
 const llmAnswerNow = `
 Provide a best-effort answer to the original question with all of the information
 you have so far without calling any more tools!
+IMPORTANT: Your tool calling ability is currently disabled.
+Do NOT attempt to output JSON to call tools. Base your response strictly on
+the text information you have already gathered.
 `
 
 const llmDuplicateCallWarning = `You are repeating the same tool call with the exact same arguments.

--- a/pkg/aflow/testdata/TestLLMTool.llm.json
+++ b/pkg/aflow/testdata/TestLLMTool.llm.json
@@ -530,7 +530,7 @@
 			{
 				"parts": [
 					{
-						"text": "\nProvide a best-effort answer to the original question with all of the information\nyou have so far without calling any more tools!\n"
+						"text": "\nProvide a best-effort answer to the original question with all of the information\nyou have so far without calling any more tools!\nIMPORTANT: Your tool calling ability is currently disabled.\nDo NOT attempt to output JSON to call tools. Base your response strictly on\nthe text information you have already gathered.\n"
 					}
 				],
 				"role": "user"

--- a/pkg/aflow/testdata/TestLLMToolMaxIters.llm.json
+++ b/pkg/aflow/testdata/TestLLMToolMaxIters.llm.json
@@ -787787,7 +787787,7 @@
 			{
 				"parts": [
 					{
-						"text": "\nProvide a best-effort answer to the original question with all of the information\nyou have so far without calling any more tools!\n"
+						"text": "\nProvide a best-effort answer to the original question with all of the information\nyou have so far without calling any more tools!\nIMPORTANT: Your tool calling ability is currently disabled.\nDo NOT attempt to output JSON to call tools. Base your response strictly on\nthe text information you have already gathered.\n"
 					}
 				],
 				"role": "user"


### PR DESCRIPTION
When tool calling is stripped to force a best-effort final answer, LLMs may still attempt to output tool call JSON unless explicitly instructed that tool calling ability is disabled.

