### PR TITLE
pkg/aflow: support custom hang timeout in crash.TargetConfig

### DIFF
--- a/pkg/aflow/action/crash/config.go
+++ b/pkg/aflow/action/crash/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/google/syzkaller/pkg/build"
 	"github.com/google/syzkaller/pkg/mgrconfig"
@@ -44,6 +45,14 @@ type TargetConfig struct {
 	Sandbox string
 	// Whether to run VM in snapshot mode (only supported with qemu VM type).
 	Snapshot bool
+	// Custom timeout for detecting when a VM is hung without console output (overrides default sysTarget NoOutput).
+	noOutputTimeout time.Duration
+}
+
+// WithNoOutputTimeout returns a copy of TargetConfig with a custom hang timeout.
+func (args TargetConfig) WithNoOutputTimeout(d time.Duration) TargetConfig {
+	args.noOutputTimeout = d
+	return args
 }
 
 // Validate checks if the target configuration is valid.
@@ -128,6 +137,10 @@ func BuildConfig(args TargetConfig, workdir string) (*mgrconfig.Config, error) {
 	}
 	if err := mgrconfig.Complete(cfg); err != nil {
 		return nil, err
+	}
+	if args.noOutputTimeout > 0 {
+		cfg.Timeouts.NoOutput = args.noOutputTimeout
+		cfg.Timeouts.NoOutputRunningTime = args.noOutputTimeout + time.Minute
 	}
 	return cfg, nil
 }

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -42,6 +42,9 @@ func checkSchemaType(typ reflect.Type) error {
 		return nil
 	}
 	for _, field := range reflect.VisibleFields(typ) {
+		if !field.IsExported() || field.Anonymous {
+			continue
+		}
 		if field.Tag.Get("jsonschema") == "" {
 			return fmt.Errorf("%v.%v does not have a jsonschema tag with description",
 				typ.Name(), field.Name)
@@ -255,7 +258,7 @@ func foreachField(data any) iter.Seq2[string, reflect.Value] {
 	return func(yield func(string, reflect.Value) bool) {
 		v := reflect.ValueOf(data).Elem()
 		for _, field := range reflect.VisibleFields(v.Type()) {
-			if field.Anonymous {
+			if !field.IsExported() || field.Anonymous {
 				continue
 			}
 			if !yield(field.Name, v.FieldByIndex(field.Index)) {

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -26,6 +26,11 @@ func TestSchema(t *testing.T) {
 		A int    `jsonschema:"aaa"`
 		B string `jsonschema:"bbb"`
 	}
+	type structWithUnexported struct {
+		A int `jsonschema:"aaa"`
+		b string
+	}
+	_ = (structWithUnexported{}).b
 	tests := []Test{
 		{
 			fn:  schemaFor[int],
@@ -37,6 +42,9 @@ func TestSchema(t *testing.T) {
 		},
 		{
 			fn: schemaFor[structWithTags],
+		},
+		{
+			fn: schemaFor[structWithUnexported],
 		},
 	}
 	for i, test := range tests {
@@ -261,6 +269,15 @@ func TestConvertFromMap(t *testing.T) {
 	}{
 		Embedded: Embedded{B: "foo"},
 		A:        1,
+	}, "", "")
+
+	testConvertFromMap(t, true, map[string]any{
+		"A": 1.0,
+	}, struct {
+		A int
+		b string
+	}{
+		A: 1,
 	}, "", "")
 }
 


### PR DESCRIPTION
Allow workflows to specify custom console output hang timeouts for short-lived VM executions in crash.TargetConfig and ignore unexported struct fields during schema tag validation.
