### PR TITLE
pkg/repro: fix and unify reproducer duration calculation

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -407,7 +407,7 @@ func (ctx *reproContext) extractProgSingle(entries []*prog.LogEntry, duration ti
 		if ret.Crashed {
 			res := &Result{
 				Prog:     ent.P,
-				Duration: max(duration, ret.Duration*3/2),
+				Duration: reproDuration(duration, ret.Duration, ctx.timeouts.Program),
 				Opts:     opts,
 			}
 			ctx.reproLogf(3, "single: successfully extracted reproducer")
@@ -521,11 +521,15 @@ func (ctx *reproContext) concatenateProgs(entries []*prog.LogEntry, dur time.Dur
 	}
 	res := &Result{
 		Prog:     p,
-		Duration: min(dur, ret.Duration*2),
+		Duration: reproDuration(dur, ret.Duration, ctx.timeouts.Program),
 		Opts:     ctx.startOpts,
 	}
 	ctx.reproLogf(3, "bisect: concatenation succeeded")
 	return res, nil
+}
+
+func reproDuration(baseTimeout, crashedDuration, progTimeout time.Duration) time.Duration {
+	return min(baseTimeout, max(progTimeout, crashedDuration)*2)
 }
 
 // Minimize calls and arguments.

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -411,3 +411,44 @@ alarm(0xa)
 	require.NotNil(t, result)
 	require.Equal(t, "pause()\nalarm(0xa)\n", string(result.Prog.Serialize()))
 }
+
+func TestReproDuration(t *testing.T) {
+	const progTimeout = 5 * time.Second
+	tests := []struct {
+		name            string
+		baseTimeout     time.Duration
+		crashedDuration time.Duration
+		want            time.Duration
+	}{
+		{
+			name:            "fast crash below progTimeout",
+			baseTimeout:     6 * time.Minute,
+			crashedDuration: 500 * time.Millisecond,
+			want:            10 * time.Second,
+		},
+		{
+			name:            "normal crash scaled by 2",
+			baseTimeout:     6 * time.Minute,
+			crashedDuration: 20 * time.Second,
+			want:            40 * time.Second,
+		},
+		{
+			name:            "slow crash capped at baseTimeout",
+			baseTimeout:     100 * time.Second,
+			crashedDuration: 80 * time.Second,
+			want:            100 * time.Second,
+		},
+		{
+			name:            "tight baseTimeout limit",
+			baseTimeout:     5 * time.Second,
+			crashedDuration: 2 * time.Second,
+			want:            5 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reproDuration(tt.baseTimeout, tt.crashedDuration, progTimeout)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
In extractProgSingle, the reproducer duration was mistakenly calculated using max(duration, ret.Duration*3/2). Because max was used instead of min, this never reduced timeouts for quickly reproducing crashes and inflated timeouts beyond the base timeout whenever the crash occurred near or at the timeout limit.

Unify the duration logic in extractProgSingle and concatenateProgs with a new reproDuration helper. Scale the observed crash time by 2x while clamping it to the base test timeout, and guarantee a minimum duration of 2 * timeouts.Program to avoid timeouts during minimization on fast crashes.
