### PR TITLE
pkg/aflow: add option to disable safety filters

### DIFF
--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -27,6 +27,7 @@ type Provider struct {
 	models          map[string]*modelInfo
 	modelPathPrefix string
 	modelOverride   string
+	noSafetyFilters bool
 	err             error
 }
 
@@ -39,8 +40,9 @@ type modelInfo struct {
 }
 
 type Config struct {
-	ModelOverride string
-	ClientConfig  *genai.ClientConfig
+	ModelOverride   string
+	ClientConfig    *genai.ClientConfig
+	NoSafetyFilters bool
 }
 
 func NewProvider(ctx context.Context, cfg Config) (*Provider, error) {
@@ -59,6 +61,8 @@ func (p *Provider) init(ctx context.Context, cfg Config) error {
 	if p.client != nil || p.err != nil {
 		return p.err
 	}
+
+	p.noSafetyFilters = cfg.NoSafetyFilters
 
 	p.models = map[string]*modelInfo{
 		"gemini-3.8-flash": {
@@ -186,6 +190,10 @@ func (c *client) GenerateContent(ctx context.Context, model string, cfg *backend
 				genaiCfg.ThinkingConfig.ThinkingLevel = genai.ThinkingLevelHigh
 			}
 		}
+	}
+
+	if c.p.noSafetyFilters {
+		genaiCfg.SafetySettings = noSafetySettings
 	}
 
 	var req []*genai.Content
@@ -374,4 +382,8 @@ func fromGenaiResponse(resp *genai.GenerateContentResponse) *backend.GenerateRes
 		}
 	}
 	return res
+}
+
+var noSafetySettings = []*genai.SafetySetting{
+	{Category: genai.HarmCategoryDangerousContent, Threshold: genai.HarmBlockThresholdBlockNone},
 }

--- a/pkg/aflow/backend/gemini/gemini.go
+++ b/pkg/aflow/backend/gemini/gemini.go
@@ -263,7 +263,11 @@ func parseLLMError(err error, model string) error {
 func parseLLMResp(resp *genai.GenerateContentResponse) error {
 	if len(resp.Candidates) == 0 || resp.Candidates[0] == nil {
 		if resp.PromptFeedback != nil {
-			return fmt.Errorf("request blocked: %v", resp.PromptFeedback.BlockReasonMessage)
+			reason := resp.PromptFeedback.BlockReasonMessage
+			if reason == "" {
+				reason = string(resp.PromptFeedback.BlockReason)
+			}
+			return fmt.Errorf("request blocked: %v", reason)
 		}
 		return fmt.Errorf("empty model response")
 	}
@@ -276,6 +280,9 @@ func parseLLMResp(resp *genai.GenerateContentResponse) error {
 		}
 		if candidate.FinishReason == genai.FinishReasonMaxTokens {
 			return &backend.OutputTokenOverflowError{Err: errors.New(string(candidate.FinishReason))}
+		}
+		if candidate.FinishMessage == "" {
+			return errors.New(string(candidate.FinishReason))
 		}
 		return fmt.Errorf("%v (%v)", candidate.FinishMessage, candidate.FinishReason)
 	}

--- a/pkg/aflow/backend/gemini/gemini_test.go
+++ b/pkg/aflow/backend/gemini/gemini_test.go
@@ -122,6 +122,24 @@ func TestParseLLMError(t *testing.T) {
 				Err: errors.New("MAX_TOKENS"),
 			},
 		},
