### PR TITLE
pkg/aflow, dashboard: feed the AI seed programs into syzbot

### DIFF
--- a/dashboard/app/ai.go
+++ b/dashboard/app/ai.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/syzkaller/dashboard/app/aidb"
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/aflow/ai"
+	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	aflowhtml "github.com/google/syzkaller/pkg/aflow/trajectory/html"
 	"github.com/google/syzkaller/pkg/email"
 	"github.com/google/syzkaller/pkg/email/lore"
@@ -1422,6 +1423,9 @@ func apiAIJobDone(ctx context.Context, req *dashapi.AIJobDoneReq) (any, error) {
 	if err = aiJobApplyLabels(ctx, job); err != nil {
 		return nil, err
 	}
+	if err := saveCandidateSeeds(ctx, job, finished); err != nil {
+		log.Errorf(ctx, "failed to save candidate seeds for job %v: %v", job.ID, err)
+	}
 	if job.Type == ai.WorkflowPatchIteration {
 		if err := finishIterationJob(ctx, job); err != nil {
 			return nil, err
@@ -1566,6 +1570,19 @@ func castJobResults[T any](job *aidb.Job) (T, error) {
 	return parseJSON[T](job.Results)
 }
 
+func castJobArgs[T any](job *aidb.Job) (T, error) {
+	var res T
+	if !job.Args.Valid {
+		return res, fmt.Errorf("job %v %v does not have args", job.Type, job.ID)
+	}
+	data, err := json.Marshal(job.Args.Value)
+	if err != nil {
+		return res, err
+	}
+	err = json.Unmarshal(data, &res)
+	return res, err
+}
+
 func parseJSON[T any](val spanner.NullJSON) (T, error) {
 	var res T
 	// Database may store older versions of the output structs.
@@ -1577,6 +1594,59 @@ func parseJSON[T any](val spanner.NullJSON) (T, error) {
 		return res, err
 	}
 	return osutil.ParseJSON[T](data)
+}
+
+func saveCandidateSeeds(ctx context.Context, job *aidb.Job, finished time.Time) error {
+	if job.Type != ai.WorkflowSeedGen && job.Type != ai.WorkflowSeedGenFileLine {
+		return nil
+	}
+	type jobTarget struct {
+		TargetOS   string
+		TargetArch string
+	}
+	target, err := castJobArgs[jobTarget](job)
+	if err != nil {
+		return fmt.Errorf("failed to cast job args for %v: %w", job.ID, err)
+	}
+	if target.TargetOS == "" || target.TargetArch == "" {
+		// Under normal operation TargetOS and TargetArch should always be set, but it is
+		// too late to fail the job now. Skip saving candidate seeds since managers would
+		// never be able to poll seeds with empty targets.
+		log.Errorf(ctx, "job %v has empty TargetOS (%q) or TargetArch (%q), skipping candidate seeds",
+			job.ID, target.TargetOS, target.TargetArch)
+		return nil
+	}
+	artifacts, err := aidb.QueryJobArtifacts(ctx, job.ID, trajectory.ArtifactSyzProg)
+	if err != nil {
+		return fmt.Errorf("failed to query job artifacts for %v: %w", job.ID, err)
+	}
+	progs := artifacts
+	if res, err := castJobResults[ai.SeedGenOutputs](job); err == nil && res.SeedSyz != "" {
+		progs = append(progs, res.SeedSyz)
+	}
+	if len(progs) == 0 {
+		return nil
+	}
+	var candidateSeeds []*aidb.CandidateSeed
+	seen := make(map[string]bool)
+	for _, p := range progs {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		candidateSeeds = append(candidateSeeds, &aidb.CandidateSeed{
+			JobID:      job.ID,
+			Namespace:  job.Namespace,
+			TargetOS:   target.TargetOS,
+			TargetArch: target.TargetArch,
+			CreatedAt:  finished,
+			Prog:       []byte(p),
+		})
+	}
+	if err := aidb.AddCandidateSeeds(ctx, candidateSeeds); err != nil {
+		return fmt.Errorf("failed to save candidate seeds for job %v: %w", job.ID, err)
+	}
+	return nil
 }
 
 func apiAITrajectoryLog(ctx context.Context, req *dashapi.AITrajectoryReq) (any, error) {

--- a/dashboard/app/ai_test.go
+++ b/dashboard/app/ai_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/prog"
+	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -1445,4 +1446,172 @@ func TestAIJobsErrorVisibility(t *testing.T) {
 	require.NotContains(t, string(respBugUser), errText)
 	require.NotContains(t, string(respBugUser), aiErrorPlaceholder)
 	require.NotContains(t, string(respBugUser), ">Error</a></th>")
+}
+
+func TestCandidateSeeds(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	build := testBuild(1)
+	c.aiClient.UploadBuild(build)
+	crash := testCrashWithRepro(build, 1)
+	c.aiClient.ReportCrash(crash)
+	extID := c.aiClient.pollEmailExtID()
+
+	c.pollAIWorkflow(t, ai.WorkflowSeedGen)
+	jobID := c.createAIJob(extID, string(ai.WorkflowSeedGen), "")
+
+	// Log tool spans with Artifacts.
+	require.NoError(t, c.agentClient.AITrajectoryLog(&dashapi.AITrajectoryReq{
+		AgentName: "test-agent",
+		JobID:     jobID,
+		Span: &trajectory.Span{
+			Seq:       0,
+			Type:      trajectory.SpanTool,
+			Name:      "execute-seed",
+			Artifacts: map[trajectory.ArtifactType]string{trajectory.ArtifactSyzProg: "syz_mount_image(0)"},
+			Started:   c.mockedTime,
+			Finished:  c.mockedTime.Add(time.Second),
+		},
+	}))
+	require.NoError(t, c.agentClient.AITrajectoryLog(&dashapi.AITrajectoryReq{
+		AgentName: "test-agent",
+		JobID:     jobID,
+		Span: &trajectory.Span{
+			Seq:       1,
+			Type:      trajectory.SpanTool,
+			Name:      "execute-seed",
+			Artifacts: map[trajectory.ArtifactType]string{trajectory.ArtifactSyzProg: "syz_mount_image(1)"},
+			Started:   c.mockedTime,
+			Finished:  c.mockedTime.Add(time.Second),
+		},
+	}))
+
+	err := c.agentClient.AIJobDone(&dashapi.AIJobDoneReq{
+		ID: jobID,
+		Results: map[string]any{
+			"SeedSyz": "syz_mount_image(2)",
+			"Success": true,
+		},
+	})
+	require.NoError(t, err)
+
+	// 1. Manager 1 polls candidate seeds.
+	pollResp, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "manager-1",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Len(t, pollResp.Seeds, 3)
+	require.NotEmpty(t, pollResp.Token)
+
+	// 2. Manager 1 marks them done.
+	err = c.aiClient.CandidateSeedsDone(&dashapi.CandidateSeedsDoneReq{
+		Name:  "manager-1",
+		Token: pollResp.Token,
+	})
+	require.NoError(t, err)
+
+	// 3. Manager 1 polls again, should get 0 seeds.
+	pollResp2, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "manager-1",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Empty(t, pollResp2.Seeds)
+	require.Empty(t, pollResp2.Token)
+
+	// 4. Manager 2 polls for the first time, should get all 3 seeds with target info.
+	pollResp3, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "manager-2",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Len(t, pollResp3.Seeds, 3)
+	require.Equal(t, targets.Linux, pollResp3.Seeds[0].TargetOS)
+	require.Equal(t, targets.AMD64, pollResp3.Seeds[0].TargetArch)
+
+	// 5. Generic client (e.g. hub) polls without target, gets all seeds.
+	pollRespHub, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name: "hub-client",
+	})
+	require.NoError(t, err)
+	require.Len(t, pollRespHub.Seeds, 3)
+	require.Equal(t, targets.Linux, pollRespHub.Seeds[0].TargetOS)
+	require.Equal(t, targets.AMD64, pollRespHub.Seeds[0].TargetArch)
+}
+
+func TestCandidateSeedsPagination(t *testing.T) {
+	c := NewSpannerCtx(t)
+	defer c.Close()
+
+	jobID, err := aidb.CreateJob(c.ctx, &aidb.Job{
+		Type:        "seed-gen",
+		Workflow:    "seed-gen",
+		Namespace:   "ains",
+		Description: "test job",
+		Link:        "http://test",
+	})
+	require.NoError(t, err)
+
+	// Insert 25 seeds sharing the exact same CreatedAt timestamp.
+	sameTime := c.mockedTime
+	var seeds []*aidb.CandidateSeed
+	for i := range 25 {
+		progBytes := []byte(fmt.Sprintf("syz_mount_image(%d)", i))
+		seeds = append(seeds, &aidb.CandidateSeed{
+			Namespace:  "ains",
+			TargetOS:   targets.Linux,
+			TargetArch: targets.AMD64,
+			CreatedAt:  sameTime,
+			ID:         fmt.Sprintf("seed-%02d", i),
+			JobID:      jobID,
+			Prog:       progBytes,
+		})
+	}
+	require.NoError(t, aidb.AddCandidateSeeds(c.ctx, seeds))
+
+	// Page 1: Poll first 20 seeds.
+	pollResp1, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "mgr-paginated",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Len(t, pollResp1.Seeds, 20)
+	require.NotEmpty(t, pollResp1.Token)
+
+	// Acknowledge Page 1.
+	require.NoError(t, c.aiClient.CandidateSeedsDone(&dashapi.CandidateSeedsDoneReq{
+		Name:  "mgr-paginated",
+		Token: pollResp1.Token,
+	}))
+
+	// Page 2: Poll remaining 5 seeds (same timestamp).
+	pollResp2, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "mgr-paginated",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Len(t, pollResp2.Seeds, 5)
+	require.NotEmpty(t, pollResp2.Token)
+
+	// Acknowledge Page 2.
+	require.NoError(t, c.aiClient.CandidateSeedsDone(&dashapi.CandidateSeedsDoneReq{
+		Name:  "mgr-paginated",
+		Token: pollResp2.Token,
+	}))
+
+	// Page 3: No more seeds.
+	pollResp3, err := c.aiClient.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+		Name:       "mgr-paginated",
+		TargetOS:   targets.Linux,
+		TargetArch: targets.AMD64,
+	})
+	require.NoError(t, err)
+	require.Empty(t, pollResp3.Seeds)
 }

