### PR TITLE
pkg/db: support read-only database opening

### DIFF
--- a/pkg/aflow/action/actionsyzlang/execute_corpus.go
+++ b/pkg/aflow/action/actionsyzlang/execute_corpus.go
@@ -77,7 +77,7 @@ func executeCorpusAction(ctx *aflow.Context, args ExecuteCorpusArgs) (ExecuteCor
 		return ExecuteCorpusResult{}, fmt.Errorf("unknown sys target: %s/%s", args.TargetOS, args.TargetArch)
 	}
 
-	corpusDB, err := db.Open(args.CorpusPath, false)
+	corpusDB, err := db.OpenReadOnly(args.CorpusPath)
 	if err != nil {
 		return ExecuteCorpusResult{}, fmt.Errorf("failed to open corpus db: %w", err)
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -28,6 +29,7 @@ type DB struct {
 	Version uint64            // arbitrary user version (0 for new database)
 	Records map[string]Record // in-memory cache, must not be modified directly
 
+	readOnly      bool
 	filename      string
 	uncompacted   int           // number of records in the file
 	pending       *bytes.Buffer // pending writes to the file
@@ -48,9 +50,10 @@ func Open(filename string, repair bool) (*DB, error) {
 	}
 	var deserializeErr error
 	db.Version, db.Records, db.uncompacted, deserializeErr = deserializeFile(db.filename)
-	// Deserialization error is considered a "soft" error if repair == true,
-	// but compact below ensures that the file is at least writable.
-	if deserializeErr != nil && !repair {
+	if errors.Is(deserializeErr, os.ErrNotExist) {
+		db.Records = make(map[string]Record)
+		deserializeErr = nil
+	} else if deserializeErr != nil && !repair {
 		return nil, deserializeErr
 	}
 	if err := db.compact(); err != nil {
@@ -59,7 +62,25 @@ func Open(filename string, repair bool) (*DB, error) {
 	return db, deserializeErr
 }
 
+// OpenReadOnly opens the specified database file for reading only.
+// Unlike Open, it does not compact or modify the database file on disk.
+func OpenReadOnly(filename string) (*DB, error) {
+	db := &DB{
+		filename: filename,
+		readOnly: true,
+	}
+	var err error
+	db.Version, db.Records, db.uncompacted, err = deserializeFile(db.filename)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
 func (db *DB) Save(key string, val []byte, seq uint64) {
+	if db.readOnly {
+		panic("modifying read-only db")
+	}
 	if seq == seqDeleted {
 		panic("reserved seq")
 	}
@@ -76,6 +97,9 @@ func (db *DB) Save(key string, val []byte, seq uint64) {
 }
 
 func (db *DB) Delete(key string) {
+	if db.readOnly {
+		panic("modifying read-only db")
+	}
 	if _, ok := db.Records[key]; !ok {
 		return
 	}
@@ -96,6 +120,9 @@ func (db *DB) DiscardData() {
 }
 
 func (db *DB) Flush() error {
+	if db.readOnly {
+		panic("modifying read-only db")
+	}
 	if db.pending == nil {
 		return nil
 	}
@@ -115,6 +142,9 @@ func (db *DB) Flush() error {
 }
 
 func (db *DB) BumpVersion(version uint64) error {
+	if db.readOnly {
+		panic("modifying read-only db")
+	}
 	if err := db.Flush(); err != nil {
 		return err
 	}
@@ -218,7 +248,7 @@ func serializeRecord(w *bytes.Buffer, key string, val []byte, seq uint64) {
 }
 
 func deserializeFile(filename string) (version uint64, records map[string]Record, uncompacted int, err error) {
-	f, err := os.OpenFile(filename, os.O_RDONLY|os.O_CREATE, osutil.DefaultFilePerm)
+	f, err := os.Open(filename)
 	if err != nil {
 		return 0, nil, 0, err
 	}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 	_ "github.com/google/syzkaller/sys"
 	"github.com/google/syzkaller/sys/targets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasic(t *testing.T) {
@@ -380,4 +382,39 @@ func TestDeterministic(t *testing.T) {
 			t.Fatal("ReadCorpus output program order is non-deterministic")
 		}
 	}
+}
+
+func TestOpenReadOnly(t *testing.T) {
+	t.Run("NonexistentFile", func(t *testing.T) {
+		nonexistent := filepath.Join(t.TempDir(), "nonexistent")
+		_, err := OpenReadOnly(nonexistent)
+		require.Error(t, err)
+		require.NoFileExists(t, nonexistent)
+	})
+
+	t.Run("ReadRecords", func(t *testing.T) {
+		fn := tempFile(t)
+		defer os.Remove(fn)
+
+		writableDB, err := Open(fn, false)
+		require.NoError(t, err)
+		writableDB.Save("key1", []byte("val1"), 1)
+		writableDB.Save("key2", []byte("val2"), 2)
+		require.NoError(t, writableDB.Flush())
+
+		require.NoError(t, os.Chmod(fn, 0400))
+		defer os.Chmod(fn, 0600)
+
+		roDB, err := OpenReadOnly(fn)
+		require.NoError(t, err)
+		require.Len(t, roDB.Records, 2)
+		require.Equal(t, []byte("val1"), roDB.Records["key1"].Val)
+		require.Equal(t, []byte("val2"), roDB.Records["key2"].Val)
+		require.NoFileExists(t, fn+".tmp")
+
+		require.Panics(t, func() { roDB.Save("key3", []byte("val3"), 3) })
+		require.Panics(t, func() { roDB.Delete("key1") })
+		require.Panics(t, func() { roDB.Flush() })
+		require.Panics(t, func() { roDB.BumpVersion(3) })
+	})
 }


### PR DESCRIPTION
db.Open compacts database files on startup. When parallel workflows share an input corpus, concurrent compactions race on temporary files and corrupt the corpus.

Add db.OpenReadOnly to deserialize the database without compacting or modifying the file on disk, and switch executeCorpusAction to use it.

***

Taken out of https://github.com/google/syzkaller/pull/7866