### PR TITLE
pkg/aflow/flow/fuzzing: add finding-triage workflow

### DIFF
--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -21,6 +21,7 @@ const (
 	WorkflowPatchTriage        = WorkflowType("patch-triage")
 	WorkflowSeedGen            = WorkflowType("seed-gen")
 	WorkflowSeedGenFileLine    = WorkflowType("seed-gen-file-line")
+	WorkflowFindingTriage      = WorkflowType("finding-triage")
 )
 
 // Outputs of various workflow types.
@@ -171,4 +172,22 @@ type SeedGenOutputs struct {
 	Success bool
 	GiveUp  bool
 	Reason  string
+}
+
+type SeriesPatch struct {
+	Seq   int
+	Title string
+	Body  string
+}
+
+type FindingTriageArgs struct {
+	TargetArch  string
+	KernelSrc   string
+	Patches     []SeriesPatch `json:",omitempty"`
+	CrashReport string
+}
+
+type FindingTriageResult struct {
+	Introduced bool   `jsonschema:"True only if crash was introduced by the tested patch series."`
+	Reasoning  string `jsonschema:"Detailed explanation analyzing crash report against patch diffs."`
 }

--- a/pkg/aflow/flow/fuzzing/finding_triage.go
+++ b/pkg/aflow/flow/fuzzing/finding_triage.go
@@ -1,0 +1,165 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
+	"github.com/google/syzkaller/pkg/aflow/tool/gitlog"
+	"github.com/google/syzkaller/pkg/aflow/tool/grepper"
+	"github.com/google/syzkaller/pkg/osutil"
+)
+
+func init() {
+	aflow.Register[ai.FindingTriageArgs, ai.FindingTriageResult](
+		ai.WorkflowFindingTriage,
+		"evaluate if a kernel crash finding was introduced by the patch series",
+		&aflow.Flow{
+			Root: aflow.Pipeline(
+				prepareFindingOverview,
+				&aflow.LLMAgent{
+					Name:     "finding-triage-evaluator",
+					Model:    aflow.CoreModel,
+					TaskType: aflow.FormalReasoningTask,
+					Outputs: aflow.ValidatedLLMOutputs[ai.FindingTriageResult](
+						func(ctx *aflow.Context, state ai.FindingTriageArgs,
+							args ai.FindingTriageResult) (ai.FindingTriageResult, error) {
+							if args.Reasoning == "" {
+								return args, aflow.BadCallError("reasoning must be provided")
+							}
+							return args, nil
+						},
+					),
+					Tools: aflow.Tools(
+						grepper.Tool,
+						codesearcher.FilesystemTools,
+						ToolSeriesPatches,
+						gitlog.ToolShow,
+						gitlog.ToolBlame,
+					),
+					Instruction: findingTriageInstruction,
+					Prompt:      findingTriagePrompt,
+				},
+			),
+		},
+	)
+}
+
+type prepareFindingOverviewArgs struct {
+	KernelSrc string
+	Patches   []ai.SeriesPatch
+}
+
+type prepareFindingOverviewResult struct {
+	DiffStat   string
+	PatchList  string
+	PatchCount int
+	HasCover   bool
+}
+
+var prepareFindingOverview = aflow.NewFuncAction("prepare-finding-overview",
+	func(ctx *aflow.Context, args prepareFindingOverviewArgs) (prepareFindingOverviewResult, error) {
+		patchCount, hasCover := countPatches(args.Patches)
+		res := prepareFindingOverviewResult{
+			PatchCount: patchCount,
+			HasCover:   hasCover,
+		}
+
+		if args.KernelSrc == "" {
+			return res, errors.New("KernelSrc must not be empty")
+		}
+
+		cmd := osutil.Command("git", "show", "--stat", "--format=", "HEAD")
+		cmd.Dir = args.KernelSrc
+		if err := osutil.Sandbox(cmd, true, true); err != nil {
+			return res, err
+		}
+		out, err := osutil.Run(time.Minute, cmd)
+		if err != nil {
+			return res, fmt.Errorf("git show --stat failed: %w", err)
+		}
+		res.DiffStat = strings.TrimSpace(string(out))
+
+		res.PatchList = formatPatchList(args.Patches)
+
+		return res, nil
+	})
+
+const findingTriageInstruction = `You are an expert Linux kernel maintainer and security engineer specializing
+in crash triage and root-cause analysis.
+Your job is to review a kernel crash report (finding) and determine if it was introduced / caused
+by the patch series being tested, or if it is a pre-existing / unrelated bug.
+
+IMPORTANT: The entire patch series has ALREADY been applied and committed as a single squashed commit
+at HEAD (or on top of the base commit) in your workspace.
+Do NOT rely on your internal knowledge of the kernel. You must actively use your tools to examine
+the source code, inspect workspace diffs, and confirm any assumptions.
+
+Available Tools:
+- {{.toolGitShow}}: View the squashed patch series commit or historical commits. Call with Commit="HEAD" (default)
+  and optional 'File' parameter to restrict the diff to a specific file or directory, or 'Stat=true' for a diffstat.
+- {{.toolSeriesPatches}}: Browse the original patch series. Call without arguments to list all patch titles,
+  or PatchNum=<N> to view the full description and diff of a specific patch (or cover letter, if present).
+- {{.toolReadFile}} & {{.toolCodesearchDirIndex}}: Read exact source code files and directory contents in the workspace.
+- {{.toolGrepper}}: Regex search across files in the workspace (git grep).
+- {{.toolGitBlame}}: Inspect line authorship and find which commit last modified specific lines of code.
+
+Triage Procedure:
+1. Analyze the Crash Report:
+   - Identify the crash type (e.g. NULL dereference, KASAN use-after-free, out-of-bounds read/write,
+     assertion failure, deadlock).
+   - Carefully examine the stack trace(s) — both the faulting call stack and, if applicable (e.g., KASAN UAF),
+     the allocation and free stacks.
+   - Note the faulting function, file name, line numbers, and the specific variables or data structures involved.
+
+2. Inspect Workspace Changes & Patch Series:
+   - Check if any files or functions from the stack trace appear in the modified files overview or the patch series.
+   - Use {{.toolGitShow}} with Commit="HEAD" and 'File' to inspect the exact diffs for relevant files
+     in the squashed commit.
+   - If needed, use {{.toolSeriesPatches}} with PatchNum=<N> to inspect the author's commit description
+     and rationale for individual patches in the series.
+   - Use {{.toolReadFile}} to inspect the actual source code at the faulting lines.
+
+3. Determine Causality:
+   - Set Introduced=true ONLY IF you are absolutely certain:
+     * There is clear, unambiguous, and conclusive evidence that the crash was directly introduced
+       or caused by the patch series.
+     * The crash occurs directly in new or modified code introduced by the patch series, or the patch series
+       altered data structures, locking, object lifetimes, or preconditions in a way that directly
+       triggered the failure in existing code.
+   - Set Introduced=false IF:
+     * There is any doubt, ambiguity, or lack of conclusive proof that the patch series caused the bug.
+     * The crash occurs in an unrelated subsystem or unmodified code path whose behavior is independent
+       of the patch series.
+     * The crash is a pre-existing kernel issue that was randomly triggered during fuzzing.
+
+4. Formulate Output:
+   - Set Introduced to true or false.
+   - In Reasoning, provide a clear, step-by-step technical explanation detailing the crash type,
+     the key stack frames, whether the affected code/structures were modified by the patch series,
+     and the causal justification for your verdict.`
+
+const findingTriagePrompt = `Target architecture: {{.TargetArch}}
+
+The kernel crash report to triage is:
+
+{{.CrashReport}}
+
+{{if .DiffStat}}
+Overview of modified files in the workspace:
+{{.DiffStat}}
+{{end}}
+
+{{if le .PatchCount 10}}
+{{.PatchList}}
+{{else}}
+The patch series contains {{.PatchCount}} patches{{if .HasCover}} and a cover letter{{end}}.
+Use {{.toolSeriesPatches}} to inspect individual patches.
+{{end}}`

