### PR TITLE
fix: handle nil programs in resource-centric mutation

### DIFF
--- a/prog/rand.go
+++ b/prog/rand.go
@@ -1017,6 +1017,9 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 	var resource *ResultArg
 	for _, idx := range r.Perm(len(s.corpus)) {
 		corpusProg := s.corpus[idx]
+		if corpusProg == nil {
+			continue
+		}
 		resources := getCompatibleResources(corpusProg, t.TypeName, r)
 		if len(resources) == 0 {
 			continue
@@ -1071,6 +1074,9 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 }
 
 func getCompatibleResources(p *Prog, resourceType string, r *randGen) (resources []*ResultArg) {
+	if p == nil {
+		return nil
+	}
 	for _, c := range p.Calls {
 		ForeachArg(c, func(arg Arg, _ *ArgCtx) {
 			// Collect only initialized resources (the ones that are already used in other calls).

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -10,6 +10,8 @@ import (
 	"math/rand"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNotEscaping(t *testing.T) {
@@ -248,4 +250,38 @@ func TestNoGenerate(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetCompatibleResourcesNil(t *testing.T) {
+	target, rs, _ := initRandomTargetTest(t, "test", "64")
+	r := newRand(target, rs)
+
+	// A nil *Prog should be handled safely and return nil without panicking.
+	require.Empty(t, getCompatibleResources(nil, "common", r))
+}
+
+func TestResourceCentricNilCorpus(t *testing.T) {
+	target, rs, _ := initRandomTargetTest(t, "test", "64")
+	r := newRand(target, rs)
+	meta := target.SyscallMap["test$consume_common"]
+	require.NotNil(t, meta)
+	resType, ok := meta.Args[0].Type.(*ResourceType)
+	require.True(t, ok)
+
+	// Corpus containing only nil programs should not panic.
+	sNil := newState(target, target.DefaultChoiceTable(), []*Prog{nil})
+	arg, calls := r.resourceCentric(sNil, resType, DirIn)
+	require.Nil(t, arg)
+	require.Nil(t, calls)
+
+	// Corpus containing nil entries alongside valid programs should skip nil entries
+	// and successfully extract compatible resources from valid programs.
+	progData := []byte("r0 = test$produce_common()\ntest$consume_common(r0)\n")
+	validProg, err := target.Deserialize(progData, Strict)
+	require.NoError(t, err)
+
+	sMixed := newState(target, target.DefaultChoiceTable(), []*Prog{nil, validProg})
+	arg, calls = r.resourceCentric(sMixed, resType, DirIn)
+	require.NotNil(t, arg)
+	require.NotEmpty(t, calls)
 }

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -276,7 +276,9 @@ func TestResourceCentricNilCorpus(t *testing.T) {
 
 	// Corpus containing nil entries alongside valid programs should skip nil entries
 	// and successfully extract compatible resources from valid programs.
-	progData := []byte("r0 = test$produce_common()\ntest$consume_common(r0)\n")
+	progData := []byte(`r0 = test$produce_common()
+test$consume_common(r0)
+`)
 	validProg, err := target.Deserialize(progData, Strict)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Fixes #7860.

`resourceCentric` can encounter a nil `*Prog` in the corpus and pass it to
`getCompatibleResources`, which dereferences `p.Calls` and can cause a nil
pointer panic.

This change:
- skips nil programs when searching the corpus
- makes `getCompatibleResources` safely handle a nil `*Prog`
- adds regression tests for nil and mixed corpus entries

## Testing

- `go test -v ./prog -run "TestGetCompatibleResourcesNil|TestResourceCentricNilCorpus"`
- `go test -short ./prog`
- `go test ./prog`
- `go vet ./prog`
- `git diff --check`