### PR TITLE
pkg/corpus: prune ubiquitous PCs in focus areas

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -57,6 +57,13 @@ func (fa *FocusArea) inAreaPCs(cover []uint64) int {
 	return count
 }
 
+// AreaCalibrateStat contains calibration statistics for a single focus area.
+type AreaCalibrateStat struct {
+	TotalPCs  int
+	PrunedPCs int
+	Progs     int
+}
+
 func NewCorpus(ctx context.Context) *Corpus {
 	return NewMonitoredCorpus(ctx, nil)
 }
@@ -88,11 +95,80 @@ func NewFocusedCorpus(ctx context.Context, updates chan<- NewItemEvent, areas []
 				stat.LenOf(&obj.progs, &corpus.mu))
 		}
 		corpus.focusAreas = append(corpus.focusAreas, &focusAreaState{
-			FocusArea:    area,
+			FocusArea: FocusArea{
+				Name:     area.Name,
+				CoverPCs: maps.Clone(area.CoverPCs),
+				Weight:   area.Weight,
+			},
 			ProgramsList: obj,
 		})
 	}
 	return corpus
+}
+
+// CalibrateFocusAreas prunes ubiquitous PCs that appear in more than threshold fraction
+// of corpus programs (bounded between minHits and maxHits), and rebuilds focus area program lists.
+func (corpus *Corpus) CalibrateFocusAreas(threshold float64, minHits, maxHits int) map[string]AreaCalibrateStat {
+	corpus.mu.Lock()
+	defer corpus.mu.Unlock()
+
+	stats := make(map[string]AreaCalibrateStat)
+	for _, area := range corpus.focusAreas {
+		stats[area.Name] = AreaCalibrateStat{
+			TotalPCs: len(area.CoverPCs),
+			Progs:    len(area.progs),
+		}
+	}
+	nProgs := len(corpus.progsMap)
+	if nProgs == 0 || threshold <= 0 || len(corpus.focusAreas) == 0 {
+		return stats
+	}
+
+	pcHits := make(map[uint64]int)
+	for _, area := range corpus.focusAreas {
+		for pc := range area.CoverPCs {
+			pcHits[pc] = 0
+		}
+	}
+	for _, item := range corpus.progsMap {
+		for _, pc := range item.Cover {
+			if _, ok := pcHits[pc]; ok {
+				pcHits[pc]++
+			}
+		}
+	}
+
+	allowedHits := int(float64(nProgs) * threshold)
+	if minHits > 0 && allowedHits < minHits {
+		allowedHits = minHits
+	}
+	if maxHits > 0 && allowedHits > maxHits {
+		allowedHits = maxHits
+	}
+
+	for _, area := range corpus.focusAreas {
+		total := len(area.CoverPCs)
+		maps.DeleteFunc(area.CoverPCs, func(pc uint64, _ struct{}) bool {
+			return pcHits[pc] > allowedHits
+		})
+		area.ProgramsList.clear()
+		st := stats[area.Name]
+		st.PrunedPCs = total - len(area.CoverPCs)
+		stats[area.Name] = st
+	}
+
+	// Clear area assignments on existing items and reapply.
+	for _, item := range corpus.progsMap {
+		item.areas = nil
+		corpus.applyFocusAreas(item)
+	}
+
+	for _, area := range corpus.focusAreas {
+		st := stats[area.Name]
+		st.Progs = len(area.progs)
+		stats[area.Name] = st
+	}
+	return stats
 }
 
 // ItemUpdate represents an update to a corpus item.

--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -229,3 +229,38 @@ func TestCallCoverPreserved(t *testing.T) {
 	callCover := corpus.CallCover()
 	require.Equal(t, cover.FromRaw([]uint64{10, 30}), callCover[prog.ExtraCallName].Cover)
 }
+
+func TestCalibrateFocusAreas(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	rs := rand.NewSource(0)
+
+	corpus := NewFocusedCorpus(context.Background(), nil, []FocusArea{{
+		Name:     "area",
+		CoverPCs: map[uint64]struct{}{1: {}, 2: {}},
+	}})
+
+	// PC 1 is ubiquitous (3/3 progs), PC 2 is rare (1/3 progs).
+	for _, cover := range [][]uint64{{1, 2}, {1}, {1}} {
+		inp := generateInput(target, rs, 1)
+		inp.Cover = cover
+		corpus.Save(inp)
+	}
+	require.Equal(t, 3, corpus.ProgsPerArea()["area"])
+
+	// Calibrate: threshold 50%, minHits 1, maxHits 2 -> allowedHits is 1.
+	// PC 1 (>1 hits) is pruned, PC 2 (1 hit) is kept.
+	stats := corpus.CalibrateFocusAreas(0.5, 1, 2)
+	require.Equal(t, AreaCalibrateStat{TotalPCs: 2, PrunedPCs: 1, Progs: 1}, stats["area"])
+	require.Equal(t, 1, corpus.ProgsPerArea()["area"])
+
+	// New program with pruned PC 1 does not match; program with PC 2 does.
+	inp := generateInput(target, rs, 1)
+	inp.Cover = []uint64{1}
+	corpus.Save(inp)
+	require.Equal(t, 1, corpus.ProgsPerArea()["area"])
+
+	inp = generateInput(target, rs, 1)
+	inp.Cover = []uint64{2}
+	corpus.Save(inp)
+	require.Equal(t, 2, corpus.ProgsPerArea()["area"])
+}

