### PR TITLE
executor: fix LTO build failure for amd64 SYZOS guest exit functions

### DIFF
--- a/executor/common_kvm_amd64_syzos.h
+++ b/executor/common_kvm_amd64_syzos.h
@@ -116,7 +116,10 @@ extern "C" {
 // which is invisible to the compiler's call graph. A plain `static` definition
 // can end up assigned to a different LTO partition than its asm caller and never
 // get linked in, even with __attribute__((used)) -- see the definitions below for
-// why they're kept non-static with a stable external symbol instead.
+// why they're kept non-static with a stable external symbol instead. They can't
+// be `inline` either: GUEST_CODE places them in a fixed "guest" section that gets
+// copied wholesale into VM guest memory, and GCC's vague/COMDAT linkage for
+// inline functions conflicts with that fixed section placement.
 GUEST_CODE void guest_uexit(uint64 exit_code);
 GUEST_CODE void nested_vm_exit_handler_intel(uint64 exit_reason, struct l2_guest_regs* regs);
 GUEST_CODE void nested_vm_exit_handler_amd(uint64 exit_reason, struct l2_guest_regs* regs);
@@ -305,12 +308,14 @@ GUEST_CODE static noinline void guest_execute_code(uint8* insns, uint64 size)
 // and can handle the call depending on the data passed as exit code.
 
 // Make sure the compiler does not optimize this function away, it is called from
-// assembly. A `static` definition isn't enough under LTO: `externally_visible`
-// only has an effect on symbols with external linkage, and without it LTO can
-// assign this definition to a different partition than uexit_irq_handler's
-// `call guest_uexit`, leaving that call unresolved at link time.
-__attribute__((used, externally_visible))
+// assembly. A plain `static` definition isn't enough under LTO: it can end up
+// assigned to a different partition than uexit_irq_handler's `call guest_uexit`,
+// leaving that call unresolved at link time. This header is only ever included
+// by executor.cc, so there's no ODR risk, and it can't be `inline` -- see the
+// comment on the forward declaration above.
+__attribute__((used))
 GUEST_CODE noinline void
+// NOLINTNEXTLINE(misc-definitions-in-headers)
 guest_uexit(uint64 exit_code)
 {
 	// Force exit_code into RAX using inline asm constraints ("a").
@@ -972,9 +977,10 @@ GUEST_CODE static void advance_l2_rip_intel(uint64 basic_reason)
 }
 
 // This function is called from inline assembly. See the comment on
-// guest_uexit() above for why it's non-static with externally_visible.
-__attribute__((used, externally_visible))
+// guest_uexit() above for why it's non-static and can't be `inline`.
+__attribute__((used))
 GUEST_CODE void
+// NOLINTNEXTLINE(misc-definitions-in-headers)
 nested_vm_exit_handler_intel(uint64 exit_reason, struct l2_guest_regs* regs)
 {
 	volatile struct syzos_globals* globals = (volatile struct syzos_globals*)X86_SYZOS_ADDR_GLOBALS;
@@ -1116,8 +1122,9 @@ GUEST_CODE static void advance_l2_rip_amd(uint64 basic_reason, uint64 cpu_id, ui
 }
 
 // This function is called from inline assembly. See the comment on
-// guest_uexit() above for why it's non-static with externally_visible.
-__attribute__((used, externally_visible)) GUEST_CODE void
+// guest_uexit() above for why it's non-static and can't be `inline`.
+__attribute__((used)) GUEST_CODE void
+// NOLINTNEXTLINE(misc-definitions-in-headers)
 nested_vm_exit_handler_amd(uint64 exit_reason, struct l2_guest_regs* regs)
 {
 	volatile struct syzos_globals* globals = (volatile struct syzos_globals*)X86_SYZOS_ADDR_GLOBALS;

--- a/executor/common_kvm_amd64_syzos.h
+++ b/executor/common_kvm_amd64_syzos.h
@@ -112,9 +112,14 @@ struct syzos_globals {
 #ifdef __cplusplus
 extern "C" {
 #endif
-GUEST_CODE static void guest_uexit(uint64 exit_code);
-GUEST_CODE static void nested_vm_exit_handler_intel(uint64 exit_reason, struct l2_guest_regs* regs);
-GUEST_CODE static void nested_vm_exit_handler_amd(uint64 exit_reason, struct l2_guest_regs* regs);
+// These three are called only from raw inline assembly (`call guest_uexit` etc.),
+// which is invisible to the compiler's call graph. A plain `static` definition
+// can end up assigned to a different LTO partition than its asm caller and never
+// get linked in, even with __attribute__((used)) -- see the definitions below for
+// why they're kept non-static with a stable external symbol instead.
+GUEST_CODE void guest_uexit(uint64 exit_code);
+GUEST_CODE void nested_vm_exit_handler_intel(uint64 exit_reason, struct l2_guest_regs* regs);
+GUEST_CODE void nested_vm_exit_handler_amd(uint64 exit_reason, struct l2_guest_regs* regs);
 #ifdef __cplusplus
 }
 #endif
@@ -300,9 +305,12 @@ GUEST_CODE static noinline void guest_execute_code(uint8* insns, uint64 size)
 // and can handle the call depending on the data passed as exit code.
 
 // Make sure the compiler does not optimize this function away, it is called from
-// assembly.
-__attribute__((used))
-GUEST_CODE static noinline void
+// assembly. A `static` definition isn't enough under LTO: `externally_visible`
+// only has an effect on symbols with external linkage, and without it LTO can
+// assign this definition to a different partition than uexit_irq_handler's
+// `call guest_uexit`, leaving that call unresolved at link time.
+__attribute__((used, externally_visible))
+GUEST_CODE noinline void
 guest_uexit(uint64 exit_code)
 {
 	// Force exit_code into RAX using inline asm constraints ("a").
@@ -963,9 +971,10 @@ GUEST_CODE static void advance_l2_rip_intel(uint64 basic_reason)
 	vmwrite(VMCS_GUEST_RIP, rip);
 }
 
-// This function is called from inline assembly.
-__attribute__((used))
-GUEST_CODE static void
+// This function is called from inline assembly. See the comment on
+// guest_uexit() above for why it's non-static with externally_visible.
+__attribute__((used, externally_visible))
+GUEST_CODE void
 nested_vm_exit_handler_intel(uint64 exit_reason, struct l2_guest_regs* regs)
 {
 	volatile struct syzos_globals* globals = (volatile struct syzos_globals*)X86_SYZOS_ADDR_GLOBALS;
@@ -1106,7 +1115,9 @@ GUEST_CODE static void advance_l2_rip_amd(uint64 basic_reason, uint64 cpu_id, ui
 	vmcb_write64(vmcb_addr, VMCB_GUEST_RIP, rip);
 }
 
-__attribute__((used)) GUEST_CODE static void
+// This function is called from inline assembly. See the comment on
+// guest_uexit() above for why it's non-static with externally_visible.
+__attribute__((used, externally_visible)) GUEST_CODE void
 nested_vm_exit_handler_amd(uint64 exit_reason, struct l2_guest_regs* regs)
 {
 	volatile struct syzos_globals* globals = (volatile struct syzos_globals*)X86_SYZOS_ADDR_GLOBALS;


### PR DESCRIPTION
Fixes #6999.

`guest_uexit`, `nested_vm_exit_handler_intel` and `nested_vm_exit_handler_amd`
are only invoked from raw inline assembly (`call guest_uexit`, etc.), which is
invisible to the compiler's call graph.

As `static` functions they have internal linkage, and under `-flto` with
multiple partitions (e.g. `-flto=auto`) GCC can place a definition in a
different LTRANS partition than its asm call site. The final link then fails
with `undefined reference to 'guest_uexit'`. `__attribute__((used))` does not
help, since it only forces the definition to be emitted, not to be resolvable
from another partition's object file.

Fix: drop `static` from all three so they get external linkage. They stay
inside the existing `extern "C"` block, so the symbol names match the ones used
in the asm. They can't be made `inline`: `GUEST_CODE` places them in a fixed
`guest` section, which conflicts with the COMDAT section GCC uses for inline
functions. The header is only included by `executor.cc`, so there is no ODR
risk, and clang-tidy's `misc-definitions-in-headers` is silenced explicitly for
these definitions.

Reproduced the reported failure with GCC 14.2 and the flags from the report
(`-flto=auto -ffat-lto-objects -static-pie`): same file, same line, same error.
With this change it links cleanly. arm64 is not affected, since its
`guest_uexit` is only ever called from C code, never from inline asm.