### PR TITLE
pkg/aflow: support Gemini 3.7 flash

### DIFF
--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -59,111 +59,47 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 		return p.err
 	}
 
+	p.models = map[string]*modelInfo{
+		"gemini-3-flash-preview": {
+			Thinking:         true,
+			MaxTemperature:   2.0,
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 65536,
+		},
+		"gemini-3.6-flash": {
+			Thinking:         true,
+			MaxTemperature:   2.0,
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 65536,
+		},
+		"gemini-3.5-flash": {
+			Thinking:         true,
+			MaxTemperature:   2.0,
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 65536,
+		},
+		"gemini-3.1-pro-preview": {
+			Thinking:         true,
+			MaxTemperature:   2.0,
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 65536,
+		},
+	}
+	if cfg.ClientConfig != nil && cfg.ClientConfig.Backend == genai.BackendVertexAI {
+		// Vertex AI backend expects the bare model name, not prefixed with "models/".
+		// E.g. "gemini-1.5-pro" instead of "models/gemini-1.5-pro".
+		p.modelPathPrefix = ""
+	} else {
+		p.modelPathPrefix = "models/"
+	}
+
 	client, err := genai.NewClient(ctx, cfg.ClientConfig)
 	if err != nil {
 		p.err = err
 		return err
 	}
 	p.client = client
-
-	isVertex := cfg.ClientConfig != nil && cfg.ClientConfig.Backend == genai.BackendVertexAI
-
-	if isVertex {
-		// Vertex AI's Models.All() endpoint often does not return the same detailed
-		// metadata (like InputTokenLimit or SupportedActions) as the Gemini Developer API,
-		// or requires special IAM permissions to list the catalog. Therefore, we hardcode
-		// the known capabilities for the models we actively use.
-		// Vertex AI backend expects the bare model name, not prefixed with "models/".
-		// E.g. "gemini-1.5-pro" instead of "models/gemini-1.5-pro".
-		p.models = map[string]*modelInfo{
-			"gemini-3-flash-preview": {
-				Thinking:         true,
-				MaxTemperature:   2.0,
-				InputTokenLimit:  1048576,
-				OutputTokenLimit: 65536,
-			},
-			"gemini-3.5-flash": {
-				Thinking:         true,
-				MaxTemperature:   2.0,
-				InputTokenLimit:  1048576,
-				OutputTokenLimit: 65536,
-			},
-			"gemini-3.6-flash": {
-				Thinking:         true,
-				MaxTemperature:   2.0,
-				InputTokenLimit:  1048576,
-				OutputTokenLimit: 65536,
-			},
-			"gemini-3.1-pro-preview": {
-				Thinking:         true,
-				MaxTemperature:   2.0,
-				InputTokenLimit:  1048576,
-				OutputTokenLimit: 65536,
-			},
-		}
-		p.modelPathPrefix = ""
-		return nil
-	}
-
-	// Gemini API. Unlike Vertex AI, the Gemini Developer API catalog endpoint (Models.All)
-	// successfully returns detailed metadata for all models (such as their InputTokenLimit,
-	// OutputTokenLimit, and SupportedActions) without requiring any special IAM configurations.
-	// Therefore, we query the catalog dynamically here.
-	const maxInitRetries = 5
-
-	var models map[string]*modelInfo
-	for i := range maxInitRetries {
-		models, err = p.queryModelsOnce(ctx, client)
-		if err == nil {
-			break
-		}
-		parsedErr := parseLLMError(err, "")
-		var retryErr *backend.RetryError
-		if !errors.As(parsedErr, &retryErr) {
-			break
-		}
-		if i == maxInitRetries-1 {
-			break
-		}
-		delay := retryErr.Delay
-		if retryErr.IsExponential {
-			delay = backend.BackoffDuration(i, retryErr.Delay)
-		}
-		select {
-		case <-ctx.Done():
-			p.err = ctx.Err()
-			return p.err
-		case <-time.After(delay):
-		}
-	}
-	if err != nil {
-		p.err = err
-		return err
-	}
-	p.models = models
-	p.modelPathPrefix = "models/"
 	return nil
-}
-
-func (p *Provider) queryModelsOnce(ctx context.Context, client *genai.Client) (map[string]*modelInfo, error) {
-	models := make(map[string]*modelInfo)
-	for m, e := range client.Models.All(ctx) {
-		if e != nil {
-			return nil, e
-		}
-		if !slices.Contains(m.SupportedActions, "generateContent") ||
-			strings.Contains(m.Name, "-image") ||
-			strings.Contains(m.Name, "-audio") {
-			continue
-		}
-		models[strings.TrimPrefix(m.Name, "models/")] = &modelInfo{
-			Thinking:         m.Thinking,
-			MaxTemperature:   m.MaxTemperature,
-			InputTokenLimit:  int(m.InputTokenLimit),
-			OutputTokenLimit: int(m.OutputTokenLimit),
-		}
-	}
-	return models, nil
 }
 
 func (p *Provider) Client(ctx context.Context) (backend.Client, error) {

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -32,6 +32,7 @@ type Provider struct {
 
 type modelInfo struct {
 	Thinking         bool
+	MinThinkingLevel backend.ThinkingLevel
 	MaxTemperature   float32
 	InputTokenLimit  int
 	OutputTokenLimit int
@@ -60,8 +61,10 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 	}
 
 	p.models = map[string]*modelInfo{
-		"gemini-3-flash-preview": {
-			Thinking:         true,
+		"gemini-3.7-flash": {
+			Thinking: true,
+			// Gemini 3.7 Flash does not support MINIMAL thinking.
+			MinThinkingLevel: backend.ThinkingLevelLow,
 			MaxTemperature:   2.0,
 			InputTokenLimit:  1048576,
 			OutputTokenLimit: 65536,
@@ -120,7 +123,7 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 	case backend.BestExpensiveModel:
 		return []string{"gemini-3.1-pro-preview"}
 	case backend.GoodBalancedModel:
-		return []string{"gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash-preview"}
+		return []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"}
 	default:
 		return nil
 	}
@@ -166,10 +169,11 @@ func (c *client) GenerateContent(ctx context.Context, model string, cfg *backend
 				genaiCfg.Tools = append(genaiCfg.Tools, genaiTool)
 			}
 		}
-		if info.Thinking && cfg.ThinkingLevel != backend.ThinkingLevelMinimal {
+		thinkingLevel := max(cfg.ThinkingLevel, info.MinThinkingLevel)
+		if info.Thinking && thinkingLevel != backend.ThinkingLevelMinimal {
 			genaiCfg.ThinkingConfig = &genai.ThinkingConfig{}
 			genaiCfg.ThinkingConfig.IncludeThoughts = cfg.IncludeThoughts
-			switch cfg.ThinkingLevel {
+			switch thinkingLevel {
 			case backend.ThinkingLevelLow:
 				genaiCfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelLow
 			case backend.ThinkingLevelMedium:

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -25,7 +25,7 @@ func TestProviderResolveModels(t *testing.T) {
 		{
 			name:     "resolves good balanced model pool",
 			category: backend.GoodBalancedModel,
-			want:     []string{"gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash-preview"},
+			want:     []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"},
 		},
 		{
 			name:     "resolves best expensive model pool",


### PR DESCRIPTION
* Drop the redundancy around model querying: there's no sense to maintain both the API querying and the hard-coded info array.
* Prefer Gemini 3.7 flash; adjust the code for it's unusual minimal thinking level.
* Deprecate Gemini 3 flash