### PR TITLE
pkg/aflow/tool/syzlang: add disassemble-context tool

### DIFF
--- a/pkg/aflow/tool/syzlang/disassemble.go
+++ b/pkg/aflow/tool/syzlang/disassemble.go
@@ -1,0 +1,183 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package syzlang
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/aflow"
+)
+
+const (
+	disassembleAddressRadius = 0x200
+	disassembleContextLines  = 50
+)
+
+var DisassembleContext = aflow.NewFuncTool("disassemble-context", disassembleContext, `
+Tool returns the source-interleaved disassembly around candidate target PC addresses.
+Use this to understand compiler-injected instrumentation (e.g., KCOV, ASAN)
+and low-level execution context of target code points.
+Returns +/- 50 lines of objdump output centered around the first target PC, with candidate target PCs marked.
+If you need to scroll, call the tool again with the first or last PC visible in the snippet in the PCs list.
+`)
+
+type DisassembleContextArgs struct {
+	PCs []string `jsonschema:"List of candidate target raw un-relocated PC addresses (hex format)."`
+}
+
+type DisassembleContextResult struct {
+	Output string `jsonschema:"The source-interleaved disassembly snippet."`
+}
+
+func disassembleContext(
+	ctx *aflow.Context, state reproduceState, args DisassembleContextArgs,
+) (DisassembleContextResult, error) {
+	var rawPCs []string
+	for _, p := range args.PCs {
+		p = strings.TrimSpace(p)
+		if p != "" && !slices.Contains(rawPCs, p) {
+			rawPCs = append(rawPCs, p)
+		}
+	}
+	if len(rawPCs) == 0 {
+		return DisassembleContextResult{}, aflow.BadCallError("no PC provided")
+	}
+
+	var pcs []uint64
+	for _, raw := range rawPCs {
+		raw = strings.TrimSpace(raw)
+		raw = strings.TrimPrefix(raw, "0x")
+		pc, err := strconv.ParseUint(raw, 16, 64)
+		if err != nil {
+			return DisassembleContextResult{}, aflow.BadCallError("invalid pc format: %v", err)
+		}
+		pcs = append(pcs, pc)
+	}
+
+	snippet, err := doDisassembleContext(pcs, state.KernelObj, state.KernelSrc)
+	if err != nil {
+		return DisassembleContextResult{}, aflow.BadCallError("%v", err)
+	}
+
+	return DisassembleContextResult{Output: snippet}, nil
+}
+
+func doDisassembleContext(pcs []uint64, kernelObj, kernelSrc string) (string, error) {
+	if len(pcs) == 0 {
+		return "", fmt.Errorf("no target PC provided")
+	}
+	pc := pcs[0]
+	vmlinux := filepath.Join(kernelObj, "vmlinux")
+	startAddr, stopAddr := computeAddressBounds(pc)
+
+	cmd := exec.Command("llvm-objdump", "-d", "-S",
+		fmt.Sprintf("--start-address=0x%x", startAddr),
+		fmt.Sprintf("--stop-address=0x%x", stopAddr),
+		vmlinux)
+	cmd.Dir = kernelSrc
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("llvm-objdump failed: %w\nOutput: %s", err, string(out))
+	}
+
+	return formatDisassemblySnippet(string(out), pcs), nil
+}
+
+func computeAddressBounds(pc uint64) (uint64, uint64) {
+	startAddr := uint64(0)
+	if pc > disassembleAddressRadius {
+		startAddr = pc - disassembleAddressRadius
+	}
+	stopAddr := pc + disassembleAddressRadius
+	if stopAddr < pc {
+		stopAddr = ^uint64(0)
+	}
+	return startAddr, stopAddr
+}
+
+// formatDisassemblySnippet processes the raw objdump output to annotate target
+// and candidate PCs, centers the output around the target PC (or the closest
+// preceding instruction if the PC does not land on an exact instruction
+// boundary), and slices a +/-disassembleContextLines context window.
+func formatDisassemblySnippet(out string, pcs []uint64) string {
+	if len(pcs) == 0 {
+		return out
+	}
+	pc := pcs[0]
+	lines := strings.Split(out, "\n")
+
+	targetIdx := -1
+	closestDist := uint64(0xffffffffffffffff)
+	exactMatch := false
+
+	for i, line := range lines {
+		addrStr, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+
+		addrStr = strings.TrimSpace(addrStr)
+		addr, err := strconv.ParseUint(addrStr, 16, 64)
+		if err == nil {
+			if addr == pc {
+				lines[i] = lines[i] + "  <-- TARGET PC"
+				targetIdx = i
+				exactMatch = true
+			} else if slices.Contains(pcs, addr) {
+				lines[i] = lines[i] + "  <-- CANDIDATE TARGET PC"
+			}
+			// If no exact instruction boundary matched the target PC yet, track the closest
+			// instruction preceding pc so the context window remains centered near the target site.
+			if !exactMatch && addr < pc {
+				dist := pc - addr
+				if dist < closestDist {
+					closestDist = dist
+					targetIdx = i
+				}
+			}
+		}
+	}
+
+	// Default to centering in the middle of output if no address could be parsed.
+	if targetIdx == -1 {
+		targetIdx = len(lines) / 2
+	}
+
+	// Slice a +/-disassembleContextLines window around targetIdx.
+	startIdx := max(0, targetIdx-disassembleContextLines)
+	endIdx := min(len(lines), targetIdx+disassembleContextLines)
+
+	snippetLines := lines[startIdx:endIdx]
+	snippet := strings.Join(snippetLines, "\n")
+
+	hasSource := false
+	for _, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), ";") {
+			hasSource = true
+			break
+		}
+	}
+
+	if !hasSource {
+		warn := "WARNING: Missing debug symbols or source code not found. " +
+			"Returning raw assembly without interleaved C source lines.\n\n"
+		snippet = warn + snippet
+	}
+
+	if len(pcs) > 1 {
+		var candidateStrs []string
+		for _, p := range pcs {
+			candidateStrs = append(candidateStrs, fmt.Sprintf("0x%x", p))
+		}
+		header := fmt.Sprintf("Candidate Target PCs: %s\n\n", strings.Join(candidateStrs, ", "))
+		snippet = header + snippet
+	}
+
+	return snippet
+}

