### PR TITLE
Makefile: enable cgo for aflow target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,8 @@ go-flags:
 	@echo "${GOHOSTFLAGS}"
 
 aflow: descriptions
-	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-aflow github.com/google/syzkaller/tools/syz-aflow
+	# syz-aflow uses codesearch clang tool which requires cgo.
+	CGO_ENABLED=1 GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-aflow github.com/google/syzkaller/tools/syz-aflow
 
 manager: descriptions
 	GOOS=$(HOSTOS) GOARCH=$(HOSTARCH) $(HOSTGO) build $(GOHOSTFLAGS) -o ./bin/syz-manager github.com/google/syzkaller/syz-manager


### PR DESCRIPTION
syz-aflow relies on the codesearch clang tool, which interfaces with C++ code and requires cgo to be registered.

Explicitly set CGO_ENABLED=1 when building syz-aflow so that codesearch support is included in the resulting binary.