--- a/dashboard/app/aidb/crud.go
+++ b/dashboard/app/aidb/crud.go
@@ -6,6 +6,7 @@ package aidb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -475,6 +476,7 @@ func StoreTrajectorySpan(ctx context.Context, jobID string, span *trajectory.Spa
 		Error:                toNullString(span.Error),
 		Args:                 toNullJSON(span.Args),
 		Results:              toNullJSON(span.Results),
+		Artifacts:            toNullJSON(span.Artifacts),
 		Instruction:          toNullString(span.Instruction),
 		Prompt:               toNullString(span.Prompt),
 		Reply:                toNullString(span.Reply),
@@ -489,6 +491,46 @@ func StoreTrajectorySpan(ctx context.Context, jobID string, span *trajectory.Spa
 	}
 	_, err = client.Apply(ctx, []*spanner.Mutation{mut})
 	return err
+}
+
+func QueryJobArtifacts(ctx context.Context, jobID string, typ trajectory.ArtifactType) ([]string, error) {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	iter := client.Single().Query(ctx, spanner.Statement{
+		SQL: `SELECT Artifacts
+			FROM TrajectorySpans
+			WHERE JobID = @jobID AND Artifacts IS NOT NULL AND Error IS NULL
+			ORDER BY Seq ASC`,
+		Params: map[string]any{
+			"jobID": jobID,
+		},
+	})
+	defer iter.Stop()
+	var artifacts []string
+	err = iter.Do(func(row *spanner.Row) error {
+		var raw spanner.NullJSON
+		if err := row.ColumnByName("Artifacts", &raw); err != nil {
+			return err
+		}
+		if raw.IsNull() {
+			return nil
+		}
+		data, err := json.Marshal(raw.Value)
+		if err != nil {
+			return err
+		}
+		var parsed map[trajectory.ArtifactType]string
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			return err
+		}
+		if val, ok := parsed[typ]; ok && val != "" {
+			artifacts = append(artifacts, val)
+		}
+		return nil
+	})
+	return artifacts, err
 }
 
 func LoadTrajectory(ctx context.Context, jobID string) ([]*TrajectorySpan, error) {
@@ -1456,8 +1498,8 @@ func selectAllFrom[T any](table string) string {
 	return fmt.Sprintf("SELECT %v FROM %v ", strings.Join(fields, ", "), table)
 }
 
-func toNullJSON(v map[string]any) spanner.NullJSON {
-	if v == nil {
+func toNullJSON[M ~map[K]V, K comparable, V any](v M) spanner.NullJSON {
+	if len(v) == 0 {
 		return spanner.NullJSON{}
 	}
 	return spanner.NullJSON{Value: v, Valid: true}
@@ -1536,4 +1578,121 @@ func extractBaseCommitArgs(job *Job, argsMap map[string]any) {
 			argsMap["BaseSuggestedBy"] = tags
 		}
 	}
+}
+
+func AddCandidateSeeds(ctx context.Context, seeds []*CandidateSeed) error {
+	if len(seeds) == 0 {
+		return nil
+	}
+	client, err := dbClient(ctx)
+	if err != nil {
+		return err
+	}
+	var mutations []*spanner.Mutation
+	for _, s := range seeds {
+		if s.ID == "" {
+			s.ID = uuid.NewString()
+		}
+		mut, err := spanner.InsertOrUpdateStruct("CandidateSeeds", s)
+		if err != nil {
+			return err
+		}
+		mutations = append(mutations, mut)
+	}
+	_, err = client.Apply(ctx, mutations)
+	return err
+}
+
+func PollCandidateSeeds(ctx context.Context, ns, clientName, targetOS, targetArch string,
+	limit int) ([]*CandidateSeed, time.Time, string, error) {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return nil, time.Time{}, "", err
+	}
+	cursor, err := readRow[ClientSeedCursor](ctx, client.Single(), spanner.Statement{
+		SQL: `SELECT Namespace, Client, LastTriagedTime, LastTriagedID
+			FROM ClientSeedCursors
+			WHERE Namespace = @ns AND Client = @client`,
+		Params: map[string]any{
+			"ns":     ns,
+			"client": clientName,
+		},
+	})
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, time.Time{}, "", err
+	}
+	sinceTime := TimeNow(ctx).Add(-24 * time.Hour)
+	sinceID := ""
+	if cursor != nil && !cursor.LastTriagedTime.IsZero() {
+		sinceTime = cursor.LastTriagedTime
+		sinceID = cursor.LastTriagedID
+	}
+	seeds, err := selectAll[CandidateSeed](ctx, spanner.Statement{
+		SQL: `SELECT Namespace, TargetOS, TargetArch, CreatedAt, ID, JobID, Prog
+			FROM CandidateSeeds
+			WHERE Namespace = @ns
+			  AND (@targetOS = '' OR TargetOS = @targetOS)
+			  AND (@targetArch = '' OR TargetArch = @targetArch)
+			  AND (CreatedAt > @sinceTime OR (CreatedAt = @sinceTime AND ID > @sinceID))
+			ORDER BY CreatedAt ASC, ID ASC
+			LIMIT @limit`,
+		Params: map[string]any{
+			"ns":         ns,
+			"targetOS":   targetOS,
+			"targetArch": targetArch,
+			"sinceTime":  sinceTime,
+			"sinceID":    sinceID,
+			"limit":      limit,
+		},
+	})
+	if err != nil {
+		return nil, time.Time{}, "", err
+	}
+	maxCreatedAt := sinceTime
+	lastID := sinceID
+	if len(seeds) > 0 {
+		last := seeds[len(seeds)-1]
+		maxCreatedAt = last.CreatedAt
+		lastID = last.ID
+	}
+	return seeds, maxCreatedAt, lastID, nil
+}
+
+func DoneCandidateSeeds(ctx context.Context, ns, clientName string, doneTime time.Time, doneID string) error {
+	client, err := dbClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		existing, err := readRow[ClientSeedCursor](ctx, txn, spanner.Statement{
+			SQL: `SELECT Namespace, Client, LastTriagedTime, LastTriagedID
+				FROM ClientSeedCursors
+				WHERE Namespace = @ns AND Client = @client`,
+			Params: map[string]any{
+				"ns":     ns,
+				"client": clientName,
+			},
+		})
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return err
+		}
+		if existing != nil && !existing.LastTriagedTime.IsZero() {
+			if doneTime.Before(existing.LastTriagedTime) ||
+				(doneTime.Equal(existing.LastTriagedTime) && doneID <= existing.LastTriagedID) {
+				return nil
+			}
+		}
+		cursor := &ClientSeedCursor{
+			Namespace:       ns,
+			Client:          clientName,
+			LastTriagedTime: doneTime,
+			LastTriagedID:   doneID,
+		}
+		mut, err := spanner.InsertOrUpdateStruct("ClientSeedCursors", cursor)
+		if err != nil {
+			return err
+		}
+		return txn.BufferWrite([]*spanner.Mutation{mut})
+	})
+	return err
 }

