### PR TITLE
pkg/aflow/flow/patching: add architectural review step to patch generation

### DIFF
--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -133,8 +133,11 @@ func init() {
 						kernel.CheckoutScratch,
 						&aflow.If{
 							Condition: "CodeItems",
+							// In patch-iteration, human reviewer feedback is the sole ground truth,
+							// so we do not run an automated architectural reviewer agent.
 							Do: patchGenerationLoop(
-								applyGitPatch, patchIterationInstruction, patchIterationPrompt, viewPatchHistoryTool),
+								applyGitPatch, patchIterationInstruction, patchIterationPrompt,
+								"", viewPatchHistoryTool),
 							Else: forwardPatchDiff,
 						},
 						patchRefinementLoop(false),

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -7,6 +7,8 @@ package patching
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/action/actionsyzlang"
@@ -92,7 +94,7 @@ func init() {
 					Tools:       common.CodeAccessTools,
 				},
 				kernel.CheckoutScratch,
-				patchGenerationLoop(nil, patchInstruction, patchPrompt),
+				patchGenerationLoop(nil, patchInstruction, patchPrompt, reviewerPrompt),
 				patchRefinementLoop(true),
 				&aflow.LLMAgent{
 					Name:        "fixes-finder",
@@ -261,7 +263,7 @@ However, the patch testing failed with the following error:
 {{.TestError}}
 
 If the error is fixable, and the fix patch is correct overall,
-the create a new fixed patch based on the provided one with the errors fixed.
+then create a new fixed patch based on the provided one with the errors fixed.
 If the error points to a fundamental issue with the approach in the patch,
 then create a new patch from scratch.
 Note: in both cases the source tree does not contain the patch yet
@@ -270,6 +272,24 @@ in its entirety from scratch using the {{.toolCodeeditor}} tool).
 {{else}}
 If the strategy looks reasonable to you, proceed with patch generation.
 {{end}}
