### PR TITLE
pkg/aflow/tool/syzlang: support checking reached PCs in execution coverage

### DIFF
--- a/pkg/aflow/action/crash/coverage.go
+++ b/pkg/aflow/action/crash/coverage.go
@@ -1,0 +1,66 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/aflow"
+)
+
+func parseHexPC(raw string) (uint64, error) {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	if s == "" {
+		return 0, fmt.Errorf("empty PC address")
+	}
+	return strconv.ParseUint(s, 16, 64)
+}
+
+// CheckPCsInCoverage checks if any of the target PCs were executed during the
+// cached run.
+func CheckPCsInCoverage(ctx *aflow.Context, executionCachedID string, targetPCs ...uint64) (bool, error) {
+	if len(targetPCs) == 0 {
+		return false, nil
+	}
+	coverage, err := LoadCoverage(ctx, executionCachedID)
+	if err != nil {
+		return false, err
+	}
+
+	targetMap := make(map[uint64]bool, len(targetPCs))
+	for _, pc := range targetPCs {
+		targetMap[pc] = true
+	}
+
+	for _, callcov := range coverage {
+		for _, frame := range callcov {
+			if targetMap[frame.PC] {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// CheckHexPCsInCoverage parses hex PC strings and returns true if any target PC
+// was executed.
+func CheckHexPCsInCoverage(ctx *aflow.Context, executionCachedID string, targetPCs ...string) (bool, error) {
+	var parsedPCs []uint64
+	for _, pcStr := range targetPCs {
+		pc, err := parseHexPC(pcStr)
+		if err != nil {
+			return false, fmt.Errorf("invalid PC %q: %w", pcStr, err)
+		}
+		parsedPCs = append(parsedPCs, pc)
+	}
+	if len(parsedPCs) == 0 {
+		return false, nil
+	}
+	return CheckPCsInCoverage(ctx, executionCachedID, parsedPCs...)
+}

--- a/pkg/aflow/action/crash/coverage_test.go
+++ b/pkg/aflow/action/crash/coverage_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package crash
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/symbolizer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHexPC(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{"0x1000", 0x1000, false},
+		{"0X1000", 0x1000, false},
+		{"1000", 0x1000, false},
+		{"  0xffffffff81001234  ", 0xffffffff81001234, false},
+		{"", 0, true},
+		{"invalid", 0, true},
+	}
+
+	for _, tt := range tests {
+		got, err := parseHexPC(tt.input)
+		if tt.wantErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		}
+	}
+}
+
+func TestCheckPCsInCoverage(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	dummyCov := [][]symbolizer.Frame{
+		{
+			{PC: 0x100, Func: "foo", File: "kernel/foo.c", Line: 10},
+			{PC: 0x200, Func: "bar", File: "kernel/bar.c", Line: 20},
+		},
+		{
+			{PC: 0x300, Func: "baz", File: "kernel/baz.c", Line: 30},
+		},
+	}
+
+	_, cachedID, err := aflow.CacheObject(ctx, "repro", "test-cov", func() (map[string]any, error) {
+		return map[string]any{"Coverage": dummyCov}, nil
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		targetPCs []uint64
+		want      bool
+	}{
+		{
+			name:      "single PC hit",
+			targetPCs: []uint64{0x200},
+			want:      true,
+		},
+		{
+			name:      "single PC miss",
+			targetPCs: []uint64{0x999},
+			want:      false,
+		},
+		{
+			name:      "multiple PCs with hit",
+			targetPCs: []uint64{0x999, 0x300, 0x888},
+			want:      true,
+		},
+		{
+			name:      "multiple PCs with no hit",
+			targetPCs: []uint64{0x999, 0x888},
+			want:      false,
+		},
+		{
+			name:      "empty target PCs",
+			targetPCs: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reached, err := CheckPCsInCoverage(ctx, cachedID, tt.targetPCs...)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, reached)
+		})
+	}
+}
+
+func TestCheckHexPCsInCoverage(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	dummyCov := [][]symbolizer.Frame{
+		{
+			{PC: 0x100, Func: "foo", File: "kernel/foo.c", Line: 10},
+			{PC: 0x200, Func: "bar", File: "kernel/bar.c", Line: 20},
+		},
+	}
+
+	_, cachedID, err := aflow.CacheObject(ctx, "repro", "test-hex-cov", func() (map[string]any, error) {
+		return map[string]any{"Coverage": dummyCov}, nil
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		targetPCs []string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "valid hex hit",
+			targetPCs: []string{"0x999", "0x100"},
+			want:      true,
+		},
+		{
+			name:      "invalid hex format",
+			targetPCs: []string{"0x999", "invalid_pc"},
+			wantErr:   true,
+		},
+		{
+			name:      "empty target PCs",
+			targetPCs: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reached, err := CheckHexPCsInCoverage(ctx, cachedID, tt.targetPCs...)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, reached)
+			}
+		})
+	}
+}

