### PR TITLE
syz-ci: include timestamps in patch testing job log

### DIFF
--- a/syz-ci/jobs.go
+++ b/syz-ci/jobs.go
@@ -600,6 +600,7 @@ func (jp *JobProcessor) testPatch(job *Job, mgrcfg *mgrconfig.Config) error {
 	trace := new(bytes.Buffer)
 	dt := &debugtracer.GenericTracer{
 		TraceWriter: io.MultiWriter(trace, log.VerboseWriter(1)),
+		WithTime:    true,
 	}
 	defer func() {
 		resp.Log = trace.Bytes()


### PR DESCRIPTION
Enable timestamps on the GenericTracer used during patch testing to help track step durations and diagnose execution delays.