### PR TITLE
pkg/aflow: pass subagent history to judge as prompt transcript

### DIFF
--- a/pkg/aflow/flow/seedgen/history_summarizer.go
+++ b/pkg/aflow/flow/seedgen/history_summarizer.go
@@ -5,7 +5,6 @@ package seedgen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/backend"
@@ -49,24 +48,7 @@ var ActionFormatFailedHistory = aflow.NewFuncAction("seedgen-format-failed-histo
 		if len(args.FailedHistory) == 0 {
 			return FormatFailedHistoryResult{}, fmt.Errorf("failed history not found in state context")
 		}
-		var sb strings.Builder
-		for _, msg := range args.FailedHistory {
-			fmt.Fprintf(&sb, "[%s]:\n", msg.Role)
-			for _, part := range msg.Parts {
-				switch {
-				case part.FunctionCall != nil:
-					fmt.Fprintf(&sb, "  Called tool %s with args: %+v\n",
-						part.FunctionCall.Name, part.FunctionCall.Args)
-				case part.FunctionResponse != nil:
-					fmt.Fprintf(&sb, "  Tool %s returned: %+v\n",
-						part.FunctionResponse.Name, part.FunctionResponse.Response)
-				case part.Text != "":
-					fmt.Fprintln(&sb, part.Text)
-				}
-			}
-			sb.WriteString("\n")
-		}
 		return FormatFailedHistoryResult{
-			FormattedFailedHistoryText: sb.String(),
+			FormattedFailedHistoryText: aflow.FormatHistoryMessages(args.FailedHistory),
 		}, nil
 	})

--- a/pkg/aflow/judge.go
+++ b/pkg/aflow/judge.go
@@ -6,7 +6,7 @@ package aflow
 import (
 	"fmt"
 	"reflect"
-	"slices"
+	"strings"
 
 	"github.com/google/syzkaller/pkg/aflow/backend"
 )
