### PR TITLE
pkg/aflow/action/crash: prepare environment prompt in configure-runner

### DIFF
--- a/pkg/aflow/action/crash/configure_runner.go
+++ b/pkg/aflow/action/crash/configure_runner.go
@@ -6,6 +6,7 @@ package crash
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/log"
@@ -25,10 +26,14 @@ type ConfigureRunnerArgs struct {
 	Snapshot   bool
 }
 
-func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct{}, error) {
+type ConfigureRunnerResult struct {
+	EnvironmentPrompt string
+}
+
+func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (ConfigureRunnerResult, error) {
 	workdir, err := ctx.TempDir()
 	if err != nil {
-		return struct{}{}, fmt.Errorf("failed to create workdir for configure-runner: %w", err)
+		return ConfigureRunnerResult{}, fmt.Errorf("failed to create workdir for configure-runner: %w", err)
 	}
 
 	targetCfg := TargetConfig{
@@ -43,21 +48,47 @@ func configureRunnerAction(ctx *aflow.Context, args ConfigureRunnerArgs) (struct
 	}
 
 	if err := targetCfg.Validate(); err != nil {
-		return struct{}{}, aflow.FlowError(err)
+		return ConfigureRunnerResult{}, aflow.FlowError(err)
 	}
 
 	cfg, err := BuildConfig(targetCfg, workdir)
 	if err != nil {
-		return struct{}{}, fmt.Errorf("failed to build config for runner: %w", err)
+		return ConfigureRunnerResult{}, fmt.Errorf("failed to build config for runner: %w", err)
 	}
 
 	// Initializes the VM pool and triggers background VM boot. Returns instantly.
 	// If it fails here, it's a hard error (e.g., vm.Create failed).
 	_, err = ctx.InitRunnerManager(cfg)
 	if err != nil {
-		return struct{}{}, aflow.FlowError(fmt.Errorf("RunnerManager init failed: %w", err))
+		return ConfigureRunnerResult{}, aflow.FlowError(fmt.Errorf("RunnerManager init failed: %w", err))
 	}
 
 	log.Logf(1, "aflow: RunnerManager configured and background VM boot started successfully")
-	return struct{}{}, nil
+	return ConfigureRunnerResult{
+		EnvironmentPrompt: formatEnvironment(args),
+	}, nil
+}
+
+func formatEnvironment(args ConfigureRunnerArgs) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Target OS: %s\n", args.TargetOS)
+	fmt.Fprintf(&b, "Target Arch: %s\n", args.TargetArch)
+	if args.Type != "" {
+		fmt.Fprintf(&b, "VM Type: %s\n", args.Type)
+	}
+	if len(args.VM) > 0 {
+		var vmConfig struct {
+			Cmdline  string `json:"cmdline"`
+			QemuArgs string `json:"qemu_args"`
+		}
+		if err := json.Unmarshal(args.VM, &vmConfig); err == nil {
+			if vmConfig.Cmdline != "" {
+				fmt.Fprintf(&b, "VM Cmdline: %s\n", vmConfig.Cmdline)
+			}
+			if vmConfig.QemuArgs != "" {
+				fmt.Fprintf(&b, "VM Qemu Args: %s\n", vmConfig.QemuArgs)
+			}
+		}
+	}
+	return b.String()
 }

--- a/pkg/aflow/action/crash/configure_runner_test.go
+++ b/pkg/aflow/action/crash/configure_runner_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatEnvironment(t *testing.T) {
+	args := ConfigureRunnerArgs{
+		TargetOS:   "linux",
+		TargetArch: "amd64",
+		Type:       "qemu",
+		VM: json.RawMessage(`{
+			"cmdline": "root=/dev/sda1 dummy_hcd.num=1",
+			"qemu_args": "-enable-kvm -m 4096M"
+		}`),
+	}
+
+	got := formatEnvironment(args)
+	want := `Target OS: linux
+Target Arch: amd64
+VM Type: qemu
+VM Cmdline: root=/dev/sda1 dummy_hcd.num=1
+VM Qemu Args: -enable-kvm -m 4096M
+`
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
Format target OS, architecture, VM type, and VM command line into an environment prompt string for LLM agents to provide runtime environment context.
