### PR TITLE
tools/syz-aflow: preserve 64-bit integer precision using json.Number (fixes #7452)

### DIFF
--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -5,10 +5,12 @@ package aflow
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -154,8 +156,126 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 		}
 		return nil
 	}
-	if field.Type() == fType {
-		field.Set(fValue)
+	if num, ok := f.(json.Number); ok {
+		if reflect.Zero(targetType).CanInt() {
+			iv, err := strconv.ParseInt(string(num), 10, targetType.Bits())
+			if err == nil {
+				res := reflect.ValueOf(iv).Convert(targetType)
+				if field.Kind() == reflect.Ptr {
+					ptr := reflect.New(targetType)
+					ptr.Elem().Set(res)
+					field.Set(ptr)
+				} else {
+					field.Set(res)
+				}
+				return nil
+			}
+			if errors.Is(err, strconv.ErrRange) {
+				if tool {
+					return BadCallError("argument %v: integer value out of range %v", name, f)
+				}
+				return fmt.Errorf("%T: field %v: integer value out of range %v", val, name, f)
+			}
+			fv, errFloat := strconv.ParseFloat(string(num), 64)
+			if errFloat == nil {
+				res := reflect.ValueOf(fv).Convert(targetType)
+				if fv != res.Convert(reflect.TypeFor[float64]()).Float() {
+					if tool {
+						return BadCallError("argument %v: float value truncated from %v to %v",
+							name, f, res.Interface())
+					}
+					return fmt.Errorf("%T: field %v: float value truncated from %v to %v",
+						val, name, f, res.Interface())
+				}
+				if field.Kind() == reflect.Ptr {
+					ptr := reflect.New(targetType)
+					ptr.Elem().Set(res)
+					field.Set(ptr)
+				} else {
+					field.Set(res)
+				}
+				return nil
+			}
+			if tool {
+				return BadCallError("argument %q has wrong type: got %T, want %v",
+					name, f, field.Type().String())
+			}
+			return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
+				val, name, f, field.Type().String())
+		}
+		if reflect.Zero(targetType).CanUint() {
+			uv, err := strconv.ParseUint(string(num), 10, targetType.Bits())
+			if err == nil {
+				res := reflect.ValueOf(uv).Convert(targetType)
+				if field.Kind() == reflect.Ptr {
+					ptr := reflect.New(targetType)
+					ptr.Elem().Set(res)
+					field.Set(ptr)
+				} else {
+					field.Set(res)
+				}
+				return nil
+			}
+			if errors.Is(err, strconv.ErrRange) {
+				if tool {
+					return BadCallError("argument %v: integer value out of range %v", name, f)
+				}
+				return fmt.Errorf("%T: field %v: integer value out of range %v", val, name, f)
+			}
+			fv, errFloat := strconv.ParseFloat(string(num), 64)
+			if errFloat == nil && fv >= 0 {
+				res := reflect.ValueOf(fv).Convert(targetType)
+				if fv != res.Convert(reflect.TypeFor[float64]()).Float() {
+					if tool {
+						return BadCallError("argument %v: float value truncated from %v to %v",
+							name, f, res.Interface())
+					}
+					return fmt.Errorf("%T: field %v: float value truncated from %v to %v",
+						val, name, f, res.Interface())
+				}
+				if field.Kind() == reflect.Ptr {
+					ptr := reflect.New(targetType)
+					ptr.Elem().Set(res)
+					field.Set(ptr)
+				} else {
+					field.Set(res)
+				}
+				return nil
+			}
+			if tool {
+				return BadCallError("argument %q has wrong type: got %T, want %v",
+					name, f, field.Type().String())
+			}
+			return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
+				val, name, f, field.Type().String())
+		}
+		if targetType.Kind() == reflect.Float32 || targetType.Kind() == reflect.Float64 {
+			fv, err := strconv.ParseFloat(string(num), targetType.Bits())
+			if err != nil {
+				if tool {
+					return BadCallError("argument %v: invalid float value %v", name, f)
+				}
+				return fmt.Errorf("%T: field %v: invalid float value %v", val, name, f)
+			}
+			res := reflect.ValueOf(fv).Convert(targetType)
+			if field.Kind() == reflect.Ptr {
+				ptr := reflect.New(targetType)
+				ptr.Elem().Set(res)
+				field.Set(ptr)
+			} else {
+				field.Set(res)
+			}
+			return nil
+		}
+	}
+	if field.Kind() == reflect.Interface || field.Type() == fType || targetType == fType {
+		if field.Kind() == reflect.Ptr && targetType == fType {
+			ptr := reflect.New(targetType)
+			ptr.Elem().Set(fValue)
+			field.Set(ptr)
+		} else {
+			field.Set(fValue)
+		}
 		return nil
 	}
 

