### PR TITLE
pkg/corpus: acquire read lock in Cover

### DIFF
--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -272,5 +272,7 @@ func (corpus *Corpus) ProgsPerArea() map[string]int {
 }
 
 func (corpus *Corpus) Cover() []uint64 {
+	corpus.mu.RLock()
+	defer corpus.mu.RUnlock()
 	return corpus.cover.Serialize()
 }


### PR DESCRIPTION
Cover calls corpus.cover.Serialize(), which iterates over the underlying map[uint64]struct{}. Without holding corpus.mu.RLock(), calling Cover concurrently with corpus.Save (which mutates corpus.cover) causes a data race and can trigger a fatal concurrent map read/write runtime panic.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
