### PR TITLE
syz-cluster: limit CC'd emails on series.

### DIFF
--- a/pkg/email/lore/parse.go
+++ b/pkg/email/lore/parse.go
@@ -36,6 +36,7 @@ type Series struct {
 	Version           int
 	Corrupted         string // If non-empty, contains a reason why the series better be ignored.
 	Tags              []string
+	CoverCc           []string
 	Patches           []Patch
 	BaseCommitHint    string
 	XStable           string
@@ -108,7 +109,7 @@ func PatchSeries(emails []*Email) []*Series {
 			}
 			seq := patch.Seq.ValueOr(1)
 			if seq == 0 {
-				// The cover email is not of interest.
+				series.CoverCc = email.Cc
 				continue
 			}
 			if !email.HasPatch {

--- a/pkg/email/lore/parse_test.go
+++ b/pkg/email/lore/parse_test.go
@@ -527,6 +527,7 @@ In-Reply-To: <Fifth>
 			Subject: "A longer series",
 			Version: 2,
 			Tags:    []string{"net"},
+			CoverCc: []string{"a@user.com", "b@user.com"},
 			Patches: []Patch{
 				{
 					Seq:   1,
@@ -561,6 +562,7 @@ In-Reply-To: <Fifth>
 			Tags:              []string{"6.18"},
 			XStable:           "review",
 			XKernelTestBranch: "linux-6.18.y",
+			CoverCc:           []string{"gregkh@linuxfoundation.org", "stable@vger.kernel.org"},
 			Patches: []Patch{
 				{
 					Seq:   1,
@@ -581,6 +583,7 @@ In-Reply-To: <Fifth>
 			assert.Equal(t, expect.Version, s.Version, "version differs")
 			assert.Equal(t, expect.XStable, s.XStable, "XStable differs")
 			assert.Equal(t, expect.XKernelTestBranch, s.XKernelTestBranch, "XKernelTestBranch differs")
+			require.Equal(t, expect.CoverCc, s.CoverCc, "CoverCc differs")
 			require.Len(t, s.Patches, len(expect.Patches), "patch count differs")
 			for i, expectPatch := range expect.Patches {
 				got := s.Patches[i]

--- a/syz-cluster/series-tracker/main.go
+++ b/syz-cluster/series-tracker/main.go
@@ -205,7 +205,15 @@ func (sf *SeriesFetcher) handleSeries(ctx context.Context, cfg *app.AppConfig, s
 			Body:  body,
 		})
 	}
-	apiSeries.Cc = sp.Emails()
+	if len(series.CoverCc) > 0 && series.XStable == "review" {
+		coverSp := seriesProcessor{}
+		for _, email := range series.CoverCc {
+			coverSp[email] = struct{}{}
+		}
+		apiSeries.Cc = coverSp.Emails()
+	} else {
+		apiSeries.Cc = sp.Emails()
+	}
 	ret, err := sf.client.UploadSeries(ctx, apiSeries)
 	if err != nil {
 		return fmt.Errorf("failed to save series: %w", err)

--- a/syz-cluster/series-tracker/main_test.go
+++ b/syz-cluster/series-tracker/main_test.go
@@ -136,3 +136,51 @@ func TestHandleSeriesReportLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleSeriesCC(t *testing.T) {
+	tests := []struct {
+		name    string
+		xStable string
+		coverCc []string
+		patchCc string
+		wantCc  []string
+	}{
+		{
+			name:    "regular series",
+			coverCc: []string{"author@test.com", "c1@test.com"},
+			patchCc: "To: p1@test.com",
+			wantCc:  []string{"author@test.com", "p1@test.com"},
+		},
+		{
+			name:    "LTS RC series",
+			xStable: "review",
+			coverCc: []string{"c2@test.com", "author@test.com", "c1@test.com", "c2@test.com"},
+			patchCc: "To: p1@test.com",
+			wantCc:  []string{"author@test.com", "c1@test.com", "c2@test.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, ctx := app.TestEnvironment(t)
+			sf := &SeriesFetcher{client: controller.TestServer(t, env)}
+			series := &lore.Series{
+				MessageID: "msg-" + tt.name,
+				XStable:   tt.xStable,
+				CoverCc:   tt.coverCc,
+				Patches: []lore.Patch{{
+					Email: &lore.Email{Email: &email.Email{MessageID: "patch", Author: "author@test.com"}},
+				}},
+			}
+			readers := map[string]lore.EmailReader{
+				"patch": {Read: func() ([]byte, error) {
+					return []byte("From: author@test.com\n" + tt.patchCc + "\n\nbody"), nil
+				}},
+			}
+			require.NoError(t, sf.handleSeries(ctx, &app.AppConfig{}, series, readers))
+			dbSeries, err := db.NewSeriesRepository(env.Spanner).GetByExtID(ctx, series.MessageID)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCc, dbSeries.Cc)
+		})
+	}
+}


### PR DESCRIPTION
This is a prerequisite of #7601 since we don't want to CC 100s of emails.