### PR TITLE
dashboard/app: test repro-c on last successful manager build commit

### DIFF
--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -1299,6 +1299,7 @@ func TestAITestReproC(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, dashapi.JobTestPatch, pollResp.Type)
+	require.Equal(t, build.KernelCommit, pollResp.KernelBranch)
 	require.Equal(t, "int main() { return 0; }", string(pollResp.ReproC))
 
 	// Complete the test job with a crash matching the bug title.

--- a/dashboard/app/jobs.go
+++ b/dashboard/app/jobs.go
@@ -2045,7 +2045,7 @@ func handleTestReproCRequest(ctx context.Context, args *testReproCReqArgs) (*Job
 			user:    args.user,
 			manager: manager,
 			repo:    build.KernelRepo,
-			branch:  build.KernelBranch,
+			branch:  build.KernelCommit,
 			reproC:  args.reproC,
 		},
 	})

--- a/dashboard/app/jobs_test.go
+++ b/dashboard/app/jobs_test.go
@@ -1389,6 +1389,20 @@ func TestReproCJob(t *testing.T) {
 	client.ReportCrash(crash)
 	rep := c.globalClient.pollBug()
 
+	// Upload a more recent failed build on the manager to ensure
+	// handleTestReproCRequest still selects the last successful build.
+	c.advanceTime(time.Hour)
+	failedBuild := testBuild(2)
+	failedBuild.Manager = build.Manager
+	failedBuild.KernelRepo = build.KernelRepo
+	failedBuild.KernelCommitDate = failedBuild.KernelCommitDate.Add(time.Hour)
+	c.expectOK(client.ReportBuildError(&dashapi.BuildErrorReq{
+		Build: *failedBuild,
+		Crash: dashapi.Crash{
+			Title: "kernel build failed",
+		},
+	}))
+
 	bug, _, _ := c.loadBug(rep.ID)
 	reproC := []byte("void main() { *(int*)0 = 0; }")
 	job, err := handleTestReproCRequest(c.ctx, &testReproCReqArgs{
@@ -1410,6 +1424,7 @@ func TestReproCJob(t *testing.T) {
 	})
 	c.expectOK(err)
 	c.expectEQ(pollResp.Type, dashapi.JobTestPatch)
+	c.expectEQ(pollResp.KernelBranch, build.KernelCommit)
 	c.expectEQ(string(pollResp.ReproC), string(reproC))
 
 	// Job succeeds with a different crash title that matches the bug via AltTitles.


### PR DESCRIPTION
Testing AI-generated C reproducers on a manager currently passes the kernel branch name to test jobs, causing syz-ci to check out branch HEAD. Kernel branches get broken once in a while, but we want to keep this functionality working regardless of transient upstream breakages.

Pass the commit hash of the manager's last successful build instead of the branch name so syz-ci tests the reproducer on a known working build.