### PR TITLE
pkg/corpus: weight focus area programs by in-focus coverage

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -47,6 +47,16 @@ type FocusArea struct {
 	Weight   float64
 }
 
+func (fa *FocusArea) inAreaPCs(cover []uint64) int {
+	var count int
+	for _, pc := range cover {
+		if _, ok := fa.CoverPCs[pc]; ok {
+			count++
+		}
+	}
+	return count
+}
+
 func NewCorpus(ctx context.Context) *Corpus {
 	return NewMonitoredCorpus(ctx, nil)
 }
@@ -161,7 +171,7 @@ func (corpus *Corpus) Save(inp NewInput) {
 			newItem.Updates = append(newItem.Updates, update)
 		}
 		corpus.progsMap[sig] = newItem
-		corpus.applyFocusAreas(newItem, inp.Cover)
+		corpus.applyFocusAreas(newItem)
 	} else {
 		item := &Item{
 			Sig:     sig,
@@ -173,8 +183,8 @@ func (corpus *Corpus) Save(inp NewInput) {
 			Updates: []ItemUpdate{update},
 		}
 		corpus.progsMap[sig] = item
-		corpus.applyFocusAreas(item, inp.Cover)
-		corpus.saveProgram(inp.Prog, inp.Signal)
+		corpus.applyFocusAreas(item)
+		corpus.saveProgram(inp.Prog, len(inp.Signal))
 	}
 	corpus.signal.Merge(inp.Signal)
 	newCover := corpus.cover.MergeDiff(inp.Cover)
@@ -191,22 +201,16 @@ func (corpus *Corpus) Save(inp NewInput) {
 	}
 }
 
-func (corpus *Corpus) applyFocusAreas(item *Item, coverDelta []uint64) {
+func (corpus *Corpus) applyFocusAreas(item *Item) {
 	for _, area := range corpus.focusAreas {
 		if _, ok := item.areas[area]; ok {
 			continue
 		}
-		matches := false
-		for _, pc := range coverDelta {
-			if _, ok := area.CoverPCs[pc]; ok {
-				matches = true
-				break
-			}
-		}
-		if !matches {
+		prio := area.inAreaPCs(item.Cover)
+		if prio == 0 {
 			continue
 		}
-		area.saveProgram(item.Prog, item.Signal)
+		area.saveProgram(item.Prog, prio)
 		if item.areas == nil {
 			item.areas = make(map[*focusAreaState]struct{})
 		}

--- a/pkg/corpus/minimize.go
+++ b/pkg/corpus/minimize.go
@@ -47,9 +47,9 @@ func (corpus *Corpus) Minimize(cover bool) {
 	for _, ctx := range signal.Minimize(inputs) {
 		inp := ctx.(*Item)
 		corpus.progsMap[inp.Sig] = inp
-		corpus.saveProgram(inp.Prog, inp.Signal)
+		corpus.saveProgram(inp.Prog, len(inp.Signal))
 		for area := range inp.areas {
-			area.saveProgram(inp.Prog, inp.Signal)
+			area.saveProgram(inp.Prog, area.inAreaPCs(inp.Cover))
 		}
 	}
 }

--- a/pkg/corpus/prio.go
+++ b/pkg/corpus/prio.go
@@ -21,7 +21,7 @@ func (pl *ProgramsList) chooseProgram(r *rand.Rand) *prog.Prog {
 	if len(pl.progs) == 0 {
 		return nil
 	}
-	randVal := r.Int63n(pl.sumPrios + 1)
+	randVal := r.Int63n(pl.sumPrios) + 1
 	idx := sort.Search(len(pl.accPrios), func(i int) bool {
 		return pl.accPrios[i] >= randVal
 	})

--- a/pkg/corpus/prio.go
+++ b/pkg/corpus/prio.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"sort"
 
-	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/prog"
 )
 
@@ -28,12 +27,11 @@ func (pl *ProgramsList) chooseProgram(r *rand.Rand) *prog.Prog {
 	return pl.progs[idx]
 }
 
-func (pl *ProgramsList) saveProgram(p *prog.Prog, signal signal.Signal) {
-	prio := int64(len(signal))
+func (pl *ProgramsList) saveProgram(p *prog.Prog, prio int) {
 	if prio == 0 {
 		prio = 1
 	}
-	pl.sumPrios += prio
+	pl.sumPrios += int64(prio)
 	pl.accPrios = append(pl.accPrios, pl.sumPrios)
 	pl.progs = append(pl.progs, p)
 }

--- a/pkg/corpus/prio_test.go
+++ b/pkg/corpus/prio_test.go
@@ -117,3 +117,45 @@ func TestFocusAreas(t *testing.T) {
 	assert.InDelta(t, secondCount, TOTAL*0.3, TOTAL/25)
 	assert.InDelta(t, thirdCount, TOTAL*0.6, TOTAL/25)
 }
+
+func TestFocusAreaInAreaWeighting(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	rs := rand.NewSource(0)
+	rnd := rand.New(rs)
+
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{
+		{
+			Name:     "patch",
+			CoverPCs: map[uint64]struct{}{10: {}, 11: {}},
+			Weight:   1.0,
+		},
+	})
+
+	// inp1 has 100 global signal entries, but only 1 PC in the focus area.
+	inp1 := generateRangedInput(target, rs, 1, 100)
+	inp1.Cover = []uint64{10}
+
+	// inp2 has only 2 global signal entries, but both of its PCs are in the focus area.
+	inp2 := generateRangedInput(target, rs, 101, 102)
+	inp2.Cover = []uint64{10, 11}
+
+	corpus.Save(inp1)
+	corpus.Save(inp2)
+
+	verifySampling := func(stage string) {
+		counts := make(map[*prog.Prog]int)
+		const iters = 10000
+		for range iters {
+			counts[corpus.ChooseProgram(rnd)]++
+		}
+		// inp2 has 2 focus PCs, inp1 has 1 focus PC.
+		// inp2 should be chosen ~2/3 (66.7%) of the time, inp1 ~1/3 (33.3%).
+		// Under the old bug (len(signal)), inp1 would be chosen ~98% of the time.
+		assert.InDelta(t, 2.0/3.0, float64(counts[inp2.Prog])/iters, 0.05, stage)
+		assert.InDelta(t, 1.0/3.0, float64(counts[inp1.Prog])/iters, 0.05, stage)
+	}
+
+	verifySampling("before minimization")
+	corpus.Minimize(true)
+	verifySampling("after minimization")
+}


### PR DESCRIPTION
Currently, when a test program matches a focus area, its priority in the focus area's ProgramsList is set to the program's global signal length. This creates a severe priority inversion: large, complex peripheral test cases (such as networking setup) that happen to touch a single PC in the focus area receive disproportionately high weights, drowning out compact test cases dedicated to the target subsystem.

Weight programs within a focus area by the number of PCs they actually cover within that focus area. Also fix an off-by-one in roulette-wheel sampling where the first program received an extra probability slot.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
