### PR TITLE
dashboard/app: clean up repro time migration tool

### DIFF
--- a/dashboard/app/admin.go
+++ b/dashboard/app/admin.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -425,86 +424,6 @@ func forceCommitInfoUpdate(ctx context.Context, w http.ResponseWriter, r *http.R
 	})
 }
 
-func findOldestReproTimes(crashes []*Crash) (oldestC, oldestSyz time.Time) {
-	for _, crash := range crashes {
-		if crash.Time.IsZero() {
-			continue
-		}
-		if crash.ReproC > 0 && (oldestC.IsZero() || crash.Time.Before(oldestC)) {
-			oldestC = crash.Time
-		}
-		if crash.ReproSyz > 0 && (oldestSyz.IsZero() || crash.Time.Before(oldestSyz)) {
-			oldestSyz = crash.Time
-		}
-	}
-	return oldestC, oldestSyz
-}
-
-func updateReproTimesForBug(ctx context.Context, key *db.Key, bug *Bug) error {
-	if !bug.HasCRepro && !bug.HasSyzRepro {
-		bug.StructVersion = bugStructVersion
-		return nil
-	}
-	var crashes []*Crash
-	_, err := db.NewQuery("Crash").Ancestor(key).GetAll(ctx, &crashes)
-	if err != nil {
-		return fmt.Errorf("failed to fetch crashes for bug %v: %w", key.StringID(), err)
-	}
-	oldestC, oldestSyz := findOldestReproTimes(crashes)
-	if bug.HasCRepro && !oldestC.IsZero() &&
-		(bug.FirstCReproTime.IsZero() || oldestC.Before(bug.FirstCReproTime)) {
-		bug.FirstCReproTime = oldestC
-	}
-	if bug.HasSyzRepro && !oldestSyz.IsZero() &&
-		(bug.FirstSyzReproTime.IsZero() || oldestSyz.Before(bug.FirstSyzReproTime)) {
-		bug.FirstSyzReproTime = oldestSyz
-	}
-	bug.StructVersion = bugStructVersion
-	return nil
-}
-
-// populateReproTime populates FirstCReproTime and FirstSyzReproTime fields for historical bugs
-// based on the oldest crash associated with a reproducer.
-// TODO: remove this function and the corresponding admin action after migration.
-func populateReproTime(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if accessLevel(ctx, r) != AccessAdmin {
-		return fmt.Errorf("admin only")
-	}
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	limit := 0
-	if limitStr := r.FormValue("limit"); limitStr != "" {
-		parsed, err := strconv.Atoi(limitStr)
-		if err != nil || parsed <= 0 {
-			return fmt.Errorf("invalid limit parameter %q", limitStr)
-		}
-		limit = parsed
-	}
-	var keys []*db.Key
-	filter := func(query *db.Query) *db.Query {
-		return query.Filter("StructVersion <", bugStructVersion)
-	}
-	errStop := errors.New("stop")
-	err := foreachBug(ctx, filter, func(bug *Bug, key *db.Key) error {
-		if limit > 0 && len(keys) >= limit {
-			return errStop
-		}
-		keys = append(keys, key)
-		return nil
-	})
-	if err != nil && !errors.Is(err, errStop) {
-		return err
-	}
-	fmt.Fprintf(w, "fetched %d bugs to update repro times\n", len(keys))
-	err = updateBatch(ctx, keys, func(key *db.Key, bug *Bug) error {
-		return updateReproTimesForBug(ctx, key, bug)
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(w, "successfully updated repro times for %d bugs\n", len(keys))
-	return nil
-}
-
 func init() {
 	// Prevent warnings about dead code.
 	runtime.KeepAlive(dropNamespace)
@@ -512,5 +431,4 @@ func init() {
 	runtime.KeepAlive(adminSendEmail)
 	runtime.KeepAlive(updateHeadReproLevel)
 	runtime.KeepAlive(updateCrashPriorities)
-	runtime.KeepAlive(populateReproTime)
 }

--- a/dashboard/app/entities_datastore_test.go
+++ b/dashboard/app/entities_datastore_test.go
@@ -60,8 +60,7 @@ func TestOldBugTagsConversion(t *testing.T) {
 	}, newBug)
 }
 
-// TODO: remove this test when populateReproTime admin action is removed after migration.
-func TestPopulateReproTime(t *testing.T) {
+func TestReportCrashReproTime(t *testing.T) {
 	c := NewCtx(t)
 	defer c.Close()
 
@@ -98,78 +97,6 @@ func TestPopulateReproTime(t *testing.T) {
 	// Verify real-time setting of FirstSyzReproTime and FirstCReproTime.
 	c.expectEQ(bug.FirstSyzReproTime, timeReproSyz)
 	c.expectEQ(bug.FirstCReproTime, timeReproC)
-
-	// Clear fields and reset StructVersion to simulate legacy bug data before DB update.
-	bugKey := bug.key(c.ctx)
-	updateSingleBug(c.ctx, bugKey, func(b *Bug) error {
-		b.FirstSyzReproTime = time.Time{}
-		b.FirstCReproTime = time.Time{}
-		b.StructVersion = 1
-		return nil
-	})
-
-	bugs, _, err = loadAllBugs(c.ctx, nil)
-	c.expectOK(err)
-	c.expectEQ(bugs[0].FirstSyzReproTime.IsZero(), true)
-	c.expectEQ(bugs[0].FirstCReproTime.IsZero(), true)
-	c.expectEQ(bugs[0].StructVersion, 1)
-
-	// Report another bug without repro.
-	build2 := testBuild(2)
-	c.client2.UploadBuild(build2)
-	crashNoRepro := testCrash(build2, 2)
-	c.client2.ReportCrash(crashNoRepro)
-
-	bugs, _, err = loadAllBugs(c.ctx, nil)
-	c.expectOK(err)
-	c.expectEQ(len(bugs), 2)
-	var bugWithoutRepro *Bug
-	for _, b := range bugs {
-		if !b.HasCRepro && !b.HasSyzRepro {
-			bugWithoutRepro = b
-		}
-	}
-	require.NotNil(t, bugWithoutRepro)
-	updateSingleBug(c.ctx, bugWithoutRepro.key(c.ctx), func(b *Bug) error {
-		b.StructVersion = 1
-		return nil
-	})
-
-	// Trigger admin action with limit=1 to verify partial migration.
-	_, err = c.AuthGET(AccessAdmin, "/admin?action=populateReproTime&limit=1")
-	c.expectOK(err)
-
-	bugs, _, err = loadAllBugs(c.ctx, nil)
-	c.expectOK(err)
-	v1Count := 0
-	v2Count := 0
-	for _, b := range bugs {
-		switch b.StructVersion {
-		case 1:
-			v1Count++
-		case bugStructVersion:
-			v2Count++
-		}
-	}
-	c.expectEQ(v1Count, 1)
-	c.expectEQ(v2Count, 1)
-
-	// Trigger admin action to populate all remaining bugs.
-	_, err = c.AuthGET(AccessAdmin, "/admin?action=populateReproTime")
-	c.expectOK(err)
-
-	bugs, _, err = loadAllBugs(c.ctx, nil)
-	c.expectOK(err)
-	for _, b := range bugs {
-		c.expectEQ(b.StructVersion, bugStructVersion)
-		if b.HasCRepro {
-			c.expectEQ(b.FirstCReproTime, timeReproC)
-			c.expectEQ(b.FirstSyzReproTime, timeReproSyz)
-		} else {
-			c.expectTrue(b.FirstCReproTime.IsZero())
-			c.expectTrue(b.FirstSyzReproTime.IsZero())
-		}
-	}
 }
 
 func TestUpdateReproLevel(t *testing.T) {

--- a/dashboard/app/main.go
+++ b/dashboard/app/main.go
@@ -1092,9 +1092,6 @@ func handleAdmin(ctx context.Context, w http.ResponseWriter, r *http.Request) er
 		return setMissingBugFields(ctx, w, r)
 	case "force_commit_info_update":
 		return forceCommitInfoUpdate(ctx, w, r)
-	case "populateReproTime":
-		// TODO: remove this case after migration.
-		return populateReproTime(ctx, w, r)
 	case "emergency_stop":
 		if err := recordEmergencyStop(ctx); err != nil {
 			return fmt.Errorf("failed to record an emergency stop: %w", err)


### PR DESCRIPTION
Following the successful migration of historical Bug entities to populate FirstCReproTime and FirstSyzReproTime, remove the temporary migration handler:

- Remove the populateReproTime admin handler from admin.go and main.go.
- Remove the migration test from entities_datastore_test.go while preserving the real-time repro timestamp recording test.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
