### PR TITLE
pkg/aflow: add optional judge agent to LLMAgent

### DIFF
--- a/pkg/aflow/judge.go
+++ b/pkg/aflow/judge.go
@@ -1,0 +1,101 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+
+	"github.com/google/syzkaller/pkg/aflow/backend"
+)
+
+// LLMJudge evaluates a subagent's execution history periodically to detect
+// loops, oscillation, or lack of progress and terminate the subagent early.
+type LLMJudge struct {
+	// Name of the judge agent (used for identification and logging).
+	Name string
+	// Model category used for the judge evaluation LLM.
+	Model backend.ModelCategory
+	// Instruction provides custom guidance or criteria for deciding whether to stop.
+	Instruction string
+	// MinIterations is the number of tool iterations to execute before judge
+	// evaluations begin. Must be strictly greater than 0.
+	MinIterations int
+	// EvaluationInterval specifies how often (in iterations) the judge is invoked
+	// after MinIterations is reached. Must be strictly greater than 0.
+	EvaluationInterval int
+	agent              *LLMAgent
+}
+
+type JudgeOutputs struct {
+	Stop   bool   `jsonschema:"Stop subagent if stuck in a loop, oscillating, or making no progress."`
+	Reason string `jsonschema:"Reason for stopping or letting it continue."`
+}
+
+type JudgeExecutionResults struct {
+	JudgeStopped  bool
+	JudgeReason   string
+	FailedHistory []*backend.Message
+}
+
+const (
+	judgeStateStopped = "JudgeStopped"
+	judgeStateReason  = "JudgeReason"
+	judgeStateHistory = "History"
+	judgeOutputStop   = "Stop"
+	judgeOutputReason = "Reason"
+)
+
+func (j *LLMJudge) verify() error {
+	if j.EvaluationInterval <= 0 {
+		return fmt.Errorf("EvaluationInterval must be greater than 0")
+	}
+	if j.MinIterations <= 0 {
+		return fmt.Errorf("MinIterations must be greater than 0")
+	}
+	j.agent = &LLMAgent{
+		Name:          j.Name,
+		Model:         j.Model,
+		MaxIterations: 1,
+		TaskType:      FormalReasoningTask,
+		Outputs:       LLMOutputs[JudgeOutputs](),
+		Instruction: j.Instruction + "\n\n" +
+			"Analyze the provided history of the subagent and call set-results with Stop and Reason.",
+		InitChatHistoryFunc: func(ctx *Context) ([]llmMessage, error) {
+			history, _ := ctx.state[judgeStateHistory].([]llmMessage)
+			return slices.Clone(history), nil
+		},
+	}
+	ctx := newVerifyContext()
+	ctx.state[judgeStateHistory] = &varState{
+		action: "judge inputs",
+		typ:    reflect.TypeFor[[]llmMessage](),
+		used:   false,
+	}
+	j.agent.verify(ctx)
+	for _, state := range ctx.state {
+		state.used = true
+	}
+	return ctx.finalize()
+}
+
+func (j *LLMJudge) Evaluate(ctx *Context, history []llmMessage) (JudgeOutputs, error) {
+	oldState := ctx.state
+	ctx.state = map[string]any{
+		judgeStateHistory: history,
+	}
+	defer func() {
+		ctx.state = oldState
+	}()
+
+	if err := j.agent.execute(ctx); err != nil {
+		return JudgeOutputs{}, err
+	}
+
+	stop, _ := ctx.state[judgeOutputStop].(bool)
+	reason, _ := ctx.state[judgeOutputReason].(string)
+
+	return JudgeOutputs{Stop: stop, Reason: reason}, nil
+}

