### PR TITLE
pkg/aflow: minor tweaks for the seedgen workflow

### DIFF
--- a/docs/linux/syzlang/skills/kvm.md
+++ b/docs/linux/syzlang/skills/kvm.md
@@ -16,6 +16,7 @@ description: KVM Virtualization and Guest Constraints (x86/amd64 Focus)
   * Use 'syz_kvm_setup_syzos_vm$x86' to allocate guest memory and load the SYZOS guest library.
   * Use 'syz_kvm_add_vcpu$x86' to initialize the vCPU and define the sequence of guest instructions/commands
     (the SYZOS payload array) that the guest vCPU will execute inside the VM context when 'ioctl$KVM_RUN' is called.
+  * For full SYZOS architecture, memory layouts, and low-level command details, consult 'docs/syzos.md'.
 - Strict KVM ioctl Sequence Order (CRITICAL INSTRUCTION):
   When configuring a VM and vCPUs, you MUST follow this exact sequence:
   1) Create VM ('ioctl$KVM_CREATE_VM')

--- a/docs/linux/syzlang/skills/usb.md
+++ b/docs/linux/syzlang/skills/usb.md
@@ -11,3 +11,9 @@ description: USB Device Emulation and Gadget Constraints (raw-gadget/dummy_hcd)
 - Endpoint I/O: Use 'syz_usb_ep_write(conn, ep, len, data)' or 'syz_usb_ep_read(conn, ep, len, data)'
   (e.g. ep 0x81 IN / 0x02 OUT) to exchange data packets with the emulated device.
 - Disconnect: Use 'syz_usb_disconnect(conn)'.
+- Forbidden Sysfs Driver Binding:
+  * Do NOT use sysfs driver binding/unbinding endpoints (such as '/bind', '/unbind', '/driver_override',
+    '/drivers_probe', or '/new_id' under '/sys/bus/usb/drivers/').
+  * Syzkaller actively neutralizes these paths to './file0' because manually binding drivers causes invalid crashes
+    rejected by maintainers.
+  * You MUST test and probe USB drivers by emulating the device with 'syz_usb_connect' instead.

--- a/pkg/aflow/flow/seedgen/generator.go
+++ b/pkg/aflow/flow/seedgen/generator.go
@@ -215,10 +215,11 @@ Workflow:
    call 'set-results' with GeneratorGiveUp=true and a reason.
 
 ## SEED GENERATION GUIDELINES
-1. PSEUDO-SYSCALL DISCOVERY:
+1. PSEUDO-SYSCALL DISCOVERY & SUBSYSTEM SKILLS:
    Before constructing complex subsystem environments (KVM VMs, USB devices, Netlink), check
-   'DocPseudoSyscalls' and 'DocSyzOS' (see below). Use '{{.toolSyzGrepper}}' (setting PathPrefix='test'
-   to search example seeds) for specialized setup helpers (e.g. 'syz_kvm_setup_syzos_vm', 'syz_usb_connect').
+   'DocPseudoSyscalls' and read the relevant subsystem skill using '{{.toolReadSyzSpec}}' (e.g.
+   'skills/kvm.md'). Use '{{.toolSyzGrepper}}' (setting PathPrefix='test' to search example seeds)
+   for specialized setup helpers (e.g. 'syz_kvm_setup_syzos_vm', 'syz_usb_connect').
 2. PRECONDITION RESEARCH:
    Instruct '{{.toolReachabilityAnalyzer}}' to find caller ` + "`if`" + ` conditions and required subsystem state
    flags leading directly to the target line before writing new program logic.
@@ -247,10 +248,6 @@ which is called within the target function.
 
 {{.SkillsPrompt}}
 
-{{if .DocSyzOS}}
-Document about SyzOS setup:
-{{.DocSyzOS}}
-{{end}}
 
 {{$lastID := .LastFailedExecutionCachedID}}
 {{$lastGen := .LastFailedGeneratedSyz}}

--- a/pkg/aflow/flow/seedgen/seedgen.go
+++ b/pkg/aflow/flow/seedgen/seedgen.go
@@ -91,7 +91,6 @@ func init() {
 				"DocProgramSyntax":             docs.ProgramSyntax,
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"DocPseudoSyscalls":            docs.PseudoSyscalls,
-				"DocSyzOS":                     docs.SyzOS,
 			},
 			Root: seedGenPipeline(
 				ActionParsePC,

--- a/pkg/aflow/flow/seedgen/seedgen_file_line.go
+++ b/pkg/aflow/flow/seedgen/seedgen_file_line.go
@@ -46,7 +46,6 @@ func init() {
 				"DocProgramSyntax":             docs.ProgramSyntax,
 				"DocSyscallDescriptionsSyntax": docs.SyscallDescriptionsSyntax,
 				"DocPseudoSyscalls":            docs.PseudoSyscalls,
-				"DocSyzOS":                     docs.SyzOS,
 			},
 			Root: seedGenPipeline(
 				kernel.Checkout,

--- a/pkg/aflow/flow/seedgen/seedgen_test.go
+++ b/pkg/aflow/flow/seedgen/seedgen_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/google/syzkaller/docs"
 	"github.com/google/syzkaller/pkg/aflow"
 	"github.com/stretchr/testify/require"
 )
@@ -99,7 +98,7 @@ func TestGeneratorAgentPromptRendering(t *testing.T) {
 		"PCs":                    []string{"0xffffffff81001234"},
 		"FunctionSource":         "void vmx_vcpu_run() { ... }",
 		"DescriptionFilesPrompt": "Description files available: dev_kvm.txt, dev_kvm_amd64.txt",
-		"DocSyzOS":               docs.SyzOS,
+		"SkillsPrompt":           "Available Subsystem Skills:\n- skills/kvm.md: KVM Virtualization",
 		"EnvironmentPrompt":      "Target OS: linux\nTarget Arch: amd64\nVM Type: qemu\n",
 		"FailedHistorySummaries": []string{"Analysis of loop 1", "Analysis of loop 2"},
 	}
@@ -114,8 +113,8 @@ func TestGeneratorAgentPromptRendering(t *testing.T) {
 	require.Contains(t, rendered, "Target OS: linux")
 	require.Contains(t, rendered, "Target Arch: amd64")
 	require.Contains(t, rendered, "VM Type: qemu")
-	require.Contains(t, rendered, "Document about SyzOS setup:")
-	require.Contains(t, rendered, "SYZOS Technical Documentation")
+	require.Contains(t, rendered, "Available Subsystem Skills:")
+	require.Contains(t, rendered, "- skills/kvm.md: KVM Virtualization")
 	require.Contains(t, rendered, "Lessons and negative constraints from previous attempts that got stuck:")
 	require.Contains(t, rendered, "Analysis of loop 1")
 	require.Contains(t, rendered, "Analysis of loop 2")

--- a/pkg/aflow/tool/syzlang/code_fixer.go
+++ b/pkg/aflow/tool/syzlang/code_fixer.go
@@ -157,11 +157,6 @@ Document about pseudo-syscalls:
 {{.DocPseudoSyscalls}}
 ===
 
-Document about SyzOS setup:
-===
-{{.DocSyzOS}}
-===
-
 `,
 	Tools: aflow.Tools(
 		ExecuteSeed,


### PR DESCRIPTION
* We should not have unconditionally included the syzos doc - it's fetchable via the skills tool. It should save some tokens.
* Update the USB documentation to prevent the agent from generating the programs that will be disarmed anyway.