### PR TITLE
dashboard/app: handle display names with commas in addresses

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -584,7 +584,7 @@ func handleAIJobPagePushToReporting(ctx context.Context, job *aidb.Job, userName
 		return fmt.Errorf("no valid next stage found")
 	}
 
-	upstreamedBy := formatUpstreamedBy(userName, userEmail)
+	upstreamedBy := email.FormatAddress(userName, userEmail)
 	args := aidb.UpstreamReportArgs{
 		Job: job,
 		Reporting: &aidb.JobReporting{

--- a/dashboard/app/ai_report.go
+++ b/dashboard/app/ai_report.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/vcs"
 	"google.golang.org/appengine/v2/log"
 )
 
@@ -95,13 +96,6 @@ func checkActionAuthorized(ctx context.Context, job *aidb.Job, req *dashapi.Send
 	}
 }
 
-func formatUpstreamedBy(name, email string) string {
-	if name != "" {
-		return fmt.Sprintf("%s <%s>", name, email)
-	}
-	return email
-}
-
 func filterStageEmails(nsCfg *Config, emails []string) []string {
 	if nsCfg.AI == nil {
 		return emails
@@ -124,7 +118,7 @@ func processUpstreamSubcommand(ctx context.Context, job *aidb.Job,
 		return err
 	}
 
-	upstreamedBy := formatUpstreamedBy(req.AuthorName, req.Author)
+	upstreamedBy := email.FormatAddress(req.AuthorName, req.Author)
 
 	nsCfg := getNsConfig(ctx, job.Namespace)
 	if nsCfg.AI == nil || len(nsCfg.AI.Stages) == 0 {
@@ -379,10 +373,14 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 	}
 	models := extractExecutedModels(trajectory)
 	var to, cc []string
+	var gitAuthors []string
 	seen := make(map[string]bool)
 	for _, a := range authors {
+		// Email recipients ('To'/'Cc') must adhere to RFC 5322 (quoting special characters like commas).
 		to = append(to, a)
 		seen[email.CanonicalEmail(a)] = true
+		// Git patch metadata ('Authors') must be unquoted (e.g. for in-body 'From:' and 'Signed-off-by:').
+		gitAuthors = append(gitAuthors, vcs.FormatGitAuthor(a))
 	}
 
 	for _, rec := range res.Recipients {
@@ -409,7 +407,7 @@ func makeNewReportResult(ctx context.Context, job *aidb.Job, res *ai.PatchingOut
 		To:          to,
 		Cc:          cc,
 		Tools:       models,
-		Authors:     authors,
+		Authors:     gitAuthors,
 		Fixes:       res.Fixes,
 		ReviewedBy:  res.ReviewedBy,
 		AckedBy:     res.AckedBy,

--- a/dashboard/app/ai_report_test.go
+++ b/dashboard/app/ai_report_test.go
@@ -1799,3 +1799,37 @@ func TestAIActionEmailsAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestUpstreamCommandWithCommaInName(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	c.SetAIConfig("ains", &AIConfig{
+		Stages: []AIPatchStageConfig{
+			{Name: "moderation", ServingIntegration: "lore", MailingList: "moderation@test.com", AddressComments: true},
+			{Name: "public", ServingIntegration: "lore", MailingList: "public@test.com", MergePatchCc: true},
+		},
+	})
+
+	_, jobID := c.setupAIPatchJob(t)
+	c.finishAIPatchJob(t, jobID, nil)
+
+	pollResp := c.pollAndConfirmReport(t, "lore", "moderation-msg-id")
+	require.True(t, pollResp.Result.CanUpstream)
+
+	// Upstream the result with an author whose name has a comma.
+	resp, err := c.globalClient.AIReportCommand(&dashapi.SendExternalCommandReq{
+		RootExtID:  "moderation-msg-id",
+		Upstream:   &dashapi.UpstreamCommand{},
+		AuthorName: "First, Second",
+		Author:     "user@email.com",
+		Source:     "lore",
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Error)
+
+	// Poll the report at the public stage.
+	pollResp = c.pollAndConfirmReport(t, "lore", "msg-id-123")
+	require.Contains(t, pollResp.Result.Patch.Authors, `First, Second <user@email.com>`)
+	require.Contains(t, pollResp.Result.To, `"First, Second" <user@email.com>`)
+}

--- a/pkg/aflow/flow/patching/tags.go
+++ b/pkg/aflow/flow/patching/tags.go
@@ -4,13 +4,13 @@
 package patching
 
 import (
-	"fmt"
 	"net/mail"
 	"slices"
 
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/email"
+	"github.com/google/syzkaller/pkg/vcs"
 )
 
 type tagExtractorArgs struct {
@@ -26,17 +26,6 @@ type tagExtractorState struct {
 	BaseTestedBy    []string
 	BaseReportedBy  []string
 	BaseSuggestedBy []string
-}
-
-func normalizeTagValue(val string) string {
-	addr, err := mail.ParseAddress(val)
-	if err != nil {
-		return val
-	}
-	if addr.Name == "" {
-		return addr.Address
-	}
-	return fmt.Sprintf("%s <%s>", addr.Name, addr.Address)
 }
 
 func validateTagExtractorOutputs(ctx *aflow.Context, state tagExtractorState,
@@ -58,7 +47,7 @@ func validateTagExtractorOutputs(ctx *aflow.Context, state tagExtractorState,
 			return args, aflow.BadCallError("value for tag %q must be a valid name and email "+
 				"(e.g. 'Name <email@example.com>'): %v", tag.Tag, err)
 		}
-		tag.Value = normalizeTagValue(tag.Value)
+		tag.Value = vcs.FormatGitAuthor(tag.Value)
 		validAddTags = append(validAddTags, tag)
 	}
 	args.AddTags = validAddTags

--- a/pkg/aflow/flow/patching/tags_test.go
+++ b/pkg/aflow/flow/patching/tags_test.go
@@ -126,24 +126,3 @@ func TestValidateTagExtractorOutputs(t *testing.T) {
 		})
 	}
 }
-
-func TestNormalizeTagValue(t *testing.T) {
-	tests := []struct {
-		val  string
-		want string
-	}{
-		{"Valid Name <valid@email.com>", "Valid Name <valid@email.com>"},
-		{"\"Valid Name\" <valid@email.com>", "Valid Name <valid@email.com>"},
-		{"  Valid Name   <valid@email.com>  ", "Valid Name <valid@email.com>"},
-		{"valid@email.com", "valid@email.com"},
-		{"<valid@email.com>", "valid@email.com"},
-		{"not an email", "not an email"}, // Fallback to raw value if it fails to parse.
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.val, func(t *testing.T) {
-			got := normalizeTagValue(tt.val)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -275,6 +275,22 @@ func EmailsMatch(val1, val2 string) bool {
 	return val1 == val2
 }
 
+// FormatAddress formats name and email as an RFC 5322 address.
+// Multi-word display names like "First Last <user@email.com>" are valid unquoted in RFC 5322,
+// but names containing delimiters (such as commas in "Last, First") require double quotes.
+// Since net/mail.Address.String() conservatively quotes any display name with whitespace,
+// we verify if the unquoted form is already valid RFC 5322 before falling back to quoted formatting.
+func FormatAddress(name, email string) string {
+	if name == "" {
+		return email
+	}
+	raw := fmt.Sprintf("%s <%s>", name, email)
+	if _, err := mail.ParseAddress(raw); err == nil {
+		return raw
+	}
+	return (&mail.Address{Name: name, Address: email}).String()
+}
+
 // Split splits email into user (without context) and domain (with @ prefix).
 func Split(email string) (string, string, error) {
 	addr, err := mail.ParseAddress(email)

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -1328,3 +1328,31 @@ func TestDirectlyAddressedTo(t *testing.T) {
 	assert.True(t, msg.DirectlyAddressedTo("12345hash"))
 	assert.False(t, msg.DirectlyAddressedTo("67890hash"))
 }
+
+func TestFormatAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		emailAddr string
+		want      string
+	}{
+		{
+			name:      "First, Second",
+			emailAddr: "user@email.com",
+			want:      `"First, Second" <user@email.com>`,
+		},
+		{
+			name:      "First Second",
+			emailAddr: "user@email.com",
+			want:      "First Second <user@email.com>",
+		},
+		{
+			name:      "",
+			emailAddr: "user@email.com",
+			want:      "user@email.com",
+		},
+	}
+	for _, tc := range tests {
+		got := FormatAddress(tc.name, tc.emailAddr)
+		require.Equal(t, tc.want, got)
+	}
+}

--- a/pkg/vcs/git.go
+++ b/pkg/vcs/git.go
@@ -998,3 +998,17 @@ func (git Git) ContainedIn(parent, commit string) (bool, error) {
 func (git Git) Diff(commitA, commitB string) ([]byte, error) {
 	return git.Run("diff", commitA+".."+commitB)
 }
+
+// FormatGitAuthor converts an email address into an unquoted Git author format (Name <email>).
+// In Git commit metadata and trailers (e.g. "Signed-off-by:", "Reviewed-by:"), display names
+// must never be double-quoted even if they contain special characters like commas
+// (e.g. "First, Second <user@email.com>").
+func FormatGitAuthor(addr string) string {
+	if parsed, err := mail.ParseAddress(addr); err == nil {
+		if parsed.Name != "" {
+			return fmt.Sprintf("%s <%s>", parsed.Name, parsed.Address)
+		}
+		return parsed.Address
+	}
+	return addr
+}

--- a/pkg/vcs/git_test.go
+++ b/pkg/vcs/git_test.go
@@ -687,3 +687,39 @@ index %s..123456 100644
 	require.Len(t, bases, 1)
 	assert.Equal(t, commitM.Hash, bases[0].Hash)
 }
+
+func TestFormatGitAuthor(t *testing.T) {
+	tests := []struct {
+		addr string
+		want string
+	}{
+		{
+			addr: `"First, Second" <user@email.com>`,
+			want: "First, Second <user@email.com>",
+		},
+		{
+			addr: "First Second <user@email.com>",
+			want: "First Second <user@email.com>",
+		},
+		{
+			addr: "  First Second   <user@email.com>  ",
+			want: "First Second <user@email.com>",
+		},
+		{
+			addr: "user@email.com",
+			want: "user@email.com",
+		},
+		{
+			addr: "<user@email.com>",
+			want: "user@email.com",
+		},
+		{
+			addr: "not an email",
+			want: "not an email",
+		},
+	}
+	for _, tc := range tests {
+		got := FormatGitAuthor(tc.addr)
+		require.Equal(t, tc.want, got)
+	}
+}


### PR DESCRIPTION
Addresses with display names containing commas (e.g. "First, Second <user@email.com>")
violate RFC 5322 syntax unless quoted, causing downstream email consumers
like lore-relay to fail to parse recipient lists and wedging the reporting
queue. Conversely, Git author metadata and commit trailers must remain
unquoted.

Introduce email.FormatAddress() to format valid RFC 5322 address strings
(quoting only when necessary), and vcs.FormatGitAuthor() to strip quotes
for Git author and trailer metadata. Update dashboard/app and pkg/aflow
to use these helpers.