### PR TITLE
executor: do not reset coverage on threads without coverage

### DIFF
--- a/executor/executor.cc
+++ b/executor/executor.cc
@@ -1213,7 +1213,7 @@ thread_t* schedule_call(int call_index, int call_num, uint64 copyout_index, uint
 	// which overlaps with comparison type in kernel exposed records. As the result write_comparisons
 	// that will try to write out data from unfinished syscalls will see these rpc::ComparisonRaw records,
 	// mis-interpret PC as type, and fail as: SYZFAIL: invalid kcov comp type (type=ffffffff8100b4e0).
-	if (flag_coverage)
+	if (cover_collection_required())
 		cover_reset(&th->cov);
 	th->executing = true;
 	th->call_index = call_index;
@@ -1563,7 +1563,7 @@ void execute_call(thread_t* th)
 		th->soft_fail_state = true;
 	}
 
-	if (flag_coverage)
+	if (cover_collection_required())
 		cover_reset(&th->cov);
 	// For pseudo-syscalls and user-space functions NONFAILING can abort before assigning to th->res.
 	// Arrange for res = -1 and errno = EFAULT result for such case.
@@ -1577,7 +1577,7 @@ void execute_call(thread_t* th)
 	// Reset the flag before the first possible fail().
 	th->soft_fail_state = false;
 
-	if (flag_coverage)
+	if (cover_collection_required())
 		cover_collect(&th->cov);
 	th->fault_injected = false;
 
@@ -1593,7 +1593,7 @@ void execute_call(thread_t* th)
 	      th->id, current_time_ms() - start_time_ms, call->name, (uint64)th->res);
 	if (th->res == (intptr_t)-1)
 		debug(" errno=%d", th->reserrno);
-	if (flag_coverage)
+	if (cover_collection_required())
 		debug(" cover=%u", th->cov.size);
 	if (th->call_props.fail_nth > 0)
 		debug(" fault=%d", th->fault_injected);

--- a/pkg/runtest/executor_test.go
+++ b/pkg/runtest/executor_test.go
@@ -212,3 +212,48 @@ func TestExecutorZeroCalls(t *testing.T) {
 	require.NoError(t, res.Err, "zero-call program execution failed:\n%s", res.Output)
 	require.Empty(t, res.Info.Calls, "expected 0 call info")
 }
+
+func TestExecutorThreadsWithoutCoverage(t *testing.T) {
+	t.Parallel()
+	target, err := prog.GetTarget("test", "64_fork")
+	require.NoError(t, err)
+	sysTarget := targets.Get(target.OS, target.Arch)
+	if sysTarget.BrokenCompiler != "" {
+		t.Skipf("skipping, broken cross-compiler: %v", sysTarget.BrokenCompiler)
+	}
+	executor := csource.BuildExecutor(t, target, "../..")
+
+	source := queue.Plain()
+	ctx := startRPCServer(t, target, executor, source, rpcParams{})
+
+	// 6 async calls keep threads 0..5 busy, so the 7th call must allocate thread 6,
+	// which is never pre-mmapped (kCoverDefaultCount = 6).
+	testProg := `
+syz_sleep_ms(0x3e8) (async)
+syz_sleep_ms(0x3e8) (async)
+syz_sleep_ms(0x3e8) (async)
+syz_sleep_ms(0x3e8) (async)
+syz_sleep_ms(0x3e8) (async)
+syz_sleep_ms(0x3e8) (async)
+syz_errno(0x0)
+`
+	p, err := target.Deserialize([]byte(testProg), prog.Strict)
+	require.NoError(t, err)
+
+	req := &queue.Request{
+		Type:         flatrpc.RequestTypeProgram,
+		Prog:         p,
+		ReturnError:  true,
+		ReturnOutput: true,
+		ExecOpts: flatrpc.ExecOpts{
+			EnvFlags:  flatrpc.ExecEnvSandboxNone | flatrpc.ExecEnvSignal | flatrpc.ExecEnvDelayKcovMmap,
+			ExecFlags: flatrpc.ExecFlagThreaded,
+		},
+	}
+	source.Submit(req)
+	res := req.Wait(ctx)
+	require.NoError(t, res.Err, "execution failed:\n%s", res.Output)
+	require.Equal(t, queue.Success, res.Status)
+	require.Len(t, res.Info.Calls, len(p.Calls))
+	require.NotZero(t, res.Info.Calls[len(p.Calls)-1].Flags&flatrpc.CallFlagFinished, "last call did not finish")
+}


### PR DESCRIPTION
Worker threads beyond the pre-mmapped count are created without a kcov buffer (cov.data == nullptr) if the program does not request coverage, such as in collide mode.

However, schedule_call() and execute_call() checked the global flag_coverage before resetting coverage, dereferencing nullptr when programs without coverage used additional worker threads.

Check cover_collection_required() instead so coverage is only reset and collected on threads that actually have coverage buffers allocated.

Reported-by: Denis Arefev <arefev@swemel.ru>