--- a/pkg/aflow/flow/fuzzing/finding_triage_test.go
+++ b/pkg/aflow/flow/fuzzing/finding_triage_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/vcs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowFindingTriageRegistered(t *testing.T) {
+	flow := aflow.Flows[string(ai.WorkflowFindingTriage)]
+	require.NotNil(t, flow, "WorkflowFindingTriage must be registered in aflow.Flows")
+}
+
+func TestPrepareFindingOverview(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
+
+	repo.CommitChangeset("initial commit", vcs.FileContent{
+		File:    "foo.c",
+		Content: "void foo() {}\n",
+	})
+	repo.CommitChangeset("second commit", vcs.FileContent{
+		File:    "foo.c",
+		Content: "void foo() { int x = 1; }\n",
+	})
+
+	patches := []ai.SeriesPatch{
+		{Seq: 1, Title: "net: fix foo"},
+		{Seq: 2, Title: "net: fix bar"},
+	}
+
+	aflow.TestAction(t, prepareFindingOverview, tmpDir,
+		prepareFindingOverviewArgs{
+			KernelSrc: repoDir,
+			Patches:   patches,
+		},
+		prepareFindingOverviewResult{
+			DiffStat:   "foo.c | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)",
+			PatchList:  "The patch series contains 2 patches:\n[1] net: fix foo\n[2] net: fix bar",
+			PatchCount: 2,
+			HasCover:   false,
+		},
+		"")
+
+	// Test with cover letter.
+	patchesWithCover := []ai.SeriesPatch{
+		{Seq: 0, Title: "net: fix bugs"},
+		{Seq: 1, Title: "net: fix foo"},
+	}
+	aflow.TestAction(t, prepareFindingOverview, tmpDir,
+		prepareFindingOverviewArgs{
+			KernelSrc: repoDir,
+			Patches:   patchesWithCover,
+		},
+		prepareFindingOverviewResult{
+			DiffStat: "foo.c | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)",
+			PatchList: "The patch series contains 1 patch and a cover letter:\n" +
+				"[0] (Cover letter) net: fix bugs\n[1] net: fix foo",
+			PatchCount: 1,
+			HasCover:   true,
+		},
+		"")
+
+	// Test error with empty KernelSrc.
+	aflow.TestAction(t, prepareFindingOverview, tmpDir,
+		prepareFindingOverviewArgs{
+			KernelSrc: "",
+			Patches:   patches,
+		},
+		prepareFindingOverviewResult{},
+		"KernelSrc must not be empty")
+
+	// Test error with invalid KernelSrc directory.
+	aflow.TestAction(t, prepareFindingOverview, tmpDir,
+		prepareFindingOverviewArgs{
+			KernelSrc: t.TempDir(),
+			Patches:   patches,
+		},
+		prepareFindingOverviewResult{},
+		`git show --stat failed: failed to run ["git" "show" "--stat" "--format=" "HEAD"]: exit status 128`)
+}

--- a/pkg/aflow/flow/fuzzing/series_tool.go
+++ b/pkg/aflow/flow/fuzzing/series_tool.go
@@ -58,14 +58,7 @@ func seriesPatches(ctx *aflow.Context, state seriesPatchesState, args seriesPatc
 		}, nil
 	}
 
