### PR TITLE
sys/linux: neutralize manual driver binding via sysfs

### DIFF
--- a/sys/linux/init.go
+++ b/sys/linux/init.go
@@ -5,7 +5,9 @@
 package linux
 
 import (
+	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
@@ -223,6 +225,14 @@ func (arch *arch) neutralize(c *prog.Call, fixStructure bool) error {
 	case "sched_setattr":
 		// Enabling a SCHED_FIFO or a SCHED_RR policy may lead to false positive stall-related crashes.
 		neutralizeSchedAttr(c.Args[1])
+	case "open", "openat", "openat2", "creat",
+		"symlink", "symlinkat", "link", "linkat":
+		// Manually binding/unbinding drivers via sysfs or forcing driver_override
+		// attaches drivers to incompatible devices or unbinds core platform hardware,
+		// triggering nonsensical crashes that maintainers reject as invalid root operations.
+		// See the discussion at:
+		// https://lore.kernel.org/all/6a88012e.dbb3a75c.13dd47.0007.GAE@google.com/T/
+		arch.neutralizePaths(c)
 	}
 
 	switch c.Meta.Name {
@@ -230,6 +240,48 @@ func (arch *arch) neutralize(c *prog.Call, fixStructure bool) error {
 		arch.neutralizeEbtables(c)
 	}
 	return nil
+}
+
+func (arch *arch) neutralizePaths(c *prog.Call) {
+	prog.ForeachArg(c, func(arg prog.Arg, _ *prog.ArgCtx) {
+		dataArg, ok := arg.(*prog.DataArg)
+		if !ok || dataArg.Dir() == prog.DirOut {
+			return
+		}
+		data := dataArg.Data()
+		if len(data) == 0 {
+			return
+		}
+		str := strings.TrimRight(string(data), "\x00")
+		clean := filepath.Clean(str)
+		if isForbiddenBindingPath(clean) {
+			bufType, _ := dataArg.Type().(*prog.BufferType)
+			var safe []byte
+			if bufType != nil && !bufType.Varlen() {
+				safe = make([]byte, bufType.Size())
+				copy(safe, "./file0")
+			} else if bufType != nil && bufType.NoZ {
+				safe = []byte("./file0")
+			} else {
+				safe = []byte("./file0\x00")
+			}
+			dataArg.SetData(safe)
+		}
+	})
+}
+
+// isForbiddenBindingPath checks whether a path targets sysfs driver binding/unbinding controls
+// (e.g. /sys/bus/.../bind, /sys/devices/.../driver_override, /sys/bus/.../drivers_probe).
+func isForbiddenBindingPath(clean string) bool {
+	if !strings.Contains(clean, "/bus/") &&
+		!strings.Contains(clean, "/devices/") &&
+		!strings.Contains(clean, "/device/") {
+		return false
+	}
+	return strings.HasSuffix(clean, "/bind") ||
+		strings.HasSuffix(clean, "/unbind") ||
+		strings.HasSuffix(clean, "/driver_override") ||
+		strings.HasSuffix(clean, "/drivers_probe")
 }
 
 func neutralizeSchedAttr(a prog.Arg) {

--- a/sys/linux/init_test.go
+++ b/sys/linux/init_test.go
@@ -149,6 +149,34 @@ syz_open_dev$tty1(0xc, 0x4, 0x1)
 			Out:       `sched_setattr(0x0, &(0x7f00000001c0)={0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, 0x0)`,
 			StrictErr: `wrong array arg`,
 		},
+		{
+			In:  `openat(0xffffffffffffff9c, &(0x7f0000000100)='./sys/bus/platform/drivers/bxt_wcove_usbc/bind\x00', 0x1, 0x0)`,
+			Out: `openat(0xffffffffffffff9c, &(0x7f0000000100)='./file0\x00', 0x1, 0x0)`,
+		},
+		{
+			In: `openat(0xffffffffffffff9c, &(0x7f0000000100)=` +
+				`'./sys/bus/platform/devices/pcspkr/driver_override\x00', 0x1, 0x0)`,
+			Out: `openat(0xffffffffffffff9c, &(0x7f0000000100)='./file0\x00', 0x1, 0x0)`,
+		},
+		{
+			In:  `openat$sysfs(0xffffffffffffff9c, &(0x7f0000000100)='/sys/bus/pci/drivers_probe\x00', 0x1, 0x0)`,
+			Out: `openat$sysfs(0xffffffffffffff9c, &(0x7f0000000100)='./file0\x00', 0x1, 0x0)`,
+		},
+		{
+			In: `openat$sysfs(0xffffffffffffff9c, &(0x7f0000000100)=` +
+				`'/sys/devices/platform/pcspkr/driver_override\x00', 0x1, 0x0)`,
+			Out: `openat$sysfs(0xffffffffffffff9c, &(0x7f0000000100)='./file0\x00', 0x1, 0x0)`,
+		},
+		{
+			In:  `symlink(&(0x7f0000000100)='./sys/bus/platform/drivers/foo/unbind\x00', &(0x7f0000000200)='./link0\x00')`,
+			Out: `symlink(&(0x7f0000000100)='./file0\x00', &(0x7f0000000200)='./link0\x00')`,
+		},
+		{
+			In: `openat(0xffffffffffffff9c, &(0x7f0000000100)='./sys/bus/platform/drivers/foo/uevent\x00', 0x1, 0x0)`,
+		},
+		{
+			In: `openat(0xffffffffffffff9c, &(0x7f0000000100)='./bind\x00', 0x1, 0x0)`,
+		},
 	})
 }
 


### PR DESCRIPTION
Writing to sysfs driver binding endpoints (/sys/bus/.../bind, unbind, driver_override, drivers_probe) forces drivers onto incompatible hardware, causing probe crashes that kernel maintainers reject as invalid root operations.

Neutralize path arguments targeting these sysfs control endpoints by rewriting them to a safe path (./file0).

See discussion at [1].

***

Once [2] is merged, this should result in a 100% protection which should also not lead to any unnecessary kernel crashes.

[1] https://lore.kernel.org/all/6a88012e.dbb3a75c.13dd47.0007.GAE@google.com/T/
[2] https://lore.kernel.org/all/20260826-bind_taint-v1-0-52b05f4a965c@linuxfoundation.org/