### PR TITLE
pkg/aflow: ignore loop errors on context cancellation in RunIsolatedManager

### DIFF
--- a/pkg/aflow/runner.go
+++ b/pkg/aflow/runner.go
@@ -85,6 +85,9 @@ func RunIsolatedManager(ctx context.Context, cfg *mgrconfig.Config, debug bool,
 	eg.Go(func() error {
 		defer cancel()
 		if err := rm.Loop(); err != nil {
+			if egCtx.Err() != nil {
+				return nil
+			}
 			return fmt.Errorf("isolated RunnerManager loop failed: %w", err)
 		}
 		if egCtx.Err() == nil {


### PR DESCRIPTION
When the action callback finishes, RunIsolatedManager executes its deferred cancel() to stop the isolated manager loop. Because Loop() terminates as a consequence of context cancellation, it returns an error (e.g. context canceled or connection closed). Previously, this was treated as an unexpected loop failure, causing RunIsolatedManager to fail even when the action succeeded.

Ignore errors returned by rm.Loop() when the errgroup context has already been canceled, allowing clean teardown after action completion.
