### PR TITLE
pkg/aflow: gracefully handle loop exhaustion

### DIFF
--- a/pkg/aflow/flow/seedgen/seedgen.go
+++ b/pkg/aflow/flow/seedgen/seedgen.go
@@ -37,6 +37,22 @@ type SeedGenInputs struct {
 	CorpusPath    string `json:",omitempty"`
 }
 
+const maxSeedGenAttempts = 5
+
+type seedGenGiveUpResult struct {
+	GeneratorGiveUp bool
+	GeneratorReason string
+}
+
+var actionSeedGenGiveUpMaxAttempts = aflow.NewFuncAction("giveup-max-attempts",
+	func(ctx *aflow.Context, args struct{}) (seedGenGiveUpResult, error) {
+		return seedGenGiveUpResult{
+			GeneratorGiveUp: true,
+			GeneratorReason: fmt.Sprintf("exceeded maximum generation attempts (%d) without reaching target PC",
+				maxSeedGenAttempts),
+		}, nil
+	})
+
 func seedGenPipeline(prefix ...aflow.Action) aflow.Action {
 	steps := append([]aflow.Action{actionsyzlang.PrepareSyzFS}, prefix...)
 	steps = append(steps,
@@ -45,8 +61,9 @@ func seedGenPipeline(prefix ...aflow.Action) aflow.Action {
 		codesearcher.PrepareIndex,
 		codesearcher.ActionExtractFunction,
 		&aflow.DoWhile{
-			While:         "ContinueLoop",
-			MaxIterations: 5,
+			While:           "ContinueLoop",
+			MaxIterations:   maxSeedGenAttempts,
+			OnMaxIterations: actionSeedGenGiveUpMaxAttempts,
 			Do: aflow.Pipeline(
 				ActionPrepareFailedDetails,
 				GeneratorAgent,

--- a/pkg/aflow/loop.go
+++ b/pkg/aflow/loop.go
@@ -13,17 +13,21 @@ import (
 
 // DoWhile represents "do { body } while (cond)" loop.
 type DoWhile struct {
-	// Dody of the loop.
+	// Body of the loop.
 	Do Action
-	// Exit condition. It should be a string state variable.
-	// The loop exists when the variable is empty.
+	// Exit condition. It should be a string or bool state variable.
+	// The loop exits when the variable is empty or false.
 	While string
-	// Max interations for the loop.
+	// Max iterations for the loop.
 	// Must be specified to avoid unintended effectively infinite loops.
 	MaxIterations int
 	// MapOutputs renames or overrides variables produced inside the loop
 	// before exposing them to the parent context upon loop completion.
 	MapOutputs map[string]string
+	// OnMaxIterations is executed when the loop reaches MaxIterations instead
+	// of returning an error. It executes after the loop finishes and MapOutputs
+	// has been applied; its outputs are not mapped by MapOutputs.
+	OnMaxIterations Action
 
 	loopVars map[string]reflect.Type
 }
@@ -35,14 +39,17 @@ func (dw *DoWhile) execute(ctx *Context) error {
 	if err := ctx.startSpan(span); err != nil {
 		return err
 	}
-	err := dw.loop(ctx)
+	exhausted, err := dw.loop(ctx)
 	if err := ctx.finishSpan(span, err); err != nil {
 		return err
+	}
+	if exhausted && dw.OnMaxIterations != nil {
+		return dw.OnMaxIterations.execute(ctx)
 	}
 	return nil
 }
 
-func (dw *DoWhile) loop(ctx *Context) error {
+func (dw *DoWhile) loop(ctx *Context) (bool, error) {
 	for name, typ := range dw.loopVars {
 		// We allow redefinition of loop variables to support nested loops.
 		// They are reset to zero values at the start of the loop.
@@ -54,11 +61,11 @@ func (dw *DoWhile) loop(ctx *Context) error {
 			Name: fmt.Sprint(iter),
 		}
 		if err := ctx.startSpan(span); err != nil {
-			return err
+			return false, err
 		}
 		err := dw.Do.execute(ctx)
 		if err := ctx.finishSpan(span, err); err != nil {
-			return err
+			return false, err
 		}
 		val := ctx.state[dw.While]
 		cond := false
@@ -69,15 +76,23 @@ func (dw *DoWhile) loop(ctx *Context) error {
 			cond = v
 		}
 		if !cond {
-			for from, to := range dw.MapOutputs {
-				if val, ok := ctx.state[from]; ok {
-					ctx.state[to] = val
-				}
-			}
-			return nil
+			dw.mapOutputs(ctx)
+			return false, nil
 		}
 	}
-	return fmt.Errorf("DoWhile reached max iteration limit %v", dw.MaxIterations)
+	if dw.OnMaxIterations != nil {
+		dw.mapOutputs(ctx)
+		return true, nil
+	}
+	return false, fmt.Errorf("DoWhile reached max iteration limit %v", dw.MaxIterations)
+}
+
+func (dw *DoWhile) mapOutputs(ctx *Context) {
+	for from, to := range dw.MapOutputs {
+		if val, ok := ctx.state[from]; ok {
+			ctx.state[to] = val
+		}
+	}
 }
 
 func (dw *DoWhile) verify(ctx *verifyContext) {
@@ -124,6 +139,9 @@ func (dw *DoWhile) verify(ctx *verifyContext) {
 				typ:    desc.typ,
 			}
 		}
+		if dw.OnMaxIterations != nil {
+			dw.verifyOnMaxIterations(ctx, origState)
+		}
 	}
 	if inputs {
 		ctx.inputs, ctx.outputs = true, false
@@ -137,7 +155,31 @@ func (dw *DoWhile) verify(ctx *verifyContext) {
 		} else {
 			state.used = true
 		}
+		if dw.OnMaxIterations != nil {
+			dw.OnMaxIterations.verify(ctx)
+		}
 	}
+}
+
+func (dw *DoWhile) verifyOnMaxIterations(ctx *verifyContext, origState map[string]*varState) {
+	loopState := ctx.state
+	ctx.state = maps.Clone(origState)
+	dw.OnMaxIterations.verify(ctx)
+	for name, desc := range ctx.state {
+		if origState[name] != nil {
+			continue
+		}
+		expected := loopState[name]
+		if expected == nil {
+			ctx.errorf("DoWhile", "output %v is produced by OnMaxIterations but not by Do", name)
+			continue
+		}
+		if expected.typ != desc.typ {
+			ctx.errorf("DoWhile", "output %v has different types in Do and OnMaxIterations: want %v, has %v",
+				name, expected.typ, desc.typ)
+		}
+	}
+	ctx.state = loopState
 }
 
 // ForEach executes an action for each element in a slice.

--- a/pkg/aflow/loop_test.go
+++ b/pkg/aflow/loop_test.go
@@ -116,6 +116,48 @@ func TestDoWhileErrors(t *testing.T) {
 			While:         "Output1",
 			MaxIterations: 10,
 		}})
+
+	for _, test := range []struct {
+		name   string
+		err    string
+		action Action
+	}{
+		{
+			name: "extra output",
+			err:  "flow test: action DoWhile: output Output2 is produced by OnMaxIterations but not by Do",
+			action: NewFuncAction("onMax", func(ctx *Context, args struct{}) (struct{ Output2 string }, error) {
+				return struct{ Output2 string }{}, nil
+			}),
+		},
+		{
+			name: "type mismatch",
+			err: "flow test: action DoWhile: output Output1 has different types in Do and OnMaxIterations: " +
+				"want string, has int",
+			action: NewFuncAction("onMax", func(ctx *Context, args struct{}) (struct{ Output1 int }, error) {
+				return struct{ Output1 int }{}, nil
+			}),
+		},
+		{
+			name: "missing input",
+			err:  "flow test: action onMax: no input Missing, available inputs: [Output1]",
+			action: NewFuncAction("onMax", func(ctx *Context, args struct {
+				Missing int
+			}) (struct{ Output1 string }, error) {
+				return struct{ Output1 string }{}, nil
+			}),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testRegistrationError[struct{}, struct{}](t, test.err, &Flow{Root: &DoWhile{
+				Do: NewFuncAction("body", func(ctx *Context, args struct{ Output1 string }) (struct{ Output1 string }, error) {
+					return struct{ Output1 string }{}, nil
+				}),
+				While:           "Output1",
+				MaxIterations:   10,
+				OnMaxIterations: test.action,
+			}})
+		})
+	}
 }
 
 func TestDoWhileMaxIters(t *testing.T) {
@@ -133,6 +175,59 @@ func TestDoWhileMaxIters(t *testing.T) {
 		nil,
 		nil,
 	)
+}
+
+func TestDoWhileOnMaxIterations(t *testing.T) {
+	type loopBodyOutputs struct {
+		Error  string
+		Val    string
+		GaveUp bool
+		Reason string
+	}
+	type onMaxOutputs struct {
+		GaveUp bool
+		Reason string
+	}
+	type expectedOutputs struct {
+		Val    string
+		GaveUp bool
+		Reason string
+	}
+
+	fallback := NewFuncAction("on-max", func(ctx *Context, args struct{}) (onMaxOutputs, error) {
+		return onMaxOutputs{GaveUp: true, Reason: "max iterations reached"}, nil
+	})
+	step := func(retErr, val string) Action {
+		return NewFuncAction("step", func(ctx *Context, args struct{}) (loopBodyOutputs, error) {
+			return loopBodyOutputs{Error: retErr, Val: val}, nil
+		})
+	}
+
+	t.Run("Exhausted", func(t *testing.T) {
+		testFlow[struct{}, expectedOutputs](t, nil, map[string]any{
+			"Val":    "loop-val",
+			"GaveUp": true,
+			"Reason": "max iterations reached",
+		}, &DoWhile{
+			Do:              step("loop", "loop-val"),
+			While:           "Error",
+			MaxIterations:   3,
+			OnMaxIterations: fallback,
+		}, nil, nil)
+	})
+
+	t.Run("NormalExit", func(t *testing.T) {
+		testFlow[struct{}, expectedOutputs](t, nil, map[string]any{
+			"Val":    "success-val",
+			"GaveUp": false,
+			"Reason": "",
+		}, &DoWhile{
+			Do:              step("", "success-val"),
+			While:           "Error",
+			MaxIterations:   3,
+			OnMaxIterations: fallback,
+		}, nil, nil)
+	})
 }
 
 func TestForEach(t *testing.T) {

--- a/pkg/aflow/testdata/TestDoWhileOnMaxIterations/Exhausted.trajectory.json
+++ b/pkg/aflow/testdata/TestDoWhileOnMaxIterations/Exhausted.trajectory.json
@@ -1,0 +1,164 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Results": {
+			"Error": "loop",
+			"GaveUp": false,
+			"Reason": "",
+			"Val": "loop-val"
+		}
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:08Z"
+	},
+	{
+		"Seq": 5,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:08Z",
+		"Finished": "0001-01-01T00:00:09Z",
+		"Results": {
+			"Error": "loop",
+			"GaveUp": false,
+			"Reason": "",
+			"Val": "loop-val"
+		}
+	},
+	{
+		"Seq": 4,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "1",
+		"Started": "0001-01-01T00:00:07Z",
+		"Finished": "0001-01-01T00:00:10Z"
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:12Z"
+	},
+	{
+		"Seq": 7,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:12Z",
+		"Finished": "0001-01-01T00:00:13Z",
+		"Results": {
+			"Error": "loop",
+			"GaveUp": false,
+			"Reason": "",
+			"Val": "loop-val"
+		}
+	},
+	{
+		"Seq": 6,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "2",
+		"Started": "0001-01-01T00:00:11Z",
+		"Finished": "0001-01-01T00:00:14Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:15Z"
+	},
+	{
+		"Seq": 8,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "on-max",
+		"Started": "0001-01-01T00:00:16Z"
+	},
+	{
+		"Seq": 8,
+		"Nesting": 1,
+		"Type": "action",
+		"Name": "on-max",
+		"Started": "0001-01-01T00:00:16Z",
+		"Finished": "0001-01-01T00:00:17Z",
+		"Results": {
+			"GaveUp": true,
+			"Reason": "max iterations reached"
+		}
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:18Z",
+		"Results": {
+			"GaveUp": true,
+			"Reason": "max iterations reached",
+			"Val": "loop-val"
+		}
+	}
+]

