### PR TITLE
pkg/aflow/syzspec: remove unused base seed and program combining helpers

### DIFF
--- a/pkg/aflow/syzspec/syzlang.go
+++ b/pkg/aflow/syzspec/syzlang.go
@@ -7,68 +7,11 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/prog"
-	"github.com/google/syzkaller/sys/targets"
 )
-
-func init() {
-	// Used externally - do not remove.
-	runtime.KeepAlive(CombineSyzPrograms)
-	runtime.KeepAlive(BaseSeedCallCount)
-	runtime.KeepAlive((*BaseTestSeed).Load)
-}
-
-type BaseTestSeed struct {
-	Path string
-	Data string
-}
-
-// Load populates Data by reading the test seed file from syzFS.
-func (s *BaseTestSeed) Load(syzFS *SyzFS) error {
-	if syzFS == nil {
-		return fmt.Errorf("missing required argument: syzFS")
-	}
-	if s.Path == "" {
-		return nil
-	}
-	data, err := syzFS.ReadFile(s.Path)
-	if err != nil {
-		return err
-	}
-	s.Data = string(data)
-	return nil
-}
-
-// CombineSyzPrograms concatenates a base test seed and a generated syz program.
-// It returns the combined program, the number of lines in the base seed.
-func CombineSyzPrograms(baseTestSeedData, generatedSyz string) (string, int) {
-	if baseTestSeedData == "" {
-		return generatedSyz, 0
-	}
-	baseLines := strings.Count(baseTestSeedData, "\n") + 1
-	return baseTestSeedData + "\n" + generatedSyz, baseLines
-}
-
-// BaseSeedCallCount parses the base test seed data and returns the number of calls it contains.
-func BaseSeedCallCount(baseTestSeedData []byte, targetArch string) (int, error) {
-	if len(baseTestSeedData) == 0 {
-		return 0, nil
-	}
-	pt, err := prog.GetTarget(targets.Linux, targetArch)
-	if err != nil {
-		return 0, err
-	}
-	p, err := pt.Deserialize(baseTestSeedData, prog.NonStrict)
-	if err != nil {
-		return 0, err
-	}
-	return len(p.Calls), nil
-}
 
 // CorpusProgramBucket holds a partition of serialized syzlang programs.
 type CorpusProgramBucket struct {

--- a/pkg/aflow/syzspec/syzlang_test.go
+++ b/pkg/aflow/syzspec/syzlang_test.go
@@ -15,72 +15,6 @@ import (
 	_ "github.com/google/syzkaller/sys"
 )
 
-func TestCombineSyzPrograms(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name         string
-		baseSeed     string
-		generatedSyz string
-		wantCombined string
-		wantBaseLen  int
-	}{
-		{
-			name:         "empty base seed",
-			baseSeed:     "",
-			generatedSyz: "r0 = openat(0x0, 0x0, 0x0)",
-			wantCombined: "r0 = openat(0x0, 0x0, 0x0)",
-			wantBaseLen:  0,
-		},
-		{
-			name:         "single line base seed",
-			baseSeed:     "syz_mount_image(0x0, 0x0)",
-			generatedSyz: "r0 = openat(0x0, 0x0, 0x0)",
-			wantCombined: "syz_mount_image(0x0, 0x0)\nr0 = openat(0x0, 0x0, 0x0)",
-			wantBaseLen:  1,
-		},
-		{
-			name:         "multiline base seed",
-			baseSeed:     "line1\nline2\nline3",
-			generatedSyz: "generated_call()",
-			wantCombined: "line1\nline2\nline3\ngenerated_call()",
-			wantBaseLen:  3,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			gotCombined, gotBaseLen := CombineSyzPrograms(tc.baseSeed, tc.generatedSyz)
-			require.Equal(t, tc.wantCombined, gotCombined)
-			require.Equal(t, tc.wantBaseLen, gotBaseLen)
-		})
-	}
-}
-
-func TestBaseSeedCallCount(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		progData []byte
-		want     int
-	}{
-		{name: "nil data", progData: nil, want: 0},
-		{name: "empty data", progData: []byte(""), want: 0},
-		{name: "single call", progData: []byte("getpid()\n"), want: 1},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			count, err := BaseSeedCallCount(tt.progData, "amd64")
-			require.NoError(t, err)
-			require.Equal(t, tt.want, count)
-		})
-	}
-}
-
 func TestSyzFS(t *testing.T) {
 	t.Parallel()
 
@@ -112,43 +46,6 @@ func TestSyzFS(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, testEntries, 1)
 	require.Equal(t, "seed1.txt", testEntries[0].Name())
-}
-
-func TestBaseTestSeedLoad(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	sysLinux := filepath.Join(tmpDir, "sys", "linux")
-	require.NoError(t, os.MkdirAll(sysLinux, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(sysLinux, "seed.txt"), []byte("seed content"), 0644))
-
-	syzFS := NewSyzFS(tmpDir, "linux")
-
-	t.Run("empty path", func(t *testing.T) {
-		seed := BaseTestSeed{Path: ""}
-		err := seed.Load(syzFS)
-		require.NoError(t, err)
-		require.Equal(t, "", seed.Data)
-	})
-
-	t.Run("nil syzFS", func(t *testing.T) {
-		seed := BaseTestSeed{Path: "seed.txt"}
-		err := seed.Load(nil)
-		require.Error(t, err)
-	})
-
-	t.Run("successful load", func(t *testing.T) {
-		seed := BaseTestSeed{Path: "seed.txt"}
-		err := seed.Load(syzFS)
-		require.NoError(t, err)
-		require.Equal(t, "seed content", seed.Data)
-	})
-
-	t.Run("file not found", func(t *testing.T) {
-		seed := BaseTestSeed{Path: "nonexistent.txt"}
-		err := seed.Load(syzFS)
-		require.Error(t, err)
-	})
 }
 
 func TestIsAutoTxt(t *testing.T) {


### PR DESCRIPTION
oops. some outdated funcs were merged accidentally

The BaseTestSeed, CombineSyzPrograms, and BaseSeedCallCount helpers are not used by any active aflow workflow or tool. Remove them to eliminate dead code and avoid artificial runtime.KeepAlive workarounds.

