### PR TITLE
prog: guard against nil ResultArg in getCompatibleResources and resourceCentric (fixes #7860)

### DIFF
--- a/prog/rand.go
+++ b/prog/rand.go
@@ -1040,7 +1040,7 @@ func (r *randGen) resourceCentric(s *state, t *ResourceType, dir Dir) (arg Arg, 
 		includeCall := false
 		var newResources []*ResultArg
 		ForeachArg(v, func(arg Arg, _ *ArgCtx) {
-			if a, ok := arg.(*ResultArg); ok {
+			if a, ok := arg.(*ResultArg); ok && a != nil {
 				if a.Res != nil && !relatedRes[a.Res] {
 					newResources = append(newResources, a.Res)
 				}
@@ -1075,7 +1075,7 @@ func getCompatibleResources(p *Prog, resourceType string, r *randGen) (resources
 		ForeachArg(c, func(arg Arg, _ *ArgCtx) {
 			// Collect only initialized resources (the ones that are already used in other calls).
 			a, ok := arg.(*ResultArg)
-			if !ok || len(a.uses) == 0 || a.Dir() != DirOut {
+			if !ok || a == nil || len(a.uses) == 0 || a.Dir() != DirOut {
 				return
 			}
 			if !r.target.isCompatibleResource(resourceType, a.Type().Name()) {

--- a/prog/rand_test.go
+++ b/prog/rand_test.go
@@ -249,3 +249,27 @@ func TestNoGenerate(t *testing.T) {
 		}
 	}
 }
+
+func TestGetCompatibleResourcesNilArg(t *testing.T) {
+	target, err := GetTarget("test", "64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := newRand(target, rand.NewSource(0))
+	c := target.SyscallMap["test$res0"]
+	if c == nil {
+		t.Skip("test$res0 not found")
+	}
+	call := &Call{
+		Meta: c,
+		Args: []Arg{(*ResultArg)(nil)},
+	}
+	p := &Prog{
+		Target: target,
+		Calls:  []*Call{call},
+	}
+	res := getCompatibleResources(p, "res0", r)
+	if len(res) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(res))
+	}
+}


### PR DESCRIPTION
Fixes #7860

### Problem
`syz-manager` can panic with a nil pointer dereference in `prog.getCompatibleResources`:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x8dc2f9]

goroutine 98588 [running]:
github.com/google/syzkaller/prog.getCompatibleResources(...)
	prog/rand.go:1074 +0x39
github.com/google/syzkaller/prog.(*randGen).resourceCentric(...)
	prog/rand.go:1020 +0xc5
```
When `ForeachArg` yields a typed nil pointer `(*ResultArg)(nil)` inside an `Arg` interface, `a, ok := arg.(*ResultArg)` succeeds with `ok == true`, but `a` is `nil`. Attempting to access `len(a.uses)` or `a.Dir()` immediately dereferences the nil pointer at offset `0x8`.

### Solution
1. Added explicit `a == nil` checks in `getCompatibleResources` and `resourceCentric` in `prog/rand.go`.
2. Added regression test `TestGetCompatibleResourcesNilArg` in `prog/rand_test.go` verifying that `getCompatibleResources` safely ignores nil `*ResultArg` without panicking.