--- a/dashboard/app/aidb/entities.go
+++ b/dashboard/app/aidb/entities.go
@@ -81,6 +81,7 @@ type TrajectorySpan struct {
 	Error                spanner.NullString
 	Args                 spanner.NullJSON
 	Results              spanner.NullJSON
+	Artifacts            spanner.NullJSON
 	Instruction          spanner.NullString
 	Prompt               spanner.NullString
 	Reply                spanner.NullString
@@ -138,4 +139,21 @@ type JobComment struct {
 	OwnEmail     bool
 	Processed    bool
 	VerifiedDKIM bool
+}
+
+type CandidateSeed struct {
+	Namespace  string
+	TargetOS   string
+	TargetArch string
+	CreatedAt  time.Time
+	ID         string
+	JobID      string
+	Prog       []byte
+}
+
+type ClientSeedCursor struct {
+	Namespace       string
+	Client          string
+	LastTriagedTime time.Time
+	LastTriagedID   string
 }

--- a/dashboard/app/aidb/migrations/23_add_candidate_seeds.down.sql
+++ b/dashboard/app/aidb/migrations/23_add_candidate_seeds.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE TrajectorySpans DROP COLUMN Artifacts;
+DROP TABLE ClientSeedCursors;
+DROP INDEX CandidateSeedsByTarget;
+ALTER TABLE CandidateSeeds DROP CONSTRAINT FK_CandidateSeedJob;
+DROP TABLE CandidateSeeds;

--- a/dashboard/app/aidb/migrations/23_add_candidate_seeds.up.sql
+++ b/dashboard/app/aidb/migrations/23_add_candidate_seeds.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE CandidateSeeds (
+	JobID		STRING(36) NOT NULL,
+	ID		STRING(36) NOT NULL,
+	Namespace	STRING(1000) NOT NULL,
+	TargetOS	STRING(100) NOT NULL,
+	TargetArch	STRING(100) NOT NULL,
+	CreatedAt	TIMESTAMP NOT NULL,
+	Prog		BYTES(MAX) NOT NULL,
+
+	CONSTRAINT FK_CandidateSeedJob FOREIGN KEY (JobID) REFERENCES Jobs (ID),
+) PRIMARY KEY (JobID, ID);
+
+CREATE INDEX CandidateSeedsByTarget ON CandidateSeeds (Namespace, TargetOS, TargetArch, CreatedAt, ID);
+
+CREATE TABLE ClientSeedCursors (
+	Namespace	STRING(1000) NOT NULL,
+	Client		STRING(1000) NOT NULL,
+	LastTriagedTime	TIMESTAMP NOT NULL,
+	LastTriagedID	STRING(36) NOT NULL,
+) PRIMARY KEY (Namespace, Client);
+
+ALTER TABLE TrajectorySpans ADD COLUMN Artifacts JSON;

--- a/dashboard/app/api.go
+++ b/dashboard/app/api.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/google/syzkaller/dashboard/app/aidb"
 	"github.com/google/syzkaller/dashboard/dashapi"
 	"github.com/google/syzkaller/pkg/asset"
 	"github.com/google/syzkaller/pkg/auth"
@@ -84,6 +85,8 @@ var apiHandlers = map[string]APIHandler{
 	"add_build_assets":      nsHandler(apiAddBuildAssets),
 	"log_to_repro":          nsHandler(apiLogToReproduce),
 	"repro_task_done":       nsHandler(apiReproTaskDone),
+	"candidate_seeds_poll":  nsHandler(apiCandidateSeedsPoll),
+	"candidate_seeds_done":  nsHandler(apiCandidateSeedsDone),
 	"client_info":           nsHandler(apiClientInfo),
 }
 
@@ -2033,4 +2036,72 @@ func apiSaveCoverage(ctx context.Context, payload io.Reader) (any, error) {
 // and use it to tag uploaded coverage data.
 func apiClientInfo(ctx context.Context, ns string, req *dashapi.ClientInfoReq) (any, error) {
 	return &dashapi.ClientInfoResp{Namespace: ns}, nil
+}
+
+const candidateSeedsPollLimit = 20
+
+func apiCandidateSeedsPoll(ctx context.Context, ns string, req *dashapi.CandidateSeedsPollReq) (any, error) {
+	if req.Name == "" {
+		return nil, errors.New("client name is empty")
+	}
+	seeds, maxCreatedAt, lastID, err := aidb.PollCandidateSeeds(
+		ctx, ns, req.Name, req.TargetOS, req.TargetArch, candidateSeedsPollLimit)
+	if err != nil {
+		return nil, err
+	}
+	resp := &dashapi.CandidateSeedsPollResp{
+		Seeds: make([]dashapi.CandidateSeed, 0, len(seeds)),
+	}
+	if len(seeds) > 0 {
+		resp.Token = encodeCandidateSeedsToken(maxCreatedAt, lastID)
+	}
+	for _, s := range seeds {
+		resp.Seeds = append(resp.Seeds, dashapi.CandidateSeed{
+			ID:         s.ID,
+			TargetOS:   s.TargetOS,
+			TargetArch: s.TargetArch,
+			Prog:       s.Prog,
+			CreatedAt:  s.CreatedAt,
+		})
+	}
+	return resp, nil
+}
+
+func apiCandidateSeedsDone(ctx context.Context, ns string, req *dashapi.CandidateSeedsDoneReq) (any, error) {
+	if req.Name == "" {
+		return nil, errors.New("client name is empty")
+	}
+	if req.Token == "" {
+		return nil, nil
+	}
+	doneTime, doneID, err := decodeCandidateSeedsToken(req.Token)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+	if doneTime.IsZero() {
+		return nil, nil
+	}
+	return nil, aidb.DoneCandidateSeeds(ctx, ns, req.Name, doneTime, doneID)
+}
+
+func encodeCandidateSeedsToken(t time.Time, id string) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339Nano) + "|" + id
+}
+
+func decodeCandidateSeedsToken(token string) (time.Time, string, error) {
+	if token == "" {
+		return time.Time{}, "", nil
+	}
+	timeStr, id, ok := strings.Cut(token, "|")
+	if !ok {
+		return time.Time{}, "", errors.New("invalid token format")
+	}
+	t, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	return t, id, nil
 }

