### PR TITLE
pkg/cover: skip TestResolveLineToPCs on broken compiler

### DIFF
--- a/pkg/cover/report_test.go
+++ b/pkg/cover/report_test.go
@@ -518,6 +518,9 @@ func TestResolveLineToPCs(t *testing.T) {
 	if target == nil {
 		t.Skip("skipping, amd64 target not found")
 	}
+	if target.BrokenCompiler != "" {
+		t.Skip("skipping the test due to broken compiler:\n" + target.BrokenCompiler)
+	}
 
 	testSource := `// Line 1: file header comment
 int compute(int x) {


### PR DESCRIPTION
Skip the test if target.BrokenCompiler is set so it does not fail on environments lacking a functional linux/amd64 compiler.