### PR TITLE
pkg/coveragedb: export uncovered target functions

### DIFF
--- a/dashboard/app/coverage.go
+++ b/dashboard/app/coverage.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -344,6 +345,36 @@ func handleFileCoverage(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Type", "text/html")
 	w.Write([]byte(content))
 	return nil
+}
+
+func handleUncoveredTargets(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	hdr, err := commonHeader(ctx, r, w, "")
+	if err != nil {
+		return err
+	}
+	nsConfig := getNsConfig(ctx, hdr.Namespace)
+	if nsConfig.Coverage == nil {
+		return ErrClientNotFound
+	}
+	var prefixes []string
+	for _, p := range r.URL.Query()["prefix"] {
+		if p = strings.TrimSpace(p); p != "" {
+			prefixes = append(prefixes, p)
+		}
+	}
+	limit := getParam[int](r, "limit")
+	client := getCoverageDBClient(ctx)
+	targets, err := coveragedb.GetCoverageTargets(ctx, client, hdr.Namespace, coveragedb.TargetFilter{
+		Prefixes: prefixes,
+		Limit:    limit,
+	})
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "\t")
+	return enc.Encode(targets)
 }
 
 var keyWebGit = "file content provider"

--- a/dashboard/app/coverage_test.go
+++ b/dashboard/app/coverage_test.go
@@ -13,12 +13,14 @@ import (
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
+	"encoding/json"
 	"github.com/google/syzkaller/pkg/coveragedb"
 	"github.com/google/syzkaller/pkg/coveragedb/testutil"
 	"github.com/google/syzkaller/pkg/covermerger"
 	mergermocks "github.com/google/syzkaller/pkg/covermerger/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func setCoverageDBClient(ctx context.Context, client *spanner.Client) context.Context {
@@ -190,4 +192,62 @@ func multiManagerCovDBFixture(t *testing.T) *spanner.Client {
 	}})
 
 	return client
