### PR TITLE
Makefile: move deadcode from lint to presubmit_aux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 	bin/syz-extract bin/syz-fmt \
 	extract generate generate_go generate_rpc generate_sys \
 	format format_go format_cpp format_sys \
-	tidy deadcode test test_race \
+	tidy lint deadcode test test_race \
 	check_copyright check_language check_whitespace check_sql_newlines check_links check_diff check_commits check_shebang check_html \
 	presubmit presubmit_aux presubmit_build presubmit_arch_linux presubmit_arch_freebsd \
 	presubmit_arch_netbsd presubmit_arch_openbsd presubmit_arch_darwin presubmit_arch_windows \
@@ -299,8 +299,10 @@ tidy: descriptions
 		--extra-arg=-std=c++17 \
 		executor/*.cc
 
-lint: deadcode check_whitespace check_sql_newlines check_links check_html check_shebang
+bin/golangci-lint: go.mod
 	CGO_ENABLED=1 $(HOSTGO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+
+lint: bin/golangci-lint check_whitespace check_sql_newlines check_links check_html check_shebang
 	CGO_ENABLED=1 $(HOSTGO) build -buildmode=plugin -o bin/syz-linter.so ./tools/syz-linter
 	bin/golangci-lint run ./...
 
@@ -324,7 +326,7 @@ presubmit:
 
 presubmit_aux:
 	$(MAKE) generate
-	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_k8s tidy
+	$(MAKE) -j100 check_commits check_diff check_copyright check_language check_k8s tidy deadcode
 	$(GO) mod tidy
 
 presubmit_build: descriptions


### PR DESCRIPTION
The deadcode tool performs whole-program analysis that cannot be cached, adding ~1 minute to every `make lint` run. In practice, dead code is rarely introduced, so running it only in CI is sufficient.

Move deadcode to `presubmit_aux` so that it remains enforced in CI while bringing `make lint` down to ~15 seconds locally:

| Cache | Before | After |
|-------|--------|-------|
| Hot   | 1m 40s | 15s   |
| Cold  | 4m 11s | 3m 34s|

In CI, `presubmit_aux` runs in parallel and completes well before the critical path, so PR latency is unaffected.

Also avoid reinstalling golangci-lint when go.mod has not changed.