### PR TITLE
pkg/aflow: use gemini-3.8-flash

### DIFF
--- a/pkg/aflow/GEMINI.md
+++ b/pkg/aflow/GEMINI.md
@@ -92,7 +92,7 @@ Workflows are typically registered using `aflow.Register`.
 ### LLM Integration
 
 - **Models**: Use `aflow.DeepReasoningModel` (Pro) for complex causal reasoning, architectural planning, and security impact analysis.
-    Use `aflow.CoreModel` (Flash 3.7+ thinking) as the primary workhorse for agentic execution, C coding, review loops, and sub-agents.
+    Use `aflow.CoreModel` (latest Flash) as the primary workhorse for agentic execution, C coding, review loops, and sub-agents.
     Use `aflow.LightweightModel` (Flash) for low-overhead text/tag extraction and context compression.
 - **Context Compression**: For agents processing very large contexts (e.g., `patching` or
     `reproc`), set `CompressTokens` to establish a threshold. The system establishes an anchor

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -61,6 +61,14 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 	}
 
 	p.models = map[string]*modelInfo{
+		"gemini-3.8-flash": {
+			Thinking: true,
+			// Gemini 3.8 Flash does not support MINIMAL thinking.
+			MinThinkingLevel: backend.ThinkingLevelLow,
+			MaxTemperature:   2.0,
+			InputTokenLimit:  1048576,
+			OutputTokenLimit: 65536,
+		},
 		"gemini-3.7-flash": {
 			Thinking: true,
 			// Gemini 3.7 Flash does not support MINIMAL thinking.
@@ -70,12 +78,6 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 			OutputTokenLimit: 65536,
 		},
 		"gemini-3.6-flash": {
-			Thinking:         true,
-			MaxTemperature:   2.0,
-			InputTokenLimit:  1048576,
-			OutputTokenLimit: 65536,
-		},
-		"gemini-3.5-flash": {
 			Thinking:         true,
 			MaxTemperature:   2.0,
 			InputTokenLimit:  1048576,
@@ -123,9 +125,9 @@ func (p *Provider) ResolveModels(category backend.ModelCategory) []string {
 	case backend.DeepReasoningModel:
 		return []string{"gemini-3.1-pro-preview"}
 	case backend.CoreModel:
-		return []string{"gemini-3.7-flash"}
+		return []string{"gemini-3.8-flash"}
 	case backend.LightweightModel:
-		return []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"}
+		return []string{"gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash"}
 	default:
 		return nil
 	}

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -25,12 +25,12 @@ func TestProviderResolveModels(t *testing.T) {
 		{
 			name:     "resolves core model pool",
 			category: backend.CoreModel,
-			want:     []string{"gemini-3.7-flash"},
+			want:     []string{"gemini-3.8-flash"},
 		},
 		{
 			name:     "resolves lightweight model pool",
 			category: backend.LightweightModel,
-			want:     []string{"gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash"},
+			want:     []string{"gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash"},
 		},
 		{
 			name:     "resolves deep reasoning model pool",


### PR DESCRIPTION
Use gemini-3.8-flash as the CoreModel and configure its minimum thinking level to LOW. Drop gemini-3.5-flash from the model catalog and the lightweight model pool.
