### PR TITLE
pkg/aflow/tool/grepper: stream lines directly instead of collecting whole output

### DIFF
--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -87,26 +87,29 @@ func grepper(ctx *aflow.Context, state state, args args) (results, error) {
 	const maxLineLen = 200
 	lines := make([][]byte, 0, maxLines)
 	var truncated bool
-	totalLines := 0
-	for line := range bytes.Lines(output) {
+	totalLines := bytes.Count(output, []byte{'\n'})
+	if len(output) > 0 && output[len(output)-1] != '\n' {
 		totalLines++
-		if len(lines) < maxLines {
-			hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
-			contentLen := len(line)
+	}
+	for line := range bytes.Lines(output) {
+		if len(lines) >= maxLines {
+			break
+		}
+		hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
+		contentLen := len(line)
+		if hasNewline {
+			contentLen--
+		}
+		if contentLen > maxLineLen {
+			newLine := slices.Clone(line[:maxLineLen])
+			newLine = append(newLine, []byte("...")...)
 			if hasNewline {
-				contentLen--
+				newLine = append(newLine, '\n')
 			}
-			if contentLen > maxLineLen {
-				newLine := slices.Clone(line[:maxLineLen])
-				newLine = append(newLine, []byte("...")...)
-				if hasNewline {
-					newLine = append(newLine, '\n')
-				}
-				lines = append(lines, newLine)
-				truncated = true
-			} else {
-				lines = append(lines, line)
-			}
+			lines = append(lines, newLine)
+			truncated = true
+		} else {
+			lines = append(lines, line)
 		}
 	}
 

--- a/pkg/aflow/tool/grepper/grepper.go
+++ b/pkg/aflow/tool/grepper/grepper.go
@@ -85,26 +85,32 @@ func grepper(ctx *aflow.Context, state state, args args) (results, error) {
 	// They can contain lines >100K. We mainly intend to match source/docs files
 	// which should not contain long lines, so cap at 200 chars.
 	const maxLineLen = 200
-	lines := slices.Collect(bytes.Lines(output))
+	lines := make([][]byte, 0, maxLines)
 	var truncated bool
-	for i, line := range lines {
-		hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
-		contentLen := len(line)
-		if hasNewline {
-			contentLen--
-		}
-		if contentLen > maxLineLen {
-			newLine := slices.Clone(line[:maxLineLen])
-			newLine = append(newLine, []byte("...")...)
+	totalLines := 0
+	for line := range bytes.Lines(output) {
+		totalLines++
+		if len(lines) < maxLines {
+			hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
+			contentLen := len(line)
 			if hasNewline {
-				newLine = append(newLine, '\n')
+				contentLen--
 			}
-			lines[i] = newLine
-			truncated = true
+			if contentLen > maxLineLen {
+				newLine := slices.Clone(line[:maxLineLen])
+				newLine = append(newLine, []byte("...")...)
+				if hasNewline {
+					newLine = append(newLine, '\n')
+				}
+				lines = append(lines, newLine)
+				truncated = true
+			} else {
+				lines = append(lines, line)
+			}
 		}
 	}
 
-	if len(lines) <= maxLines {
+	if totalLines <= maxLines {
 		if truncated {
 			return results{string(slices.Concat(lines...))}, nil
 		}
@@ -115,6 +121,6 @@ Full output is too long, showing %v out of %v lines.
 Use more precise expression if possible.
 
 %s
-`, maxLines, len(lines), slices.Concat(lines[:maxLines]...))
+`, maxLines, totalLines, slices.Concat(lines...))
 	return results{res}, nil
 }


### PR DESCRIPTION
### Motivation
In `pkg/aflow/tool/grepper/grepper.go`, when an LLM issues broad grep queries (e.g. `.*` or common symbols in kernel sources), `slices.Collect(bytes.Lines(output))` allocates a slice for every single line in the entire grep output (up to millions of lines). Furthermore, the loop iterated over all lines in the collected slice to clamp line lengths (`contentLen > maxLineLen`), even though at most `maxLines = 500` are ever returned to the caller.

Similar to commit 1fe56c0 (`pkg/aflow: add TruncateText to avoid allocating line slices`), this PR avoids collecting all lines into a slice.

### Changes
- Stream lines directly with `for line := range bytes.Lines(output)`.
- Pre-allocate `lines` with capacity `maxLines` (500) and only collect and clamp line lengths for lines up to `maxLines`.
- For subsequent lines, only increment `totalLines` to preserve the exact total count report (`Full output is too long, showing %v out of %v lines`).
- When `totalLines <= maxLines`, preserves exact original behavior and output.