+{{else if .ReviewFeedback}}
+
+Another developer tried to fix this bug with the following strategy:
+
+{{.PatchExplanation}}
+
+and the following patch:
+
+{{.PatchDiff}}
+
+However, a senior maintainer reviewed the patch and requested architectural/design revisions:
+
+{{.ReviewFeedback}}
+
+Revise the patch to eliminate these architectural flaws, satisfy maintainer invariants,
+and address all reviewer feedback.
+Note: the source tree does not contain the patch yet (so you need to recreate the complete,
+revised patch from scratch using the {{.toolCodeeditor}} tool).
 {{end}}
 `
 
@@ -350,27 +370,127 @@ are specified, letter capitalization, style, etc.
 // https://docs.kernel.org/process/submitting-patches.html
 const patchDescriptionLineLength = 75
 
-func patchGenerationLoop(beforeEach aflow.Action, instruction, prompt string, extraTools ...aflow.Tool) aflow.Action {
-	actions := []aflow.Action{}
+const reviewerPrompt = `
+Bug title:
+{{.ReproducedBugTitle}}
+
+The crash report:
+{{.ReproducedCrashReport}}
+
+The root cause explanation:
+{{.BugExplanation}}
+
+The proposed patch diff:
+{{.PatchDiff}}
+
+Review this patch diff against the crash report, root cause explanation, and kernel architectural design guidelines.
+`
+
+// nolint: lll
+type patchReviewerOutputs struct {
+	ReviewApproved bool     `jsonschema:"True if the patch solves the root cause cleanly without band-aids or architectural violations."`
+	ReviewComments []string `jsonschema:"List of actionable feedback items addressing architectural flaws, invariant violations, or memory/concurrency bugs."`
+}
+
+func validatePatchReviewerOutputs(ctx *aflow.Context, state struct{}, args patchReviewerOutputs) (
+	patchReviewerOutputs, error) {
+	if !args.ReviewApproved && !slices.ContainsFunc(args.ReviewComments, func(c string) bool {
+		return strings.TrimSpace(c) != ""
+	}) {
+		return args, aflow.BadCallError("ReviewComments cannot be empty when ReviewApproved is false")
+	}
+	return args, nil
+}
+
+type testFailureOutputs struct {
+	NeedsIteration bool
+	ReviewFeedback string
+	ReviewApproved bool
+	ReviewComments []string
+}
+
+type reviewEvaluation struct {
+	NeedsIteration bool
+	ReviewFeedback string
+}
+
+var evaluatePatchReview = aflow.NewFuncAction("evaluate-patch-review",
+	func(ctx *aflow.Context, args patchReviewerOutputs) (reviewEvaluation, error) {
+		if args.ReviewApproved {
+			return reviewEvaluation{}, nil
+		}
+		var comments []string
+		for _, c := range args.ReviewComments {
+			c = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(c), "-*"))
+			if c == "" {
+				continue
+			}
+			comments = append(comments, "- "+c)
+		}
+		if len(comments) == 0 {
+			return reviewEvaluation{}, nil
+		}
+		return reviewEvaluation{
+			NeedsIteration: true,
+			ReviewFeedback: strings.Join(comments, "\n"),
+		}, nil
+	})
+
+var setTestFailure = aflow.NewFuncAction("set-test-failure",
+	func(ctx *aflow.Context, args struct{}) (testFailureOutputs, error) {
+		return testFailureOutputs{
+			NeedsIteration: true,
+		}, nil
+	})
+
+// patchGenerationLoop creates an iterative patch generation loop.
+// If reviewerPrompt is non-empty, the loop invokes patch-reviewer to evaluate architectural guidelines.
+// When reviewerPrompt is empty (e.g., in patch-iteration where human reviewer feedback is the sole
+// source of truth), the loop iterates strictly on test/build failures.
+func patchGenerationLoop(beforeEach aflow.Action, instruction, prompt, reviewerPrompt string,
+	extraTools ...aflow.Tool) aflow.Action {
+	var actions []aflow.Action
 	if beforeEach != nil {
 		actions = append(actions, beforeEach)
 	}
+	actions = append(actions,
+		&aflow.LLMAgent{
+			Name:        "patch-generator",
+			Model:       aflow.BestExpensiveModel,
+			Reply:       "PatchExplanation",
+			TaskType:    aflow.FormalReasoningTask,
+			Instruction: instruction,
+			Prompt:      prompt,
+			Tools:       aflow.Tools(common.CodeAccessTools, codeeditor.Tool, patchdiff.Tool, extraTools),
+		},
+		crash.TestPatch,
+	)
+
+	while := "TestError"
+	if reviewerPrompt != "" {
+		while = "NeedsIteration"
+		actions = append(actions, &aflow.If{
+			Condition: "TestError",
+			Do:        setTestFailure,
+			Else: aflow.Pipeline(
+				&aflow.LLMAgent{
+					Name:        "patch-reviewer",
+					Model:       aflow.BestExpensiveModel,
+					Outputs:     aflow.ValidatedLLMOutputs[patchReviewerOutputs](validatePatchReviewerOutputs),
+					TaskType:    aflow.FormalReasoningTask,
+					Instruction: common.Prompt(prompts, "prompts/design_instruction.md"),
+					Prompt:      reviewerPrompt,
+					Tools:       common.CodeAccessTools,
+				},
+				evaluatePatchReview,
+			),
+		})
+	}
 
 	return &aflow.DoWhile{
-		While:         "TestError",
+		While:         while,
 		MaxIterations: 10,
-		Do: aflow.Pipeline(append(actions,
-			&aflow.LLMAgent{
-				Name:        "patch-generator",
-				Model:       aflow.BestExpensiveModel,
-				Reply:       "PatchExplanation",
-				TaskType:    aflow.FormalReasoningTask,
-				Instruction: instruction,
-				Prompt:      prompt,
-				Tools:       aflow.Tools(common.CodeAccessTools, codeeditor.Tool, patchdiff.Tool, extraTools),
-			},
-			crash.TestPatch, // -> PatchDiff or TestError
-		)...),
+		Do:            aflow.Pipeline(actions...),
 	}
 }
 

--- a/pkg/aflow/flow/patching/patching_test.go
+++ b/pkg/aflow/flow/patching/patching_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import (
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePatchReviewerOutputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		outputs   patchReviewerOutputs
+		wantError string
+	}{
+		{
+			name: "approved with no comments",
+			outputs: patchReviewerOutputs{
+				ReviewApproved: true,
+				ReviewComments: nil,
+			},
+		},
+		{
+			name: "rejected with comments",
+			outputs: patchReviewerOutputs{
+				ReviewApproved: false,
+				ReviewComments: []string{"fix memory leak"},
+			},
+		},
+		{
+			name: "rejected with empty comments",
+			outputs: patchReviewerOutputs{
+				ReviewApproved: false,
+				ReviewComments: []string{},
+			},
+			wantError: "ReviewComments cannot be empty when ReviewApproved is false",
+		},
+		{
+			name: "rejected with whitespace comments",
+			outputs: patchReviewerOutputs{
+				ReviewApproved: false,
+				ReviewComments: []string{"   ", "\t"},
+			},
+			wantError: "ReviewComments cannot be empty when ReviewApproved is false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validatePatchReviewerOutputs(nil, struct{}{}, tt.outputs)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.outputs, got)
+			}
+		})
+	}
+}
+
+func TestEvaluatePatchReview(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       patchReviewerOutputs
+		wantResult reviewEvaluation
+	}{
+		{
+			name: "approved",
+			args: patchReviewerOutputs{
+				ReviewApproved: true,
+				ReviewComments: []string{"minor note"},
+			},
+			wantResult: reviewEvaluation{},
+		},
+		{
+			name: "rejected with bullet formatting and trimming",
+			args: patchReviewerOutputs{
+				ReviewApproved: false,
+				ReviewComments: []string{
+					"- already has bullet",
+					"* asterisk bullet",
+					"plain comment",
+					"   ",
+					"-  ",
+				},
+			},
+			wantResult: reviewEvaluation{
+				NeedsIteration: true,
+				ReviewFeedback: "- already has bullet\n- asterisk bullet\n- plain comment",
+			},
+		},
+		{
+			name: "rejected with only whitespace comments",
+			args: patchReviewerOutputs{
+				ReviewApproved: false,
+				ReviewComments: []string{"  ", "- "},
+			},
+			wantResult: reviewEvaluation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aflow.TestAction(t, evaluatePatchReview, "", tt.args, tt.wantResult, "")
+		})
+	}
+}
+
+func TestSetTestFailure(t *testing.T) {
+	aflow.TestAction(t, setTestFailure, "", struct{}{}, testFailureOutputs{
+		NeedsIteration: true,
+	}, "")
+}
+
+func TestPatchGenerationLoopVariants(t *testing.T) {
+	// Verify loop without reviewer targets TestError.
+	loopNoReview := patchGenerationLoop(nil, "instruction", "prompt", "")
+	require.NotNil(t, loopNoReview)
+
+	// Verify loop with reviewer targets NeedsIteration.
+	loopWithReview := patchGenerationLoop(nil, "instruction", "prompt", reviewerPrompt)
+	require.NotNil(t, loopWithReview)
+}

--- a/pkg/aflow/flow/patching/prompts.go
+++ b/pkg/aflow/flow/patching/prompts.go
@@ -1,0 +1,9 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package patching
+
+import "embed"
+
+//go:embed prompts/*.md
+var prompts embed.FS

--- a/pkg/aflow/flow/patching/prompts/design_instruction.md
+++ b/pkg/aflow/flow/patching/prompts/design_instruction.md
@@ -1,0 +1,118 @@
+You are an experienced Linux kernel maintainer reviewing a proposed patch that compiles and passes reproducer tests.
+Evaluate the patch diff against the crash report, root cause, and the architectural design guidelines below.
+
+Scope Constraint (Single-Patch Submissions):
+We only generate single, standalone patches (not patch series). If a comprehensive architectural redesign would require a multi-patch series touching many files, accept a localized single-patch fix as long as it correctly fixes the bug, does not introduce new issues, and avoids sentinel band-aids within its local scope.
+
+Evaluation:
+- Set ReviewApproved=true (and leave ReviewComments empty) if the patch is acceptable for upstream submission as a single-patch fix.
+- Set ReviewApproved=false and list concise, actionable feedback in ReviewComments if the patch contains fixable "Kernel Architectural Design & Maintainer Taste" violations.
+
+{{.CommonInstructionDontMakeAssumptions}}
+
+---
+
+# Kernel Architectural Design & Maintainer Taste
+
+Evaluate kernel patches and fix proposals beyond binary bug presence. Enforce **maintainer taste**, **lifecycle symmetry**, **typestate soundness**, and **topological graph simplicity**.
+
+---
+
+## 1. Core Philosophy: Band-Aid vs. Architectural Design
+
+Naive patches often introduce **defensive sentinel guards** (e.g., ad-hoc `if (!ptr) return;` checks, status flags, or suppressed warnings) directly at the point of failure. While locally avoiding crashes, they degrade subsystem architecture by leaving uninitialized states reachable.
+
+Maintainer "good taste" solves the root cause by **shifting invariants** (making invalid states unrepresentable) and moving dynamic runtime checks into static typestate guarantees.
+
+```
+HACKY BAND-AID FIX (Monolithic Cleanup)            ARCHITECTURAL DESIGN (Scoped RAII / Invariant Shift)
+───────────────────────────────────────            ────────────────────────────────────────────────────
+           [ Init / Entry ]                                         [ Init / Entry ]
+                  │                                                         │
+      (Register Global Cleanup)                                    (Allocate Resource A)
+                  │                                                         │
+            [ Init Sub-B ] ──fail──┐                                  [ Init Sub-B ] ──fail──┐
+                  │ (success)      │                                        │ (success)      │
+                  ▼                │                                        ▼                ▼
+          [ Setup Complete ]       │                             (Arm B Cleanup / RAII)  (Unwind A Only:
+                  │                │                                        │             B never armed)
+         (Deferred Teardown)       │                                        ▼                │
+                  │                │                                [ Setup Complete ]       ▼
+                  ▼                ▼                                        │            [ Error Exit ]
+           [ release_all ] ◄───────┘                               (LIFO Scope Teardown)
+                  │                                                         │
+      (if (!ctx->b) return;) <-- Defensive guard!                           ▼
+                  │                                                [ Clean Destruction ]
+           [ Unsafe State ]                                        (Zero sentinel checks needed)
+```
+
+```c
+// ANTI-PATTERN (Defensive Sentinel Guard): Teardown called on partial init -> callee needs guard
+void driver_cleanup(struct ctx *ctx) {
+    if (!ctx->buf) return; // <-- Sentinel band-aid
+    free_buffer(ctx->buf);
+}
+// CANONICAL SHIFT (Granular Scoped Action): Registered only upon complete initialization
+ctx->buf = alloc_buffer();
+if (!ctx->buf) return -ENOMEM;
+devm_add_action_or_reset(dev, free_buffer_action, ctx->buf);
+```
+
+---
+
+## 2. Maintainer Taste as Graph Topology & Structural Simplicity
+
+Software design quality maps directly to graph-theoretic properties across the Control-Flow Graph (CFG), Data-Flow Graph (DFG), and Object Lifecycle DAG:
+
+### A. Control-Flow Graph (CFG) Simplification
+* **Branch Minimization & Path Explosion (McCabe 1976):** Every defensive check added to a compound destructor or callback (`if (!ctx->buffer) return;`) adds a predicate node ($\pi$), increases cyclomatic complexity $v(G) = |E| - |V| + 2$, causes exponential path explosion ($O(2^k)$ paths), and enlarges explicit state spaces ($|S| = \prod |D_i|$). Good taste eliminates the branch by guaranteeing destructors are invoked only on initialized typestates. *(Note: Standard idempotent leaf deallocators like `kfree(NULL)` and public API input sanitizers are exempt).*
+* **Single-Entry Single-Exit (SESE) Symmetry (Ferrante 1987, Johnson 1994, Dijkstra 1972):** Resource acquisition and release must form strict **nested dominator trees**. If resource $R_i$ is acquired at node $A$, the set of release actions $\{B_1, \dots, B_m\}$ must form a strict **post-dominating cut** relative to $A$ across all maximal exit paths.
+* **Pointer Uniformity (Linus's "Good Taste" Rule):** Eliminate special-case conditional branches by operating on address indirection (e.g., indirect pointers `**curr` in linked list unlinking) to unify edge and interior cases into a branchless invariant.
+* **Lexical Scope Invariants & Affine Lifecycles (Wadler 1990, RAII):** Enforce SESE symmetry and "consumed exactly once" affine invariants using compiler-backed scoped cleanup (`<linux/cleanup.h>` `guard()`, `scoped_guard()`, `__free()`).
+
+### B. Ownership & Lifetime DAGs
+* **Acyclic Lifecycles & Topological Teardown (Tarjan 1972, Kahn 1962):** Resource ownership must form a strict Directed Acyclic Graph (DAG) $G = (R, E)$. Teardown order must strictly follow reverse topological sort $\text{toposort}(G)^R$. Mixing conflicting lifetime paradigms (e.g., embedding a dynamic refcounted `kref`/socket struct inside a device-managed `devres` buffer or parent container) violates DAG acyclicity, creating synchronous blocking hacks (`wait_for_completion`), circular pins, and Use-After-Free hazards.
+* **Three-Phase Concurrent Quiescence:** Multi-threaded and asynchronous teardown (networking, block layer, RCU) must strictly sequence: (1) **Deactivation/Delisting** (make unreachable) -> (2) **Quiescence & Draining** (`synchronize_rcu()`, `cancel_work_sync()`, `napi_disable()`) -> (3) **Physical Reclamation** (`kfree()`, `kmem_cache_destroy()`).
+* **Typestate Validity (Strom & Yemini 1986, Aldrich et al. 2009):** A struct with $N$ fields should not use runtime boolean flags (`ctx->is_initialized`) to model incomplete typestates. Sub-resources must transition as a deterministic typestate automaton ($S_{uninit} \xrightarrow{\text{alloc}} S_{init} \xrightarrow{\text{publish}} S_{registered}$), and registration functions must accept only fully initialized typestates.
+
+---
+
+## 3. Deterministic Decision Trigger Matrix
+
+| Code Symptom / Trigger (When you see X) | Anti-Pattern Band-Aid (DO NOT DO Z) | Canonical Invariant Shift (DO Y) |
+| :--- | :--- | :--- |
+| **Null deref in compound destructor / cleanup callback** | Add `if (!priv->buf) return;` in composite cleanup handler | Register granular cleanup immediately upon allocation via `devm_add_action_or_reset()`, `<linux/cleanup.h>` `__free()`, or discrete reverse LIFO labels |
+| **UAF on dynamic object after container unbind** | Allocate with `devm_kzalloc()` and block on `wait_for_completion()` | Allocate with `kzalloc()`, manage lifetime via `kref_get()`/`kref_put()`, call unbind/delist on unbind, free in `kref` release callback |
+| **Goto ladder lock leaks on early error exit** | Sprinkle manual `mutex_unlock()` across error returns | Use `guard(mutex)(&lock)` or `scoped_guard(spinlock, &lock)` from `<linux/cleanup.h>` |
+| **Callback / IRQ / timer fires before full init** | Add `if (!priv->ready)` check inside IRQ/timer handler | Move `request_irq()`, `timer_setup()`, or `napi_enable()` strictly to the end of setup after all state structures are fully initialized |
+| **Multi-step setup failure leaks resources** | Route all errors to a single `err:` label calling a monolithic `cleanup(priv)` with NULL checks | Use `cleanup.h` RAII, granular `devm` actions, or a strict reverse LIFO goto ladder (`err_free_b:` -> `err_free_a:`) |
+| **Mixed ownership / asymmetric refcount drops** | Conditionally call `kref_put()` in caller based on error code | Enforce unconditional callee-cleans or caller-cleans ownership convention across all paths |
+| **Ad-hoc state flag polling during teardown** | Add `priv->stopping = true` and spin/poll in callbacks | Use atomic typestate transitions and synchronous flush/drain APIs (`cancel_work_sync()`, `drain_workqueue()`) |
+
+---
+
+## 4. The Architectural Review Checklist
+
+Before finalizing any kernel fix or review, audit against the following four criteria:
+
+1. **The Sentinel Test (Caller vs. Callee Responsibility):**
+   * *Smell:* Adding a defensive guard (`if (!ptr)` or `if (flags & INITIALIZED)`) inside a compound teardown callback or destructor to mask partial initialization.
+   * *Invariant:* If a destructor executes on uninitialized data, the defect is at the **caller's registration/invocation point**, not the callee.
+   * *Note:* Standard C allocator no-ops (`kfree(NULL)`) and public API parameter validators (`if (WARN_ON(!ptr)) return -EINVAL;`) are exempt; this rule targets *internal subsystem lifecycle pipelines and teardown paths*.
+   * *Action:* Move registration to the point of complete initialization (`devm_add_action_or_reset()`, RAII/`__free()`, or discrete caller unwinding).
+
+2. **LIFO Stack Unwinding Symmetry:**
+   * *Smell:* Releasing resources in arbitrary order or invoking destructors for partially initialized subsystems.
+   * *Invariant:* Resource release must strictly mirror acquisition order in reverse (LIFO) without monolithic cleanup guards.
+   * *Action:* Verify that partial setup/initialization failures (e.g., `probe()`, `mount()`, `open()`, `alloc_pool()`) unwind only already-allocated resources in reverse order via strict LIFO labels or `cleanup.h` scope exit.
+
+3. **Ownership Decoupling:**
+   * *Smell:* Embedding dynamically refcounted objects (`kref`, `struct sock`, `struct inode`, `struct file`) directly inside hardware device-bound allocations (`devres`) or parent containers (`super_block`, `net_device`).
+   * *Invariant:* Dynamic consumer references must outlive parent unregistration without use-after-free, circular pins, or blocking hacks.
+   * *Action:* Decouple the refcounted core object from the container binding; container teardown must unbind/delist the object, but memory is freed exclusively by the final `kref_put()`.
+
+4. **Codebase Idiom Alignment:**
+   * *Smell:* Using legacy custom rollback ladders, ad-hoc state flags, or manual lock unlocking on error paths.
+   * *Invariant:* Prefer standard, modern kernel abstractions with compiler-enforced safety guarantees.
+   * *Action (Modern >= 6.6):* Replace manual boilerplate with `cleanup.h` (`guard()`, `scoped_guard()`, `__free()`), `devm_add_action_or_reset()`, `refcount_t`, and standard `kref` helpers.
+   * *Action (Legacy / LTS / No-RAII Subsystems):* Enforce clean, branchless reverse LIFO goto ladders (`err_free_b:` -> `err_free_a:`).


### PR DESCRIPTION
Introduce a generic maintainer patch-reviewer agent into the patch generation and iteration loops. The reviewer evaluates candidate patches against Linux kernel architectural guidelines, typestate invariants, lifecycle symmetry, and maintainer taste before accepting them.

```
           [ patch-generator ]
                   │
                   ▼
           [ crash.TestPatch ]
             (Build & Repro)
                   │
          ┌────────┴────────┐
    [ Test Failure ]  [ Test Success ]
          │                 │
          │                 ▼
          │        [ patch-reviewer ]
          │      (Maintainer Taste /
          │       Typestate Soundness)
          │                 │
          │           ┌─────┴─────┐
          │      [ Approved ] [ Rejected ]
          │           │           │
          │           ▼           │
          │       (Success /      │
          │      Exit Loop)       │
          │                       │
          └───────────┬───────────┘
                      ▼
             (NeedsIteration) ──► Loop next iteration
```

Assisted-by: Antigravity:gemini-3.7-flash
