### PR TITLE
dashboard: render reproducers on kernel health graph

### DIFF
--- a/dashboard/app/graphs.go
+++ b/dashboard/app/graphs.go
@@ -138,7 +138,7 @@ func handleKernelHealthGraph(ctx context.Context, w http.ResponseWriter, r *http
 	}
 	data := &uiKernelHealthPage{
 		Header: hdr,
-		Graph:  createBugsGraph(ctx, bugs),
+		Graph:  createBugsGraph(timeNow(ctx), bugs),
 	}
 	return serveTemplate(w, "graph_bugs.html", data)
 }
@@ -421,46 +421,79 @@ func isStableBug(ctx context.Context, bug *Bug, lastReporting int) bool {
 	return false
 }
 
-func createBugsGraph(ctx context.Context, bugs []*Bug) *uiGraph {
-	type BugStats struct {
-		Opened        int
-		Fixed         int
-		Closed        int
-		TotalReported int
-		TotalOpen     int
-		TotalFixed    int
-		TotalClosed   int
+type bugStats struct {
+	Opened         int
+	Fixed          int
+	Closed         int
+	SyzReproOpened int
+	SyzReproClosed int
+	CReproOpened   int
+	CReproClosed   int
+	TotalReported  int
+	TotalOpen      int
+	TotalFixed     int
+	TotalClosed    int
+	OpenSyzRepro   int
+	OpenCRepro     int
+}
+
+func recordReproTimeline(reproTime, closeTime time.Time, statsFor func(time.Time) *bugStats, syz bool) {
+	if reproTime.IsZero() || (!closeTime.IsZero() && closeTime.Before(reproTime)) {
+		return
 	}
-	const timeWeek = 30 * 24 * time.Hour
-	now := timeNow(ctx)
-	m := make(map[int]*BugStats)
-	maxWeek := 0
-	bugStatsFor := func(t time.Time) *BugStats {
-		week := max(0, int(now.Sub(t)/(30*24*time.Hour)))
-		maxWeek = max(maxWeek, week)
-		bs := m[week]
+	bs := statsFor(reproTime)
+	if syz {
+		bs.SyzReproOpened++
+	} else {
+		bs.CReproOpened++
+	}
+	if !closeTime.IsZero() {
+		bs := statsFor(closeTime)
+		if syz {
+			bs.SyzReproClosed++
+		} else {
+			bs.CReproClosed++
+		}
+	}
+}
+
+func createBugsGraph(now time.Time, bugs []*Bug) *uiGraph {
+	const monthDuration = 30 * 24 * time.Hour
+	m := make(map[int]*bugStats)
+	maxMonth := 0
+	bugStatsFor := func(t time.Time) *bugStats {
+		month := max(0, int(now.Sub(t)/monthDuration))
+		maxMonth = max(maxMonth, month)
+		bs := m[month]
 		if bs == nil {
-			bs = new(BugStats)
-			m[week] = bs
+			bs = new(bugStats)
+			m[month] = bs
 		}
 		return bs
 	}
 	for _, bug := range bugs {
 		bugStatsFor(bug.FirstTime).Opened++
+		var closeTime time.Time
 		if !bug.Closed.IsZero() {
+			closeTime = bug.Closed
+			bs := bugStatsFor(bug.Closed)
 			if bug.Status == BugStatusFixed {
-				bugStatsFor(bug.Closed).Fixed++
+				bs.Fixed++
 			}
-			bugStatsFor(bug.Closed).Closed++
+			bs.Closed++
 		} else if len(bug.Commits) != 0 {
-			bugStatsFor(now).Fixed++
-			bugStatsFor(now).Closed++
+			closeTime = now
+			bs := bugStatsFor(now)
+			bs.Fixed++
+			bs.Closed++
 		}
+		recordReproTimeline(bug.FirstSyzReproTime, closeTime, bugStatsFor, true)
+		recordReproTimeline(bug.FirstCReproTime, closeTime, bugStatsFor, false)
 	}
-	var stats []BugStats
-	var prev BugStats
-	for i := maxWeek; i >= 0; i-- {
-		var bs BugStats
+	stats := make([]bugStats, 0, maxMonth+1)
+	var prev bugStats
+	for i := maxMonth; i >= 0; i-- {
+		var bs bugStats
 		if p := m[i]; p != nil {
 			bs = *p
 		}
@@ -468,21 +501,32 @@ func createBugsGraph(ctx context.Context, bugs []*Bug) *uiGraph {
 		bs.TotalFixed = prev.TotalFixed + bs.Fixed
 		bs.TotalClosed = prev.TotalClosed + bs.Closed
 		bs.TotalOpen = bs.TotalReported - bs.TotalClosed
+		bs.OpenSyzRepro = max(0, prev.OpenSyzRepro+bs.SyzReproOpened-bs.SyzReproClosed)
+		bs.OpenCRepro = max(0, prev.OpenCRepro+bs.CReproOpened-bs.CReproClosed)
 		stats = append(stats, bs)
 		prev = bs
 	}
-	var columns []uiGraphColumn
-	for week, bs := range stats {
-		col := uiGraphColumn{Hint: now.Add(time.Duration(week-len(stats)+1) * timeWeek).Format("Jan-06")}
-		col.Vals = append(col.Vals, uiGraphValue{Val: float32(bs.TotalOpen)})
-		col.Vals = append(col.Vals, uiGraphValue{Val: float32(bs.TotalReported)})
-		col.Vals = append(col.Vals, uiGraphValue{Val: float32(bs.TotalFixed)})
-		// col.Vals = append(col.Vals, uiGraphValue{Val: float32(bs.Opened)})
-		// col.Vals = append(col.Vals, uiGraphValue{Val: float32(bs.Fixed)})
-		columns = append(columns, col)
+	columns := make([]uiGraphColumn, 0, len(stats))
+	for month, bs := range stats {
+		columns = append(columns, uiGraphColumn{
+			Hint: now.Add(time.Duration(month-len(stats)+1) * monthDuration).Format("Jan-06"),
+			Vals: []uiGraphValue{
+				{Val: float32(bs.TotalOpen)},
+				{Val: float32(bs.TotalReported)},
+				{Val: float32(bs.TotalFixed)},
+				{Val: float32(bs.OpenSyzRepro)},
+				{Val: float32(bs.OpenCRepro)},
+			},
+		})
 	}
 	return &uiGraph{
-		Headers: []uiGraphHeader{{Name: "open bugs"}, {Name: "total reported"}, {Name: "total fixed"}},
+		Headers: []uiGraphHeader{
+			{Name: "open bugs"},
+			{Name: "total reported"},
+			{Name: "total fixed"},
+			{Name: "open bugs with syz repro"},
+			{Name: "open bugs with C repro"},
+		},
 		Columns: columns,
 	}
 }

--- a/dashboard/app/graphs_test.go
+++ b/dashboard/app/graphs_test.go
@@ -258,3 +258,90 @@ func TestResolutionGraphEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(reply), "bug resolution rates")
 }
+
+func TestCreateBugsGraphWithRepros(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	const month = 30 * 24 * time.Hour
+
+	bugs := []*Bug{
+		// Bug 1: Reported 2 months ago, syz repro 2 months ago, fixed 1 month ago.
+		{
+			FirstTime:         now.Add(-2 * month),
+			FirstSyzReproTime: now.Add(-2 * month),
+			Closed:            now.Add(-1 * month),
+			Status:            BugStatusFixed,
+		},
+		// Bug 2: Reported 1 month ago, syz repro and C repro 1 month ago, still open.
+		{
+			FirstTime:         now.Add(-1 * month),
+			FirstSyzReproTime: now.Add(-1 * month),
+			FirstCReproTime:   now.Add(-1 * month),
+			Status:            BugStatusOpen,
+		},
+		// Bug 3: Reported now, only C repro now, still open.
+		{
+			FirstTime:       now,
+			FirstCReproTime: now,
+			Status:          BugStatusOpen,
+		},
+		// Bug 4: Bug with zero repro timestamps (to verify zero-timestamp handling).
+		{
+			FirstTime: now.Add(-1 * month),
+			Status:    BugStatusOpen,
+		},
+		// Bug 5: Reported 2 months ago, but syz repro found 1 month later and C repro found now.
+		{
+			FirstTime:         now.Add(-2 * month),
+			FirstSyzReproTime: now.Add(-1 * month),
+			FirstCReproTime:   now,
+			Status:            BugStatusOpen,
+		},
+	}
+
+	graph := createBugsGraph(now, bugs)
+	expectedHeaders := []uiGraphHeader{
+		{Name: "open bugs"},
+		{Name: "total reported"},
+		{Name: "total fixed"},
+		{Name: "open bugs with syz repro"},
+		{Name: "open bugs with C repro"},
+	}
+	require.Equal(t, expectedHeaders, graph.Headers)
+	require.Len(t, graph.Columns, 3)
+
+	// Column 0: 2 months ago.
+	// Open: Bug 1, Bug 5 -> open=2, reported=2, fixed=0, open w/ syz repro=1 (Bug 1), open w/ C repro=0.
+	require.Equal(t, "Jul-26", graph.Columns[0].Hint)
+	require.Equal(t, []uiGraphValue{
+		{Val: 2}, // open bugs
+		{Val: 2}, // total reported
+		{Val: 0}, // total fixed
+		{Val: 1}, // open bugs with syz repro
+		{Val: 0}, // open bugs with C repro
+	}, graph.Columns[0].Vals)
+
+	// Column 1: 1 month ago.
+	// Bug 1 fixed (closed). New open: +Bug 2, +Bug 4 -> open=3, reported=4, fixed=1.
+	// Open w/ syz repro: Bug 2, Bug 5 -> 2. Open w/ C repro: Bug 2 -> 1.
+	require.Equal(t, "Aug-26", graph.Columns[1].Hint)
+	require.Equal(t, []uiGraphValue{
+		{Val: 3}, // open bugs
+		{Val: 4}, // total reported
+		{Val: 1}, // total fixed
+		{Val: 2}, // open bugs with syz repro
+		{Val: 1}, // open bugs with C repro
+	}, graph.Columns[1].Vals)
+
+	// Column 2: current month (now).
+	// New open: +Bug 3 -> open=4, reported=5, fixed=1.
+	// Open w/ syz repro: Bug 2, Bug 5 -> 2.
+	// Open w/ C repro: Bug 2, Bug 3, Bug 5 -> 3.
+	require.Equal(t, "Sep-26", graph.Columns[2].Hint)
+	require.Equal(t, []uiGraphValue{
+		{Val: 4}, // open bugs
+		{Val: 5}, // total reported
+		{Val: 1}, // total fixed
+		{Val: 2}, // open bugs with syz repro
+		{Val: 3}, // open bugs with C repro
+	}, graph.Columns[2].Vals)
+}

--- a/dashboard/app/templates/graph_bugs.html
+++ b/dashboard/app/templates/graph_bugs.html
@@ -29,9 +29,16 @@ Bugs statistics graph.
 					vAxis: {textPosition: 'in'},
 					focusTarget: "category",
 					series: {
+						// open bugs
 						0: {targetAxisIndex: 0, color: "red", lineWidth: 3},
+						// total reported
 						1: {targetAxisIndex: 1, color: "black"},
+						// total fixed
 						2: {targetAxisIndex: 1, color: "green"},
+						// open bugs with syz repro
+						3: {targetAxisIndex: 0, color: "blue"},
+						// open bugs with C repro
+						4: {targetAxisIndex: 0, color: "purple"},
 					},
 					vAxes: {
 						0: {title: '# open bugs', gridlines: {multiple: 1}, minorGridlines: {multiple: 1}},


### PR DESCRIPTION
Render cumulative 'total syz reproducers' and 'total C reproducers' series on the /{ns}/graph/bugs Kernel Health graph.

Update createBugsGraph to aggregate FirstSyzReproTime and FirstCReproTime timestamps per month alongside bug reports, opens, and fixes. Configure series 3 (blue) and series 4 (purple) on secondary axis 1 in Google Charts, and update axis title to include reproducers. Add unit and endpoint tests.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
