### PR TITLE
pkg/csource: pass choice table to GenerateAllSyzProg

### DIFF
--- a/pkg/csource/csource_test.go
+++ b/pkg/csource/csource_test.go
@@ -91,7 +91,7 @@ func testTarget(t *testing.T, target *prog.Target, full bool, ct *prog.ChoiceTab
 	// but this makes the NULL argument warnings go away (they showed up in ".constprop" versions).
 	// Testing 2 programs takes too long since we have lots of options permutations and OS/arch.
 	// So we use the as-is in short tests and minimized version in full tests.
-	syzProg := target.GenerateAllSyzProg(rs)
+	syzProg := target.GenerateAllSyzProg(rs, ct)
 	var opts []Options
 	if !full || testing.Short() {
 		p.Calls = append(p.Calls, syzProg.Calls...)

--- a/prog/prog_test.go
+++ b/prog/prog_test.go
@@ -242,8 +242,8 @@ func testCrossArchProg(t *testing.T, p *Prog, crossTargets []*Target) {
 
 func TestSpecialStructs(t *testing.T) {
 	testEachTargetRandom(t, func(t *testing.T, target *Target, rs rand.Source, iters int) {
-		_ = target.GenerateAllSyzProg(rs)
 		ct := target.DefaultChoiceTable()
+		_ = target.GenerateAllSyzProg(rs, ct)
 		for special, gen := range target.SpecialTypes {
 			t.Run(special, func(t *testing.T) {
 				var typ Type

--- a/prog/rand.go
+++ b/prog/rand.go
@@ -670,12 +670,12 @@ func (r *randGen) generateParticularCallUnsafe(s *state, meta *Syscall) (calls [
 }
 
 // GenerateAllSyzProg generates a program that contains all pseudo syz_ calls for testing.
-func (target *Target) GenerateAllSyzProg(rs rand.Source) *Prog {
+func (target *Target) GenerateAllSyzProg(rs rand.Source, ct *ChoiceTable) *Prog {
 	p := &Prog{
 		Target: target,
 	}
 	r := newRand(target, rs)
-	s := newState(target, target.DefaultChoiceTable(), nil)
+	s := newState(target, ct, nil)
 	for _, meta := range target.PseudoSyscalls() {
 		calls := r.generateParticularCallUnsafe(s, meta)
 		for _, c := range calls {


### PR DESCRIPTION
GenerateAllSyzProg still hardcoded DefaultChoiceTable, which caused auto-generated calls like socketcall to leak into TestGenerate when generating dependencies for pseudo-syscalls. This broke TestGenerate on arm64 hosts where linux/amd64 runs as the first target.

Accept an explicit ChoiceTable in GenerateAllSyzProg and pass the filtered table from TestGenerate.

Cc #5410.

***

It should fix the following syzkaller build/test failure:
https://syzkaller.appspot.com/text?tag=CrashLog&x=167d1179580000