### PR TITLE
dashboard/app: add AI jobs statistics graphs page

### DIFF
--- a/dashboard/app/ai_stats.go
+++ b/dashboard/app/ai_stats.go
@@ -15,11 +15,68 @@ import (
 )
 
 type uiAIGraphsPage struct {
-	Header            *uiHeader
+	Header *uiHeader
+	*uiAIGraphs
+}
+
+type uiAIGraphs struct {
 	TokenGraph        *uiGraph
 	JobTypeTokenGraph *uiGraph
 	FinishedJobsGraph *uiGraph
 	JobTypesGraph     *uiGraph
+}
+
+func aiGraphsKey(ns string) string {
+	return fmt.Sprintf("%s-ai-graphs", ns)
+}
+
+func loadAIGraphs(ctx context.Context, ns string) (*uiAIGraphs, error) {
+	var modelTokens []*aidb.MonthlyModelTokenStat
+	var jobTypeTokens []*aidb.MonthlyJobTypeTokenStat
+	var finishedJobs []*aidb.MonthlyFinishedJobsStat
+	var jobTypes []*aidb.MonthlyJobTypeStat
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		var err error
+		modelTokens, err = aidb.LoadMonthlyModelTokenStats(egCtx, ns)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		jobTypeTokens, err = aidb.LoadMonthlyJobTypeTokenStats(egCtx, ns)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		finishedJobs, err = aidb.LoadMonthlyFinishedJobsStats(egCtx, ns)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		jobTypes, err = aidb.LoadMonthlyJobTypeStats(egCtx, ns)
+		return err
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &uiAIGraphs{
+		TokenGraph:        createAITokenGraph(modelTokens),
+		JobTypeTokenGraph: createAIJobTypeTokenGraph(jobTypeTokens),
+		FinishedJobsGraph: createAIFinishedJobsGraph(finishedJobs),
+		JobTypesGraph:     createAIJobTypesGraph(jobTypes),
+	}, nil
+}
+
+func CachedAIGraphs(ctx context.Context, ns string) (*uiAIGraphs, error) {
+	return cachedObject(ctx,
+		aiGraphsKey(ns),
+		6*time.Hour,
+		func(ctx context.Context) (*uiAIGraphs, error) {
+			return loadAIGraphs(ctx, ns)
+		},
+	)
 }
 
 func handleAIGraphs(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
@@ -34,47 +91,14 @@ func handleAIGraphs(ctx context.Context, w http.ResponseWriter, r *http.Request)
 		return ErrClientNotFound
 	}
 
-	var modelTokens []*aidb.MonthlyModelTokenStat
-	var jobTypeTokens []*aidb.MonthlyJobTypeTokenStat
-	var finishedJobs []*aidb.MonthlyFinishedJobsStat
-	var jobTypes []*aidb.MonthlyJobTypeStat
-
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		var err error
-		modelTokens, err = aidb.LoadMonthlyModelTokenStats(egCtx, hdr.Namespace)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		jobTypeTokens, err = aidb.LoadMonthlyJobTypeTokenStats(egCtx, hdr.Namespace)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		finishedJobs, err = aidb.LoadMonthlyFinishedJobsStats(egCtx, hdr.Namespace)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		jobTypes, err = aidb.LoadMonthlyJobTypeStats(egCtx, hdr.Namespace)
-		return err
-	})
-	if err := eg.Wait(); err != nil {
+	graphs, err := CachedAIGraphs(ctx, hdr.Namespace)
+	if err != nil {
 		return err
 	}
 
-	tokenGraph := createAITokenGraph(modelTokens)
-	jobTypeTokenGraph := createAIJobTypeTokenGraph(jobTypeTokens)
-	finishedGraph := createAIFinishedJobsGraph(finishedJobs)
-	jobTypesGraph := createAIJobTypesGraph(jobTypes)
-
 	page := &uiAIGraphsPage{
-		Header:            hdr,
-		TokenGraph:        tokenGraph,
-		JobTypeTokenGraph: jobTypeTokenGraph,
-		FinishedJobsGraph: finishedGraph,
-		JobTypesGraph:     jobTypesGraph,
+		Header:     hdr,
+		uiAIGraphs: graphs,
 	}
 
 	return serveTemplate(w, "graph_ai.html", page)

--- a/dashboard/app/ai_stats.go
+++ b/dashboard/app/ai_stats.go
@@ -31,25 +31,13 @@ func aiGraphsKey(ns string) string {
 }
 
 func loadAIGraphs(ctx context.Context, ns string) (*uiAIGraphs, error) {
-	var modelTokens []*aidb.MonthlyModelTokenStat
-	var jobTypeTokens []*aidb.MonthlyJobTypeTokenStat
-	var finishedJobs []*aidb.MonthlyFinishedJobsStat
+	var tokens []*aidb.MonthlyTokenStat
 	var jobTypes []*aidb.MonthlyJobTypeStat
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var err error
-		modelTokens, err = aidb.LoadMonthlyModelTokenStats(egCtx, ns)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		jobTypeTokens, err = aidb.LoadMonthlyJobTypeTokenStats(egCtx, ns)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		finishedJobs, err = aidb.LoadMonthlyFinishedJobsStats(egCtx, ns)
+		tokens, err = aidb.LoadMonthlyTokenStats(egCtx, ns)
 		return err
 	})
 	eg.Go(func() error {
@@ -62,9 +50,9 @@ func loadAIGraphs(ctx context.Context, ns string) (*uiAIGraphs, error) {
 	}
 
 	return &uiAIGraphs{
-		TokenGraph:        createAITokenGraph(modelTokens),
-		JobTypeTokenGraph: createAIJobTypeTokenGraph(jobTypeTokens),
-		FinishedJobsGraph: createAIFinishedJobsGraph(finishedJobs),
+		TokenGraph:        createAITokenGraph(tokens),
+		JobTypeTokenGraph: createAIJobTypeTokenGraph(tokens),
+		FinishedJobsGraph: createAIFinishedJobsGraph(jobTypes),
 		JobTypesGraph:     createAIJobTypesGraph(jobTypes),
 	}, nil
 }
@@ -173,19 +161,19 @@ func tokensToMonthlySeries[T any](stats []T, get func(T) (time.Time, string, int
 	return createAIMonthlyMultiSeriesGraph(items)
 }
 
-func createAITokenGraph(stats []*aidb.MonthlyModelTokenStat) *uiGraph {
-	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyModelTokenStat) (time.Time, string, int64) {
+func createAITokenGraph(stats []*aidb.MonthlyTokenStat) *uiGraph {
+	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyTokenStat) (time.Time, string, int64) {
 		return s.Month, s.Model, s.TotalTokens
 	})
 }
 
-func createAIJobTypeTokenGraph(stats []*aidb.MonthlyJobTypeTokenStat) *uiGraph {
-	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyJobTypeTokenStat) (time.Time, string, int64) {
+func createAIJobTypeTokenGraph(stats []*aidb.MonthlyTokenStat) *uiGraph {
+	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyTokenStat) (time.Time, string, int64) {
 		return s.Month, s.Type, s.TotalTokens
 	})
 }
 
