### PR TITLE
pkg/aflow/syzspec: support blob replacement for large data payloads

### DIFF
--- a/pkg/aflow/action/actionsyzlang/crepro.go
+++ b/pkg/aflow/action/actionsyzlang/crepro.go
@@ -6,9 +6,9 @@ package actionsyzlang
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/syzspec"
 	"github.com/google/syzkaller/pkg/csource"
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/sys"
@@ -26,8 +26,6 @@ type createCReproArgs struct {
 type createCReproResult struct {
 	SimplifiedCRepro string
 }
-
-var stringLiteralSeq = regexp.MustCompile(`"(?:[^"\\]|\\.)*"(?:\s*"(?:[^"\\]|\\.)*")*`)
 
 func createCRepro(ctx *aflow.Context, args createCReproArgs) (createCReproResult, error) {
 	if args.ReproSyz == "" {
@@ -53,7 +51,7 @@ func createCRepro(ctx *aflow.Context, args createCReproArgs) (createCReproResult
 const maxStringLiteralSeqLen = 128
 
 func truncateLargeData(cRepro string) string {
-	return stringLiteralSeq.ReplaceAllStringFunc(cRepro, func(match string) string {
+	return syzspec.StringLiteralSeq.ReplaceAllStringFunc(cRepro, func(match string) string {
 		if len(match) > maxStringLiteralSeqLen {
 			return `"... [truncated large byte array] ..."`
 		}

--- a/pkg/aflow/action/actionsyzlang/format.go
+++ b/pkg/aflow/action/actionsyzlang/format.go
@@ -28,6 +28,7 @@ func formatActionFunc(ctx *aflow.Context, args FormatArgs) (FormatResult, error)
 	if err != nil {
 		return FormatResult{}, err
 	}
+	args.CandidateReproSyz = ctx.RestoreBlobs(args.CandidateReproSyz)
 	p, err := pt.Deserialize([]byte(args.CandidateReproSyz), prog.NonStrict)
 	if err != nil {
 		return FormatResult{}, fmt.Errorf("failed to deserialize syzkaller program: %w", err)

--- a/pkg/aflow/action/actionsyzlang/format_test.go
+++ b/pkg/aflow/action/actionsyzlang/format_test.go
@@ -6,6 +6,7 @@ package actionsyzlang
 import (
 	"testing"
 
+	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,13 +18,21 @@ func TestFormat(t *testing.T) {
 			validProg := `r0 = openat(0xffffffffffffff9c, &AUTO='./file1\x00', 0x42, 0x1ff)
 write(r0, &AUTO="01010101", 0x4)
 `
-			res, err := formatActionFunc(nil, FormatArgs{TargetOS: "linux", TargetArch: arch, CandidateReproSyz: validProg})
+			res, err := formatActionFunc(&aflow.Context{}, FormatArgs{
+				TargetOS:          "linux",
+				TargetArch:        arch,
+				CandidateReproSyz: validProg,
+			})
 			require.NoError(t, err)
 			require.NotEmpty(t, res.ReproSyz)
 
 			// Test invalid program.
 			invalidProg := `r0 = unknown_syscall_name(0x123)`
-			_, err2 := formatActionFunc(nil, FormatArgs{TargetOS: "linux", TargetArch: arch, CandidateReproSyz: invalidProg})
+			_, err2 := formatActionFunc(&aflow.Context{}, FormatArgs{
+				TargetOS:          "linux",
+				TargetArch:        arch,
+				CandidateReproSyz: invalidProg,
+			})
 			require.Error(t, err2)
 			require.Contains(t, err2.Error(), "unknown syscall")
 		})

--- a/pkg/aflow/action/crash/execute_seed.go
+++ b/pkg/aflow/action/crash/execute_seed.go
@@ -43,11 +43,11 @@ func ExecuteSeedFunc(ctx *aflow.Context, args ExecuteSeedArgs) (string, error) {
 		return "", err
 	}
 
-	fullSyz := args.ReproSyz
+	fullSyz := ctx.RestoreBlobs(args.ReproSyz)
 	// We perform normalization so that the cache key is calculated correctly.
 	p, err := target.Deserialize([]byte(fullSyz), prog.Strict)
 	if err != nil {
-		return "", aflow.BadCallError("%v%s", err.Error(), deserializationErrorHelp)
+		return "", aflow.BadCallError("%v%s", ctx.ReplaceBlobs(err.Error()), deserializationErrorHelp)
 	}
 	if len(p.Calls) > prog.MaxCalls {
 		return "", aflow.BadCallError("program has %d calls, exceeding the limit of %d", len(p.Calls), prog.MaxCalls)

--- a/pkg/aflow/action/crash/reproduce.go
+++ b/pkg/aflow/action/crash/reproduce.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
@@ -24,12 +23,6 @@ import (
 	"github.com/google/syzkaller/pkg/symbolizer"
 	"github.com/google/syzkaller/sys/targets"
 )
-
-func init() {
-	// TODO: remove once callers in downstream packages use these helpers.
-	runtime.KeepAlive(LoadSeedProgramDetails)
-	runtime.KeepAlive(LoadCallErrors)
-}
 
 var ErrDidNotCrash = errors.New("reproducer did not crash")
 
@@ -70,8 +63,9 @@ type RunTestResult struct {
 }
 
 // RunTest boots the kernel and runs a single test program.
-func RunTest(args ReproduceArgs, workdir string, collectCoverage bool) (RunTestResult, error) {
+func RunTest(ctx *aflow.Context, args ReproduceArgs, workdir string, collectCoverage bool) (RunTestResult, error) {
 	res := RunTestResult{}
+	args.ReproSyz = ctx.RestoreBlobs(args.ReproSyz)
 	if err := args.Validate(); err != nil {
 		return res, fmt.Errorf("run test: %w", err)
 	}
@@ -239,13 +233,13 @@ func LoadCoverage(ctx *aflow.Context, cachedID string) ([][]symbolizer.Frame, er
 	return cached.Coverage, nil
 }
 
-// LoadSeedProgramDetails retrieves the generated syzkaller program from a cached execution.
+// LoadSeedProgramDetails retrieves the generated syzkaller program from a cached execution with blob payloads replaced.
 func LoadSeedProgramDetails(ctx *aflow.Context, cachedID string) (string, error) {
 	cached, err := aflow.RetrieveObject[cachedExecution](ctx, cachedID)
 	if err != nil {
 		return "", err
 	}
-	return cached.GeneratedSyz, nil
+	return ctx.ReplaceBlobs(cached.GeneratedSyz), nil
 }
 
 // LoadCallErrors retrieves the list of syscall error details from a cached execution.
@@ -279,7 +273,7 @@ func ReproduceFuncWithCoverage(ctx *aflow.Context, args ReproduceArgs,
 		if err != nil {
 			return res, err
 		}
-		testRes, err := RunTest(args, workdir, collectCoverage)
+		testRes, err := RunTest(ctx, args, workdir, collectCoverage)
 		if testRes.Report != nil {
 			res.BugTitle = testRes.Report.Title
 			res.Report = string(testRes.Report.Report)

--- a/pkg/aflow/action/crash/run_c_repro.go
+++ b/pkg/aflow/action/crash/run_c_repro.go
@@ -69,7 +69,7 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	}
 
 	// Run 1: without strace.
-	res1, err1 := RunTest(reproduceArgs, workdir, false)
+	res1, err1 := RunTest(ctx, reproduceArgs, workdir, false)
 	if err1 != nil {
 		return RunCReproResult{}, err1
 	}
@@ -90,7 +90,7 @@ func RunCReproFunc(ctx *aflow.Context, args RunCReproArgs) (RunCReproResult, err
 	// Run 2: with strace (only if first run didn't crash and didn't have boot error)
 	if !result.CandidateReproduced && result.TestError == "" && args.NeedStrace && args.StraceBin != "" {
 		reproduceArgs.NeedStrace = true
-		res2, err2 := RunTest(reproduceArgs, workdir, false)
+		res2, err2 := RunTest(ctx, reproduceArgs, workdir, false)
 		if err2 != nil {
 			return result, err2 // Return what we had from Run 1, plus the error.
 		}

--- a/pkg/aflow/action/crash/test.go
+++ b/pkg/aflow/action/crash/test.go
@@ -128,7 +128,7 @@ func testPatchRepro(ctx *aflow.Context, args testArgs) (string, error) {
 		ReproSyz:  args.ReproSyz,
 		ReproC:    args.ReproC,
 	}
-	testRes, err := RunTest(reproduceArgs, workdir, false)
+	testRes, err := RunTest(ctx, reproduceArgs, workdir, false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -16,6 +16,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/google/syzkaller/pkg/aflow/syzspec"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
@@ -202,6 +203,7 @@ type Context struct {
 	runnerDebug    bool
 	tokenLimit     int
 	consumedTokens int64
+	blobs          syzspec.BlobStore
 	stubContext
 }
 
@@ -210,6 +212,16 @@ type stubContext struct {
 	sleep           func(time.Duration)
 	generateContent func(string, *backend.GenerateConfig, []*backend.Message) (
 		*backend.GenerateResponse, error)
+}
+
+// ReplaceBlobs replaces large string literal blobs in content with short placeholders.
+func (ctx *Context) ReplaceBlobs(content string) string {
+	return ctx.blobs.ReplaceBlobs(content)
+}
+
+// RestoreBlobs restores all placeholders in content back to their original blobs.
+func (ctx *Context) RestoreBlobs(content string) string {
+	return ctx.blobs.RestoreBlobs(content)
 }
 
 // runWithState executes the given function with the context's state temporarily

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -109,6 +109,7 @@ func formatReproFinderOutputs(ctx *aflow.Context, state ReproFinderState,
 	if err != nil {
 		return res, err
 	}
+	res.ReproSyz = ctx.RestoreBlobs(res.ReproSyz)
 	p, err := pt.Deserialize([]byte(res.ReproSyz), prog.NonStrict)
 	if err != nil {
 		return res, aflow.BadCallError("failed to deserialize syzkaller program: %v", err)

--- a/pkg/aflow/syzspec/blobs.go
+++ b/pkg/aflow/syzspec/blobs.go
@@ -1,0 +1,66 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package syzspec provides utilities and actions for parsing and analyzing syzlang descriptions.
+package syzspec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sync"
+)
+
+const minBlobLen = 128
+
+var (
+	StringLiteralSeq = regexp.MustCompile(`"(?:[^"\\]|\\.)*"(?:\s*"(?:[^"\\]|\\.)*")*`)
+	placeholderRegex = regexp.MustCompile(`"\$BLOB_[a-f0-9]{12}"`)
+)
+
+// BlobStore manages the mapping between large data blobs and their placeholders.
+type BlobStore struct {
+	mu                sync.RWMutex
+	placeholderToBlob map[string]string
+}
+
+// RegisterBlob registers a data blob string and returns its placeholder.
+func (s *BlobStore) RegisterBlob(blob string) string {
+	h := sha256.Sum256([]byte(blob))
+	hashStr := hex.EncodeToString(h[:6]) // Use 12 hex characters.
+	ph := fmt.Sprintf("\"$BLOB_%s\"", hashStr)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.placeholderToBlob == nil {
+		s.placeholderToBlob = make(map[string]string)
+	}
+	s.placeholderToBlob[ph] = blob
+	return ph
+}
+
+// ReplaceBlobs replaces all large string literal blobs in the content with their placeholders.
+func (s *BlobStore) ReplaceBlobs(content string) string {
+	return StringLiteralSeq.ReplaceAllStringFunc(content, func(match string) string {
+		if len(match) >= minBlobLen {
+			return s.RegisterBlob(match)
+		}
+		return match
+	})
+}
+
+// RestoreBlobs restores all placeholders in the content back to their original blobs.
+func (s *BlobStore) RestoreBlobs(content string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.placeholderToBlob) == 0 {
+		return content
+	}
+	return placeholderRegex.ReplaceAllStringFunc(content, func(match string) string {
+		if blob, ok := s.placeholderToBlob[match]; ok {
+			return blob
+		}
+		return match
+	})
+}

--- a/pkg/aflow/syzspec/blobs_test.go
+++ b/pkg/aflow/syzspec/blobs_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package syzspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobPlaceholders(t *testing.T) {
+	var store BlobStore
+	input := `syz_mount_image$btrfs(&AUTO='btrfs\x00', &AUTO='./file0\x00', 0x0, &AUTO, 0x1, AUTO, &AUTO="$` +
+		`eJzs3W2MXFX9B/Azs9tt2f8/ZosBAV/ULpCgpLRsLLpUdgcSiqSBTAAToEALWqG2` +
+		`PENQHsJQCVqxYbVWUwOKbCIuQWgTbSUUGWEp2LRhu4AWi1QUFUJAI1LQQjTcuWd2` +
+		`5s7O7gZDW+DzaWbOPfM759xzLzdh+uI7DQ==")`
+
+	// Test ReplaceBlobs.
+	replaced := store.ReplaceBlobs(input)
+	// The length of the output should be much smaller.
+	require.Less(t, len(replaced), len(input))
+	require.Contains(t, replaced, "$BLOB_")
+	require.NotContains(t, replaced, "$eJ")
+
+	// Test RestoreBlobs.
+	restored := store.RestoreBlobs(replaced)
+	require.Equal(t, input, restored)
+}
+
+func TestMultipleBlobs(t *testing.T) {
+	var store BlobStore
+	input := `syz_mount_image$btrfs(&AUTO="$` +
+		`eJzs3W2MXFX9B/Azs9tt2f8/ZosBAV/ULpCgpLRsLLpUdgcSiqSBTAAToEALWqG2` +
+		`PENQHsJQCVqxYbVWUwOKbCIuQWgTbSUUGWEp2LRhu4AWi1QUFUJAI1LQQjTcuWd2` +
+		`5s7O7gZDW+DzaWbOPfM759xzLzdh+uI7DQ==")
+syz_mount_image$f2fs(&AUTO="$` +
+		`eJzs3D9vG2UcB/DfNbQCWkqEGNh4JEByJGKd7aSCskRUVQdIFdEyMji2Y7lN7ChO` +
+		`nNCJhT8vgg0m3gMvgI2lQ98BEhsSS4UE8t0FoYqhgInB+Xyku+/dc9ffc491y+9U` +
+		`JYBzazn9/FMWV+O5iFiKiCsRxXFWbYWNMl6JiFcj4sIftqwa/33gUkQ8HxFXp8XL` +
+		`mll16atvP/vo6x/ee+PLb75byr/4/Mf5rRqYt9cjYm+/PD7eK3PUL/NeNd6eDIrc` +
+		`W5tUWV7Yu1+dj8o87m0XFY7bp/e1i2z1y/tH+0fjae7stjvT7A92ivH9YTnheNI/` +
+		`rVP8g3vtg+K829sucjAeFdl/UD7XSZUPxodlnW5V7+OifBwenmY53jvplevZv19k` +
+		`Z3hYjZd1R93eyTQnVVbTRXf77/++/xfvD4ZHJ2nSOxgPRsO0Xm/k9Xz1oHNtNc8b` +
+		`b7dW+932Tudar7nWbe+spVpvYzzaXUm1fqeTardu3FhJjbzerOdvplu3P0y73VSb` +
+		`5ruD4dHhYHe8kpr11nq9sZJea6Q7m1tp64ObNze37qbN0TDdHk1SK0+N1vX15vXW` +
+		`2nrzt3UzJu59Z+p7IznY8F4gQD+Mv0/MA/6f/1/6H/P/fq1b/wjXi==")`
+
+	replaced := store.ReplaceBlobs(input)
+	require.Contains(t, replaced, "$BLOB_")
+
+	restored := store.RestoreBlobs(replaced)
+	require.Equal(t, input, restored)
+}
+
+func TestNonCompressedBase64Blob(t *testing.T) {
+	var store BlobStore
+	// Non-compressed base64 blob >= 128 chars.
+	nonCompressedB64 := `"$SGVsbG8gV29ybGQhIFRoaXMgaXMgYSB0ZXN0IG9mIGEgbm9uLWNvbXByZXNzZWQg` +
+		`YmFzZTY0IGJsb2IgdGhhdCBpcyBsb25nIGVub3VnaCB0byBleGNlZWQgdGhlIDEyOCBjaGFyYWN0ZXIgdGhyZXNob2xkLi4u"`
+	input := `syz_mount_image$ext4(&AUTO=` + nonCompressedB64 + `)`
+
+	replaced := store.ReplaceBlobs(input)
+	require.Contains(t, replaced, "$BLOB_")
+	require.NotContains(t, replaced, "SGVsbG8gV29ybGQh")
+
+	restored := store.RestoreBlobs(replaced)
+	require.Equal(t, input, restored)
+}
+
+func TestShortStringNotReplaced(t *testing.T) {
+	var store BlobStore
+	// String shorter than minBlobLen (128) should be kept as-is.
+	input := `syz_mount_image$btrfs(&AUTO='btrfs\x00', &AUTO="./short_file_path\x00")`
+	replaced := store.ReplaceBlobs(input)
+	require.Equal(t, input, replaced)
+}
+
+func TestZeroValueBlobStore(t *testing.T) {
+	var store BlobStore
+	input := `syz_mount_image$btrfs(&AUTO="$` +
+		`eJzs3W2MXFX9B/Azs9tt2f8/ZosBAV/ULpCgpLRsLLpUdgcSiqSBTAAToEALWqG2` +
+		`PENQHsJQCVqxYbVWUwOKbCIuQWgTbSUUGWEp2LRhu4AWi1QUFUJAI1LQQjTcuWd2` +
+		`5s7O7gZDW+DzaWbOPfM759xzLzdh+uI7DQ==")`
+
+	// Should work safely with empty/nil map on RestoreBlobs.
+	require.Equal(t, "unrelated text", store.RestoreBlobs("unrelated text"))
+
+	// Should lazily initialize on ReplaceBlobs.
+	replaced := store.ReplaceBlobs(input)
+	require.Contains(t, replaced, "$BLOB_")
+
+	restored := store.RestoreBlobs(replaced)
+	require.Equal(t, input, restored)
+}

--- a/pkg/aflow/tool/syzlang/corpus_search.go
+++ b/pkg/aflow/tool/syzlang/corpus_search.go
@@ -81,7 +81,7 @@ func corpusCodeSearch(ctx *aflow.Context, state CorpusCodeSearchState,
 		if !ok {
 			continue
 		}
-		fmt.Fprintf(&b, "=== Program %d ===\n%s\n", i+1, strings.TrimSpace(progStr))
+		fmt.Fprintf(&b, "=== Program %d ===\n%s\n", i+1, strings.TrimSpace(ctx.ReplaceBlobs(progStr)))
 	}
 
 	return CorpusCodeSearchResult{Output: b.String()}, nil

--- a/pkg/aflow/tool/syzlang/execute_test.go
+++ b/pkg/aflow/tool/syzlang/execute_test.go
@@ -4,9 +4,11 @@
 package syzlang
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/image"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +47,61 @@ func TestExecuteSeed_DeserializeErrors(t *testing.T) {
 			require.Contains(t, err.Error(), "Syzlang Syntax Reminders:")
 		})
 	}
+}
+
+func TestExecuteSeed_BlobPlaceholder(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	compressed := image.Compress(data)
+	b64 := image.EncodeB64(compressed)
+	input := fmt.Sprintf(
+		`syz_mount_image$btrfs(&AUTO='btrfs\x00', &AUTO='./file0\x00', 0x0, &AUTO, 0x1, AUTO, &AUTO="$%s")`,
+		b64,
+	)
+
+	ctx := &aflow.Context{}
+	programWithPlaceholder := ctx.ReplaceBlobs(input)
+	require.Contains(t, programWithPlaceholder, "$BLOB_")
+
+	state := reproduceState{
+		TargetOS:   "linux",
+		TargetArch: "amd64",
+	}
+	args := ExecuteSeedArgs{
+		ReproSyz: programWithPlaceholder,
+	}
+
+	_, err := executeSeed(ctx, state, args)
+	require.ErrorContains(t, err, "VM configuration is missing")
+}
+
+func TestExecuteSeed_BlobPlaceholderError(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	compressed := image.Compress(data)
+	b64 := image.EncodeB64(compressed)
+
+	input := fmt.Sprintf(`syz_mount_image$btrfs(invalid_arg, &AUTO="$%s")`, b64)
+	ctx := &aflow.Context{}
+	programWithPlaceholder := ctx.ReplaceBlobs(input)
+	require.Contains(t, programWithPlaceholder, "$BLOB_")
+
+	state := reproduceState{
+		TargetOS:   "linux",
+		TargetArch: "amd64",
+	}
+	args := ExecuteSeedArgs{
+		ReproSyz: programWithPlaceholder,
+	}
+
+	_, err := executeSeed(ctx, state, args)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "$BLOB_")
+	require.NotContains(t, err.Error(), fmt.Sprintf("$%s", b64))
 }
 
 func TestExecuteSeed(t *testing.T) {

--- a/pkg/aflow/tool/syzlang/reproduce.go
+++ b/pkg/aflow/tool/syzlang/reproduce.go
@@ -65,13 +65,14 @@ func reproduce(ctx *aflow.Context, state reproduceState, args ReproduceArgs) (Re
 		return ReproduceResult{}, aflow.BadCallError("syz program cannot be empty")
 	}
 
+	args.ReproSyz = ctx.RestoreBlobs(args.ReproSyz)
 	pt, err := prog.GetTarget(state.TargetOS, state.TargetArch)
 	if err != nil {
 		return ReproduceResult{}, err
 	}
 	_, err = pt.Deserialize([]byte(args.ReproSyz), prog.Strict)
 	if err != nil {
-		return ReproduceResult{}, aflow.BadCallError("%v", err)
+		return ReproduceResult{}, aflow.BadCallError("%v", ctx.ReplaceBlobs(err.Error()))
 	}
 
 	if state.Image == "" || state.VM == nil {


### PR DESCRIPTION
Syzlang test and reproduction programs often contain large data blobs (e.g., compressed disk images, USB descriptors, long byte sequences) that consume unnecessary LLM context window tokens and bloat logs.

Introduce blob placeholder management in syzspec to replace large string literals with short placeholders in prompts and tool outputs, and restore them prior to program deserialization and execution.