-	lines := slices.Collect(strings.Lines(target.Body))
-	var body string
-	if len(lines) > maxPatchLines {
-		body = fmt.Sprintf("%s\n[Output truncated: showing %d of %d lines]",
-			strings.TrimRight(strings.Join(lines[:maxPatchLines], ""), "\n"), maxPatchLines, len(lines))
-	} else {
-		body = target.Body
-	}
+	body := aflow.TruncateText(target.Body, maxPatchLines)
 
 	prefix := fmt.Sprintf("Patch [%d]", target.Seq)
 	if target.Seq == 0 {

--- a/pkg/aflow/flow/fuzzing/series_tool.go
+++ b/pkg/aflow/flow/fuzzing/series_tool.go
@@ -1,0 +1,118 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+)
+
+var ToolSeriesPatches = aflow.NewFuncTool("series-patches", seriesPatches, `
+Tool allows exploring the original patch series submitted for testing.
+Omit PatchNum to return the complete numbered list of all patch titles in the series.
+Provide PatchNum to view full description and diff of a specific patch
+(pass 0 for cover letter, if present).
+`)
+
+type seriesPatchesState struct {
+	Patches []ai.SeriesPatch
+}
+
+type seriesPatchesArgs struct {
+	PatchNum *int `jsonschema:"Patch sequence number (or 0 for cover, if present). Omit to list."`
+}
+
+type seriesPatchesResult struct {
+	Output string `jsonschema:"Formatted patch list or content of the selected patch."`
+}
+
+const maxPatchLines = 1000
+
+func seriesPatches(ctx *aflow.Context, state seriesPatchesState, args seriesPatchesArgs) (seriesPatchesResult, error) {
+	if len(state.Patches) == 0 {
+		return seriesPatchesResult{Output: "No patches available in the series."}, nil
+	}
+
+	if args.PatchNum == nil {
+		return seriesPatchesResult{Output: formatPatchList(state.Patches)}, nil
+	}
+
+	targetNum := *args.PatchNum
+	var target *ai.SeriesPatch
+	if idx := slices.IndexFunc(state.Patches, func(p ai.SeriesPatch) bool {
+		return p.Seq == targetNum
+	}); idx >= 0 {
+		target = &state.Patches[idx]
+	}
+
+	if target == nil {
+		list := formatPatchList(state.Patches)
+		return seriesPatchesResult{
+			Output: fmt.Sprintf("%s\n\n(Note: PatchNum %d was not found, showing full patch list above)",
+				list, targetNum),
+		}, nil
+	}
+
+	lines := slices.Collect(strings.Lines(target.Body))
+	var body string
+	if len(lines) > maxPatchLines {
+		body = fmt.Sprintf("%s\n[Output truncated: showing %d of %d lines]",
+			strings.TrimRight(strings.Join(lines[:maxPatchLines], ""), "\n"), maxPatchLines, len(lines))
+	} else {
+		body = target.Body
+	}
+
+	prefix := fmt.Sprintf("Patch [%d]", target.Seq)
+	if target.Seq == 0 {
+		prefix = "Cover letter [0]"
+	}
+	output := fmt.Sprintf("%s %s:\n\n%s", prefix, target.Title, body)
+
+	return seriesPatchesResult{
+		Output: strings.TrimSpace(output),
+	}, nil
+}
+
+func countPatches(patches []ai.SeriesPatch) (count int, hasCover bool) {
+	for _, p := range patches {
+		if p.Seq == 0 {
+			hasCover = true
+		} else {
+			count++
+		}
+	}
+	return count, hasCover
+}
+
+func formatPatchList(patches []ai.SeriesPatch) string {
+	if len(patches) == 0 {
+		return ""
+	}
+	count, hasCover := countPatches(patches)
+	var b strings.Builder
+	cover := ""
+	if hasCover {
+		cover = " and a cover letter"
+	}
+	fmt.Fprintf(&b, "The patch series contains %s%s:\n", pluralizePatches(count), cover)
+	for _, p := range patches {
+		if p.Seq == 0 {
+			fmt.Fprintf(&b, "[0] (Cover letter) %s\n", p.Title)
+		} else {
+			fmt.Fprintf(&b, "[%d] %s\n", p.Seq, p.Title)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func pluralizePatches(count int) string {
+	if count == 1 {
+		return "1 patch"
+	}
+	return fmt.Sprintf("%d patches", count)
+}

--- a/pkg/aflow/flow/fuzzing/series_tool_test.go
+++ b/pkg/aflow/flow/fuzzing/series_tool_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package fuzzing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolSeriesPatches(t *testing.T) {
+	patches := []ai.SeriesPatch{
+		{
+			Seq:   0,
+			Title: "net: tcp: fix RTO bugs",
+			Body:  "Subject: [PATCH 0/2] net: tcp: fix RTO bugs\n\nCover letter description.\n",
+		},
+		{
+			Seq:   1,
+			Title: "net: tcp: fix retransmission timeout",
+			Body: "Subject: [PATCH 1/2] net: tcp: fix retransmission timeout\n\n" +
+				"Fix RTO calculation.\n\n--- a/net/ipv4/tcp.c\n+++ b/net/ipv4/tcp.c\n@@ -1 +1 @@\n-old\n+new\n",
+		},
+		{
+			Seq:   2,
+			Title: "net: tcp: optimize window calculation",
+			Body: "Subject: [PATCH 2/2] net: tcp: optimize window calculation\n\n" +
+				"Optimize window scale.\n",
+		},
+	}
+
+	// Test listing mode with PatchNum=nil.
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: patches},
+		seriesPatchesArgs{},
+		func(res seriesPatchesResult) {
+			assert.Contains(t, res.Output, "The patch series contains 2 patches and a cover letter:")
+			assert.Contains(t, res.Output, "[0] (Cover letter) net: tcp: fix RTO bugs")
+			assert.Contains(t, res.Output, "[1] net: tcp: fix retransmission timeout")
+			assert.Contains(t, res.Output, "[2] net: tcp: optimize window calculation")
+		},
+		"")
+
+	// Test cover letter with PatchNum=0.
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: patches},
+		seriesPatchesArgs{PatchNum: new(0)},
+		func(res seriesPatchesResult) {
+			require.Equal(t, `Cover letter [0] net: tcp: fix RTO bugs:
+
+Subject: [PATCH 0/2] net: tcp: fix RTO bugs
+
+Cover letter description.`, res.Output)
+		},
+		"")
+
+	// Test detail mode with valid PatchNum=1.
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: patches},
+		seriesPatchesArgs{PatchNum: new(1)},
+		func(res seriesPatchesResult) {
+			assert.Contains(t, res.Output, "Patch [1] net: tcp: fix retransmission timeout:")
+			assert.Contains(t, res.Output, "Fix RTO calculation.")
+			assert.Contains(t, res.Output, "+new")
+		},
+		"")
+
+	// Test detail mode with valid PatchNum=2.
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: patches},
+		seriesPatchesArgs{PatchNum: new(2)},
+		func(res seriesPatchesResult) {
+			assert.Contains(t, res.Output, "Patch [2] net: tcp: optimize window calculation:")
+			assert.Contains(t, res.Output, "Optimize window scale.")
+		},
+		"")
+
+	// Test non-existent PatchNum (e.g. 5).
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: patches},
+		seriesPatchesArgs{PatchNum: new(5)},
+		func(res seriesPatchesResult) {
+			assert.Contains(t, res.Output, "The patch series contains 2 patches and a cover letter:")
+			assert.Contains(t, res.Output, "[0] (Cover letter) net: tcp: fix RTO bugs")
+			assert.Contains(t, res.Output, "PatchNum 5 was not found")
+		},
+		"")
+
+	// Test empty patches slice.
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: nil},
+		seriesPatchesArgs{},
+		func(res seriesPatchesResult) {
+			assert.Equal(t, "No patches available in the series.", res.Output)
+		},
+		"")
+
+	// Test patch truncation.
+	longBody := strings.Repeat("line\n", 1100)
+	aflow.TestTool(t, ToolSeriesPatches,
+		seriesPatchesState{Patches: []ai.SeriesPatch{{Seq: 1, Title: "long patch", Body: longBody}}},
+		seriesPatchesArgs{PatchNum: new(1)},
+		func(res seriesPatchesResult) {
+			assert.Contains(t, res.Output, "[Output truncated: showing 1000 of 1100 lines]")
+		},
+		"")
+}
+
+func TestFormatPatchList(t *testing.T) {
+	tests := []struct {
+		name    string
+		patches []ai.SeriesPatch
+		want    string
+	}{
+		{
+			name:    "empty",
+			patches: nil,
+			want:    "",
+		},
+		{
+			name: "single patch without cover",
+			patches: []ai.SeriesPatch{
+				{Seq: 1, Title: "fix bug"},
+			},
+			want: "The patch series contains 1 patch:\n[1] fix bug",
+		},
+		{
+			name: "multiple patches without cover",
+			patches: []ai.SeriesPatch{
+				{Seq: 1, Title: "fix bug 1"},
+				{Seq: 2, Title: "fix bug 2"},
+			},
+			want: "The patch series contains 2 patches:\n[1] fix bug 1\n[2] fix bug 2",
+		},
+		{
+			name: "single patch with cover",
+			patches: []ai.SeriesPatch{
+				{Seq: 0, Title: "cover"},
+				{Seq: 1, Title: "fix bug"},
+			},
+			want: "The patch series contains 1 patch and a cover letter:\n[0] (Cover letter) cover\n[1] fix bug",
+		},
+		{
+			name: "multiple patches with cover",
+			patches: []ai.SeriesPatch{
+				{Seq: 0, Title: "cover"},
+				{Seq: 1, Title: "fix bug 1"},
+				{Seq: 2, Title: "fix bug 2"},
+			},
+			want: "The patch series contains 2 patches and a cover letter:\n" +
+				"[0] (Cover letter) cover\n" +
+				"[1] fix bug 1\n" +
+				"[2] fix bug 2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatPatchList(tt.patches)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/google/syzkaller/pkg/aflow"
-	"github.com/google/syzkaller/pkg/aflow/action/kernel"
 	"github.com/google/syzkaller/pkg/osutil"
-	"github.com/google/syzkaller/pkg/vcs"
 )
 
 var sinceRegex = regexp.MustCompile(`^\d+\s+(years?|months?|weeks?|days?)$`)
@@ -54,10 +52,13 @@ It helps to identify which commit last modified specific lines of code.
 	Tools = []aflow.Tool{ToolLog, ToolShow, ToolBlame}
 )
 
-const maxOutputLines = 1000
+const (
+	maxOutputLines = 1000
+	headCommit     = "HEAD"
+)
 
 type state struct {
-	KernelCommit string
+	KernelSrc string
 }
 
 type logArgs struct {
@@ -120,18 +121,13 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 		gitArgs = append(gitArgs, "--no-merges")
 	}
 
-	gitArgs = append(gitArgs, state.KernelCommit)
+	gitArgs = append(gitArgs, headCommit)
 
 	if args.PathPrefix != "" {
 		gitArgs = append(gitArgs, "--", args.PathPrefix)
 	}
 
-	var output []byte
-	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
-		var err error
-		output, err = runGit(kernelRepoDir, 10*time.Minute, gitArgs...)
-		return err
-	})
+	output, err := runGit(state.KernelSrc, 10*time.Minute, gitArgs...)
 	if err != nil {
 		return logResult{}, gitBadCallError(err, "git log",
 			"Please specify a tighter search scope (e.g. by providing a PathPrefix).")
@@ -153,26 +149,21 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 		return showResult{}, aflow.BadCallError("commit hash is required")
 	}
 