--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -8,11 +8,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/google/syzkaller/pkg/cover"
 	"github.com/google/syzkaller/pkg/signal"
 	"github.com/google/syzkaller/pkg/stat"
 	"github.com/google/syzkaller/prog"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCorpusOperation(t *testing.T) {
@@ -208,4 +210,22 @@ func TestFocusedCorpusReSave(t *testing.T) {
 
 	// Verify that the program is not double-counted in the focus area.
 	assert.Len(t, corpus.focusAreas[0].progs, 1)
+}
+
+func TestCallCoverPreserved(t *testing.T) {
+	target := getTarget(t, targets.TestOS, targets.TestArch64)
+	corpus := NewCorpus(context.Background())
+	rs := rand.NewSource(0)
+
+	inp1 := generateInput(target, rs, 1)
+	inp1.Cover = []uint64{10, 20}
+	corpus.Save(inp1)
+
+	inp2 := generateInput(target, rs, 2)
+	inp2.Call = -1
+	inp2.Cover = []uint64{10, 30}
+	corpus.Save(inp2)
+
+	callCover := corpus.CallCover()
+	require.Equal(t, cover.FromRaw([]uint64{10, 30}), callCover[prog.ExtraCallName].Cover)
 }

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -23,23 +23,22 @@ func (cov *Cover) Merge(raw []uint64) {
 	}
 }
 
-// MergeDiff merges raw into coverage and returns newly added PCs. Overwrites/mutates raw.
+// MergeDiff merges raw into coverage and returns newly added PCs.
 func (cov *Cover) MergeDiff(raw []uint64) []uint64 {
 	c := *cov
 	if c == nil {
 		c = make(Cover)
 		*cov = c
 	}
-	n := 0
+	var diff []uint64
 	for _, pc := range raw {
 		if _, ok := c[pc]; ok {
 			continue
 		}
 		c[pc] = struct{}{}
-		raw[n] = pc
-		n++
+		diff = append(diff, pc)
 	}
-	return raw[:n]
+	return diff
 }
 
 func (cov *Cover) Serialize() []uint64 {

--- a/pkg/manager/diff/kernel.go
+++ b/pkg/manager/diff/kernel.go
@@ -200,6 +200,9 @@ func (kc *kernelContext) setupFuzzer(features flatrpc.Feature, syscalls map[*pro
 	filtered := manager.FilterCandidates(candidates, syscalls, false).Candidates
 	log.Logf(0, "%s: adding %d seeds", kc.name, len(filtered))
 	fuzzerObj.AddCandidates(filtered)
+	if len(kc.coverFilters.Areas) > 0 {
+		go kc.calibrateFocusAreas(corpusObj, fuzzerObj)
+	}
 
 	go func() {
 		if !kc.cfg.Cover {
@@ -303,4 +306,31 @@ func (kc *kernelContext) Features() flatrpc.Feature {
 
 func (kc *kernelContext) Reporter() *report.Reporter {
 	return kc.reporter
+}
+
+const (
+	focusAreaThreshold = 0.10 // 10%
+	focusAreaMinHits   = 10   // do not prune if <= 10 progs match
+	focusAreaMaxHits   = 100  // prune if > 100 progs match regardless of corpus size
+)
+
+func (kc *kernelContext) calibrateFocusAreas(corpusObj *corpus.Corpus, fuzzerObj *fuzzer.Fuzzer) {
+	const checkPeriod = 5 * time.Second
+	ticker := time.NewTicker(checkPeriod)
+	defer ticker.Stop()
+	for !fuzzerObj.CandidateTriageFinished() && kc.TriageProgress() < 0.99 {
+		select {
+		case <-ticker.C:
+		case <-kc.ctx.Done():
+			return
+		}
+	}
+	stats := corpusObj.CalibrateFocusAreas(focusAreaThreshold, focusAreaMinHits, focusAreaMaxHits)
+	for areaName, st := range stats {
+		if areaName == "" && st.TotalPCs == 0 {
+			continue
+		}
+		log.Logf(0, "%s: focus area %q calibrated: %d/%d PCs pruned, %d progs matching",
+			kc.name, areaName, st.PrunedPCs, st.TotalPCs, st.Progs)
+	}
 }


### PR DESCRIPTION
When patch testing touches widely-used functions or files (e.g. core mm,
locks, or VFS), focus areas often match 20% to 80% of the corpus. This
dilutes mutational focus and drowns out targeted test cases.

Prune focus PCs that appear in more than 10% of corpus programs once
initial triage finishes, bounded between 10 and 100 programs to avoid
over-pruning small corpora while capping bloat on large ones.