### PR TITLE
syz-cluster: use AI to triage findings

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -152,6 +152,6 @@ func writeMessage(v int, severity, msg string, args ...any) {
 type VerboseWriter int
 
 func (w VerboseWriter) Write(data []byte) (int, error) {
-	Logf(int(w), "%s", data)
+	Logf(int(w), "%s", bytes.TrimRight(data, "\r\n"))
 	return len(data), nil
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -5,6 +5,8 @@ package log
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -44,4 +46,17 @@ type noFormat struct{ *testing.T }
 func (nf noFormat) String() string {
 	nf.T.Fatalf("must not be formatted")
 	return ""
+}
+
+func TestVerboseWriter(t *testing.T) {
+	prependTime = false
+	defer func() { prependTime = true }()
+	w := VerboseWriter(1)
+	n, err := w.Write([]byte("foo\n"))
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	n, err = w.Write([]byte("bar\r\n"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Contains(t, CachedLogOutput(), "foo\nbar\n")
 }

--- a/pkg/manager/diff_store.go
+++ b/pkg/manager/diff_store.go
@@ -171,6 +171,10 @@ func (s *DiffFuzzerStore) PlainTextDump() []byte {
 	return buf.Bytes()
 }
 
+func (s *DiffFuzzerStore) SaveFile(title, name string, data []byte) string {
+	return s.saveFile(title, name, data)
+}
+
 func (s *DiffFuzzerStore) saveFile(title, name string, data []byte) string {
 	hash := crashHash(title)
 	path := filepath.Join(s.BasePath, "crashes", hash)

--- a/syz-cluster/dashboard/handler.go
+++ b/syz-cluster/dashboard/handler.go
@@ -575,6 +575,9 @@ func (h *dashboardHandler) findingInfo(w http.ResponseWriter, r *http.Request) e
 		return err
 	case "c_repro":
 		return h.streamBlob(w, finding.CReproURI)
+	case "triage_trajectory":
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		return h.streamBlob(w, finding.TriageTrajectoryURI)
 	default:
 		return fmt.Errorf("%w: unknown key value", errBadRequest)
 	}

--- a/syz-cluster/dashboard/templates/templates.html
+++ b/syz-cluster/dashboard/templates/templates.html
@@ -17,6 +17,9 @@
         <span class="badge bg-secondary me-1">[invalidated]</span>
       {{else}}
         <span class="badge bg-danger me-1">finding</span>
+        {{if and .ConfirmedByAI.Valid .ConfirmedByAI.Bool}}
+          <span class="badge bg-info text-dark me-1">AI confirmed</span>
+        {{end}}
       {{end}}
       {{if .ReportURI}}
         <a href="/findings/{{.ID}}/report" class="modal-link-raw fw-bold text-dark">{{.Title}}</a>
@@ -28,6 +31,7 @@
       {{if .LogURI}}<a href="/findings/{{.ID}}/log" class="btn btn-sm btn-outline-secondary modal-link-raw py-0 px-1">Log</a>{{end}}
       {{if .SyzReproURI}}<a href="/findings/{{.ID}}/syz_repro" class="btn btn-sm btn-outline-danger modal-link-raw py-0 px-1 ms-1">Syz Repro</a>{{end}}
       {{if .CReproURI}}<a href="/findings/{{.ID}}/c_repro" class="btn btn-sm btn-outline-danger modal-link-raw py-0 px-1 ms-1">C Repro</a>{{end}}
+      {{if .TriageTrajectoryURI}}<a href="/findings/{{.ID}}/triage_trajectory" class="btn btn-sm btn-outline-info py-0 px-1 ms-1" target="_blank">AI Trajectory</a>{{end}}
     </div>
   </div>
   {{end}}

--- a/syz-cluster/pkg/api/api.go
+++ b/syz-cluster/pkg/api/api.go
@@ -63,6 +63,8 @@ type FuzzConfig struct {
 	SkipCoverCheck bool `json:"skip_cover_check" yaml:"skip_cover_check"`
 	// Only report the bugs that match the regexp.
 	BugTitleRe string `json:"bug_title_re" yaml:"bug_title_re"`
+	BaseCommit string `json:"base_commit,omitempty" yaml:"base_commit,omitempty"`
+	BaseTree   string `json:"base_tree,omitempty" yaml:"base_tree,omitempty"`
 }
 
 // Tree represents a git tree. The triage step of the workflow will request these from controller.
@@ -168,14 +170,16 @@ type BootResult struct {
 // RawFinding is a kernel crash, boot error, etc. found during a test.
 // It's reported as RawFinding, but for the report purposes it's converted to Finding.
 type RawFinding struct {
-	SessionID    string `json:"session_id"`
-	TestName     string `json:"test_name"`
-	Title        string `json:"title"`
-	Report       []byte `json:"report"`
-	Log          []byte `json:"log"`
-	SyzRepro     []byte `json:"syz_repro"`
-	SyzReproOpts []byte `json:"syz_repro_opts"`
-	CRepro       []byte `json:"c_repro"`
+	SessionID        string `json:"session_id"`
+	TestName         string `json:"test_name"`
+	Title            string `json:"title"`
+	Report           []byte `json:"report"`
+	Log              []byte `json:"log"`
+	SyzRepro         []byte `json:"syz_repro"`
+	SyzReproOpts     []byte `json:"syz_repro_opts"`
+	CRepro           []byte `json:"c_repro"`
+	ConfirmedByAI    bool   `json:"confirmed_by_ai,omitempty"`
+	TriageTrajectory []byte `json:"triage_trajectory,omitempty"`
 }
 
 type Series struct {
@@ -269,13 +273,15 @@ type SessionReport struct {
 }
 
 type Finding struct {
-	Title        string    `json:"title"`
-	Report       string    `json:"report"`
-	LogURL       string    `json:"log_url"`
-	Build        BuildInfo `json:"build"`
-	LinkCRepro   string    `json:"c_repro"`
-	LinkSyzRepro string    `json:"syz_repro"`
-	Invalidated  bool      `json:"invalidated"`
+	Title                string    `json:"title"`
+	Report               string    `json:"report"`
+	LogURL               string    `json:"log_url"`
+	Build                BuildInfo `json:"build"`
+	LinkCRepro           string    `json:"c_repro"`
+	LinkSyzRepro         string    `json:"syz_repro"`
+	LinkTriageTrajectory string    `json:"triage_trajectory,omitempty"`
+	Invalidated          bool      `json:"invalidated"`
+	ConfirmedByAI        bool      `json:"confirmed_by_ai,omitempty"`
 }
 
 type BuildInfo struct {

--- a/syz-cluster/pkg/api/urls.go
+++ b/syz-cluster/pkg/api/urls.go
@@ -26,6 +26,10 @@ func (g *URLGenerator) FindingCRepro(findingID string) string {
 	return fmt.Sprintf("%s/findings/%s/c_repro", g.baseURL, findingID)
 }
 
+func (g *URLGenerator) FindingTriageTrajectory(findingID string) string {
+	return fmt.Sprintf("%s/findings/%s/triage_trajectory", g.baseURL, findingID)
+}
+
 func (g *URLGenerator) Series(seriesID string) string {
 	return fmt.Sprintf("%s/series/%s", g.baseURL, seriesID)
 }

--- a/syz-cluster/pkg/controller/api_test.go
+++ b/syz-cluster/pkg/controller/api_test.go
@@ -106,6 +106,54 @@ func TestAPISaveFinding(t *testing.T) {
 		assert.NotEmpty(t, findings[0].CReproURI)
 	})
 
+	t.Run("save AI confirmed finding", func(t *testing.T) {
+		finding := &api.RawFinding{
+			SessionID:        ids.SessionID,
+			TestName:         "test",
+			Title:            "ai-confirmed crash",
+			Report:           []byte("ai confirmed report"),
+			Log:              []byte("ai confirmed log"),
+			ConfirmedByAI:    true,
+			TriageTrajectory: []byte("<html>trajectory</html>"),
+		}
+		err = client.UploadFinding(ctx, finding)
+		require.NoError(t, err)
+
+		findingRepo := db.NewFindingRepository(env.Spanner)
+		findings, err := findingRepo.ListForSession(ctx, ids.SessionID, db.NoLimit)
+		require.NoError(t, err)
+		require.Len(t, findings, 2)
+
+		var targetFinding *db.Finding
+		for _, f := range findings {
+			if f.Title == "ai-confirmed crash" {
+				targetFinding = f
+			}
+		}
+		require.NotNil(t, targetFinding)
+		assert.True(t, targetFinding.ConfirmedByAI.Bool)
+		assert.NotEmpty(t, targetFinding.TriageTrajectoryURI)
+	})
+
+	t.Run("save unreproduced AI confirmed finding", func(t *testing.T) {
+		finding := &api.RawFinding{
+			SessionID:        ids.SessionID,
+			TestName:         "test",
+			Title:            "unreproduced crash",
+			Report:           []byte("unreproduced report"),
+			Log:              []byte("unreproduced log"),
+			ConfirmedByAI:    true,
+			TriageTrajectory: []byte("<html>unreproduced trajectory</html>"),
+		}
+		err = client.UploadFinding(ctx, finding)
+		require.NoError(t, err)
+
+		findingRepo := db.NewFindingRepository(env.Spanner)
+		findings, err := findingRepo.ListForSession(ctx, ids.SessionID, db.NoLimit)
+		require.NoError(t, err)
+		require.Len(t, findings, 3)
+	})
+
 	t.Run("session stopped", func(t *testing.T) {
 		MarkSessionFinished(t, env, ids.SessionID)
 		finding := &api.RawFinding{

--- a/syz-cluster/pkg/db/entities.go
+++ b/syz-cluster/pkg/db/entities.go
@@ -171,17 +171,19 @@ type SessionTestStep struct {
 }
 
 type Finding struct {
-	ID              string           `spanner:"ID"`
-	SessionID       string           `spanner:"SessionID"`
-	TestName        string           `spanner:"TestName"`
-	Title           string           `spanner:"Title"`
-	ReportURI       string           `spanner:"ReportURI"`
-	LogURI          string           `spanner:"LogURI"`
-	SyzReproURI     string           `spanner:"SyzReproURI"`
-	SyzReproOptsURI string           `spanner:"SyzReproOptsURI"`
-	CReproURI       string           `spanner:"CReproURI"`
-	InvalidatedAt   spanner.NullTime `spanner:"InvalidatedAt"`
-	CreatedAt       spanner.NullTime `spanner:"CreatedAt"`
+	ID                  string           `spanner:"ID"`
+	SessionID           string           `spanner:"SessionID"`
+	TestName            string           `spanner:"TestName"`
+	Title               string           `spanner:"Title"`
+	ReportURI           string           `spanner:"ReportURI"`
+	LogURI              string           `spanner:"LogURI"`
+	SyzReproURI         string           `spanner:"SyzReproURI"`
+	SyzReproOptsURI     string           `spanner:"SyzReproOptsURI"`
+	CReproURI           string           `spanner:"CReproURI"`
+	InvalidatedAt       spanner.NullTime `spanner:"InvalidatedAt"`
+	CreatedAt           spanner.NullTime `spanner:"CreatedAt"`
+	ConfirmedByAI       spanner.NullBool `spanner:"ConfirmedByAI"`
+	TriageTrajectoryURI string           `spanner:"TriageTrajectoryURI"`
 }
 
 func (f *Finding) SetInvalidatedAt(t time.Time) {

--- a/syz-cluster/pkg/db/migrations/19_add_finding_triage.down.sql
+++ b/syz-cluster/pkg/db/migrations/19_add_finding_triage.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Findings DROP COLUMN ConfirmedByAI;
+ALTER TABLE Findings DROP COLUMN TriageTrajectoryURI;

--- a/syz-cluster/pkg/db/migrations/19_add_finding_triage.up.sql
+++ b/syz-cluster/pkg/db/migrations/19_add_finding_triage.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Findings ADD COLUMN ConfirmedByAI BOOL;
+ALTER TABLE Findings ADD COLUMN TriageTrajectoryURI STRING(512);

--- a/syz-cluster/pkg/report/template.txt
+++ b/syz-cluster/pkg/report/template.txt
@@ -52,6 +52,9 @@ C repro:   {{.LinkCRepro}}
 {{- if .LinkSyzRepro}}
 syz repro: {{.LinkSyzRepro}}
 {{- end}}
+{{- if and $.Report.Moderation .LinkTriageTrajectory}}
+AI triage: {{.LinkTriageTrajectory}}
+{{- end}}
 
 {{.Report -}}
 {{end}}

--- a/syz-cluster/pkg/service/finding.go
+++ b/syz-cluster/pkg/service/finding.go
@@ -57,13 +57,14 @@ func (s *FindingService) Save(ctx context.Context, req *api.RawFinding) error {
 			return nil, nil
 		}
 		finding := &db.Finding{
-			ID:        uuid.NewString(),
-			SessionID: req.SessionID,
-			TestName:  req.TestName,
-			Title:     req.Title,
-			CreatedAt: spanner.NullTime{Time: time.Now(), Valid: true},
+			ID:            uuid.NewString(),
+			SessionID:     req.SessionID,
+			TestName:      req.TestName,
+			Title:         req.Title,
+			CreatedAt:     spanner.NullTime{Time: time.Now(), Valid: true},
+			ConfirmedByAI: spanner.NullBool{Bool: req.ConfirmedByAI, Valid: req.ConfirmedByAI},
 		}
-		// TODO: if it's not actually addded, these blobs will be orphaned.
+		// TODO: if it's not actually added, these blobs will be orphaned.
 		err := s.saveAssets(finding, req)
 		if err != nil {
 			return nil, err
@@ -84,6 +85,7 @@ func (s *FindingService) saveAssets(finding *db.Finding, req *api.RawFinding) er
 		{&finding.SyzReproURI, req.SyzRepro, "syz_repro"},
 		{&finding.SyzReproOptsURI, req.SyzReproOpts, "syz_repro_opts"},
 		{&finding.CReproURI, req.CRepro, "c_repro"},
+		{&finding.TriageTrajectoryURI, req.TriageTrajectory, "triage_trajectory"},
 	} {
 		if len(asset.value) == 0 {
 			continue
@@ -131,14 +133,18 @@ func (s *FindingService) List(ctx context.Context, sessionID string, limit int) 
 	var ret []*api.Finding
 	for _, item := range list {
 		finding := &api.Finding{
-			Title:  item.Title,
-			LogURL: s.urls.FindingLog(item.ID),
+			Title:         item.Title,
+			LogURL:        s.urls.FindingLog(item.ID),
+			ConfirmedByAI: item.ConfirmedByAI.Bool,
 		}
 		if item.SyzReproURI != "" {
 			finding.LinkSyzRepro = s.urls.FindingSyzRepro(item.ID)
 		}
 		if item.CReproURI != "" {
 			finding.LinkCRepro = s.urls.FindingCRepro(item.ID)
+		}
+		if item.TriageTrajectoryURI != "" {
+			finding.LinkTriageTrajectory = s.urls.FindingTriageTrajectory(item.ID)
 		}
 		if !item.InvalidatedAt.IsNull() {
 			finding.Invalidated = true

--- a/syz-cluster/pkg/triage/ai.go
+++ b/syz-cluster/pkg/triage/ai.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/aflow/backend"
 	"github.com/google/syzkaller/pkg/aflow/backend/gemini"
 	_ "github.com/google/syzkaller/pkg/aflow/flow"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
@@ -36,9 +37,20 @@ type AITriageResult struct {
 	Trajectory     []byte
 }
 
+type AIFindingTriageResult struct {
+	Introduced bool
+	Reasoning  string
+	Trajectory []byte
+}
+
 const (
-	aiEvaluationTimeout = time.Hour
-	defaultTokenLimit   = 5 * 1000 * 1000 // 5M tokens
+	aiEvaluationTimeout     = time.Hour
+	aiFindingTriageTimeout  = 15 * time.Minute
+	seriesTriageTokenLimit  = 5 * 1000 * 1000  // 5M tokens
+	findingTriageTokenLimit = 10 * 1000 * 1000 // 10M tokens
+	// TODO: Set TargetArch dynamically based on the targets for the patch/finding.
+	// For now it's hardcoded as we only fuzz amd64 anyway.
+	defaultTriageArch = "amd64"
 )
 
 func CommitPatchForAflow(ops *GitTreeOps) error {
@@ -52,16 +64,52 @@ func CommitPatchForAflow(ops *GitTreeOps) error {
 	return nil
 }
 
-func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Series,
-	tracer debugtracer.DebugTracer, kernelSrcDir string) (*AITriageResult, error) {
+type AIClient struct {
+	provider backend.Provider
+	cache    *aflow.Cache
+	tracer   debugtracer.DebugTracer
+}
+
+func NewAIClient(ctx context.Context, config *app.AppConfig, tracer debugtracer.DebugTracer) (*AIClient, error) {
+	if tracer == nil {
+		tracer = &debugtracer.NullTracer{}
+	}
+
 	apiKey, err := gcpsecret.Resolve(ctx, config.AI.GeminiAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve Gemini API key: %w", err)
 	}
 
-	aiCtx, cancel := context.WithTimeout(ctx, aiEvaluationTimeout)
-	defer cancel()
+	cache, err := aflow.NewCache("/tmp/aflow-cache", 1024*1024*1024)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create aflow cache: %w", err)
+	}
 
+	provider, err := gemini.NewProvider(ctx, gemini.Config{
+		ClientConfig: &genai.ClientConfig{
+			APIKey: apiKey,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize LLM provider: %w", err)
+	}
+
+	return &AIClient{
+		provider: provider,
+		cache:    cache,
+		tracer:   tracer,
+	}, nil
+}
+
+func (c *AIClient) Close() error {
+	if c.provider != nil {
+		c.provider.Close()
+	}
+	return nil
+}
+
+func (c *AIClient) execute(ctx context.Context, flowType ai.WorkflowType, args any,
+	tokenLimit int) (map[string]any, []byte, error) {
 	var spans []*trajectory.Span
 	seenID := make(map[int]struct{})
 	onEvent := func(span *trajectory.Span) error {
@@ -74,48 +122,26 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 		return nil
 	}
 
-	args := ai.PatchTriageArgs{
-		// TODO: Set TargetArch dynamically based on the fuzzing targets for the patch.
-		// For now it's irrelevant as we only fuzz amd64 anyway.
-		TargetArch: "amd64",
-		KernelSrc:  kernelSrcDir,
-	}
 	argsBytes, err := json.Marshal(args)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal initial args: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal initial args: %w", err)
 	}
 	var initialState map[string]any
 	if err := json.Unmarshal(argsBytes, &initialState); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal initial state: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal initial state: %w", err)
 	}
 
-	tracer.Logf("starting AI patch evaluation...")
-	workflowDesc := aflow.Flows[string(ai.WorkflowPatchTriage)]
+	workflowDesc := aflow.Flows[string(flowType)]
 	if workflowDesc == nil {
-		return nil, fmt.Errorf("failed to find workflow %s", ai.WorkflowPatchTriage)
+		return nil, nil, fmt.Errorf("failed to find workflow %s", flowType)
 	}
 
-	cache, err := aflow.NewCache("/tmp/aflow-cache", 1024*1024*1024)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create aflow cache: %w", err)
-	}
-
-	provider, err := gemini.NewProvider(aiCtx, gemini.Config{
-		ClientConfig: &genai.ClientConfig{
-			APIKey: apiKey,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize LLM provider: %w", err)
-	}
-	defer provider.Close()
-
-	outputs, err := workflowDesc.Execute(aiCtx, initialState, aflow.ExecuteOptions{
-		Provider:   provider,
+	outputs, execErr := workflowDesc.Execute(ctx, initialState, aflow.ExecuteOptions{
+		Provider:   c.provider,
 		Workdir:    "/tmp/aflow-cache",
-		Cache:      cache,
+		Cache:      c.cache,
 		OnEvent:    onEvent,
-		TokenLimit: defaultTokenLimit,
+		TokenLimit: tokenLimit,
 	})
 
 	var htmlReport []byte
@@ -123,9 +149,23 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 	if renderErr := aflowhtml.RenderReport(buf, spans); renderErr == nil {
 		htmlReport = buf.Bytes()
 	} else {
-		tracer.Logf("failed to render trajectory: %v", renderErr)
+		c.tracer.Logf("failed to render trajectory: %v", renderErr)
 	}
 
+	return outputs, htmlReport, execErr
+}
+
+func (c *AIClient) EvaluatePatch(ctx context.Context, series *api.Series,
+	kernelSrcDir string) (*AITriageResult, error) {
+	aiCtx, cancel := context.WithTimeout(ctx, aiEvaluationTimeout)
+	defer cancel()
+
+	c.tracer.Logf("starting AI patch evaluation...")
+	args := ai.PatchTriageArgs{
+		TargetArch: defaultTriageArch,
+		KernelSrc:  kernelSrcDir,
+	}
+	outputs, htmlReport, err := c.execute(aiCtx, ai.WorkflowPatchTriage, args, seriesTriageTokenLimit)
 	if err != nil {
 		return &AITriageResult{Trajectory: htmlReport}, err
 	}
@@ -139,7 +179,7 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 		return nil, fmt.Errorf("AI evaluation returned invalid data: %w", err)
 	}
 
-	tracer.Logf("AI verdict: WorthFuzzing=%v (Reason: %s)", result.WorthFuzzing, result.Reasoning)
+	c.tracer.Logf("AI verdict: WorthFuzzing=%v (Reason: %s)", result.WorthFuzzing, result.Reasoning)
 
 	return &AITriageResult{
 		WorthFuzzing:   result.WorthFuzzing,
@@ -150,4 +190,60 @@ func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Serie
 		Reasoning:      result.Reasoning,
 		Trajectory:     htmlReport,
 	}, nil
+}
+
+func (c *AIClient) EvaluateFinding(ctx context.Context, series *api.Series,
+	crashReport, kernelSrcDir string) (*AIFindingTriageResult, error) {
+	aiCtx, cancel := context.WithTimeout(ctx, aiFindingTriageTimeout)
+	defer cancel()
+
+	c.tracer.Logf("starting AI finding triage evaluation...")
+	var seriesPatches []ai.SeriesPatch
+	if series != nil {
+		for _, p := range series.Patches {
+			seriesPatches = append(seriesPatches, ai.SeriesPatch{
+				Seq:   p.Seq,
+				Title: p.Title,
+				Body:  string(p.Body),
+			})
+		}
+	}
+
+	args := ai.FindingTriageArgs{
+		TargetArch:  defaultTriageArch,
+		KernelSrc:   kernelSrcDir,
+		Patches:     seriesPatches,
+		CrashReport: crashReport,
+	}
+	outputs, htmlReport, err := c.execute(aiCtx, ai.WorkflowFindingTriage, args, findingTriageTokenLimit)
+	if err != nil {
+		return &AIFindingTriageResult{Trajectory: htmlReport}, err
+	}
+
+	outBytes, err := json.Marshal(outputs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal outputs: %w", err)
+	}
+	var result ai.FindingTriageResult
+	if err := json.Unmarshal(outBytes, &result); err != nil {
+		return nil, fmt.Errorf("AI evaluation returned invalid data: %w", err)
+	}
+
+	c.tracer.Logf("AI verdict: Introduced=%v (Reason: %s)", result.Introduced, result.Reasoning)
+
+	return &AIFindingTriageResult{
+		Introduced: result.Introduced,
+		Reasoning:  result.Reasoning,
+		Trajectory: htmlReport,
+	}, nil
+}
+
+func EvaluatePatch(ctx context.Context, config *app.AppConfig, series *api.Series,
+	tracer debugtracer.DebugTracer, kernelSrcDir string) (*AITriageResult, error) {
+	client, err := NewAIClient(ctx, config, tracer)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+	return client.EvaluatePatch(ctx, series, kernelSrcDir)
 }

--- a/syz-cluster/workflow/fuzz/Dockerfile
+++ b/syz-cluster/workflow/fuzz/Dockerfile
@@ -10,7 +10,7 @@ FROM ${IMAGE_PREFIX}syz-cluster-build:${IMAGE_TAG} AS builder
 # Regular setup (SMOKE_TEST=0)
 FROM debian:bookworm AS setup-0
 RUN apt-get update && \
-    apt-get install -y qemu-system openssh-client curl cpp gcc
+    apt-get install -y qemu-system openssh-client curl cpp gcc git
 
 # Install clang tools.
 RUN apt-get install -y -q gnupg software-properties-common apt-transport-https
@@ -31,6 +31,7 @@ FROM setup-${SMOKE_TEST} AS final
 
 # pkg/osutil uses syzkaller user for sandboxing.
 RUN useradd --create-home syzkaller
+RUN git config --system --add safe.directory '*'
 
 COPY --from=builder /build/bin/ /syzkaller/bin/
 COPY --from=builder /build/syz-cluster/bin/fuzz-action /bin/fuzz-action

--- a/syz-cluster/workflow/fuzz/main.go
+++ b/syz-cluster/workflow/fuzz/main.go
@@ -19,15 +19,20 @@ import (
 
 	"github.com/google/syzkaller/pkg/build"
 	"github.com/google/syzkaller/pkg/db"
+	"github.com/google/syzkaller/pkg/debugtracer"
 	"github.com/google/syzkaller/pkg/log"
 	"github.com/google/syzkaller/pkg/manager"
 	"github.com/google/syzkaller/pkg/manager/diff"
 	"github.com/google/syzkaller/pkg/mgrconfig"
 	"github.com/google/syzkaller/pkg/osutil"
+	"github.com/google/syzkaller/pkg/report"
+	"github.com/google/syzkaller/pkg/repro"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/google/syzkaller/syz-cluster/pkg/app"
 	"github.com/google/syzkaller/syz-cluster/pkg/fuzzconfig"
+	"github.com/google/syzkaller/syz-cluster/pkg/triage"
+	"github.com/google/syzkaller/syz-cluster/pkg/workspace"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,6 +44,7 @@ var (
 	flagTime         = flag.String("time", "1h", "how long to fuzz")
 	flagWorkdir      = flag.String("workdir", "/workdir", "base workdir path")
 	flagTestName     = flag.String("test_name", "", "test name")
+	flagRepository   = flag.String("repository", "", "path to a kernel checkout")
 )
 
 func main() {
@@ -79,6 +85,7 @@ func main() {
 	}
 	log.Logf(0, "fuzzing is finished")
 	logFinalState(store)
+	triageUnreproducedFindings(ctx, config, client, store)
 	if err := reportStatus(ctx, config, client, status, store); err != nil {
 		app.Fatalf("failed to update the test: %v", err)
 	}
@@ -166,7 +173,7 @@ func run(ctx context.Context, config *api.FuzzConfig, client *api.Client,
 					app.Errorf("failed to report a base kernel crash %q: %v", title, err)
 				}
 			case bug := <-bugs:
-				err := reportFinding(groupCtx, config, client, bug)
+				err := reportFinding(groupCtx, client, bug.Report, bug.Repro, nil)
 				if err != nil {
 					app.Errorf("failed to report a finding %q: %v", bug.Report.Title, err)
 				}
@@ -334,26 +341,32 @@ func reportStatus(ctx context.Context, config *api.FuzzConfig, client *api.Clien
 	return nil
 }
 
-func reportFinding(ctx context.Context, config *api.FuzzConfig, client *api.Client, bug *diff.Bug) error {
+func reportFinding(ctx context.Context, client *api.Client,
+	crashReport *report.Report, reproResult *repro.Result,
+	aiResult *triage.AIFindingTriageResult) error {
 	finding := &api.RawFinding{
 		SessionID: *flagSession,
 		TestName:  *flagTestName,
-		Title:     bug.Report.Title,
-		Report:    bug.Report.Report,
-		Log:       bug.Report.Output,
+		Title:     crashReport.Title,
+		Report:    crashReport.Report,
+		Log:       crashReport.Output,
 	}
-	if repro := bug.Repro; repro != nil {
-		if repro.Prog != nil {
-			finding.SyzRepro = repro.Prog.Serialize()
-			finding.SyzReproOpts = repro.Opts.Serialize()
+	if reproResult != nil {
+		if reproResult.Prog != nil {
+			finding.SyzRepro = reproResult.Prog.Serialize()
+			finding.SyzReproOpts = reproResult.Opts.Serialize()
 		}
-		if repro.CRepro {
+		if reproResult.CRepro {
 			var err error
-			finding.CRepro, err = repro.CProgram()
+			finding.CRepro, err = reproResult.CProgram()
 			if err != nil {
 				app.Errorf("failed to generate C program: %v", err)
 			}
 		}
+	}
+	if aiResult != nil {
+		finding.ConfirmedByAI = aiResult.Introduced
+		finding.TriageTrajectory = aiResult.Trajectory
 	}
 	return client.UploadFinding(ctx, finding)
 }
@@ -487,4 +500,144 @@ func setupFocusAreas(config *api.FuzzConfig, patched *mgrconfig.Config) {
 		},
 		Weight: 10.0,
 	})
+}
+
+func triageUnreproducedFindings(ctx context.Context, config *api.FuzzConfig, client *api.Client,
+	store *manager.DiffFuzzerStore) {
+	if *flagRepository == "" {
+		return
+	}
+	appConfig, err := app.Config()
+	if err != nil {
+		log.Logf(0, "failed to load app config for finding triage: %v", err)
+		return
+	}
+	if appConfig.AI == nil || appConfig.AI.Empty() {
+		return
+	}
+
+	candidates := filterFindingCandidates(store.List())
+	if len(candidates) == 0 {
+		return
+	}
+
+	tracer := &debugtracer.GenericTracer{TraceWriter: log.VerboseWriter(0)}
+	aiClient, err := triage.NewAIClient(ctx, appConfig, tracer)
+	if err != nil {
+		log.Logf(0, "failed to initialize AI client for finding triage: %v", err)
+		return
+	}
+	defer aiClient.Close()
+
+	series, err := client.GetSessionSeries(ctx, *flagSession)
+	if err != nil || series == nil {
+		log.Logf(0, "failed to query series for AI triage: %v", err)
+		return
+	}
+
+	err = setupTriageWorkspace(config, series, tracer)
+	if err != nil {
+		log.Logf(0, "failed to prepare workspace for AI triage: %v", err)
+		return
+	}
+
+	reporter := &unreproducedReporter{
+		client:   client,
+		aiClient: aiClient,
+		store:    store,
+		series:   series,
+	}
+
+	for _, bug := range candidates {
+		if err := reporter.processFinding(ctx, bug); err != nil {
+			log.Logf(0, "failed to process unreproduced finding %q: %v", bug.Title, err)
+		}
+	}
+}
+
+func setupTriageWorkspace(config *api.FuzzConfig, series *api.Series, tracer debugtracer.DebugTracer) error {
+	ws, err := workspace.New(*flagRepository, tracer)
+	if err != nil {
+		return fmt.Errorf("failed to initialize workspace: %w", err)
+	}
+
+	if _, err := ws.Checkout(config.BaseTree, config.BaseCommit, series.PatchBodies()); err != nil {
+		return fmt.Errorf("failed to checkout and apply patches: %w", err)
+	}
+	if err := ws.CommitPatches(); err != nil {
+		return fmt.Errorf("failed to commit patches: %w", err)
+	}
+	return nil
+}
+
+type unreproducedReporter struct {
+	client   *api.Client
+	aiClient *triage.AIClient
+	store    *manager.DiffFuzzerStore
+	series   *api.Series
+}
+
+func (r *unreproducedReporter) processFinding(ctx context.Context, bug manager.DiffBug) error {
+	reportBytes, err := os.ReadFile(filepath.Join(r.store.BasePath, bug.Patched.Report))
+	if err != nil {
+		return fmt.Errorf("failed to read report: %w", err)
+	}
+
+	log.Logf(0, "evaluating unreproduced finding %q with AI", bug.Title)
+	aiResult, err := r.aiClient.EvaluateFinding(
+		ctx, r.series, string(reportBytes), *flagRepository,
+	)
+	if aiResult != nil && len(aiResult.Trajectory) > 0 {
+		r.store.SaveFile(bug.Title, "triage.html", aiResult.Trajectory)
+	}
+	if err != nil {
+		return fmt.Errorf("AI evaluation failed: %w", err)
+	}
+
+	var logBytes []byte
+	if bug.Patched.CrashLog != "" {
+		var readErr error
+		logBytes, readErr = os.ReadFile(filepath.Join(r.store.BasePath, bug.Patched.CrashLog))
+		if readErr != nil {
+			return fmt.Errorf("failed to read crash log: %w", readErr)
+		}
+	}
+
+	if aiResult.Introduced {
+		log.Logf(0, "AI confirmed unreproduced finding %q was introduced by patch series (reason: %s)",
+			bug.Title, aiResult.Reasoning)
+		err := reportFinding(ctx, r.client, &report.Report{
+			Title:  bug.Title,
+			Report: reportBytes,
+			Output: logBytes,
+		}, nil, aiResult)
+		if err != nil {
+			return fmt.Errorf("failed to upload AI-confirmed finding: %w", err)
+		}
+	} else {
+		log.Logf(0, "AI rejected unreproduced finding %q (reason: %s)", bug.Title, aiResult.Reasoning)
+		if *flagBaseBuild != "" {
+			if bErr := r.client.UploadBaseFinding(ctx, &api.BaseFindingInfo{
+				BuildID: *flagBaseBuild,
+				Title:   bug.Title,
+			}); bErr != nil {
+				return fmt.Errorf("failed to upload base finding: %w", bErr)
+			}
+		}
+	}
+	return nil
+}
+
+func filterFindingCandidates(bugs []manager.DiffBug) []manager.DiffBug {
+	var candidates []manager.DiffBug
+	for _, bug := range bugs {
+		if bug.Status == manager.DiffBugStatusIgnored || bug.Base.Crashes > 0 || bug.Base.NotCrashed {
+			continue
+		}
+		if bug.Patched.Crashes == 0 || bug.Patched.Report == "" {
+			continue
+		}
+		candidates = append(candidates, bug)
+	}
+	return candidates
 }

--- a/syz-cluster/workflow/fuzz/main_test.go
+++ b/syz-cluster/workflow/fuzz/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/syzkaller/pkg/build"
+	"github.com/google/syzkaller/pkg/manager"
 	"github.com/google/syzkaller/pkg/osutil"
 	"github.com/google/syzkaller/syz-cluster/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,36 @@ func TestBugTitleRe(t *testing.T) {
 	assert.False(t, titleMatchesFilter(&api.FuzzConfig{
 		BugTitleRe: `^Prefix:`,
 	}, "Without prefix"))
+}
+
+func TestFilterFindingCandidates(t *testing.T) {
+	bugs := []manager.DiffBug{
+		{
+			Title:   "candidate crash 1",
+			Patched: manager.DiffBugInfo{Crashes: 5, Report: "report1"},
+		},
+		{
+			Title:   "reproduced crash",
+			Base:    manager.DiffBugInfo{NotCrashed: true},
+			Patched: manager.DiffBugInfo{Crashes: 5, Report: "report_repro"},
+		},
+		{
+			Title:   "crash on base too",
+			Base:    manager.DiffBugInfo{Crashes: 2},
+			Patched: manager.DiffBugInfo{Crashes: 5, Report: "report2"},
+		},
+		{
+			Title:   "crash without report",
+			Patched: manager.DiffBugInfo{Crashes: 5, Report: ""},
+		},
+		{
+			Title:   "ignored status crash",
+			Status:  manager.DiffBugStatusIgnored,
+			Patched: manager.DiffBugInfo{Crashes: 5, Report: "report3"},
+		},
+	}
+
+	candidates := filterFindingCandidates(bugs)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "candidate crash 1", candidates[0].Title)
 }

--- a/syz-cluster/workflow/fuzz/workflow-template.yaml
+++ b/syz-cluster/workflow/fuzz/workflow-template.yaml
@@ -24,6 +24,28 @@ spec:
           - name: config
             path: /tmp/config.json
       timeout: 4h
+      initContainers:
+        - name: setup-repo
+          image: ${IMAGE_PREFIX}fuzz-action:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              git clone --shared -c remote.origin.fetch="+refs/heads/*:refs/heads/*" /kernel-repo /workdir/repo
+              git -C /workdir/repo commit-graph write --reachable
+              chown -R syzkaller:syzkaller /workdir/repo
+          env:
+            - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
+              value: "1"
+            - name: HOME
+              value: "/home/syzkaller"
+          volumeMounts:
+            - name: base-kernel-repo
+              mountPath: /kernel-repo
+              readOnly: true
+            - name: workdir
+              mountPath: /workdir
       container:
         image: ${IMAGE_PREFIX}fuzz-action:${IMAGE_TAG}
         imagePullPolicy: IfNotPresent
@@ -36,6 +58,7 @@ spec:
           "--test_name", "{{inputs.parameters.test-name}}",
           "--time", "3h",
           "--workdir", "/workdir",
+          "--repository", "/workdir/repo",
           "--vv", "1"
           ]
         resources:
@@ -45,11 +68,23 @@ spec:
           limits:
             cpu: 30
             memory: 96G
+        env:
+          - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
+            value: "1"
+          - name: HOME
+            value: "/home/syzkaller"
         volumeMounts:
         - name: workdir
           mountPath: /workdir
         - name: dev-kvm
           mountPath: /dev/kvm
+        - name: base-kernel-repo
+          mountPath: /kernel-repo
+          readOnly: true
+        - name: aflow-cache
+          mountPath: /tmp/aflow-cache
+        - name: config-volume
+          mountPath: /config
         # Needed for /dev/kvm.
         # TODO: there's a "device plugin" mechanism in k8s that can share it more safely.
         securityContext:
@@ -63,3 +98,11 @@ spec:
           hostPath:
             path: /dev/kvm
             type: CharDevice
+        - name: base-kernel-repo
+          persistentVolumeClaim:
+            claimName: base-kernel-repo-pv-claim
+        - name: aflow-cache
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: global-config

--- a/syz-cluster/workflow/triage/main.go
+++ b/syz-cluster/workflow/triage/main.go
@@ -194,6 +194,8 @@ func (triager *seriesTriager) prepareFuzzingTask(ctx context.Context, series *ap
 		*fuzzCfg = *target.FuzzConfig
 	}
 	fuzzCfg.FocusSymbols = triager.aiVerdict.FocusSymbols
+	fuzzCfg.BaseCommit = result.Commit
+	fuzzCfg.BaseTree = result.Tree.Name
 	testTarget := &api.TestTarget{
 		Base:    base,
 		Patched: base,


### PR DESCRIPTION
For the findings for which we haven't found a reproducer, let's use AI to determine if they were introduced by the patch series.

See individual commits.

Closes https://github.com/google/syzkaller/issues/7734.