-	var output []byte
-	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
-		if _, err := runGit(kernelRepoDir, time.Minute, "cat-file", "-e", commitHash+"^{commit}"); err != nil {
-			return gitBadCallError(err, "git show", fmt.Sprintf("commit %v does not exist", commitHash))
-		}
+	if _, err := runGit(state.KernelSrc, time.Minute, "cat-file", "-e", commitHash+"^{commit}"); err != nil {
+		return showResult{}, gitBadCallError(err, "git show", fmt.Sprintf("commit %v does not exist", commitHash))
+	}
 
-		if filePath != "" {
-			out, err := runGit(kernelRepoDir, time.Minute, "ls-tree", "--name-only", commitHash, "--", filePath)
-			if err != nil {
-				return err
-			}
-			if len(bytes.TrimSpace(out)) == 0 {
-				return aflow.BadCallError("file %q is not present on commit %q", filePath, commitHash)
-			}
+	if filePath != "" {
+		out, err := runGit(state.KernelSrc, time.Minute, "ls-tree", "--name-only", commitHash, "--", filePath)
+		if err != nil {
+			return showResult{}, err
 		}
+		if len(bytes.TrimSpace(out)) == 0 {
+			return showResult{}, aflow.BadCallError("file %q is not present on commit %q", filePath, commitHash)
+		}
+	}
 
-		var err error
-		output, err = runGit(kernelRepoDir, 5*time.Minute, "show", "--no-color", args.Commit)
-		return err
-	})
+	output, err := runGit(state.KernelSrc, 5*time.Minute, "show", "--no-color", args.Commit)
 	if err != nil {
 		return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different commit.")
 	}