--- a/pkg/aflow/schema.go
+++ b/pkg/aflow/schema.go
@@ -157,17 +157,20 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 		return nil
 	}
 	if num, ok := f.(json.Number); ok {
-		if reflect.Zero(targetType).CanInt() {
+		setVal := func(res reflect.Value) {
+			if field.Kind() == reflect.Ptr {
+				ptr := reflect.New(targetType)
+				ptr.Elem().Set(res)
+				field.Set(ptr)
+			} else {
+				field.Set(res)
+			}
+		}
+		switch targetType.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			iv, err := strconv.ParseInt(string(num), 10, targetType.Bits())
 			if err == nil {
-				res := reflect.ValueOf(iv).Convert(targetType)
-				if field.Kind() == reflect.Ptr {
-					ptr := reflect.New(targetType)
-					ptr.Elem().Set(res)
-					field.Set(ptr)
-				} else {
-					field.Set(res)
-				}
+				setVal(reflect.ValueOf(iv).Convert(targetType))
 				return nil
 			}
 			if errors.Is(err, strconv.ErrRange) {
@@ -187,13 +190,7 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 					return fmt.Errorf("%T: field %v: float value truncated from %v to %v",
 						val, name, f, res.Interface())
 				}
-				if field.Kind() == reflect.Ptr {
-					ptr := reflect.New(targetType)
-					ptr.Elem().Set(res)
-					field.Set(ptr)
-				} else {
-					field.Set(res)
-				}
+				setVal(res)
 				return nil
 			}
 			if tool {
@@ -202,18 +199,10 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 			}
 			return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
 				val, name, f, field.Type().String())
-		}
-		if reflect.Zero(targetType).CanUint() {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			uv, err := strconv.ParseUint(string(num), 10, targetType.Bits())
 			if err == nil {
-				res := reflect.ValueOf(uv).Convert(targetType)
-				if field.Kind() == reflect.Ptr {
-					ptr := reflect.New(targetType)
-					ptr.Elem().Set(res)
-					field.Set(ptr)
-				} else {
-					field.Set(res)
-				}
+				setVal(reflect.ValueOf(uv).Convert(targetType))
 				return nil
 			}
 			if errors.Is(err, strconv.ErrRange) {
@@ -233,13 +222,7 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 					return fmt.Errorf("%T: field %v: float value truncated from %v to %v",
 						val, name, f, res.Interface())
 				}
-				if field.Kind() == reflect.Ptr {
-					ptr := reflect.New(targetType)
-					ptr.Elem().Set(res)
-					field.Set(ptr)
-				} else {
-					field.Set(res)
-				}
+				setVal(res)
 				return nil
 			}
 			if tool {
@@ -248,8 +231,7 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 			}
 			return fmt.Errorf("%T: field %q has wrong type: got %T, want %v",
 				val, name, f, field.Type().String())
-		}
-		if targetType.Kind() == reflect.Float32 || targetType.Kind() == reflect.Float64 {
+		case reflect.Float32, reflect.Float64:
 			fv, err := strconv.ParseFloat(string(num), targetType.Bits())
 			if err != nil {
 				if tool {
@@ -257,14 +239,7 @@ func setField(field reflect.Value, val, f any, name string, tool bool) error {
 				}
 				return fmt.Errorf("%T: field %v: invalid float value %v", val, name, f)
 			}
-			res := reflect.ValueOf(fv).Convert(targetType)
-			if field.Kind() == reflect.Ptr {
-				ptr := reflect.New(targetType)
-				ptr.Elem().Set(res)
-				field.Set(ptr)
-			} else {
-				field.Set(res)
-			}
+			setVal(reflect.ValueOf(fv).Convert(targetType))
 			return nil
 		}
 	}

--- a/pkg/aflow/schema_test.go
+++ b/pkg/aflow/schema_test.go
@@ -4,6 +4,7 @@
 package aflow
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -262,6 +263,71 @@ func TestConvertFromMap(t *testing.T) {
 		Embedded: Embedded{B: "foo"},
 		A:        1,
 	}, "", "")
