### PR TITLE
pkg/vcs: backport __vdso_sgx_enter_enclave export fix

### DIFF
--- a/pkg/vcs/linux_patches.go
+++ b/pkg/vcs/linux_patches.go
@@ -145,4 +145,10 @@ var pickLinuxCommits = []BackportCommit{
 		GuiltyHash: `2a04739139b2b2761571e18937e2400e71eff664`,
 		FixHash:    `c5d296bad640b190c52ef7508114d70e971a4bba`,
 	},
+	{
+		// Fixes `ld.lld: error: version script assignment of 'LINUX_2.6' to symbol '__vdso_sgx_enter_enclave' failed`.
+		// Title: x86/vdso: Conditionally export __vdso_sgx_enter_enclave()
+		GuiltyHash: `84664369520170f48546c55cbc1f3fbde9b1e140`,
+		FixHash:    `45be2ad007a9c6bea70249c4cf3e4905afe4caeb`,
+	},
 }


### PR DESCRIPTION
With newer versions of ld.lld (which default to --no-undefined-version), building older Linux kernels (v5.11 through v6.1) fails when CONFIG_X86_SGX is disabled because the vDSO linker script unconditionally exports the symbol:

  ld.lld: error: version script assignment of 'LINUX_2.6' to symbol
  '__vdso_sgx_enter_enclave' failed: symbol not defined

Backport upstream commit 45be2ad007a9 to conditionally export the symbol only when CONFIG_X86_SGX is enabled, allowing bisection across these kernel releases.