### PR TITLE
pkg/report: extract worker function in workqueue lockup titles

### DIFF
--- a/pkg/report/linux.go
+++ b/pkg/report/linux.go
@@ -1894,6 +1894,12 @@ var linuxOopses = append([]*oops{
 			},
 			{
 				title:        compile("BUG: workqueue lockup"),
+				report:       compile("BUG: workqueue lockup(?:.*\\n)+?.*Workqueue:\\s+\\S+\\s+([a-zA-Z0-9_]+)"),
+				fmt:          "BUG: workqueue lockup in %[1]v",
+				noStackTrace: true,
+			},
+			{
+				title:        compile("BUG: workqueue lockup"),
 				fmt:          "BUG: workqueue lockup",
 				noStackTrace: true,
 			},

--- a/pkg/report/testdata/linux/report/1009
+++ b/pkg/report/testdata/linux/report/1009
@@ -1,0 +1,162 @@
+TITLE: BUG: workqueue lockup in wg_packet_handshake_receive_worker
+
+[  282.092519][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  282.105140][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  286.486862][    C0] BUG: workqueue lockup - pool cpus=0 node=0 flags=0x0 nice=0 stuck for 168s!
+[  286.496941][    C0] Showing busy workqueues and worker pools:
+[  286.503548][    C0] workqueue events: flags=0x100
+[  286.508486][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=12 refcnt=13
+[  286.508541][    C0]     pending: nsim_dev_hwstats_traffic_work, 3*psi_avgs_work, vmstat_shepherd, psi_avgs_work, 4*ovs_dp_masks_rebalance, delayed_vfree_work, psi_avgs_work
+[  286.508711][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.508752][    C0]     in-flight: 5684:reg_todo for 170s
+[  286.508798][    C0] workqueue events_long: flags=0x100
+[  286.550082][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  286.550142][    C0]     pending: 2*defense_work_handler
+[  286.550188][    C0] workqueue events_unbound: flags=0x2
+[  286.568314][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=18 refcnt=19
+[  286.568360][    C0]     in-flight: 13:cfg80211_wiphy_work for 178s ,86:cfg80211_wiphy_work for 179s
+[  286.568467][    C0]     pending: 3*macvlan_process_broadcast, 2*cfg80211_wiphy_work, 7*macvlan_process_broadcast, 2*nsim_dev_trap_report_work, fsnotify_connector_destroy_workfn, fsnotify_mark_destroy_workfn
+[  286.568632][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=22 refcnt=23
+[  286.568668][    C0]     in-flight: 3307:cfg80211_wiphy_work for 171s ,57:cfg80211_wiphy_work for 174s ,1116:cfg80211_wiphy_work for 170s ,3324:cfg80211_wiphy_work for 168s ,47:cfg80211_wiphy_work for 173s ,3306:cfg80211_wiphy_work for 174s ,35:cfg80211_wiphy_work for 176s ,769:cfg80211_wiphy_work for 172s
+[  286.569014][    C0]     pending: flush_memcg_stats_dwork, 3*nsim_dev_trap_report_work, cfg80211_wiphy_work, toggle_allocation_gate, 2*cfg80211_wiphy_work, crng_reseed, 5*cfg80211_wiphy_work
+[  286.569206][    C0] workqueue events_freezable: flags=0x104
+[  286.661155][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.661207][    C0]     pending: update_balloon_stats_func
+[  286.661247][    C0] workqueue events_power_efficient: flags=0x180
+[  286.680527][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=6 refcnt=7
+[  286.680575][    C0]     in-flight: 5630:neigh_periodic_work for 168s
+[  286.680636][    C0]     pending: wg_ratelimiter_gc_entries, neigh_managed_work, gc_worker, 2*check_lifetime
+[  286.680726][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  286.680766][    C0]     in-flight: 5700:reg_check_chans_work for 117s ,5699:crda_timeout_work for 160s
+[  286.680849][    C0] workqueue mm_percpu_wq: flags=0x108
+[  286.726830][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.726879][    C0]     pending: vmstat_update
+[  286.726985][    C0] workqueue ipv6_addrconf: flags=0x6000a
+[  286.744602][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=11 MAYDAY
+[  286.744648][    C0]     in-flight: 3196(RESCUER):addrconf_verify_work for 102s
+[  286.744710][    C0]     pending: mayday_cursor_func
+[  286.744743][    C0]     inactive: 5*addrconf_verify_work
+[  286.744787][    C0] workqueue bat_events: flags=0x6000a
+[  286.776076][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=45 MAYDAY
+[  286.776122][    C0]     in-flight: 3227(RESCUER):batadv_tt_purge for 28s
+[  286.776188][    C0]     pending: mayday_cursor_func
+[  286.776220][    C0]     inactive: batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_purge_orig, 5*batadv_mcast_mla_update, batadv_purge_orig, 13*batadv_iv_send_outstanding_bat_ogm_packet, 3*batadv_purge_orig, 2*batadv_iv_send_outstanding_bat_ogm_packet, batadv_tt_purge, batadv_bla_periodic_work, batadv_dat_purge, 3*batadv_tt_purge
+[  286.776621][    C0] workqueue wg-kex-wg0: flags=0x124
+[  286.842901][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.842954][    C0]     pending: wg_packet_handshake_receive_worker
+[  286.842991][    C0] workqueue wg-kex-wg0: flags=0x6
+[  286.861809][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  286.861858][    C0]     pending: wg_packet_handshake_send_worker
+[  286.861894][    C0] workqueue wg-kex-wg1: flags=0x124
+[  286.880276][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.880337][    C0]     in-flight: 5719:wg_packet_handshake_receive_worker for 180s
+[  286.880400][    C0] workqueue wg-kex-wg1: flags=0x6
+[  286.900631][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  286.900674][    C0]     in-flight: 12:wg_packet_handshake_send_worker for 27s
+[  286.900731][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  286.900769][    C0]     pending: wg_packet_handshake_send_worker
+[  286.900801][    C0] workqueue wg-kex-wg0: flags=0x6
+[  286.933126][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  286.933179][    C0]     pending: wg_packet_handshake_send_worker
+[  286.933219][    C0] workqueue wg-kex-wg2: flags=0x124
+[  286.951588][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.951641][    C0]     pending: wg_packet_handshake_receive_worker
+[  286.951689][    C0] workqueue wg-kex-wg2: flags=0x6
+[  286.970521][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  286.970565][    C0]     pending: 2*wg_packet_handshake_send_worker
+[  286.970604][    C0] workqueue wg-kex-wg1: flags=0x124
+[  286.989182][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  286.989234][    C0]     pending: wg_packet_handshake_receive_worker
+[  286.989271][    C0] workqueue wg-kex-wg1: flags=0x6
+[  286.993705][    C1] net_ratelimit: 10187 callbacks suppressed
+[  286.993789][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  286.998781][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  286.998906][    C0]     pending: 2*wg_packet_handshake_send_worker
+[  286.999011][    C0] workqueue wg-kex-wg2: flags=0x6
+[  287.004462][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  287.008094][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  287.008139][    C0]     pending: 2*wg_packet_handshake_send_worker
+[  287.008234][    C0] workqueue wg-kex-wg0: flags=0x124
+[  287.015220][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  287.025980][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  287.026027][    C0]     in-flight: 24:wg_packet_handshake_receive_worker for 19s
+[  287.026079][    C0] workqueue wg-kex-wg0: flags=0x6
+[  287.034156][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  287.039297][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  287.039342][    C0]     pending: 2*wg_packet_handshake_send_worker
+[  287.039419][    C0] workqueue wg-kex-wg1: flags=0x124
+[  287.045529][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:0c, vlan:0)
+[  287.056421][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  287.056468][    C0]     in-flight: 5728:wg_packet_handshake_receive_worker for 180s
+[  287.056525][    C0] workqueue wg-kex-wg1: flags=0x6
+[  287.064934][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:1b, vlan:0)
+[  287.070025][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.070071][    C0]     pending: wg_packet_handshake_send_worker
+[  287.070137][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.070241][    C0]     pending: wg_packet_handshake_send_worker
+[  287.070330][    C0] workqueue wg-kex-wg0: flags=0x124
+[  287.076474][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:1b, vlan:0)
+[  287.087321][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  287.087368][    C0]     in-flight: 5726:wg_packet_handshake_receive_worker for 171s
+[  287.087424][    C0] workqueue wg-kex-wg0: flags=0x6
+[  287.095976][    C1] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:1b, vlan:0)
+[  287.102280][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.102322][    C0]     pending: wg_packet_handshake_send_worker
+[  287.102376][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.102484][    C0]     pending: wg_packet_handshake_send_worker
+[  287.102643][    C0] workqueue wg-kex-wg0: flags=0x124
+[  287.108917][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:4a:fd:f2:8e:b9:d9, vlan:0)
+[  287.119377][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  287.119424][    C0]     in-flight: 10:wg_packet_handshake_receive_worker for 171s
+[  287.119480][    C0] workqueue wg-kex-wg0: flags=0x6
+[  287.127706][    C1] bridge0: received packet on veth0_to_bridge with own address as source address (addr:4a:fd:f2:8e:b9:d9, vlan:0)
+[  287.132707][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.132753][    C0]     pending: wg_packet_handshake_send_worker
+[  287.132874][    C0] workqueue wg-crypt-wg0: flags=0x128
+[  287.351185][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  287.351239][    C0]     pending: wg_packet_encrypt_worker
+[  287.351276][    C0] workqueue wg-kex-wg2: flags=0x6
+[  287.369424][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.369471][    C0]     pending: wg_packet_handshake_send_worker
+[  287.369509][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.369544][    C0]     pending: wg_packet_handshake_send_worker
+[  287.369575][    C0] workqueue wg-kex-wg1: flags=0x6
+[  287.400748][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.400799][    C0]     pending: wg_packet_handshake_send_worker
+[  287.400835][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.400879][    C0]     pending: wg_packet_handshake_send_worker
+[  287.400910][    C0] workqueue wg-kex-wg1: flags=0x6
+[  287.432084][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.432133][    C0]     pending: wg_packet_handshake_send_worker
+[  287.432172][    C0] workqueue wg-crypt-wg1: flags=0x128
+[  287.450622][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  287.450674][    C0]     pending: wg_packet_decrypt_worker, wg_packet_encrypt_worker
+[  287.450725][    C0] workqueue wg-kex-wg2: flags=0x6
+[  287.470950][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  287.470999][    C0]     pending: 2*wg_packet_handshake_send_worker
+[  287.471039][    C0] workqueue wg-kex-wg2: flags=0x6
+[  287.489413][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.489460][    C0]     pending: wg_packet_handshake_send_worker
+[  287.489493][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  287.489528][    C0]     pending: wg_packet_handshake_send_worker
+[  287.489566][    C0] pool 2: cpus=0 node=0 flags=0x0 nice=0 hung=169s workers=8 idle: 9 187 5727
+[  287.489645][    C0] pool 6: cpus=1 node=0 flags=0x0 nice=0 hung=0s workers=7 idle: 42 809 5359
+[  287.489718][    C0] pool 8: cpus=0-1 flags=0x6 nice=0 hung=6s workers=12 manager: 5896
+[  287.489762][    C0] Showing backtraces of busy workers in stalled worker pools:
+[  287.549176][    C0] pool 2:
+[  287.549190][    C0] task:kworker/0:1     state:R  running task     stack:23976 pid:10    tgid:10    ppid:2      task_flags:0x4208060 flags:0x00080000
+[  287.549261][    C0] Workqueue: wg-kex-wg0 wg_packet_handshake_receive_worker
+[  287.549310][    C0] Call Trace:
+[  287.549317][    C0]  <TASK>
+[  287.549332][    C0]  __schedule+0x17d9/0x56c0
+[  287.549370][    C0]  ? lockdep_hardirqs_on+0x7a/0x110
+[  287.549395][    C0]  ? kernel_fpu_end+0x62/0x80
+[  287.549419][    C0]  ? __local_bh_enable_ip+0xd0/0x130
+[  287.549479][    C0]  ? __pfx___schedule+0x10/0x10
+[  287.549499][    C0]  ? __asan_memset+0x22/0x50
+[  287.549527][    C0]  ? encode_point+0x8346/0x84b0
+[  287.549552][    C0]  ? check_path+0x21/0x40
+[  287.549594][    C0]  ? preempt_schedule_thunk+0x16/0x40
+[  287.549623][    C0]  preempt_schedule_common+0x82/0xd0
+[  287.549645][    C0]  ? kernel_fpu_end+0x62/0x80
+[  287.549669][    C0]  preempt_schedule_thunk+0x16/0x40

--- a/pkg/report/testdata/linux/report/1010
+++ b/pkg/report/testdata/linux/report/1010
@@ -1,0 +1,127 @@
+TITLE: BUG: workqueue lockup in nsim_fib_event_work
+
+[  117.366533][    C0] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:1b, vlan:0)
+[  117.366656][    C0] bridge0: received packet on bridge_slave_0 with own address as source address (addr:aa:aa:aa:aa:aa:1b, vlan:0)
+[  120.818093][    C0] BUG: workqueue lockup - pool cpus=0 node=0 flags=0x0 nice=0 stuck for 56s!
+[  120.818193][    C0] Showing busy workqueues and worker pools:
+[  120.818202][    C0] workqueue events: flags=0x100
+[  120.818233][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=20 refcnt=21
+[  120.818252][    C0]     in-flight: 9:nsim_fib_event_work for 58s nsim_fib_event_work ,1074:nsim_fib_event_work for 57s
+[  120.818295][    C0]     pending: free_obj_work, drm_fb_helper_damage_work, 2*nsim_dev_hwstats_traffic_work, psi_avgs_work, ovs_dp_masks_rebalance, rht_deferred_worker, psi_avgs_work, 4*l2cap_info_timeout, ovs_dp_masks_rebalance, vmstat_shepherd, 2*ovs_dp_masks_rebalance, nsim_fib_event_work
+[  120.818406][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  120.818423][    C0]     in-flight: 4474:reg_todo for 50s
+[  120.818443][    C0]     pending: psi_avgs_work
+[  120.818455][    C0] workqueue events_long: flags=0x100
+[  120.818464][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=9 refcnt=10
+[  120.818484][    C0]     pending: 9*defense_work_handler
+[  120.818505][    C0] workqueue events_unbound: flags=0x2
+[  120.818513][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=2 refcnt=3
+[  120.818529][    C0]     in-flight: 4964:cfg80211_wiphy_work for 39s cfg80211_wiphy_work
+[  120.818561][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=12 refcnt=13
+[  120.818575][    C0]     in-flight: 3998:fsnotify_mark_destroy_workfn for 56s ,1401:fsnotify_connector_destroy_workfn for 56s ,3906:cfg80211_wiphy_work for 51s cfg80211_wiphy_work ,12:cfg80211_wiphy_work for 44s cfg80211_wiphy_work ,39:cfg80211_wiphy_work for 55s cfg80211_wiphy_work ,40:nsim_dev_trap_report_work for 4s
+[  120.818684][    C0]     pending: nsim_dev_trap_report_work, toggle_allocation_gate, flush_memcg_stats_dwork
+[  120.818711][    C0] workqueue events_power_efficient: flags=0x82
+[  120.818719][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  120.818733][    C0]     in-flight: 3803:neigh_periodic_work for 19s
+[  120.818754][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=7 refcnt=8
+[  120.818768][    C0]     in-flight: 15:crda_timeout_work for 5s
+[  120.818785][    C0]     pending: gc_worker, do_cache_clean, fb_flashcursor, wg_ratelimiter_gc_entries, 2*neigh_managed_work
+[  120.818830][    C0] workqueue rcu_gp: flags=0x108
+[  120.818838][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.818854][    C0]     pending: srcu_invoke_callbacks
+[  120.818873][    C0] workqueue netns: flags=0x6000a
+[  120.818882][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=5
+[  120.818895][    C0]     in-flight: 869:cleanup_net for 59s
+[  120.818912][    C0]     inactive: cleanup_net
+[  120.818925][    C0] workqueue mm_percpu_wq: flags=0x108
+[  120.818933][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.818949][    C0]     pending: vmstat_update
+[  120.818969][    C0] workqueue writeback: flags=0x4a
+[  120.818978][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  120.818992][    C0]     in-flight: 1228:wb_workfn for 49s
+[  120.819046][    C0] workqueue mld: flags=0x40108
+[  120.819054][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=47
+[  120.819070][    C0]     in-flight: 4936:mld_dad_work for 56s
+[  120.819086][    C0]     inactive: mld_dad_work, mld_ifc_work, 2*mld_dad_work, 2*mld_ifc_work, 3*mld_dad_work, mld_ifc_work, mld_dad_work, mld_ifc_work, 2*mld_dad_work, 2*mld_ifc_work, 3*mld_dad_work, 4*mld_ifc_work, 3*mld_dad_work, 2*mld_ifc_work, 3*mld_dad_work, 5*mld_ifc_work, 9*mld_dad_work
+[  120.819198][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=8
+[  120.819214][    C0]     in-flight: 4781:mld_dad_work for 0s
+[  120.819229][    C0]     inactive: 5*mld_dad_work, mld_ifc_work
+[  120.819248][    C0] workqueue ipv6_addrconf: flags=0x6000a
+[  120.819256][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=83 MAYDAY
+[  120.819270][    C0]     in-flight: 2820(RESCUER):addrconf_dad_work for 26s
+[  120.819286][    C0]     inactive: 77*addrconf_dad_work
+[  120.819313][    C0] workqueue bat_events: flags=0x6000a
+[  120.819321][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=49 MAYDAY
+[  120.819335][    C0]     in-flight: 2852(RESCUER):batadv_tt_purge for 12s
+[  120.819353][    C0]     inactive: 3*batadv_tt_purge, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, batadv_dat_purge, batadv_bla_periodic_work, 6*batadv_mcast_mla_update, 8*batadv_iv_send_outstanding_bat_ogm_packet, batadv_purge_orig, batadv_iv_send_outstanding_bat_ogm_packet, 2*batadv_purge_orig, batadv_iv_send_outstanding_bat_ogm_packet, 3*batadv_purge_orig, 4*batadv_iv_send_outstanding_bat_ogm_packet, 2*batadv_tt_purge
+[  120.819504][    C0] workqueue wg-kex-wg0: flags=0x124
+[  120.819512][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819528][    C0]     pending: wg_packet_handshake_receive_worker
+[  120.819544][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  120.819560][    C0]     in-flight: 4809:wg_packet_handshake_receive_worker for 15s wg_packet_handshake_receive_worker
+[  120.819588][    C0] workqueue wg-kex-wg0: flags=0x6
+[  120.819597][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  120.819612][    C0]     pending: wg_packet_handshake_send_worker
+[  120.819627][    C0] workqueue wg-crypt-wg0: flags=0x128
+[  120.819635][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=3 refcnt=4
+[  120.819651][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker, wg_packet_decrypt_worker
+[  120.819679][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819694][    C0]     pending: wg_packet_decrypt_worker
+[  120.819709][    C0] workqueue wg-kex-wg1: flags=0x124
+[  120.819717][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819733][    C0]     pending: wg_packet_handshake_receive_worker
+[  120.819749][    C0] workqueue wg-kex-wg1: flags=0x6
+[  120.819758][    C0]   pwq 8: cpus=0-1 flags=0x6 nice=0 active=1 refcnt=2
+[  120.819772][    C0]     pending: wg_packet_handshake_send_worker
+[  120.819787][    C0] workqueue wg-crypt-wg1: flags=0x128
+[  120.819795][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=3 refcnt=4
+[  120.819811][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker, wg_packet_decrypt_worker
+[  120.819839][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819854][    C0]     pending: wg_packet_decrypt_worker
+[  120.819868][    C0] workqueue wg-kex-wg2: flags=0x124
+[  120.819876][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819892][    C0]     pending: wg_packet_handshake_receive_worker
+[  120.819907][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.819923][    C0]     in-flight: 24:wg_packet_handshake_receive_worker for 8s
+[  120.819944][    C0] workqueue wg-crypt-wg2: flags=0x128
+[  120.819952][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  120.819968][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker
+[  120.820000][    C0] workqueue wg-crypt-wg0: flags=0x128
+[  120.820008][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=3 refcnt=4
+[  120.820024][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker, wg_packet_decrypt_worker
+[  120.820052][    C0]   pwq 6: cpus=1 node=0 flags=0x0 nice=0 active=1 refcnt=2
+[  120.820068][    C0]     pending: wg_packet_tx_worker
+[  120.820083][    C0] workqueue wg-crypt-wg1: flags=0x128
+[  120.820091][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=3 refcnt=4
+[  120.820107][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker, wg_packet_decrypt_worker
+[  120.820136][    C0] workqueue wg-crypt-wg2: flags=0x128
+[  120.820148][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=2 refcnt=3
+[  120.820165][    C0]     pending: wg_packet_encrypt_worker, wg_packet_tx_worker
+[  120.820197][    C0] pool 2: cpus=0 node=0 flags=0x0 nice=0 hung=56s workers=6 idle: 4831 1511 10
+[  120.820235][    C0] pool 6: cpus=1 node=0 flags=0x0 nice=0 hung=0s workers=6 idle: 866 26
+[  120.820266][    C0] pool 8: cpus=0-1 flags=0x6 nice=0 hung=4s workers=12 manager: 4965
+[  120.820289][    C0] Showing backtraces of busy workers in stalled worker pools:
+[  120.820297][    C0] pool 2:
+[  120.820302][    C0] task:kworker/0:0     state:R  running task     stack:0     pid:9     tgid:9     ppid:2      task_flags:0x4208060 flags:0x00000010
+[  120.820317][    C0] Workqueue: events nsim_fib_event_work
+[  120.820328][    C0] Call trace:
+[  120.820332][    C0]  __switch_to+0x2b0/0x6e0 (T)
+[  120.820344][    C0]  __schedule+0x1370/0x2d80
+[  120.820353][    C0]  preempt_schedule_common+0xd4/0x190
+[  120.820361][    C0]  preempt_schedule+0x60/0x78
+[  120.820369][    C0]  irq_work_queue+0xa0/0xa4
+[  120.820378][    C0]  nsim_fib_event+0x3170/0x60c4
+[  120.820388][    C0]  nsim_fib_event_work+0x1d8/0x320
+[  120.820398][    C0]  process_scheduled_works+0x788/0x10b8
+[  120.820408][    C0]  worker_thread+0x798/0xbd0
+[  120.820417][    C0]  kthread+0x304/0x3d4
+[  120.820426][    C0]  ret_from_fork+0x10/0x20
+[  120.820435][    C0] pool 2:
+[  120.820438][    C0] task:kworker/0:5     state:R  running task     stack:0     pid:4936  tgid:4936  ppid:2      task_flags:0x4208060 flags:0x00000010
+[  120.820451][    C0] Workqueue: mld mld_dad_work
+[  120.820458][    C0] Call trace:
+[  120.820461][    C0]  __switch_to+0x2b0/0x6e0 (T)
+[  120.820469][    C0]  __schedule+0x1370/0x2d80
+[  120.820480][    C0]  preempt_schedule_common+0xd4/0x190
+[  120.820488][    C0]  preempt_schedule+0x60/0x78
+[  120.820496][    C0]  __local_bh_enable_ip+0x20c/0x35c

--- a/pkg/report/testdata/linux/report/1011
+++ b/pkg/report/testdata/linux/report/1011
@@ -1,0 +1,14 @@
+TITLE: BUG: workqueue lockup
+
+[   42.731746][ T6029] loop0: detected capacity change from 0 to 256
+[   42.754078][ T6032] netlink: 'syz.4.501': attribute type 1 has an invalid length.
+[   42.891299][ T6035] Process accounting resumed
+[   53.773184][    C0] sched: DL replenish lagged too much
+[   78.708803][ T1597] ieee802154 phy0 wpan0: encryption failed: -22
+[   78.717807][ T1597] ieee802154 phy1 wpan1: encryption failed: -22
+[   90.749082][    C0] BUG: workqueue lockup - pool cpus=0 node=0 flags=0x0 nice=0 stuck for 35s!
+[   90.749180][    C0] Showing busy workqueues and worker pools:
+[   90.749189][    C0] workqueue events: flags=0x100
+[   90.749226][    C0]   pwq 2: cpus=0 node=0 flags=0x0 nice=0 active=18 refcnt=19
+[   90.749244][    C0]     pending: 5*nsim_dev_hwstats_traffic_work, psi_avgs_work, 6*ovs_dp_masks_rebalance, 4*psi_avgs_work, vmstat_shepherd, psi_avgs_work
+


### PR DESCRIPTION
Currently, all workqueue lockups collapse into a single generic title, bucketing unrelated bugs from different subsystems together on syzbot.

Extract the busy worker function from the watchdog report to attribute lockups to specific functions, falling back to the generic title if no worker is executing.

https://syzkaller.appspot.com/bug?extid=f0b66b520b54883d4b9d