--- a/pkg/aflow/judge_test.go
+++ b/pkg/aflow/judge_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLLMJudgeVerify(t *testing.T) {
+	tests := []struct {
+		name       string
+		judge      *LLMJudge
+		wantErrMsg string
+	}{
+		{
+			name: "valid configuration",
+			judge: &LLMJudge{
+				Name:               "valid-judge",
+				Model:              "model1",
+				EvaluationInterval: 1,
+				MinIterations:      1,
+				Instruction:        "Analyze history",
+			},
+			wantErrMsg: "",
+		},
+		{
+			name: "zero EvaluationInterval",
+			judge: &LLMJudge{
+				Name:               "zero-interval-judge",
+				Model:              "model1",
+				EvaluationInterval: 0,
+				Instruction:        "Analyze history",
+			},
+			wantErrMsg: "EvaluationInterval must be greater than 0",
+		},
+		{
+			name: "negative EvaluationInterval",
+			judge: &LLMJudge{
+				Name:               "neg-interval-judge",
+				Model:              "model1",
+				EvaluationInterval: -1,
+				Instruction:        "Analyze history",
+			},
+			wantErrMsg: "EvaluationInterval must be greater than 0",
+		},
+		{
+			name: "zero MinIterations",
+			judge: &LLMJudge{
+				Name:               "zero-min-iters-judge",
+				Model:              "model1",
+				EvaluationInterval: 1,
+				MinIterations:      0,
+				Instruction:        "Analyze history",
+			},
+			wantErrMsg: "MinIterations must be greater than 0",
+		},
+		{
+			name: "negative MinIterations",
+			judge: &LLMJudge{
+				Name:               "neg-min-iters-judge",
+				Model:              "model1",
+				EvaluationInterval: 1,
+				MinIterations:      -1,
+				Instruction:        "Analyze history",
+			},
+			wantErrMsg: "MinIterations must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.judge.verify()
+			if tt.wantErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestLLMJudgeInitChatHistory(t *testing.T) {
+	judge := &LLMJudge{
+		Name:               "test-judge",
+		Model:              "model1",
+		EvaluationInterval: 1,
+		MinIterations:      1,
+		Instruction:        "Judge the history",
+	}
+	require.NoError(t, judge.verify())
+
+	rawHistory := []llmMessage{
+		{
+			content: &backend.Message{
+				Role:  backend.RoleUser,
+				Parts: []backend.Part{{Text: "initial prompt"}},
+			},
+			tokenCount: 1000,
+		},
+		{
+			content: &backend.Message{
+				Role: backend.RoleModel,
+				Parts: []backend.Part{
+					{
+						FunctionCall: &backend.FunctionCall{Name: "execute-seed"},
+					},
+					{
+						Thought: true,
+						Text:    "analyzing seed",
+					},
+				},
+			},
+			tokenCount: 500,
+		},
+		{
+			content: &backend.Message{
+				Role: backend.RoleUser,
+				Parts: []backend.Part{
+					{
+						FunctionResponse: &backend.FunctionResponse{
+							Name:     "execute-seed",
+							Response: map[string]any{"output": "seed run success"},
+						},
+					},
+				},
+			},
+			tokenCount: 50000,
+		},
+	}
+
+	ctx := &Context{
+		state: map[string]any{
+			judgeStateHistory: rawHistory,
+		},
+	}
+	gotHistory, err := judge.agent.InitChatHistoryFunc(ctx)
+	require.NoError(t, err)
+	require.Equal(t, rawHistory, gotHistory)
+}

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -54,6 +54,9 @@ type LLMAgent struct {
 	// Used to control truncation behavior (sub-agents can be forced to answer now).
 	SubAgent bool
 
+	// InitChatHistoryFunc overrides the default single-prompt initialization of a.req.
+	InitChatHistoryFunc func(*Context) ([]llmMessage, error)
+
 	// Token limit for historical messages. If > 0, when the total input tokens exceed this limit,
 	// the agent will pause, call a cheaper model to summarize the entire history, and then drop
 	// all intermediate messages, leaving only the anchor prompt and the new summary.
@@ -62,6 +65,9 @@ type LLMAgent struct {
 	// Maximum number of iterations for the agent execution.
 	// If 0, default to defaultMaxLLMIterations (250).
 	MaxIterations int
+
+	// Optional evaluator/judge agent that is invoked after each iteration to inspect history.
+	Judge *LLMJudge
 }
 
 type agentSession struct {
@@ -315,6 +321,9 @@ func (a *LLMAgent) executeOne(ctx *Context, candidate int) (string, map[string]a
 	if maxIterations <= 0 {
 		maxIterations = defaultMaxLLMIterations
 	}
+	if a.Judge != nil {
+		maps.Insert(ctx.state, maps.All(convertToMap(JudgeExecutionResults{})))
+	}
 	s := &agentSession{
 		LLMAgent:      a,
 		maxIterations: maxIterations,
@@ -356,13 +365,27 @@ func (a *agentSession) maxIterationsError() error {
 	return fmt.Errorf("agent reached max iterations limit (%v)", a.maxIterations)
 }
 
+func (a *agentSession) initReq(ctx *Context, prompt string) error {
+	if a.InitChatHistoryFunc != nil {
+		var err error
+		a.req, err = a.InitChatHistoryFunc(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		a.req = []llmMessage{{content: &backend.Message{
+			Role:  backend.RoleUser,
+			Parts: []backend.Part{{Text: prompt}},
+		}}}
+	}
+	return nil
+}
+
 func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map[string]Tool,
 	instruction, prompt string, candidate int) (string, map[string]any, error) {
-	a.req = []llmMessage{{content: &backend.Message{
-		Role:  backend.RoleUser,
-		Parts: []backend.Part{{Text: prompt}},
-	}}}
-
+	if err := a.initReq(ctx, prompt); err != nil {
+		return "", nil, err
+	}
 	var anchorTokens int
 	for iter := 0; iter < a.maxIterations || a.tryAnswerNow(cfg, false); iter++ {
 		var currentInputTokens int
@@ -431,25 +454,27 @@ func (a *agentSession) chat(ctx *Context, cfg *backend.GenerateConfig, tools map
 		})
 
 		if len(calls) == 0 {
-			reply, wrong, err := a.checkFinalReply(ctx, reply)
+			reply, outputs, ok, err := a.handleFinalReply(ctx, reply)
 			if err != nil {
 				return "", nil, err
 			}
-			if wrong != "" {
-				a.req = append(a.req, llmMessage{content: &backend.Message{
-					Role:  backend.RoleUser,
-					Parts: []backend.Part{{Text: wrong}},
-				}})
+			if ok {
 				continue
 			}
-			// This is the final reply.
-			return reply, a.outputs, nil
+			return reply, outputs, nil
 		}
 		// This is not the final reply, LLM asked to execute some tools.
 		// Append the current reply, and tool responses to the next request.
 		err = a.callTools(ctx, tools, calls)
 		if err != nil {
 			return "", nil, err
+		}
+		stopped, err := a.evaluateJudge(ctx, iter)
+		if err != nil {
+			return "", nil, err
+		}
+		if stopped {
+			return reply, a.outputs, nil
 		}
 		if a.outputs != nil {
 			if a.Reply == "" {
@@ -475,6 +500,51 @@ func (a *agentSession) updateInputTokens(inputTokens int, anchorTokens *int) {
 	if *anchorTokens == 0 {
 		*anchorTokens = inputTokens
 	}
+}
+
+func (a *agentSession) handleFinalReply(ctx *Context, reply string) (string, map[string]any, bool, error) {
+	reply, wrong, err := a.checkFinalReply(ctx, reply)
+	if err != nil {
+		return "", nil, false, err
+	}
+	if wrong != "" {
+		a.req = append(a.req, llmMessage{content: &backend.Message{
+			Role:  backend.RoleUser,
+			Parts: []backend.Part{{Text: wrong}},
+		}})
+		return "", nil, true, nil
+	}
+	return reply, a.outputs, false, nil
+}
+
+func (a *agentSession) evaluateJudge(ctx *Context, iter int) (bool, error) {
+	if a.Judge == nil {
+		return false, nil
+	}
+	if iter < a.Judge.MinIterations || (iter-a.Judge.MinIterations)%a.Judge.EvaluationInterval != 0 {
+		return false, nil
+	}
+	decision, err := a.Judge.Evaluate(ctx, a.req)
+	if err != nil {
+		return false, fmt.Errorf("judge agent failed: %w", err)
+	}
+	if decision.Stop {
+		maps.Insert(ctx.state, maps.All(convertToMap(JudgeExecutionResults{
+			JudgeStopped:  true,
+			JudgeReason:   decision.Reason,
+			FailedHistory: extractHistoryMessages(a.req),
+		})))
+		return true, nil
+	}
+	return false, nil
+}
+
+func extractHistoryMessages(history []llmMessage) []*backend.Message {
+	var messages []*backend.Message
+	for _, msg := range history {
+		messages = append(messages, msg.content)
+	}
+	return messages
 }
 
 func (a *agentSession) checkFinalReply(ctx *Context, reply string) (string, string, error) {
@@ -918,7 +988,9 @@ func (a *LLMAgent) verify(ctx *verifyContext) {
 	// Verify dataflow. All dynamic variables must be provided by inputs,
 	// or preceding actions.
 	a.verifyTemplate(ctx, "Instruction", a.Instruction)
-	a.verifyTemplate(ctx, "Prompt", a.Prompt)
+	if a.InitChatHistoryFunc == nil {
+		a.verifyTemplate(ctx, "Prompt", a.Prompt)
+	}
 	for _, tool := range a.Tools {
 		name := tool.declaration().Name
 		if !toolNameRe.MatchString(name) {
@@ -937,6 +1009,15 @@ func (a *LLMAgent) verify(ctx *verifyContext) {
 		if a.Outputs != nil {
 			a.Outputs.tool.verify(ctx)
 			a.Outputs.provideOutputs(ctx, a.Name, a.Candidates > 1)
+		}
+	}
+	if a.Judge != nil {
+		if a.Candidates > 1 {
+			ctx.errorf(a.Name, "Candidates > 1 is not supported with Judge")
+		}
+		provideOutputs[JudgeExecutionResults](ctx, a.Name)
+		if err := a.Judge.verify(); err != nil {
+			ctx.errorf(a.Name, "judge verification failed: %v", err)
 		}
 	}
 }

--- a/pkg/aflow/llm_agent_test.go
+++ b/pkg/aflow/llm_agent_test.go
@@ -6,6 +6,7 @@ package aflow
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -336,6 +337,26 @@ func TestAgentRegistrationErrors(t *testing.T) {
 				Prompt:      "Initial Prompt",
 			},
 		})
+	testRegistrationError[struct{}, struct{}](t,
+		"flow test: action smarty: Candidates > 1 is not supported with Judge",
+		&Flow{
+			Root: &LLMAgent{
+				Name:        "smarty",
+				Model:       "model",
+				Reply:       "Result",
+				TaskType:    FormalReasoningTask,
+				Instruction: "Instructions",
+				Prompt:      "Initial Prompt",
+				Candidates:  2,
+				Judge: &LLMJudge{
+					Name:               "judge",
+					Model:              "model",
+					EvaluationInterval: 1,
+					MinIterations:      1,
+					Instruction:        "Judge",
+				},
+			},
+		})
 }
 
 func TestOutputOverflow(t *testing.T) {
@@ -593,4 +614,109 @@ func TestMaxParallelToolCalls(t *testing.T) {
 		nil,
 	)
 	require.Equal(t, 0, toolExecutionCount, "tools should not be executed when maxParallelToolCalls is exceeded")
+}
+
+func TestLLMJudge(t *testing.T) {
+	type flowOutputs struct {
+		Reply         string
+		JudgeStopped  bool
+		JudgeReason   string
+		FailedHistory []*backend.Message
+	}
+	type toolResults struct {
+		Res int `jsonschema:"res"`
+	}
+
+	agent := &LLMAgent{
+		Reply: "Reply",
+		Tools: []Tool{
+			NewFuncTool("tick", func(ctx *Context, state struct{}, args struct{}) (toolResults, error) {
+				return toolResults{42}, nil
+			}, "ticker"),
+		},
+		Judge: &LLMJudge{
+			Name:               "test-judge",
+			Model:              "model1",
+			MinIterations:      2,
+			EvaluationInterval: 1,
+			Instruction:        "Judge the history",
+		},
+	}
+
+	expectedHistory := []*backend.Message{
+		{Role: "user", Parts: []backend.Part{{Text: "Prompt"}}},
+		{Role: "model", Parts: []backend.Part{{FunctionCall: &backend.FunctionCall{
+			ID:   "id1",
+			Name: "tick",
+		}}}},
+		{Role: "user", Parts: []backend.Part{{FunctionResponse: &backend.FunctionResponse{
+			ID:       "id1",
+			Name:     "tick",
+			Response: map[string]any{"Res": 42},
+		}}}},
+		{Role: "model", Parts: []backend.Part{{FunctionCall: &backend.FunctionCall{
+			ID:   "id2",
+			Name: "tick",
+		}}}},
+		{Role: "user", Parts: []backend.Part{{FunctionResponse: &backend.FunctionResponse{
+			ID:       "id2",
+			Name:     "tick",
+			Response: map[string]any{"Res": 42},
+		}}}},
+		{Role: "model", Parts: []backend.Part{{FunctionCall: &backend.FunctionCall{
+			ID:   "id3",
+			Name: "tick",
+		}}}},
+		{Role: "user", Parts: []backend.Part{{FunctionResponse: &backend.FunctionResponse{
+			ID:       "id3",
+			Name:     "tick",
+			Response: map[string]any{"Res": 42},
+		}}}},
+	}
+
+	testFlow[struct{}, flowOutputs](t, nil, convertToMap(flowOutputs{
+		Reply:         "",
+		JudgeStopped:  true,
+		JudgeReason:   "stuck in tick loop",
+		FailedHistory: expectedHistory,
+	}),
+		agent,
+		[]any{
+			// Iteration 0: LLM calls tick tool.
+			createToolCallResponse(50, "id1", "tick"),
+			// Iteration 1: LLM calls tick tool again.
+			createToolCallResponse(50, "id2", "tick"),
+			// Iteration 2: we use a single smart callback to handle both smarty's Turn 2 and the Judge's Turn.
+			func(model string, cfg *backend.GenerateConfig, req []*backend.Message) (*backend.GenerateResponse, error) {
+				if strings.Contains(cfg.SystemInstruction.Parts[0].Text, "Judge the history") {
+					// This is the judge invocation!
+					lastMsg := req[len(req)-1]
+					hasSetResultsResponse := false
+					for _, part := range lastMsg.Parts {
+						if part.FunctionResponse != nil && part.FunctionResponse.Name == "set-results" {
+							hasSetResultsResponse = true
+							break
+						}
+					}
+					if !hasSetResultsResponse {
+						return &backend.GenerateResponse{
+							Parts: []backend.Part{
+								{FunctionCall: &backend.FunctionCall{
+									Name: "set-results",
+									Args: map[string]any{"Stop": true, "Reason": "stuck in tick loop"},
+								}},
+							},
+						}, nil
+					}
+					// Turn 1 of judge: return final reply.
+					return &backend.GenerateResponse{
+						Parts: []backend.Part{{Text: "Done"}},
+					}, nil
+				}
+				// This is the parent smarty agent Turn 2. Call tick tool.
+				return createToolCallResponse(50, "id3", "tick"), nil
+			},
+		},
+		nil,
+	)
 }

--- a/pkg/aflow/llm_tool.go
+++ b/pkg/aflow/llm_tool.go
@@ -16,8 +16,6 @@ import (
 // It can do complex multi-step research, and provide a concise answer to the parent LLM
 // without polluting its context window.
 type StructuredLLMTool[State, Args, Results any] struct {
-	// Most fields match that of LLMAgent.
-	// The prompt is not specified here, and is provided by the parent LLM.
 	Name     string
 	Model    backend.ModelCategory
 	TaskType TaskType
@@ -36,6 +34,9 @@ type StructuredLLMTool[State, Args, Results any] struct {
 	// Maximum number of iterations for the tool execution.
 	// If 0, default to defaultMaxLLMIterations (250).
 	MaxIterations int
+
+	// Optional evaluator/judge agent that is invoked after each iteration to inspect history.
+	Judge *LLMJudge
 
 	agent *LLMAgent
 }
@@ -97,10 +98,19 @@ func (t *StructuredLLMTool[State, Args, Results]) execute(ctx *Context, args map
 		return nil, err
 	}
 
+	// Emit BadCallError to inform caller if the subagent was stopped by the judge.
+	if stopped, _ := subState[judgeStateStopped].(bool); stopped {
+		reason, _ := subState[judgeStateReason].(string)
+		if reason != "" {
+			return nil, BadCallError("subagent %q was stopped by judge: %s", t.Name, reason)
+		}
+		return nil, BadCallError("subagent %q was stopped by judge", t.Name)
+	}
+
 	// Extract the generated results cleanly using type conversion.
-	res, err := convertFromMap[Results](subState, false, true)
+	res, err := convertFromMap[Results](subState, false, false)
 	if err != nil {
-		return nil, err
+		return nil, BadCallError("subagent %q failed to produce results: %v", t.Name, err)
 	}
 	return convertToMap(res), nil
 }
@@ -136,6 +146,7 @@ func (t *StructuredLLMTool[State, Args, Results]) verify(ctx *verifyContext) {
 		Tools:         t.Tools,
 		SubAgent:      true,
 		MaxIterations: t.MaxIterations,
+		Judge:         t.Judge,
 	}
 
 	if t.Outputs != nil {

--- a/pkg/aflow/llm_tool_test.go
+++ b/pkg/aflow/llm_tool_test.go
@@ -254,3 +254,84 @@ func TestLLMToolValidation(t *testing.T) {
 		nil,
 	)
 }
+
+func TestStructuredLLMToolWithJudge(t *testing.T) {
+	type outputs struct {
+		Reply string
+	}
+	type testResult struct {
+		Answer string `jsonschema:"Answer"`
+	}
+	type toolResults struct {
+		Res int `jsonschema:"res"`
+	}
+
+	testFlow[struct{}, outputs](t, nil, map[string]any{"Reply": "RECOVERED_AFTER_JUDGE_STOP"},
+		&LLMAgent{
+			Reply: "Reply",
+			Tools: []Tool{
+				&StructuredLLMTool[struct{}, DefaultLLMArgs, testResult]{
+					Name:        "researcher",
+					Model:       "sub-agent-model",
+					TaskType:    FormalReasoningTask,
+					Description: "researcher description",
+					Instruction: "researcher instruction",
+					Prompt:      `{{.Question}}`,
+					Tools: []Tool{
+						NewFuncTool("tick", func(ctx *Context, state struct{}, args struct{}) (toolResults, error) {
+							return toolResults{42}, nil
+						}, "ticker"),
+					},
+					Judge: &LLMJudge{
+						Name:               "test-judge",
+						Model:              "judge-model",
+						MinIterations:      1,
+						EvaluationInterval: 1,
+						Instruction:        "Judge the history",
+					},
+				},
+			},
+		},
+		[]any{
+			// Turn 0: Main agent calls researcher subagent.
+			&backend.Part{
+				FunctionCall: &backend.FunctionCall{
+					ID:   "id0",
+					Name: "researcher",
+					Args: map[string]any{
+						"Question": "What is the answer?",
+					},
+				},
+			},
+			// Turn 1: Subagent calls tick tool (iteration 0).
+			createToolCallResponse(50, "tick_id1", "tick"),
+			// Handle subsequent calls: Subagent iteration 1, Judge evaluation, and Main agent final turn.
+			func(model string, cfg *backend.GenerateConfig, req []*backend.Message) (*backend.GenerateResponse, error) {
+				if cfg.SystemInstruction != nil && len(cfg.SystemInstruction.Parts) > 0 &&
+					strings.Contains(cfg.SystemInstruction.Parts[0].Text, "Judge the history") {
+					lastPart := req[len(req)-1].Parts[0]
+					if lastPart.FunctionResponse == nil || lastPart.FunctionResponse.Name != "set-results" {
+						return &backend.GenerateResponse{
+							Parts: []backend.Part{
+								{FunctionCall: &backend.FunctionCall{
+									Name: "set-results",
+									Args: map[string]any{"Stop": true, "Reason": "oscillation detected in researcher"},
+								}},
+							},
+						}, nil
+					}
+					return &backend.GenerateResponse{Parts: []backend.Part{{Text: "Done"}}}, nil
+				}
+				for _, part := range req[len(req)-1].Parts {
+					if part.FunctionResponse != nil && part.FunctionResponse.Name == "researcher" {
+						errStr, _ := part.FunctionResponse.Response["error"].(string)
+						assert.Contains(t, errStr, "subagent \"researcher\" was stopped by judge: oscillation detected in researcher")
+						return &backend.GenerateResponse{Parts: []backend.Part{{Text: "RECOVERED_AFTER_JUDGE_STOP"}}}, nil
+					}
+				}
+				return createToolCallResponse(50, "tick_id2", "tick"), nil
+			},
+		},
+		nil,
+	)
+}

--- a/pkg/aflow/testdata/TestLLMJudge.llm.json
+++ b/pkg/aflow/testdata/TestLLMJudge.llm.json
@@ -1,0 +1,303 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "ticker",
+							"name": "tick",
+							"parametersJsonSchema": {
+								"type": "object",
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Res": {
+										"type": "integer",
+										"description": "res"
+									}
+								},
+								"required": [
+									"Res"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id2",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id2",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model1",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Reason": {
+										"type": "string",
+										"description": "Reason for stopping or letting it continue."
+									},
+									"Stop": {
+										"type": "boolean",
+										"description": "Stop subagent if stuck in a loop, oscillating, or making no progress."
+									}
+								},
+								"required": [
+									"Stop",
+									"Reason"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Reason": {
+										"type": "string",
+										"description": "Reason for stopping or letting it continue."
+									},
+									"Stop": {
+										"type": "boolean",
+										"description": "Stop subagent if stuck in a loop, oscillating, or making no progress."
+									}
+								},
+								"required": [
+									"Stop",
+									"Reason"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id1",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id2",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id2",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id3",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id3",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestLLMJudge.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMJudge.trajectory.json
@@ -1,0 +1,306 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z",
+		"InputTokens": 50,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:05Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:06Z",
+		"Results": {
+			"Res": 42
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"InputTokens": 50,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:09Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Results": {
+			"Res": 42
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"InputTokens": 50,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:13Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
+		"Results": {
+			"Res": 42
+		}
+	},
+	{
+		"Seq": 8,
+		"Nesting": 2,
+		"Type": "agent",
+		"Name": "test-judge",
+		"Model": "model1",
+		"Started": "0001-01-01T00:00:15Z",
+		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+	},
+	{
+		"Seq": 9,
+		"Nesting": 3,
+		"Type": "llm",
+		"Name": "test-judge",
+		"Model": "model1",
+		"Started": "0001-01-01T00:00:16Z"
+	},
+	{
+		"Seq": 9,
+		"Nesting": 3,
+		"Type": "llm",
+		"Name": "test-judge",
+		"Model": "model1",
+		"Started": "0001-01-01T00:00:16Z",
+		"Finished": "0001-01-01T00:00:17Z"
+	},
+	{
+		"Seq": 10,
+		"Nesting": 3,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:18Z",
+		"Args": {
+			"Reason": "stuck in tick loop",
+			"Stop": true
+		}
+	},
+	{
+		"Seq": 10,
+		"Nesting": 3,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:18Z",
+		"Finished": "0001-01-01T00:00:19Z",
+		"Args": {
+			"Reason": "stuck in tick loop",
+			"Stop": true
+		},
+		"Results": {
+			"Reason": "stuck in tick loop",
+			"Stop": true
+		}
+	},
+	{
+		"Seq": 8,
+		"Nesting": 2,
+		"Type": "agent",
+		"Name": "test-judge",
+		"Model": "model1",
+		"Started": "0001-01-01T00:00:15Z",
+		"Finished": "0001-01-01T00:00:20Z",
+		"Results": {
+			"Reason": "stuck in tick loop",
+			"Stop": true
+		},
+		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:21Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:22Z",
+		"Results": {
+			"FailedHistory": [
+				{
+					"parts": [
+						{
+							"text": "Prompt"
+						}
+					],
+					"role": "user"
+				},
+				{
+					"parts": [
+						{
+							"functionCall": {
+								"id": "id1",
+								"name": "tick"
+							}
+						}
+					],
+					"role": "model"
+				},
+				{
+					"parts": [
+						{
+							"functionResponse": {
+								"id": "id1",
+								"name": "tick",
+								"response": {
+									"Res": 42
+								}
+							}
+						}
+					],
+					"role": "user"
+				},
+				{
+					"parts": [
+						{
+							"functionCall": {
+								"id": "id2",
+								"name": "tick"
+							}
+						}
+					],
+					"role": "model"
+				},
+				{
+					"parts": [
+						{
+							"functionResponse": {
+								"id": "id2",
+								"name": "tick",
+								"response": {
+									"Res": 42
+								}
+							}
+						}
+					],
+					"role": "user"
+				},
+				{
+					"parts": [
+						{
+							"functionCall": {
+								"id": "id3",
+								"name": "tick"
+							}
+						}
+					],
+					"role": "model"
+				},
+				{
+					"parts": [
+						{
+							"functionResponse": {
+								"id": "id3",
+								"name": "tick",
+								"response": {
+									"Res": 42
+								}
+							}
+						}
+					],
+					"role": "user"
+				}
+			],
+			"JudgeReason": "stuck in tick loop",
+			"JudgeStopped": true,
+			"Reply": ""
+		}
+	}
+]

--- a/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.llm.json
+++ b/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.llm.json
@@ -1,0 +1,401 @@
+[
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher description",
+							"name": "researcher",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Question": {
+										"type": "string",
+										"description": "Question you have."
+									}
+								},
+								"required": [
+									"Question"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "ticker",
+							"name": "tick",
+							"parametersJsonSchema": {
+								"type": "object",
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Res": {
+										"type": "integer",
+										"description": "res"
+									}
+								},
+								"required": [
+									"Res"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				},
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "What is the answer?"
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "sub-agent-model",
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "What is the answer?"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "tick_id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "tick_id1",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "judge-model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "Use this tool to provide results of the analysis.",
+							"name": "set-results",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Reason": {
+										"type": "string",
+										"description": "Reason for stopping or letting it continue."
+									},
+									"Stop": {
+										"type": "boolean",
+										"description": "Stop subagent if stuck in a loop, oscillating, or making no progress."
+									}
+								},
+								"required": [
+									"Stop",
+									"Reason"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Reason": {
+										"type": "string",
+										"description": "Reason for stopping or letting it continue."
+									},
+									"Stop": {
+										"type": "boolean",
+										"description": "Stop subagent if stuck in a loop, oscillating, or making no progress."
+									}
+								},
+								"required": [
+									"Stop",
+									"Reason"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "What is the answer?"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "tick_id1",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "tick_id1",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "tick_id2",
+							"name": "tick"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "tick_id2",
+							"response": {
+								"Res": 42
+							},
+							"name": "tick"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	},
+	{
+		"Model": "model",
+		"Config": {
+			"systemInstruction": {
+				"parts": [
+					{
+						"text": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n"
+					}
+				],
+				"role": "user"
+			},
+			"temperature": 0.3,
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"description": "researcher description",
+							"name": "researcher",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Question": {
+										"type": "string",
+										"description": "Question you have."
+									}
+								},
+								"required": [
+									"Question"
+								],
+								"additionalProperties": false
+							},
+							"responseJsonSchema": {
+								"type": "object",
+								"properties": {
+									"Answer": {
+										"type": "string",
+										"description": "Answer"
+									}
+								},
+								"required": [
+									"Answer"
+								],
+								"additionalProperties": false
+							}
+						}
+					]
+				}
+			],
+			"thinkingLevel": 3,
+			"includeThoughts": true
+		},
+		"Request": [
+			{
+				"parts": [
+					{
+						"text": "Prompt"
+					}
+				],
+				"role": "user"
+			},
+			{
+				"parts": [
+					{
+						"functionCall": {
+							"id": "id0",
+							"args": {
+								"Question": "What is the answer?"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "model"
+			},
+			{
+				"parts": [
+					{
+						"functionResponse": {
+							"id": "id0",
+							"response": {
+								"error": "subagent \"researcher\" was stopped by judge: oscillation detected in researcher"
+							},
+							"name": "researcher"
+						}
+					}
+				],
+				"role": "user"
+			}
+		]
+	}
+]

--- a/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.trajectory.json
+++ b/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.trajectory.json
@@ -1,0 +1,260 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "researcher",
+		"Started": "0001-01-01T00:00:05Z",
+		"Args": {
+			"Question": "What is the answer?"
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "agent",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:06Z",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What is the answer?"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"InputTokens": 50,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 6,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:09Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:09Z",
+		"Finished": "0001-01-01T00:00:10Z",
+		"Results": {
+			"Res": 42
+		}
+	},
+	{
+		"Seq": 7,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 4,
+		"Type": "llm",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:12Z",
+		"InputTokens": 50,
+		"OutputTokens": 10
+	},
+	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:13Z"
+	},
+	{
+		"Seq": 8,
+		"Nesting": 4,
+		"Type": "tool",
+		"Name": "tick",
+		"Started": "0001-01-01T00:00:13Z",
+		"Finished": "0001-01-01T00:00:14Z",
+		"Results": {
+			"Res": 42
+		}
+	},
+	{
+		"Seq": 9,
+		"Nesting": 4,
+		"Type": "agent",
+		"Name": "test-judge",
+		"Model": "judge-model",
+		"Started": "0001-01-01T00:00:15Z",
+		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+	},
+	{
+		"Seq": 10,
+		"Nesting": 5,
+		"Type": "llm",
+		"Name": "test-judge",
+		"Model": "judge-model",
+		"Started": "0001-01-01T00:00:16Z"
+	},
+	{
+		"Seq": 10,
+		"Nesting": 5,
+		"Type": "llm",
+		"Name": "test-judge",
+		"Model": "judge-model",
+		"Started": "0001-01-01T00:00:16Z",
+		"Finished": "0001-01-01T00:00:17Z"
+	},
+	{
+		"Seq": 11,
+		"Nesting": 5,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:18Z",
+		"Args": {
+			"Reason": "oscillation detected in researcher",
+			"Stop": true
+		}
+	},
+	{
+		"Seq": 11,
+		"Nesting": 5,
+		"Type": "tool",
+		"Name": "set-results",
+		"Started": "0001-01-01T00:00:18Z",
+		"Finished": "0001-01-01T00:00:19Z",
+		"Args": {
+			"Reason": "oscillation detected in researcher",
+			"Stop": true
+		},
+		"Results": {
+			"Reason": "oscillation detected in researcher",
+			"Stop": true
+		}
+	},
+	{
+		"Seq": 9,
+		"Nesting": 4,
+		"Type": "agent",
+		"Name": "test-judge",
+		"Model": "judge-model",
+		"Started": "0001-01-01T00:00:15Z",
+		"Finished": "0001-01-01T00:00:20Z",
+		"Results": {
+			"Reason": "oscillation detected in researcher",
+			"Stop": true
+		},
+		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 3,
+		"Type": "agent",
+		"Name": "researcher",
+		"Model": "sub-agent-model",
+		"Started": "0001-01-01T00:00:06Z",
+		"Finished": "0001-01-01T00:00:21Z",
+		"Instruction": "researcher instruction\nPrefer calling several tools at the same time to save round-trips.\n\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "What is the answer?"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 2,
+		"Type": "tool",
+		"Name": "researcher",
+		"Started": "0001-01-01T00:00:05Z",
+		"Finished": "0001-01-01T00:00:22Z",
+		"Error": "subagent \"researcher\" was stopped by judge: oscillation detected in researcher",
+		"Args": {
+			"Question": "What is the answer?"
+		}
+	},
+	{
+		"Seq": 12,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:23Z"
+	},
+	{
+		"Seq": 12,
+		"Nesting": 2,
+		"Type": "llm",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:23Z",
+		"Finished": "0001-01-01T00:00:24Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "agent",
+		"Name": "smarty",
+		"Model": "model",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:25Z",
+		"Instruction": "Instruction\nPrefer calling several tools at the same time to save round-trips.\n",
+		"Prompt": "Prompt",
+		"Reply": "RECOVERED_AFTER_JUDGE_STOP"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:26Z",
+		"Results": {
+			"Reply": "RECOVERED_AFTER_JUDGE_STOP"
+		}
+	}
+]


### PR DESCRIPTION
Subagents in agentic flows can occasionally get stuck in repetitive loops or make no progress, leading to excessive token consumption and delayed completion. Adding the option to add a judge agent to a LLMAgent allows periodic evaluation of subagent execution history to detect non-productive patterns and stop runaway subagents early with feedback.

