### PR TITLE
dashboard/app: forward alt titles when reporting candidate repro crashes

### DIFF
--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -1176,11 +1176,12 @@ func reportCandidateReproCrash(ctx context.Context, job *Job, req *dashapi.JobDo
 		return
 	}
 	crashReq := &dashapi.Crash{
-		BuildID: req.Build.ID,
-		Title:   req.CrashTitle,
-		Log:     req.CrashLog,
-		Report:  req.CrashReport,
-		ReproC:  reproC,
+		BuildID:   req.Build.ID,
+		Title:     req.CrashTitle,
+		AltTitles: req.CrashAltTitles,
+		Log:       req.CrashLog,
+		Report:    req.CrashReport,
+		ReproC:    reproC,
 	}
 	if _, err := reportCrash(ctx, build, crashReq); err != nil {
 		log.Errorf(ctx, "job %v: failed to report candidate repro crash: %v", req.ID, err)

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1411,11 +1412,12 @@ func TestReproCJob(t *testing.T) {
 	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)
 	c.expectEQ(string(pollResp.ReproC), string(reproC))
 
-	// Job succeeds with crash matching the bug title.
+	// Job succeeds with a different crash title that matches the bug via AltTitles.
 	jobDoneReq := &dashapi.JobDoneReq{
-		ID:         pollResp.ID,
-		Build:      *testBuild(2),
-		CrashTitle: rep.Title,
+		ID:             pollResp.ID,
+		Build:          *testBuild(2),
+		CrashTitle:     "different crash title",
+		CrashAltTitles: []string{rep.Title},
 	}
 	c.expectOK(c.globalClient.JobDone(jobDoneReq))
 
@@ -1424,6 +1426,10 @@ func TestReproCJob(t *testing.T) {
 	c.expectEQ(rep2.Type, dashapi.ReportRepro)
 	c.expectEQ(string(rep2.ReproC), string(reproC))
 	c.expectNE(rep2.ReproCLink, "")
+
+	bug, _, _ = c.loadBug(rep.ID)
+	c.expectEQ(bug.HasCRepro, true)
+	c.expectTrue(slices.Contains(bug.AltTitles, "different crash title"))
 }
 
 func TestReproCJobError(t *testing.T) {


### PR DESCRIPTION
syz-ci sends alternative crash titles via dashapi.JobDoneReq.CrashAltTitles (populated in testPatch), but reportCandidateReproCrash previously dropped them when calling reportCrash.

This caused findBugForCrash to create a duplicate bug instead of merging the reproducer if the reproduced crash title differed from the original bug.

Forward CrashAltTitles to dashapi.Crash in reportCandidateReproCrash so crashes are matched and deduplicated properly.