### PR TITLE
pkg/aflow: add one more model category

### DIFF
--- a/pkg/aflow/GEMINI.md
+++ b/pkg/aflow/GEMINI.md
@@ -91,8 +91,9 @@ Workflows are typically registered using `aflow.Register`.
 
 ### LLM Integration
 
-- **Models**: Prefer `aflow.GoodBalancedModel` (Flash) for simple tasks and `aflow.BestExpensiveModel` (Pro)
-    for complex reasoning.
+- **Models**: Use `aflow.DeepReasoningModel` (Pro) for complex causal reasoning, architectural planning, and security impact analysis.
+    Use `aflow.CoreModel` (Flash 3.7+ thinking) as the primary workhorse for agentic execution, C coding, review loops, and sub-agents.
+    Use `aflow.LightweightModel` (Flash) for low-overhead text/tag extraction and context compression.
 - **Context Compression**: For agents processing very large contexts (e.g., `patching` or
     `reproc`), set `CompressTokens` to establish a threshold. The system establishes an anchor
     token baseline from the first prompt and calculates a delta for subsequent turns. When the

--- a/pkg/aflow/backend/backend.go
+++ b/pkg/aflow/backend/backend.go
@@ -102,10 +102,15 @@ type Client interface {
 type ModelCategory string
 
 const (
-	// BestExpensiveModel is the most capable, but potentially slower and more expensive model.
-	BestExpensiveModel ModelCategory = "best-expensive"
-	// GoodBalancedModel is a fast, cost-effective model with good capabilities.
-	GoodBalancedModel ModelCategory = "good-balanced"
+	// DeepReasoningModel is the frontier model for complex causal diagnosis,
+	// architectural planning, and security impact analysis.
+	DeepReasoningModel ModelCategory = "deep-reasoning"
+	// CoreModel is the primary workhorse model for agentic execution,
+	// multi-turn tool interaction, code synthesis, and review loops.
+	CoreModel ModelCategory = "core"
+	// LightweightModel is a low-overhead model for deterministic extraction,
+	// formatting, and context compression.
+	LightweightModel ModelCategory = "lightweight"
 )
 
 // Provider represents an LLM provider (e.g., Gemini, Claude).

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -120,9 +120,11 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 		return []string{p.modelOverride}
 	}
 	switch category {
-	case backend.BestExpensiveModel:
+	case backend.DeepReasoningModel:
 		return []string{"gemini-3.1-pro-preview"}
-	case backend.GoodBalancedModel:
+	case backend.CoreModel:
+		return []string{"gemini-3.7-flash"}
+	case backend.LightweightModel:
 		return []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"}
 	default:
 		return nil

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -23,13 +23,18 @@ func TestProviderResolveModels(t *testing.T) {
 		want          []string
 	}{
 		{
-			name:     "resolves good balanced model pool",
-			category: backend.GoodBalancedModel,
+			name:     "resolves core model pool",
+			category: backend.CoreModel,
+			want:     []string{"gemini-3.7-flash"},
+		},
+		{
+			name:     "resolves lightweight model pool",
+			category: backend.LightweightModel,
 			want:     []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"},
 		},
 		{
-			name:     "resolves best expensive model pool",
-			category: backend.BestExpensiveModel,
+			name:     "resolves deep reasoning model pool",
+			category: backend.DeepReasoningModel,
 			want:     []string{"gemini-3.1-pro-preview"},
 		},
 		{
@@ -40,7 +45,7 @@ func TestProviderResolveModels(t *testing.T) {
 		{
 			name:          "respects provider level override",
 			modelOverride: "override-model",
-			category:      backend.GoodBalancedModel,
+			category:      backend.CoreModel,
 			want:          []string{"override-model"},
 		},
 		{

--- a/pkg/aflow/flow/assessment/kcsan.go
+++ b/pkg/aflow/flow/assessment/kcsan.go
@@ -38,7 +38,7 @@ func init() {
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
 					Name:  "expert",
-					Model: aflow.GoodBalancedModel,
+					Model: aflow.CoreModel,
 					Reply: "ExplanationRaw",
 					Outputs: aflow.LLMOutputs[struct {
 						Benign bool `jsonschema:"If the data race is benign or not."`

--- a/pkg/aflow/flow/assessment/moderation.go
+++ b/pkg/aflow/flow/assessment/moderation.go
@@ -33,7 +33,7 @@ func init() {
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
 					Name:  "expert",
-					Model: aflow.GoodBalancedModel,
+					Model: aflow.CoreModel,
 					Reply: "ExplanationRaw",
 					Outputs: aflow.LLMOutputs[struct {
 						Actionable bool `jsonschema:"If the report is actionable or not."`

--- a/pkg/aflow/flow/assessment/security.go
+++ b/pkg/aflow/flow/assessment/security.go
@@ -48,7 +48,7 @@ func init() {
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
 					Name:        "expert",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.DeepReasoningModel,
 					Reply:       "ExplanationRaw",
 					Outputs:     aflow.LLMOutputs[securityOutputs](),
 					TaskType:    aflow.FormalReasoningTask,

--- a/pkg/aflow/flow/fuzzing/patch_triage.go
+++ b/pkg/aflow/flow/fuzzing/patch_triage.go
@@ -28,7 +28,7 @@ func init() {
 				readPatchDiff,
 				&aflow.LLMAgent{
 					Name:     "patch-evaluator",
-					Model:    aflow.BestExpensiveModel,
+					Model:    aflow.CoreModel,
 					TaskType: aflow.FormalReasoningTask,
 					Outputs: aflow.ValidatedLLMOutputs[patchEvalOutput](
 						func(ctx *aflow.Context, state ai.PatchTriageArgs, args patchEvalOutput) (patchEvalOutput, error) {
@@ -57,7 +57,7 @@ func init() {
 					Condition: "WorthFuzzing",
 					Do: &aflow.LLMAgent{
 						Name:     "kmsan-evaluator",
-						Model:    aflow.BestExpensiveModel,
+						Model:    aflow.CoreModel,
 						TaskType: aflow.FormalReasoningTask,
 						Outputs:  aflow.LLMOutputs[kmsanEvalOutput](),
 						Tools: aflow.Tools(

--- a/pkg/aflow/flow/patching/formatting.go
+++ b/pkg/aflow/flow/patching/formatting.go
@@ -36,7 +36,7 @@ func patchRefinementLoop(initStyleItems bool) aflow.Action {
 			Do: aflow.Pipeline(
 				&aflow.LLMAgent{
 					Name:        "patch-formatter",
-					Model:       aflow.GoodBalancedModel,
+					Model:       aflow.CoreModel,
 					Reply:       "FormatterExplanation",
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: formatterInstruction,

--- a/pkg/aflow/flow/patching/iteration.go
+++ b/pkg/aflow/flow/patching/iteration.go
@@ -115,7 +115,7 @@ func init() {
 				// Analyze comments to decide whether we need to generate a new patch version.
 				&aflow.LLMAgent{
 					Name:        "verdict-agent",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.CoreModel,
 					Outputs:     aflow.ValidatedLLMOutputs[verdictAgentOutputs](validateVerdictOutputs),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: verdictInstruction,
@@ -146,7 +146,7 @@ func init() {
 							Do: aflow.Pipeline(
 								&aflow.LLMAgent{
 									Name:        "fixes-finder",
-									Model:       aflow.BestExpensiveModel,
+									Model:       aflow.CoreModel,
 									Outputs:     aflow.ValidatedLLMOutputs[fixesFinderArgs](validateFixesHashes),
 									TaskType:    aflow.FormalReasoningTask,
 									Instruction: fixesIterationInstruction,
@@ -159,7 +159,7 @@ func init() {
 						getRecentCommits,
 						&aflow.LLMAgent{
 							Name:        "changelog-generator",
-							Model:       aflow.GoodBalancedModel,
+							Model:       aflow.CoreModel,
 							Outputs:     aflow.ValidatedLLMOutputs[changelogGeneratorOutputs](validateChangelogOutputs),
 							TaskType:    aflow.FormalReasoningTask,
 							Instruction: changelogInstruction,
@@ -179,7 +179,7 @@ func init() {
 						Do: aflow.Pipeline(
 							&aflow.LLMAgent{
 								Name:  "comment-reply-agent",
-								Model: aflow.BestExpensiveModel,
+								Model: aflow.CoreModel,
 								// nolint: lll
 								Outputs: aflow.LLMOutputs[struct {
 									Action    string `jsonschema:"Either 'reply' or 'ignore'"`

--- a/pkg/aflow/flow/patching/patching.go
+++ b/pkg/aflow/flow/patching/patching.go
@@ -77,7 +77,7 @@ func init() {
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
 					Name:        "debugger",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.DeepReasoningModel,
 					Reply:       "BugExplanation",
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: debuggingInstruction,
@@ -86,7 +86,7 @@ func init() {
 				},
 				&aflow.LLMAgent{
 					Name:        "history-explorer",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.DeepReasoningModel,
 					Reply:       "HistoricalContext",
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: historyExplorerInstruction,
@@ -98,7 +98,7 @@ func init() {
 				patchRefinementLoop(true),
 				&aflow.LLMAgent{
 					Name:        "fixes-finder",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.CoreModel,
 					Outputs:     aflow.ValidatedLLMOutputs[fixesFinderArgs](validateFixesHashes),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: fixesInstruction,
@@ -110,7 +110,7 @@ func init() {
 				getRecentCommits,
 				&aflow.LLMAgent{
 					Name:  "description-generator",
-					Model: aflow.BestExpensiveModel,
+					Model: aflow.CoreModel,
 					ValidatedReply: aflow.LLMReply("PatchDescription",
 						func(ctx *aflow.Context, state struct{}, reply string) (string, error) {
 							return email.WordWrap(reply, patchDescriptionLineLength), nil
@@ -456,7 +456,7 @@ func patchGenerationLoop(beforeEach aflow.Action, instruction, prompt, reviewerP
 	actions = append(actions,
 		&aflow.LLMAgent{
 			Name:        "patch-generator",
-			Model:       aflow.BestExpensiveModel,
+			Model:       aflow.CoreModel,
 			Reply:       "PatchExplanation",
 			TaskType:    aflow.FormalReasoningTask,
 			Instruction: instruction,
@@ -475,7 +475,7 @@ func patchGenerationLoop(beforeEach aflow.Action, instruction, prompt, reviewerP
 			Else: aflow.Pipeline(
 				&aflow.LLMAgent{
 					Name:        "patch-reviewer",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.CoreModel,
 					Outputs:     aflow.ValidatedLLMOutputs[patchReviewerOutputs](validatePatchReviewerOutputs),
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: common.Prompt(prompts, "prompts/design_instruction.md"),

--- a/pkg/aflow/flow/patching/tags.go
+++ b/pkg/aflow/flow/patching/tags.go
@@ -135,7 +135,7 @@ var tagsMergerAction = aflow.NewFuncAction("tags-merger", mergeTags)
 
 var tagExtractor = &aflow.LLMAgent{
 	Name:        "tag-extractor",
-	Model:       aflow.GoodBalancedModel,
+	Model:       aflow.LightweightModel,
 	Outputs:     aflow.ValidatedLLMOutputs[tagExtractorArgs](validateTagExtractorOutputs),
 	TaskType:    aflow.FormalReasoningTask,
 	Instruction: tagExtractorInstruction,

--- a/pkg/aflow/flow/repro/repro.go
+++ b/pkg/aflow/flow/repro/repro.go
@@ -58,7 +58,7 @@ func init() {
 				actionsyzlang.PrepareSyzFS,
 				&aflow.LLMAgent{
 					Name:    "crash-repro-finder",
-					Model:   aflow.BestExpensiveModel,
+					Model:   aflow.DeepReasoningModel,
 					Outputs: aflow.ValidatedLLMOutputs[ReproFinderResult, ReproFinderState](formatReproFinderOutputs),
 					Tools: aflow.Tools(
 						common.CodeAccessTools,

--- a/pkg/aflow/flow/reproc/reproc.go
+++ b/pkg/aflow/flow/reproc/reproc.go
@@ -380,7 +380,7 @@ func init() {
 				codesearcher.PrepareIndex,
 				&aflow.LLMAgent{
 					Name:        "initial-researcher",
-					Model:       aflow.BestExpensiveModel,
+					Model:       aflow.DeepReasoningModel,
 					Reply:       "InitialReproStrategy",
 					TaskType:    aflow.FormalReasoningTask,
 					Instruction: initialResearcherInstruction,
@@ -395,7 +395,7 @@ func init() {
 							Condition: "OracleFeedback",
 							Do: &aflow.LLMAgent{
 								Name:        "strategy-refiner",
-								Model:       aflow.BestExpensiveModel,
+								Model:       aflow.DeepReasoningModel,
 								Reply:       "RefinedReproStrategy",
 								TaskType:    aflow.FormalReasoningTask,
 								Instruction: refinerInstruction,
@@ -406,7 +406,7 @@ func init() {
 						MergeStrategy,
 						&aflow.LLMAgent{
 							Name:        "repro-generator",
-							Model:       aflow.BestExpensiveModel,
+							Model:       aflow.DeepReasoningModel,
 							Outputs:     aflow.ValidatedLLMOutputs[GeneratorResult, GeneratorValidationState](validateGeneratorOutputs),
 							TaskType:    aflow.FormalReasoningTask,
 							Instruction: generatorInstruction,
@@ -423,7 +423,7 @@ func init() {
 									Condition: "CompilerError",
 									Do: &aflow.LLMAgent{
 										Name:        "repro-repairer",
-										Model:       aflow.BestExpensiveModel,
+										Model:       aflow.DeepReasoningModel,
 										Reply:       "RepairedCandidateReproC",
 										TaskType:    aflow.FormalReasoningTask,
 										Instruction: repairerInstruction,
@@ -437,7 +437,7 @@ func init() {
 						TruncateLog,
 						&aflow.LLMAgent{
 							Name:        "repro-oracle",
-							Model:       aflow.BestExpensiveModel,
+							Model:       aflow.DeepReasoningModel,
 							Outputs:     aflow.ValidatedLLMOutputs[OracleResult, OracleValidationState](validateOracleOutputs),
 							TaskType:    aflow.FormalReasoningTask,
 							Instruction: oracleInstruction,

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -99,8 +99,9 @@ const (
 	// Consts to use for LLMAgent.Model.
 	// These are aliases for the backend constants to avoid requiring users
 	// of the aflow package to import the backend package just to specify the model.
-	BestExpensiveModel = backend.BestExpensiveModel
-	GoodBalancedModel  = backend.GoodBalancedModel
+	DeepReasoningModel = backend.DeepReasoningModel
+	CoreModel          = backend.CoreModel
+	LightweightModel   = backend.LightweightModel
 
 	// Default limit for consecutive identical tool calls.
 	defaultLoopDetectionLimit = 3
@@ -620,7 +621,7 @@ func (a *agentSession) compressContext(
 	span := &trajectory.Span{
 		Type:  trajectory.SpanLLM,
 		Name:  a.Name + "-compressor",
-		Model: string(backend.GoodBalancedModel),
+		Model: string(backend.LightweightModel),
 	}
 	if err := ctx.startSpan(span); err != nil {
 		return nil, 0, err
@@ -652,7 +653,7 @@ func (a *agentSession) compressContext(
 		rawReq = append(rawReq, msg.content)
 	}
 
-	resp, err := a.generateContent(ctx, cfg, rawReq, 0, backend.GoodBalancedModel, span)
+	resp, err := a.generateContent(ctx, cfg, rawReq, 0, backend.LightweightModel, span)
 	if err != nil {
 		return nil, 0, ctx.finishSpan(span, err)
 	}

--- a/pkg/aflow/testdata/TestTokenCompression.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompression.llm.json
@@ -91,7 +91,7 @@
 		]
 	},
 	{
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Config": {
 			"systemInstruction": {
 				"parts": [

--- a/pkg/aflow/testdata/TestTokenCompression.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompression.trajectory.json
@@ -95,7 +95,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Started": "0001-01-01T00:00:11Z"
 	},
 	{
@@ -103,7 +103,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Started": "0001-01-01T00:00:11Z",
 		"Finished": "0001-01-01T00:00:12Z",
 		"Reply": "compressed summary",

--- a/pkg/aflow/testdata/TestTokenCompressionResetsHistory.llm.json
+++ b/pkg/aflow/testdata/TestTokenCompressionResetsHistory.llm.json
@@ -154,7 +154,7 @@
 		]
 	},
 	{
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Config": {
 			"systemInstruction": {
 				"parts": [

--- a/pkg/aflow/testdata/TestTokenCompressionResetsHistory.trajectory.json
+++ b/pkg/aflow/testdata/TestTokenCompressionResetsHistory.trajectory.json
@@ -132,7 +132,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Started": "0001-01-01T00:00:15Z"
 	},
 	{
@@ -140,7 +140,7 @@
 		"Nesting": 2,
 		"Type": "llm",
 		"Name": "smarty-compressor",
-		"Model": "good-balanced",
+		"Model": "lightweight",
 		"Started": "0001-01-01T00:00:15Z",
 		"Finished": "0001-01-01T00:00:16Z",
 		"Reply": "compressed summary",

--- a/pkg/aflow/tool/codeexpert/codeexpert.go
+++ b/pkg/aflow/tool/codeexpert/codeexpert.go
@@ -27,7 +27,7 @@ func New(enableGit bool) *aflow.LLMTool[struct{}, aflow.DefaultLLMArgs] {
 
 	return &aflow.LLMTool[struct{}, aflow.DefaultLLMArgs]{
 		Name:        "codeexpert",
-		Model:       aflow.GoodBalancedModel,
+		Model:       aflow.CoreModel,
 		TaskType:    aflow.FormalReasoningTask,
 		Description: description,
 		Instruction: inst,


### PR DESCRIPTION
Recent models like Gemini 3.7 Flash with extended thinking excel at code generation, tool loops, and reviews, while Pro models remain best for deep causal diagnosis and security analysis.

Split model categories into DeepReasoningModel (complex reasoning and security), CoreModel (primary workhorse for agents, coding, and review), and LightweightModel (simple extraction and compression). Update existing workflows across pkg/aflow accordingly.