### PR TITLE
executor: use an absolute interpreter path for binfmt_misc

### DIFF
--- a/executor/common_linux.h
+++ b/executor/common_linux.h
@@ -5503,7 +5503,7 @@ static const char* setup_binfmt_misc()
 		return NULL;
 	}
 	if (!write_file("/proc/sys/fs/binfmt_misc/register", ":syz0:M:0:\x01::./file0:") ||
-	    !write_file("/proc/sys/fs/binfmt_misc/register", ":syz1:M:1:\x02::./file0:POC"))
+	    !write_file("/proc/sys/fs/binfmt_misc/register", ":syz1:M:1:\x02::/proc/thread-self/cwd/file0:POC"))
 		return "write(/proc/sys/fs/binfmt_misc/register) failed";
 	return NULL;
 }


### PR DESCRIPTION
Linux commit 7830e96d001c ("binfmt_misc: require an absolute interpreter path with 'C'") rejects relative interpreter paths when C is set without F. This causes registration of syz1, which uses ./file0 with POC, to fail with EINVAL.

Use /proc/thread-self/cwd/file0 for syz1 so that the interpreter path is absolute while file0 is still resolved in the executing thread's working directory. This retains the POC flags and allows each test to create or replace its own interpreter.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
