### PR TITLE
pkg/cover: make Cover.MergeDiff non-mutating

### DIFF
--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -8,11 +8,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/stat"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCorpusOperation(t *testing.T) {
@@ -208,4 +210,27 @@ func TestFocusedCorpusReSave(t *testing.T) {
 
 	// Verify that the program is not double-counted in the focus area.
 	assert.Len(t, corpus.focusAreas[0].progs, 1)
+}
+
+// Regression test for #7852: ensure saving an input with partially overlapping
+// coverage does not mutate item.Cover in-place, preserving full coverage in CallCover.
+func TestCallCoverPreserved(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewCorpus(context.Background())
+	rs := rand.NewSource(0)
+
+	inp1 := generateInput(target, rs, 1)
+	inp1.Cover = []uint64{10, 20}
+	corpus.Save(inp1)
+
+	// Save an input with partially overlapping coverage (PC 10 exists, 30 is new).
+	// Call = -1 isolates it under prog.ExtraCallName.
+	inp2 := generateInput(target, rs, 2)
+	inp2.Call = -1
+	inp2.Cover = []uint64{10, 30}
+	corpus.Save(inp2)
+
+	// In-place mutation would overwrite PC 10 with 30, leaving only [30].
+	callCover := corpus.CallCover()
+	require.Equal(t, cover.FromRaw([]uint64{10, 30}), callCover[prog.ExtraCallName].Cover)
 }

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -23,23 +23,22 @@ func (cov *Cover) Merge(raw []uint64) {
 	}
 }
 
-// MergeDiff merges raw into coverage and returns newly added PCs. Overwrites/mutates raw.
+// MergeDiff merges raw into coverage and returns newly added PCs.
 func (cov *Cover) MergeDiff(raw []uint64) []uint64 {
 	c := *cov
 	if c == nil {
 		c = make(Cover)
 		*cov = c
 	}
-	n := 0
+	var diff []uint64
 	for _, pc := range raw {
 		if _, ok := c[pc]; ok {
 			continue
 		}
 		c[pc] = struct{}{}
-		raw[n] = pc
-		n++
+		diff = append(diff, pc)
 	}
-	return raw[:n]
+	return diff
 }
 
 func (cov *Cover) Serialize() []uint64 {

--- a/pkg/cover/cover_test.go
+++ b/pkg/cover/cover_test.go
@@ -49,7 +49,9 @@ func TestMergeDiff(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			var cov Cover
 			cov.Merge(test.init)
+			orig := slices.Clone(test.merge)
 			diff := cov.MergeDiff(test.merge)
+			require.Equal(t, orig, test.merge)
 			require.Equal(t, test.diff, diff, "result is wrong")
 			result := cov.Serialize()
 			slices.Sort(result)


### PR DESCRIPTION
Cover.MergeDiff compacts newly discovered PCs into the input slice in-place. When corpus.Save stores a new program, it assigns item.Cover directly to inp.Cover and immediately calls MergeDiff on it. If earlier PCs in the slice are already known to the corpus, newer PCs overwrite the beginning of the slice's backing array, erasing earlier PCs and leaving duplicate entries in item.Cover.

This corruption causes corpus.CallCover() to undercount per-syscall coverage. In syz-manager, the artificially deflated coverage-to-program ratio causes active syscalls to be marked as saturated, permanently dropping new inputs for them. It also distorts focus area prioritization and displays incomplete coverage in the web UI.

Return newly added PCs in a separate slice instead of modifying the input slice in-place.