--- a/pkg/aflow/tool/syzlang/disassemble_test.go
+++ b/pkg/aflow/tool/syzlang/disassemble_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package syzlang
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisassembleContextValidation(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+	state := reproduceState{}
+
+	// No PC provided.
+	_, err := disassembleContext(ctx, state, DisassembleContextArgs{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no PC provided")
+
+	// Invalid hex PC format.
+	_, err = disassembleContext(ctx, state, DisassembleContextArgs{PCs: []string{"invalid_hex"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid pc format")
+
+	// Invalid hex PC format in PCs slice.
+	_, err = disassembleContext(ctx, state, DisassembleContextArgs{PCs: []string{"0xffffff", "bad_pc"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid pc format")
+}
+
+func TestComputeAddressBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		pc        uint64
+		wantStart uint64
+		wantStop  uint64
+	}{
+		{
+			name:      "normal",
+			pc:        0x1000,
+			wantStart: 0xe00,
+			wantStop:  0x1200,
+		},
+		{
+			name:      "underflow",
+			pc:        0x100,
+			wantStart: 0x0,
+			wantStop:  0x300,
+		},
+		{
+			name:      "underflow boundary",
+			pc:        0x200,
+			wantStart: 0x0,
+			wantStop:  0x400,
+		},
+		{
+			name:      "overflow",
+			pc:        ^uint64(0) - 0x100,
+			wantStart: ^uint64(0) - 0x300,
+			wantStop:  ^uint64(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStart, gotStop := computeAddressBounds(tt.pc)
+			require.Equal(t, tt.wantStart, gotStart)
+			require.Equal(t, tt.wantStop, gotStop)
+		})
+	}
+}
+
+func TestDisassembleTargetIdxClosestResolution(t *testing.T) {
+	// Build a mock objdump output with 150 lines:
+	// addresses from 0x1000 upwards by 4 bytes.
+	var lines []string
+	for i := range 150 {
+		addr := uint64(0x1000 + i*4)
+		lines = append(lines, fmt.Sprintf("%x:\tnop", addr))
+	}
+	out := strings.Join(lines, "\n")
+
+	// Target PC is 0x1185 (0x1184 + 1), which is not an exact instruction address.
+	// The closest instruction address < 0x1185 is 0x1184 (line index 97).
+	// With the snippet centered around line 97 (+/- 50 lines, i.e. lines 47..147),
+	// lines near line 0 (0x1000:) should NOT be included,
+	// and lines near line 97 (0x1184:) MUST be included.
+	pc := uint64(0x1185)
+	snippet := formatDisassemblySnippet(out, []uint64{pc})
+
+	require.Contains(t, snippet, "1184:\tnop", "snippet should contain the closest preceding instruction")
+	require.NotContains(t, snippet, "1000:\tnop", "snippet should NOT be centered around the first line")
+}
+
+func TestDisassembleSnippetExactMatchAndCandidates(t *testing.T) {
+	lines := []string{
+		"; source line 1",
+		"1000:\tmov %rax, %rbx",
+		"1004:\tadd $1, %rax",
+		"1008:\tret",
+	}
+	out := strings.Join(lines, "\n")
+
+	// Exact match with candidates.
+	snippet := formatDisassemblySnippet(out, []uint64{0x1004, 0x1008})
+	require.Contains(t, snippet, "1004:\tadd $1, %rax  <-- TARGET PC")
+	require.Contains(t, snippet, "1008:\tret  <-- CANDIDATE TARGET PC")
+	require.Contains(t, snippet, "Candidate Target PCs: 0x1004, 0x1008")
+	require.NotContains(t, snippet, "WARNING: Missing debug symbols")
+}
+
+func TestDisassembleSnippetEmptyPCs(t *testing.T) {
+	out := "1000:\tnop"
+	snippet := formatDisassemblySnippet(out, nil)
+	require.Equal(t, out, snippet)
+
+	_, err := doDisassembleContext(nil, "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no target PC provided")
+}
+
+func TestDisassembleSnippetMissingDebugSymbols(t *testing.T) {
+	lines := []string{
+		"1000:\tmov %rax, %rbx",
+		"1004:\tret",
+	}
+	out := strings.Join(lines, "\n")
+	snippet := formatDisassemblySnippet(out, []uint64{0x1000})
+	require.Contains(t, snippet, "WARNING: Missing debug symbols")
+}


### PR DESCRIPTION
Add a LLM tool enabling agents to disassemble the vmlinux binary to read assembly code. This helps the agent to understand the exact context and provides it with information about how to reach e.g. a specific PC address.
