### PR TITLE
pkg/aflow: place system warning before function response

### DIFF
--- a/pkg/aflow/func_tool_test.go
+++ b/pkg/aflow/func_tool_test.go
@@ -6,6 +6,7 @@ package aflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -80,6 +81,46 @@ func TestToolLoopDetection(t *testing.T) {
 	diffCall := &backend.FunctionCall{Name: "diff-tool", Args: args}
 	err = session.recordAndCheckDuplicate(diffCall)
 	require.NoError(t, err, "unexpected error on different call: %v", err)
+}
+
+func TestToolLoopDetectionWarningOrder(t *testing.T) {
+	session := &agentSession{LLMAgent: &LLMAgent{Name: "test-agent"}}
+	tool := NewFuncTool("test-tool", func(ctx *Context, state struct{}, args struct {
+		Query string `jsonschema:"query"`
+	}) (struct{}, error) {
+		return struct{}{}, nil
+	}, "test tool")
+	otherTool := NewFuncTool("other-tool", func(ctx *Context, state struct{}, args struct {
+		Query string `jsonschema:"query"`
+	}) (struct{}, error) {
+		return struct{}{}, nil
+	}, "other tool")
+	tools := map[string]Tool{"test-tool": tool, "other-tool": otherTool}
+	ctx := newTestContext(t, nil)
+	args := map[string]any{"Query": "test"}
+
+	for i := range defaultLoopDetectionLimit {
+		call := &backend.FunctionCall{ID: fmt.Sprintf("call%d", i), Name: "test-tool", Args: args}
+		err := session.callTools(ctx, tools, []*backend.FunctionCall{call})
+		require.NoError(t, err)
+	}
+
+	// In the next turn, execute parallel calls where the second call is a duplicate.
+	// All SYSTEM WARNING text parts must precede ALL FunctionResponse parts, and
+	// the warning must explicitly mention the tool name.
+	otherCall := &backend.FunctionCall{ID: "call-other", Name: "other-tool", Args: args}
+	dupCall := &backend.FunctionCall{ID: "call-dup", Name: "test-tool", Args: args}
+	err := session.callTools(ctx, tools, []*backend.FunctionCall{otherCall, dupCall})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, session.req)
+	lastMsg := session.req[len(session.req)-1].content
+	require.Len(t, lastMsg.Parts, 3)
+	require.Contains(t, lastMsg.Parts[0].Text, `SYSTEM WARNING for tool "test-tool":`)
+	require.NotNil(t, lastMsg.Parts[1].FunctionResponse)
+	require.Equal(t, "call-other", lastMsg.Parts[1].FunctionResponse.ID)
+	require.NotNil(t, lastMsg.Parts[2].FunctionResponse)
+	require.Equal(t, "call-dup", lastMsg.Parts[2].FunctionResponse.ID)
 }
 
 func TestToolHistorySequentialLeak(t *testing.T) {

--- a/pkg/aflow/llm_agent.go
+++ b/pkg/aflow/llm_agent.go
@@ -795,9 +795,7 @@ func (a *agentSession) callTools(ctx *Context, tools map[string]Tool, calls []*b
 		}})
 		return nil
 	}
-	responses := &backend.Message{
-		Role: backend.RoleUser,
-	}
+	var warnings, responses []backend.Part
 	for _, call := range calls {
 		span := &trajectory.Span{
 			Type: trajectory.SpanTool,
@@ -833,23 +831,28 @@ func (a *agentSession) callTools(ctx *Context, tools map[string]Tool, calls []*b
 					call.Name, toolErr, call.Args)
 			}
 		}
-		responses.Parts = append(responses.Parts, backend.Part{
+		if isDuplicateErr(toolErr) {
+			warnings = append(warnings, backend.Part{
+				Text: fmt.Sprintf("SYSTEM WARNING for tool %q: %s", call.Name, toolErr.Error()),
+			})
+		}
+		responses = append(responses, backend.Part{
 			FunctionResponse: &backend.FunctionResponse{
 				ID:       call.ID,
 				Name:     call.Name,
 				Response: span.Results,
 			},
 		})
-		if isDuplicateErr(toolErr) {
-			responses.Parts = append(responses.Parts, backend.Part{
-				Text: fmt.Sprintf("SYSTEM WARNING: %s", toolErr.Error()),
-			})
-		}
 		if toolErr == nil && a.Outputs != nil && tool == a.Outputs.tool {
 			a.outputs = span.Results
 		}
 	}
-	a.req = append(a.req, llmMessage{content: responses})
+	// All warning text parts must precede function responses;
+	// having text after function responses confuses the Vertex AI API.
+	a.req = append(a.req, llmMessage{content: &backend.Message{
+		Role:  backend.RoleUser,
+		Parts: append(warnings, responses...),
+	}})
 	return nil
 }
 


### PR DESCRIPTION
When an LLM repeats tool calls, syzkaller emits a system warning to nudge the model to change course. Currently, this warning text is appended after the tool execution result in the response message.

Placing plain text after a function response within the same turn confuses the Vertex AI API. Prepend the warning text before the function response part instead so the model receives the warning context without disrupting the API turn format.