--- a/pkg/aflow/testdata/TestDoWhileOnMaxIterations/NormalExit.trajectory.json
+++ b/pkg/aflow/testdata/TestDoWhileOnMaxIterations/NormalExit.trajectory.json
@@ -1,0 +1,73 @@
+[
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z"
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z"
+	},
+	{
+		"Seq": 3,
+		"Nesting": 3,
+		"Type": "action",
+		"Name": "step",
+		"Started": "0001-01-01T00:00:04Z",
+		"Finished": "0001-01-01T00:00:05Z",
+		"Results": {
+			"Error": "",
+			"GaveUp": false,
+			"Reason": "",
+			"Val": "success-val"
+		}
+	},
+	{
+		"Seq": 2,
+		"Nesting": 2,
+		"Type": "iteration",
+		"Name": "0",
+		"Started": "0001-01-01T00:00:03Z",
+		"Finished": "0001-01-01T00:00:06Z"
+	},
+	{
+		"Seq": 1,
+		"Nesting": 1,
+		"Type": "loop",
+		"Name": "",
+		"Started": "0001-01-01T00:00:02Z",
+		"Finished": "0001-01-01T00:00:07Z"
+	},
+	{
+		"Seq": 0,
+		"Nesting": 0,
+		"Type": "flow",
+		"Name": "test",
+		"Started": "0001-01-01T00:00:01Z",
+		"Finished": "0001-01-01T00:00:08Z",
+		"Results": {
+			"GaveUp": false,
+			"Reason": "",
+			"Val": "success-val"
+		}
+	}
+]


### PR DESCRIPTION
For the seedgen workflow, not reaching the target PC is an expected outcome, we don't want to bucket such workflow runs with those who have had actual errors.

Let's introduce an explicit parameter for the loop control struct to handle such situations gracefully and, inside the seedgen workflow, use it to craft a custom GiveUp reason.