+}
+
+func TestUncoveredTargets(t *testing.T) {
+	c := NewCtx(t)
+	defer c.Close()
+
+	client := testutil.SetupCoverageTestDB(t)
+	hist := &coveragedb.HistoryRecord{
+		Namespace: "test2",
+		Repo:      "repo1",
+		Commit:    "abcdef1234567890",
+		Duration:  30,
+		DateTo:    civil.Date{Year: 2026, Month: 9, Day: 30},
+		Session:   "sess-targets",
+	}
+	testutil.InsertCoverageData(t, client, "*", hist, []*coveragedb.FileCoverageWithLineInfo{
+		{
+			FileCoverageWithDetails: coveragedb.FileCoverageWithDetails{
+				Filepath:     "arch/x86/kvm/x86.c",
+				Instrumented: 2,
+				Covered:      1,
+			},
+			LinesInstrumented: []int64{10, 20},
+			HitCounts:         []int64{0, 1},
+		},
+	})
+	testutil.InsertFunctionsData(t, client, hist, []*coveragedb.FuncLines{
+		{
+			FilePath: "arch/x86/kvm/x86.c",
+			FuncName: "kvm_arch_vcpu_ioctl",
+			Lines:    []int64{10},
+		},
+	})
+	c.setCoverageMocks("test2", client, nil)
+
+	// Valid namespace returns 200 OK with JSON targets.
+	raw, err := c.GET("/test2/coverage/uncovered-targets")
+	require.NoError(t, err)
+	var targets coveragedb.CoverageTargets
+	require.NoError(t, json.Unmarshal(raw, &targets))
+	require.Equal(t, coveragedb.CoverageTargets{
+		KernelRepo:   hist.Repo,
+		KernelCommit: hist.Commit,
+		Targets: []coveragedb.UncoveredFunction{
+			{
+				FilePath:   "arch/x86/kvm/x86.c",
+				FuncName:   "kvm_arch_vcpu_ioctl",
+				HasCovered: false,
+				Lines:      []int64{10},
+			},
+		},
+	}, targets)
+
+	// Namespace without coverage returns 404.
+	_, err = c.GET("/test1/coverage/uncovered-targets")
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, http.StatusNotFound, httpErr.Code)
 }

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -74,6 +74,7 @@ func initHTTPHandlers() {
 	http.Handle("/{ns}/graph/coverage", handlerWrapper(handleCoverageGraph))
 	http.Handle("/{ns}/graph/ai", handlerWrapper(handleAIGraphs))
 	http.Handle("/{ns}/coverage/file", handlerWrapper(handleFileCoverage))
+	http.Handle("/{ns}/coverage/uncovered-targets", handlerWrapper(handleUncoveredTargets))
 	http.Handle("/{ns}/coverage", handlerWrapper(handleCoverageHeatmap))
 	http.Handle("/{ns}/coverage/subsystems", handlerWrapper(handleSubsystemsCoverageHeatmap))
 	http.Handle("/{ns}/repos", handlerWrapper(handleRepos))

--- a/pkg/coveragedb/targets.go
+++ b/pkg/coveragedb/targets.go
@@ -1,0 +1,192 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package coveragedb
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"cloud.google.com/go/spanner"
+	pkgspanner "github.com/google/syzkaller/pkg/spanner"
+)
+
+type TargetFilter struct {
+	Prefixes []string
+	Limit    int
+}
+
+type CoverageTargets struct {
+	KernelRepo   string              `json:"kernel_repo"`
+	KernelCommit string              `json:"kernel_commit"`
+	Targets      []UncoveredFunction `json:"targets"`
+}
+
+type UncoveredFunction struct {
+	FilePath   string  `json:"file_path"`
+	FuncName   string  `json:"func_name"`
+	HasCovered bool    `json:"has_covered"`
+	Lines      []int64 `json:"lines"`
+}
+
+type latestMergeHistoryRow struct {
+	Session string
+	Repo    string
+	Commit  string
+}
+
+type targetFileRow struct {
+	FilePath          string
+	LinesInstrumented []int64
+	HitCounts         []int64
+}
+
+// GetCoverageTargets queries the latest aggregated coverage session and returns uncovered functions
+// located in files that have partial coverage, optionally filtered by path prefixes and capped by limit.
+func GetCoverageTargets(ctx context.Context, client *spanner.Client, ns string,
+	filter TargetFilter) (*CoverageTargets, error) {
+	if client == nil {
+		return nil, fmt.Errorf("nil spanner client")
+	}
+	history, err := queryLatestMergeHistory(ctx, client, ns)
+	if err != nil {
+		return nil, fmt.Errorf("queryLatestMergeHistory: %w", err)
+	}
+	if history == nil {
+		return &CoverageTargets{Targets: []UncoveredFunction{}}, nil
+	}
+
+	files, err := queryPartiallyCoveredFiles(ctx, client, history.Session, filter.Prefixes)
+	if err != nil {
+		return nil, fmt.Errorf("queryPartiallyCoveredFiles: %w", err)
+	}
+	if len(files) == 0 {
+		return &CoverageTargets{
+			KernelRepo:   history.Repo,
+			KernelCommit: history.Commit,
+			Targets:      []UncoveredFunction{},
+		}, nil
+	}
+
+	funcs, err := queryFunctions(ctx, client, history.Session, filter.Prefixes)
+	if err != nil {
+		return nil, fmt.Errorf("queryFunctions: %w", err)
+	}
+
+	fileCovered := make(map[string]map[int64]bool, len(files))
+	for _, f := range files {
+		if len(f.LinesInstrumented) != len(f.HitCounts) {
+			continue
+		}
+		covered := make(map[int64]bool)
+		for i, hits := range f.HitCounts {
+			if hits > 0 {
+				covered[f.LinesInstrumented[i]] = true
+			}
+		}
+		fileCovered[f.FilePath] = covered
+	}
+
+	candidates := []UncoveredFunction{}
+	for _, fn := range funcs {
+		covered, ok := fileCovered[fn.FilePath]
+		if !ok {
+			continue
+		}
+		hasCovered := false
+		var uncovered []int64
+		for _, l := range fn.Lines {
+			if covered[l] {
+				hasCovered = true
+			} else {
+				uncovered = append(uncovered, l)
+			}
+		}
+		if len(uncovered) == 0 {
+			continue
+		}
+		slices.Sort(uncovered)
+		candidates = append(candidates, UncoveredFunction{
+			FilePath:   fn.FilePath,
+			FuncName:   fn.FuncName,
+			HasCovered: hasCovered,
+			Lines:      slices.Compact(uncovered),
+		})
+	}
+
+	slices.SortFunc(candidates, func(a, b UncoveredFunction) int {
+		return cmp.Or(
+			cmp.Compare(a.FilePath, b.FilePath),
+			cmp.Compare(a.FuncName, b.FuncName),
+		)
+	})
+
+	if filter.Limit > 0 && len(candidates) > filter.Limit {
+		candidates = candidates[:filter.Limit]
+	}
+
+	return &CoverageTargets{
+		KernelRepo:   history.Repo,
+		KernelCommit: history.Commit,
+		Targets:      candidates,
+	}, nil
+}
+
+func queryLatestMergeHistory(ctx context.Context, client *spanner.Client, ns string) (*latestMergeHistoryRow, error) {
+	rows, err := queryRows[latestMergeHistoryRow](ctx, client, `
+SELECT session, repo, commit
+FROM merge_history
+WHERE namespace = $1
+ORDER BY dateto DESC, duration DESC
+LIMIT 1`, map[string]any{"p1": ns})
+	if err != nil || len(rows) == 0 {
+		return nil, err
+	}
+	return rows[0], nil
+}
+
+func queryPartiallyCoveredFiles(ctx context.Context, client *spanner.Client, session string,
+	prefixes []string) ([]*targetFileRow, error) {
+	params := map[string]any{"p1": session}
+	sql := `
+SELECT filepath, linesinstrumented, hitcounts
+FROM files
+WHERE session = $1 AND manager = '*' AND covered > 0 AND covered < instrumented` + prefixClause(prefixes, params)
+	return queryRows[targetFileRow](ctx, client, sql, params)
+}
+
+func queryFunctions(ctx context.Context, client *spanner.Client, session string,
+	prefixes []string) ([]*FuncLines, error) {
+	params := map[string]any{"p1": session}
+	sql := `
+SELECT filepath, funcname, lines
+FROM functions
+WHERE session = $1` + prefixClause(prefixes, params)
+	return queryRows[FuncLines](ctx, client, sql, params)
+}
+
+func queryRows[T any](ctx context.Context, client *spanner.Client, sql string, params map[string]any) ([]*T, error) {
+	iter := client.Single().Query(ctx, spanner.Statement{
+		SQL:    sql,
+		Params: params,
+	})
+	defer iter.Stop()
+	return pkgspanner.ReadRows[T](iter)
+}
+
+func prefixClause(prefixes []string, params map[string]any) string {
+	if len(prefixes) == 0 {
+		return ""
+	}
+	baseIdx := len(params)
+	conds := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
+		idx := baseIdx + i + 1
+		conds[i] = fmt.Sprintf("starts_with(filepath, $%d)", idx)
+		params[fmt.Sprintf("p%d", idx)] = prefix
+	}
+	return " AND (" + strings.Join(conds, " OR ") + ")"
+}