--- a/pkg/aflow/tool/syzlang/coverage.go
+++ b/pkg/aflow/tool/syzlang/coverage.go
@@ -42,6 +42,10 @@ If the trace is too large, it will be truncated. You can use 'Offset' and 'Limit
 through trace output lines.
 `)
 
+	CheckPCReached = aflow.NewFuncTool("check-pc-reached", checkPCReached, `
+Checks if any of the target PCs were reached during the execution attempt.
+`)
+
 	Coverage = []aflow.Tool{CoverageFiles, FileCoverage, ExecutionTrace}
 )
 
@@ -79,7 +83,7 @@ func getCoverageFiles(ctx *aflow.Context, state reproduceState, args CoverageFil
 }
 
 type FileCoverageArgs struct {
-	ExecutionCachedID string   `jsonschema:"Cached ID returned by the reproduce-crash tool."`
+	ExecutionCachedID string   `jsonschema:"Cached ID returned by the reproduce-crash or execute-seed tool."`
 	Filename          string   `jsonschema:"Name of the source file to inspect."`
 	Functions         []string `jsonschema:"Optional list of functions. If empty, returns all."`
 }
@@ -171,6 +175,10 @@ func (f *coverageFormatter) buildSnippet(fnName string, start, end int, lines []
 func getFileCoverage(ctx *aflow.Context, state reproduceState, args FileCoverageArgs) (FileCoverageResult, error) {
 	if !filepath.IsLocal(args.Filename) {
 		return FileCoverageResult{}, aflow.BadCallError("filename must be a safe, local relative path")
+	}
+	if args.ExecutionCachedID == "" {
+		return FileCoverageResult{}, aflow.BadCallError(
+			"no previous execution found. You must execute a seed before requesting coverage.")
 	}
 
 	coverage, err := crash.LoadCoverage(ctx, args.ExecutionCachedID)
@@ -587,4 +595,34 @@ func truncateTrace(out []string, maxLines int) []string {
 
 	newOut = append(newOut, out[len(out)-half:]...)
 	return newOut
+}
+
+type CheckPCReachedArgs struct {
+	ExecutionCachedID string `jsonschema:"The cached execution ID of the attempt."`
+}
+
+type CheckPCReachedResult struct {
+	Reached bool `jsonschema:"True if the target PC was reached during execution."`
+}
+
+type checkPCState struct {
+	PCs []string `json:",omitempty"`
+}
+
+func checkPCReached(
+	ctx *aflow.Context, state checkPCState, args CheckPCReachedArgs) (CheckPCReachedResult, error) {
+	if args.ExecutionCachedID == "" {
+		return CheckPCReachedResult{}, aflow.BadCallError("no ExecutionCachedID provided")
+	}
+
+	if len(state.PCs) == 0 {
+		return CheckPCReachedResult{}, fmt.Errorf("no target PC(s) found in state")
+	}
+
+	reached, err := crash.CheckHexPCsInCoverage(ctx, args.ExecutionCachedID, state.PCs...)
+	if err != nil {
+		return CheckPCReachedResult{}, aflow.BadCallError("failed to check PC in coverage: %v", err)
+	}
+
+	return CheckPCReachedResult{Reached: reached}, nil
 }

--- a/pkg/aflow/tool/syzlang/coverage_test.go
+++ b/pkg/aflow/tool/syzlang/coverage_test.go
@@ -33,9 +33,9 @@ func TestCoverageFiles(t *testing.T) {
 		return map[string]any{"Coverage": dummyCov}, nil
 	})
 	require.NoError(t, err)
-	res, err := getCoverageFiles(ctx, reproduceState{TargetOS: "linux", TargetArch: "amd64"}, CoverageFilesArgs{
-		ExecutionCachedID: reproExecCachedID,
-	})
+	res, err := getCoverageFiles(ctx,
+		reproduceState{TargetOS: "linux", TargetArch: "amd64"},
+		CoverageFilesArgs{ExecutionCachedID: reproExecCachedID})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"kernel/bar.c", "kernel/foo.c"}, res.Files)
@@ -468,4 +468,44 @@ func TestIsNoiseFunction(t *testing.T) {
 			require.Equal(t, tt.want, isNoiseFunction(tt.name))
 		})
 	}
+}
+
+func TestCheckPCReached(t *testing.T) {
+	ctx := aflow.NewTestContext(t)
+
+	dummyCov := [][]symbolizer.Frame{
+		{
+			{PC: 0x100, Func: "foo", File: "kernel/foo.c", Line: 10},
+			{PC: 0x200, Func: "bar", File: "kernel/bar.c", Line: 20},
+		},
+	}
+
+	_, reproExecCachedID, err := aflow.CacheObject(ctx, "repro", "check-pc-desc", func() (map[string]any, error) {
+		return map[string]any{"Coverage": dummyCov}, nil
+	})
+	require.NoError(t, err)
+
+	// Test 1: PCs in state matched.
+	res, err := checkPCReached(ctx, checkPCState{PCs: []string{"0x200"}}, CheckPCReachedArgs{
+		ExecutionCachedID: reproExecCachedID,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Reached)
+
+	// Test 2: PC not reached.
+	res, err = checkPCReached(ctx, checkPCState{PCs: []string{"0x999"}}, CheckPCReachedArgs{
+		ExecutionCachedID: reproExecCachedID,
+	})
+	require.NoError(t, err)
+	require.False(t, res.Reached)
+
+	// Test 3: Missing ExecutionCachedID.
+	_, err = checkPCReached(ctx, checkPCState{PCs: []string{"0x100"}}, CheckPCReachedArgs{})
+	require.Error(t, err)
+
+	// Test 4: Missing target PCs in state.
+	_, err = checkPCReached(ctx, checkPCState{}, CheckPCReachedArgs{
+		ExecutionCachedID: reproExecCachedID,
+	})
+	require.Error(t, err)
 }


### PR DESCRIPTION
Workflows such as seed generation and reproduction need to verify whether specific program counters (PCs) were hit during an execution attempt. Provide helper functions in crash action to check coverage traces for target PCs and expose a check-pc-reached tool to syzlang LLM agents.