+
+	u64Val := uint64(18446744071636006420)
+	testConvertFromMap(t, false, map[string]any{
+		"I":  json.Number("42"),
+		"U":  json.Number("18446744071636006420"),
+		"F":  json.Number("3.14"),
+		"I2": json.Number("2.0"),
+		"P":  json.Number("18446744071636006420"),
+	}, struct {
+		I  int
+		U  uint64
+		F  float64
+		I2 int
+		P  *uint64
+	}{
+		I:  42,
+		U:  18446744071636006420,
+		F:  3.14,
+		I2: 2,
+		P:  &u64Val,
+	}, "", "")
+
+	testConvertFromMap(t, true, map[string]any{
+		"I0": json.Number("1.1"),
+	}, struct {
+		I0 int
+	}{},
+		`argument I0: float value truncated from 1.1 to 1`,
+		`struct { I0 int }: field I0: float value truncated from 1.1 to 1`)
+
+	testConvertFromMap(t, true, map[string]any{
+		"I0": json.Number("9999999999999999999999999999999999999999999"),
+	}, struct {
+		I0 int
+	}{},
+		`argument I0: integer value out of range 9999999999999999999999999999999999999999999`,
+		`struct { I0 int }: field I0: integer value out of range 9999999999999999999999999999999999999999999`)
+}
+
+func TestConvertFromMapJsonNumber(t *testing.T) {
+	inputJSON := []byte(`{
+		"PC": 18446744071636006420,
+		"PCs": [18446744071636006420, 18446744071636006421],
+		"Nested": {
+			"Address": 18446744071636006420
+		}
+	}`)
+	dec := json.NewDecoder(bytes.NewReader(inputJSON))
+	dec.UseNumber()
+	var raw map[string]any
+	require.NoError(t, dec.Decode(&raw))
+
+	type Nested struct {
+		Address uint64
+	}
+	type Target struct {
+		PC     uint64
+		PCs    []uint64
+		Nested Nested
+	}
+	got, err := convertFromMap[Target](raw, false, false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(18446744071636006420), got.PC)
+	require.Equal(t, []uint64{18446744071636006420, 18446744071636006421}, got.PCs)
+	require.Equal(t, uint64(18446744071636006420), got.Nested.Address)
 }
 
 func testConvertFromMap[T any](t *testing.T, strict bool, input map[string]any, output T, toolErr, nonToolErr string) {

--- a/tools/syz-aflow/aflow.go
+++ b/tools/syz-aflow/aflow.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -112,8 +113,10 @@ func run(ctx context.Context, args RunArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to open -input file: %w", err)
 	}
+	dec := json.NewDecoder(bytes.NewReader(inputData))
+	dec.UseNumber()
 	var inputs map[string]any
-	if err := json.Unmarshal(inputData, &inputs); err != nil {
+	if err := dec.Decode(&inputs); err != nil {
 		return err
 	}
 	if err := expandFileInputs(inputs, filepath.Dir(args.InputFile)); err != nil {


### PR DESCRIPTION
### Motivation
Fixes #7452

When running `syz-aflow` with an input JSON file that contains large 64-bit integers (such as kernel PC addresses, e.g. `18446744071636006420`), decoding directly into untyped `map[string]any` with `json.Unmarshal` defaults all numbers to Go `float64`. Since `float64` only maintains 53 bits of mantissa precision, large 64-bit addresses get rounded and silently lose precision (e.g. `18446744071636006420` becomes `18446744071636006912`).

### Changes
1. **`tools/syz-aflow/aflow.go`**:
   - Use `json.NewDecoder(bytes.NewReader(inputData))` with `dec.UseNumber()` to decode JSON inputs, preserving numeric values verbatim as `json.Number` without 53-bit floating-point truncation.
2. **`pkg/aflow/schema.go`**:
   - In `setField`, added handling for `json.Number`:
     - Parses integers using `strconv.ParseInt` with target bit size (`targetType.Bits()`), detecting overflow range errors and float truncation.
     - Parses unsigned integers using `strconv.ParseUint` with target bit size (`targetType.Bits()`), preserving exact 64-bit uints such as kernel addresses.
     - Parses floats using `strconv.ParseFloat`.
     - Supports pointer indirection and interface assignment for target types.
3. **`pkg/aflow/schema_test.go`**:
   - Added unit test cases to `TestConvertFromMap` for `json.Number` covering full 64-bit ranges (`18446744071636006420`), floating point conversion, truncation detection, and range validation.
   - Added `TestConvertFromMapJsonNumber` verifying end-to-end JSON decoding with `UseNumber()` into scalar, slice, and nested struct targets without precision loss.