@@ -194,13 +185,8 @@ func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, err
 	args.End = max(args.End, args.Start)
 	args.End = min(args.End, args.Start+maxOutputLines)
 	lineRange := fmt.Sprintf("%d,%d", args.Start, args.End)
-	var output []byte
-	err := kernel.UseLinuxRepo(ctx, func(kernelRepoDir string, _ vcs.Repo) error {
-		var err error
-		output, err = runGit(kernelRepoDir, 5*time.Minute,
-			"blame", "-s", "-L", lineRange, "--abbrev=12", state.KernelCommit, "--", args.File)
-		return err
-	})
+	output, err := runGit(state.KernelSrc, 5*time.Minute,
+		"blame", "-s", "-L", lineRange, "--abbrev=12", headCommit, "--", args.File)
 	if err != nil {
 		return blameResult{}, gitBadCallError(err, "git blame", "Consider specifying a smaller line range.")
 	}

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
@@ -190,7 +189,7 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 			Timeout: "Consider specifying a different commit.",
 		})
 	}
-	return showResult{Output: truncate(output, maxOutputLines)}, nil
+	return showResult{Output: aflow.TruncateText(string(output), maxOutputLines)}, nil
 }
 
 type blameArgs struct {
@@ -215,7 +214,7 @@ func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, err
 			Timeout: "Consider specifying a smaller line range.",
 		})
 	}
