### PR TITLE
pkg/aflow: add seed execution action and tools

### DIFF
--- a/pkg/aflow/action/crash/execute_seed.go
+++ b/pkg/aflow/action/crash/execute_seed.go
@@ -1,0 +1,182 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/flatrpc"
+	"github.com/google/syzkaller/pkg/fuzzer/queue"
+	"github.com/google/syzkaller/pkg/hash"
+	"github.com/google/syzkaller/pkg/log"
+	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
+)
+
+type ExecuteSeedArgs struct {
+	TargetConfig
+	ReproSyz string
+}
+
+const deserializationErrorHelp = `
+
+Syzlang Syntax Reminders:
+- Multi-line statements are not supported. Each syscall must be on a single line.
+- Inline comments (inside syscalls) are not supported. Put comments on their own lines.
+- Double quotes ("...") are only for hex sequences. Use single quotes ('...') for strings and paths.`
+
+// ExecuteSeedFunc boots the kernel and runs a single test program to collect coverage.
+// It differs from ReproduceFuncWithCoverage in that it forces threaded mode and
+// returns coverage data even if the execution fails with an error (e.g., timeout).
+func ExecuteSeedFunc(ctx *aflow.Context, args ExecuteSeedArgs) (string, error) {
+	if args.TargetArch == "" {
+		args.TargetArch = targets.AMD64
+	}
+
+	target, err := prog.GetTarget(targets.Linux, args.TargetArch)
+	if err != nil {
+		return "", err
+	}
+
+	fullSyz := args.ReproSyz
+	// We perform normalization so that the cache key is calculated correctly.
+	p, err := target.Deserialize([]byte(fullSyz), prog.Strict)
+	if err != nil {
+		return "", aflow.BadCallError("%v%s", err.Error(), deserializationErrorHelp)
+	}
+	if len(p.Calls) > prog.MaxCalls {
+		return "", aflow.BadCallError("program has %d calls, exceeding the limit of %d", len(p.Calls), prog.MaxCalls)
+	}
+	fullSyz = string(p.Serialize())
+
+	if args.Image == "" || len(args.VM) == 0 {
+		return "", fmt.Errorf("VM configuration is missing")
+	}
+	imageHash, err := hash.File(args.Image)
+	if err != nil {
+		return "", err
+	}
+
+	desc := fmt.Sprintf("seed-exec: kernel commit %v, kernel config hash %v, image hash %v,"+
+		" vm %v, vm config hash %v, syz repro hash %v",
+		args.KernelCommit, hash.String(args.KernelConfig), imageHash.String(),
+		args.Type, hash.String(args.VM), hash.String(fullSyz))
+	cached, cachedID, err := aflow.CacheObject(ctx, "seed-exec", desc, func() (cachedExecution, error) {
+		var res cachedExecution
+		res.GeneratedSyz = args.ReproSyz
+
+		rm, err := ctx.GetRunnerManager()
+		if err != nil {
+			return res, fmt.Errorf("failed to get runner manager: %w", err)
+		}
+
+		runRes, err := rm.Submit(ctx.Context, p)
+		if err != nil {
+			return res, aflow.FlowError(fmt.Errorf("RunnerManager Submit failed: %w", err))
+		}
+
+		log.Logf(1, "VM Console Output:\n%s", runRes.Output)
+
+		crashes := rm.RecentCrashes()
+		if len(crashes) > 0 {
+			res.BugTitle = crashes[0].Title
+			res.Report = fmt.Sprintf("The kernel crashed after one of the previous executions:\n%s", string(crashes[0].Report))
+			for _, rep := range crashes[1:] {
+				res.OtherReports = append(res.OtherReports, string(rep.Report))
+			}
+		}
+
+		if runRes.Status == queue.ExecFailure && runRes.Err != nil {
+			res.Error = runRes.Err.Error()
+		}
+
+		if runRes.Info != nil {
+			res.CallErrors = extractCallErrors(runRes.Info, p.Calls)
+			var err error
+			res.Coverage, err = extractCoverage(runRes.Info, args.TargetConfig)
+			if err != nil {
+				return res, err
+			}
+		}
+
+		return res, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+	if cached.Error != "" {
+		return "", errors.New(cached.Error)
+	}
+	if cached.BugTitle != "" {
+		return "", fmt.Errorf("kernel crashed: %s", cached.BugTitle)
+	}
+
+	return cachedID, nil
+}
+
+func extractCallErrors(info *flatrpc.ProgInfo, calls []*prog.Call) []CallError {
+	var callErrors []CallError
+	for i, call := range info.Calls {
+		if call == nil {
+			continue
+		}
+		if call.Error != 0 || call.Flags&flatrpc.CallFlagFinished == 0 {
+			callName := "unknown"
+			if i < len(calls) {
+				callName = calls[i].Meta.Name
+			}
+			var errStr string
+			if call.Flags&flatrpc.CallFlagExecuted == 0 {
+				errStr = "call unexecuted (executor halted on an earlier call)"
+			} else if call.Flags&flatrpc.CallFlagFinished == 0 {
+				errStr = "call execution timed out or hung"
+			} else {
+				errStr = syscall.Errno(call.Error).Error()
+			}
+			callErrors = append(callErrors, CallError{
+				Index:    i,
+				CallName: callName,
+				Errno:    call.Error,
+				Error:    errStr,
+			})
+		}
+	}
+	return callErrors
+}
+
+// extractCoverage converts raw coverage PCs from ProgInfo into symbolized source code frames.
+// It skips symbolization and returns nil if no coverage data was collected.
+func extractCoverage(info *flatrpc.ProgInfo, args TargetConfig) ([][]symbolizer.Frame, error) {
+	var cov [][]uint64
+	hasCov := false
+	for _, call := range info.Calls {
+		if call == nil {
+			cov = append(cov, nil)
+			continue
+		}
+		cov = append(cov, call.Cover)
+		if len(call.Cover) > 0 {
+			hasCov = true
+		}
+	}
+	if info.Extra != nil && len(info.Extra.Cover) > 0 {
+		cov = append(cov, info.Extra.Cover)
+		hasCov = true
+	} else {
+		cov = append(cov, nil)
+	}
+	if !hasCov {
+		return nil, nil
+	}
+	symbolized, err := symbolize(args, cov)
+	if err != nil {
+		return nil, fmt.Errorf("failed to symbolize coverage: %w", err)
+	}
+	return symbolized, nil
+}

--- a/pkg/aflow/tool/syzlang/execute.go
+++ b/pkg/aflow/tool/syzlang/execute.go
@@ -1,0 +1,77 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package syzlang
+
+import (
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/action/crash"
+)
+
+var (
+	ExecuteSeed = aflow.NewFuncTool("execute-seed", executeSeed, `
+Tool executes the given syz program in a VM to collect coverage.
+It allows calls to block without hanging the execution by running in threaded mode.
+It returns an ExecutionCachedID even if the execution times out or doesn't crash.
+`)
+
+	GetExecutedProgram = aflow.NewFuncTool("get-executed-program", getExecutedProgram, `
+Tool returns the syzlang program that was executed for the given ExecutionCachedID.
+`)
+)
+
+type ExecuteSeedArgs struct {
+	ReproSyz string `jsonschema:"Syz program to execute."`
+}
+
+type ExecuteSeedResult struct {
+	ExecutionCachedID string            `jsonschema:"Cached ID. Pass to coverage tools to explore executed code."`
+	CallErrors        []crash.CallError `jsonschema:"List of calls that failed. Empty if all succeeded."`
+}
+
+func executeSeed(ctx *aflow.Context, state reproduceState, args ExecuteSeedArgs) (ExecuteSeedResult, error) {
+	if args.ReproSyz == "" {
+		return ExecuteSeedResult{}, aflow.BadCallError("syz program cannot be empty")
+	}
+
+	executeArgs := crash.ExecuteSeedArgs{
+		TargetConfig: state.targetConfig(""),
+		ReproSyz:     args.ReproSyz,
+	}
+	executionCachedID, err := crash.ExecuteSeedFunc(ctx, executeArgs)
+	if err != nil {
+		return ExecuteSeedResult{}, err
+	}
+
+	callErrors, err := crash.LoadCallErrors(ctx, executionCachedID)
+	if err != nil {
+		return ExecuteSeedResult{}, err
+	}
+
+	return ExecuteSeedResult{
+		ExecutionCachedID: executionCachedID,
+		CallErrors:        callErrors,
+	}, nil
+}
+
+type GetExecutedProgramArgs struct {
+	ExecutionCachedID string `jsonschema:"Cached ID of the execution."`
+}
+
+type GetExecutedProgramResult struct {
+	SyzProgram string `jsonschema:"The generated syzlang program."`
+}
+
+func getExecutedProgram(ctx *aflow.Context, state reproduceState,
+	args GetExecutedProgramArgs) (GetExecutedProgramResult, error) {
+	if args.ExecutionCachedID == "" {
+		return GetExecutedProgramResult{}, aflow.BadCallError("ExecutionCachedID is required")
+	}
+	generated, err := crash.LoadSeedProgramDetails(ctx, args.ExecutionCachedID)
+	if err != nil {
+		return GetExecutedProgramResult{}, aflow.BadCallError("failed to load program details: %v", err)
+	}
+	return GetExecutedProgramResult{
+		SyzProgram: generated,
+	}, nil
+}

--- a/pkg/aflow/tool/syzlang/execute_test.go
+++ b/pkg/aflow/tool/syzlang/execute_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package syzlang
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteSeed_DeserializeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+	}{
+		{
+			name:    "double quotes",
+			program: `openat(0xffffffffffffff9c, "hello", 0x0, 0x0)`,
+		},
+		{
+			name: "multi-line statement",
+			program: `openat(0xffffffffffffff9c,
+0x0, 0x0)`,
+		},
+		{
+			name:    "inline comment",
+			program: `openat(0xffffffffffffff9c, # inline comment`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &aflow.Context{}
+			state := reproduceState{
+				TargetOS:   "linux",
+				TargetArch: "amd64",
+			}
+			args := ExecuteSeedArgs{
+				ReproSyz: tc.program,
+			}
+			_, err := executeSeed(ctx, state, args)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Syzlang Syntax Reminders:")
+		})
+	}
+}
+
+func TestExecuteSeed(t *testing.T) {
+	state := reproduceState{
+		TargetOS:   "linux",
+		TargetArch: "amd64",
+		Syzkaller:  "../../../..",
+	}
+
+	tests := []struct {
+		name      string
+		program   string
+		wantError string
+	}{
+		{
+			name:      "valid program",
+			program:   "getrlimit(0x0, 0x0)",
+			wantError: "VM configuration is missing",
+		},
+		{
+			name:      "empty program",
+			program:   "",
+			wantError: "syz program cannot be empty",
+		},
+		{
+			name:      "invalid program syntax",
+			program:   "invalid_call()",
+			wantError: "unknown syscall",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := executeSeed(&aflow.Context{}, state, ExecuteSeedArgs{
+				ReproSyz: tc.program,
+			})
+			if tc.wantError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -11,6 +11,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 )
 
 type Sig [sha1.Size]byte
@@ -40,6 +42,22 @@ func Hash(pieces ...any) Sig {
 func String(pieces ...any) string {
 	sig := Hash(pieces...)
 	return sig.String()
+}
+
+// File computes the SHA-1 hash of a file by streaming its contents.
+func File(path string) (Sig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Sig{}, err
+	}
+	defer f.Close()
+	h := sha1.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return Sig{}, err
+	}
+	var sig Sig
+	copy(sig[:], h.Sum(nil))
+	return sig, nil
 }
 
 func (sig *Sig) String() string {

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -4,7 +4,11 @@
 package hash
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHash(t *testing.T) {
@@ -20,4 +24,19 @@ func TestHash(t *testing.T) {
 	if String(X{0}) == String(X{1}) {
 		t.Fatal("equal hashes")
 	}
+}
+
+func TestFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "testfile")
+	content := []byte("hello syzkaller file hashing")
+	err := os.WriteFile(filePath, content, 0600)
+	require.NoError(t, err)
+
+	sig, err := File(filePath)
+	require.NoError(t, err)
+	require.Equal(t, "25a4c3561ef3167a6dedd74da7fd6e2f2c03c286", sig.String())
+
+	_, err = File(filepath.Join(dir, "nonexistent"))
+	require.Error(t, err)
 }


### PR DESCRIPTION
Enable LLM agents and workflows to execute individual syzkaller programs in non-crashing, threaded VM runs to collect coverage and syscall error diagnostics.

Extracted execution handling into a dedicated action and tool layer to allow reusable seed execution across different agent workflows.

