### PR TITLE
pkg/aflow/backend/gemini: add gemini-3.6-flash model config

### DIFF
--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -88,6 +88,12 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 				InputTokenLimit:  1048576,
 				OutputTokenLimit: 65536,
 			},
+			"gemini-3.6-flash": {
+				Thinking:         true,
+				MaxTemperature:   2.0,
+				InputTokenLimit:  1048576,
+				OutputTokenLimit: 65536,
+			},
 			"gemini-3.1-pro-preview": {
 				Thinking:         true,
 				MaxTemperature:   2.0,
@@ -178,7 +184,7 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 	case backend.BestExpensiveModel:
 		return []string{"gemini-3.1-pro-preview"}
 	case backend.GoodBalancedModel:
-		return []string{"gemini-3.5-flash", "gemini-3-flash-preview"}
+		return []string{"gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash-preview"}
 	default:
 		return nil
 	}

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -25,7 +25,7 @@ func TestProviderResolveModels(t *testing.T) {
 		{
 			name:     "resolves good balanced model pool",
 			category: backend.GoodBalancedModel,
-			want:     []string{"gemini-3.5-flash", "gemini-3-flash-preview"},
+			want:     []string{"gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash-preview"},
 		},
 		{
 			name:     "resolves best expensive model pool",


### PR DESCRIPTION
Enable Gemini 3.6 Flash thinking model support to allow aflow backend agents and workflows to use it for fast reasoning and execution.

