### PR TITLE
executor: fix segfault when kcov buffer is not mmapped

### DIFF
--- a/executor/executor_linux.h
+++ b/executor/executor_linux.h
@@ -269,7 +269,8 @@ static void cover_reset(cover_t* cov)
 			fail("KCOV_RESET_TRACE failed");
 	} else {
 		cover_unprotect(cov);
-		*(uint64*)cov->data = 0;
+		if (cov->data != nullptr)
+			*(uint64*)cov->data = 0;
 		cover_protect(cov);
 	}
 	cov->overflow = false;
@@ -278,6 +279,8 @@ static void cover_reset(cover_t* cov)
 template <typename cover_data_t>
 static void cover_collect_impl(cover_t* cov)
 {
+	if (cov->data == nullptr)
+		return;
 	cov->size = *(cover_data_t*)cov->data;
 	cov->overflow = (cov->data + (cov->size + 2) * sizeof(cover_data_t)) > cov->data_end;
 }


### PR DESCRIPTION
   0# segv_handler at executor/common.h:128
   1#      at :0
   2# cover_reset at executor/executor_linux.h:224
   3# schedule_call at executor/executor.cc:1212
   4# execute_one at executor/executor.cc:1095
   5# loop at executor/common.h:660
   6# do_sandbox_none at executor/common_linux.h:4651
   7# main at executor/executor.cc:680
   8# __libc_start_call_main at :0
   9# __libc_start_main at :0
  10# _start at :0

   0# segv_handler at executor/common.h:128
   1#      at :0
   2# cover_collect_impl<long long unsigned int> at executor/executor_linux.h:232
   3# cover_collect at executor/executor_linux.h:239
   4# execute_call at executor/executor.cc:1576
   5# worker_thread at executor/executor.cc:1534
   6# start_thread at :0
   7# __clone3 at :0

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
