### PR TITLE
pkg/repro: handle and report divergent crashes during reproduction

### DIFF
--- a/pkg/instance/execprog.go
+++ b/pkg/instance/execprog.go
@@ -156,9 +156,6 @@ func (inst *ExecProgInstance) runCommand(command string, opts RunOptions) (*RunR
 	if rep == nil {
 		inst.Logf(2, "program did not crash")
 	} else {
-		if err := inst.reporter.Symbolize(rep); err != nil {
-			inst.Logf(0, "failed to symbolize report: %v", err)
-		}
 		inst.Logf(2, "program crashed: %v", rep.Title)
 	}
 	res := &RunResult{

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -417,6 +417,9 @@ func (inst *inst) testInstance() error {
 		return &TestError{Title: err.Error()}
 	}
 	if out.Report != nil {
+		if err := inst.reporter.Symbolize(out.Report); err != nil {
+			log.Logf(0, "failed to symbolize report: %v", err)
+		}
 		return &TestError{Title: out.Report.Title, Report: out.Report}
 	}
 	return nil
@@ -435,6 +438,9 @@ func (inst *inst) testRepro() ([]byte, [][]uint64, error) {
 			return nil, nil, err
 		}
 		if res.Report != nil {
+			if err := inst.reporter.Symbolize(res.Report); err != nil {
+				log.Logf(0, "failed to symbolize report: %v", err)
+			}
 			err = &CrashError{Report: res.Report}
 		}
 		return res.Output, res.Coverage, err

--- a/pkg/manager/diff/diff_test.go
+++ b/pkg/manager/diff/diff_test.go
@@ -216,28 +216,28 @@ func (m *mockRunner) Results() <-chan reproRunnerResult {
 	return m.doneCh
 }
 
-func mockRepro(title string, err error) func(context.Context, []byte, repro.Environment) (
+func mockRepro(title string, err error) func(context.Context, *report.Report, repro.Environment) (
 	*repro.Result, *repro.Stats, error) {
 	return mockReproCallback(title, err, nil)
 }
 
 func mockReproCallback(title string, returnErr error,
-	callback func()) func(context.Context, []byte, repro.Environment) (
+	callback func()) func(context.Context, *report.Report, repro.Environment) (
 	*repro.Result, *repro.Stats, error) {
-	return func(ctx context.Context, crashLog []byte, env repro.Environment) (*repro.Result, *repro.Stats, error) {
+	return func(ctx context.Context, target *report.Report, env repro.Environment) (*repro.Result, *repro.Stats, error) {
 		if callback != nil {
 			callback()
 		}
 		if returnErr != nil {
 			return nil, nil, returnErr
 		}
-		target, err := prog.GetTarget("test", "64")
+		progTarget, err := prog.GetTarget("test", "64")
 		if err != nil {
 			return nil, nil, err
 		}
 		return &repro.Result{
 			Report: &report.Report{Title: title},
-			Prog:   target.DataMmapProg(),
+			Prog:   progTarget.DataMmapProg(),
 		}, &repro.Stats{}, nil
 	}
 }

--- a/pkg/manager/diff/diff_test.go
+++ b/pkg/manager/diff/diff_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/syzkaller/pkg/repro"
 	"github.com/google/syzkaller/prog"
 	_ "github.com/google/syzkaller/prog/test"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/google/syzkaller/vm"
 	"github.com/google/syzkaller/vm/dispatcher"
 )
@@ -56,13 +57,25 @@ func newTestEnv(t *testing.T, cfg *Config) *testEnv {
 		divergentCrashes: make(chan *report.Report, 128),
 	}
 
+	testReporter, err := report.NewReporter(&mgrconfig.Config{
+		Derived: mgrconfig.Derived{
+			TargetOS:     targets.Linux,
+			TargetVMArch: targets.AMD64,
+			SysTarget:    targets.Get(targets.Linux, targets.AMD64),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	base := &MockKernel{
-		CrashesCh: make(chan *report.Report, 1),
-		LoopFunc:  func(ctx context.Context) error { return nil },
+		CrashesCh:   make(chan *report.Report, 1),
+		LoopFunc:    func(ctx context.Context) error { return nil },
+		ReporterVal: testReporter,
 	}
 	newKernel := &MockKernel{
-		CrashesCh: make(chan *report.Report, 1),
-		LoopFunc:  func(ctx context.Context) error { return nil },
+		CrashesCh:   make(chan *report.Report, 1),
+		LoopFunc:    func(ctx context.Context) error { return nil },
+		ReporterVal: testReporter,
 	}
 
 	newKernel.PoolVal = dispatcher.NewPool[*vm.Instance](1, func(ctx context.Context, index int) (*vm.Instance, error) {
@@ -166,6 +179,12 @@ func (mk *MockKernel) Features() flatrpc.Feature {
 
 func (mk *MockKernel) Reporter() *report.Reporter {
 	return mk.ReporterVal
+}
+
+func (mk *MockKernel) Symbolize(rep *report.Report) {
+	if mk.ReporterVal != nil {
+		_ = mk.ReporterVal.Symbolize(rep)
+	}
 }
 
 func (mk *MockKernel) FinishCorpusTriage() {

--- a/pkg/manager/diff/diff_test.go
+++ b/pkg/manager/diff/diff_test.go
@@ -48,11 +48,12 @@ func newTestEnv(t *testing.T, cfg *Config) *testEnv {
 	}
 
 	diffCtx := &diffContext{
-		cfg:           *cfg,
-		doneRepro:     make(chan *manager.ReproResult, 1),
-		store:         cfg.Store,
-		reproAttempts: map[string]int{},
-		patchedOnly:   cfg.PatchedOnly,
+		cfg:              *cfg,
+		doneRepro:        make(chan *manager.ReproResult, 1),
+		store:            cfg.Store,
+		reproAttempts:    map[string]int{},
+		patchedOnly:      cfg.PatchedOnly,
+		divergentCrashes: make(chan *report.Report, 128),
 	}
 
 	base := &MockKernel{

--- a/pkg/manager/diff/kernel.go
+++ b/pkg/manager/diff/kernel.go
@@ -304,3 +304,9 @@ func (kc *kernelContext) Features() flatrpc.Feature {
 func (kc *kernelContext) Reporter() *report.Reporter {
 	return kc.reporter
 }
+
+func (kc *kernelContext) Symbolize(rep *report.Report) {
+	if err := kc.reporter.Symbolize(rep); err != nil {
+		log.Logf(0, "%s: failed to symbolize report: %v", kc.name, err)
+	}
+}

--- a/pkg/manager/diff/manager.go
+++ b/pkg/manager/diff/manager.go
@@ -209,7 +209,7 @@ loop:
 			// We have finished reproducing a crash from the patched instance.
 			if ret.Repro != nil && ret.Repro.Report != nil {
 				origTitle := ret.Crash.Report.Title
-				if ret.Repro.Report.Title == origTitle {
+				if ret.Repro.Report.SameBug(ret.Crash.Report) {
 					origTitle = "-SAME-"
 				}
 				log.Logf(1, "found repro for %q (orig title: %q, reliability: %2.f), took %.2f minutes",

--- a/pkg/manager/diff/manager.go
+++ b/pkg/manager/diff/manager.go
@@ -100,13 +100,14 @@ func Run(ctx context.Context, baseCfg, newCfg *mgrconfig.Config, cfg Config) err
 	}
 
 	diffCtx := &diffContext{
-		cfg:           cfg,
-		doneRepro:     make(chan *manager.ReproResult),
-		base:          base,
-		new:           new,
-		store:         cfg.Store,
-		reproAttempts: map[string]int{},
-		patchedOnly:   cfg.PatchedOnly,
+		cfg:              cfg,
+		doneRepro:        make(chan *manager.ReproResult),
+		base:             base,
+		new:              new,
+		store:            cfg.Store,
+		reproAttempts:    map[string]int{},
+		patchedOnly:      cfg.PatchedOnly,
+		divergentCrashes: make(chan *report.Report, 128),
 	}
 	if newCfg.HTTP != "" {
 		diffCtx.http = &manager.HTTPServer{
@@ -143,10 +144,11 @@ type diffContext struct {
 	store *manager.DiffFuzzerStore
 	http  *manager.HTTPServer
 
-	doneRepro   chan *manager.ReproResult
-	base        Kernel
-	new         Kernel
-	patchedOnly chan *Bug
+	doneRepro        chan *manager.ReproResult
+	base             Kernel
+	new              Kernel
+	patchedOnly      chan *Bug
+	divergentCrashes chan *report.Report
 
 	mu            sync.Mutex
 	reproAttempts map[string]int
@@ -228,21 +230,26 @@ loop:
 			}
 			dc.store.SaveRepro(ret)
 		case rep := <-dc.new.Crashes():
-			// A new crash is found on the patched instance.
-			crash := &manager.Crash{Report: rep}
-			need := dc.NeedRepro(crash)
-			log.Logf(0, "patched crashed: %v [need repro = %v]",
-				rep.Title, need)
-			dc.store.PatchedCrashed(rep.Title, rep.Report, rep.Output)
-			if need {
-				dc.store.UpdateStatus(rep.Title, manager.DiffBugStatusVerifying)
-				reproLoop.Enqueue(crash)
-			} else {
-				dc.store.UpdateStatus(rep.Title, manager.DiffBugStatusIgnored)
-			}
+			dc.handleNewCrash(rep, reproLoop)
+		case rep := <-dc.divergentCrashes:
+			dc.handleNewCrash(rep, reproLoop)
 		}
 	}
 	return g.Wait()
+}
+
+func (dc *diffContext) handleNewCrash(rep *report.Report, reproLoop *manager.ReproLoop) {
+	crash := &manager.Crash{Report: rep}
+	need := dc.NeedRepro(crash)
+	log.Logf(0, "patched crashed: %v [need repro = %v]",
+		rep.Title, need)
+	dc.store.PatchedCrashed(rep.Title, rep.Report, rep.Output)
+	if need {
+		dc.store.UpdateStatus(rep.Title, manager.DiffBugStatusVerifying)
+		reproLoop.Enqueue(crash)
+	} else {
+		dc.store.UpdateStatus(rep.Title, manager.DiffBugStatusIgnored)
+	}
 }
 
 func (dc *diffContext) handleReproResult(ctx context.Context, ret reproRunnerResult, reproLoop *manager.ReproLoop) {
@@ -415,11 +422,19 @@ func (dc *diffContext) RunRepro(ctx context.Context, crash *manager.Crash) *mana
 	dc.mu.Unlock()
 
 	res, stats, err := dc.cfg.runRepro(ctx, crash.Output, repro.Environment{
-		Config:   dc.new.Config(),
-		Features: dc.new.Features(),
-		Reporter: dc.new.Reporter(),
-		Pool:     dc.new.Pool(),
-		Fast:     !crash.FullRepro,
+		Config:       dc.new.Config(),
+		Features:     dc.new.Features(),
+		Reporter:     dc.new.Reporter(),
+		Pool:         dc.new.Pool(),
+		Fast:         !crash.FullRepro,
+		TargetReport: crash.Report,
+		OnDivergentCrash: func(rep *report.Report) {
+			log.Logf(0, "reproducing %q yielded divergent crash %q", crash.Title, rep.Title)
+			select {
+			case dc.divergentCrashes <- rep:
+			case <-ctx.Done():
+			}
+		},
 	})
 	if res != nil && res.Report != nil {
 		dc.mu.Lock()

--- a/pkg/manager/diff/manager.go
+++ b/pkg/manager/diff/manager.go
@@ -137,6 +137,7 @@ type Kernel interface {
 	Pool() *vm.Dispatcher
 	Features() flatrpc.Feature
 	Reporter() *report.Reporter
+	Symbolize(rep *report.Report)
 }
 
 type diffContext struct {
@@ -210,6 +211,7 @@ loop:
 		case ret := <-dc.doneRepro:
 			// We have finished reproducing a crash from the patched instance.
 			if ret.Repro != nil && ret.Repro.Report != nil {
+				dc.new.Symbolize(ret.Repro.Report)
 				origTitle := ret.Crash.Report.Title
 				if ret.Repro.Report.SameBug(ret.Crash.Report) {
 					origTitle = "-SAME-"
@@ -239,6 +241,7 @@ loop:
 }
 
 func (dc *diffContext) handleNewCrash(rep *report.Report, reproLoop *manager.ReproLoop) {
+	dc.new.Symbolize(rep)
 	crash := &manager.Crash{Report: rep}
 	need := dc.NeedRepro(crash)
 	log.Logf(0, "patched crashed: %v [need repro = %v]",
@@ -309,6 +312,7 @@ func (dc *diffContext) ignoreCrash(ctx context.Context, title string) bool {
 }
 
 func (dc *diffContext) reportBaseCrash(ctx context.Context, rep *report.Report) {
+	dc.base.Symbolize(rep)
 	dc.store.BaseCrashed(rep.Title, rep.Report)
 	if dc.cfg.BaseCrashes == nil {
 		return

--- a/pkg/manager/diff/manager.go
+++ b/pkg/manager/diff/manager.go
@@ -47,7 +47,7 @@ type Config struct {
 	IgnoreCrash func(context.Context, string) (bool, error)
 
 	runner   runner
-	runRepro func(context.Context, []byte, repro.Environment) (*repro.Result, *repro.Stats, error)
+	runRepro func(context.Context, *report.Report, repro.Environment) (*repro.Result, *repro.Stats, error)
 }
 
 func (cfg *Config) TriageDeadline() <-chan time.Time {
@@ -425,13 +425,12 @@ func (dc *diffContext) RunRepro(ctx context.Context, crash *manager.Crash) *mana
 	dc.reproAttempts[crash.Title]++
 	dc.mu.Unlock()
 
-	res, stats, err := dc.cfg.runRepro(ctx, crash.Output, repro.Environment{
-		Config:       dc.new.Config(),
-		Features:     dc.new.Features(),
-		Reporter:     dc.new.Reporter(),
-		Pool:         dc.new.Pool(),
-		Fast:         !crash.FullRepro,
-		TargetReport: crash.Report,
+	res, stats, err := dc.cfg.runRepro(ctx, crash.Report, repro.Environment{
+		Config:   dc.new.Config(),
+		Features: dc.new.Features(),
+		Reporter: dc.new.Reporter(),
+		Pool:     dc.new.Pool(),
+		Fast:     !crash.FullRepro,
 		OnDivergentCrash: func(rep *report.Report) {
 			log.Logf(0, "reproducing %q yielded divergent crash %q", crash.Title, rep.Title)
 			select {

--- a/pkg/manager/diff/manager_test.go
+++ b/pkg/manager/diff/manager_test.go
@@ -209,3 +209,23 @@ func TestDiffRetryRepro(t *testing.T) {
 	default:
 	}
 }
+
+func TestDiffDivergentCrash(t *testing.T) {
+	// During repro of title1, a divergent crash title2 is reported -> title2 is queued and reproduced.
+	env := newTestEnv(t, &Config{
+		runRepro: func(ctx context.Context, log []byte, reproEnv repro.Environment) (*repro.Result, *repro.Stats, error) {
+			if reproEnv.TargetReport.Title == "title1" && reproEnv.OnDivergentCrash != nil {
+				reproEnv.OnDivergentCrash(&report.Report{Title: "title2", Report: []byte("log2")})
+			}
+			return nil, nil, errors.New("repro failed")
+		},
+	})
+	defer env.close()
+
+	env.new.FinishCorpusTriage()
+	env.start()
+
+	env.new.CrashesCh <- &report.Report{Title: "title1", Report: []byte("log1")}
+	env.waitForStatus("title1", manager.DiffBugStatusCompleted)
+	env.waitForStatus("title2", manager.DiffBugStatusCompleted)
+}

--- a/pkg/manager/diff/manager_test.go
+++ b/pkg/manager/diff/manager_test.go
@@ -213,8 +213,9 @@ func TestDiffRetryRepro(t *testing.T) {
 func TestDiffDivergentCrash(t *testing.T) {
 	// During repro of title1, a divergent crash title2 is reported -> title2 is queued and reproduced.
 	env := newTestEnv(t, &Config{
-		runRepro: func(ctx context.Context, log []byte, reproEnv repro.Environment) (*repro.Result, *repro.Stats, error) {
-			if reproEnv.TargetReport.Title == "title1" && reproEnv.OnDivergentCrash != nil {
+		runRepro: func(ctx context.Context, target *report.Report,
+			reproEnv repro.Environment) (*repro.Result, *repro.Stats, error) {
+			if target.Title == "title1" && reproEnv.OnDivergentCrash != nil {
 				reproEnv.OnDivergentCrash(&report.Report{Title: "title2", Report: []byte("log2")})
 			}
 			return nil, nil, errors.New("repro failed")

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -90,6 +90,17 @@ func (rep *Report) String() string {
 	return fmt.Sprintf("crash: %v\n%s", rep.Title, rep.Report)
 }
 
+func (rep *Report) PrependOutput(prefix []byte) {
+	if len(prefix) == 0 {
+		return
+	}
+	rep.Output = slices.Concat(prefix, rep.Output)
+	n := len(prefix)
+	rep.StartPos += n
+	rep.EndPos += n
+	rep.SkipPos += n
+}
+
 // NewReporter creates reporter for the specified OS/Type.
 func NewReporter(cfg *mgrconfig.Config) (*Reporter, error) {
 	var localModules []*vminfo.KernelModule

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -90,6 +90,23 @@ func (rep *Report) String() string {
 	return fmt.Sprintf("crash: %v\n%s", rep.Title, rep.Report)
 }
 
+func (rep *Report) SameBug(other *Report) bool {
+	if rep == nil || other == nil {
+		return false
+	}
+	if rep.Title == other.Title ||
+		slices.Contains(other.AltTitles, rep.Title) ||
+		slices.Contains(rep.AltTitles, other.Title) {
+		return true
+	}
+	for _, title := range rep.AltTitles {
+		if slices.Contains(other.AltTitles, title) {
+			return true
+		}
+	}
+	return false
+}
+
 func (rep *Report) PrependOutput(prefix []byte) {
 	if len(prefix) == 0 {
 		return

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -603,3 +603,23 @@ func TestIPv6TitleReplacement(t *testing.T) {
 		})
 	}
 }
+
+func TestReportPrependOutput(t *testing.T) {
+	rep := &Report{
+		Output:   []byte("kernel crash output"),
+		StartPos: 7,
+		EndPos:   12,
+		SkipPos:  19,
+	}
+	prefix := []byte("executing program 0:\nalarm(0xa)\n")
+	rep.PrependOutput(prefix)
+
+	require.Equal(t, "executing program 0:\nalarm(0xa)\nkernel crash output", string(rep.Output))
+	require.Equal(t, 7+len(prefix), rep.StartPos)
+	require.Equal(t, 12+len(prefix), rep.EndPos)
+	require.Equal(t, 19+len(prefix), rep.SkipPos)
+
+	// Prepending empty prefix does nothing.
+	rep.PrependOutput(nil)
+	require.Equal(t, "executing program 0:\nalarm(0xa)\nkernel crash output", string(rep.Output))
+}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -604,6 +604,70 @@ func TestIPv6TitleReplacement(t *testing.T) {
 	}
 }
 
+func TestSameBug(t *testing.T) {
+	tests := []struct {
+		name string
+		rep1 *Report
+		rep2 *Report
+		want bool
+	}{
+		{
+			name: "both nil",
+			rep1: nil,
+			rep2: nil,
+			want: false,
+		},
+		{
+			name: "one nil",
+			rep1: &Report{Title: "titleA"},
+			rep2: nil,
+			want: false,
+		},
+		{
+			name: "same title",
+			rep1: &Report{Title: "titleA"},
+			rep2: &Report{Title: "titleA"},
+			want: true,
+		},
+		{
+			name: "different title, no alt",
+			rep1: &Report{Title: "titleA"},
+			rep2: &Report{Title: "titleB"},
+			want: false,
+		},
+		{
+			name: "rep1 title matches rep2 alt",
+			rep1: &Report{Title: "titleA"},
+			rep2: &Report{Title: "titleB", AltTitles: []string{"titleA"}},
+			want: true,
+		},
+		{
+			name: "rep2 title matches rep1 alt",
+			rep1: &Report{Title: "titleA", AltTitles: []string{"titleB"}},
+			rep2: &Report{Title: "titleB"},
+			want: true,
+		},
+		{
+			name: "alt titles intersect",
+			rep1: &Report{Title: "titleA", AltTitles: []string{"common"}},
+			rep2: &Report{Title: "titleB", AltTitles: []string{"common"}},
+			want: true,
+		},
+		{
+			name: "alt titles do not intersect",
+			rep1: &Report{Title: "titleA", AltTitles: []string{"alt1"}},
+			rep2: &Report{Title: "titleB", AltTitles: []string{"alt2"}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.rep1.SameBug(tt.rep2))
+			require.Equal(t, tt.want, tt.rep2.SameBug(tt.rep1))
+		})
+	}
+}
+
 func TestReportPrependOutput(t *testing.T) {
 	rep := &Report{
 		Output:   []byte("kernel crash output"),

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -688,10 +688,8 @@ func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, er
 	for range attempts {
 		const errAttempts = 3
 		for range errAttempts {
-			// It's hard to classify all kinds of errors into the one worth repeating
-			// and not. So let's just retry runs for all errors.
-			// If the problem is transient, it will likely go away.
-			// If the problem is permanent, it will just be the same.
+			// Repeat the run multiple times to work around transient errors.
+			// If the run fails every time, take the last error.
 			result, err = callback()
 			if err == nil {
 				break

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -79,38 +79,50 @@ type execInterface interface {
 }
 
 type Environment struct {
-	Config       *mgrconfig.Config
-	Features     flatrpc.Feature
-	Reporter     *report.Reporter
-	Pool         *vm.Dispatcher
-	TargetReport *report.Report
+	Config   *mgrconfig.Config
+	Features flatrpc.Feature
+	Reporter *report.Reporter
+	Pool     *vm.Dispatcher
 	// The Fast repro mode restricts the repro log bisection,
 	// it skips multiple simpifications and C repro generation.
 	Fast             bool
 	OnDivergentCrash func(rep *report.Report)
 
 	logf func(string, ...any)
+	exec execInterface
 }
 
-func Run(ctx context.Context, log []byte, env Environment) (*Result, *Stats, error) {
-	return runInner(ctx, log, env, &poolWrapper{
-		cfg:      env.Config,
-		reporter: env.Reporter,
-		pool:     env.Pool,
-	})
+func Run(ctx context.Context, target *report.Report, env Environment) (*Result, *Stats, error) {
+	if target == nil || target.Title == "" {
+		return nil, nil, fmt.Errorf("target report with title is required")
+	}
+	return runInner(ctx, target, target.Output, env, env.exec)
+}
+
+func RunFromLog(ctx context.Context, log []byte, env Environment) (*Result, *Stats, error) {
+	if env.Reporter != nil {
+		if rep := env.Reporter.Parse(log); rep != nil && rep.Title != "" {
+			return Run(ctx, rep, env)
+		}
+	}
+	return runInner(ctx, nil, log, env, env.exec)
 }
 
 var ErrEmptyCrashLog = errors.New("no programs")
 
-func runInner(ctx context.Context, crashLog []byte, env Environment, exec execInterface) (*Result, *Stats, error) {
+func runInner(ctx context.Context, targetReport *report.Report, crashLog []byte, env Environment,
+	exec execInterface) (*Result, *Stats, error) {
+	if exec == nil {
+		exec = &poolWrapper{
+			cfg:      env.Config,
+			reporter: env.Reporter,
+			pool:     env.Pool,
+		}
+	}
 	cfg := env.Config
 	entries := cfg.Target.ParseLog(crashLog, prog.NonStrict)
 	if len(entries) == 0 {
 		return nil, nil, fmt.Errorf("log (%d bytes) parse failed: %w", len(crashLog), ErrEmptyCrashLog)
-	}
-	targetReport := env.TargetReport
-	if targetReport == nil {
-		targetReport = env.Reporter.Parse(crashLog)
 	}
 	testTimeouts := []time.Duration{
 		max(30*time.Second, 3*cfg.Timeouts.Program), // to catch simpler crashes (i.e. no races and no hangs)
@@ -122,17 +134,17 @@ func runInner(ctx context.Context, crashLog []byte, env Environment, exec execIn
 		crashType = targetReport.Type
 	}
 	switch {
-	case targetReport == nil || targetReport.Title == "":
-		// Lost connection can be detected faster,
-		// but theoretically if it's caused by a race it may need the largest timeout.
-		// No output can only be reproduced with the max timeout.
-		// As a compromise we use the smallest and the largest timeouts.
-		testTimeouts = []time.Duration{testTimeouts[0], testTimeouts[2]}
 	case crashType == crash.MemoryLeak:
 		// Memory leaks can't be detected quickly because of expensive setup and scanning.
 		testTimeouts = testTimeouts[1:]
 	case crashType == crash.Hang:
 		testTimeouts = testTimeouts[2:]
+	case targetReport == nil:
+		// Lost connection can be detected faster,
+		// but theoretically if it's caused by a race it may need the largest timeout.
+		// No output can only be reproduced with the max timeout.
+		// As a compromise we use the smallest and the largest timeouts.
+		testTimeouts = []time.Duration{testTimeouts[0], testTimeouts[2]}
 	}
 	if env.Fast {
 		testTimeouts = []time.Duration{30 * time.Second, 5 * time.Minute}

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -52,22 +52,21 @@ type Stats struct {
 }
 
 type reproContext struct {
-	ctx            context.Context
-	exec           execInterface
-	logf           func(string, ...any)
-	target         *targets.Target
-	crashTitle     string
-	crashType      crash.Type
-	crashStart     int
-	crashExecutor  *report.ExecutorInfo
-	entries        []*prog.LogEntry
-	testTimeouts   []time.Duration
-	startOpts      csource.Options
-	stats          *Stats
-	report         *report.Report
-	timeouts       targets.Timeouts
-	observedTitles map[string]crash.Type
-	fast           bool
+	ctx               context.Context
+	exec              execInterface
+	logf              func(string, ...any)
+	target            *targets.Target
+	targetReport      *report.Report
+	origExecutor      *report.ExecutorInfo
+	entries           []*prog.LogEntry
+	testTimeouts      []time.Duration
+	startOpts         csource.Options
+	stats             *Stats
+	report            *report.Report
+	timeouts          targets.Timeouts
+	reportedDivergent map[string]bool
+	fast              bool
+	onDivergentCrash  func(rep *report.Report)
 }
 
 // execInterface describes the interfaces needed by pkg/repro.
@@ -79,13 +78,15 @@ type execInterface interface {
 }
 
 type Environment struct {
-	Config   *mgrconfig.Config
-	Features flatrpc.Feature
-	Reporter *report.Reporter
-	Pool     *vm.Dispatcher
+	Config       *mgrconfig.Config
+	Features     flatrpc.Feature
+	Reporter     *report.Reporter
+	Pool         *vm.Dispatcher
+	TargetReport *report.Report
 	// The Fast repro mode restricts the repro log bisection,
 	// it skips multiple simpifications and C repro generation.
-	Fast bool
+	Fast             bool
+	OnDivergentCrash func(rep *report.Report)
 
 	logf func(string, ...any)
 }
@@ -106,23 +107,21 @@ func runInner(ctx context.Context, crashLog []byte, env Environment, exec execIn
 	if len(entries) == 0 {
 		return nil, nil, fmt.Errorf("log (%d bytes) parse failed: %w", len(crashLog), ErrEmptyCrashLog)
 	}
-	crashStart := len(crashLog)
-	crashTitle, crashType := "", crash.UnknownType
-	var crashExecutor *report.ExecutorInfo
-	if rep := env.Reporter.Parse(crashLog); rep != nil {
-		crashStart = rep.StartPos
-		crashTitle = rep.Title
-		crashType = rep.Type
-		crashExecutor = rep.Executor
+	targetReport := env.TargetReport
+	if targetReport == nil {
+		targetReport = env.Reporter.Parse(crashLog)
 	}
 	testTimeouts := []time.Duration{
 		max(30*time.Second, 3*cfg.Timeouts.Program), // to catch simpler crashes (i.e. no races and no hangs)
 		max(100*time.Second, 20*cfg.Timeouts.Program),
 		cfg.Timeouts.NoOutputRunningTime, // to catch "no output", races and hangs
 	}
+	var crashType crash.Type
+	if targetReport != nil {
+		crashType = targetReport.Type
+	}
 	switch {
-	case crashTitle == "":
-		crashTitle = "no output/lost connection"
+	case targetReport == nil || targetReport.Title == "":
 		// Lost connection can be detected faster,
 		// but theoretically if it's caused by a race it may need the largest timeout.
 		// No output can only be reproduced with the max timeout.
@@ -137,23 +136,25 @@ func runInner(ctx context.Context, crashLog []byte, env Environment, exec execIn
 	if env.Fast {
 		testTimeouts = []time.Duration{30 * time.Second, 5 * time.Minute}
 	}
+	var origExecutor *report.ExecutorInfo
+	if targetReport != nil {
+		origExecutor = targetReport.Executor
+	}
 	reproCtx := &reproContext{
-		ctx:           ctx,
-		exec:          exec,
-		target:        cfg.SysTarget,
-		crashTitle:    crashTitle,
-		crashType:     crashType,
-		crashStart:    crashStart,
-		crashExecutor: crashExecutor,
-
-		entries:        entries,
-		testTimeouts:   testTimeouts,
-		startOpts:      createStartOptions(cfg, env.Features, crashType),
-		stats:          new(Stats),
-		timeouts:       cfg.Timeouts,
-		observedTitles: map[string]crash.Type{},
-		fast:           env.Fast,
-		logf:           env.logf,
+		ctx:               ctx,
+		exec:              exec,
+		target:            cfg.SysTarget,
+		targetReport:      targetReport,
+		origExecutor:      origExecutor,
+		entries:           entries,
+		testTimeouts:      testTimeouts,
+		startOpts:         createStartOptions(cfg, env.Features, crashType),
+		stats:             new(Stats),
+		timeouts:          cfg.Timeouts,
+		reportedDivergent: map[string]bool{},
+		fast:              env.Fast,
+		onDivergentCrash:  env.OnDivergentCrash,
+		logf:              env.logf,
 	}
 
 	return reproCtx.run()
@@ -171,9 +172,9 @@ func (ctx *reproContext) run() (*Result, *Stats, error) {
 		for attempts := 0; ctx.report.Corrupted && attempts < 3; attempts++ {
 			ctx.reproLogf(3, "report is corrupted, running repro again")
 			if res.CRepro {
-				_, err = ctx.testCProg(res.Prog, res.Duration, res.Opts, false)
+				_, err = ctx.testCProg(res.Prog, res.Duration, res.Opts)
 			} else {
-				_, err = ctx.testProg(res.Prog, res.Duration, res.Opts, false)
+				_, err = ctx.testProg(res.Prog, res.Duration, res.Opts)
 			}
 			if err != nil {
 				return nil, nil, err
@@ -223,14 +224,6 @@ func createStartOptions(cfg *mgrconfig.Config, features flatrpc.Feature,
 }
 
 func (ctx *reproContext) repro() (*Result, error) {
-	// Cut programs that were executed after crash.
-	for i, ent := range ctx.entries {
-		if ent.Start > ctx.crashStart {
-			ctx.entries = ctx.entries[:i]
-			break
-		}
-	}
-
 	reproStart := time.Now()
 	defer func() {
 		ctx.reproLogf(3, "reproducing took %s", time.Since(reproStart))
@@ -274,7 +267,7 @@ func (ctx *reproContext) repro() (*Result, error) {
 	}
 	// Validate the resulting reproducer - a random rare kernel crash might have diverted the process.
 	res.Reliability, err = calculateReliability(func() (bool, error) {
-		ret, err := ctx.testProg(res.Prog, res.Duration, res.Opts, false)
+		ret, err := ctx.testProg(res.Prog, res.Duration, res.Opts)
 		if err != nil {
 			return false, err
 		}
@@ -323,18 +316,15 @@ func (ctx *reproContext) extractProg(entries []*prog.LogEntry) (*Result, error) 
 	}()
 
 	var toTest []*prog.LogEntry
-	if ctx.crashExecutor != nil {
+	if ctx.origExecutor != nil {
 		for _, entry := range entries {
-			// Note: we don't check ProcID b/c hanged programs are assigned fake unique proc IDs
-			// that don't match "Comm" in the kernel panic message.
-			if entry.ID == ctx.crashExecutor.ExecID {
+			if entry.ID == ctx.origExecutor.ExecID {
 				toTest = append(toTest, entry)
 				ctx.reproLogf(3, "first checking the prog from the crash report")
 				break
 			}
 		}
 	}
-
 	if len(toTest) == 0 {
 		ctx.reproLogf(3, "testing a last program of every proc")
 		toTest = lastEntries(entries)
@@ -400,7 +390,7 @@ func (ctx *reproContext) extractProgSingle(entries []*prog.LogEntry, duration ti
 
 	opts := ctx.startOpts
 	for _, ent := range entries {
-		ret, err := ctx.testProg(ent.P, duration, opts, false)
+		ret, err := ctx.testProg(ent.P, duration, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -428,7 +418,7 @@ func (ctx *reproContext) extractProgBisect(entries []*prog.LogEntry, baseDuratio
 	}
 
 	// First check if replaying the log may crash the kernel at all.
-	ret, err := ctx.testProgs(entries, duration(len(entries)), opts, false)
+	ret, err := ctx.testProgs(entries, duration(len(entries)), opts)
 	if !ret.Crashed {
 		ctx.reproLogf(3, "replaying the whole log did not cause a kernel crash")
 		return nil, nil
@@ -439,7 +429,7 @@ func (ctx *reproContext) extractProgBisect(entries []*prog.LogEntry, baseDuratio
 
 	// Bisect the log to find multiple guilty programs.
 	entries, err = ctx.bisectProgs(entries, func(progs []*prog.LogEntry) (bool, error) {
-		ret, err := ctx.testProgs(progs, duration(len(progs)), opts, false)
+		ret, err := ctx.testProgs(progs, duration(len(progs)), opts)
 		return ret.Crashed, err
 	})
 	if err != nil {
@@ -486,7 +476,7 @@ func (ctx *reproContext) concatenateProgs(entries []*prog.LogEntry, dur time.Dur
 					if i+1 < len(entries) {
 						newEntries = append(newEntries, entries[i+1:]...)
 					}
-					ret, err := ctx.testProgs(newEntries, dur, ctx.startOpts, false)
+					ret, err := ctx.testProgs(newEntries, dur, ctx.startOpts)
 					if err != nil {
 						testErr = err
 						ctx.reproLogf(0, "concatenation step failed with %v", err)
@@ -510,7 +500,7 @@ func (ctx *reproContext) concatenateProgs(entries []*prog.LogEntry, dur time.Dur
 		ctx.reproLogf(2, "bisect: concatenated prog still exceeds %d calls", prog.MaxCalls)
 		return nil, nil
 	}
-	ret, err := ctx.testProg(p, dur, ctx.startOpts, false)
+	ret, err := ctx.testProg(p, dur, ctx.startOpts)
 	if err != nil {
 		ctx.reproLogf(3, "bisect: error during concatenation testing: %v", err)
 		return nil, err
@@ -554,7 +544,7 @@ func (ctx *reproContext) minimizeProg(res *Result) (*Result, error) {
 			// will immediately exit.
 			return false
 		}
-		ret, err := ctx.testProg(p1, res.Duration, res.Opts, false)
+		ret, err := ctx.testProg(p1, res.Duration, res.Opts)
 		if err != nil {
 			ctx.reproLogf(2, "minimization failed with %v", err)
 			testErr = err
@@ -582,7 +572,7 @@ func (ctx *reproContext) simplifyProg(res *Result) (*Result, error) {
 		if !simplify(&opts) || !checkOpts(&opts, ctx.timeouts, res.Duration) {
 			continue
 		}
-		ret, err := ctx.testProg(res.Prog, res.Duration, opts, true)
+		ret, err := ctx.testProg(res.Prog, res.Duration, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -618,7 +608,7 @@ func (ctx *reproContext) extractC(res *Result) (*Result, error) {
 		ctx.stats.ExtractCTime = time.Since(start)
 	}()
 
-	ret, err := ctx.testCProg(res.Prog, res.Duration, res.Opts, true)
+	ret, err := ctx.testCProg(res.Prog, res.Duration, res.Opts)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +629,7 @@ func (ctx *reproContext) simplifyC(res *Result) (*Result, error) {
 		if !simplify(&opts) || !checkOpts(&opts, ctx.timeouts, res.Duration) {
 			continue
 		}
-		ret, err := ctx.testCProg(res.Prog, res.Duration, opts, true)
+		ret, err := ctx.testCProg(res.Prog, res.Duration, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -674,10 +664,9 @@ func checkOpts(opts *csource.Options, timeouts targets.Timeouts, timeout time.Du
 	return true
 }
 
-func (ctx *reproContext) testProg(p *prog.Prog, duration time.Duration, opts csource.Options,
-	strict bool) (ret verdict, err error) {
+func (ctx *reproContext) testProg(p *prog.Prog, duration time.Duration, opts csource.Options) (ret verdict, err error) {
 	entry := prog.LogEntry{P: p}
-	return ctx.testProgs([]*prog.LogEntry{&entry}, duration, opts, strict)
+	return ctx.testProgs([]*prog.LogEntry{&entry}, duration, opts)
 }
 
 type verdict struct {
@@ -685,71 +674,57 @@ type verdict struct {
 	Duration time.Duration
 }
 
-func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, err error), strict bool) (
-	verdict, error) {
+func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, err error),
+	onDivergent func(rep *report.Report), retryDivergent bool) (verdict, error) {
 	var result *instance.RunResult
 	var err error
 
-	const attempts = 3
+	attempts := 1
+	if retryDivergent {
+		attempts = 2
+	}
 	for range attempts {
-		// It's hard to classify all kinds of errors into the one worth repeating
-		// and not. So let's just retry runs for all errors.
-		// If the problem is transient, it will likely go away.
-		// If the problem is permanent, it will just be the same.
-		result, err = callback()
-		if err == nil {
-			break
+		const errAttempts = 3
+		for range errAttempts {
+			// It's hard to classify all kinds of errors into the one worth repeating
+			// and not. So let's just retry runs for all errors.
+			// If the problem is transient, it will likely go away.
+			// If the problem is permanent, it will just be the same.
+			result, err = callback()
+			if err == nil {
+				break
+			}
 		}
-	}
-	if err != nil {
-		return verdict{}, err
-	}
-	rep := result.Report
-	if rep == nil {
-		return verdict{false, result.Duration}, nil
-	}
-	if rep.Suppressed {
-		ctx.reproLogf(2, "suppressed program crash: %v", rep.Title)
-		return verdict{false, result.Duration}, nil
-	}
-	if ctx.crashType == crash.MemoryLeak && rep.Type != crash.MemoryLeak {
-		ctx.reproLogf(2, "not a leak crash: %v", rep.Title)
-		return verdict{false, result.Duration}, nil
-	}
-	if _, ok := ctx.observedTitles[rep.Title]; ok {
-		// Already established title, always permit.
-	} else if !isHighPrioReport(rep.Type) && ctx.observedHighPrioCrash() {
-		ctx.reproLogf(2, "ignore low priority crash: %v", rep.Title)
-		return verdict{false, result.Duration}, nil
-	} else if strict && len(ctx.observedTitles) > 0 {
-		ctx.reproLogf(2, "a never seen crash title: %v, ignore", rep.Title)
-		return verdict{false, result.Duration}, nil
-	} else {
-		ctx.observedTitles[rep.Title] = rep.Type
-	}
-	ctx.report = rep
-	return verdict{true, result.Duration}, nil
-}
-
-func (ctx *reproContext) observedHighPrioCrash() bool {
-	if isHighPrioReport(ctx.crashType) {
-		return true
-	}
-	for _, typ := range ctx.observedTitles {
-		if isHighPrioReport(typ) {
-			return true
+		if err != nil {
+			return verdict{}, err
 		}
+		rep := result.Report
+		if rep == nil {
+			return verdict{false, result.Duration}, nil
+		}
+		if rep.Suppressed {
+			ctx.reproLogf(2, "suppressed program crash: %v", rep.Title)
+			return verdict{false, result.Duration}, nil
+		}
+		if ctx.targetReport != nil && ctx.targetReport.Type == crash.MemoryLeak && rep.Type != crash.MemoryLeak {
+			ctx.reproLogf(2, "not a leak crash: %v", rep.Title)
+			return verdict{false, result.Duration}, nil
+		}
+		if ctx.targetReport != nil && !ctx.targetReport.SameBug(rep) {
+			ctx.reproLogf(2, "divergent crash: %v (target: %v)", rep.Title, ctx.targetReport.Title)
+			if onDivergent != nil && !ctx.reportedDivergent[rep.Title] {
+				ctx.reportedDivergent[rep.Title] = true
+				onDivergent(rep)
+			}
+			continue
+		}
+		if ctx.targetReport == nil {
+			ctx.targetReport = rep
+		}
+		ctx.report = rep
+		return verdict{true, result.Duration}, nil
 	}
-	return false
-}
-
-func isHighPrioReport(typ crash.Type) bool {
-	switch typ {
-	case crash.LostConnection, crash.NoOutput, crash.SyzFailure, crash.UnexpectedReboot:
-		return false
-	default:
-		return true
-	}
+	return verdict{false, result.Duration}, nil
 }
 
 var ErrNoVMs = errors.New("all VMs failed to boot")
@@ -765,8 +740,8 @@ func encodeEntries(entries []*prog.LogEntry) []byte {
 	return buf.Bytes()
 }
 
-func (ctx *reproContext) testProgs(entries []*prog.LogEntry, duration time.Duration, opts csource.Options,
-	strict bool) (ret verdict, err error) {
+func (ctx *reproContext) testProgs(entries []*prog.LogEntry, duration time.Duration,
+	opts csource.Options) (ret verdict, err error) {
 	if len(entries) == 0 {
 		return ret, fmt.Errorf("no programs to execute")
 	}
@@ -785,28 +760,35 @@ func (ctx *reproContext) testProgs(entries []*prog.LogEntry, duration time.Durat
 	ctx.reproLogf(2, "testing program (duration=%v, %+v): %s", duration, opts, program)
 	ctx.reproLogf(3, "detailed listing:\n%s", pstr)
 	return ctx.getVerdict(func() (*instance.RunResult, error) {
-		return ctx.exec.RunSyz(ctx.ctx, pstr, instance.RunOptions{
+		res, err := ctx.exec.RunSyz(ctx.ctx, pstr, instance.RunOptions{
 			Opts:     opts,
 			Duration: duration,
 		}, ctx.reproLogf)
-	}, strict)
+		if res != nil && res.Report != nil {
+			res.Report.PrependOutput(pstr)
+		}
+		return res, err
+	}, ctx.onDivergentCrash, len(entries) > 1)
 }
 
-func (ctx *reproContext) testCProg(p *prog.Prog, duration time.Duration, opts csource.Options,
-	strict bool) (ret verdict, err error) {
+func (ctx *reproContext) testCProg(p *prog.Prog, duration time.Duration,
+	opts csource.Options) (ret verdict, err error) {
 	return ctx.getVerdict(func() (*instance.RunResult, error) {
 		return ctx.exec.RunC(ctx.ctx, p, instance.RunOptions{
 			Opts:     opts,
 			Duration: duration,
 		}, ctx.reproLogf)
-	}, strict)
+	}, nil, false)
 }
 
 func (ctx *reproContext) reproLogf(level int, format string, args ...any) {
 	if ctx.logf != nil {
 		ctx.logf(format, args...)
 	}
-	prefix := fmt.Sprintf("reproducing crash '%v': ", ctx.crashTitle)
+	prefix := "reproducing crash: "
+	if ctx.targetReport != nil && ctx.targetReport.Title != "" {
+		prefix = fmt.Sprintf("reproducing crash '%v': ", ctx.targetReport.Title)
+	}
 	log.Logf(level, prefix+format, args...)
 	ctx.stats.Log = append(ctx.stats.Log, []byte(fmt.Sprintf(format, args...)+"\n")...)
 }
@@ -835,11 +817,11 @@ func (ctx *reproContext) bisectProgs(progs []*prog.LogEntry, pred func([]*prog.L
 			ctx.reproLogf(3, "bisect: "+msg, args...)
 		},
 	}, progs, func(elem *prog.LogEntry) bool {
-		if ctx.crashExecutor == nil {
+		if ctx.origExecutor == nil {
 			return false
 		}
 		// If the program was mentioned in the crash report, always keep it during bisection.
-		return elem.ID == ctx.crashExecutor.ExecID
+		return elem.ID == ctx.origExecutor.ExecID
 	})
 	if err == minimize.ErrTooManyChunks {
 		ctx.reproLogf(3, "bisect: too many guilty chunks, aborting")

--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -66,6 +66,7 @@ type reproContext struct {
 	timeouts          targets.Timeouts
 	reportedDivergent map[string]bool
 	fast              bool
+	validating        bool
 	onDivergentCrash  func(rep *report.Report)
 }
 
@@ -266,6 +267,7 @@ func (ctx *reproContext) repro() (*Result, error) {
 		}
 	}
 	// Validate the resulting reproducer - a random rare kernel crash might have diverted the process.
+	ctx.validating = true
 	res.Reliability, err = calculateReliability(func() (bool, error) {
 		ret, err := ctx.testProg(res.Prog, res.Duration, res.Opts)
 		if err != nil {
@@ -711,8 +713,15 @@ func (ctx *reproContext) getVerdict(callback func() (rep *instance.RunResult, er
 			return verdict{false, result.Duration}, nil
 		}
 		if ctx.targetReport != nil && !ctx.targetReport.SameBug(rep) {
+			// At the validation stage, we are testing the already extracted and minimized program.
+			// If it triggers different titles of the same bug type, we cannot do much with them
+			// anyway, so accept them towards reliability rather than dropping the reproducer.
+			if ctx.validating && ctx.targetReport.Type != crash.UnknownType && rep.Type == ctx.targetReport.Type {
+				ctx.report = rep
+				return verdict{true, result.Duration}, nil
+			}
 			ctx.reproLogf(2, "divergent crash: %v (target: %v)", rep.Title, ctx.targetReport.Title)
-			if onDivergent != nil && !ctx.reportedDivergent[rep.Title] {
+			if onDivergent != nil && !ctx.validating && !ctx.reportedDivergent[rep.Title] {
 				ctx.reportedDivergent[rep.Title] = true
 				onDivergent(rep)
 			}

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -153,7 +153,7 @@ func (tei *testExecInterface) RunSyz(_ context.Context, syzProg []byte, _ instan
 	return tei.run(syzProg)
 }
 
-func runTestReproEnv(t *testing.T, log string, env Environment, exec execInterface) (*Result, *Stats, error) {
+func testEnvironment(t *testing.T, exec execInterface) Environment {
 	mgrConfig := &mgrconfig.Config{
 		Derived: mgrconfig.Derived{
 			TargetOS:     targets.Linux,
@@ -171,15 +171,17 @@ func runTestReproEnv(t *testing.T, log string, env Environment, exec execInterfa
 	if err != nil {
 		t.Fatal(err)
 	}
-	env.Config = mgrConfig
-	env.Features = flatrpc.AllFeatures
-	env.Reporter = reporter
-	env.logf = t.Logf
-	return runInner(context.Background(), []byte(log), env, exec)
+	return Environment{
+		Config:   mgrConfig,
+		Features: flatrpc.AllFeatures,
+		Reporter: reporter,
+		logf:     t.Logf,
+		exec:     exec,
+	}
 }
 
 func runTestRepro(t *testing.T, log string, exec execInterface) (*Result, *Stats, error) {
-	return runTestReproEnv(t, log, Environment{}, exec)
+	return RunFromLog(context.Background(), []byte(log), testEnvironment(t, exec))
 }
 
 const testReproLog = `
@@ -397,11 +399,12 @@ func TestBrokenCompilerRepro(t *testing.T) {
 		Fast:     false,
 		Reporter: reporter,
 		logf:     t.Logf,
+		exec: &testExecInterface{
+			run: testExecRunner,
+		},
 	}
 
-	result, _, err := runInner(context.Background(), []byte(testReproLog), env, &testExecInterface{
-		run: testExecRunner,
-	})
+	result, _, err := RunFromLog(context.Background(), []byte(testReproLog), env)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, false, result.CRepro, "C repro should have been skipped")
@@ -488,15 +491,7 @@ alarm(0xa)
 pause()
 `
 	var divergentReports []*report.Report
-	env := Environment{
-		TargetReport: &report.Report{
-			Title: "panic: target error",
-		},
-		OnDivergentCrash: func(rep *report.Report) {
-			divergentReports = append(divergentReports, rep)
-		},
-	}
-	result, _, err := runTestReproEnv(t, log, env, &testExecInterface{
+	env := testEnvironment(t, &testExecInterface{
 		run: func(p []byte) (*instance.RunResult, error) {
 			if strings.Contains(string(p), "pause()") {
 				return fakeCrashResult("WARNING: unrelated warning"), nil
@@ -507,6 +502,14 @@ pause()
 			return fakeCrashResult(""), nil
 		},
 	})
+	env.OnDivergentCrash = func(rep *report.Report) {
+		divergentReports = append(divergentReports, rep)
+	}
+	target := &report.Report{
+		Title:  "panic: target error",
+		Output: []byte(log),
+	}
+	result, _, err := Run(context.Background(), target, env)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "panic: target error", result.Report.Title)
@@ -517,14 +520,15 @@ pause()
 	require.Contains(t, string(divergentReports[0].Output), "pause()")
 }
 
-func TestNoInitialReport(t *testing.T) {
+func TestLogWithoutReport(t *testing.T) {
 	const log = `
 2015/12/21 12:18:05 executing program 1:
 alarm(0xa)
 2015/12/21 12:18:10 executing program 2:
 pause()
 `
-	result, _, err := runTestRepro(t, log, &testExecInterface{
+	var divergentReports []*report.Report
+	env := testEnvironment(t, &testExecInterface{
 		run: func(p []byte) (*instance.RunResult, error) {
 			if strings.Contains(string(p), "pause()") {
 				return fakeCrashResult("WARNING: first crash"), nil
@@ -532,10 +536,15 @@ pause()
 			return fakeCrashResult(""), nil
 		},
 	})
+	env.OnDivergentCrash = func(rep *report.Report) {
+		divergentReports = append(divergentReports, rep)
+	}
+	result, _, err := RunFromLog(context.Background(), []byte(log), env)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "WARNING: first crash", result.Report.Title)
 	require.Equal(t, "pause()\n", string(result.Prog.Serialize()))
+	require.Empty(t, divergentReports)
 }
 
 // Verify that if Executor.ExecID is present in the crash report, that program is tested
@@ -547,17 +556,16 @@ alarm(0xa)
 2015/12/21 12:18:10 executing program 2 (id=200):
 pause()
 `
-	env := Environment{
-		TargetReport: &report.Report{
-			Title: "panic: target error",
-			Type:  crash.TitleToType("panic: target error"),
-			Executor: &report.ExecutorInfo{
-				ExecID: 100,
-			},
+	target := &report.Report{
+		Title:  "panic: target error",
+		Type:   crash.TitleToType("panic: target error"),
+		Output: []byte(log),
+		Executor: &report.ExecutorInfo{
+			ExecID: 100,
 		},
 	}
 	var testedProgs []string
-	result, _, err := runTestReproEnv(t, log, env, &testExecInterface{
+	result, _, err := Run(context.Background(), target, testEnvironment(t, &testExecInterface{
 		run: func(p []byte) (*instance.RunResult, error) {
 			testedProgs = append(testedProgs, string(p))
 			if strings.Contains(string(p), "alarm(0xa)") {
@@ -565,7 +573,7 @@ pause()
 			}
 			return fakeCrashResult(""), nil
 		},
-	})
+	}))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "alarm(0xa)\n", string(result.Prog.Serialize()))

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -83,6 +83,32 @@ func TestBisect(t *testing.T) {
 	}
 }
 
+func TestBisectWithFixed(t *testing.T) {
+	ctx := &reproContext{
+		stats: new(Stats),
+		logf:  t.Logf,
+		origExecutor: &report.ExecutorInfo{
+			ExecID: 42,
+		},
+	}
+	progs := []*prog.LogEntry{
+		{ID: 10},
+		{ID: 42},
+		{ID: 20},
+	}
+	res, err := ctx.bisectProgs(progs, func(p []*prog.LogEntry) (bool, error) {
+		for _, e := range p {
+			if e.ID == 42 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, 42, res[0].ID)
+}
+
 func TestSimplifies(t *testing.T) {
 	opts := csource.Options{
 		Threaded:     true,
@@ -127,7 +153,7 @@ func (tei *testExecInterface) RunSyz(_ context.Context, syzProg []byte, _ instan
 	return tei.run(syzProg)
 }
 
-func runTestRepro(t *testing.T, log string, exec execInterface) (*Result, *Stats, error) {
+func runTestReproEnv(t *testing.T, log string, env Environment, exec execInterface) (*Result, *Stats, error) {
 	mgrConfig := &mgrconfig.Config{
 		Derived: mgrconfig.Derived{
 			TargetOS:     targets.Linux,
@@ -145,14 +171,15 @@ func runTestRepro(t *testing.T, log string, exec execInterface) (*Result, *Stats
 	if err != nil {
 		t.Fatal(err)
 	}
-	env := Environment{
-		Config:   mgrConfig,
-		Features: flatrpc.AllFeatures,
-		Fast:     false,
-		Reporter: reporter,
-		logf:     t.Logf,
-	}
+	env.Config = mgrConfig
+	env.Features = flatrpc.AllFeatures
+	env.Reporter = reporter
+	env.logf = t.Logf
 	return runInner(context.Background(), []byte(log), env, exec)
+}
+
+func runTestRepro(t *testing.T, log string, exec execInterface) (*Result, *Stats, error) {
+	return runTestReproEnv(t, log, Environment{}, exec)
 }
 
 const testReproLog = `
@@ -451,4 +478,97 @@ func TestReproDuration(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestDivergentCrash(t *testing.T) {
+	const log = `
+2015/12/21 12:18:05 executing program 1:
+alarm(0xa)
+2015/12/21 12:18:10 executing program 2:
+pause()
+`
+	var divergentReports []*report.Report
+	env := Environment{
+		TargetReport: &report.Report{
+			Title: "panic: target error",
+		},
+		OnDivergentCrash: func(rep *report.Report) {
+			divergentReports = append(divergentReports, rep)
+		},
+	}
+	result, _, err := runTestReproEnv(t, log, env, &testExecInterface{
+		run: func(p []byte) (*instance.RunResult, error) {
+			if strings.Contains(string(p), "pause()") {
+				return fakeCrashResult("WARNING: unrelated warning"), nil
+			}
+			if strings.Contains(string(p), "alarm(0xa)") {
+				return fakeCrashResult("panic: target error"), nil
+			}
+			return fakeCrashResult(""), nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "panic: target error", result.Report.Title)
+	require.Equal(t, "alarm(0xa)\n", string(result.Prog.Serialize()))
+
+	require.Len(t, divergentReports, 1)
+	require.Equal(t, "WARNING: unrelated warning", divergentReports[0].Title)
+	require.Contains(t, string(divergentReports[0].Output), "pause()")
+}
+
+func TestNoInitialReport(t *testing.T) {
+	const log = `
+2015/12/21 12:18:05 executing program 1:
+alarm(0xa)
+2015/12/21 12:18:10 executing program 2:
+pause()
+`
+	result, _, err := runTestRepro(t, log, &testExecInterface{
+		run: func(p []byte) (*instance.RunResult, error) {
+			if strings.Contains(string(p), "pause()") {
+				return fakeCrashResult("WARNING: first crash"), nil
+			}
+			return fakeCrashResult(""), nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "WARNING: first crash", result.Report.Title)
+	require.Equal(t, "pause()\n", string(result.Prog.Serialize()))
+}
+
+// Verify that if Executor.ExecID is present in the crash report, that program is tested
+// first rather than the last entry of each proc.
+func TestCrashExecutorPriority(t *testing.T) {
+	const log = `
+2015/12/21 12:18:05 executing program 1 (id=100):
+alarm(0xa)
+2015/12/21 12:18:10 executing program 2 (id=200):
+pause()
+`
+	env := Environment{
+		TargetReport: &report.Report{
+			Title: "panic: target error",
+			Type:  crash.TitleToType("panic: target error"),
+			Executor: &report.ExecutorInfo{
+				ExecID: 100,
+			},
+		},
+	}
+	var testedProgs []string
+	result, _, err := runTestReproEnv(t, log, env, &testExecInterface{
+		run: func(p []byte) (*instance.RunResult, error) {
+			testedProgs = append(testedProgs, string(p))
+			if strings.Contains(string(p), "alarm(0xa)") {
+				return fakeCrashResult("panic: target error"), nil
+			}
+			return fakeCrashResult(""), nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "alarm(0xa)\n", string(result.Prog.Serialize()))
+	require.NotEmpty(t, testedProgs)
+	require.Contains(t, testedProgs[0], "alarm(0xa)")
 }

--- a/pkg/repro/repro_test.go
+++ b/pkg/repro/repro_test.go
@@ -572,3 +572,51 @@ pause()
 	require.NotEmpty(t, testedProgs)
 	require.Contains(t, testedProgs[0], "alarm(0xa)")
 }
+
+// Verify that during the validation phase, title switches of the same bug type are accepted
+// towards reliability, while low-priority failures and different bug types are ignored.
+func TestValidationRelaxedMatching(t *testing.T) {
+	ctx := &reproContext{
+		targetReport: &report.Report{
+			Title: "WARNING in sock_init_data",
+			Type:  crash.Warning,
+		},
+		stats:      new(Stats),
+		validating: true,
+	}
+	// Title variation of the same bug type is accepted.
+	v, err := ctx.getVerdict(func() (*instance.RunResult, error) {
+		return &instance.RunResult{
+			Report: &report.Report{
+				Title: "WARNING in sock_setsockopt",
+				Type:  crash.Warning,
+			},
+		}, nil
+	}, nil, false)
+	require.NoError(t, err)
+	require.True(t, v.Crashed)
+
+	// Downgrade to low-priority failure (e.g. lost connection) is rejected.
+	v, err = ctx.getVerdict(func() (*instance.RunResult, error) {
+		return &instance.RunResult{
+			Report: &report.Report{
+				Title: "lost connection to test machine",
+				Type:  crash.LostConnection,
+			},
+		}, nil
+	}, nil, false)
+	require.NoError(t, err)
+	require.False(t, v.Crashed)
+
+	// Different bug type (e.g. BUG vs Warning) is rejected.
+	v, err = ctx.getVerdict(func() (*instance.RunResult, error) {
+		return &instance.RunResult{
+			Report: &report.Report{
+				Title: "BUG: unable to handle kernel paging request",
+				Type:  crash.Bug,
+			},
+		}, nil
+	}, nil, false)
+	require.NoError(t, err)
+	require.False(t, v.Crashed)
+}

--- a/pkg/repro/strace.go
+++ b/pkg/repro/strace.go
@@ -75,5 +75,5 @@ func (strace *StraceResult) IsSameBug(repro *Result) bool {
 	if strace == nil || strace.Report == nil || repro.Report == nil {
 		return false
 	}
-	return strace.Report.Title == repro.Report.Title
+	return strace.Report.SameBug(repro.Report)
 }

--- a/pkg/rpcserver/last_executing.go
+++ b/pkg/rpcserver/last_executing.go
@@ -94,9 +94,5 @@ func PrependExecuting(rep *report.Report, lastExec []ExecRecord) {
 		fmt.Fprintf(buf, "%v ago: executing program %v (id=%v):\n%s\n", exec.Time, exec.Proc, exec.ID, exec.Prog)
 	}
 	fmt.Fprintf(buf, "kernel console output (not intermixed with test programs):\n\n")
-	rep.Output = append(buf.Bytes(), rep.Output...)
-	n := len(buf.Bytes())
-	rep.StartPos += n
-	rep.EndPos += n
-	rep.SkipPos += n
+	rep.PrependOutput(buf.Bytes())
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -882,6 +882,15 @@ func (mgr *Manager) saveRepro(res *manager.ReproResult) {
 		}
 	}
 
+	if err := mgr.reporter.Symbolize(repro.Report); err != nil {
+		log.Errorf("failed to symbolize report: %v", err)
+	}
+	if res.Strace != nil && res.Strace.Report != nil {
+		if err := mgr.reporter.Symbolize(res.Strace.Report); err != nil {
+			log.Errorf("failed to symbolize report: %v", err)
+		}
+	}
+
 	if mgr.dash != nil {
 		// Note: we intentionally don't set Corrupted for reproducers:
 		// 1. This is reproducible so can be debugged even with corrupted report.

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -537,14 +537,13 @@ func reportReproError(err error) {
 }
 
 func (mgr *Manager) RunRepro(ctx context.Context, crash *manager.Crash) *manager.ReproResult {
-	res, stats, err := repro.Run(ctx, crash.Output, repro.Environment{
-		Config:       mgr.cfg,
-		Features:     mgr.enabledFeatures,
-		Reporter:     mgr.reporter,
-		Pool:         mgr.pool,
-		TargetReport: crash.Report,
+	res, stats, err := runRepro(ctx, crash, repro.Environment{
+		Config:   mgr.cfg,
+		Features: mgr.enabledFeatures,
+		Reporter: mgr.reporter,
+		Pool:     mgr.pool,
 		OnDivergentCrash: func(rep *report.Report) {
-			log.Logf(0, "reproducing %q yielded divergent crash %q", crash.Title, rep.Title)
+			log.Logf(0, "reproducing %q yielded divergent crash %q", crash.FullTitle(), rep.Title)
 			select {
 			case mgr.crashes <- &manager.Crash{Report: rep}:
 			case <-ctx.Done():
@@ -576,6 +575,14 @@ func (mgr *Manager) RunRepro(ctx context.Context, crash *manager.Crash) *manager
 	mgr.processRepro(ret)
 
 	return ret
+}
+
+func runRepro(ctx context.Context, crash *manager.Crash, env repro.Environment) (
+	*repro.Result, *repro.Stats, error) {
+	if crash.Report == nil || crash.Report.Title == "" {
+		return repro.RunFromLog(ctx, crash.Output, env)
+	}
+	return repro.Run(ctx, crash.Report, env)
 }
 
 func (mgr *Manager) processRepro(res *manager.ReproResult) {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -538,10 +538,18 @@ func reportReproError(err error) {
 
 func (mgr *Manager) RunRepro(ctx context.Context, crash *manager.Crash) *manager.ReproResult {
 	res, stats, err := repro.Run(ctx, crash.Output, repro.Environment{
-		Config:   mgr.cfg,
-		Features: mgr.enabledFeatures,
-		Reporter: mgr.reporter,
-		Pool:     mgr.pool,
+		Config:       mgr.cfg,
+		Features:     mgr.enabledFeatures,
+		Reporter:     mgr.reporter,
+		Pool:         mgr.pool,
+		TargetReport: crash.Report,
+		OnDivergentCrash: func(rep *report.Report) {
+			log.Logf(0, "reproducing %q yielded divergent crash %q", crash.Title, rep.Title)
+			select {
+			case mgr.crashes <- &manager.Crash{Report: rep}:
+			case <-ctx.Done():
+			}
+		},
 	})
 	ret := &manager.ReproResult{
 		Crash: crash,

--- a/tools/syz-crush/crush.go
+++ b/tools/syz-crush/crush.go
@@ -122,7 +122,7 @@ func main() {
 		count++
 		if rep != nil {
 			crashes++
-			storeCrash(cfg, rep)
+			storeCrash(cfg, reporter, rep)
 		}
 		log.Printf("instances executed: %v, crashes: %v", count, crashes)
 	}
@@ -130,8 +130,13 @@ func main() {
 	log.Printf("all done. reproduced %v crashes. reproduce rate %.2f%%", crashes, float64(crashes)/float64(count)*100.0)
 }
 
-func storeCrash(cfg *mgrconfig.Config, res *instance.RunResult) {
+func storeCrash(cfg *mgrconfig.Config, reporter *report.Reporter, res *instance.RunResult) {
 	rep := res.Report
+	if reporter != nil && len(rep.Report) > 0 {
+		if err := reporter.Symbolize(rep); err != nil {
+			log.Printf("failed to symbolize report: %v", err)
+		}
+	}
 	id := hash.String([]byte(rep.Title))
 	dir := filepath.Join(filepath.Dir(flag.Args()[0]), "crashes", id)
 	osutil.MkdirAll(dir)

--- a/tools/syz-repro/repro.go
+++ b/tools/syz-repro/repro.go
@@ -67,7 +67,7 @@ func main() {
 	go func() {
 		defer done()
 
-		res, stats, err := repro.Run(ctx, data, repro.Environment{
+		res, stats, err := repro.RunFromLog(ctx, data, repro.Environment{
 			Config:   cfg,
 			Features: flatrpc.AllFeatures,
 			Reporter: reporter,


### PR DESCRIPTION
During bug reproduction, replaying logs can trigger unrelated kernel
crashes. Previously, these were either discarded or mishandled by title
filters, losing new crash reports and failing reproduction attempts.

Forward newly observed divergent crashes to the manager via an OnDivergentCrash
callback, and grant multi-program runs an extra retry to trigger the target bug.
Use Report.SameBug for title matching, and lock in the first observed crash when
reproducing without an initial target report.

Drop log truncation based on report StartPos because external report offsets
do not match the current log and programs are no longer interleaved with console
output. Clean up obsolete reproducer state and simplify bisection with generic
slice minimization.

***

May be much easier to review with disabled whitespaces in the git diff - there many identation changes.