### PR TITLE
pkg/cover/backend: fix CleanPath() for out-of-tree modules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ Alhuda Khan
 Felix Hoffmann
 manchangfengxu
 Roshan Kumar
+Aaron Li

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -168,3 +168,4 @@ Alhuda Khan
 Felix Hoffmann
 manchangfengxu
 Roshan Kumar
+Aaron Li

--- a/pkg/cover/backend/path.go
+++ b/pkg/cover/backend/path.go
@@ -40,11 +40,25 @@ func CleanPath(path string, kernelDirs *mgrconfig.KernelDirs, splitBuildDelimite
 		path = strings.TrimPrefix(abs, kernelDirs.BuildSrc)
 		absPath = filepath.Join(kernelDirs.Src, path)
 	default:
-		// Assume this is relative path.
-		if filepath.IsAbs(path) {
-			absPath = path
-		} else {
-			absPath = filepath.Join(kernelDirs.Src, path)
+		ok := false
+		// Further check out-of-tree modules.
+		for _, mDir := range kernelDirs.ModuleObj {
+			if strings.HasPrefix(abs, mDir+string(filepath.Separator)) {
+				// Display absolute paths for out-of-tree modules to
+				// avoid confusing with kernel modules.
+				path = abs
+				absPath = abs
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			// Assume this is relative path.
+			if filepath.IsAbs(path) {
+				absPath = path
+			} else {
+				absPath = filepath.Join(kernelDirs.Src, path)
+			}
 		}
 	}
 	relPath = strings.TrimLeft(filepath.Clean(path), "/\\")

--- a/pkg/cover/backend/path_test.go
+++ b/pkg/cover/backend/path_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/mgrconfig"
+	"github.com/stretchr/testify/require"
 )
 
 type CleanPathAndroidTest struct {
@@ -122,4 +123,17 @@ func TestPathCleanerKernelSrcPath(t *testing.T) {
 	if rel != "relative/path" || abs != "/some_src_dir/relative/path" {
 		t.Errorf("expected rel=relative/path, abs=/some_src_dir/relative/path, got %q, %q", rel, abs)
 	}
+}
+
+func TestPathCleanerModulePath(t *testing.T) {
+	// Test that an absolute path pointing to an out-of-tree module is properly normalized.
+	kernelDirs := &mgrconfig.KernelDirs{
+		ModuleObj: []string{"/some/module/dir", "/another/module/src"},
+	}
+	rel, abs := CleanPath("/some/module/dir/relative/path", kernelDirs, nil)
+	require.Equal(t, rel, "some/module/dir/relative/path")
+	require.Equal(t, abs, "/some/module/dir/relative/path")
+	rel, abs = CleanPath("/another/module/src/relative/path", kernelDirs, nil)
+	require.Equal(t, rel, "another/module/src/relative/path")
+	require.Equal(t, abs, "/another/module/src/relative/path")
 }

--- a/pkg/mgrconfig/load.go
+++ b/pkg/mgrconfig/load.go
@@ -298,19 +298,27 @@ func (cfg *Config) CompleteKernelDirs() {
 		cfg.KernelBuildSrc = cfg.KernelSrc
 	}
 	cfg.KernelBuildSrc = osutil.Abs(cfg.KernelBuildSrc)
+
+	moduleObj := make([]string, len(cfg.ModuleObj))
+	for idx, dir := range cfg.ModuleObj {
+		moduleObj[idx] = osutil.Abs(dir)
+	}
+	cfg.ModuleObj = moduleObj
 }
 
 type KernelDirs struct {
-	Src      string
-	Obj      string
-	BuildSrc string
+	Src       string
+	Obj       string
+	BuildSrc  string
+	ModuleObj []string
 }
 
 func (cfg *Config) KernelDirs() *KernelDirs {
 	return &KernelDirs{
-		Src:      cfg.KernelSrc,
-		Obj:      cfg.KernelObj,
-		BuildSrc: cfg.KernelBuildSrc,
+		Src:       cfg.KernelSrc,
+		Obj:       cfg.KernelObj,
+		BuildSrc:  cfg.KernelBuildSrc,
+		ModuleObj: cfg.ModuleObj,
 	}
 }
 


### PR DESCRIPTION
The syz-manager's module_obj config option allows specifying a list of directories containing out-of-tree modules.  It's reasonable for such directories to be located outside the kernel source/build directory. However, the CleanPath() would then generate the wrong absolute paths, making them unable to be viewed within the coverage browser.

An out-of-tree module is generally built in-place, so the .ko module and the source files are located at the same directory.  Therefore, fix CleanPath() to further check the configured module_obj directories to generate the correct absolute paths for the coverage browser.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