+		{
+			resp: &genai.GenerateContentResponse{
+				PromptFeedback: &genai.GenerateContentResponsePromptFeedback{
+					BlockReason: genai.BlockedReasonSafety,
+				},
+			},
+			outputErr: errors.New("request blocked: SAFETY"),
+		},
+		{
+			resp: &genai.GenerateContentResponse{
+				Candidates: []*genai.Candidate{
+					{
+						FinishReason: genai.FinishReasonSafety,
+					},
+				},
+			},
+			outputErr: errors.New("SAFETY"),
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/syz-agent/agent/agent.go
+++ b/syz-agent/agent/agent.go
@@ -334,7 +334,8 @@ func (s *Server) executeJob(ctx context.Context, req *dashapi.AIJobPollResp) (ou
 	}
 
 	geminiCfg := gemini.Config{
-		ModelOverride: s.cfg.Model,
+		ModelOverride:   s.cfg.Model,
+		NoSafetyFilters: !s.cfg.SafetyFilters,
 	}
 	switch backend {
 	case backendVertex:

--- a/syz-agent/agent/config.go
+++ b/syz-agent/agent/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	DefaultBackend string `json:"default_backend"`
 	GeminiAPIKey   string `json:"gemini_api_key"`
 	CloudProject   string `json:"-"`
+	SafetyFilters  bool   `json:"safety_filters"`
 }
 
 func loadConfig(configFile string) (*Config, error) {
@@ -64,6 +65,7 @@ func loadConfig(configFile string) (*Config, error) {
 		CacheSize:       1 << 40, // 1TB
 		GeminiAPIKey:    "env:GOOGLE_API_KEY",
 		DefaultBackend:  backendGemini,
+		SafetyFilters:   true,
 	}
 	if err := config.LoadFile(configFile, cfg); err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)

--- a/syz-agent/agent/config_test.go
+++ b/syz-agent/agent/config_test.go
@@ -43,6 +43,7 @@ func TestConfigPlainValues(t *testing.T) {
 	assert.Equal(t, "test-dashboard-client", cfg.DashboardClient)
 	assert.Equal(t, "test-dashboard-key", cfg.DashboardKey)
 	assert.Equal(t, "test-gemini-key", cfg.GeminiAPIKey)
+	assert.True(t, cfg.SafetyFilters)
 }
 
 func TestConfigEnvResolution(t *testing.T) {
@@ -150,5 +151,37 @@ func TestConfigBackendRoutingValidation(t *testing.T) {
 		_, err = loadConfig(confFile)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), `is not a registered workflow`)
+	})
+}
+
+func TestConfigSafetyFilters(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "syz-agent-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	confFile := filepath.Join(tmpDir, "config.json")
+	writeConfig := func(val string) {
+		content := `{
+			"targets": {"linux/amd64": {"image": "image1"}},
+			"dashboard_client": "test-client",
+			"dashboard_key": "test-key",
+			"safety_filters": ` + val + `
+		}`
+		err := os.WriteFile(confFile, []byte(content), 0644)
+		assert.NoError(t, err)
+	}
+
+	t.Run("explicitly disabled", func(t *testing.T) {
+		writeConfig("false")
+		cfg, err := loadConfig(confFile)
+		assert.NoError(t, err)
+		assert.False(t, cfg.SafetyFilters)
+	})
+
+	t.Run("explicitly enabled", func(t *testing.T) {
+		writeConfig("true")
+		cfg, err := loadConfig(confFile)
+		assert.NoError(t, err)
+		assert.True(t, cfg.SafetyFilters)
 	})
 }

--- a/syz-agent/k8s/overlays/prod-agent/agent-config.json
+++ b/syz-agent/k8s/overlays/prod-agent/agent-config.json
@@ -4,6 +4,7 @@
   "dashboard_key": "gcp-secret:syz-agent-dashboard-key",
   "gemini_api_key": "gcp-secret:syz-agent-gemini-key",
   "default_backend": "gemini",
+  "safety_filters": false,
   "workflow_backends": {
     "repro-c": "vertex"
   },

--- a/tools/syz-aflow/gemini.go
+++ b/tools/syz-aflow/gemini.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/google/syzkaller/pkg/aflow/backend/gemini"
 	"google.golang.org/genai"
 )
+
+var flagNoSafetyFilters = flag.Bool("no-safety-filters", false, "disable safety filters for Gemini/Vertex requests")
 
 func init() {
 	RegisterProvider("gemini", func(ctx context.Context, model string) (backend.Provider, error) {
@@ -23,7 +26,8 @@ func init() {
 			return nil, fmt.Errorf("gemini provider requires GOOGLE_API_KEY or GEMINI_API_KEY environment variable to be set")
 		}
 		provider, err := gemini.NewProvider(ctx, gemini.Config{
-			ModelOverride: model,
+			ModelOverride:   model,
+			NoSafetyFilters: *flagNoSafetyFilters,
 			ClientConfig: &genai.ClientConfig{
 				APIKey: apiKey,
 			},
@@ -44,7 +48,8 @@ func init() {
 			location = "global"
 		}
 		provider, err := gemini.NewProvider(ctx, gemini.Config{
-			ModelOverride: model,
+			ModelOverride:   model,
+			NoSafetyFilters: *flagNoSafetyFilters,
 			ClientConfig: &genai.ClientConfig{
 				Backend:  genai.BackendVertexAI,
 				Project:  project,


### PR DESCRIPTION
Gemini 3.8 Flash is noticeably more sensitive to cybersecurity content
than earlier models, frequently triggering safety filters on kernel crash
traces, reproducers, and vulnerability details.

Introduce an option to disable safety filters across the Gemini backend,
syz-aflow, and syz-agent, configuring the dangerous content threshold
to BLOCK_NONE.