--- a/pkg/coveragedb/targets_test.go
+++ b/pkg/coveragedb/targets_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package coveragedb_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/google/syzkaller/pkg/coveragedb"
+	"github.com/google/syzkaller/pkg/coveragedb/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func saveMergeResult(t *testing.T, client *spanner.Client, descr *coveragedb.HistoryRecord,
+	files []*coveragedb.MergedCoverageRecord, funcs []*coveragedb.FuncLines) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, f := range files {
+		require.NoError(t, enc.Encode(coveragedb.JSONLWrapper{MCR: f}))
+	}
+	for _, fn := range funcs {
+		require.NoError(t, enc.Encode(coveragedb.JSONLWrapper{FL: fn}))
+	}
+	_, err := coveragedb.SaveMergeResult(t.Context(), client, descr, json.NewDecoder(&buf))
+	require.NoError(t, err)
+}
+
+func saveSession(t *testing.T, client *spanner.Client, descr *coveragedb.HistoryRecord,
+	filePath, funcName string) {
+	saveMergeResult(t, client, descr, []*coveragedb.MergedCoverageRecord{
+		makeFileRecord(filePath, map[int]int64{10: 0, 20: 1}),
+	}, []*coveragedb.FuncLines{
+		{FilePath: filePath, FuncName: funcName, Lines: []int64{10}},
+	})
+}
+
+func makeFileRecord(path string, lineHits map[int]int64) *coveragedb.MergedCoverageRecord {
+	cov := &coveragedb.Coverage{}
+	for line, hits := range lineHits {
+		cov.AddLineHitCount(line, hits)
+	}
+	return &coveragedb.MergedCoverageRecord{
+		Manager:  "*",
+		FilePath: path,
+		FileData: cov,
+	}
+}
+
+func TestGetCoverageTargets(t *testing.T) {
+	t.Run("nil client", func(t *testing.T) {
+		got, err := coveragedb.GetCoverageTargets(t.Context(), nil, "upstream", coveragedb.TargetFilter{})
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("empty database", func(t *testing.T) {
+		client := testutil.SetupCoverageTestDB(t)
+		got, err := coveragedb.GetCoverageTargets(t.Context(), client, "upstream", coveragedb.TargetFilter{})
+		require.NoError(t, err)
+		require.Equal(t, &coveragedb.CoverageTargets{
+			Targets: []coveragedb.UncoveredFunction{},
+		}, got)
+	})
+
+	t.Run("target discovery and filtering", func(t *testing.T) {
+		client := testutil.SetupCoverageTestDB(t)
+		ctx := t.Context()
+
+		dateOld := civil.Date{Year: 2026, Month: 8, Day: 31}
+		dateNew := civil.Date{Year: 2026, Month: 9, Day: 30}
+
+		// Older session in upstream namespace (should NOT be used by GetCoverageTargets).
+		saveSession(t, client, &coveragedb.HistoryRecord{
+			Namespace: "upstream",
+			Repo:      "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+			Commit:    "old_commit_1111",
+			Duration:  30,
+			DateTo:    dateOld,
+		}, "net/core/dev.c", "old_func")
+
+		// Session in another namespace (android) to verify namespace isolation.
+		saveSession(t, client, &coveragedb.HistoryRecord{
+			Namespace: "android",
+			Repo:      "https://android.googlesource.com/kernel/common",
+			Commit:    "android_commit_2222",
+			Duration:  30,
+			DateTo:    dateNew,
+		}, "net/core/dev.c", "android_func")
+
+		// Latest session in upstream namespace.
+		latestHist := &coveragedb.HistoryRecord{
+			Namespace: "upstream",
+			Repo:      "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+			Commit:    "latest_commit_3333",
+			Duration:  30,
+			DateTo:    dateNew,
+		}
+
+		files := []*coveragedb.MergedCoverageRecord{
+			// Partially covered file: arch/x86/kvm/mmu.c (lines 10, 20 uncovered; lines 30, 40 covered).
+			makeFileRecord("arch/x86/kvm/mmu.c", map[int]int64{10: 0, 20: 0, 30: 5, 40: 2}),
+			// Partially covered file: net/core/dev.c (lines 100, 110 uncovered; line 120 covered).
+			makeFileRecord("net/core/dev.c", map[int]int64{100: 0, 110: 0, 120: 3}),
+			// Partially covered file: fs/ext4/super.c (line 200 uncovered; line 210 covered).
+			makeFileRecord("fs/ext4/super.c", map[int]int64{200: 0, 210: 1}),
+			// Fully uncovered file: drivers/gpu/drm.c (covered = 0) -> should be excluded.
+			makeFileRecord("drivers/gpu/drm.c", map[int]int64{300: 0, 310: 0}),
+			// Fully covered file: mm/slab.c (covered = instrumented) -> should be excluded.
+			makeFileRecord("mm/slab.c", map[int]int64{400: 1, 410: 2}),
+		}
+
+		funcs := []*coveragedb.FuncLines{
+			// In arch/x86/kvm/mmu.c:
+			// Uncovered function: lines 10, 20 have hitcount 0 -> CANDIDATE!
+			{
+				FilePath: "arch/x86/kvm/mmu.c",
+				FuncName: "kvm_mmu_calc_shadow",
+				Lines:    []int64{20, 10}, // Out of order to verify line sorting.
+			},
+			// Fully covered function: lines 30, 40 have hitcounts 5, 2 -> excluded.
+			{
+				FilePath: "arch/x86/kvm/mmu.c",
+				FuncName: "kvm_mmu_init_page",
+				Lines:    []int64{30, 40},
+			},
+			// Function with no lines -> excluded.
+			{
+				FilePath: "arch/x86/kvm/mmu.c",
+				FuncName: "empty_kvm_func",
+				Lines:    nil,
+			},
+
+			// In net/core/dev.c:
+			// Uncovered function: lines 100, 110 have hitcount 0 -> CANDIDATE!
+			{
+				FilePath: "net/core/dev.c",
+				FuncName: "dev_queue_xmit_nit",
+				Lines:    []int64{100, 110},
+			},
+			// Partially covered function: line 110 hitcount 0, line 120 hitcount 3 -> CANDIDATE with HasCovered: true!
+			{
+				FilePath: "net/core/dev.c",
+				FuncName: "dev_hard_start_xmit",
+				Lines:    []int64{110, 120},
+			},
+
+			// In fs/ext4/super.c:
+			// Uncovered function: line 200 has hitcount 0 -> CANDIDATE!
+			{
+				FilePath: "fs/ext4/super.c",
+				FuncName: "ext4_destroy_inode",
+				Lines:    []int64{200},
+			},
+
+			// In drivers/gpu/drm.c (fully uncovered file): should be excluded!
+			{
+				FilePath: "drivers/gpu/drm.c",
+				FuncName: "drm_init_device",
+				Lines:    []int64{300, 310},
+			},
+
+			// In mm/slab.c (fully covered file): should be excluded!
+			{
+				FilePath: "mm/slab.c",
+				FuncName: "kmem_cache_create",
+				Lines:    []int64{400, 410},
+			},
+		}
+
+		saveMergeResult(t, client, latestHist, files, funcs)
+
+		allTargets := []coveragedb.UncoveredFunction{
+			{
+				FilePath: "arch/x86/kvm/mmu.c",
+				FuncName: "kvm_mmu_calc_shadow",
+				Lines:    []int64{10, 20},
+			},
+			{
+				FilePath: "fs/ext4/super.c",
+				FuncName: "ext4_destroy_inode",
+				Lines:    []int64{200},
+			},
+			{
+				FilePath:   "net/core/dev.c",
+				FuncName:   "dev_hard_start_xmit",
+				HasCovered: true,
+				Lines:      []int64{110},
+			},
+			{
+				FilePath: "net/core/dev.c",
+				FuncName: "dev_queue_xmit_nit",
+				Lines:    []int64{100, 110},
+			},
+		}
+
+		t.Run("all targets without prefix filter", func(t *testing.T) {
+			got, err := coveragedb.GetCoverageTargets(ctx, client, "upstream", coveragedb.TargetFilter{})
+			require.NoError(t, err)
+			require.Equal(t, latestHist.Repo, got.KernelRepo)
+			require.Equal(t, latestHist.Commit, got.KernelCommit)
+			require.Equal(t, allTargets, got.Targets)
+		})
+
+		t.Run("filter by folder prefixes", func(t *testing.T) {
+			got, err := coveragedb.GetCoverageTargets(ctx, client, "upstream", coveragedb.TargetFilter{
+				Prefixes: []string{"net/", "arch/x86/kvm/"},
+			})
+			require.NoError(t, err)
+			require.Equal(t, []coveragedb.UncoveredFunction{allTargets[0], allTargets[2], allTargets[3]}, got.Targets)
+		})
+
+		t.Run("filter with non-matching prefix returns empty targets", func(t *testing.T) {
+			got, err := coveragedb.GetCoverageTargets(ctx, client, "upstream", coveragedb.TargetFilter{
+				Prefixes: []string{"kernel/bpf/"},
+			})
+			require.NoError(t, err)
+			require.Empty(t, got.Targets)
+		})
+
+		t.Run("limit results", func(t *testing.T) {
+			got, err := coveragedb.GetCoverageTargets(ctx, client, "upstream", coveragedb.TargetFilter{
+				Prefixes: []string{"net/", "arch/x86/kvm/"},
+				Limit:    1,
+			})
+			require.NoError(t, err)
+			require.Equal(t, allTargets[:1], got.Targets)
+		})
+	})
+}


### PR DESCRIPTION
Automated seed generation workflows require reachable targets to expand coverage. Uncovered lines in partially covered files are ideal candidates because syzkaller already exercises those files, avoiding unreachable drivers or unconfigured subsystems.

Add GetCoverageTargets in pkg/coveragedb to retrieve functions with uncovered lines from the latest coverage session, and expose them via a /{ns}/coverage/uncovered-targets HTTP endpoint with prefix filtering and limits.

Cc https://github.com/google/syzkaller/issues/7857
