### PR TITLE
pkg/aflow/action/crash: decouple symbolization config and cache exec details

### DIFF
--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -23,6 +24,12 @@ import (
 	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
+
+func init() {
+	// TODO: remove once callers in downstream packages use these helpers.
+	runtime.KeepAlive(LoadSeedProgramDetails)
+	runtime.KeepAlive(LoadCallErrors)
+}
 
 var ErrDidNotCrash = errors.New("reproducer did not crash")
 
@@ -181,7 +188,7 @@ func aggregateTestResults(validResults []instance.EnvTestResult,
 	}
 
 	if res.Report == nil && res.BootError == "" && firstCoverage != nil {
-		coverage, err := symbolize(args, firstCoverage)
+		coverage, err := symbolize(args.TargetConfig, firstCoverage)
 		if err != nil {
 			return res, fmt.Errorf("failed to symbolize coverage: %w", err)
 		}
@@ -204,6 +211,14 @@ func parseTestError(err *instance.TestError) string {
 	return fmt.Sprintf("%v: %v\n%s", what, err.Title, extraInfo)
 }
 
+// CallError represents execution error details for a single syscall in a program.
+type CallError struct {
+	Index    int    `jsonschema:"0-based index of the failed syscall."`
+	CallName string `jsonschema:"Name of the syscall that failed."`
+	Errno    int32  `jsonschema:"The raw error code (errno) returned."`
+	Error    string `jsonschema:"String representation of the error."`
+}
+
 type cachedExecution struct {
 	BugTitle       string
 	Report         string
@@ -211,14 +226,35 @@ type cachedExecution struct {
 	FaultInjection string
 	Error          string
 	Coverage       [][]symbolizer.Frame
+	CallErrors     []CallError
+	GeneratedSyz   string
 }
 
+// LoadCoverage retrieves the symbolized coverage frames from a cached execution.
 func LoadCoverage(ctx *aflow.Context, cachedID string) ([][]symbolizer.Frame, error) {
 	cached, err := aflow.RetrieveObject[cachedExecution](ctx, cachedID)
 	if err != nil {
 		return nil, err
 	}
 	return cached.Coverage, nil
+}
+
+// LoadSeedProgramDetails retrieves the generated syzkaller program from a cached execution.
+func LoadSeedProgramDetails(ctx *aflow.Context, cachedID string) (string, error) {
+	cached, err := aflow.RetrieveObject[cachedExecution](ctx, cachedID)
+	if err != nil {
+		return "", err
+	}
+	return cached.GeneratedSyz, nil
+}
+
+// LoadCallErrors retrieves the list of syscall error details from a cached execution.
+func LoadCallErrors(ctx *aflow.Context, cachedID string) ([]CallError, error) {
+	cached, err := aflow.RetrieveObject[cachedExecution](ctx, cachedID)
+	if err != nil {
+		return nil, err
+	}
+	return cached.CallErrors, nil
 }
 
 func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
@@ -254,6 +290,7 @@ func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
 		res.FaultInjection = testRes.FaultInjection
 		res.Error = testRes.BootError
 		res.Coverage = testRes.Coverage
+		res.GeneratedSyz = args.ReproSyz
 		return res, err
 	})
 	if err != nil {
@@ -279,7 +316,7 @@ func ReproduceFunc(ctx *aflow.Context, args ReproduceArgs) (reproduceResult, err
 
 var makeSymbolizer = symbolizer.Make
 
-func symbolize(args ReproduceArgs, coverage [][]uint64) ([][]symbolizer.Frame, error) {
+func symbolize(args TargetConfig, coverage [][]uint64) ([][]symbolizer.Frame, error) {
 	if len(coverage) == 0 {
 		return nil, nil
 	}

--- a/pkg/aflow/action/crash/reproduce_test.go
+++ b/pkg/aflow/action/crash/reproduce_test.go
@@ -140,11 +140,9 @@ func TestSymbolize(t *testing.T) {
 		return mock
 	}
 
-	args := ReproduceArgs{
-		TargetConfig: TargetConfig{
-			TargetArch: "amd64",
-			Type:       "qemu",
-		},
+	args := TargetConfig{
+		TargetArch: "amd64",
+		Type:       "qemu",
 	}
 	// amd64 instruction length is 5.
 	// So 0x1005 should be shifted to 0x1000.

--- a/pkg/aflow/tool/syzlang/reproduce.go
+++ b/pkg/aflow/tool/syzlang/reproduce.go
@@ -31,6 +31,7 @@ type ReproduceResult struct {
 }
 
 type reproduceState struct {
+	AgentName    string
 	TargetOS     string
 	TargetArch   string
 	KernelSrc    string
@@ -41,6 +42,22 @@ type reproduceState struct {
 	Type         string
 	VM           json.RawMessage
 	Syzkaller    string
+}
+
+func (s reproduceState) targetConfig(sandbox string) crash.TargetConfig {
+	return crash.TargetConfig{
+		AgentName:    s.AgentName,
+		TargetArch:   s.TargetArch,
+		Syzkaller:    s.Syzkaller,
+		Image:        s.Image,
+		Type:         s.Type,
+		VM:           s.VM,
+		KernelSrc:    s.KernelSrc,
+		KernelObj:    s.KernelObj,
+		KernelCommit: s.KernelCommit,
+		KernelConfig: s.KernelConfig,
+		Sandbox:      sandbox,
+	}
 }
 
 func reproduce(ctx *aflow.Context, state reproduceState, args ReproduceArgs) (ReproduceResult, error) {
@@ -64,19 +81,8 @@ func reproduce(ctx *aflow.Context, state reproduceState, args ReproduceArgs) (Re
 	}
 
 	reproArgs := crash.ReproduceArgs{
-		TargetConfig: crash.TargetConfig{
-			TargetArch:   state.TargetArch,
-			Syzkaller:    state.Syzkaller,
-			Image:        state.Image,
-			Type:         state.Type,
-			VM:           state.VM,
-			KernelSrc:    state.KernelSrc,
-			KernelObj:    state.KernelObj,
-			KernelCommit: state.KernelCommit,
-			KernelConfig: state.KernelConfig,
-			Sandbox:      args.Sandbox,
-		},
-		ReproSyz: args.ReproSyz,
+		TargetConfig: state.targetConfig(args.Sandbox),
+		ReproSyz:     args.ReproSyz,
 	}
 
 	if err := reproArgs.Validate(); err != nil {


### PR DESCRIPTION
Downstream agent flows and analysis tools need access to intermediate
reproduction run context (such as the generated syzkaller program and
per-call syscall execution errors) without re-executing programs in a VM
or duplicating state. In addition, internal symbolization only requires
target environment configuration, so decoupling it from full reproduction
arguments removes unnecessary parameter dependencies.
