### PR TITLE
tools/docker: add loong64 cross compiler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ kiwigitops
 Robert Femmer
 Alhuda Khan
 Felix Hoffmann
+manchangfengxu

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -166,3 +166,4 @@ Xianjun Zeng
 Peiyang He
 Alhuda Khan
 Felix Hoffmann
+manchangfengxu

--- a/tools/docker/env/Dockerfile
+++ b/tools/docker/env/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=git-builder /opt/git /opt/git
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
     g++ \
     g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
-    g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu
+    g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu g++-loongarch64-linux-gnu
 
 # Install architecture-specific packages (only for amd64).
 RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \

--- a/tools/docker/syzbot/Dockerfile
+++ b/tools/docker/syzbot/Dockerfile
@@ -40,7 +40,7 @@ RUN test "$(uname -m)" != x86_64 && exit 0 || \
 	  libc6-dev-i386 libc6-dev-i386-amd64-cross lib32gcc-14-dev lib32stdc++-14-dev \
 	  # Cross-compilation:
 	  g++-arm-linux-gnueabi g++-aarch64-linux-gnu g++-powerpc64le-linux-gnu \
-	  g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu
+	  g++-mips64el-linux-gnuabi64 g++-s390x-linux-gnu g++-riscv64-linux-gnu g++-loongarch64-linux-gnu
 
 # Since go 1.21 the toolchain required by go.mod is automatically downloaded.
 # There is no need to version up golang here after go.mod changes.


### PR DESCRIPTION
Install the LoongArch cross compiler in the development and syzbot images so the Linux/loong64 target and executor can be built by the standard CI environment.

This change is split out from #7566 as requested. 

Testing:
 - `CI=true make presubmit_aux`
 - Verified that Debian trixie installs `g++-loongarch64-linux-gnu` 4:14.2.0-1 on both amd64 and arm64.
 - Verified that the package provides `loongarch64-linux-gnu-g++` 14.2.0 on both platforms.
 - The resulting env Dockerfile was previously built locally and used to pass the complete `CI=true make presubmit` suite for #7566.