### PR TITLE
pkg/build: recognize missing file errors

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -355,6 +355,7 @@ var buildFailureCauses = [...]buildFailureCause{
 	{pattern: regexp.MustCompile(`^Killed$`)},
 	{pattern: regexp.MustCompile(`error\[.*?\]: `)},
 	{weak: true, pattern: regexp.MustCompile(`: not found`)},
+	{weak: true, pattern: regexp.MustCompile(`: [nN]o such file or directory`)},
 	{weak: true, pattern: regexp.MustCompile(`: final link failed: `)},
 	{weak: true, pattern: regexp.MustCompile(`collect2: error: `)},
 	{weak: true, pattern: regexp.MustCompile(`(ERROR|FAILED): Build did NOT complete`)},

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -619,4 +619,16 @@ make[4]: *** [scripts/Makefile.build:287: kernel/trace/bpf_trace.o] Error 1
 		"",
 		"",
 	},
+	{`
+  REMOVE  arch/x86/include/generated/asm/.tmp_cpufeaturemasks.h
+  UPD     arch/x86/include/generated/asm/cpufeaturemasks.h
+mv: cannot stat 'arch/x86/include/generated/asm/.tmp_cpufeaturemasks.h': No such file or directory
+make[1]: *** [arch/x86/Makefile:269: arch/x86/include/generated/asm/cpufeaturemasks.h] Error 1
+make[1]: *** Waiting for unfinished jobs....
+make: *** [Makefile:248: __sub-make] Error 2
+`,
+		"mv: cannot stat 'arch/x86/include/generated/asm/.tmp_cpufeaturemasks.h': No such file or directory",
+		"",
+		"",
+	},
 }


### PR DESCRIPTION
Build steps can fail due to missing files (e.g. in helper scripts or `mv`) without emitting standard compiler error markers. Without matching these, reports fall back to uninformative "exit status 2".

Add a weak pattern for `: [nN]o such file or directory` to capture these failures when no stronger error is present.

***

Context: https://syzkaller.appspot.com/bug?extid=6dc178e84a9bc2e1bc3e