### PR TITLE
pkg/codesearch: index documentation files in directory listings

### DIFF
--- a/pkg/codesearch/codesearch.go
+++ b/pkg/codesearch/codesearch.go
@@ -464,11 +464,16 @@ func dirIndex(root, subdir string) (bool, []string, []string, error) {
 			// These are internal things like .git, etc.
 		} else if entry.IsDir() {
 			subdirs = append(subdirs, entry.Name())
-		} else if IsSourceFile(filepath.Join(subdir, entry.Name())) {
+		} else if IsSourceFile(filepath.Join(subdir, entry.Name())) || isDocumentationFile(entry.Name()) {
 			files = append(files, entry.Name())
 		}
 	}
 	return true, subdirs, files, err
+}
+
+func isDocumentationFile(file string) bool {
+	ext := filepath.Ext(file)
+	return ext == ".txt" || ext == ".rst" || ext == ".md"
 }
 
 func DirIndex(srcDirs []string, dir string) ([]string, []string, error) {

--- a/pkg/codesearch/codesearch_test.go
+++ b/pkg/codesearch/codesearch_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/clangtool/tooltest"
 	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/tools/clang/codesearch"
+	clangtoolimpl "github.com/google/syzkaller/tools/clang/codesearch"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,4 +107,28 @@ func TestFindReferencesInvalidRange(t *testing.T) {
 	require.Len(t, info, 2)
 	require.Empty(t, info[0].SourceSnippet)
 	require.Empty(t, info[1].SourceSnippet)
+}
+
+func TestIsDocumentationFile(t *testing.T) {
+	docFiles := []string{
+		"Documentation/admin-guide/index.rst",
+		"README.md",
+		"notes.txt",
+	}
+	for _, file := range docFiles {
+		t.Run(file, func(t *testing.T) {
+			require.True(t, isDocumentationFile(file))
+		})
+	}
+
+	nonDocFiles := []string{
+		"source.c",
+		"header.h",
+		"Makefile",
+	}
+	for _, file := range nonDocFiles {
+		t.Run(file, func(t *testing.T) {
+			require.False(t, isDocumentationFile(file))
+		})
+	}
 }


### PR DESCRIPTION
To enable agent workflows to discover and inspect kernel documentation alongside source files when navigating directory trees.