@@ -58,20 +58,23 @@ func (j *LLMJudge) verify() error {
 	j.agent = &LLMAgent{
 		Name:          j.Name,
 		Model:         j.Model,
-		MaxIterations: 1,
+		MaxIterations: 3,
 		TaskType:      FormalReasoningTask,
 		Outputs:       LLMOutputs[JudgeOutputs](),
 		Instruction: j.Instruction + "\n\n" +
-			"Analyze the provided history of the subagent and call set-results with Stop and Reason.",
-		InitChatHistoryFunc: func(ctx *Context) ([]llmMessage, error) {
-			history, _ := ctx.state[judgeStateHistory].([]llmMessage)
-			return slices.Clone(history), nil
-		},
+			"Analyze the provided execution history of the subagent and call set-results with Stop and Reason.",
+		Prompt: `Below is the execution history of the subagent under evaluation:
+<execution_history>
+{{.` + judgeStateHistory + `}}
+</execution_history>
+
+Evaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.
+Call set-results with Stop and Reason.`,
 	}
 	ctx := newVerifyContext()
 	ctx.state[judgeStateHistory] = &varState{
 		action: "judge inputs",
-		typ:    reflect.TypeFor[[]llmMessage](),
+		typ:    reflect.TypeFor[string](),
 		used:   false,
 	}
 	j.agent.verify(ctx)
@@ -84,7 +87,7 @@ func (j *LLMJudge) verify() error {
 func (j *LLMJudge) Evaluate(ctx *Context, history []llmMessage) (JudgeOutputs, error) {
 	oldState := ctx.state
 	ctx.state = map[string]any{
-		judgeStateHistory: history,
+		judgeStateHistory: formatJudgeHistory(history),
 	}
 	defer func() {
 		ctx.state = oldState
@@ -98,4 +101,32 @@ func (j *LLMJudge) Evaluate(ctx *Context, history []llmMessage) (JudgeOutputs, e
 	reason, _ := ctx.state[judgeOutputReason].(string)
 
 	return JudgeOutputs{Stop: stop, Reason: reason}, nil
+}
+
+func formatJudgeHistory(history []llmMessage) string {
+	return FormatHistoryMessages(extractHistoryMessages(history))
+}
+
+func FormatHistoryMessages(messages []*backend.Message) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		fmt.Fprintf(&sb, "[%s]:\n", msg.Role)
+		for _, part := range msg.Parts {
+			switch {
+			case part.FunctionCall != nil:
+				fmt.Fprintf(&sb, "  Called tool %s with args: %+v\n",
+					part.FunctionCall.Name, part.FunctionCall.Args)
+			case part.FunctionResponse != nil:
+				fmt.Fprintf(&sb, "  Tool %s returned: %+v\n",
+					part.FunctionResponse.Name, part.FunctionResponse.Response)
+			case part.Text != "":
+				fmt.Fprintln(&sb, part.Text)
+			}
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }

--- a/pkg/aflow/judge_test.go
+++ b/pkg/aflow/judge_test.go
@@ -84,7 +84,7 @@ func TestLLMJudgeVerify(t *testing.T) {
 	}
 }
 
-func TestLLMJudgeInitChatHistory(t *testing.T) {
+func TestLLMJudgeFormatHistory(t *testing.T) {
 	judge := &LLMJudge{
 		Name:               "test-judge",
 		Model:              "model1",
@@ -133,12 +133,8 @@ func TestLLMJudgeInitChatHistory(t *testing.T) {
 		},
 	}
 
-	ctx := &Context{
-		state: map[string]any{
-			judgeStateHistory: rawHistory,
-		},
-	}
-	gotHistory, err := judge.agent.InitChatHistoryFunc(ctx)
-	require.NoError(t, err)
-	require.Equal(t, rawHistory, gotHistory)
+	formatted := formatJudgeHistory(rawHistory)
+	require.Contains(t, formatted, "[user]:\ninitial prompt")
+	require.Contains(t, formatted, "[model]:\n  Called tool execute-seed")
+	require.Contains(t, formatted, "Tool execute-seed returned: map[output:seed run success]")
 }

--- a/pkg/aflow/testdata/TestLLMJudge.llm.json
+++ b/pkg/aflow/testdata/TestLLMJudge.llm.json
@@ -159,7 +159,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+						"text": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
 					}
 				],
 				"role": "user"
@@ -218,82 +218,7 @@
 			{
 				"parts": [
 					{
-						"text": "Prompt"
-					}
-				],
-				"role": "user"
-			},
-			{
-				"parts": [
-					{
-						"functionCall": {
-							"id": "id1",
-							"name": "tick"
-						}
-					}
-				],
-				"role": "model"
-			},
-			{
-				"parts": [
-					{
-						"functionResponse": {
-							"id": "id1",
-							"response": {
-								"Res": 42
-							},
-							"name": "tick"
-						}
-					}
-				],
-				"role": "user"
-			},
-			{
-				"parts": [
-					{
-						"functionCall": {
-							"id": "id2",
-							"name": "tick"
-						}
-					}
-				],
-				"role": "model"
-			},
-			{
-				"parts": [
-					{
-						"functionResponse": {
-							"id": "id2",
-							"response": {
-								"Res": 42
-							},
-							"name": "tick"
-						}
-					}
-				],
-				"role": "user"
-			},
-			{
-				"parts": [
-					{
-						"functionCall": {
-							"id": "id3",
-							"name": "tick"
-						}
-					}
-				],
-				"role": "model"
-			},
-			{
-				"parts": [
-					{
-						"functionResponse": {
-							"id": "id3",
-							"response": {
-								"Res": 42
-							},
-							"name": "tick"
-						}
+						"text": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nPrompt\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 					}
 				],
 				"role": "user"

--- a/pkg/aflow/testdata/TestLLMJudge.trajectory.json
+++ b/pkg/aflow/testdata/TestLLMJudge.trajectory.json
@@ -134,7 +134,8 @@
 		"Name": "test-judge",
 		"Model": "model1",
 		"Started": "0001-01-01T00:00:15Z",
-		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+		"Instruction": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nPrompt\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 	},
 	{
 		"Seq": 9,
@@ -192,7 +193,8 @@
 			"Reason": "stuck in tick loop",
 			"Stop": true
 		},
-		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+		"Instruction": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nPrompt\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 	},
 	{
 		"Seq": 1,

--- a/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.llm.json
+++ b/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.llm.json
@@ -192,7 +192,7 @@
 			"systemInstruction": {
 				"parts": [
 					{
-						"text": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+						"text": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
 					}
 				],
 				"role": "user"
@@ -251,57 +251,7 @@
 			{
 				"parts": [
 					{
-						"text": "What is the answer?"
-					}
-				],
-				"role": "user"
-			},
-			{
-				"parts": [
-					{
-						"functionCall": {
-							"id": "tick_id1",
-							"name": "tick"
-						}
-					}
-				],
-				"role": "model"
-			},
-			{
-				"parts": [
-					{
-						"functionResponse": {
-							"id": "tick_id1",
-							"response": {
-								"Res": 42
-							},
-							"name": "tick"
-						}
-					}
-				],
-				"role": "user"
-			},
-			{
-				"parts": [
-					{
-						"functionCall": {
-							"id": "tick_id2",
-							"name": "tick"
-						}
-					}
-				],
-				"role": "model"
-			},
-			{
-				"parts": [
-					{
-						"functionResponse": {
-							"id": "tick_id2",
-							"response": {
-								"Res": 42
-							},
-							"name": "tick"
-						}
+						"text": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nWhat is the answer?\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 					}
 				],
 				"role": "user"

--- a/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.trajectory.json
+++ b/pkg/aflow/testdata/TestStructuredLLMToolWithJudge.trajectory.json
@@ -134,7 +134,8 @@
 		"Name": "test-judge",
 		"Model": "judge-model",
 		"Started": "0001-01-01T00:00:15Z",
-		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+		"Instruction": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nWhat is the answer?\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 	},
 	{
 		"Seq": 10,
@@ -192,7 +193,8 @@
 			"Reason": "oscillation detected in researcher",
 			"Stop": true
 		},
-		"Instruction": "Judge the history\n\nAnalyze the provided history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n"
+		"Instruction": "Judge the history\n\nAnalyze the provided execution history of the subagent and call set-results with Stop and Reason.\n\nUse set-results tool to provide results of the analysis.\nIt must be called exactly once before the final reply.\nIgnore results of this tool.\n",
+		"Prompt": "Below is the execution history of the subagent under evaluation:\n\u003cexecution_history\u003e\n[user]:\nWhat is the answer?\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n[model]:\n  Called tool tick with args: map[]\n\n[user]:\n  Tool tick returned: map[Res:42]\n\n\n\u003c/execution_history\u003e\n\nEvaluate whether the subagent is stuck, oscillating, or making no progress based on the history above.\nCall set-results with Stop and Reason."
 	},
 	{
 		"Seq": 4,


### PR DESCRIPTION
Previously, LLMJudge injected the subagent's raw chat messages directly as its own conversation history via InitChatHistoryFunc. This caused the Judge LLM to adopt the subagent's role and attempt to continue research using subagent-specific tools that were unavailable to the Judge, leading to tool errors and max iteration failures.

Pass the subagent history as a formatted text transcript in the Judge's prompt instead, and increase MaxIterations to 3 to allow recovery if set-results is omitted on the first turn.