-func createAIFinishedJobsGraph(stats []*aidb.MonthlyFinishedJobsStat) *uiGraph {
+func createAIFinishedJobsGraph(stats []*aidb.MonthlyJobTypeStat) *uiGraph {
 	monthMap := make(map[time.Time]int64)
 	var months []time.Time
 	for _, s := range stats {
@@ -193,7 +181,7 @@ func createAIFinishedJobsGraph(stats []*aidb.MonthlyFinishedJobsStat) *uiGraph {
 		if _, ok := monthMap[m]; !ok {
 			months = append(months, m)
 		}
-		monthMap[m] += s.FinishedCount
+		monthMap[m] += s.Count
 	}
 	slices.SortFunc(months, func(a, b time.Time) int {
 		return a.Compare(b)

--- a/dashboard/app/ai_stats.go
+++ b/dashboard/app/ai_stats.go
@@ -1,0 +1,206 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/google/syzkaller/dashboard/app/aidb"
+	"golang.org/x/sync/errgroup"
+)
+
+type uiAIGraphsPage struct {
+	Header            *uiHeader
+	TokenGraph        *uiGraph
+	JobTypeTokenGraph *uiGraph
+	FinishedJobsGraph *uiGraph
+	JobTypesGraph     *uiGraph
+}
+
+func handleAIGraphs(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	hdr, err := commonHeader(ctx, r, w, "")
+	if err != nil {
+		return err
+	}
+	if !hdr.Admin {
+		return ErrAccess
+	}
+	if !hdr.AI {
+		return ErrClientNotFound
+	}
+
+	var modelTokens []*aidb.MonthlyModelTokenStat
+	var jobTypeTokens []*aidb.MonthlyJobTypeTokenStat
+	var finishedJobs []*aidb.MonthlyFinishedJobsStat
+	var jobTypes []*aidb.MonthlyJobTypeStat
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		var err error
+		modelTokens, err = aidb.LoadMonthlyModelTokenStats(egCtx, hdr.Namespace)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		jobTypeTokens, err = aidb.LoadMonthlyJobTypeTokenStats(egCtx, hdr.Namespace)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		finishedJobs, err = aidb.LoadMonthlyFinishedJobsStats(egCtx, hdr.Namespace)
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		jobTypes, err = aidb.LoadMonthlyJobTypeStats(egCtx, hdr.Namespace)
+		return err
+	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	tokenGraph := createAITokenGraph(modelTokens)
+	jobTypeTokenGraph := createAIJobTypeTokenGraph(jobTypeTokens)
+	finishedGraph := createAIFinishedJobsGraph(finishedJobs)
+	jobTypesGraph := createAIJobTypesGraph(jobTypes)
+
+	page := &uiAIGraphsPage{
+		Header:            hdr,
+		TokenGraph:        tokenGraph,
+		JobTypeTokenGraph: jobTypeTokenGraph,
+		FinishedJobsGraph: finishedGraph,
+		JobTypesGraph:     jobTypesGraph,
+	}
+
+	return serveTemplate(w, "graph_ai.html", page)
+}
+
+type aiMonthlySeriesData struct {
+	month  time.Time
+	series string
+	val    int64
+}
+
+func createAIMonthlyMultiSeriesGraph(items []aiMonthlySeriesData) *uiGraph {
+	monthMap := make(map[time.Time]map[string]int64)
+	var months []time.Time
+	var seriesList []string
+	seriesSeen := make(map[string]bool)
+
+	for _, item := range items {
+		m := time.Date(item.month.Year(), item.month.Month(), 1, 0, 0, 0, 0, time.UTC)
+		if monthMap[m] == nil {
+			monthMap[m] = make(map[string]int64)
+			months = append(months, m)
+		}
+		s := item.series
+		if s == "" {
+			s = "unknown"
+		}
+		if !seriesSeen[s] {
+			seriesSeen[s] = true
+			seriesList = append(seriesList, s)
+		}
+		monthMap[m][s] += item.val
+	}
+	slices.SortFunc(months, func(a, b time.Time) int {
+		return a.Compare(b)
+	})
+	slices.Sort(seriesList)
+
+	var headers []uiGraphHeader
+	for _, s := range seriesList {
+		headers = append(headers, uiGraphHeader{Name: s})
+	}
+
+	var columns []uiGraphColumn
+	for _, m := range months {
+		col := uiGraphColumn{Hint: m.Format("Jan-06")}
+		for _, s := range seriesList {
+			val := monthMap[m][s]
+			col.Vals = append(col.Vals, uiGraphValue{
+				Val: float32(val),
+			})
+			col.Annotation += float32(val)
+		}
+		columns = append(columns, col)
+	}
+	return &uiGraph{
+		Headers: headers,
+		Columns: columns,
+	}
+}
+
+func tokensToMonthlySeries[T any](stats []T, get func(T) (time.Time, string, int64)) *uiGraph {
+	var items []aiMonthlySeriesData
+	for _, s := range stats {
+		month, series, val := get(s)
+		items = append(items, aiMonthlySeriesData{
+			month:  month,
+			series: series,
+			val:    val,
+		})
+	}
+	return createAIMonthlyMultiSeriesGraph(items)
+}
+
+func createAITokenGraph(stats []*aidb.MonthlyModelTokenStat) *uiGraph {
+	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyModelTokenStat) (time.Time, string, int64) {
+		return s.Month, s.Model, s.TotalTokens
+	})
+}
+
+func createAIJobTypeTokenGraph(stats []*aidb.MonthlyJobTypeTokenStat) *uiGraph {
+	return tokensToMonthlySeries(stats, func(s *aidb.MonthlyJobTypeTokenStat) (time.Time, string, int64) {
+		return s.Month, s.Type, s.TotalTokens
+	})
+}
+
+func createAIFinishedJobsGraph(stats []*aidb.MonthlyFinishedJobsStat) *uiGraph {
+	monthMap := make(map[time.Time]int64)
+	var months []time.Time
+	for _, s := range stats {
+		m := time.Date(s.Month.Year(), s.Month.Month(), 1, 0, 0, 0, 0, time.UTC)
+		if _, ok := monthMap[m]; !ok {
+			months = append(months, m)
+		}
+		monthMap[m] += s.FinishedCount
+	}
+	slices.SortFunc(months, func(a, b time.Time) int {
+		return a.Compare(b)
+	})
+	headers := []uiGraphHeader{{Name: "Finished Jobs", Color: "#4285F4"}}
+	var columns []uiGraphColumn
+	for _, m := range months {
+		count := monthMap[m]
+		col := uiGraphColumn{
+			Hint:       m.Format("Jan-06"),
+			Annotation: float32(count),
+			Vals: []uiGraphValue{{
+				Val: float32(count),
+			}},
+		}
+		columns = append(columns, col)
+	}
+	return &uiGraph{
+		Headers: headers,
+		Columns: columns,
+	}
+}
+
+func createAIJobTypesGraph(stats []*aidb.MonthlyJobTypeStat) *uiGraph {
+	var items []aiMonthlySeriesData
+	for _, s := range stats {
+		items = append(items, aiMonthlySeriesData{
+			month:  s.Month,
+			series: s.Type,
+			val:    s.Count,
+		})
+	}
+	return createAIMonthlyMultiSeriesGraph(items)
+}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1573,3 +1573,90 @@ func TestAIJobsErrorVisibility(t *testing.T) {
 	require.NotContains(t, string(respBugUser), aiErrorPlaceholder)
 	require.NotContains(t, string(respBugUser), ">Error</a></th>")
 }
+
+func TestAIGraphBuilders(t *testing.T) {
+	jan := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	checkCol := func(col uiGraphColumn, hint string, ann float32, vals ...float32) {
+		require.Equal(t, hint, col.Hint)
+		require.Equal(t, ann, col.Annotation)
+		require.Len(t, col.Vals, len(vals))
+		for i, v := range vals {
+			require.Equal(t, v, col.Vals[i].Val)
+		}
+	}
+
+	// Token graph test.
+	tokenStats := []*aidb.MonthlyModelTokenStat{
+		{Model: "gemini-2.5-pro", Month: jan, TotalTokens: 1250},
+		{Model: "gemini-2.0-flash", Month: jan, TotalTokens: 600},
+		{Model: "gemini-2.5-pro", Month: feb, TotalTokens: 2400},
+	}
+	tokenGraph := createAITokenGraph(tokenStats)
+	require.Len(t, tokenGraph.Headers, 2)
+	require.Equal(t, "gemini-2.0-flash", tokenGraph.Headers[0].Name)
+	require.Equal(t, "gemini-2.5-pro", tokenGraph.Headers[1].Name)
+	require.Len(t, tokenGraph.Columns, 2)
+	checkCol(tokenGraph.Columns[0], "Jan-26", 1850, 600, 1250)
+	checkCol(tokenGraph.Columns[1], "Feb-26", 2400, 0, 2400)
+
+	// Job type tokens graph test.
+	jobTypeTokenStats := []*aidb.MonthlyJobTypeTokenStat{
+		{Type: "patching", Month: jan, TotalTokens: 1000},
+		{Type: "repro-c", Month: jan, TotalTokens: 850},
+		{Type: "repro-c", Month: feb, TotalTokens: 2400},
+	}
+	jobTypeTokenGraph := createAIJobTypeTokenGraph(jobTypeTokenStats)
+	require.Len(t, jobTypeTokenGraph.Headers, 2)
+	require.Equal(t, "patching", jobTypeTokenGraph.Headers[0].Name)
+	require.Equal(t, "repro-c", jobTypeTokenGraph.Headers[1].Name)
+	require.Len(t, jobTypeTokenGraph.Columns, 2)
+	checkCol(jobTypeTokenGraph.Columns[0], "Jan-26", 1850, 1000, 850)
+	checkCol(jobTypeTokenGraph.Columns[1], "Feb-26", 2400, 0, 2400)
+
+	// Finished jobs graph test.
+	finishedStats := []*aidb.MonthlyFinishedJobsStat{
+		{Month: jan, FinishedCount: 1},
+		{Month: feb, FinishedCount: 2},
+	}
+	finishedGraph := createAIFinishedJobsGraph(finishedStats)
+	require.Len(t, finishedGraph.Headers, 1)
+	require.Equal(t, "Finished Jobs", finishedGraph.Headers[0].Name)
+	require.Len(t, finishedGraph.Columns, 2)
+	checkCol(finishedGraph.Columns[0], "Jan-26", 1, 1)
+	checkCol(finishedGraph.Columns[1], "Feb-26", 2, 2)
+
+	// Job types graph test.
+	jobTypeStats := []*aidb.MonthlyJobTypeStat{
+		{Type: "patching", Month: jan, Count: 1},
+		{Type: "repro-c", Month: feb, Count: 1},
+	}
+	jobTypesGraph := createAIJobTypesGraph(jobTypeStats)
+	require.Len(t, jobTypesGraph.Headers, 2)
+	require.Equal(t, "patching", jobTypesGraph.Headers[0].Name)
+	require.Equal(t, "repro-c", jobTypesGraph.Headers[1].Name)
+	require.Len(t, jobTypesGraph.Columns, 2)
+	checkCol(jobTypesGraph.Columns[0], "Jan-26", 1, 1, 0)
+	checkCol(jobTypesGraph.Columns[1], "Feb-26", 1, 0, 1)
+}
+
+func TestAIGraphsEndpoint(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	// Public and regular users cannot access the graphs page.
+	_, err := c.AuthGET(AccessPublic, "/ains/graph/ai")
+	require.Error(t, err)
+	_, err = c.AuthGET(AccessUser, "/ains/graph/ai")
+	require.Error(t, err)
+
+	// Admin can access the page.
+	respAdmin, err := c.AuthGET(AccessAdmin, "/ains/graph/ai")
+	require.NoError(t, err)
+	require.Contains(t, string(respAdmin), "Total Token Consumption (Per Model)")
+
+	// Non-AI namespace is rejected even for admin.
+	_, err = c.AuthGET(AccessAdmin, "/test1/graph/ai")
+	require.Error(t, err)
+}

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1587,11 +1587,12 @@ func TestAIGraphBuilders(t *testing.T) {
 		}
 	}
 
-	// Token graph test.
-	tokenStats := []*aidb.MonthlyModelTokenStat{
-		{Model: "gemini-2.5-pro", Month: jan, TotalTokens: 1250},
-		{Model: "gemini-2.0-flash", Month: jan, TotalTokens: 600},
-		{Model: "gemini-2.5-pro", Month: feb, TotalTokens: 2400},
+	// Token and job type token graph tests.
+	tokenStats := []*aidb.MonthlyTokenStat{
+		{Type: "patching", Model: "gemini-2.5-pro", Month: jan, TotalTokens: 1000},
+		{Type: "repro-c", Model: "gemini-2.5-pro", Month: jan, TotalTokens: 250},
+		{Type: "repro-c", Model: "gemini-2.0-flash", Month: jan, TotalTokens: 600},
+		{Type: "repro-c", Model: "gemini-2.5-pro", Month: feb, TotalTokens: 2400},
 	}
 	tokenGraph := createAITokenGraph(tokenStats)
 	require.Len(t, tokenGraph.Headers, 2)
@@ -1601,13 +1602,7 @@ func TestAIGraphBuilders(t *testing.T) {
 	checkCol(tokenGraph.Columns[0], "Jan-26", 1850, 600, 1250)
 	checkCol(tokenGraph.Columns[1], "Feb-26", 2400, 0, 2400)
 
-	// Job type tokens graph test.
-	jobTypeTokenStats := []*aidb.MonthlyJobTypeTokenStat{
-		{Type: "patching", Month: jan, TotalTokens: 1000},
-		{Type: "repro-c", Month: jan, TotalTokens: 850},
-		{Type: "repro-c", Month: feb, TotalTokens: 2400},
-	}
-	jobTypeTokenGraph := createAIJobTypeTokenGraph(jobTypeTokenStats)
+	jobTypeTokenGraph := createAIJobTypeTokenGraph(tokenStats)
 	require.Len(t, jobTypeTokenGraph.Headers, 2)
 	require.Equal(t, "patching", jobTypeTokenGraph.Headers[0].Name)
 	require.Equal(t, "repro-c", jobTypeTokenGraph.Headers[1].Name)
@@ -1615,30 +1610,25 @@ func TestAIGraphBuilders(t *testing.T) {
 	checkCol(jobTypeTokenGraph.Columns[0], "Jan-26", 1850, 1000, 850)
 	checkCol(jobTypeTokenGraph.Columns[1], "Feb-26", 2400, 0, 2400)
 
-	// Finished jobs graph test.
-	finishedStats := []*aidb.MonthlyFinishedJobsStat{
-		{Month: jan, FinishedCount: 1},
-		{Month: feb, FinishedCount: 2},
+	// Finished jobs and job types graph test.
+	jobTypeStats := []*aidb.MonthlyJobTypeStat{
+		{Type: "patching", Month: jan, Count: 1},
+		{Type: "repro-c", Month: feb, Count: 2},
 	}
-	finishedGraph := createAIFinishedJobsGraph(finishedStats)
+	finishedGraph := createAIFinishedJobsGraph(jobTypeStats)
 	require.Len(t, finishedGraph.Headers, 1)
 	require.Equal(t, "Finished Jobs", finishedGraph.Headers[0].Name)
 	require.Len(t, finishedGraph.Columns, 2)
 	checkCol(finishedGraph.Columns[0], "Jan-26", 1, 1)
 	checkCol(finishedGraph.Columns[1], "Feb-26", 2, 2)
 
-	// Job types graph test.
-	jobTypeStats := []*aidb.MonthlyJobTypeStat{
-		{Type: "patching", Month: jan, Count: 1},
-		{Type: "repro-c", Month: feb, Count: 1},
-	}
 	jobTypesGraph := createAIJobTypesGraph(jobTypeStats)
 	require.Len(t, jobTypesGraph.Headers, 2)
 	require.Equal(t, "patching", jobTypesGraph.Headers[0].Name)
 	require.Equal(t, "repro-c", jobTypesGraph.Headers[1].Name)
 	require.Len(t, jobTypesGraph.Columns, 2)
 	checkCol(jobTypesGraph.Columns[0], "Jan-26", 1, 1, 0)
-	checkCol(jobTypesGraph.Columns[1], "Feb-26", 1, 0, 1)
+	checkCol(jobTypesGraph.Columns[1], "Feb-26", 2, 0, 2)
 }
 
 func TestAIGraphsEndpoint(t *testing.T) {

--- a/dashboard/app/aidb/crud_stats.go
+++ b/dashboard/app/aidb/crud_stats.go
@@ -1,0 +1,107 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aidb
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+type MonthlyModelTokenStat struct {
+	Model       string
+	Month       time.Time
+	TotalTokens int64
+}
+
+type MonthlyJobTypeTokenStat struct {
+	Type        string
+	Month       time.Time
+	TotalTokens int64
+}
+
+type MonthlyFinishedJobsStat struct {
+	Month         time.Time
+	FinishedCount int64
+}
+
+type MonthlyJobTypeStat struct {
+	Type  string
+	Month time.Time
+	Count int64
+}
+
+func LoadMonthlyModelTokenStats(ctx context.Context, namespace string) ([]*MonthlyModelTokenStat, error) {
+	return selectAll[MonthlyModelTokenStat](ctx, spanner.Statement{
+		SQL: `SELECT
+			COALESCE(TrajectorySpans.Model, 'unknown') AS Model,
+			TIMESTAMP_TRUNC(TrajectorySpans.Started, MONTH) AS Month,
+			SUM(
+				COALESCE(TrajectorySpans.InputTokens, 0) +
+				COALESCE(TrajectorySpans.OutputTokens, 0) +
+				COALESCE(TrajectorySpans.OutputThoughtsTokens, 0)
+			) AS TotalTokens
+		FROM TrajectorySpans
+		JOIN Jobs ON TrajectorySpans.JobID = Jobs.ID
+		WHERE TrajectorySpans.Type = 'llm'
+		  AND Jobs.Namespace = @namespace
+		GROUP BY Model, Month
+		ORDER BY Month ASC`,
+		Params: map[string]any{"namespace": namespace},
+	})
+}
+
+func LoadMonthlyJobTypeTokenStats(ctx context.Context, namespace string) ([]*MonthlyJobTypeTokenStat, error) {
+	return selectAll[MonthlyJobTypeTokenStat](ctx, spanner.Statement{
+		SQL: `SELECT
+			Jobs.Type AS Type,
+			TIMESTAMP_TRUNC(TrajectorySpans.Started, MONTH) AS Month,
+			SUM(
+				COALESCE(TrajectorySpans.InputTokens, 0) +
+				COALESCE(TrajectorySpans.OutputTokens, 0) +
+				COALESCE(TrajectorySpans.OutputThoughtsTokens, 0)
+			) AS TotalTokens
+		FROM TrajectorySpans
+		JOIN Jobs ON TrajectorySpans.JobID = Jobs.ID
+		WHERE TrajectorySpans.Type = 'llm'
+		  AND Jobs.Namespace = @namespace
+		GROUP BY Type, Month
+		ORDER BY Month ASC`,
+		Params: map[string]any{"namespace": namespace},
+	})
+}
+
+func LoadMonthlyFinishedJobsStats(ctx context.Context, namespace string) ([]*MonthlyFinishedJobsStat, error) {
+	return selectAll[MonthlyFinishedJobsStat](ctx, spanner.Statement{
+		SQL: `SELECT
+			TIMESTAMP_TRUNC(Finished, MONTH) AS Month,
+			COUNT(*) AS FinishedCount
+		FROM Jobs
+		-- Exclude jobs that failed early (e.g. due to a restart) without generating any trajectory spans.
+		WHERE Finished IS NOT NULL
+		  AND EXISTS (SELECT 1 FROM TrajectorySpans WHERE TrajectorySpans.JobID = Jobs.ID)
+		  AND Namespace = @namespace
+		GROUP BY Month
+		ORDER BY Month ASC`,
+		Params: map[string]any{"namespace": namespace},
+	})
+}
+
+func LoadMonthlyJobTypeStats(ctx context.Context, namespace string) ([]*MonthlyJobTypeStat, error) {
+	return selectAll[MonthlyJobTypeStat](ctx, spanner.Statement{
+		SQL: `SELECT
+			Type,
+			TIMESTAMP_TRUNC(Finished, MONTH) AS Month,
+			COUNT(*) AS Count
+		FROM Jobs
+		-- Exclude jobs that failed early (e.g. due to a restart) without generating any trajectory spans.
+		WHERE Finished IS NOT NULL
+		  AND EXISTS (SELECT 1 FROM TrajectorySpans WHERE TrajectorySpans.JobID = Jobs.ID)
+		  AND Namespace = @namespace
+		GROUP BY Type, Month
+		ORDER BY Month ASC`,
+		Params: map[string]any{"namespace": namespace},
+	})
+}

--- a/dashboard/app/aidb/crud_stats.go
+++ b/dashboard/app/aidb/crud_stats.go
@@ -10,21 +10,11 @@ import (
 	"cloud.google.com/go/spanner"
 )
 
-type MonthlyModelTokenStat struct {
+type MonthlyTokenStat struct {
+	Type        string
 	Model       string
 	Month       time.Time
 	TotalTokens int64
-}
-
-type MonthlyJobTypeTokenStat struct {
-	Type        string
-	Month       time.Time
-	TotalTokens int64
-}
-
-type MonthlyFinishedJobsStat struct {
-	Month         time.Time
-	FinishedCount int64
 }
 
 type MonthlyJobTypeStat struct {
@@ -33,9 +23,10 @@ type MonthlyJobTypeStat struct {
 	Count int64
 }
 
-func LoadMonthlyModelTokenStats(ctx context.Context, namespace string) ([]*MonthlyModelTokenStat, error) {
-	return selectAll[MonthlyModelTokenStat](ctx, spanner.Statement{
+func LoadMonthlyTokenStats(ctx context.Context, namespace string) ([]*MonthlyTokenStat, error) {
+	return selectAll[MonthlyTokenStat](ctx, spanner.Statement{
 		SQL: `SELECT
+			Jobs.Type AS Type,
 			COALESCE(TrajectorySpans.Model, 'unknown') AS Model,
 			TIMESTAMP_TRUNC(TrajectorySpans.Started, MONTH) AS Month,
 			SUM(
@@ -47,43 +38,7 @@ func LoadMonthlyModelTokenStats(ctx context.Context, namespace string) ([]*Month
 		JOIN Jobs ON TrajectorySpans.JobID = Jobs.ID
 		WHERE TrajectorySpans.Type = 'llm'
 		  AND Jobs.Namespace = @namespace
-		GROUP BY Model, Month
-		ORDER BY Month ASC`,
-		Params: map[string]any{"namespace": namespace},
-	})
-}
-
-func LoadMonthlyJobTypeTokenStats(ctx context.Context, namespace string) ([]*MonthlyJobTypeTokenStat, error) {
-	return selectAll[MonthlyJobTypeTokenStat](ctx, spanner.Statement{
-		SQL: `SELECT
-			Jobs.Type AS Type,
-			TIMESTAMP_TRUNC(TrajectorySpans.Started, MONTH) AS Month,
-			SUM(
-				COALESCE(TrajectorySpans.InputTokens, 0) +
-				COALESCE(TrajectorySpans.OutputTokens, 0) +
-				COALESCE(TrajectorySpans.OutputThoughtsTokens, 0)
-			) AS TotalTokens
-		FROM TrajectorySpans
-		JOIN Jobs ON TrajectorySpans.JobID = Jobs.ID
-		WHERE TrajectorySpans.Type = 'llm'
-		  AND Jobs.Namespace = @namespace
-		GROUP BY Type, Month
-		ORDER BY Month ASC`,
-		Params: map[string]any{"namespace": namespace},
-	})
-}
-
-func LoadMonthlyFinishedJobsStats(ctx context.Context, namespace string) ([]*MonthlyFinishedJobsStat, error) {
-	return selectAll[MonthlyFinishedJobsStat](ctx, spanner.Statement{
-		SQL: `SELECT
-			TIMESTAMP_TRUNC(Finished, MONTH) AS Month,
-			COUNT(*) AS FinishedCount
-		FROM Jobs
-		-- Exclude jobs that failed early (e.g. due to a restart) without generating any trajectory spans.
-		WHERE Finished IS NOT NULL
-		  AND EXISTS (SELECT 1 FROM TrajectorySpans WHERE TrajectorySpans.JobID = Jobs.ID)
-		  AND Namespace = @namespace
-		GROUP BY Month
+		GROUP BY Type, Model, Month
 		ORDER BY Month ASC`,
 		Params: map[string]any{"namespace": namespace},
 	})

--- a/dashboard/app/cache.go
+++ b/dashboard/app/cache.go
@@ -64,7 +64,7 @@ func cacheUpdate(w http.ResponseWriter, r *http.Request) {
 		log.Errorf(c, "failed load backports: %v", err)
 		return
 	}
-	for ns := range getConfig(c).Namespaces {
+	for ns, cfg := range getConfig(c).Namespaces {
 		bugs, _, err := loadNamespaceBugs(c, ns)
 		if err != nil {
 			log.Errorf(c, "failed load ns=%v bugs: %v", ns, err)
@@ -80,6 +80,14 @@ func cacheUpdate(w http.ResponseWriter, r *http.Request) {
 		graph := createFoundBugs(c, filterStableGraphBugs(c, bugs, ns))
 		if err := setCachedObject(c, foundBugsGraphKey(ns), 6*time.Hour, graph); err != nil {
 			log.Errorf(c, "failed to store found bugs graph for ns=%v: %v", ns, err)
+		}
+		if cfg.AI != nil {
+			graphs, err := loadAIGraphs(c, ns)
+			if err != nil {
+				log.Errorf(c, "failed to build ai graphs for ns=%v: %v", ns, err)
+			} else if err := setCachedObject(c, aiGraphsKey(ns), 6*time.Hour, graphs); err != nil {
+				log.Errorf(c, "failed to store ai graphs for ns=%v: %v", ns, err)
+			}
 		}
 	}
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -72,6 +72,7 @@ func initHTTPHandlers() {
 	http.Handle("/{ns}/graph/crashes", handlerWrapper(handleGraphCrashes))
 	http.Handle("/{ns}/graph/found-bugs", handlerWrapper(handleFoundBugsGraph))
 	http.Handle("/{ns}/graph/coverage", handlerWrapper(handleCoverageGraph))
+	http.Handle("/{ns}/graph/ai", handlerWrapper(handleAIGraphs))
 	http.Handle("/{ns}/coverage/file", handlerWrapper(handleFileCoverage))
 	http.Handle("/{ns}/coverage", handlerWrapper(handleCoverageHeatmap))
 	http.Handle("/{ns}/coverage/subsystems", handlerWrapper(handleSubsystemsCoverageHeatmap))

--- a/dashboard/app/templates/graph_ai.html
+++ b/dashboard/app/templates/graph_ai.html
@@ -1,0 +1,105 @@
+{{/*
+Copyright 2026 syzkaller project authors. All rights reserved.
+Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+AI jobs statistics graphs.
+*/}}
+
+<!doctype html>
+<html>
+<head>
+	<title>{{.Header.Namespace}} AI Jobs Stats</title>
+	{{template "head" .Header}}
+
+	<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+	<script type="text/javascript">
+		google.load("visualization", "1", {packages:["corechart"]});
+		google.setOnLoadCallback(drawCharts);
+
+		function drawColumnChart(elemId, headers, rows, vAxisTitle, isStacked, colors) {
+			var data = new google.visualization.DataTable();
+			data.addColumn({type: 'string'});
+			headers.forEach(function(h) {
+				data.addColumn({type: 'number', label: h});
+			});
+			data.addColumn({type: 'number', role: 'annotation'});
+			data.addRows(rows);
+
+			var options = {
+				width: "100%",
+				chartArea: {width: isStacked ? '80%' : '85%', height: '75%', left: 80, top: 35},
+				legend: {position: isStacked ? 'right' : 'none'},
+				focusTarget: "category",
+				isStacked: isStacked,
+				vAxis: {title: vAxisTitle, minValue: 0, textPosition: 'out'},
+				hAxis: {title: 'Month', textPosition: 'out', maxAlternation: 1},
+				annotations: { textStyle: { color: 'black', bold: true }}
+			};
+			if (colors) {
+				options.colors = colors;
+			}
+			new google.visualization.ColumnChart(document.getElementById(elemId)).draw(data, options);
+		}
+
+		function drawCharts() {
+			{{if .TokenGraph.Columns}}
+			drawColumnChart('token_graph_div',
+				[{{range .TokenGraph.Headers}}"{{.Name}}",{{end}}],
+				[{{range .TokenGraph.Columns}}["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],{{end}}],
+				'Tokens', true);
+			{{end}}
+
+			{{if .JobTypeTokenGraph.Columns}}
+			drawColumnChart('job_type_token_graph_div',
+				[{{range .JobTypeTokenGraph.Headers}}"{{.Name}}",{{end}}],
+				[{{range .JobTypeTokenGraph.Columns}}["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],{{end}}],
+				'Tokens', true);
+			{{end}}
+
+			{{if .FinishedJobsGraph.Columns}}
+			drawColumnChart('finished_jobs_graph_div',
+				[{{range .FinishedJobsGraph.Headers}}"{{.Name}}",{{end}}],
+				[{{range .FinishedJobsGraph.Columns}}["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],{{end}}],
+				'Finished Jobs', false, ['#4285F4']);
+			{{end}}
+
+			{{if .JobTypesGraph.Columns}}
+			drawColumnChart('job_types_graph_div',
+				[{{range .JobTypesGraph.Headers}}"{{.Name}}",{{end}}],
+				[{{range .JobTypesGraph.Columns}}["{{.Hint}}", {{range .Vals}}{{.Val}},{{end}} {{.Annotation}}],{{end}}],
+				'Jobs', true);
+			{{end}}
+		}
+	</script>
+</head>
+<body>
+	{{template "header" .Header}}
+	<h3 style="margin: 20px 20px 10px 20px;">Total Token Consumption (Per Model)</h3>
+	{{if .TokenGraph.Columns}}
+		<div id="token_graph_div" style="height: 400px; margin-bottom: 30px;"></div>
+	{{else}}
+		<p style="margin: 20px;">No token consumption data available.</p>
+	{{end}}
+
+	<h3 style="margin: 20px 20px 10px 20px;">Total Token Consumption (Per Job Type)</h3>
+	{{if .JobTypeTokenGraph.Columns}}
+		<div id="job_type_token_graph_div" style="height: 400px; margin-bottom: 30px;"></div>
+	{{else}}
+		<p style="margin: 20px;">No token consumption data available.</p>
+	{{end}}
+
+	<h3 style="margin: 20px 20px 10px 20px;">Total Finished Jobs</h3>
+	{{if .FinishedJobsGraph.Columns}}
+		<div id="finished_jobs_graph_div" style="height: 400px; margin-bottom: 30px;"></div>
+	{{else}}
+		<p style="margin: 20px;">No finished jobs data available.</p>
+	{{end}}
+
+	<h3 style="margin: 20px 20px 10px 20px;">Job Type Distribution</h3>
+	{{if .JobTypesGraph.Columns}}
+		<div id="job_types_graph_div" style="height: 400px; margin-bottom: 30px;"></div>
+	{{else}}
+		<p style="margin: 20px;">No job type distribution data available.</p>
+	{{end}}
+</body>
+</html>

--- a/dashboard/app/templates/templates.html
+++ b/dashboard/app/templates/templates.html
@@ -102,7 +102,7 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 			</li>
 			
 			<li class="nav-item dropdown">
-				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)) (eq .URLPath (printf "/%v/graph/resolution" $.Namespace)) (eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
+				<a class="nav-link dropdown-toggle {{if or (eq .URLPath (printf "/%v/graph/bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/found-bugs" $.Namespace)) (eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)) (eq .URLPath (printf "/%v/graph/resolution" $.Namespace)) (eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace)) (eq .URLPath (printf "/%v/graph/ai" $.Namespace))}}active{{end}}" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">
 					<span style="color:DarkOrange;">📈</span>Graphs
 				</a>
 				<ul class="dropdown-menu">
@@ -111,6 +111,9 @@ Use of this source code is governed by Apache 2 LICENSE that can be found in the
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/lifetimes" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/lifetimes">Bug Lifetimes</a></li>
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/resolution" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/resolution">Bug Resolution Rate</a></li>
 					<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/fuzzing" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/fuzzing">Fuzzing</a></li>
+					{{if and .Admin .AI}}
+						<li><a class="dropdown-item {{if eq .URLPath (printf "/%v/graph/ai" $.Namespace)}}active{{end}}" href="/{{$.Namespace}}/graph/ai">AI Stats</a></li>
+					{{end}}
 				</ul>
 			</li>
 


### PR DESCRIPTION
Provide monthly visualization charts for AI token consumption per model, finished job counts, and job type distributions to track LLM usage and agent workload trends.

Aggregate token spans and jobs by month in Spanner queries, expose charts to admins via Google Charts, and add unit tests for graph builders and endpoint access control.