--- a/dashboard/dashapi/ai.go
+++ b/dashboard/dashapi/ai.go
@@ -5,6 +5,7 @@ package dashapi
 
 import (
 	"errors"
+	"time"
 
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/trajectory"
@@ -57,6 +58,42 @@ func (dash *Dashboard) AIJobDone(req *AIJobDoneReq) error {
 
 func (dash *Dashboard) AITrajectoryLog(req *AITrajectoryReq) error {
 	return dash.Query("ai_trajectory_log", req, nil)
+}
+
+type CandidateSeedsPollReq struct {
+	Name       string
+	TargetOS   string
+	TargetArch string
+}
+
+type CandidateSeed struct {
+	ID         string
+	TargetOS   string
+	TargetArch string
+	Prog       []byte
+	CreatedAt  time.Time
+}
+
+type CandidateSeedsPollResp struct {
+	Seeds []CandidateSeed
+	Token string
+}
+
+type CandidateSeedsDoneReq struct {
+	Name  string
+	Token string
+}
+
+func (dash *Dashboard) CandidateSeedsPoll(req *CandidateSeedsPollReq) (*CandidateSeedsPollResp, error) {
+	resp := new(CandidateSeedsPollResp)
+	if err := dash.Query("candidate_seeds_poll", req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (dash *Dashboard) CandidateSeedsDone(req *CandidateSeedsDoneReq) error {
+	return dash.Query("candidate_seeds_done", req, nil)
 }
 
 // SendExternalCommandReq represents a request to report a patch action externally (upstream or reject).

--- a/pkg/aflow/action/crash/execute_seed.go
+++ b/pkg/aflow/action/crash/execute_seed.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/google/syzkaller/pkg/aflow"
+	"github.com/google/syzkaller/pkg/aflow/trajectory"
 	"github.com/google/syzkaller/pkg/flatrpc"
 	"github.com/google/syzkaller/pkg/fuzzer/queue"
 	"github.com/google/syzkaller/pkg/hash"
@@ -53,6 +54,7 @@ func ExecuteSeedFunc(ctx *aflow.Context, args ExecuteSeedArgs) (string, error) {
 		return "", aflow.BadCallError("program has %d calls, exceeding the limit of %d", len(p.Calls), prog.MaxCalls)
 	}
 	fullSyz = string(p.Serialize())
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, fullSyz)
 
 	if args.Image == "" || len(args.VM) == 0 {
 		return "", fmt.Errorf("VM configuration is missing")

--- a/pkg/aflow/ai/ai.go
+++ b/pkg/aflow/ai/ai.go
@@ -4,7 +4,10 @@
 // Package ai contains common workflow definitions.
 package ai
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type WorkflowType string
 
@@ -164,6 +167,23 @@ type PatchTriageResult struct {
 	FocusSymbols  []string
 	EnableConfigs []string
 	Reasoning     string
+}
+
+type SeedGenArgs struct {
+	AgentName     string
+	RawPC         string
+	KernelRepo    string
+	KernelCommit  string
+	KernelConfig  string
+	Image         string
+	Type          string
+	VM            json.RawMessage
+	CorpusVMCount int `json:",omitempty"`
+	Syzkaller     string
+	TargetOS      string
+	TargetArch    string
+	Snapshot      bool
+	CorpusPath    string `json:",omitempty"`
 }
 
 type SeedGenOutputs struct {

--- a/pkg/aflow/execute.go
+++ b/pkg/aflow/execute.go
@@ -196,6 +196,7 @@ type Context struct {
 	onEvent        onEvent
 	spanSeq        int
 	spanNesting    int
+	activeSpans    []*trajectory.Span
 	runnerMu       sync.Mutex
 	runnerManager  *RunnerManager
 	runnerEg       *errgroup.Group
@@ -205,6 +206,18 @@ type Context struct {
 	consumedTokens int64
 	blobs          syzspec.BlobStore
 	stubContext
+}
+
+// RecordArtifact associates a named artifact with the current active span.
+func (ctx *Context) RecordArtifact(typ trajectory.ArtifactType, data string) {
+	if data == "" || len(ctx.activeSpans) == 0 {
+		return
+	}
+	current := ctx.activeSpans[len(ctx.activeSpans)-1]
+	if current.Artifacts == nil {
+		current.Artifacts = make(map[trajectory.ArtifactType]string)
+	}
+	current.Artifacts[typ] = data
 }
 
 type stubContext struct {
@@ -334,14 +347,18 @@ func (ctx *Context) startSpan(span *trajectory.Span) error {
 	span.Nesting = ctx.spanNesting
 	ctx.spanNesting++
 	span.Started = ctx.timeNow()
+	ctx.activeSpans = append(ctx.activeSpans, span)
 	return ctx.onEvent(span)
 }
 
 func (ctx *Context) finishSpan(span *trajectory.Span, spanErr error) error {
 	ctx.spanNesting--
-	if ctx.spanNesting < 0 {
+	last := len(ctx.activeSpans) - 1
+	if ctx.spanNesting < 0 || last < 0 || ctx.activeSpans[last] != span {
 		panic("unbalanced spans")
 	}
+	ctx.activeSpans[last] = nil
+	ctx.activeSpans = ctx.activeSpans[:last]
 	span.Finished = ctx.timeNow()
 	if spanErr != nil {
 		span.Error = spanErr.Error()

--- a/pkg/aflow/flow/seedgen/seedgen.go
+++ b/pkg/aflow/flow/seedgen/seedgen.go
@@ -5,7 +5,6 @@
 package seedgen
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strconv"
@@ -19,23 +18,6 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/ai"
 	"github.com/google/syzkaller/pkg/aflow/tool/codesearcher"
 )
-
-type SeedGenInputs struct {
-	AgentName     string
-	RawPC         string
-	KernelRepo    string
-	KernelCommit  string
-	KernelConfig  string
-	Image         string
-	Type          string
-	VM            json.RawMessage
-	CorpusVMCount int `json:",omitempty"`
-	Syzkaller     string
-	TargetOS      string
-	TargetArch    string
-	Snapshot      bool
-	CorpusPath    string `json:",omitempty"`
-}
 
 func seedGenPipeline(prefix ...aflow.Action) aflow.Action {
 	steps := append([]aflow.Action{actionsyzlang.PrepareSyzFS}, prefix...)
@@ -66,7 +48,7 @@ func seedGenPipeline(prefix ...aflow.Action) aflow.Action {
 }
 
 func init() {
-	aflow.Register[SeedGenInputs, ai.SeedGenOutputs](
+	aflow.Register[ai.SeedGenArgs, ai.SeedGenOutputs](
 		ai.WorkflowSeedGen,
 		"generate a syzlang program to reach a specific code position",
 		&aflow.Flow{

--- a/pkg/aflow/flow_test.go
+++ b/pkg/aflow/flow_test.go
@@ -495,3 +495,63 @@ func TestConsumeTokens(t *testing.T) {
 		require.Contains(t, err.Error(), "workflow reached token limit (100)")
 	})
 }
+
+func TestRecordArtifact(t *testing.T) {
+	ctx := &Context{
+		onEvent: func(*trajectory.Span) error { return nil },
+		stubContext: stubContext{
+			timeNow: time.Now,
+		},
+	}
+	parent := &trajectory.Span{Name: "parent"}
+	require.NoError(t, ctx.startSpan(parent))
+
+	// Record artifact on parent span.
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, "parent-prog")
+	require.Equal(t, "parent-prog", parent.Artifacts[trajectory.ArtifactSyzProg])
+
+	// Child span.
+	child := &trajectory.Span{Name: "child"}
+	require.NoError(t, ctx.startSpan(child))
+
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, "child-prog")
+	require.Equal(t, "child-prog", child.Artifacts[trajectory.ArtifactSyzProg])
+	require.Equal(t, "parent-prog", parent.Artifacts[trajectory.ArtifactSyzProg])
+
+	// Empty artifact is ignored.
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, "")
+	require.Equal(t, "child-prog", child.Artifacts[trajectory.ArtifactSyzProg])
+
+	require.NoError(t, ctx.finishSpan(child, nil))
+
+	// After child finishes, recording goes back to parent.
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, "parent-prog-updated")
+	require.Equal(t, "parent-prog-updated", parent.Artifacts[trajectory.ArtifactSyzProg])
+
+	require.NoError(t, ctx.finishSpan(parent, nil))
+	require.Empty(t, ctx.activeSpans)
+
+	// Recording with no active spans does not crash.
+	ctx.RecordArtifact(trajectory.ArtifactSyzProg, "orphan-prog")
+
+	// Test recording artifact inside an action.
+	var finishedSpan *trajectory.Span
+	actionCtx := &Context{
+		onEvent: func(span *trajectory.Span) error {
+			if !span.Finished.IsZero() {
+				finishedSpan = span
+			}
+			return nil
+		},
+		stubContext: stubContext{
+			timeNow: time.Now,
+		},
+	}
+	action := NewFuncAction("action-record-artifact", func(ctx *Context, in struct{}) (struct{}, error) {
+		ctx.RecordArtifact(trajectory.ArtifactSyzProg, "action-prog")
+		return struct{}{}, nil
+	})
+	require.NoError(t, action.execute(actionCtx))
+	require.NotNil(t, finishedSpan)
+	require.Equal(t, "action-prog", finishedSpan.Artifacts[trajectory.ArtifactSyzProg])
+}

--- a/pkg/aflow/trajectory/trajectory.go
+++ b/pkg/aflow/trajectory/trajectory.go
@@ -32,6 +32,9 @@ type Span struct {
 	Args    map[string]any `json:",omitzero"`
 	Results map[string]any `json:",omitzero"`
 
+	// Artifacts produced or operated on during this step.
+	Artifacts map[ArtifactType]string `json:",omitzero"`
+
 	// Agent invocation.
 	Instruction string `json:",omitzero"`
 	Prompt      string `json:",omitzero"`
@@ -46,6 +49,12 @@ type Span struct {
 	OutputTokens         int `json:",omitzero"`
 	OutputThoughtsTokens int `json:",omitzero"`
 }
+
+type ArtifactType string
+
+const (
+	ArtifactSyzProg ArtifactType = "syz-prog"
+)
 
 type SpanType string
 

--- a/pkg/fuzzer/fuzzer.go
+++ b/pkg/fuzzer/fuzzer.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	pkgfeatures "github.com/google/syzkaller/pkg/vminfo/features"
@@ -367,6 +368,34 @@ type Candidate struct {
 }
 
 func (fuzzer *Fuzzer) AddCandidates(candidates []Candidate) {
+	fuzzer.addCandidates(candidates, nil)
+}
+
+func (fuzzer *Fuzzer) AddCandidatesWait(ctx context.Context, candidates []Candidate) {
+	if len(candidates) == 0 {
+		return
+	}
+	done := make(chan struct{})
+	fuzzer.addCandidates(candidates, func() {
+		close(done)
+	})
+	select {
+	case <-ctx.Done():
+	case <-done:
+	}
+}
+
+func (fuzzer *Fuzzer) addCandidates(candidates []Candidate, onDone func()) {
+	if len(candidates) == 0 {
+		if onDone != nil {
+			onDone()
+		}
+		return
+	}
+	var remaining atomic.Int32
+	if onDone != nil {
+		remaining.Store(int32(len(candidates)))
+	}
 	fuzzer.statCandidates.Add(len(candidates))
 	for _, candidate := range candidates {
 		req := &queue.Request{
@@ -374,6 +403,14 @@ func (fuzzer *Fuzzer) AddCandidates(candidates []Candidate) {
 			ExecOpts:  setFlags(flatrpc.ExecFlagCollectSignal),
 			Stat:      fuzzer.statExecCandidate,
 			Important: true,
+		}
+		if onDone != nil {
+			req.OnDone(func(req *queue.Request, res *queue.Result) bool {
+				if remaining.Add(-1) == 0 {
+					onDone()
+				}
+				return true
+			})
 		}
 		fuzzer.enqueue(fuzzer.candidateQueue, req, candidate.Flags|progCandidate, 0)
 	}

--- a/pkg/fuzzer/fuzzer_test.go
+++ b/pkg/fuzzer/fuzzer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFuzz(t *testing.T) {
@@ -249,4 +250,55 @@ func checkGoroutineLeaks() {
 	if err != "" {
 		panic(err)
 	}
+}
+
+func TestAddCandidatesWait(t *testing.T) {
+	target, err := prog.GetTarget(targets.TestOS, targets.TestArch64Fuzz)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	fuzzer := NewFuzzer(ctx, &Config{
+		Corpus:   corpus.NewMonitoredCorpus(ctx, nil),
+		Coverage: true,
+	}, rand.New(testutil.RandSource(t)), target)
+
+	// 1. Empty candidates should return immediately.
+	fuzzer.AddCandidatesWait(ctx, nil)
+
+	// 2. Non-empty candidates.
+	const testProg = `syz_compare(&AUTO="00000000", 0x4, &AUTO=@conditional={0x0, @void, @void, @void}, AUTO)`
+	p, err := target.Deserialize([]byte(testProg), prog.NonStrict)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		fuzzer.AddCandidatesWait(ctx, []Candidate{
+			{Prog: p},
+			{Prog: p.Clone()},
+		})
+		close(done)
+	}()
+
+	for fuzzer.statCandidates.Val() < 2 {
+		time.Sleep(time.Millisecond)
+	}
+
+	for range 2 {
+		req := fuzzer.Next()
+		require.NotNil(t, req)
+		req.Done(&queue.Result{
+			Status: queue.Success,
+		})
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("AddCandidatesWait timed out")
+	}
+
+	// 3. Cancelled context unblocks immediately.
+	cancCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	fuzzer.AddCandidatesWait(cancCtx, []Candidate{{Prog: p}})
 }

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -1208,6 +1208,7 @@ func (mgr *Manager) MachineChecked(features flatrpc.Feature,
 		go mgr.fuzzerLoop(fuzzerObj)
 		if mgr.dash != nil {
 			go mgr.dashboardReporter()
+			go mgr.dashboardCandidateSeeds()
 			if mgr.cfg.Reproduce {
 				go mgr.dashboardReproTasks()
 			}
@@ -1506,6 +1507,48 @@ func (mgr *Manager) dashboardReproTasks() {
 					Title:  resp.Title,
 					Output: resp.CrashLog,
 				},
+			}
+		}
+	}
+}
+
+func (mgr *Manager) dashboardCandidateSeeds() {
+	for {
+		time.Sleep(5 * time.Minute)
+		fuzzerObj := mgr.fuzzer.Load()
+		if fuzzerObj == nil || !fuzzerObj.CandidateTriageFinished() {
+			continue
+		}
+		resp, err := mgr.dash.CandidateSeedsPoll(&dashapi.CandidateSeedsPollReq{
+			Name:       mgr.cfg.Name,
+			TargetOS:   mgr.cfg.TargetOS,
+			TargetArch: mgr.cfg.TargetArch,
+		})
+		if err != nil {
+			log.Logf(0, "failed to poll candidate seeds: %v", err)
+			continue
+		}
+		if len(resp.Seeds) == 0 {
+			continue
+		}
+		var candidates []fuzzer.Candidate
+		for _, seed := range resp.Seeds {
+			p, err := mgr.target.Deserialize(seed.Prog, prog.NonStrict)
+			if err != nil {
+				log.Logf(1, "failed to deserialize candidate seed %v: %v", seed.ID, err)
+				continue
+			}
+			candidates = append(candidates, fuzzer.Candidate{
+				Prog: p,
+			})
+		}
+		fuzzerObj.AddCandidatesWait(context.Background(), candidates)
+		if resp.Token != "" {
+			if err := mgr.dash.CandidateSeedsDone(&dashapi.CandidateSeedsDoneReq{
+				Name:  mgr.cfg.Name,
+				Token: resp.Token,
+			}); err != nil {
+				log.Logf(0, "failed to confirm candidate seeds: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Cc https://github.com/google/syzkaller/issues/7857

* Explicitly remember the executed programs in the AI trajectory.
* Save the candidate programs in the DB we use for AI jobs.
* Offer an API to read/confirm the seed programs.

***

A separate question is how to best integrate it.

One option is to integrate it right into `syz-hub`. As of now, any change to syz-hub is excessively painful, so we would first need to refactor its code and change how it's deployed in our infra.

Another option is to (perhaps temporarily) make `syz-managers` poll dashboard for these seeds. This is the option implemented in this PR.

Whatever the option is, the first 3 commits are generic enough to be used in both cases. The dashboard keeps per-client cursors, so both managers and syz-hub could be the clients here.