-	return blameResult{Output: truncate(output, maxOutputLines)}, nil
+	return blameResult{Output: aflow.TruncateText(string(output), maxOutputLines)}, nil
 }
 
 type gitAdvice struct {
@@ -261,18 +260,6 @@ func isBadCall(output []byte) bool {
 		bytes.Contains(output, []byte("no match")) ||
 		bytes.Contains(output, []byte("has only")) ||
 		bytes.Contains(output, []byte("no such path"))
-}
-
-func truncate(output []byte, maxLines int) string {
-	lines := slices.Collect(bytes.Lines(output))
-	if len(lines) <= maxLines {
-		return string(output)
-	}
-	return fmt.Sprintf(`
-Full output is too long, showing %v out of %v lines.
-
-%s
-`, maxLines, len(lines), slices.Concat(lines[:maxLines]))
 }
 
 func runGit(dir string, timeout time.Duration, args ...string) ([]byte, error) {

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -132,8 +132,9 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 
 	output, err := runGit(state.KernelSrc, 10*time.Minute, gitArgs...)
 	if err != nil {
-		return logResult{}, gitBadCallError(err, "git log",
-			"Please specify a tighter search scope (e.g. by providing a PathPrefix).")
+		return logResult{}, gitBadCallError(err, "git log", gitAdvice{
+			Timeout: "Please specify a tighter search scope (e.g. by providing a PathPrefix).",
+		})
 	}
 	return logResult{Output: string(output)}, nil
 }
@@ -159,13 +160,15 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 	}
 
 	if _, err := runGit(state.KernelSrc, time.Minute, "cat-file", "-e", commitHash+"^{commit}"); err != nil {
-		return showResult{}, gitBadCallError(err, "git show", fmt.Sprintf("commit %v does not exist", commitHash))
+		return showResult{}, gitBadCallError(err, "git show", gitAdvice{
+			NotFound: fmt.Sprintf("commit %v does not exist", commitHash),
+		})
 	}
 
 	if filePath != "" {
 		out, err := runGit(state.KernelSrc, time.Minute, "ls-tree", "--name-only", commitHash, "--", filePath)
 		if err != nil {
-			return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different file path.")
+			return showResult{}, gitBadCallError(err, "git show", gitAdvice{})
 		}
 		if len(bytes.TrimSpace(out)) == 0 {
 			return showResult{}, aflow.BadCallError("file %q is not present on commit %q", filePath, commitHash)
@@ -183,7 +186,9 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 
 	output, err := runGit(state.KernelSrc, 5*time.Minute, gitArgs...)
 	if err != nil {
-		return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different commit.")
+		return showResult{}, gitBadCallError(err, "git show", gitAdvice{
+			Timeout: "Consider specifying a different commit.",
+		})
 	}
 	return showResult{Output: truncate(output, maxOutputLines)}, nil
 }
@@ -206,37 +211,56 @@ func gitBlame(ctx *aflow.Context, state state, args blameArgs) (blameResult, err
 	output, err := runGit(state.KernelSrc, 5*time.Minute,
 		"blame", "-s", "-L", lineRange, "--abbrev=12", headCommit, "--", args.File)
 	if err != nil {
-		return blameResult{}, gitBadCallError(err, "git blame", "Consider specifying a smaller line range.")
+		return blameResult{}, gitBadCallError(err, "git blame", gitAdvice{
+			Timeout: "Consider specifying a smaller line range.",
+		})
 	}
 	return blameResult{Output: truncate(output, maxOutputLines)}, nil
 }
 
-func gitBadCallError(err error, name, advice string) error {
+type gitAdvice struct {
+	Timeout  string
+	NotFound string
+}
+
+func gitBadCallError(err error, name string, advice gitAdvice) error {
 	var verr *osutil.VerboseError
 	if !errors.As(err, &verr) {
 		return err
 	}
 	if errors.Is(err, osutil.ErrTimeout) {
-		return aflow.BadCallError("%s timed out. %s", name, advice)
+		if advice.Timeout != "" {
+			return aflow.BadCallError("%s timed out. %s", name, advice.Timeout)
+		}
+		return aflow.BadCallError("%s timed out", name)
 	}
-	if verr.ExitCode == 128 && (bytes.Contains(verr.Output, []byte("bad object")) ||
-		bytes.Contains(verr.Output, []byte("Not a valid object name")) ||
-		bytes.Contains(verr.Output, []byte("bad revision")) ||
-		bytes.Contains(verr.Output, []byte("unknown revision")) ||
-		bytes.Contains(verr.Output, []byte("ambiguous argument")) ||
-		bytes.Contains(verr.Output, []byte("no match")) ||
-		bytes.Contains(verr.Output, []byte("has only")) ||
-		bytes.Contains(verr.Output, []byte("no such path"))) {
-		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
-	}
-	// This should mean an invalid grep expression.
-	if verr.ExitCode == 128 && bytes.Contains(verr.Output, []byte("fatal:")) {
-		return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
+	if verr.ExitCode == 128 {
+		if advice.NotFound != "" && isNotFound(verr.Output) {
+			return aflow.BadCallError("%s failed: %s", name, advice.NotFound)
+		}
+		if isBadCall(verr.Output) || bytes.Contains(verr.Output, []byte("fatal:")) {
+			return aflow.BadCallError("%s failed: %s", name, bytes.TrimSpace(verr.Output))
+		}
 	}
 	if verr.ExitCode == 1 && len(verr.Output) == 0 {
 		return nil // No matches is a valid result.
 	}
 	return err
+}
+
+func isNotFound(output []byte) bool {
+	return bytes.Contains(output, []byte("bad object")) ||
+		bytes.Contains(output, []byte("Not a valid object name")) ||
+		bytes.Contains(output, []byte("bad revision")) ||
+		bytes.Contains(output, []byte("unknown revision"))
+}
+
+func isBadCall(output []byte) bool {
+	return isNotFound(output) ||
+		bytes.Contains(output, []byte("ambiguous argument")) ||
+		bytes.Contains(output, []byte("no match")) ||
+		bytes.Contains(output, []byte("has only")) ||
+		bytes.Contains(output, []byte("no such path"))
 }
 
 func truncate(output []byte, maxLines int) string {

--- a/pkg/aflow/tool/gitlog/gitlog.go
+++ b/pkg/aflow/tool/gitlog/gitlog.go
@@ -43,6 +43,9 @@ Use 'Since' to limit how far back to search. It accepts duration strings like "3
 	ToolShow = aflow.NewFuncTool("git-show", gitShow, `
 Tool provides full information about a specific git commit, including its title,
 full description, and the diff.
+Defaults to 'HEAD' if Commit is omitted.
+Use the 'File' parameter to restrict the diff to a specific file or directory path.
+Use the 'Stat' parameter to see a diffstat summary of modified files and line counts.
 `)
 	ToolBlame = aflow.NewFuncTool("git-blame", gitBlame, `
 Tool provides git blame for a given file and line range.
@@ -136,7 +139,9 @@ func gitLog(ctx *aflow.Context, state state, args logArgs) (logResult, error) {
 }
 
 type showArgs struct {
-	Commit string `jsonschema:"Commit hash or reference (hash:file/name.c)."`
+	Commit string `jsonschema:"Commit hash or reference (e.g. 'HEAD'). Defaults to 'HEAD' if omitted." json:",omitempty"`
+	File   string `jsonschema:"Optional: restrict the commit diff to a specific file or directory." json:",omitempty"`
+	Stat   bool   `jsonschema:"Optional: if true, show diffstat summary of modified files." json:",omitempty"`
 }
 
 type showResult struct {
@@ -144,9 +149,13 @@ type showResult struct {
 }
 
 func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error) {
+	if args.Commit == "" {
+		args.Commit = headCommit
+	}
 	commitHash, filePath, _ := strings.Cut(args.Commit, ":")
 	if commitHash == "" {
-		return showResult{}, aflow.BadCallError("commit hash is required")
+		commitHash = headCommit
+		args.Commit = headCommit + ":" + filePath
 	}
 
 	if _, err := runGit(state.KernelSrc, time.Minute, "cat-file", "-e", commitHash+"^{commit}"); err != nil {
@@ -156,14 +165,23 @@ func gitShow(ctx *aflow.Context, state state, args showArgs) (showResult, error)
 	if filePath != "" {
 		out, err := runGit(state.KernelSrc, time.Minute, "ls-tree", "--name-only", commitHash, "--", filePath)
 		if err != nil {
-			return showResult{}, err
+			return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different file path.")
 		}
 		if len(bytes.TrimSpace(out)) == 0 {
 			return showResult{}, aflow.BadCallError("file %q is not present on commit %q", filePath, commitHash)
 		}
 	}
 
-	output, err := runGit(state.KernelSrc, 5*time.Minute, "show", "--no-color", args.Commit)
+	gitArgs := []string{"show", "--no-color"}
+	if args.Stat {
+		gitArgs = append(gitArgs, "--stat")
+	}
+	gitArgs = append(gitArgs, args.Commit)
+	if args.File != "" {
+		gitArgs = append(gitArgs, "--", args.File)
+	}
+
+	output, err := runGit(state.KernelSrc, 5*time.Minute, gitArgs...)
 	if err != nil {
 		return showResult{}, gitBadCallError(err, "git show", "Consider specifying a different commit.")
 	}

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -16,7 +16,8 @@ import (
 func TestGitShow(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	repo := vcs.MakeTestRepo(t, filepath.Join(tmpDir, "repo", "linux"))
+	repoDir := filepath.Join(tmpDir, "repo", "linux")
+	repo := vcs.MakeTestRepo(t, repoDir)
 	c1 := repo.CommitChangeset("initial commit", vcs.FileContent{
 		File: "foo.c",
 		Content: `
@@ -28,7 +29,7 @@ void foo() {
 
 	// Test git-show.
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{Commit: c1.Hash},
 		func(res showResult) {
 			expected := fmt.Sprintf(`(?s)^commit %s
@@ -48,14 +49,14 @@ diff --git a/foo\.c b/foo\.c
 
 	// Test git-show with non-existing commit.
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567"},
 		showResult{},
 		`git show failed: fatal: Not a valid object name 0123456789abcdef0123456789abcdef01234567^{commit}`,
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567:missing.c"},
 		showResult{},
 		`git show failed: fatal: Not a valid object name 0123456789abcdef0123456789abcdef01234567^{commit}`,
@@ -63,21 +64,22 @@ diff --git a/foo\.c b/foo\.c
 
 	// Test git-show with non-existing file.
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{Commit: c1.Hash + ":missing.c"},
 		showResult{},
 		fmt.Sprintf(`file "missing.c" is not present on commit "%s"`, c1.Hash),
 		aflow.TestWorkdir(tmpDir))
 
+	// Test git-show with empty commit.
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{},
 		showResult{},
 		`commit hash is required`,
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolShow,
-		state{},
+		state{KernelSrc: repoDir},
 		showArgs{Commit: ":mm/mmap.c"},
 		showResult{},
 		`commit hash is required`,
@@ -109,7 +111,7 @@ void foo() {
 
 	// Test git-blame.
 	aflow.TestTool(t, ToolBlame,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		blameArgs{File: "foo.c", Start: 3, End: 4},
 		func(res blameResult) {
 			expected := fmt.Sprintf(`(?m)^\^%s.* 3\) 	// BUG HERE
@@ -121,7 +123,7 @@ $`, c1.Hash[:12], c2.Hash[:12])
 
 	// Test git-blame with non-existent file.
 	aflow.TestTool(t, ToolBlame,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		blameArgs{File: "non_existing.c", Start: 1, End: 1},
 		blameResult{},
 		"git blame failed: fatal: no such path non_existing.c in HEAD",
@@ -129,7 +131,7 @@ $`, c1.Hash[:12], c2.Hash[:12])
 
 	// Test git-blame out of bounds line range.
 	aflow.TestTool(t, ToolBlame,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		blameArgs{File: "foo.c", Start: 1000, End: 1001},
 		blameResult{},
 		"git blame failed: fatal: file foo.c has only 5 lines",
@@ -169,7 +171,7 @@ void foo() {
 
 	// Test git-log message search.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
@@ -177,14 +179,14 @@ void foo() {
 
 	// Test git-log multiple message regexps.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"third", "commit"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log message search case-insensitive.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"COMMIT"}},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
@@ -192,56 +194,56 @@ void foo() {
 
 	// Test git-log code search (-G).
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{CodeRegexp: "fixed"},
 		logResult{Output: fmt.Sprintf("%s third commit\n", c3.Hash[:12])},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log symbol search (-L).
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{SymbolName: "foo", SourcePath: "foo.c"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log path prefix.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{PathPrefix: "foo.c"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s initial commit\n", c3.Hash[:12], c1.Hash[:12])},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log no matches.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"non-existing"}},
 		logResult{},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log code search (-G) no matches.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{CodeRegexp: "non-existing"},
 		logResult{},
 		"", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log error: missing SourcePath for symbol search.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{SymbolName: "foo"},
 		logResult{},
 		"SourcePath is required when SymbolName is set", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log error: SymbolName and PathPrefix conflict.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{SymbolName: "foo", SourcePath: "foo.c", PathPrefix: "foo.c"},
 		logResult{},
 		"SymbolName and PathPrefix cannot be used together", aflow.TestWorkdir(tmpDir))
 
 	// Test git-log error: no filters provided.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{},
 		logResult{},
 		"at least one of CodeRegexp, SymbolName, MessageRegexps, or PathPrefix must be set",
@@ -249,14 +251,14 @@ void foo() {
 
 	// Test git-log error: symbol not found.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{SymbolName: "non_existing_symbol", SourcePath: "foo.c"},
 		logResult{},
 		"git log failed: fatal: -L parameter 'non_existing_symbol' starting at line 1: no match",
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{CodeRegexp: `foo\(`, SourcePath: "foo.c"},
 		logResult{Output: fmt.Sprintf("%s second commit\n%s initial commit\n",
 			c2.Hash[:12], c1.Hash[:12])},
@@ -265,7 +267,7 @@ void foo() {
 
 	// Bad grep expression.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{CodeRegexp: `foo(`, SourcePath: "foo.c"},
 		logResult{},
 		`git log failed: fatal: invalid regex: `,
@@ -273,14 +275,14 @@ void foo() {
 
 	// Test git-log with valid Since parameter.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}, Since: "3 years"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
 		"", aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}, Since: "1 day"},
 		logResult{Output: fmt.Sprintf("%s third commit\n%s second commit\n%s initial commit\n",
 			c3.Hash[:12], c2.Hash[:12], c1.Hash[:12])},
@@ -288,21 +290,21 @@ void foo() {
 
 	// Test git-log with invalid Since parameter.
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}, Since: "yesterday"},
 		logResult{},
 		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}, Since: "3 decades"},
 		logResult{},
 		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolLog,
-		state{KernelCommit: "HEAD"},
+		state{KernelSrc: repoDir},
 		logArgs{MessageRegexps: []string{"commit"}, Since: "some years"},
 		logResult{},
 		"invalid Since parameter format, must be like '3 years', '1 month', '5 days'",

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -52,14 +52,14 @@ diff --git a/foo\.c b/foo\.c
 		state{KernelSrc: repoDir},
 		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567"},
 		showResult{},
-		`git show failed: fatal: Not a valid object name 0123456789abcdef0123456789abcdef01234567^{commit}`,
+		`git show failed: commit 0123456789abcdef0123456789abcdef01234567 does not exist`,
 		aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolShow,
 		state{KernelSrc: repoDir},
 		showArgs{Commit: "0123456789abcdef0123456789abcdef01234567:missing.c"},
 		showResult{},
-		`git show failed: fatal: Not a valid object name 0123456789abcdef0123456789abcdef01234567^{commit}`,
+		`git show failed: commit 0123456789abcdef0123456789abcdef01234567 does not exist`,
 		aflow.TestWorkdir(tmpDir))
 
 	// Test git-show with non-existing file.

--- a/pkg/aflow/tool/gitlog/gitlog_test.go
+++ b/pkg/aflow/tool/gitlog/gitlog_test.go
@@ -70,19 +70,63 @@ diff --git a/foo\.c b/foo\.c
 		fmt.Sprintf(`file "missing.c" is not present on commit "%s"`, c1.Hash),
 		aflow.TestWorkdir(tmpDir))
 
-	// Test git-show with empty commit.
+	// Test git-show defaults to HEAD.
 	aflow.TestTool(t, ToolShow,
 		state{KernelSrc: repoDir},
 		showArgs{},
-		showResult{},
-		`commit hash is required`,
-		aflow.TestWorkdir(tmpDir))
+		func(res showResult) {
+			assert.Contains(t, res.Output, "initial commit")
+			assert.Contains(t, res.Output, "+void foo() {")
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test git-show with Stat=true.
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repoDir},
+		showArgs{Stat: true},
+		func(res showResult) {
+			assert.Contains(t, res.Output, "initial commit")
+			assert.Contains(t, res.Output, "foo.c | 4 ++++")
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test git-show with File filter.
+	c2 := repo.CommitChangeset("second commit",
+		vcs.FileContent{File: "foo.c", Content: "void foo() { int x = 1; }\n"},
+		vcs.FileContent{File: "bar.c", Content: "void bar() {}\n"},
+	)
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repoDir},
+		showArgs{Commit: c2.Hash, File: "bar.c"},
+		func(res showResult) {
+			assert.Contains(t, res.Output, "second commit")
+			assert.Contains(t, res.Output, "+void bar() {}")
+			assert.NotContains(t, res.Output, "int x = 1;")
+		},
+		"", aflow.TestWorkdir(tmpDir))
+
+	// Test git-show with :file syntax (defaults commit to HEAD).
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repoDir},
+		showArgs{Commit: ":foo.c"},
+		func(res showResult) {
+			assert.Contains(t, res.Output, "void foo() { int x = 1; }")
+		},
+		"", aflow.TestWorkdir(tmpDir))
 
 	aflow.TestTool(t, ToolShow,
 		state{KernelSrc: repoDir},
-		showArgs{Commit: ":mm/mmap.c"},
+		showArgs{Commit: ":missing.c"},
 		showResult{},
-		`commit hash is required`,
+		`file "missing.c" is not present on commit "HEAD"`,
+		aflow.TestWorkdir(tmpDir))
+
+	// Test git-show with invalid file path causing ls-tree to fail.
+	aflow.TestTool(t, ToolShow,
+		state{KernelSrc: repoDir},
+		showArgs{Commit: c1.Hash + "::(invalid"},
+		showResult{},
+		`git show failed: fatal: Invalid pathspec magic 'invalid' in ':(invalid'`,
 		aflow.TestWorkdir(tmpDir))
 }
 

--- a/pkg/aflow/truncate.go
+++ b/pkg/aflow/truncate.go
@@ -1,0 +1,30 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TruncateText truncates text to maxLines, appending a notice with the total line count if truncated.
+func TruncateText(text string, maxLines int) string {
+	pos := 0
+	for range maxLines {
+		idx := strings.IndexByte(text[pos:], '\n')
+		if idx < 0 {
+			return text
+		}
+		pos += idx + 1
+	}
+	if pos >= len(text) {
+		return text
+	}
+	total := maxLines + strings.Count(text[pos:], "\n")
+	if !strings.HasSuffix(text, "\n") {
+		total++
+	}
+	return fmt.Sprintf("%s\n[Output truncated: showing %d of %d lines]",
+		strings.TrimRight(text[:pos], "\n"), maxLines, total)
+}

--- a/pkg/aflow/truncate_test.go
+++ b/pkg/aflow/truncate_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package aflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateText(t *testing.T) {
+	// Case 1: Within limit (not truncated).
+	short := "line 1\nline 2\nline 3\n"
+	require.Equal(t, short, TruncateText(short, 5))
+
+	// Case 2: Exceeding limit (truncated).
+	long := "line 1\nline 2\nline 3\nline 4\nline 5\n"
+	want := "line 1\nline 2\n[Output truncated: showing 2 of 5 lines]"
+	require.Equal(t, want, TruncateText(long, 2))
+}


### PR DESCRIPTION
Taking `pkg/aflow` related commits out of https://github.com/google/syzkaller/pull/7800.
Cc https://github.com/google/syzkaller/issues/7734.

***

Fuzzing patch series can trigger pre-existing bugs or unrelated crashes
that require time-consuming manual triage when no reproducer is available.

Introduce a finding-triage workflow that uses an LLM agent to evaluate
whether a crash was introduced by the tested patch series. The agent
inspects repository diffs and uses a new series-patches tool to browse
individual patches and cover letters.