### PR TITLE
pkg/report: replace IPv6 addresses in titles

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -348,6 +348,11 @@ var dynamicTitleReplacement = []replacement{
 		"IP",
 	},
 	{
+		// Replace IPv6 addresses.
+		regexp.MustCompile(`(^|\W)([0-9a-f:]*::[0-9a-f:]*|(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4})(\W|$)`),
+		"${1}IPV6ADDR${3}",
+	},
+	{
 		// Replace that everything looks like a file line number with "LINE".
 		regexp.MustCompile(`(\.\w+)(:[0-9]+)+`),
 		"${1}:LINE",

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/syzkaller/pkg/testutil"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var flagUpdate = flag.Bool("update", false, "update test files accordingly to current results")
@@ -564,6 +565,41 @@ func TestSplitReportBytes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			splitted := SplitReportBytes(test.input)
 			assert.Equal(t, test.wantFirst, string(splitted[0]))
+		})
+	}
+}
+
+func TestIPv6TitleReplacement(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "short",
+			title: "here's IP: aaaa::",
+			want:  "here's IP: IPV6ADDR",
+		},
+		{
+			name:  "long",
+			title: "long IP: 2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			want:  "long IP: IPV6ADDR",
+		},
+		{
+			name:  "unrelated 0:0:0",
+			title: "some 0:0:0 text",
+			want:  "some NUM:NUM:NUM text",
+		},
+		{
+			name:  "unrelated colons",
+			title: "other a:b:c text",
+			want:  "other a:b:c text",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := replaceTable(dynamicTitleReplacement, test.title)
+			require.Equal(t, test.want, got)
 		})
 	}
 }

--- a/pkg/report/testdata/linux/report/1007
+++ b/pkg/report/testdata/linux/report/1007
@@ -1,0 +1,7 @@
+TITLE: BUG: Address IPV6ADDR on device lo is missing its host route.
+
+[  184.801206][ T1191] IPv6: BUG: Address fc00:: on device lo is missing its host route.
+[  184.804883][ T4795] lo speed is unknown, defaulting to 1000
+[  184.804923][ T4795] syz0: Port: 1 Link ACTIVE
+SYZFAIL: failed to recv rpc
+fd=3 want=4 recv=0 n=0 (errno 9: Bad file descriptor)

--- a/pkg/report/testdata/linux/report/1008
+++ b/pkg/report/testdata/linux/report/1008
@@ -1,0 +1,7 @@
+TITLE: BUG: Address IPV6ADDR on device lo is missing its host route.
+
+[  184.801206][ T1191] IPv6: BUG: Address 2001:0db8:85a3:0000:0000:8a2e:0370:7334 on device lo is missing its host route.
+[  184.804883][ T4795] lo speed is unknown, defaulting to 1000
+[  184.804923][ T4795] syz0: Port: 1 Link ACTIVE
+SYZFAIL: failed to recv rpc
+fd=3 want=4 recv=0 n=0 (errno 9: Bad file descriptor)


### PR DESCRIPTION
Kernel crash reports can contain dynamic IPv6 addresses, causing identical bugs to be reported under different titles.

Replace IPv6 addresses in titles with IPV6ADDR to prevent duplicate bug reports.